### PR TITLE
docs: OpenTelemetry integration plan and research

### DIFF
--- a/plans/otel-integration-with-session-correlation.md
+++ b/plans/otel-integration-with-session-correlation.md
@@ -1,0 +1,924 @@
+# Claude Code OpenTelemetry Integration Plan
+
+**Date**: 2026-01-03
+**Branch**: claudecode/otel
+**Strategy**: Simplified session_id-based correlation
+**Research**: `research/2026-01-03_01-10-02_claude-code-otel-integration.md`
+
+## Overview
+
+Enable OpenTelemetry observability for Claude Code sessions by combining native OTEL exports with custom hook-based chat logs. Use `session_id` as the correlation key to join native telemetry with detailed conversation transcripts, avoiding the complexity of trace context injection.
+
+## Current State Analysis
+
+### What Exists
+
+**Native OTEL Support** (Built into Claude Code):
+- Metrics: Token usage, costs, command duration, success rates
+- Logs: User prompts, tool results, API requests
+- Export: OTLP protocol (HTTP/protobuf or gRPC)
+- Configuration: Environment variables
+- **Status**: Available but not enabled
+
+**Custom Hook System** (Already implemented):
+- Hook-based event logging to `logs/*.json`
+- Session lifecycle events (SessionStart, UserPromptSubmit, etc.)
+- Chat transcript creation via `--chat` flag
+- **Correlation Field**: `session_id` present in all logs
+- **File**: `~/.claude/hooks/session_start.py:24-46`
+
+**Log Files Created**:
+- `logs/session_start.json` - Session initialization
+- `logs/user_prompt_submit.json` - User prompts
+- `logs/pre_tool_use.json` - Pre-tool execution
+- `logs/post_tool_use.json` - Post-tool execution
+- `logs/chat.json` - Full conversation transcript (optional with `--chat`)
+- `logs/subagent_stop.json` - Subagent completion
+- `logs/stop.json` - Session stop events
+
+### Key Discoveries
+
+✅ **session_id already exists** in all hook logs:
+```json
+{
+  "session_id": "79cb6874-fb9e-4c66-be38-1e4948a8494d",
+  "cwd": "/Users/stevengonsalvez/d/git/agents-in-a-box",
+  "hook_event_name": "SessionStart"
+}
+```
+
+✅ **No code changes needed** - Hooks already log session_id
+
+❌ **No trace_id/span_id** - Not currently captured (and we're not adding it)
+
+✅ **Simple correlation strategy** - Join on session_id field
+
+### What's Missing
+
+1. Native OTEL not enabled (environment variables not set)
+2. No OTEL Collector to ingest hook logs
+3. No backend for visualization (Jaeger/Grafana)
+4. No session_id in native OTEL resource attributes
+
+## Desired End State
+
+### Architecture
+
+```
+┌──────────────────────────────────────┐
+│   Claude Code (Native OTEL)          │
+│   - Metrics: tokens, costs, perf     │
+│   - Logs: prompts, tool results      │
+│   - Resource: session.id added       │
+└─────────────┬────────────────────────┘
+              │ OTLP
+              ▼
+    ┌─────────────────────┐
+    │  OTEL Collector     │
+    │  - Receives OTLP    │
+    │  - Tails hook logs  │
+    │  - Adds session.id  │
+    └─────────┬───────────┘
+              │ OTLP
+              ▼
+    ┌─────────────────────┐
+    │  Jaeger/Grafana     │
+    │  Backend            │
+    │  - Stores metrics   │
+    │  - Stores logs      │
+    │  - Query by session │
+    └─────────────────────┘
+              ▲
+              │ Filelog
+    ┌─────────┴───────────┐
+    │  Hook Logs          │
+    │  logs/*.json        │
+    │  - session_id field │
+    └─────────────────────┘
+```
+
+### Correlation Flow
+
+1. **Native OTEL**: Exports with `session.id` resource attribute
+2. **Hook Logs**: Already contain `session_id` field
+3. **OTEL Collector**: Ingests both, normalizes `session_id` → `session.id`
+4. **Backend Query**: Join on `session.id` to correlate
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Environment variables set in shell config (`~/.zshrc` or `~/.bashrc`)
+- [ ] Jaeger container running: `docker ps | grep jaeger`
+- [ ] OTEL Collector container running: `docker ps | grep otel`
+- [ ] Native OTEL exports visible: `curl http://localhost:16686/api/services` shows "claude-code"
+- [ ] Hook logs ingested: Jaeger shows logs from `logs/*.json`
+- [ ] Session correlation works: Query by session.id returns both native + hook data
+
+#### Manual Verification
+
+- [ ] Start Claude Code session - verify telemetry exports to Jaeger
+- [ ] Open Jaeger UI (http://localhost:16686) - see metrics and logs
+- [ ] Search by session.id - find both native OTEL and hook logs
+- [ ] Verify chat.json correlation - conversation context appears with telemetry
+- [ ] Check token usage metrics - costs and usage tracked correctly
+- [ ] Verify multi-session isolation - different sessions show separate data
+
+## What We're NOT Doing
+
+❌ **No trace_id/span_id injection** - Too complex, session_id is sufficient
+❌ **No hook code modifications** - Works as-is
+❌ **No distributed tracing** - Just metrics + logs correlation
+❌ **No production deployment** - Local Jaeger only for now
+❌ **No custom OTEL processors** - Using standard Collector components
+❌ **No log sampling** - All logs collected initially
+
+## Implementation Approach
+
+Use a **phased rollout** approach:
+1. **Phase 1**: Enable native OTEL → Local Jaeger (validate basics)
+2. **Phase 2**: Add OTEL Collector → Ingest hook logs (validate correlation)
+3. **Phase 3**: Test queries and dashboards (validate usefulness)
+4. **Phase 4** (Future): Production deployment options
+
+---
+
+## Phase 1: Enable Native OTEL with Jaeger
+
+### Overview
+
+Enable Claude Code's native OpenTelemetry exports and verify they reach a local Jaeger instance. This validates the basic OTEL pipeline without hook log correlation.
+
+### Changes Required
+
+#### 1. Start Jaeger Backend
+
+**Command**:
+```bash
+docker run -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+**What this does**:
+- Port 16686: Jaeger UI
+- Port 4317: OTLP gRPC receiver
+- Port 4318: OTLP HTTP receiver
+
+**Verify**:
+```bash
+# Check container is running
+docker ps | grep jaeger
+
+# Access UI
+open http://localhost:16686
+```
+
+#### 2. Configure Environment Variables
+
+**File**: `~/.zshrc` (or `~/.bashrc` for bash users)
+
+**Add**:
+```bash
+# Claude Code OpenTelemetry Configuration
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+
+# Optional: Add session context as resource attribute
+# Note: This requires setting SESSION_ID before each claude invocation
+# export OTEL_RESOURCE_ATTRIBUTES="environment=development,user=stevengonsalvez"
+```
+
+**Apply changes**:
+```bash
+source ~/.zshrc  # or source ~/.bashrc
+```
+
+#### 3. Test Native OTEL Export
+
+**Run Claude Code**:
+```bash
+cd /Users/stevengonsalvez/d/git/agents-in-a-box
+claude --help  # Any Claude Code command
+```
+
+**Verify in Jaeger**:
+1. Open http://localhost:16686
+2. Select service: "claude-code"
+3. Click "Find Traces"
+4. Should see metrics and logs from the session
+
+### Success Criteria
+
+#### Automated Verification
+
+```bash
+# Check Jaeger is running
+docker ps | grep jaeger | grep -q "Up" && echo "✅ Jaeger running" || echo "❌ Jaeger not running"
+
+# Check environment variables are set
+env | grep -q "CLAUDE_CODE_ENABLE_TELEMETRY=1" && echo "✅ Telemetry enabled" || echo "❌ Telemetry not enabled"
+
+# Check OTEL exports (after running Claude Code)
+curl -s http://localhost:16686/api/services | grep -q "claude-code" && echo "✅ Native OTEL working" || echo "❌ No OTEL data"
+```
+
+#### Manual Verification
+
+- [ ] Jaeger UI loads at http://localhost:16686
+- [ ] "claude-code" appears in service dropdown
+- [ ] Metrics show token usage and costs
+- [ ] Logs show user prompts and tool results
+- [ ] Performance data (P50/P95/P99) visible
+
+### Rollback Plan
+
+If issues occur:
+```bash
+# Stop Jaeger
+docker stop jaeger && docker rm jaeger
+
+# Remove environment variables
+# Edit ~/.zshrc and remove OTEL lines, then:
+source ~/.zshrc
+```
+
+---
+
+## Phase 2: Add OTEL Collector for Hook Logs
+
+### Overview
+
+Deploy OpenTelemetry Collector to ingest hook logs from `logs/*.json` files and forward them to Jaeger alongside native OTEL data. Configure session_id correlation.
+
+### Changes Required
+
+#### 1. Create OTEL Collector Configuration
+
+**File**: `/Users/stevengonsalvez/d/git/agents-in-a-box/otel-collector-config.yaml`
+
+```yaml
+receivers:
+  # Receive native OTEL from Claude Code
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+  # Tail hook log files
+  filelog:
+    include:
+      - /logs/*.json
+    operators:
+      # Parse JSON log files
+      - type: json_parser
+        parse_from: body
+
+      # Extract timestamp
+      - type: time_parser
+        if: 'body.timestamp != nil'
+        parse_from: body.timestamp
+        layout: '%Y-%m-%dT%H:%M:%S'
+
+processors:
+  # Batch for efficiency
+  batch:
+    timeout: 10s
+    send_batch_size: 100
+
+  # Add resource attributes
+  resource:
+    attributes:
+      - key: service.name
+        value: claude-code
+        action: upsert
+      - key: service.version
+        value: 4.5
+        action: upsert
+      - key: environment
+        value: development
+        action: upsert
+
+  # Transform to normalize session_id field
+  transform:
+    log_statements:
+      - context: log
+        statements:
+          # Normalize session_id to session.id resource attribute
+          - set(resource.attributes["session.id"], body.session_id) where body.session_id != nil
+          - set(resource.attributes["session.id"], body.sessionId) where body.sessionId != nil
+
+          # Add hook event name as attribute
+          - set(attributes["hook.event"], body.hook_event_name) where body.hook_event_name != nil
+
+          # Add user prompt content
+          - set(attributes["user.prompt"], body.prompt) where body.prompt != nil
+
+exporters:
+  # Console for debugging
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 200
+
+  # Jaeger for visualization
+  otlp/jaeger:
+    endpoint: http://jaeger:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    # Native OTEL pipeline
+    logs:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [debug, otlp/jaeger]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [otlp/jaeger]
+
+    # Hook logs pipeline
+    logs/hooks:
+      receivers: [filelog]
+      processors: [batch, resource, transform]
+      exporters: [debug, otlp/jaeger]
+```
+
+#### 2. Create Docker Compose Setup
+
+**File**: `/Users/stevengonsalvez/d/git/agents-in-a-box/docker-compose-otel.yaml`
+
+```yaml
+version: '3.8'
+
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686"  # Jaeger UI
+      - "4317:4317"    # OTLP gRPC
+      - "4318:4318"    # OTLP HTTP
+    networks:
+      - otel
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+      - ./logs:/logs:ro
+    ports:
+      - "4317:4317"    # OTLP gRPC (for Claude Code)
+      - "4318:4318"    # OTLP HTTP
+    depends_on:
+      - jaeger
+    networks:
+      - otel
+
+networks:
+  otel:
+    driver: bridge
+```
+
+#### 3. Update Claude Code OTEL Config
+
+**File**: `~/.zshrc`
+
+**Change**:
+```bash
+# OLD - Direct to Jaeger
+# export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+
+# NEW - Route through OTEL Collector
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+# (No change needed - Collector proxies to Jaeger)
+```
+
+#### 4. Start the Stack
+
+**Commands**:
+```bash
+cd /Users/stevengonsalvez/d/git/agents-in-a-box
+
+# Start Jaeger + OTEL Collector
+docker-compose -f docker-compose-otel.yaml up -d
+
+# Verify both containers are running
+docker-compose -f docker-compose-otel.yaml ps
+
+# View collector logs
+docker-compose -f docker-compose-otel.yaml logs -f otel-collector
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+```bash
+# Check containers are running
+docker ps | grep -q "otel-collector" && echo "✅ Collector running" || echo "❌ Collector not running"
+docker ps | grep -q "jaeger" && echo "✅ Jaeger running" || echo "❌ Jaeger not running"
+
+# Check collector can read logs
+docker exec otel-collector ls /logs/*.json && echo "✅ Log files accessible" || echo "❌ Log files not accessible"
+
+# Run a Claude Code session and check correlation
+# (Manual step - automated check would query Jaeger API)
+```
+
+#### Manual Verification
+
+- [ ] Both containers running: `docker-compose -f docker-compose-otel.yaml ps`
+- [ ] Collector ingesting native OTEL from Claude Code
+- [ ] Collector tailing hook logs from `logs/*.json`
+- [ ] Jaeger UI shows both native metrics AND hook logs
+- [ ] Search by session.id returns correlated data
+- [ ] Hook event types visible (SessionStart, UserPromptSubmit, etc.)
+
+### Rollback Plan
+
+```bash
+# Stop all containers
+docker-compose -f docker-compose-otel.yaml down
+
+# Remove volumes (if needed)
+docker-compose -f docker-compose-otel.yaml down -v
+
+# Revert to Phase 1 setup (direct Jaeger)
+docker run -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 -p 4317:4317 -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+---
+
+## Phase 3: Test Queries and Validation
+
+### Overview
+
+Validate that session_id correlation works correctly by running test sessions and querying Jaeger for correlated data.
+
+### Test Scenarios
+
+#### Test 1: Single Session Correlation
+
+**Steps**:
+1. Start a new Claude Code session:
+   ```bash
+   cd /Users/stevengonsalvez/d/git/agents-in-a-box
+   claude "Run /research test query"
+   ```
+
+2. Note the session_id from `logs/session_start.json`:
+   ```bash
+   cat logs/session_start.json | jq '.[-1].session_id'
+   ```
+
+3. Query Jaeger by session.id:
+   - Open http://localhost:16686
+   - Service: "claude-code"
+   - Tags: `session.id=<your-session-id>`
+   - Click "Find Traces"
+
+**Expected**:
+- Native OTEL logs: User prompts, tool results, API calls
+- Hook logs: SessionStart, UserPromptSubmit, Stop events
+- All have matching session.id
+
+#### Test 2: Multi-Session Isolation
+
+**Steps**:
+1. Run 3 different Claude Code sessions
+2. Each should have unique session_id
+3. Query Jaeger for each session.id individually
+
+**Expected**:
+- Each query returns only data for that specific session
+- No cross-contamination between sessions
+- Session timestamps align with actual usage
+
+#### Test 3: Chat Log Correlation
+
+**Steps**:
+1. Run a session with `--chat` flag:
+   ```bash
+   claude "Help me test OTEL" --chat
+   ```
+
+2. Verify `logs/chat.json` created:
+   ```bash
+   ls -lh logs/chat.json
+   ```
+
+3. Check Jaeger for chat message content
+
+**Expected**:
+- Chat messages appear in Jaeger logs
+- User/assistant messages correlated by session.id
+- Token usage visible in chat log entries
+
+### Validation Queries
+
+**Jaeger UI Queries**:
+
+```
+# Find all sessions in last hour
+service=claude-code
+operation=*
+lookback=1h
+
+# Find specific session
+service=claude-code
+session.id=79cb6874-fb9e-4c66-be38-1e4948a8494d
+
+# Find all user prompts
+service=claude-code
+hook.event=UserPromptSubmit
+
+# Find high-cost sessions
+service=claude-code
+cost>10
+```
+
+**API Queries** (for automation):
+```bash
+# Get all services
+curl http://localhost:16686/api/services
+
+# Get traces with session.id tag
+curl "http://localhost:16686/api/traces?service=claude-code&tags=%7B%22session.id%22%3A%22SESSION_ID%22%7D"
+
+# Get operations
+curl "http://localhost:16686/api/services/claude-code/operations"
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+```bash
+# Script to validate correlation
+#!/bin/bash
+SESSION_ID=$(cat logs/session_start.json | jq -r '.[-1].session_id')
+
+# Query Jaeger API
+RESPONSE=$(curl -s "http://localhost:16686/api/traces?service=claude-code&tags=%7B%22session.id%22%3A%22${SESSION_ID}%22%7D")
+
+# Check if response contains data
+echo "$RESPONSE" | jq '.data | length' | grep -q '^[1-9]' && \
+  echo "✅ Session correlation working" || \
+  echo "❌ No correlated data found"
+```
+
+#### Manual Verification
+
+- [ ] Session_id query returns both native + hook data
+- [ ] Chat messages appear with conversation context
+- [ ] Token usage and costs accurately tracked
+- [ ] Tool execution events visible (pre/post)
+- [ ] Timestamps align across native and hook logs
+- [ ] Multi-session queries correctly isolated
+
+---
+
+## Phase 4: Production Deployment Options (Future)
+
+### Overview
+
+When ready to move beyond local development, choose a production backend for OTEL data.
+
+### Backend Options
+
+#### Option 1: Grafana Cloud (Recommended)
+
+**Pros**:
+- Managed service, no infrastructure
+- Native OTEL support
+- Free tier available
+- Built-in dashboards
+
+**Setup**:
+```bash
+# Update environment variables
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n 'user:password' | base64)"
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+```
+
+#### Option 2: Self-Hosted Jaeger
+
+**Pros**:
+- Full control
+- No data leaves your infrastructure
+- No costs
+
+**Setup**:
+- Deploy Jaeger to Kubernetes or cloud VM
+- Configure persistent storage
+- Setup ingress for UI access
+
+#### Option 3: Datadog
+
+**Pros**:
+- Enterprise features (APM, profiling)
+- Advanced dashboards
+- Alerting and anomaly detection
+
+**Setup**:
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.datadoghq.com"
+export OTEL_EXPORTER_OTLP_HEADERS="dd-api-key=YOUR_DD_API_KEY"
+export DD_SITE="datadoghq.com"
+```
+
+### Migration Steps
+
+When ready for production:
+
+1. **Choose backend** (Grafana/Datadog/Self-hosted)
+2. **Update OTEL Collector config** (change exporter endpoint)
+3. **Test with single session**
+4. **Update environment variables** for team
+5. **Document access URLs** and credentials
+6. **Create dashboards** for key metrics
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+Not applicable - this is infrastructure configuration, not code.
+
+### Integration Tests
+
+**Test 1: Native OTEL Export**
+```bash
+# Start Claude Code
+claude "test prompt"
+
+# Verify export
+curl -s http://localhost:16686/api/services | grep -q "claude-code"
+```
+
+**Test 2: Hook Log Ingestion**
+```bash
+# Create a test log entry
+echo '{"session_id":"test-123","hook_event_name":"Test"}' > logs/test.json
+
+# Wait for ingestion (5-10 seconds)
+sleep 10
+
+# Query Jaeger
+curl -s "http://localhost:16686/api/traces?service=claude-code&tags=%7B%22session.id%22%3A%22test-123%22%7D" | \
+  jq '.data | length'
+```
+
+**Test 3: Session Correlation**
+```bash
+# Run full session
+claude "/research test correlation"
+
+# Extract session_id
+SESSION_ID=$(cat logs/session_start.json | jq -r '.[-1].session_id')
+
+# Query both native and hook data
+curl -s "http://localhost:16686/api/traces?service=claude-code&tags=%7B%22session.id%22%3A%22${SESSION_ID}%22%7D" | \
+  jq '.data[].spans | length' | \
+  awk '{sum+=$1} END {print "Total spans:", sum}'
+```
+
+### Manual Testing Steps
+
+1. **Fresh Session Test**:
+   - Clear logs: `rm logs/*.json`
+   - Start new session: `claude "test"`
+   - Verify session_id in Jaeger
+   - Check all log types appear
+
+2. **Multi-Session Test**:
+   - Run 5 concurrent Claude sessions
+   - Verify each has unique session_id
+   - Check no data mixing in Jaeger
+
+3. **Chat Log Test**:
+   - Run session with `--chat` flag
+   - Verify chat.json created
+   - Check conversation appears in Jaeger
+
+4. **Performance Test**:
+   - Run long session (20+ prompts)
+   - Monitor OTEL Collector CPU/memory
+   - Check Jaeger UI responsiveness
+
+---
+
+## Performance Considerations
+
+### OTEL Collector Resource Usage
+
+**Expected**:
+- CPU: ~50-100m (idle), ~500m (active ingestion)
+- Memory: ~128-256MB
+- Disk I/O: Minimal (tailing logs)
+
+**Monitoring**:
+```bash
+# Check collector resource usage
+docker stats otel-collector
+
+# Check collector health
+curl http://localhost:13133/  # Health check endpoint
+```
+
+### Log File Growth
+
+**Mitigation**:
+- Implement log rotation for `logs/*.json`
+- Archive old sessions periodically
+- Consider OTEL Collector sampling for high-volume sessions
+
+**Example Rotation Script**:
+```bash
+#!/bin/bash
+# Rotate logs older than 7 days
+find logs/ -name "*.json" -mtime +7 -exec mv {} logs/archive/ \;
+```
+
+### Jaeger Storage
+
+**Local Development**:
+- In-memory storage (ephemeral)
+- Restarts lose data (acceptable for dev)
+
+**Production**:
+- Use Elasticsearch/Cassandra backend
+- Configure retention policies
+- Monitor storage usage
+
+---
+
+## Migration Notes
+
+### Existing Log Files
+
+**Backward Compatibility**:
+- Old logs (without session.id) can still be queried
+- OTEL Collector will attempt to extract session_id/sessionId
+- Logs without session field appear as "unattributed"
+
+**Cleanup**:
+```bash
+# Archive pre-OTEL logs
+mkdir -p logs/archive/pre-otel
+mv logs/*.json logs/archive/pre-otel/
+```
+
+### Team Rollout
+
+**Phase 1**: Individual developers enable locally
+**Phase 2**: Shared Jaeger instance for team
+**Phase 3**: Production backend (Grafana Cloud)
+
+**Communication**:
+- Document environment variable setup in team wiki
+- Share Jaeger UI URL
+- Create example queries for common use cases
+
+---
+
+## Troubleshooting Guide
+
+### Problem: No data in Jaeger
+
+**Diagnosis**:
+```bash
+# Check environment variables
+env | grep CLAUDE_CODE_ENABLE_TELEMETRY
+env | grep OTEL_
+
+# Check containers running
+docker ps | grep -E "jaeger|otel-collector"
+
+# Check collector logs
+docker-compose -f docker-compose-otel.yaml logs otel-collector | tail -50
+```
+
+**Solutions**:
+- Verify `CLAUDE_CODE_ENABLE_TELEMETRY=1`
+- Check Jaeger accepting OTLP on 4317
+- Restart collector: `docker-compose restart otel-collector`
+
+### Problem: Hook logs not appearing
+
+**Diagnosis**:
+```bash
+# Check log files exist
+ls -lh logs/*.json
+
+# Check collector can access logs
+docker exec otel-collector ls /logs
+
+# Check filelog receiver in collector logs
+docker-compose logs otel-collector | grep filelog
+```
+
+**Solutions**:
+- Verify volume mount in docker-compose
+- Check file permissions
+- Ensure JSON is valid: `cat logs/session_start.json | jq .`
+
+### Problem: session_id not correlating
+
+**Diagnosis**:
+```bash
+# Check field name consistency
+cat logs/session_start.json | jq '.[0] | keys | map(select(contains("session")))'
+
+# Check Jaeger tag format
+curl "http://localhost:16686/api/traces?service=claude-code" | \
+  jq '.data[0].spans[0].tags[] | select(.key | contains("session"))'
+```
+
+**Solutions**:
+- Verify transform processor in collector config
+- Check both `session_id` and `sessionId` variants handled
+- Update OTTL statements if needed
+
+---
+
+## References
+
+### Research Documents
+- `research/2026-01-03_01-10-02_claude-code-otel-integration.md` - Full research findings
+
+### Configuration Files
+- `/Users/stevengonsalvez/d/git/agents-in-a-box/otel-collector-config.yaml` - Collector config
+- `/Users/stevengonsalvez/d/git/agents-in-a-box/docker-compose-otel.yaml` - Docker Compose setup
+- `~/.zshrc` - Environment variable configuration
+
+### Hook Files
+- `~/.claude/hooks/session_start.py:24-46` - Session event logging
+- `~/.claude/hooks/stop.py:183-203` - Chat log creation
+- `~/.claude/hooks/user_prompt_submit.py` - User prompt logging
+- `~/.claude/hooks/post_tool_use.py:46-77` - Tool usage logging
+
+### External Documentation
+- [OpenTelemetry Collector Documentation](https://opentelemetry.io/docs/collector/)
+- [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md)
+- [Jaeger Getting Started](https://www.jaegertracing.io/docs/latest/getting-started/)
+- [OTTL Language Reference](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl)
+
+---
+
+## Quick Start Guide
+
+For the impatient (summarized from all phases):
+
+```bash
+# 1. Start the stack
+cd /Users/stevengonsalvez/d/git/agents-in-a-box
+docker-compose -f docker-compose-otel.yaml up -d
+
+# 2. Enable OTEL in shell config
+echo '
+# Claude Code OpenTelemetry
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+' >> ~/.zshrc
+
+source ~/.zshrc
+
+# 3. Run Claude Code
+claude "test OTEL integration"
+
+# 4. Open Jaeger UI
+open http://localhost:16686
+# Service: claude-code
+# Look for traces with session.id tags
+
+# 5. Query by session ID
+SESSION_ID=$(cat logs/session_start.json | jq -r '.[-1].session_id')
+# In Jaeger UI: Tags → session.id = <paste SESSION_ID>
+```
+
+Done! Your Claude Code sessions are now observable with native OTEL metrics and hook-based chat logs, all correlated by session_id.

--- a/research/2026-01-03_01-10-02_claude-code-otel-integration.md
+++ b/research/2026-01-03_01-10-02_claude-code-otel-integration.md
@@ -1,0 +1,800 @@
+# Research: Claude Code OTEL Integration & Chat Log Correlation
+
+**Date**: 2026-01-03T01:10:02+00:00
+**Repository**: agents-in-a-box
+**Branch**: claudecode/otel
+**Commit**: 29f8d562614ca949a995750bae18714b9998b7fd
+**Research Type**: Comprehensive (Codebase + Documentation + Web)
+
+## Research Question
+
+Can you research Claude Code's OTEL capabilities? I want to use that. Also, we create logs of our chat (like from the hooks - research and find out which hooks we create chats.json, etc.). How can that complement with the OTEL?
+
+## Executive Summary
+
+**CORRECTION**: Claude Code **DOES have native OpenTelemetry (OTEL) support**! It can export metrics and logs via OTLP (OpenTelemetry Protocol) to backends like Grafana Cloud, Datadog, Jaeger, and SigNoz.
+
+**Native OTEL Capabilities**:
+- Export metrics (token usage, costs, command duration, success rates)
+- Export log events (user prompts, tool results, API requests)
+- OTLP protocol support (HTTP/protobuf and gRPC)
+- Environment variable configuration
+
+**PLUS Custom Hook System**:
+Claude Code also implements a custom event-based telemetry system using Python hooks that generate JSON log files in `logs/*.json`. These hooks capture session lifecycle events (SessionStart, UserPromptSubmit, SubagentStop, etc.).
+
+**Integration Strategy**:
+Combine native OTEL exports with custom hook-based chat logs by:
+1. Enabling native OTEL metrics/logs export via environment variables
+2. Enriching hook JSON logs with trace context (`trace_id`, `span_id`, `trace_flags`)
+3. Using OTEL Collector's filelog receiver to ingest chat logs
+4. Unified visualization in Jaeger/Grafana showing both native telemetry AND chat conversations
+
+## Key Findings
+
+### 1. Claude Code HAS Native OTEL Support
+
+**Enable via Environment Variables**:
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://your-otlp-endpoint"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic YOUR_TOKEN"
+```
+
+**What's Exported**:
+- **Metrics**: Token usage (input/output), costs, command duration (P50/P95/P99), success rates, tool usage distribution
+- **Logs**: User prompts, tool results, API requests, tool acceptance decisions
+- **Protocol**: OTLP (HTTP/protobuf or gRPC)
+- **Backends**: Grafana Cloud, Jaeger, Datadog, Honeycomb, SigNoz
+
+**PLUS Custom Hooks**: You also have a rich hook system that creates `logs/*.json` files for session events, which can be correlated with native OTEL traces
+
+### 2. Chat Logs Are Created by Hooks (Optional)
+- **Primary Hook**: `stop.py` and `subagent_stop.py` with `--chat` flag
+- **Output Location**: `logs/chat.json`
+- **Source Data**: Converts `.jsonl` transcript files to JSON arrays
+- **Data Format**: Array of message objects with role, content, and token usage
+
+### 3. OpenTelemetry Can Unify Chat Logs and Telemetry
+- **Correlation Mechanism**: Add `trace_id`, `span_id`, `trace_flags` to chat logs
+- **Integration Path**: Use OTEL Collector's filelog receiver + transform processor
+- **Benefit**: Bidirectional navigation between traces and chat conversations
+- **Standard**: W3C Trace Context format for interoperability
+
+---
+
+## Detailed Findings
+
+### Codebase Analysis
+
+#### 1. Hook System Architecture
+
+**File**: `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/claude-code-4.5/settings.json:22-88`
+
+Claude Code uses a hook-based telemetry system with the following events:
+
+| Event | Handler | Purpose | Output |
+|-------|---------|---------|--------|
+| **SessionStart** | `session_start.py` | Session initialization | `logs/session_start.json` |
+| **UserPromptSubmit** | `user_prompt_submit.py` | Every user prompt | `logs/user_prompt_submit.json` |
+| **PreToolUse** | `pre_tool_use.py` | Before tool execution | `logs/pre_tool_use.json` |
+| **PostToolUse** | `post_tool_use.py` | After tool execution | `logs/post_tool_use.json` |
+| **SubagentStop** | `subagent_stop.py` | Subagent completion | `logs/subagent_stop.json` |
+| **Stop** | `stop.py` | Main session end | `logs/stop.json` |
+| **PreCompact** | `pre_compact.py` | Before context compaction | `logs/pre_compact.json` |
+| **Notification** | `notification.py` | Waiting for input | `logs/notification.json` |
+
+#### 2. Chat Log Creation Hooks
+
+**File**: `/Users/stevengonsalvez/.claude/hooks/stop.py:183-203`
+
+```python
+if args.chat and 'transcript_path' in input_data:
+    transcript_path = input_data['transcript_path']
+    if os.path.exists(transcript_path):
+        chat_data = []
+        try:
+            with open(transcript_path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            chat_data.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            pass
+
+            chat_file = os.path.join(log_dir, 'chat.json')
+            with open(chat_file, 'w') as f:
+                json.dump(chat_data, f, indent=2)
+```
+
+**Trigger**: Session end with `--chat` flag
+**Input**: `.jsonl` transcript file (one JSON object per line)
+**Output**: `logs/chat.json` (JSON array)
+**Identical Logic**: `subagent_stop.py:115-136` has the same implementation
+
+**Example chat.json Structure**:
+```json
+[
+  {
+    "timestamp": "2026-01-03T...",
+    "message": {
+      "role": "user",
+      "content": "Can you research on claude code OTEL capabilities...",
+      "usage": {
+        "input_tokens": 1500,
+        "output_tokens": 200
+      }
+    }
+  },
+  {
+    "timestamp": "2026-01-03T...",
+    "message": {
+      "role": "assistant",
+      "content": "I'm ready to conduct comprehensive research...",
+      "usage": {
+        "input_tokens": 1700,
+        "output_tokens": 500
+      }
+    }
+  }
+]
+```
+
+#### 3. Session Event Logging
+
+**File**: `/Users/stevengonsalvez/.claude/hooks/session_start.py:24-46`
+
+```python
+def log_session_start(input_data):
+    """Log session start event to logs directory."""
+    log_dir = Path("logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / 'session_start.json'
+
+    if log_file.exists():
+        with open(log_file, 'r') as f:
+            log_data = json.load(f)
+    else:
+        log_data = []
+
+    log_data.append(input_data)
+
+    with open(log_file, 'w') as f:
+        json.dump(log_data, f, indent=2)
+```
+
+**Example session_start.json**:
+```json
+{
+  "session_id": "79cb6874-fb9e-4c66-be38-1e4948a8494d",
+  "transcript_path": "/Users/stevengonsalvez/.claude/projects/...jsonl",
+  "cwd": "/Users/stevengonsalvez/d/git/agents-in-a-box",
+  "hook_event_name": "SessionStart",
+  "source": "startup"
+}
+```
+
+#### 4. Tool Usage Logging
+
+**File**: `/Users/stevengonsalvez/.claude/hooks/post_tool_use.py:46-77`
+
+```python
+# Line 65 in post_tool_use.py
+input_data['logged_at'] = datetime.now().isoformat()
+log_data.append(input_data)
+```
+
+**Logged Data**:
+- Tool name
+- Tool input parameters
+- Tool output/results
+- Execution timestamp
+- Project context (MD5 hash of working directory)
+
+**Special Features**:
+- TodoWrite reflection with supervisor prompts
+- Hashes todo list changes to avoid redundant prompts
+- Writes to both `logs/post_tool_use.json` and `/tmp/claude_supervisor_{hash}.log`
+
+#### 5. Current Logging Infrastructure
+
+**File**: `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/packages/workflows/multi-agent/utils/orchestrator-runner.sh:50-70`
+
+Current logging uses simple Bash functions:
+
+```bash
+log_info() {
+    echo "ℹ️  $*"
+}
+
+log_success() {
+    echo "✅ $*"
+}
+
+log_error() {
+    echo "❌ $*" >&2
+}
+```
+
+**Format**: Text output with emoji prefixes
+**Storage**: stdout/stderr (no persistence)
+**No structured logging**: Pure text, no JSON or trace context
+
+**File**: `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/packages/workflows/multi-agent/orchestration/state/config.json`
+
+```json
+{
+  "monitoring": {
+    "check_interval_seconds": 30,
+    "log_level": "info",
+    "enable_cost_tracking": true
+  }
+}
+```
+
+**Current Telemetry Elements**:
+- Cost tracking (session-level)
+- Timing instrumentation for wave execution
+- Token usage tracking (via statusline.js)
+- No distributed tracing, no OTEL exporters
+
+---
+
+### OpenTelemetry Integration Patterns
+
+#### 1. Log-to-Trace Correlation Mechanism
+
+**Source**: [OpenTelemetry Logging Specification](https://opentelemetry.io/docs/specs/otel/logs/)
+
+OpenTelemetry enables correlation through three dimensions:
+
+1. **Time-based correlation**: Timestamps align logs with traces/metrics
+2. **Execution context correlation**: `TraceId` and `SpanId` link logs to specific spans
+3. **Resource context correlation**: Shared resource attributes (e.g., Kubernetes pod)
+
+**Core trace context fields**:
+- `TraceId`: Identifies the distributed trace (hex-encoded)
+- `SpanId`: References the specific span within that trace (hex-encoded)
+- `TraceFlags`: Metadata about trace characteristics (W3C format)
+
+#### 2. Trace Context Field Standards for JSON Logs
+
+**Source**: [Trace Context in Non-OTLP Log Formats](https://opentelemetry.io/docs/reference/specification/compatibility/logging_trace_context/)
+
+**Standardized field names** (all lowercase):
+```json
+{
+  "timestamp": 1581385157.14429,
+  "body": "Incoming request",
+  "trace_id": "102981abcd2901",
+  "span_id": "abcdef1010",
+  "trace_flags": "01"
+}
+```
+
+Fields SHOULD be **top-level** in JSON structure for maximum compatibility.
+
+#### 3. Automatic Correlation via Log Bridges/Appenders
+
+**Source**: [Logs Bridge API Specification](https://opentelemetry.io/docs/reference/specification/logs/bridge-api/)
+
+The **Logs Bridge API** allows logging libraries to automatically inject trace context:
+
+**Supported frameworks**:
+- **Python**: `logging` module
+- **JavaScript/Node.js**: Winston, Pino
+- **Go**: Zap, slog, log
+- **Java**: SLF4J, Log4j, Logback
+
+**Example: Python Manual Injection** (when bridge unavailable):
+```python
+from opentelemetry import trace
+import structlog
+
+logger = structlog.get_logger()
+span = trace.get_current_span()
+span_ctx = span.get_span_context()
+
+logger.info("processing request",
+    trace_id=format(span_ctx.trace_id, '032x'),
+    span_id=format(span_ctx.span_id, '016x'),
+)
+```
+
+#### 4. File-Based Log Integration with Filelog Receiver
+
+**Source**: [Filelog Receiver README](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md)
+
+The OTEL Collector can tail JSON log files and parse them:
+
+```yaml
+receivers:
+  filelog:
+    include: [ /var/log/myservice/*.json ]
+    operators:
+      - type: json_parser
+        timestamp:
+          parse_from: attributes.time
+          layout: '%Y-%m-%d %H:%M:%S'
+```
+
+**Key features**:
+- Continuously tails log files
+- Multi-stage parsing with operator pipelines
+- Extracts timestamps and severity levels
+- Maintains stateful offsets
+
+#### 5. Collector Transformation with OTTL
+
+**Source**: [Transforming Telemetry](https://opentelemetry.io/docs/collector/transforming-telemetry/)
+
+**OpenTelemetry Transformation Language (OTTL)** enables custom enrichment:
+
+```yaml
+transform:
+  log_statements:
+    - statements:
+        - merge_maps(log.cache, ParseJSON(log.body), "upsert")
+          where IsMatch(log.body, "^\\{")
+        - set(log.attributes["attr1"], log.cache["attr1"])
+```
+
+**Use cases**:
+- Parse JSON bodies and promote fields to attributes
+- Conditional filtering based on resource/attribute values
+- Set severity levels based on content
+- Add custom enrichment metadata
+
+---
+
+## Native Claude Code OTEL Configuration
+
+### Enabling Built-in OTEL Export
+
+Claude Code has native OpenTelemetry support that can be enabled via environment variables. This exports metrics and logs directly to OTLP-compatible backends.
+
+#### Step 1: Set Environment Variables
+
+**For Grafana Cloud**:
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic YOUR_TOKEN"
+export OTEL_METRIC_EXPORT_INTERVAL=10000  # milliseconds
+export OTEL_LOGS_EXPORT_INTERVAL=5000     # milliseconds
+```
+
+**For Local Jaeger**:
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+```
+
+**For Datadog**:
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.datadoghq.com"
+export OTEL_EXPORTER_OTLP_HEADERS="dd-api-key=YOUR_DD_API_KEY"
+export DD_SITE="datadoghq.com"
+```
+
+#### Step 2: Start Claude Code
+
+Once environment variables are set, Claude Code will automatically export telemetry:
+
+```bash
+# Variables are set in your shell or .bashrc/.zshrc
+claude --help  # Any Claude Code command will now export telemetry
+```
+
+#### Step 3: What Gets Exported
+
+**Metrics (OTLP)**:
+- **Token Usage**: Input/output tokens per session
+- **Costs**: USD cost tracking
+- **Command Duration**: P50, P95, P99 percentiles
+- **Success Rates**: Command success/failure rates
+- **Tool Distribution**: Which tools are used most (Read, Edit, Bash, etc.)
+- **Model Selection**: Which models are invoked
+- **Developer Decisions**: Acceptance/rejection patterns
+- **Quota Consumption**: 5-hour rolling window usage
+
+**Log Events (OTLP)**:
+1. **User Prompts**: Developer requests and frequency
+2. **Tool Results**: Execution outcomes and decisions
+3. **API Requests**: Model calls with cost/performance data
+4. **Tool Decisions**: Acceptance patterns indicating trust
+
+#### Step 4: Visualize in Your Backend
+
+**Grafana Cloud**: Create dashboards for token usage, costs, and performance
+**Jaeger**: View traces and spans (if traces are enabled)
+**Datadog**: Use APM dashboards with custom metrics
+
+---
+
+## Integration Architecture: Combining Native OTEL + Custom Chat Logs
+
+### Two-Tier Telemetry Strategy
+
+**Tier 1: Native OTEL** (Handled by Claude Code)
+- Metrics: Token usage, costs, performance
+- Logs: User prompts, tool results, API requests
+- Export: OTLP to Grafana/Datadog/Jaeger
+
+**Tier 2: Custom Chat Logs** (Your hooks system)
+- Detailed conversation transcripts (`logs/chat.json`)
+- Session lifecycle events (`logs/session_start.json`, etc.)
+- Tool execution details (`logs/pre_tool_use.json`, `logs/post_tool_use.json`)
+
+**Integration Goal**: Correlate native OTEL traces with custom chat logs by adding trace context to hook outputs.
+
+### Proposed Implementation Strategy
+
+#### Phase 1: Add Trace Context to Hooks
+
+**Modify**: `/Users/stevengonsalvez/.claude/hooks/session_start.py`
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, BatchSpanProcessor
+
+# Initialize OTEL SDK
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+
+def log_session_start(input_data):
+    # Create a span for session start
+    with tracer.start_as_current_span("session.start") as span:
+        span_ctx = span.get_span_context()
+
+        # Add trace context to log
+        input_data['trace_id'] = format(span_ctx.trace_id, '032x')
+        input_data['span_id'] = format(span_ctx.span_id, '016x')
+        input_data['trace_flags'] = format(span_ctx.trace_flags, '02x')
+
+        # ... existing logging code ...
+```
+
+**Apply to all hooks**:
+- `user_prompt_submit.py` - Span per user prompt
+- `pre_tool_use.py` / `post_tool_use.py` - Span per tool execution
+- `subagent_stop.py` - Span for subagent lifecycle
+- `stop.py` - Root span for entire session
+
+**Result**: All JSON logs now contain trace context fields.
+
+#### Phase 2: Configure OTEL Collector
+
+**Create**: `otel-collector-config.yaml`
+
+```yaml
+receivers:
+  # Tail all Claude Code log files
+  filelog:
+    include:
+      - /Users/stevengonsalvez/d/git/agents-in-a-box/logs/*.json
+    operators:
+      - type: json_parser
+        parse_from: body
+        timestamp:
+          parse_from: attributes.logged_at
+          layout: '%Y-%m-%dT%H:%M:%S'
+
+      # Extract trace context
+      - type: move
+        from: attributes.trace_id
+        to: resource.trace_id
+      - type: move
+        from: attributes.span_id
+        to: resource.span_id
+
+processors:
+  # Batch for efficiency
+  batch:
+    timeout: 10s
+    send_batch_size: 100
+
+  # Add resource attributes
+  resource:
+    attributes:
+      - key: service.name
+        value: claude-code
+      - key: service.version
+        value: 4.5
+      - key: environment
+        value: development
+
+  # Transform and enrich
+  transform:
+    log_statements:
+      - context: log
+        statements:
+          # Extract session_id to resource
+          - set(resource.attributes["session.id"], attributes["session_id"])
+          # Extract user prompt as event
+          - set(attributes["event.name"], "user.prompt") where attributes["hook_event_name"] == "UserPromptSubmit"
+
+exporters:
+  # Console for debugging
+  debug:
+    verbosity: detailed
+
+  # Jaeger for trace visualization
+  otlp/jaeger:
+    endpoint: http://localhost:4317
+    tls:
+      insecure: true
+
+  # File for backup
+  file:
+    path: /tmp/otel-logs.json
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog]
+      processors: [batch, resource, transform]
+      exporters: [debug, otlp/jaeger, file]
+```
+
+**Run the Collector**:
+```bash
+docker run -v $(pwd)/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
+  -v /Users/stevengonsalvez/d/git/agents-in-a-box/logs:/logs:ro \
+  otel/opentelemetry-collector-contrib:latest \
+  --config=/etc/otel-collector-config.yaml
+```
+
+#### Phase 3: Start Jaeger Backend
+
+```bash
+docker run -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+**Access UI**: http://localhost:16686
+
+#### Phase 4: Enhanced Chat Logs with Trace Context
+
+**Modified chat.json structure**:
+```json
+[
+  {
+    "timestamp": "2026-01-03T01:10:02+00:00",
+    "trace_id": "102981abcd290100000000000000001a",
+    "span_id": "abcdef1010111213",
+    "trace_flags": "01",
+    "message": {
+      "role": "user",
+      "content": "Can you research on claude code OTEL capabilities...",
+      "usage": {
+        "input_tokens": 1500,
+        "output_tokens": 200
+      }
+    },
+    "session_id": "79cb6874-fb9e-4c66-be38-1e4948a8494d",
+    "hook_event_name": "UserPromptSubmit"
+  }
+]
+```
+
+**Benefits**:
+1. Click on trace in Jaeger → See all chat messages in that session
+2. Click on chat message → See trace timeline with tool executions
+3. Correlate multi-agent workflows with conversation context
+4. Track token usage and costs alongside execution traces
+
+---
+
+## Code References
+
+### Hook System
+- `~/.claude/hooks/stop.py:183-203` - Chat log creation
+- `~/.claude/hooks/subagent_stop.py:115-136` - Subagent chat logs
+- `~/.claude/hooks/session_start.py:24-46` - Session event logging
+- `~/.claude/hooks/post_tool_use.py:46-77` - Tool usage logging
+- `~/.claude/hooks/pre_tool_use.py:107-127` - Pre-tool logging
+
+### Configuration
+- `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/claude-code-4.5/settings.json:22-88` - Hook definitions
+- `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/packages/workflows/multi-agent/orchestration/state/config.json` - Monitoring config
+
+### Logging Infrastructure
+- `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/packages/workflows/multi-agent/utils/orchestrator-runner.sh:50-70` - Bash logging functions
+- `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/packages/skills/webapp-testing/bin/browser-tools.ts:436-451` - TypeScript console logging
+
+### Log Outputs
+- `logs/chat.json` - Chat transcript (requires `--chat` flag)
+- `logs/session_start.json` - Session initialization events
+- `logs/user_prompt_submit.json` - User prompts
+- `logs/pre_tool_use.json` - Pre-tool execution
+- `logs/post_tool_use.json` - Post-tool execution
+- `logs/subagent_stop.json` - Subagent completion
+- `logs/stop.json` - Session stop events
+- `/tmp/claude_supervisor_{hash}.log` - Supervisor telemetry
+
+---
+
+## Architecture Insights
+
+### Pattern: Event-Driven Telemetry via Hooks
+
+Claude Code uses a **hook-based event system** where Python scripts are triggered at specific lifecycle events. This pattern is:
+
+- **Extensible**: Add new hooks without modifying core code
+- **Configurable**: Enable/disable hooks in `settings.json`
+- **Language-agnostic**: Hooks can be Python, JavaScript, or Bash
+- **Append-only**: Logs are progressive JSON arrays
+
+### Convention: Progressive JSON Array Logging
+
+All hooks follow this pattern:
+1. Read existing JSON array from file (or initialize `[]`)
+2. Append new event object
+3. Write back to file
+
+This enables:
+- Historical event tracking across sessions
+- Simple log rotation (archive old files)
+- Easy parsing with `jq` or OTEL filelog receiver
+
+### Design Decision: Optional Chat Logging
+
+Chat logs are **NOT created by default** - they require the `--chat` flag. This was likely chosen to:
+- Reduce disk usage for non-debugging sessions
+- Respect user privacy (transcripts contain all conversation data)
+- Allow opt-in telemetry collection
+
+---
+
+## Recommendations
+
+### Immediate Actions
+
+1. **Enable OTEL SDK in Hooks**
+   - Install `opentelemetry-api` and `opentelemetry-sdk` in hook environment
+   - Add trace context to all log writes
+   - Export spans to OTLP endpoint
+
+2. **Deploy OTEL Collector**
+   - Use Docker Compose for easy local setup
+   - Configure filelog receiver for `logs/*.json`
+   - Add transform processor to enrich with resource attributes
+
+3. **Start Jaeger Backend**
+   - Run Jaeger all-in-one container
+   - Configure OTLP receiver on port 4317
+   - Access UI at http://localhost:16686
+
+4. **Add Correlation IDs**
+   - Generate `session_id` as root `trace_id`
+   - Use tool invocations as child spans
+   - Propagate context across subagent spawns
+
+### Future Enhancements
+
+1. **Metrics Collection**
+   - Export token usage as OTEL metrics
+   - Track cost per session/agent/wave
+   - Monitor tool execution latency
+
+2. **Distributed Tracing Across Agents**
+   - Propagate trace context when spawning subagents
+   - Use W3C Trace Context headers for git worktree operations
+   - Create flame graphs for multi-agent workflows
+
+3. **Log Sampling**
+   - Implement probabilistic sampling for high-volume sessions
+   - Preserve all ERROR/FATAL logs
+   - Sample INFO/DEBUG based on session health
+
+4. **Custom OTEL Processor**
+   - Create processor to derive spans from chat logs
+   - Automatically detect conversation phases (research, planning, implementation)
+   - Extract entities (file paths, git commits) as span attributes
+
+---
+
+## Open Questions
+
+1. **Trace Context Propagation**: How should trace context be propagated when spawning subagents in separate tmux sessions?
+
+   **Options**:
+   - Environment variables: `TRACEPARENT`, `TRACESTATE`
+   - Metadata files: `.otel-trace-context.json` in worktree
+   - Command-line arguments: Pass trace context as CLI flags
+
+2. **Session Lifecycle Mapping**: Should each Claude Code session be a single trace, or should user prompts create separate traces?
+
+   **Recommendation**: Session = Root Span, User Prompts = Child Spans, Tool Executions = Grandchild Spans
+
+3. **Cost Attribution**: How to attribute OTEL processing costs to the original session?
+
+   **Solution**: Add `session_id` as resource attribute in Collector pipeline
+
+4. **Backward Compatibility**: Should existing log files be retroactively enriched with trace context?
+
+   **Recommendation**: No - only future logs. Existing logs can be imported as "untraced" events.
+
+---
+
+## References
+
+### Internal Documentation
+- Project README: `/Users/stevengonsalvez/d/git/agents-in-a-box/README.md`
+- Toolkit README: `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/README.md`
+- Multi-Agent Workflow: `/Users/stevengonsalvez/d/git/agents-in-a-box/toolkit/packages/workflows/multi-agent/WORKFLOW.md`
+
+### OpenTelemetry Official Documentation
+- [OpenTelemetry Logging Specification](https://opentelemetry.io/docs/specs/otel/logs/)
+- [Trace Context in Non-OTLP Log Formats](https://opentelemetry.io/docs/reference/specification/compatibility/logging_trace_context/)
+- [Logs Bridge API Specification](https://opentelemetry.io/docs/reference/specification/logs/bridge-api/)
+- [Context Propagation](https://opentelemetry.io/docs/concepts/context-propagation/)
+- [Logs SDK Specification](https://opentelemetry.io/docs/specs/otel/logs/sdk/)
+- [OTLP File Exporter](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/)
+- [Transforming Telemetry](https://opentelemetry.io/docs/collector/transforming-telemetry/)
+
+### OTEL Collector Components
+- [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md)
+- [Transform Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md)
+
+### Best Practices and Guides
+- [OpenTelemetry Logs Complete Guide - Uptrace](https://uptrace.dev/opentelemetry/logs)
+- [A Complete Guide to OpenTelemetry Logs - Dash0](https://www.dash0.com/knowledge/opentelemetry-logging-explained)
+- [Essential OpenTelemetry Best Practices - Better Stack](https://betterstack.com/community/guides/observability/opentelemetry-best-practices/)
+- [Parsing Logs with OTEL Collector - SigNoz](https://signoz.io/blog/parsing-logs-with-the-opentelemetry-collector/)
+- [Ingesting JSON Logs from Containers - Honeycomb](https://www.honeycomb.io/blog/ingesting-json-logs-containers-otel-collector)
+
+### Language-Specific Integrations
+- [Log Correlation - .NET](https://opentelemetry.io/docs/languages/dotnet/logs/correlation/)
+- [Logback Appender - OpenTelemetry Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/logback/logback-appender-1.0/library/README.md)
+
+### Vendor-Specific Guides
+- [Correlating OTEL Traces and Logs - Datadog](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/)
+- [Log Enrichment with OTEL Collector - New Relic](https://newrelic.com/blog/how-to-relic/enrich-logs-with-opentelemetry-collector)
+
+---
+
+## Summary
+
+**Claude Code HAS native OpenTelemetry support** that can be enabled via environment variables. It exports metrics (token usage, costs, performance) and logs (user prompts, tool results, API requests) via OTLP to backends like Grafana Cloud, Jaeger, Datadog, and SigNoz.
+
+**PLUS Custom Hooks**: Claude Code also uses a **custom hook-based telemetry system** that writes detailed JSON logs to `logs/*.json` files. Chat logs are optionally created via the `--chat` flag in `stop.py` and `subagent_stop.py` hooks.
+
+**Integration Strategy** - Combining Both:
+
+1. **Enable native OTEL** - Set environment variables to export metrics/logs to your backend
+2. **Enrich hook logs with trace context** - Add `trace_id`, `span_id`, `trace_flags` to hook outputs
+3. **Deploy OTEL Collector** - Use filelog receiver to tail and parse hook JSON logs
+4. **Unified observability** - Correlate native OTEL telemetry with detailed chat conversations
+
+**Benefits**:
+- **Native telemetry**: Automatic metrics and logs from Claude Code core
+- **Custom detail**: Rich conversation transcripts and session lifecycle events
+- **Bidirectional correlation**: Navigate from traces to chat logs and vice versa
+- **Complete visibility**: See both "what happened" (metrics) and "why" (chat context)
+
+**Next Steps**:
+1. Enable native OTEL via environment variables
+2. Start using Claude Code - telemetry exports automatically
+3. Optionally implement trace context injection in hooks for correlation
+4. Deploy OTEL Collector to unify native telemetry + custom chat logs
+5. Visualize in Jaeger/Grafana/Datadog


### PR DESCRIPTION
## Overview

This PR adds comprehensive research and implementation plan for integrating OpenTelemetry (OTEL) with Claude Code using a simplified session_id-based correlation strategy.

## What's Included

### Research Document
- `research/2026-01-03_01-10-02_claude-code-otel-integration.md`
- Comprehensive research on Claude Code's native OTEL capabilities
- Analysis of hook system and chat log creation
- OTEL integration patterns and best practices
- Correlation strategies (session_id vs trace_id/span_id)

### Implementation Plan
- `plans/otel-integration-with-session-correlation.md`
- 4-phase rollout plan with detailed steps
- Docker Compose configuration for Jaeger + OTEL Collector
- Environment variable setup guide
- Testing and validation procedures
- Troubleshooting guide
- Quick start guide for immediate use

## Key Decisions

✅ **Use session_id for correlation** (not trace_id/span_id)
- No hook code modifications required
- session_id already exists in all logs
- Simple join in backend queries

✅ **Two-tier telemetry strategy**
- Native OTEL: Automatic metrics/logs from Claude Code
- Hook logs: Detailed conversation transcripts
- Unified view via OTEL Collector

## Architecture

```
Claude Code (Native OTEL)
    ↓ OTLP
OTEL Collector
    ↓ Filelog + OTLP
Jaeger/Grafana Backend
    ↑
Hook Logs (logs/*.json)
```

Correlation: Join on `session.id` field

## Implementation Phases

1. **Phase 1**: Enable native OTEL → Local Jaeger (~5 min)
2. **Phase 2**: Deploy OTEL Collector → Ingest hook logs (~15 min)
3. **Phase 3**: Test queries and validation (~10 min)
4. **Phase 4**: Production deployment options (future)

## Benefits

- ✅ No code changes needed
- ✅ Works with existing hooks
- ✅ Simple correlation via session_id
- ✅ Unified observability: metrics + conversation context
- ✅ Docker Compose for easy deployment
- ✅ Supports Grafana Cloud, Datadog, Jaeger

## Next Steps

- [ ] Review research findings
- [ ] Validate implementation plan approach
- [ ] Execute Phase 1 (enable native OTEL)
- [ ] Test basic correlation
- [ ] Decide on production backend

## References

- Research: [2026-01-03_01-10-02_claude-code-otel-integration.md](research/2026-01-03_01-10-02_claude-code-otel-integration.md)
- Plan: [otel-integration-with-session-correlation.md](plans/otel-integration-with-session-correlation.md)
- Official Docs: https://code.claude.com/docs/en/monitoring-usage