### PR TITLE
feat(cli): full CLI feature parity with TUI (15 commands)

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agents-box"
+name = "ainb"
 version = "0.5.5-beta1"
 edition = "2021"
 authors = ["Agents-in-a-Box Team"]
@@ -8,6 +8,14 @@ license = "MIT"
 repository = "https://github.com/your-org/agents-box"
 keywords = ["claude", "docker", "tui", "development", "containers"]
 categories = ["command-line-utilities", "development-tools"]
+
+[[bin]]
+name = "ainb"
+path = "src/main.rs"
+
+[lib]
+name = "ainb"
+path = "src/lib.rs"
 
 [dependencies]
 # Core

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -56,6 +56,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4.4", features = ["derive"] }
+clap_complete = "4.4"  # Shell completion generation
 tempfile = "3.8"
 nix = { version = "0.27", features = ["user"] }
 arboard = "3.3"  # Cross-platform clipboard support

--- a/ainb-tui/scripts/cli-smoke-test.sh
+++ b/ainb-tui/scripts/cli-smoke-test.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# ABOUTME: Isolated smoke tests for Wave 1 CLI commands (config, recover, run).
+#
+# Runs the real `ainb` binary against an isolated HOME and TMUX_TMPDIR so it
+# has ZERO impact on the user's real ~/.agents-in-a-box/, ~/.claude/, or tmux
+# sessions. Verifies end-to-end behaviour of:
+#   - ainb config {show,get,set,reset,path}
+#   - ainb recover {list,cleanup}
+#   - ainb run + list + status + logs + kill (with stubbed claude binary)
+#   - Multi-provider validation for --tool codex/gemini/copilot
+#
+# Usage: ./scripts/cli-smoke-test.sh
+
+set -euo pipefail
+
+# ---- Isolation setup --------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BINARY="$CRATE_ROOT/target/debug/ainb"
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "ERROR: $BINARY not found. Run 'cargo build' first." >&2
+    exit 1
+fi
+
+# Snapshot real-data timestamps so we can verify isolation at the end
+REAL_HOME="$HOME"
+REAL_SESSIONS_STAT=""
+REAL_CONFIG_STAT=""
+[[ -f "$REAL_HOME/.agents-in-a-box/sessions.json" ]] && REAL_SESSIONS_STAT=$(stat -f %m "$REAL_HOME/.agents-in-a-box/sessions.json" 2>/dev/null || true)
+[[ -f "$REAL_HOME/.agents-in-a-box/config/config.toml" ]] && REAL_CONFIG_STAT=$(stat -f %m "$REAL_HOME/.agents-in-a-box/config/config.toml" 2>/dev/null || true)
+REAL_CLAUDE_AGENT_COUNT=$(find "$REAL_HOME/.claude/agents" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+
+# Build isolated sandbox
+TEST_ROOT=$(mktemp -d -t ainb-smoke-XXXXXX)
+export HOME="$TEST_ROOT/home"
+export TMUX_TMPDIR="$TEST_ROOT/tmux"
+mkdir -p "$HOME" "$TMUX_TMPDIR"
+
+cleanup() {
+    local exit_code=$?
+    echo ""
+    echo "--- Cleanup ---"
+    # Kill any tmux sessions in the isolated socket before wiping
+    if [[ -d "$TMUX_TMPDIR" ]]; then
+        while IFS= read -r -d '' socket; do
+            [[ -S "$socket" ]] && tmux -S "$socket" kill-server 2>/dev/null || true
+        done < <(find "$TMUX_TMPDIR" -name default -type s -print0 2>/dev/null)
+    fi
+    rm -rf "$TEST_ROOT"
+
+    # Verify isolation worked — real user data MUST be untouched
+    local leak=0
+    if [[ -f "$REAL_HOME/.agents-in-a-box/sessions.json" ]]; then
+        local now=$(stat -f %m "$REAL_HOME/.agents-in-a-box/sessions.json" 2>/dev/null || true)
+        if [[ "$now" != "$REAL_SESSIONS_STAT" ]]; then
+            echo "LEAK: real sessions.json was modified!" >&2
+            leak=1
+        fi
+    fi
+    if [[ -f "$REAL_HOME/.agents-in-a-box/config/config.toml" ]]; then
+        local now=$(stat -f %m "$REAL_HOME/.agents-in-a-box/config/config.toml" 2>/dev/null || true)
+        if [[ "$now" != "$REAL_CONFIG_STAT" ]]; then
+            echo "LEAK: real config.toml was modified!" >&2
+            leak=1
+        fi
+    fi
+    local now_count=$(find "$REAL_HOME/.claude/agents" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$now_count" != "$REAL_CLAUDE_AGENT_COUNT" ]]; then
+        echo "LEAK: ~/.claude/agents count changed ($REAL_CLAUDE_AGENT_COUNT -> $now_count)" >&2
+        leak=1
+    fi
+
+    if [[ $leak -eq 0 ]]; then
+        echo "✓ Isolation verified: real user data untouched"
+    else
+        echo "✗ ISOLATION FAILURE — check damage in $REAL_HOME" >&2
+        exit 2
+    fi
+
+    if [[ $exit_code -eq 0 ]]; then
+        echo "✓ All smoke tests passed"
+    else
+        echo "✗ Smoke tests failed (exit $exit_code)"
+    fi
+    exit $exit_code
+}
+trap cleanup EXIT INT TERM
+
+# ---- Test helpers -----------------------------------------------------------
+
+PASS=0
+FAIL=0
+
+section() { echo; echo "=== $* ==="; }
+
+assert() {
+    local desc="$1"; shift
+    if "$@"; then
+        echo "  ✓ $desc"
+        PASS=$((PASS+1))
+    else
+        echo "  ✗ $desc" >&2
+        FAIL=$((FAIL+1))
+    fi
+}
+
+run_ainb() {
+    # Run binary with isolated env; prints output to stdout
+    "$BINARY" "$@"
+}
+
+# ---- Preflight --------------------------------------------------------------
+
+section "Preflight"
+echo "  TEST_ROOT=$TEST_ROOT"
+echo "  HOME=$HOME"
+echo "  TMUX_TMPDIR=$TMUX_TMPDIR"
+echo "  BINARY=$BINARY"
+
+assert "binary is executable" test -x "$BINARY"
+assert "HOME is isolated" test "$HOME" != "$REAL_HOME"
+assert "HOME is under TEST_ROOT" test "${HOME#$TEST_ROOT}" != "$HOME"
+
+# ---- Test 4a: config command ------------------------------------------------
+
+section "4a. config command (pure filesystem)"
+
+# path: should list 3 config locations
+output=$(run_ainb config path 2>&1)
+assert "config path runs successfully" test $? -eq 0
+assert "config path mentions project-level" grep -qi "project" <<<"$output"
+assert "config path mentions user-level" grep -qi "user" <<<"$output"
+assert "config path references isolated HOME" grep -q "$HOME" <<<"$output"
+
+# show: with empty home, should return defaults (not error)
+output=$(run_ainb config show 2>&1 || true)
+assert "config show runs" test -n "$output"
+
+# show --format json: valid JSON
+output=$(run_ainb --format json config show 2>&1 || true)
+assert "config show --format json is valid JSON" bash -c "echo '$output' | jq -e . >/dev/null 2>&1"
+
+# set → get round trip
+run_ainb config set authentication.default_model opus >/dev/null 2>&1
+output=$(run_ainb config get authentication.default_model 2>&1 | tr -d '"' | tr -d ' ')
+assert "config set+get round trip returns 'opus'" test "$output" = "opus"
+
+# set only modified isolated config (sanity check)
+assert "isolated config file exists" test -f "$HOME/.agents-in-a-box/config/config.toml"
+assert "config contains the set value" grep -q "opus" "$HOME/.agents-in-a-box/config/config.toml"
+
+# set a different key
+run_ainb config set authentication.default_model sonnet >/dev/null 2>&1
+output=$(run_ainb config get authentication.default_model 2>&1 | tr -d '"' | tr -d ' ')
+assert "config set can change value back" test "$output" = "sonnet"
+
+# reset with force
+run_ainb config reset --force >/dev/null 2>&1 || true
+# After reset the file may be empty or regenerated — check command succeeded
+assert "config reset --force succeeded" test $? -eq 0
+
+# ---- Test 4b: recover command -----------------------------------------------
+
+section "4b. recover command (empty + seeded orphan)"
+
+# Empty home: recover list should succeed with zero orphans
+output=$(run_ainb recover list 2>&1 || true)
+assert "recover list runs on empty home" test $? -eq 0
+
+# JSON format
+output=$(run_ainb --format json recover list 2>&1 || true)
+assert "recover list --format json is valid JSON" bash -c "echo '$output' | jq -e . >/dev/null 2>&1"
+
+# Seed a fake orphan: SessionStore entry with a tmux session name that doesn't exist
+# on the isolated socket. Note: agent_type must match enum serialization ("Claude" not "claude").
+mkdir -p "$HOME/.agents-in-a-box"
+SESSION_UUID="12345678-1234-1234-1234-123456789abc"
+cat > "$HOME/.agents-in-a-box/sessions.json" <<EOF
+{
+  "sessions": {
+    "ainb-test-orphan": {
+      "session_id": "$SESSION_UUID",
+      "tmux_session_name": "ainb-test-orphan",
+      "worktree_path": "/tmp/nonexistent-worktree-$SESSION_UUID",
+      "workspace_name": "test-workspace",
+      "created_at": "2026-01-01T00:00:00Z",
+      "agent_type": "Claude"
+    }
+  }
+}
+EOF
+
+# recover list should now find the orphan (tmux session doesn't exist → stale metadata)
+output=$(run_ainb recover list 2>&1 || true)
+assert "recover list detects seeded orphan" grep -q "test-workspace\|ainb-test-orphan" <<<"$output"
+
+# recover cleanup --force should remove it
+run_ainb recover cleanup --force >/dev/null 2>&1 || true
+
+# After cleanup the orphan should be gone
+output=$(run_ainb recover list 2>&1 || true)
+assert "recover cleanup removed orphan" bash -c "! grep -q 'ainb-test-orphan' <<<\"$output\""
+
+# ---- Test 4c: run + list + status + kill (with stubbed claude) --------------
+
+section "4c. run command lifecycle (with stubbed provider)"
+
+# Create a throwaway git repo inside TEST_ROOT
+TEST_REPO="$TEST_ROOT/test-repo"
+git init -q "$TEST_REPO"
+(cd "$TEST_REPO" && git -c user.email=test@test.local -c user.name=Test -c commit.gpgsign=false commit --allow-empty -q -m "init")
+
+# Stub the claude binary so we don't need a real install
+mkdir "$TEST_ROOT/fake-bin"
+cat > "$TEST_ROOT/fake-bin/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "fake claude started with args: $*"
+# Loop forever so tmux session stays alive
+while :; do sleep 60; done
+STUB
+chmod +x "$TEST_ROOT/fake-bin/claude"
+export PATH="$TEST_ROOT/fake-bin:$PATH"
+
+# Skip run lifecycle if tmux is not installed
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "  ⚠ tmux not installed — skipping 4c"
+else
+    # Run the command (no --attach so it returns)
+    output=$(run_ainb run --repo "$TEST_REPO" --worktree --name smoke-test 2>&1 || true)
+    assert "run command completes" grep -qi "session.*created\|Session ID" <<<"$output"
+
+    # Give tmux a moment to stabilise
+    sleep 1
+
+    # list should show our session
+    output=$(run_ainb list 2>&1 || true)
+    assert "list shows smoke-test session" grep -q "smoke-test\|test-repo" <<<"$output"
+
+    # list --format json is valid
+    output=$(run_ainb --format json list 2>&1 || true)
+    assert "list --format json is valid" bash -c "echo '$output' | jq -e 'type == \"array\"' >/dev/null 2>&1"
+
+    # status should report on the session (find by prefix)
+    # The actual session name is workspace-based; use smoke-test if present
+    output=$(run_ainb status smoke-test 2>&1 || run_ainb status test-repo 2>&1 || true)
+    assert "status command runs for smoke-test" test -n "$output"
+
+    # logs should capture something (the fake claude echoed output)
+    output=$(run_ainb logs smoke-test --lines 10 2>&1 || run_ainb logs test-repo --lines 10 2>&1 || true)
+    assert "logs command runs" test -n "$output"
+
+    # kill --force should terminate it
+    run_ainb kill smoke-test --force >/dev/null 2>&1 || run_ainb kill test-repo --force >/dev/null 2>&1 || true
+
+    sleep 1
+    output=$(run_ainb list 2>&1 || true)
+    # After kill, session should not appear in list (or list is empty)
+    assert "kill removed session from list" bash -c "! grep -q 'smoke-test' <<<\"$output\""
+fi
+
+# ---- Test 4d: Multi-provider validation -------------------------------------
+
+section "4d. multi-provider --tool flag validation (Phase 1)"
+
+# Remove stub claude and ensure codex/gemini/copilot aren't on PATH
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin"  # Reset to minimal PATH (no fake-bin)
+
+# Each should fail with a helpful "not found" error, proving --tool is wired up
+output=$(run_ainb run --tool codex --repo "$TEST_REPO" 2>&1 || true)
+assert "codex validation fires when not installed" grep -qi "codex" <<<"$output"
+
+output=$(run_ainb run --tool gemini --repo "$TEST_REPO" 2>&1 || true)
+assert "gemini validation fires when not installed" grep -qi "gemini" <<<"$output"
+
+output=$(run_ainb run --tool copilot --repo "$TEST_REPO" 2>&1 || true)
+assert "copilot validation fires when not installed" grep -qi "copilot" <<<"$output"
+
+# Restore useful PATH for Wave 2+3 tests (need tmux, git, jq)
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# ---- Test 4e: favorites command (Phase 5) ----------------------------------
+
+section "4e. favorites command (Phase 5)"
+
+# Empty list
+output=$(run_ainb favorites list 2>&1 || true)
+assert "favorites list runs on empty store" test $? -eq 0
+
+# Add a favorite
+run_ainb favorites add "torvalds/linux" --alias linux --description "kernel" >/dev/null 2>&1 || true
+output=$(run_ainb favorites list 2>&1 || true)
+assert "favorites list shows added entry" grep -q "linux\|torvalds" <<<"$output"
+assert "favorites.yaml was created" test -f "$HOME/.agents-in-a-box/favorites.yaml"
+
+# JSON format
+output=$(run_ainb --format json favorites list 2>&1 || true)
+assert "favorites list --format json is valid" bash -c "echo '$output' | jq -e . >/dev/null 2>&1"
+
+# Add a second favorite and record usage
+run_ainb favorites add "https://github.com/rust-lang/rust" --alias rust >/dev/null 2>&1 || true
+run_ainb favorites use linux >/dev/null 2>&1 || true
+
+# Remove one
+run_ainb favorites remove linux >/dev/null 2>&1 || true
+output=$(run_ainb favorites list 2>&1 || true)
+assert "favorites remove deleted the entry" bash -c "! grep -q 'torvalds' <<<\"$output\""
+
+# ---- Test 4f: presets command (Phase 7) ------------------------------------
+
+section "4f. presets command (Phase 7)"
+
+# list should show built-in presets (rust-backend, typescript-frontend, fast-iteration)
+output=$(run_ainb presets list 2>&1 || true)
+assert "presets list shows built-in rust-backend" grep -qi "rust-backend\|rust_backend" <<<"$output"
+
+# show the built-in
+output=$(run_ainb presets show rust-backend 2>&1 || true)
+assert "presets show displays a preset" test -n "$output"
+
+# JSON format
+output=$(run_ainb --format json presets list 2>&1 || true)
+assert "presets list --format json is valid" bash -c "echo '$output' | jq -e . >/dev/null 2>&1"
+
+# Apply to CWD - should write .agents-box/preset.toml
+(cd "$TEST_ROOT" && "$BINARY" presets apply rust-backend >/dev/null 2>&1) || true
+assert "presets apply wrote preset.toml" test -f "$TEST_ROOT/.agents-box/preset.toml"
+
+# Delete attempt on built-in should fail gracefully
+output=$(run_ainb presets delete rust-backend 2>&1 || true)
+assert "presets delete rejects built-in presets" grep -qi "built-in\|cannot\|not.*custom\|not.*allowed" <<<"$output"
+
+# ---- Test 4g: git command (Phase 4) ----------------------------------------
+
+section "4g. git command (Phase 4)"
+
+# worktrees list should succeed on empty home (no worktrees exist)
+output=$(run_ainb git worktrees 2>&1 || true)
+assert "git worktrees runs on empty home" test $? -eq 0
+
+# JSON format
+output=$(run_ainb --format json git worktrees 2>&1 || true)
+assert "git worktrees --format json is valid" bash -c "echo '$output' | jq -e . >/dev/null 2>&1"
+
+# Cleanup with dry-run should not modify anything
+output=$(run_ainb git cleanup --dry-run 2>&1 || true)
+assert "git cleanup --dry-run runs" test $? -eq 0
+
+# ---- Test 4h: init command (Phase 6) ---------------------------------------
+
+section "4h. init command (Phase 6)"
+
+# --check should report prereqs without modifying anything
+output=$(run_ainb init --check 2>&1 || true)
+assert "init --check runs" test -n "$output"
+assert "init --check reports tmux" grep -qi "tmux" <<<"$output"
+assert "init --check reports git" grep -qi "git" <<<"$output"
+
+# --status (may report not-yet-onboarded on empty home)
+output=$(run_ainb init --status 2>&1 || true)
+assert "init --status runs" test $? -eq 0
+
+# --check with --format json
+output=$(run_ainb --format json init --check 2>&1 || true)
+assert "init --check --format json is valid" bash -c "echo '$output' | jq -e . >/dev/null 2>&1"
+
+# ---- Summary ---------------------------------------------------------------
+
+section "Summary"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/ainb-tui/src/cli/attach.rs
+++ b/ainb-tui/src/cli/attach.rs
@@ -1,0 +1,159 @@
+// ABOUTME: CLI attach command - attach to a session's tmux
+//
+// Finds the session by ID or name prefix and attaches to its tmux session.
+// Uses exec to replace the current process with tmux attach.
+
+use anyhow::Result;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+use uuid::Uuid;
+
+use super::AttachArgs;
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+
+/// Execute the attach command
+#[allow(clippy::unused_async)]
+pub async fn execute(args: AttachArgs) -> Result<()> {
+    let session = find_session(&args.session)?;
+    let tmux_name = &session.tmux_session_name;
+
+    // Check tmux session exists
+    let exists = Command::new("tmux")
+        .args(["has-session", "-t", tmux_name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if !exists {
+        anyhow::bail!("Tmux session '{tmux_name}' no longer exists");
+    }
+
+    println!("Attaching to session: {}", session.workspace_name);
+    println!("Detach with: Ctrl+B, then D");
+    println!();
+
+    // Exec replaces the current process with tmux attach
+    let err = Command::new("tmux")
+        .args(["attach-session", "-t", tmux_name])
+        .exec();
+
+    // If we get here, exec failed
+    Err(anyhow::anyhow!("Failed to attach: {err}"))
+}
+
+/// Find a session by ID (full or partial UUID) or workspace name prefix
+///
+/// Matching priority:
+/// 1. Exact UUID match
+/// 2. UUID prefix match (e.g., "abc" matches "abc12345-...")
+/// 3. Workspace name prefix match (case-insensitive)
+pub fn find_session(id_or_name: &str) -> Result<SessionMetadata> {
+    let store = SessionStore::load();
+
+    if store.sessions.is_empty() {
+        anyhow::bail!("No sessions found. Run 'ainb run' to create a session.");
+    }
+
+    // First, try exact UUID match
+    if let Ok(uuid) = Uuid::parse_str(id_or_name) {
+        for session in store.sessions.values() {
+            if session.session_id == uuid {
+                return Ok(session.clone());
+            }
+        }
+    }
+
+    // Try UUID prefix match
+    let id_lower = id_or_name.to_lowercase();
+    let mut uuid_matches: Vec<&SessionMetadata> = store
+        .sessions
+        .values()
+        .filter(|s| s.session_id.to_string().to_lowercase().starts_with(&id_lower))
+        .collect();
+
+    match uuid_matches.len() {
+        1 => return Ok(uuid_matches.remove(0).clone()),
+        n if n > 1 => {
+            let ids: Vec<String> = uuid_matches
+                .iter()
+                .map(|s| format!("  {} ({})", &s.session_id.to_string()[..8], s.workspace_name))
+                .collect();
+            anyhow::bail!(
+                "Ambiguous session ID prefix '{id_or_name}'. Matches:\n{}",
+                ids.join("\n")
+            );
+        }
+        _ => {}
+    }
+
+    // Try workspace name prefix match (case-insensitive)
+    let mut name_matches: Vec<&SessionMetadata> = store
+        .sessions
+        .values()
+        .filter(|s| s.workspace_name.to_lowercase().starts_with(&id_lower))
+        .collect();
+
+    match name_matches.len() {
+        1 => return Ok(name_matches.remove(0).clone()),
+        n if n > 1 => {
+            let names: Vec<String> = name_matches
+                .iter()
+                .map(|s| format!("  {} ({})", s.workspace_name, &s.session_id.to_string()[..8]))
+                .collect();
+            anyhow::bail!(
+                "Ambiguous session name prefix '{id_or_name}'. Matches:\n{}",
+                names.join("\n")
+            );
+        }
+        _ => {}
+    }
+
+    anyhow::bail!(
+        "No session found matching '{id_or_name}'. Use 'ainb list' to see available sessions."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    #[allow(dead_code)]
+    fn make_test_session(id: &str, workspace: &str) -> SessionMetadata {
+        SessionMetadata {
+            session_id: Uuid::parse_str(id).unwrap(),
+            tmux_session_name: format!("tmux_test_{workspace}"),
+            worktree_path: PathBuf::from("/tmp/test"),
+            workspace_name: workspace.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_find_session_exact_uuid() {
+        // This test requires mocking SessionStore, which would need refactoring
+        // For now, we test the parsing logic indirectly through integration tests
+    }
+
+    #[test]
+    fn test_uuid_prefix_matching_logic() {
+        let uuid_str = "12345678-1234-1234-1234-123456789abc";
+        let uuid = Uuid::parse_str(uuid_str).unwrap();
+
+        // Verify prefix matching logic
+        assert!(uuid.to_string().to_lowercase().starts_with("12345678"));
+        assert!(uuid.to_string().to_lowercase().starts_with("1234"));
+        assert!(!uuid.to_string().to_lowercase().starts_with("abcd"));
+    }
+
+    #[test]
+    fn test_workspace_name_matching_logic() {
+        let workspace = "my-awesome-project";
+        let id_lower = "my-awe";
+
+        // Verify workspace name prefix matching logic
+        assert!(workspace.to_lowercase().starts_with(&id_lower.to_lowercase()));
+        assert!(!workspace.to_lowercase().starts_with("other"));
+    }
+}

--- a/ainb-tui/src/cli/config_cmd.rs
+++ b/ainb-tui/src/cli/config_cmd.rs
@@ -1,0 +1,665 @@
+// ABOUTME: CLI config command for viewing and modifying application configuration
+//
+// Subcommands:
+//   show:  Display full merged config (TOML or JSON)
+//   get:   Get a specific value using dot-notation
+//   set:   Set a value in user-level config
+//   reset: Reset user config to defaults
+//   path:  Show config file locations with existence markers
+//   edit:  Open user config in $EDITOR
+
+use anyhow::{Context, Result, anyhow};
+use clap::Subcommand;
+use serde::Serialize;
+use std::fs;
+use std::io::{self, Write as _};
+use std::process::Command;
+
+use super::OutputFormat;
+use crate::config::AppConfig;
+
+/// JSON output for the `path` subcommand
+#[derive(Debug, Serialize)]
+struct ConfigPathEntry {
+    scope: String,
+    path: String,
+    exists: bool,
+}
+
+#[derive(Subcommand)]
+pub enum ConfigCommands {
+    /// Display current configuration (merged from all sources)
+    Show,
+    /// Get a specific config value using dot-notation (e.g., `authentication.default_model`)
+    Get {
+        /// Config key in dot-notation
+        key: String,
+    },
+    /// Set a config value in user-level config
+    Set {
+        /// Config key in dot-notation
+        key: String,
+        /// Value to set
+        value: String,
+    },
+    /// Reset user configuration to defaults
+    Reset {
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        force: bool,
+    },
+    /// Show config file locations
+    Path,
+    /// Open user config in $EDITOR
+    Edit,
+}
+
+/// Execute a config subcommand
+#[allow(clippy::unused_async)]
+pub async fn execute(command: ConfigCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        ConfigCommands::Show => cmd_show(format),
+        ConfigCommands::Get { key } => cmd_get(&key, format),
+        ConfigCommands::Set { key, value } => cmd_set(&key, &value),
+        ConfigCommands::Reset { force } => cmd_reset(force),
+        ConfigCommands::Path => cmd_path(format),
+        ConfigCommands::Edit => cmd_edit(),
+    }
+}
+
+/// Display the full merged configuration
+fn cmd_show(format: OutputFormat) -> Result<()> {
+    let config = AppConfig::load().context("Failed to load configuration")?;
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&config)
+                .context("Failed to serialize config as JSON")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            let toml_str =
+                toml::to_string_pretty(&config).context("Failed to serialize config as TOML")?;
+            println!("{toml_str}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Get a specific config value by dot-notation key
+fn cmd_get(key: &str, format: OutputFormat) -> Result<()> {
+    let config = AppConfig::load().context("Failed to load configuration")?;
+    let toml_value =
+        toml::Value::try_from(&config).context("Failed to convert config to TOML value")?;
+
+    let value = navigate_toml(&toml_value, key)?;
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&toml_to_json(value))
+                .context("Failed to serialize value as JSON")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            print_toml_value(value);
+        }
+    }
+
+    Ok(())
+}
+
+/// Set a config value in the user-level config file
+fn cmd_set(key: &str, value: &str) -> Result<()> {
+    let config_dir = AppConfig::get_user_config_dir()?;
+    fs::create_dir_all(&config_dir)?;
+    let config_path = config_dir.join("config.toml");
+
+    // Load existing user config or start with empty table
+    let mut root = if config_path.exists() {
+        let content = fs::read_to_string(&config_path).context("Failed to read user config")?;
+        content.parse::<toml::Value>().context("Failed to parse user config")?
+    } else {
+        toml::Value::Table(toml::map::Map::new())
+    };
+
+    set_toml_value(&mut root, key, value)?;
+
+    let content = toml::to_string_pretty(&root).context("Failed to serialize config")?;
+    fs::write(&config_path, &content).context("Failed to write user config")?;
+
+    println!("Set {key} = {value}");
+    println!("Saved to {}", config_path.display());
+
+    Ok(())
+}
+
+/// Reset user configuration to defaults
+fn cmd_reset(force: bool) -> Result<()> {
+    let config_dir = AppConfig::get_user_config_dir()?;
+    let config_path = config_dir.join("config.toml");
+
+    if !config_path.exists() {
+        println!("No user config file found. Nothing to reset.");
+        return Ok(());
+    }
+
+    if !force {
+        print!("Reset user config at {}? [y/N] ", config_path.display());
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    fs::remove_file(&config_path).context("Failed to remove user config")?;
+
+    println!("User config reset to defaults.");
+    println!("Removed: {}", config_path.display());
+
+    Ok(())
+}
+
+/// Show all config file locations with existence markers
+fn cmd_path(format: OutputFormat) -> Result<()> {
+    let paths = AppConfig::get_config_paths();
+
+    let scopes = ["project", "user", "system"];
+
+    match format {
+        OutputFormat::Json => {
+            let entries: Vec<ConfigPathEntry> = paths
+                .iter()
+                .zip(scopes.iter())
+                .map(|(path, scope)| ConfigPathEntry {
+                    scope: (*scope).to_string(),
+                    path: path.display().to_string(),
+                    exists: path.exists(),
+                })
+                .collect();
+            let json = serde_json::to_string_pretty(&entries)
+                .context("Failed to serialize config paths")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            let labels = ["Project config", "User config", "System config"];
+
+            println!("Configuration file locations (highest precedence first):");
+            println!("{}", "\u{2501}".repeat(60));
+
+            for (i, path) in paths.iter().enumerate() {
+                let exists = path.exists();
+                let marker = if exists { "\u{2713}" } else { "\u{2717}" };
+                let label = labels.get(i).unwrap_or(&"Config");
+                println!("  {marker} {label}: {}", path.display());
+            }
+
+            println!();
+            println!("Use 'ainb config edit' to open the user config in your editor.");
+        }
+    }
+
+    Ok(())
+}
+
+/// Open user config in $EDITOR
+fn cmd_edit() -> Result<()> {
+    let config_dir = AppConfig::get_user_config_dir()?;
+    fs::create_dir_all(&config_dir)?;
+    let config_path = config_dir.join("config.toml");
+
+    // Create with defaults if missing
+    if !config_path.exists() {
+        let default_config = AppConfig::default();
+        let content = toml::to_string_pretty(&default_config)
+            .context("Failed to serialize default config")?;
+        fs::write(&config_path, &content).context("Failed to create default config file")?;
+        println!("Created default config at {}", config_path.display());
+    }
+
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+
+    println!("Opening {} with {editor}...", config_path.display());
+
+    let status = Command::new(&editor)
+        .arg(&config_path)
+        .status()
+        .with_context(|| format!("Failed to launch editor '{editor}'"))?;
+
+    if !status.success() {
+        return Err(anyhow!("Editor exited with non-zero status"));
+    }
+
+    Ok(())
+}
+
+// --- TOML navigation helpers ---
+
+/// Navigate a TOML value tree using dot-notation keys
+fn navigate_toml<'a>(value: &'a toml::Value, key: &str) -> Result<&'a toml::Value> {
+    let parts = parse_dot_key(key);
+    if parts.is_empty() {
+        return Err(anyhow!("Empty key"));
+    }
+
+    let mut current = value;
+    for (i, part) in parts.iter().enumerate() {
+        if let toml::Value::Table(table) = current {
+            current = table.get(part.as_str()).ok_or_else(|| {
+                let path = parts[..=i].join(".");
+                anyhow!("Key '{path}' not found in configuration")
+            })?;
+        } else {
+            let path = parts[..i].join(".");
+            return Err(anyhow!("Cannot index into non-table value at '{path}'"));
+        }
+    }
+
+    Ok(current)
+}
+
+/// Set a value in a TOML tree using dot-notation keys
+fn set_toml_value(root: &mut toml::Value, key: &str, raw_value: &str) -> Result<()> {
+    let parts = parse_dot_key(key);
+    if parts.is_empty() {
+        return Err(anyhow!("Empty key"));
+    }
+
+    // Navigate to parent, creating intermediate tables as needed
+    let mut current = root;
+    for part in &parts[..parts.len() - 1] {
+        current = current
+            .as_table_mut()
+            .ok_or_else(|| anyhow!("Cannot set key in non-table value"))?
+            .entry(part)
+            .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    }
+
+    let table = current
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("Cannot set key in non-table value"))?;
+
+    let leaf_key = &parts[parts.len() - 1];
+    let parsed = parse_toml_scalar(raw_value);
+    table.insert(leaf_key.clone(), parsed);
+
+    Ok(())
+}
+
+/// Parse a dot-notation key into parts
+fn parse_dot_key(key: &str) -> Vec<String> {
+    key.split('.').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
+}
+
+/// Parse a raw string value into the most appropriate TOML scalar
+fn parse_toml_scalar(raw: &str) -> toml::Value {
+    // Try boolean
+    if raw.eq_ignore_ascii_case("true") {
+        return toml::Value::Boolean(true);
+    }
+    if raw.eq_ignore_ascii_case("false") {
+        return toml::Value::Boolean(false);
+    }
+
+    // Try integer
+    if let Ok(i) = raw.parse::<i64>() {
+        return toml::Value::Integer(i);
+    }
+
+    // Try float (only if it contains a dot to avoid int-like strings)
+    if raw.contains('.') {
+        if let Ok(f) = raw.parse::<f64>() {
+            return toml::Value::Float(f);
+        }
+    }
+
+    // Default to string
+    toml::Value::String(raw.to_string())
+}
+
+/// Print a TOML value in human-readable text format
+fn print_toml_value(value: &toml::Value) {
+    match value {
+        toml::Value::String(s) => println!("{s}"),
+        toml::Value::Integer(i) => println!("{i}"),
+        toml::Value::Float(f) => println!("{f}"),
+        toml::Value::Boolean(b) => println!("{b}"),
+        toml::Value::Array(arr) => {
+            for item in arr {
+                print_toml_value(item);
+            }
+        }
+        toml::Value::Table(_) | toml::Value::Datetime(_) => {
+            // For complex values, fall back to TOML representation
+            let s = toml::to_string_pretty(value).unwrap_or_else(|_| format!("{value:?}"));
+            print!("{s}");
+        }
+    }
+}
+
+/// Convert a `toml::Value` to `serde_json::Value` for JSON output
+fn toml_to_json(value: &toml::Value) -> serde_json::Value {
+    match value {
+        toml::Value::String(s) => serde_json::Value::String(s.clone()),
+        toml::Value::Integer(i) => serde_json::json!(i),
+        toml::Value::Float(f) => serde_json::json!(f),
+        toml::Value::Boolean(b) => serde_json::Value::Bool(*b),
+        toml::Value::Array(arr) => serde_json::Value::Array(arr.iter().map(toml_to_json).collect()),
+        toml::Value::Table(table) => {
+            let map: serde_json::Map<String, serde_json::Value> =
+                table.iter().map(|(k, v)| (k.clone(), toml_to_json(v))).collect();
+            serde_json::Value::Object(map)
+        }
+        toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_dot_key tests ---
+
+    #[test]
+    fn test_parse_dot_key_simple() {
+        assert_eq!(parse_dot_key("authentication"), vec!["authentication"]);
+    }
+
+    #[test]
+    fn test_parse_dot_key_nested() {
+        assert_eq!(
+            parse_dot_key("authentication.default_model"),
+            vec!["authentication", "default_model"]
+        );
+    }
+
+    #[test]
+    fn test_parse_dot_key_deep() {
+        assert_eq!(parse_dot_key("a.b.c.d"), vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn test_parse_dot_key_empty() {
+        let result: Vec<String> = parse_dot_key("");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_dot_key_trims_whitespace() {
+        assert_eq!(
+            parse_dot_key(" authentication . default_model "),
+            vec!["authentication", "default_model"]
+        );
+    }
+
+    // --- parse_toml_scalar tests ---
+
+    #[test]
+    fn test_parse_scalar_boolean_true() {
+        assert_eq!(parse_toml_scalar("true"), toml::Value::Boolean(true));
+    }
+
+    #[test]
+    fn test_parse_scalar_boolean_false() {
+        assert_eq!(parse_toml_scalar("false"), toml::Value::Boolean(false));
+    }
+
+    #[test]
+    fn test_parse_scalar_boolean_case_insensitive() {
+        assert_eq!(parse_toml_scalar("True"), toml::Value::Boolean(true));
+        assert_eq!(parse_toml_scalar("FALSE"), toml::Value::Boolean(false));
+    }
+
+    #[test]
+    fn test_parse_scalar_integer() {
+        assert_eq!(parse_toml_scalar("42"), toml::Value::Integer(42));
+        assert_eq!(parse_toml_scalar("-1"), toml::Value::Integer(-1));
+        assert_eq!(parse_toml_scalar("0"), toml::Value::Integer(0));
+    }
+
+    #[test]
+    fn test_parse_scalar_float() {
+        assert_eq!(parse_toml_scalar("3.14"), toml::Value::Float(3.14));
+    }
+
+    #[test]
+    fn test_parse_scalar_string() {
+        assert_eq!(
+            parse_toml_scalar("sonnet"),
+            toml::Value::String("sonnet".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_scalar_string_with_special_chars() {
+        assert_eq!(
+            parse_toml_scalar("agents/"),
+            toml::Value::String("agents/".to_string())
+        );
+    }
+
+    // --- navigate_toml tests ---
+
+    #[test]
+    fn test_navigate_toml_top_level() {
+        let value = toml::Value::Table({
+            let mut m = toml::map::Map::new();
+            m.insert(
+                "version".to_string(),
+                toml::Value::String("1.0".to_string()),
+            );
+            m
+        });
+
+        let result = navigate_toml(&value, "version").unwrap();
+        assert_eq!(result.as_str(), Some("1.0"));
+    }
+
+    #[test]
+    fn test_navigate_toml_nested() {
+        let value = toml::Value::Table({
+            let mut root = toml::map::Map::new();
+            let mut auth = toml::map::Map::new();
+            auth.insert(
+                "default_model".to_string(),
+                toml::Value::String("sonnet".to_string()),
+            );
+            root.insert("authentication".to_string(), toml::Value::Table(auth));
+            root
+        });
+
+        let result = navigate_toml(&value, "authentication.default_model").unwrap();
+        assert_eq!(result.as_str(), Some("sonnet"));
+    }
+
+    #[test]
+    fn test_navigate_toml_missing_key() {
+        let value = toml::Value::Table(toml::map::Map::new());
+        let result = navigate_toml(&value, "nonexistent");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_navigate_toml_index_into_non_table() {
+        let value = toml::Value::Table({
+            let mut m = toml::map::Map::new();
+            m.insert("name".to_string(), toml::Value::String("test".to_string()));
+            m
+        });
+
+        let result = navigate_toml(&value, "name.sub");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("non-table"));
+    }
+
+    #[test]
+    fn test_navigate_toml_returns_subtable() {
+        let value = toml::Value::Table({
+            let mut root = toml::map::Map::new();
+            let mut auth = toml::map::Map::new();
+            auth.insert(
+                "cli_provider".to_string(),
+                toml::Value::String("claude".to_string()),
+            );
+            auth.insert(
+                "default_model".to_string(),
+                toml::Value::String("sonnet".to_string()),
+            );
+            root.insert("authentication".to_string(), toml::Value::Table(auth));
+            root
+        });
+
+        let result = navigate_toml(&value, "authentication").unwrap();
+        assert!(result.is_table());
+    }
+
+    // --- set_toml_value tests ---
+
+    #[test]
+    fn test_set_toml_value_top_level() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        set_toml_value(&mut root, "name", "test-project").unwrap();
+
+        let table = root.as_table().unwrap();
+        assert_eq!(table["name"].as_str(), Some("test-project"));
+    }
+
+    #[test]
+    fn test_set_toml_value_nested_creates_intermediate() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        set_toml_value(&mut root, "authentication.default_model", "opus").unwrap();
+
+        let auth = root.as_table().unwrap()["authentication"].as_table().unwrap();
+        assert_eq!(auth["default_model"].as_str(), Some("opus"));
+    }
+
+    #[test]
+    fn test_set_toml_value_preserves_existing() {
+        let mut root = toml::Value::Table({
+            let mut m = toml::map::Map::new();
+            let mut auth = toml::map::Map::new();
+            auth.insert(
+                "cli_provider".to_string(),
+                toml::Value::String("claude".to_string()),
+            );
+            auth.insert(
+                "default_model".to_string(),
+                toml::Value::String("sonnet".to_string()),
+            );
+            m.insert("authentication".to_string(), toml::Value::Table(auth));
+            m
+        });
+
+        set_toml_value(&mut root, "authentication.default_model", "opus").unwrap();
+
+        let auth = root.as_table().unwrap()["authentication"].as_table().unwrap();
+        assert_eq!(auth["default_model"].as_str(), Some("opus"));
+        assert_eq!(auth["cli_provider"].as_str(), Some("claude"));
+    }
+
+    #[test]
+    fn test_set_toml_value_boolean() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        set_toml_value(&mut root, "ui_preferences.show_git_status", "false").unwrap();
+
+        let ui = root.as_table().unwrap()["ui_preferences"].as_table().unwrap();
+        assert_eq!(ui["show_git_status"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn test_set_toml_value_integer() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        set_toml_value(&mut root, "docker.timeout", "120").unwrap();
+
+        let docker = root.as_table().unwrap()["docker"].as_table().unwrap();
+        assert_eq!(docker["timeout"].as_integer(), Some(120));
+    }
+
+    // --- toml_to_json tests ---
+
+    #[test]
+    fn test_toml_to_json_string() {
+        let toml_val = toml::Value::String("hello".to_string());
+        let json_val = toml_to_json(&toml_val);
+        assert_eq!(json_val, serde_json::Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn test_toml_to_json_integer() {
+        let toml_val = toml::Value::Integer(42);
+        let json_val = toml_to_json(&toml_val);
+        assert_eq!(json_val, serde_json::json!(42));
+    }
+
+    #[test]
+    fn test_toml_to_json_boolean() {
+        let toml_val = toml::Value::Boolean(true);
+        let json_val = toml_to_json(&toml_val);
+        assert_eq!(json_val, serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn test_toml_to_json_table() {
+        let toml_val = toml::Value::Table({
+            let mut m = toml::map::Map::new();
+            m.insert("key".to_string(), toml::Value::String("value".to_string()));
+            m
+        });
+        let json_val = toml_to_json(&toml_val);
+        assert_eq!(
+            json_val["key"],
+            serde_json::Value::String("value".to_string())
+        );
+    }
+
+    // --- cmd_show integration tests ---
+
+    #[test]
+    fn test_show_output_contains_version() {
+        // Verify AppConfig can be serialized to TOML
+        let config = AppConfig::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(toml_str.contains("version"));
+        assert!(toml_str.contains("authentication"));
+    }
+
+    #[test]
+    fn test_show_output_json_contains_fields() {
+        let config = AppConfig::default();
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        assert!(json.contains("version"));
+        assert!(json.contains("authentication"));
+        assert!(json.contains("default_model"));
+    }
+
+    #[test]
+    fn test_get_from_real_config() {
+        // Load default config, convert to TOML value, navigate
+        let config = AppConfig::default();
+        let toml_value = toml::Value::try_from(&config).unwrap();
+
+        let model = navigate_toml(&toml_value, "authentication.default_model").unwrap();
+        assert_eq!(model.as_str(), Some("sonnet"));
+
+        let version = navigate_toml(&toml_value, "version").unwrap();
+        assert!(version.as_str().is_some());
+    }
+
+    // --- cmd_path test ---
+
+    #[test]
+    fn test_config_paths_returns_three_locations() {
+        let paths = AppConfig::get_config_paths();
+        assert_eq!(
+            paths.len(),
+            3,
+            "Expected project, user, and system config paths"
+        );
+    }
+}

--- a/ainb-tui/src/cli/favorites.rs
+++ b/ainb-tui/src/cli/favorites.rs
@@ -1,0 +1,517 @@
+// ABOUTME: CLI favorites command for managing the repository favorites store
+//
+// Subcommands:
+//   list:    Show all favorites sorted by usage count (descending)
+//   add:     Add a favorite (auto-detects source type)
+//   remove:  Remove a favorite by alias
+//   use:     Record usage of a favorite (updates last_used + use_count)
+
+use anyhow::{Context, Result, anyhow};
+use clap::Subcommand;
+use serde::Serialize;
+use std::path::Path;
+
+use super::OutputFormat;
+use crate::config::favorites_store::{Favorite, FavoritesStore, SourceType};
+
+#[derive(Subcommand)]
+pub enum FavoritesCommands {
+    /// List all favorites sorted by usage (most used first)
+    List,
+    /// Add a new favorite repository
+    Add {
+        /// Repository source: owner/repo, https URL, ssh URL, or local path
+        source: String,
+        /// Friendly alias for this favorite (used to look it up later)
+        #[arg(long)]
+        alias: String,
+        /// Optional human-readable description
+        #[arg(long)]
+        description: Option<String>,
+        /// Comma-separated list of tags
+        #[arg(long)]
+        tags: Option<String>,
+    },
+    /// Remove a favorite by alias
+    Remove {
+        /// Alias of the favorite to remove
+        alias: String,
+    },
+    /// Record usage of a favorite (bumps use_count and last_used)
+    Use {
+        /// Alias of the favorite to record usage for
+        alias: String,
+    },
+}
+
+/// JSON output shape for `favorites list`
+#[derive(Debug, Serialize)]
+struct FavoriteJson<'a> {
+    alias: &'a str,
+    source: &'a str,
+    source_type: &'static str,
+    description: Option<&'a str>,
+    tags: &'a [String],
+    use_count: u64,
+    last_used: String,
+    created_at: String,
+}
+
+impl<'a> From<&'a Favorite> for FavoriteJson<'a> {
+    fn from(f: &'a Favorite) -> Self {
+        Self {
+            alias: &f.alias,
+            source: &f.source,
+            source_type: f.source_type.display_name(),
+            description: f.description.as_deref(),
+            tags: &f.tags,
+            use_count: f.stats.use_count,
+            last_used: f.stats.last_used.to_rfc3339(),
+            created_at: f.stats.created_at.to_rfc3339(),
+        }
+    }
+}
+
+/// Execute a favorites subcommand
+#[allow(clippy::unused_async)]
+pub async fn execute(command: FavoritesCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        FavoritesCommands::List => cmd_list(format),
+        FavoritesCommands::Add {
+            source,
+            alias,
+            description,
+            tags,
+        } => cmd_add(&source, &alias, description.as_deref(), tags.as_deref()),
+        FavoritesCommands::Remove { alias } => cmd_remove(&alias),
+        FavoritesCommands::Use { alias } => cmd_use(&alias),
+    }
+}
+
+/// List all favorites sorted by usage count (descending)
+fn cmd_list(format: OutputFormat) -> Result<()> {
+    let store = FavoritesStore::load();
+    let sorted = store.sorted_by_usage();
+
+    match format {
+        OutputFormat::Json => {
+            let entries: Vec<FavoriteJson<'_>> = sorted.iter().map(|f| FavoriteJson::from(*f)).collect();
+            let json =
+                serde_json::to_string_pretty(&entries).context("Failed to serialize favorites as JSON")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            if sorted.is_empty() {
+                println!("No favorites yet. Add one with 'ainb favorites add <source> --alias <name>'.");
+                return Ok(());
+            }
+
+            println!("Favorites (sorted by usage):");
+            println!("{}", "\u{2501}".repeat(72));
+
+            for fav in sorted {
+                let tags = if fav.tags.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", fav.tags.join(", "))
+                };
+
+                let desc = fav
+                    .description
+                    .as_deref()
+                    .map(|d| format!(" — {d}"))
+                    .unwrap_or_default();
+
+                println!(
+                    "  {alias} ({kind})  uses={count}{tags}",
+                    alias = fav.alias,
+                    kind = fav.source_type.display_name(),
+                    count = fav.stats.use_count,
+                    tags = tags,
+                );
+                println!("      source: {}{desc}", fav.source);
+            }
+
+            println!();
+            println!("Total: {} favorite(s)", store.len());
+        }
+    }
+
+    Ok(())
+}
+
+/// Add a new favorite, auto-detecting source type from the input string
+fn cmd_add(source: &str, alias: &str, description: Option<&str>, tags: Option<&str>) -> Result<()> {
+    if alias.trim().is_empty() {
+        return Err(anyhow!("Alias cannot be empty"));
+    }
+    if source.trim().is_empty() {
+        return Err(anyhow!("Source cannot be empty"));
+    }
+
+    let source_type = detect_source_type(source);
+
+    let mut store = FavoritesStore::load();
+
+    let mut fav = Favorite::new(alias.to_string(), source.to_string(), source_type.clone());
+    fav.description = description.map(str::to_string);
+    fav.tags = parse_tags(tags);
+
+    store
+        .add(fav)
+        .map_err(|e| anyhow!("Failed to add favorite '{alias}': {e}"))?;
+
+    store.save().context("Failed to save favorites store")?;
+
+    println!(
+        "Added favorite '{alias}' ({kind}) → {source}",
+        kind = source_type.display_name(),
+    );
+
+    Ok(())
+}
+
+/// Remove a favorite by alias
+fn cmd_remove(alias: &str) -> Result<()> {
+    let mut store = FavoritesStore::load();
+
+    let removed = store
+        .remove(alias)
+        .ok_or_else(|| anyhow!("No favorite found with alias '{alias}'"))?;
+
+    store.save().context("Failed to save favorites store")?;
+
+    println!("Removed favorite '{}' ({})", removed.alias, removed.source);
+    Ok(())
+}
+
+/// Record usage of a favorite
+fn cmd_use(alias: &str) -> Result<()> {
+    let mut store = FavoritesStore::load();
+
+    if !store.has_alias(alias) {
+        return Err(anyhow!("No favorite found with alias '{alias}'"));
+    }
+
+    store.record_use(alias);
+    store.save().context("Failed to save favorites store")?;
+
+    let count = store.get(alias).map(|f| f.stats.use_count).unwrap_or(0);
+    println!("Recorded use of '{alias}' (use_count = {count})");
+
+    Ok(())
+}
+
+// --- helpers ---
+
+/// Detect the source type from a raw input string.
+///
+/// Order of checks:
+/// 1. HTTPS / HTTP URL → `HttpsUrl`
+/// 2. SSH URL (git@... or scp-like with `::`) → `SshUrl`
+/// 3. Existing local filesystem path → `LocalPath`
+/// 4. `owner/repo` shorthand (single slash, no whitespace, no protocol) → `GithubShorthand`
+/// 5. Fallback: treat as `LocalPath` (the user gave us something path-like)
+pub(crate) fn detect_source_type(input: &str) -> SourceType {
+    let trimmed = input.trim();
+
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        return SourceType::HttpsUrl;
+    }
+
+    if trimmed.starts_with("git@") || trimmed.contains("::") {
+        return SourceType::SshUrl;
+    }
+
+    // If it points at an existing path on disk, prefer LocalPath.
+    if Path::new(trimmed).exists() {
+        return SourceType::LocalPath;
+    }
+
+    if is_github_shorthand(trimmed) {
+        return SourceType::GithubShorthand;
+    }
+
+    // Fallback: assume it was meant as a path the user will create.
+    SourceType::LocalPath
+}
+
+/// True if input looks like `owner/repo` GitHub shorthand: exactly one `/`,
+/// non-empty segments, no whitespace, no scheme markers.
+fn is_github_shorthand(input: &str) -> bool {
+    if input.contains(char::is_whitespace) {
+        return false;
+    }
+    if input.contains("://") || input.starts_with('/') || input.starts_with('.') || input.starts_with('~') {
+        return false;
+    }
+
+    let parts: Vec<&str> = input.split('/').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    !parts[0].is_empty() && !parts[1].is_empty()
+}
+
+/// Parse a comma-separated tag string into a vector of trimmed, non-empty tags.
+fn parse_tags(raw: Option<&str>) -> Vec<String> {
+    raw.map(|s| {
+        s.split(',')
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(str::to_string)
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect_source_type tests ---
+
+    #[test]
+    fn test_detect_https_url() {
+        assert_eq!(
+            detect_source_type("https://github.com/anthropics/claude-code"),
+            SourceType::HttpsUrl
+        );
+        assert_eq!(
+            detect_source_type("http://example.com/repo.git"),
+            SourceType::HttpsUrl
+        );
+    }
+
+    #[test]
+    fn test_detect_ssh_url_git_at() {
+        assert_eq!(
+            detect_source_type("git@github.com:anthropics/claude-code.git"),
+            SourceType::SshUrl
+        );
+    }
+
+    #[test]
+    fn test_detect_ssh_url_double_colon() {
+        // scp-like / rsync-style remote with `::`
+        assert_eq!(
+            detect_source_type("rsync.example.com::module/path"),
+            SourceType::SshUrl
+        );
+    }
+
+    #[test]
+    fn test_detect_github_shorthand() {
+        assert_eq!(
+            detect_source_type("anthropics/claude-code"),
+            SourceType::GithubShorthand
+        );
+        assert_eq!(detect_source_type("rust-lang/rust"), SourceType::GithubShorthand);
+    }
+
+    #[test]
+    fn test_detect_local_path_existing() {
+        // /tmp exists on every Unix system used in CI.
+        let st = detect_source_type("/tmp");
+        assert_eq!(st, SourceType::LocalPath);
+    }
+
+    #[test]
+    fn test_detect_fallback_to_local_path() {
+        // No slash, not a URL, doesn't exist → fallback LocalPath.
+        assert_eq!(
+            detect_source_type("not-a-real-thing-xyz"),
+            SourceType::LocalPath
+        );
+    }
+
+    #[test]
+    fn test_detect_three_segments_not_shorthand() {
+        // Three slashes is not GitHub shorthand. Falls through to local path.
+        assert_eq!(
+            detect_source_type("a/b/c"),
+            SourceType::LocalPath
+        );
+    }
+
+    #[test]
+    fn test_is_github_shorthand_rejects_whitespace() {
+        assert!(!is_github_shorthand("owner /repo"));
+        assert!(!is_github_shorthand("owner/ repo"));
+    }
+
+    #[test]
+    fn test_is_github_shorthand_rejects_empty_segments() {
+        assert!(!is_github_shorthand("/repo"));
+        assert!(!is_github_shorthand("owner/"));
+        assert!(!is_github_shorthand("/"));
+    }
+
+    #[test]
+    fn test_is_github_shorthand_rejects_path_like() {
+        assert!(!is_github_shorthand("./local/repo"));
+        assert!(!is_github_shorthand("~/repo"));
+    }
+
+    // --- parse_tags tests ---
+
+    #[test]
+    fn test_parse_tags_none() {
+        assert!(parse_tags(None).is_empty());
+    }
+
+    #[test]
+    fn test_parse_tags_empty_string() {
+        assert!(parse_tags(Some("")).is_empty());
+    }
+
+    #[test]
+    fn test_parse_tags_single() {
+        assert_eq!(parse_tags(Some("frontend")), vec!["frontend".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_tags_multiple_with_whitespace() {
+        assert_eq!(
+            parse_tags(Some("frontend, react ,  ui")),
+            vec!["frontend".to_string(), "react".to_string(), "ui".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_tags_filters_empty() {
+        assert_eq!(
+            parse_tags(Some("a,,b,  ,c")),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    // --- store-level round-trip tests (in-memory) ---
+
+    #[test]
+    fn test_add_and_remove_round_trip_in_store() {
+        let mut store = FavoritesStore::default();
+
+        let fav = Favorite::new(
+            "claude".to_string(),
+            "anthropics/claude-code".to_string(),
+            detect_source_type("anthropics/claude-code"),
+        );
+        store.add(fav).unwrap();
+
+        assert!(store.has_alias("claude"));
+        assert_eq!(store.len(), 1);
+        assert_eq!(
+            store.get("claude").unwrap().source_type,
+            SourceType::GithubShorthand
+        );
+
+        let removed = store.remove("claude");
+        assert!(removed.is_some());
+        assert_eq!(store.len(), 0);
+        assert!(!store.has_alias("claude"));
+    }
+
+    #[test]
+    fn test_sorted_by_usage_descending() {
+        let mut store = FavoritesStore::default();
+
+        store
+            .add(Favorite::new(
+                "low".to_string(),
+                "owner/low".to_string(),
+                SourceType::GithubShorthand,
+            ))
+            .unwrap();
+        store
+            .add(Favorite::new(
+                "mid".to_string(),
+                "owner/mid".to_string(),
+                SourceType::GithubShorthand,
+            ))
+            .unwrap();
+        store
+            .add(Favorite::new(
+                "high".to_string(),
+                "owner/high".to_string(),
+                SourceType::GithubShorthand,
+            ))
+            .unwrap();
+
+        store.record_use("low");
+        store.record_use("mid");
+        store.record_use("mid");
+        store.record_use("high");
+        store.record_use("high");
+        store.record_use("high");
+
+        let sorted = store.sorted_by_usage();
+        assert_eq!(sorted[0].alias, "high");
+        assert_eq!(sorted[1].alias, "mid");
+        assert_eq!(sorted[2].alias, "low");
+    }
+
+    #[test]
+    fn test_record_use_increments_count() {
+        let mut store = FavoritesStore::default();
+
+        store
+            .add(Favorite::new(
+                "test".to_string(),
+                "owner/repo".to_string(),
+                SourceType::GithubShorthand,
+            ))
+            .unwrap();
+
+        let initial_last_used = store.get("test").unwrap().stats.last_used;
+
+        // Sleep to ensure last_used timestamp moves forward
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        store.record_use("test");
+
+        let fav = store.get("test").unwrap();
+        assert_eq!(fav.stats.use_count, 1);
+        assert!(fav.stats.last_used >= initial_last_used);
+    }
+
+    #[test]
+    fn test_favorite_json_serialization() {
+        let mut fav = Favorite::new(
+            "react".to_string(),
+            "facebook/react".to_string(),
+            SourceType::GithubShorthand,
+        );
+        fav.description = Some("UI library".to_string());
+        fav.tags = vec!["frontend".to_string(), "ui".to_string()];
+
+        let json_view = FavoriteJson::from(&fav);
+        let s = serde_json::to_string(&json_view).unwrap();
+
+        assert!(s.contains("\"alias\":\"react\""));
+        assert!(s.contains("\"source\":\"facebook/react\""));
+        assert!(s.contains("\"source_type\":\"GitHub\""));
+        assert!(s.contains("\"description\":\"UI library\""));
+        assert!(s.contains("\"frontend\""));
+        assert!(s.contains("\"use_count\":0"));
+    }
+
+    #[test]
+    fn test_add_duplicate_alias_fails() {
+        let mut store = FavoritesStore::default();
+
+        store
+            .add(Favorite::new(
+                "dup".to_string(),
+                "owner/a".to_string(),
+                SourceType::GithubShorthand,
+            ))
+            .unwrap();
+
+        let result = store.add(Favorite::new(
+            "dup".to_string(),
+            "owner/b".to_string(),
+            SourceType::GithubShorthand,
+        ));
+        assert!(result.is_err());
+    }
+}

--- a/ainb-tui/src/cli/git_cmd.rs
+++ b/ainb-tui/src/cli/git_cmd.rs
@@ -1,0 +1,749 @@
+// ABOUTME: CLI git command - worktree inspection and cleanup
+//
+// Subcommands:
+//   worktrees: List all managed worktrees with session association status
+//   cleanup:   Remove orphaned worktrees not referenced by any session
+//   status:    Show git status for a specific session's worktree
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use git2::{Repository, StatusOptions};
+use serde::Serialize;
+use std::io::{self, Write};
+use std::path::Path;
+use uuid::Uuid;
+
+use super::OutputFormat;
+use crate::cli::util::find_session;
+use crate::git::{WorktreeInfo, WorktreeManager};
+use crate::interactive::session_manager::SessionStore;
+
+/// Subcommands for the `git` command
+#[derive(Subcommand)]
+pub enum GitCommands {
+    /// List all managed worktrees and their session association
+    Worktrees,
+    /// Remove orphaned worktrees (not referenced by any session)
+    Cleanup {
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        force: bool,
+        /// Preview what would be removed without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show git status for a specific session's worktree
+    Status {
+        /// Session ID (full/partial UUID) or workspace name prefix
+        session: String,
+    },
+}
+
+/// Worktree association status relative to the session store
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorktreeStatus {
+    /// Worktree is referenced by an active session
+    Active,
+    /// Worktree has no corresponding session entry
+    Orphaned,
+}
+
+impl std::fmt::Display for WorktreeStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::Orphaned => write!(f, "orphaned"),
+        }
+    }
+}
+
+/// Serializable entry for the `worktrees` subcommand output
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeEntry {
+    pub session_id: String,
+    pub path: String,
+    pub branch: String,
+    pub commit: Option<String>,
+    pub source_repository: String,
+    pub status: WorktreeStatus,
+    pub workspace_name: Option<String>,
+}
+
+/// Serializable per-file git status record
+#[derive(Debug, Clone, Serialize)]
+pub struct FileStatus {
+    pub path: String,
+    pub status: String,
+}
+
+/// Serializable git status report for the `status` subcommand
+#[derive(Debug, Clone, Serialize)]
+pub struct GitStatusReport {
+    pub session_id: String,
+    pub workspace_name: String,
+    pub worktree_path: String,
+    pub branch: String,
+    pub commit: Option<String>,
+    pub files_changed: usize,
+    pub staged: usize,
+    pub unstaged: usize,
+    pub untracked: usize,
+    pub files: Vec<FileStatus>,
+}
+
+/// Entry point for the `git` command family
+#[allow(clippy::unused_async)]
+pub async fn execute(command: GitCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        GitCommands::Worktrees => cmd_worktrees(format),
+        GitCommands::Cleanup { force, dry_run } => cmd_cleanup(force, dry_run, format),
+        GitCommands::Status { session } => cmd_status(&session, format),
+    }
+}
+
+/// List all managed worktrees with their session association status
+fn cmd_worktrees(format: OutputFormat) -> Result<()> {
+    let manager = WorktreeManager::new().context("Failed to initialize WorktreeManager")?;
+    let worktrees =
+        manager.list_all_worktrees().context("Failed to enumerate managed worktrees")?;
+    let store = SessionStore::load();
+
+    let entries: Vec<WorktreeEntry> =
+        worktrees.iter().map(|(id, info)| build_entry(*id, info, &store)).collect();
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&entries)
+                .context("Failed to serialize worktree entries")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            if entries.is_empty() {
+                println!("No managed worktrees found.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<9} {:<20} {:<30} {:<10} PATH",
+                "STATUS", "WORKSPACE", "BRANCH", "SESSION"
+            );
+            println!("{}", "-".repeat(100));
+
+            for entry in &entries {
+                let short_id = short_session_id(&entry.session_id);
+                let workspace = entry.workspace_name.as_deref().unwrap_or("-");
+                println!(
+                    "{:<9} {:<20} {:<30} {:<10} {}",
+                    entry.status.to_string(),
+                    truncate(workspace, 20),
+                    truncate(&entry.branch, 30),
+                    short_id,
+                    entry.path,
+                );
+            }
+
+            println!();
+            let orphaned_count =
+                entries.iter().filter(|e| e.status == WorktreeStatus::Orphaned).count();
+            let active_count = entries.len() - orphaned_count;
+            println!(
+                "{} worktree(s) - {} active, {} orphaned.",
+                entries.len(),
+                active_count,
+                orphaned_count
+            );
+            if orphaned_count > 0 {
+                println!("  Run: ainb git cleanup [--dry-run] [--force] to remove orphans.");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Remove orphaned worktrees not referenced by any session
+fn cmd_cleanup(force: bool, dry_run: bool, format: OutputFormat) -> Result<()> {
+    let manager = WorktreeManager::new().context("Failed to initialize WorktreeManager")?;
+    let worktrees =
+        manager.list_all_worktrees().context("Failed to enumerate managed worktrees")?;
+    let store = SessionStore::load();
+
+    let orphans: Vec<(Uuid, WorktreeInfo)> =
+        worktrees.into_iter().filter(|(id, _)| is_orphaned(id, &store)).collect();
+
+    let entries: Vec<WorktreeEntry> =
+        orphans.iter().map(|(id, info)| build_entry(*id, info, &store)).collect();
+
+    if orphans.is_empty() {
+        match format {
+            OutputFormat::Json => println!("[]"),
+            OutputFormat::Text => println!("No orphaned worktrees to clean up."),
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        match format {
+            OutputFormat::Json => {
+                let json = serde_json::to_string_pretty(&entries)
+                    .context("Failed to serialize orphan entries")?;
+                println!("{json}");
+            }
+            OutputFormat::Text => {
+                println!(
+                    "Dry run - {} orphaned worktree(s) would be removed:",
+                    orphans.len()
+                );
+                for entry in &entries {
+                    let short_id = short_session_id(&entry.session_id);
+                    println!("  - {short_id}  {}  ({})", entry.branch, entry.path);
+                }
+                println!();
+                println!("Re-run without --dry-run to perform cleanup.");
+            }
+        }
+        return Ok(());
+    }
+
+    if !force {
+        println!("Will remove {} orphaned worktree(s):", orphans.len());
+        for entry in &entries {
+            let short_id = short_session_id(&entry.session_id);
+            println!("  - {short_id}  {}", entry.path);
+        }
+        print!("\nProceed? [y/N] ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let mut removed = 0u32;
+    let mut errors = 0u32;
+    for (id, info) in &orphans {
+        match manager.remove_worktree(*id) {
+            Ok(()) => {
+                removed += 1;
+                println!("  Removed: {}", info.path.display());
+            }
+            Err(e) => {
+                errors += 1;
+                eprintln!("  Error removing {}: {e}", info.path.display());
+            }
+        }
+    }
+
+    println!();
+    println!("Cleanup complete: {removed} removed, {errors} error(s).");
+    Ok(())
+}
+
+/// Show git status for a specific session's worktree
+fn cmd_status(session: &str, format: OutputFormat) -> Result<()> {
+    let metadata = find_session(session)?;
+    let report = build_status_report(
+        &metadata.session_id.to_string(),
+        &metadata.workspace_name,
+        &metadata.worktree_path,
+    )?;
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&report)
+                .context("Failed to serialize git status report")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            let short_id = short_session_id(&report.session_id);
+            println!("Session: {} ({})", report.workspace_name, short_id);
+            println!("Branch:  {}", report.branch);
+            if let Some(ref c) = report.commit {
+                let short = &c[..12.min(c.len())];
+                println!("Commit:  {short}");
+            }
+            println!("Path:    {}", report.worktree_path);
+            println!();
+            if report.files_changed == 0 {
+                println!("Working tree clean.");
+            } else {
+                println!(
+                    "{} file(s) changed - {} staged, {} unstaged, {} untracked",
+                    report.files_changed, report.staged, report.unstaged, report.untracked
+                );
+                for file in &report.files {
+                    println!("  [{}] {}", file.status, file.path);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// --- pure helpers (unit-tested) ---
+
+/// Check whether a worktree's `session_id` is not referenced by any session in the store
+pub fn is_orphaned(session_id: &Uuid, store: &SessionStore) -> bool {
+    !store.sessions.values().any(|m| m.session_id == *session_id)
+}
+
+/// Build a `WorktreeEntry` from a worktree record + session store context
+fn build_entry(session_id: Uuid, info: &WorktreeInfo, store: &SessionStore) -> WorktreeEntry {
+    let status = if is_orphaned(&session_id, store) {
+        WorktreeStatus::Orphaned
+    } else {
+        WorktreeStatus::Active
+    };
+
+    let workspace_name = store
+        .sessions
+        .values()
+        .find(|m| m.session_id == session_id)
+        .map(|m| m.workspace_name.clone());
+
+    WorktreeEntry {
+        session_id: session_id.to_string(),
+        path: info.path.display().to_string(),
+        branch: info.branch_name.clone(),
+        commit: info.commit_hash.clone(),
+        source_repository: info.source_repository.display().to_string(),
+        status,
+        workspace_name,
+    }
+}
+
+/// Open a worktree with git2 and produce a structured status report
+fn build_status_report(
+    session_id: &str,
+    workspace_name: &str,
+    worktree_path: &Path,
+) -> Result<GitStatusReport> {
+    let repo = Repository::open(worktree_path).with_context(|| {
+        format!(
+            "Failed to open git repository at {}",
+            worktree_path.display()
+        )
+    })?;
+
+    let head = repo.head().ok();
+    let branch = head
+        .as_ref()
+        .and_then(|h| h.shorthand().map(String::from))
+        .unwrap_or_else(|| "unknown".to_string());
+    let commit = head.as_ref().and_then(|h| h.target()).map(|oid| oid.to_string());
+
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true).recurse_untracked_dirs(true);
+
+    let statuses = repo.statuses(Some(&mut opts)).context("Failed to read git status")?;
+
+    let mut files = Vec::new();
+    let mut staged = 0usize;
+    let mut unstaged = 0usize;
+    let mut untracked = 0usize;
+
+    for entry in statuses.iter() {
+        let flags = entry.status();
+        let path = entry.path().unwrap_or("").to_string();
+        let status_str = status_flags_to_string(flags);
+
+        if flags.is_wt_new() {
+            untracked += 1;
+        }
+        if flags.is_index_new()
+            || flags.is_index_modified()
+            || flags.is_index_deleted()
+            || flags.is_index_renamed()
+            || flags.is_index_typechange()
+        {
+            staged += 1;
+        }
+        if flags.is_wt_modified()
+            || flags.is_wt_deleted()
+            || flags.is_wt_renamed()
+            || flags.is_wt_typechange()
+        {
+            unstaged += 1;
+        }
+
+        files.push(FileStatus { path, status: status_str });
+    }
+
+    Ok(GitStatusReport {
+        session_id: session_id.to_string(),
+        workspace_name: workspace_name.to_string(),
+        worktree_path: worktree_path.display().to_string(),
+        branch,
+        commit,
+        files_changed: files.len(),
+        staged,
+        unstaged,
+        untracked,
+        files,
+    })
+}
+
+/// Convert git2 status flags to a short porcelain-ish status string
+fn status_flags_to_string(flags: git2::Status) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if flags.is_index_new() {
+        parts.push("A");
+    }
+    if flags.is_index_modified() {
+        parts.push("M");
+    }
+    if flags.is_index_deleted() {
+        parts.push("D");
+    }
+    if flags.is_index_renamed() {
+        parts.push("R");
+    }
+    if flags.is_index_typechange() {
+        parts.push("T");
+    }
+    if flags.is_wt_new() {
+        parts.push("??");
+    }
+    if flags.is_wt_modified() {
+        parts.push("m");
+    }
+    if flags.is_wt_deleted() {
+        parts.push("d");
+    }
+    if flags.is_wt_renamed() {
+        parts.push("r");
+    }
+    if flags.is_wt_typechange() {
+        parts.push("t");
+    }
+    if flags.is_conflicted() {
+        parts.push("U");
+    }
+    if parts.is_empty() {
+        parts.push("?");
+    }
+    parts.join("")
+}
+
+/// Shorten a session id to its first 8 chars (UUID prefix) for display
+fn short_session_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+/// Truncate a string with an ellipsis for fixed-width table columns
+fn truncate(s: &str, max_len: usize) -> String {
+    if max_len <= 3 {
+        return ".".repeat(max_len);
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_len {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interactive::session_manager::SessionMetadata;
+    use crate::models::session::SessionAgentType;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    fn make_metadata(id: Uuid, tmux: &str, workspace: &str) -> SessionMetadata {
+        SessionMetadata {
+            session_id: id,
+            tmux_session_name: tmux.to_string(),
+            worktree_path: PathBuf::from(format!("/tmp/wt-{tmux}")),
+            workspace_name: workspace.to_string(),
+            created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
+        }
+    }
+
+    fn make_worktree_info(id: Uuid, branch: &str) -> WorktreeInfo {
+        WorktreeInfo {
+            id,
+            path: PathBuf::from(format!("/tmp/worktrees/by-name/repo--{branch}--{}", &id.to_string()[..8])),
+            session_path: PathBuf::from(format!("/tmp/worktrees/by-session/{id}")),
+            branch_name: branch.to_string(),
+            source_repository: PathBuf::from("/tmp/source-repo"),
+            commit_hash: Some("abcdef1234567890".to_string()),
+        }
+    }
+
+    // --- is_orphaned ---
+
+    #[test]
+    fn test_is_orphaned_empty_store() {
+        let store = SessionStore::default();
+        let id = Uuid::new_v4();
+        assert!(is_orphaned(&id, &store));
+    }
+
+    #[test]
+    fn test_is_orphaned_when_id_not_present() {
+        let mut store = SessionStore::default();
+        let meta = make_metadata(Uuid::new_v4(), "tmux_a", "ws-a");
+        store.sessions.insert(meta.tmux_session_name.clone(), meta);
+        let other = Uuid::new_v4();
+        assert!(is_orphaned(&other, &store));
+    }
+
+    #[test]
+    fn test_is_not_orphaned_when_id_present() {
+        let id = Uuid::new_v4();
+        let mut store = SessionStore::default();
+        let meta = make_metadata(id, "tmux_a", "ws-a");
+        store.sessions.insert(meta.tmux_session_name.clone(), meta);
+        assert!(!is_orphaned(&id, &store));
+    }
+
+    #[test]
+    fn test_is_orphaned_distinguishes_ids() {
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        let mut store = SessionStore::default();
+        let meta = make_metadata(id_a, "tmux_a", "ws-a");
+        store.sessions.insert(meta.tmux_session_name.clone(), meta);
+        assert!(!is_orphaned(&id_a, &store));
+        assert!(is_orphaned(&id_b, &store));
+    }
+
+    // --- build_entry ---
+
+    #[test]
+    fn test_build_entry_active_copies_workspace_name() {
+        let id = Uuid::new_v4();
+        let info = make_worktree_info(id, "feat/foo");
+        let mut store = SessionStore::default();
+        let meta = make_metadata(id, "tmux_x", "my-workspace");
+        store.sessions.insert(meta.tmux_session_name.clone(), meta);
+
+        let entry = build_entry(id, &info, &store);
+        assert_eq!(entry.status, WorktreeStatus::Active);
+        assert_eq!(entry.workspace_name.as_deref(), Some("my-workspace"));
+        assert_eq!(entry.branch, "feat/foo");
+        assert_eq!(entry.session_id, id.to_string());
+        assert_eq!(entry.commit.as_deref(), Some("abcdef1234567890"));
+    }
+
+    #[test]
+    fn test_build_entry_orphaned_when_no_session() {
+        let id = Uuid::new_v4();
+        let info = make_worktree_info(id, "main");
+        let store = SessionStore::default();
+
+        let entry = build_entry(id, &info, &store);
+        assert_eq!(entry.status, WorktreeStatus::Orphaned);
+        assert!(entry.workspace_name.is_none());
+    }
+
+    // --- WorktreeStatus Display/Serialize ---
+
+    #[test]
+    fn test_worktree_status_display() {
+        assert_eq!(WorktreeStatus::Active.to_string(), "active");
+        assert_eq!(WorktreeStatus::Orphaned.to_string(), "orphaned");
+    }
+
+    #[test]
+    fn test_worktree_status_json_active() {
+        let json = serde_json::to_value(WorktreeStatus::Active).unwrap();
+        assert_eq!(json, serde_json::Value::String("active".to_string()));
+    }
+
+    #[test]
+    fn test_worktree_status_json_orphaned() {
+        let json = serde_json::to_value(WorktreeStatus::Orphaned).unwrap();
+        assert_eq!(json, serde_json::Value::String("orphaned".to_string()));
+    }
+
+    // --- WorktreeEntry serialization ---
+
+    #[test]
+    fn test_worktree_entry_json_fields() {
+        let id = Uuid::new_v4();
+        let info = make_worktree_info(id, "main");
+        let store = SessionStore::default();
+        let entry = build_entry(id, &info, &store);
+
+        let json = serde_json::to_value(&entry).unwrap();
+        assert!(json["session_id"].is_string());
+        assert!(json["path"].is_string());
+        assert_eq!(json["branch"], serde_json::Value::String("main".to_string()));
+        assert_eq!(json["status"], serde_json::Value::String("orphaned".to_string()));
+        assert!(json["commit"].is_string());
+    }
+
+    // --- truncate ---
+
+    #[test]
+    fn test_truncate_short() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long() {
+        assert_eq!(truncate("hello world foo", 10), "hello w...");
+    }
+
+    #[test]
+    fn test_truncate_exact() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_tiny_max_len() {
+        assert_eq!(truncate("hello", 2), "..");
+    }
+
+    // --- short_session_id ---
+
+    #[test]
+    fn test_short_session_id_full_uuid() {
+        let id = "12345678-1234-1234-1234-123456789abc";
+        assert_eq!(short_session_id(id), "12345678");
+    }
+
+    #[test]
+    fn test_short_session_id_short_input() {
+        assert_eq!(short_session_id("abc"), "abc");
+    }
+
+    // --- status_flags_to_string ---
+
+    #[test]
+    fn test_status_flags_empty() {
+        let flags = git2::Status::empty();
+        // Empty = no flags set; helper returns "?" placeholder
+        assert_eq!(status_flags_to_string(flags), "?");
+    }
+
+    #[test]
+    fn test_status_flags_wt_new_is_untracked() {
+        let flags = git2::Status::WT_NEW;
+        assert_eq!(status_flags_to_string(flags), "??");
+    }
+
+    #[test]
+    fn test_status_flags_index_modified() {
+        let flags = git2::Status::INDEX_MODIFIED;
+        assert_eq!(status_flags_to_string(flags), "M");
+    }
+
+    #[test]
+    fn test_status_flags_index_new() {
+        let flags = git2::Status::INDEX_NEW;
+        assert_eq!(status_flags_to_string(flags), "A");
+    }
+
+    #[test]
+    fn test_status_flags_combined_staged_and_unstaged() {
+        let flags = git2::Status::INDEX_MODIFIED | git2::Status::WT_MODIFIED;
+        let s = status_flags_to_string(flags);
+        assert!(s.contains('M'), "expected 'M' in {s}");
+        assert!(s.contains('m'), "expected 'm' in {s}");
+    }
+
+    // --- GitStatusReport serialization ---
+
+    #[test]
+    fn test_git_status_report_serialize() {
+        let report = GitStatusReport {
+            session_id: "12345678-1234-1234-1234-123456789abc".to_string(),
+            workspace_name: "test-ws".to_string(),
+            worktree_path: "/tmp/wt".to_string(),
+            branch: "main".to_string(),
+            commit: Some("deadbeef".to_string()),
+            files_changed: 2,
+            staged: 1,
+            unstaged: 1,
+            untracked: 0,
+            files: vec![
+                FileStatus { path: "a.rs".to_string(), status: "M".to_string() },
+                FileStatus { path: "b.rs".to_string(), status: "m".to_string() },
+            ],
+        };
+
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["files_changed"], serde_json::json!(2));
+        assert_eq!(json["staged"], serde_json::json!(1));
+        assert_eq!(json["branch"], serde_json::Value::String("main".to_string()));
+        assert_eq!(json["files"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_file_status_serialize() {
+        let fs = FileStatus { path: "src/main.rs".to_string(), status: "M".to_string() };
+        let json = serde_json::to_value(&fs).unwrap();
+        assert_eq!(json["path"], serde_json::Value::String("src/main.rs".to_string()));
+        assert_eq!(json["status"], serde_json::Value::String("M".to_string()));
+    }
+
+    // --- build_status_report uses git2 against a real repo ---
+
+    #[test]
+    fn test_build_status_report_clean_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(tmp.path()).unwrap();
+
+        // Create an initial commit so HEAD resolves
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[]).unwrap();
+        drop(tree);
+
+        let report = build_status_report("session-id", "test-ws", tmp.path()).unwrap();
+
+        assert_eq!(report.files_changed, 0);
+        assert_eq!(report.staged, 0);
+        assert_eq!(report.unstaged, 0);
+        assert_eq!(report.untracked, 0);
+        assert_eq!(report.workspace_name, "test-ws");
+        assert!(report.commit.is_some());
+    }
+
+    #[test]
+    fn test_build_status_report_detects_untracked() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(tmp.path()).unwrap();
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[]).unwrap();
+        drop(tree);
+
+        std::fs::write(tmp.path().join("new_file.txt"), "hello").unwrap();
+
+        let report = build_status_report("session-id", "test-ws", tmp.path()).unwrap();
+
+        assert_eq!(report.files_changed, 1);
+        assert_eq!(report.untracked, 1);
+        assert_eq!(report.files[0].path, "new_file.txt");
+        assert_eq!(report.files[0].status, "??");
+    }
+
+    #[test]
+    fn test_build_status_report_missing_repo_errors() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Not a git repository
+        let result = build_status_report("session-id", "ws", tmp.path());
+        assert!(result.is_err());
+    }
+}

--- a/ainb-tui/src/cli/init.rs
+++ b/ainb-tui/src/cli/init.rs
@@ -1,0 +1,620 @@
+// ABOUTME: CLI init command for first-time setup and prerequisite checking
+//
+// Usage:
+//   ainb init                     - Run first-time setup (create default config)
+//   ainb init --check             - Check prerequisites only (non-destructive)
+//   ainb init --status            - Show onboarding completion status
+//   ainb init --reset [--force]   - Factory reset ~/.agents-in-a-box
+
+use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
+use std::fs;
+use std::io::{self, Write as _};
+use std::path::PathBuf;
+
+use super::OutputFormat;
+use crate::config::{AppConfig, OnboardingConfig};
+
+#[derive(clap::Args)]
+pub struct InitArgs {
+    /// Only check prerequisites, don't modify any files
+    #[arg(long)]
+    pub check: bool,
+
+    /// Show current onboarding completion status
+    #[arg(long)]
+    pub status: bool,
+
+    /// Factory reset: remove ~/.agents-in-a-box entirely
+    #[arg(long)]
+    pub reset: bool,
+
+    /// Skip interactive confirmation (required for non-interactive --reset)
+    #[arg(long, short)]
+    pub force: bool,
+}
+
+/// Status for a single prerequisite check
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrereqStatus {
+    /// Tool is installed and available
+    Ok,
+    /// Required tool is missing
+    Missing,
+    /// Optional tool is missing
+    Warning,
+}
+
+/// Result of checking a single prerequisite
+#[derive(Debug, Clone, Serialize)]
+pub struct PrereqCheck {
+    pub name: String,
+    pub required: bool,
+    pub status: PrereqStatus,
+    pub path: Option<String>,
+    pub message: String,
+}
+
+/// Full prerequisite report
+#[derive(Debug, Clone, Serialize)]
+pub struct PrereqReport {
+    pub checks: Vec<PrereqCheck>,
+    pub all_required_present: bool,
+}
+
+/// Output structure for `--status`
+#[derive(Debug, Serialize)]
+struct StatusReport {
+    completed: bool,
+    completed_at: Option<String>,
+    version: String,
+    base_dir: String,
+    base_dir_exists: bool,
+    config_path: String,
+    config_exists: bool,
+    skipped_dependencies: Vec<String>,
+}
+
+/// Validate that at most one mode flag is set
+fn validate_flags(check: bool, status: bool, reset: bool) -> Result<()> {
+    let count = [check, status, reset].iter().filter(|x| **x).count();
+    if count > 1 {
+        return Err(anyhow!(
+            "--check, --status, and --reset are mutually exclusive"
+        ));
+    }
+    Ok(())
+}
+
+/// Entry point for `ainb init`
+#[allow(clippy::unused_async)]
+pub async fn execute(args: InitArgs, format: OutputFormat) -> Result<()> {
+    validate_flags(args.check, args.status, args.reset)?;
+
+    if args.reset {
+        cmd_reset(args.force, format)
+    } else if args.status {
+        cmd_status(format)
+    } else if args.check {
+        cmd_check(format)
+    } else {
+        cmd_setup(format)
+    }
+}
+
+// --- Prerequisite checking ---------------------------------------------------
+
+/// Real PATH lookup using the `which` crate
+fn real_lookup(name: &str) -> Option<PathBuf> {
+    which::which(name).ok()
+}
+
+/// Build a single prerequisite check entry using a caller-supplied lookup
+fn check_prerequisite<F>(
+    name: &str,
+    required: bool,
+    ok_message: &str,
+    missing_message: &str,
+    lookup: &F,
+) -> PrereqCheck
+where
+    F: Fn(&str) -> Option<PathBuf>,
+{
+    match lookup(name) {
+        Some(path) => PrereqCheck {
+            name: name.to_string(),
+            required,
+            status: PrereqStatus::Ok,
+            path: Some(path.display().to_string()),
+            message: ok_message.to_string(),
+        },
+        None => PrereqCheck {
+            name: name.to_string(),
+            required,
+            status: if required {
+                PrereqStatus::Missing
+            } else {
+                PrereqStatus::Warning
+            },
+            path: None,
+            message: missing_message.to_string(),
+        },
+    }
+}
+
+/// Run the full prerequisite sweep using the provided lookup function.
+///
+/// Exposed (pub) for testability - tests pass a mock lookup that consults a
+/// canned list of "installed" tools.
+pub fn run_checks<F>(lookup: F) -> PrereqReport
+where
+    F: Fn(&str) -> Option<PathBuf>,
+{
+    let checks = vec![
+        check_prerequisite(
+            "tmux",
+            true,
+            "Terminal multiplexer available",
+            "Install tmux (macOS: `brew install tmux`, Debian/Ubuntu: `apt install tmux`)",
+            &lookup,
+        ),
+        check_prerequisite(
+            "git",
+            true,
+            "Git available",
+            "Install git (macOS: `brew install git`, Debian/Ubuntu: `apt install git`)",
+            &lookup,
+        ),
+        check_prerequisite(
+            "claude",
+            false,
+            "Claude CLI available",
+            "Claude CLI not found - install it or pass `--tool codex|gemini|copilot` to `ainb run`",
+            &lookup,
+        ),
+        check_prerequisite(
+            "docker",
+            false,
+            "Docker available (optional, for containerized sessions)",
+            "Docker not found - optional, only needed for containerized sessions",
+            &lookup,
+        ),
+    ];
+
+    let all_required_present = checks
+        .iter()
+        .all(|c| !c.required || c.status == PrereqStatus::Ok);
+
+    PrereqReport {
+        checks,
+        all_required_present,
+    }
+}
+
+/// Print the prerequisite report in text form
+fn print_report_text(report: &PrereqReport) {
+    println!("Prerequisite check:");
+    println!("{}", "\u{2501}".repeat(60));
+
+    for c in &report.checks {
+        let marker = match c.status {
+            PrereqStatus::Ok => "\u{2713}",      // ✓
+            PrereqStatus::Missing => "\u{2717}", // ✗
+            PrereqStatus::Warning => "\u{26A0}", // ⚠
+        };
+        let tag = if c.required { "required" } else { "optional" };
+        println!("  {marker} {:<7} [{tag}] - {}", c.name, c.message);
+        if let Some(path) = &c.path {
+            println!("      \u{21B3} {path}");
+        }
+    }
+
+    println!();
+    if report.all_required_present {
+        println!("All required prerequisites are available.");
+    } else {
+        println!("Missing required prerequisites (see above).");
+    }
+}
+
+// --- Subcommand implementations ---------------------------------------------
+
+/// `ainb init --check`
+fn cmd_check(format: OutputFormat) -> Result<()> {
+    let report = run_checks(real_lookup);
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&report)
+                .context("Failed to serialize prerequisite report")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => print_report_text(&report),
+    }
+
+    if !report.all_required_present {
+        return Err(anyhow!("Required prerequisites missing"));
+    }
+
+    Ok(())
+}
+
+/// `ainb init` (no flags) - first-time setup
+fn cmd_setup(format: OutputFormat) -> Result<()> {
+    let report = run_checks(real_lookup);
+
+    if matches!(format, OutputFormat::Text) {
+        print_report_text(&report);
+        println!();
+    }
+
+    if !report.all_required_present {
+        if matches!(format, OutputFormat::Json) {
+            let json = serde_json::to_string_pretty(&report)
+                .context("Failed to serialize prerequisite report")?;
+            println!("{json}");
+        }
+        return Err(anyhow!(
+            "Cannot complete setup - required prerequisites are missing. Install them and run `ainb init` again."
+        ));
+    }
+
+    // Ensure base directory exists
+    let base_dir = OnboardingConfig::base_dir()?;
+    fs::create_dir_all(&base_dir)
+        .with_context(|| format!("Failed to create {}", base_dir.display()))?;
+
+    // Create default AppConfig if the user-level config file is missing
+    let user_dir = AppConfig::get_user_config_dir()?;
+    fs::create_dir_all(&user_dir)
+        .with_context(|| format!("Failed to create {}", user_dir.display()))?;
+    let config_path = user_dir.join("config.toml");
+    let created_config = if !config_path.exists() {
+        let default = AppConfig::default();
+        default.save().context("Failed to write default config")?;
+        true
+    } else {
+        false
+    };
+
+    // Mark onboarding as complete and persist
+    let mut onboarding = OnboardingConfig::load().context("Failed to load onboarding config")?;
+    onboarding.mark_completed();
+    onboarding
+        .save()
+        .context("Failed to save onboarding config")?;
+
+    match format {
+        OutputFormat::Json => {
+            let output = serde_json::json!({
+                "base_dir": base_dir.display().to_string(),
+                "config_path": config_path.display().to_string(),
+                "created_default_config": created_config,
+                "onboarding_completed": true,
+                "prerequisites": report,
+            });
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).context("Failed to serialize output")?
+            );
+        }
+        OutputFormat::Text => {
+            println!("Setup complete.");
+            println!("  Base dir:    {}", base_dir.display());
+            println!("  Config file: {}", config_path.display());
+            if created_config {
+                println!("  Created default config file.");
+            } else {
+                println!("  Existing config preserved.");
+            }
+            println!("  Onboarding marked as completed.");
+        }
+    }
+
+    Ok(())
+}
+
+/// `ainb init --status`
+fn cmd_status(format: OutputFormat) -> Result<()> {
+    let onboarding = OnboardingConfig::load().context("Failed to load onboarding config")?;
+    let base_dir = OnboardingConfig::base_dir()?;
+    let user_dir = AppConfig::get_user_config_dir()?;
+    let config_path = user_dir.join("config.toml");
+
+    let report = StatusReport {
+        completed: onboarding.completed,
+        completed_at: onboarding.completed_at.clone(),
+        version: onboarding.version.clone(),
+        base_dir: base_dir.display().to_string(),
+        base_dir_exists: base_dir.exists(),
+        config_path: config_path.display().to_string(),
+        config_exists: config_path.exists(),
+        skipped_dependencies: onboarding.skipped_dependencies.clone(),
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&report)
+                .context("Failed to serialize status report")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            println!("Onboarding status:");
+            println!("{}", "\u{2501}".repeat(60));
+            let marker = if report.completed {
+                "\u{2713}"
+            } else {
+                "\u{2717}"
+            };
+            println!("  {marker} Completed:    {}", report.completed);
+            if let Some(when) = &report.completed_at {
+                println!("    Completed at: {when}");
+            }
+            println!("    Version:      {}", report.version);
+            let base_marker = if report.base_dir_exists {
+                "\u{2713}"
+            } else {
+                "\u{2717}"
+            };
+            println!("  {base_marker} Base dir:     {}", report.base_dir);
+            let cfg_marker = if report.config_exists {
+                "\u{2713}"
+            } else {
+                "\u{2717}"
+            };
+            println!("  {cfg_marker} Config file:  {}", report.config_path);
+            if !report.skipped_dependencies.is_empty() {
+                println!(
+                    "    Skipped deps: {}",
+                    report.skipped_dependencies.join(", ")
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// `ainb init --reset`
+fn cmd_reset(force: bool, format: OutputFormat) -> Result<()> {
+    let base_dir = OnboardingConfig::base_dir()?;
+
+    if !base_dir.exists() {
+        match format {
+            OutputFormat::Json => {
+                let out = serde_json::json!({
+                    "reset": false,
+                    "base_dir": base_dir.display().to_string(),
+                    "message": "Base directory does not exist - nothing to reset",
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            }
+            OutputFormat::Text => {
+                println!("Nothing to reset: {} does not exist", base_dir.display());
+            }
+        }
+        return Ok(());
+    }
+
+    if !force {
+        print!(
+            "This will permanently delete {} and all its contents. Continue? [y/N] ",
+            base_dir.display()
+        );
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    OnboardingConfig::factory_reset().context("Failed to perform factory reset")?;
+
+    match format {
+        OutputFormat::Json => {
+            let out = serde_json::json!({
+                "reset": true,
+                "base_dir": base_dir.display().to_string(),
+            });
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+        OutputFormat::Text => {
+            println!("Factory reset complete.");
+            println!("  Removed: {}", base_dir.display());
+        }
+    }
+
+    Ok(())
+}
+
+// --- Tests ------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a mock PATH-lookup closure that treats the provided list as
+    /// "installed" and everything else as missing.
+    fn make_lookup(installed: Vec<&'static str>) -> impl Fn(&str) -> Option<PathBuf> {
+        move |name: &str| {
+            if installed.contains(&name) {
+                Some(PathBuf::from(format!("/fake/bin/{name}")))
+            } else {
+                None
+            }
+        }
+    }
+
+    // --- validate_flags ---
+
+    #[test]
+    fn test_validate_flags_none_set() {
+        assert!(validate_flags(false, false, false).is_ok());
+    }
+
+    #[test]
+    fn test_validate_flags_single_set() {
+        assert!(validate_flags(true, false, false).is_ok());
+        assert!(validate_flags(false, true, false).is_ok());
+        assert!(validate_flags(false, false, true).is_ok());
+    }
+
+    #[test]
+    fn test_validate_flags_two_set_rejected() {
+        assert!(validate_flags(true, true, false).is_err());
+        assert!(validate_flags(true, false, true).is_err());
+        assert!(validate_flags(false, true, true).is_err());
+    }
+
+    #[test]
+    fn test_validate_flags_all_three_rejected() {
+        let err = validate_flags(true, true, true).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    // --- check_prerequisite ---
+
+    #[test]
+    fn test_check_prerequisite_found_sets_ok_and_path() {
+        let lookup = make_lookup(vec!["tmux"]);
+        let c = check_prerequisite("tmux", true, "ok-msg", "missing-msg", &lookup);
+        assert_eq!(c.status, PrereqStatus::Ok);
+        assert_eq!(c.path.as_deref(), Some("/fake/bin/tmux"));
+        assert_eq!(c.message, "ok-msg");
+        assert!(c.required);
+    }
+
+    #[test]
+    fn test_check_prerequisite_missing_required_is_missing() {
+        let lookup = make_lookup(vec![]);
+        let c = check_prerequisite("tmux", true, "ok-msg", "missing-msg", &lookup);
+        assert_eq!(c.status, PrereqStatus::Missing);
+        assert!(c.path.is_none());
+        assert_eq!(c.message, "missing-msg");
+    }
+
+    #[test]
+    fn test_check_prerequisite_missing_optional_is_warning() {
+        let lookup = make_lookup(vec![]);
+        let c = check_prerequisite("docker", false, "ok-msg", "missing-msg", &lookup);
+        assert_eq!(c.status, PrereqStatus::Warning);
+        assert!(c.path.is_none());
+        assert!(!c.required);
+    }
+
+    // --- run_checks ---
+
+    #[test]
+    fn test_run_checks_all_four_tools_present() {
+        let report = run_checks(make_lookup(vec!["tmux", "git", "claude", "docker"]));
+        assert!(report.all_required_present);
+        assert_eq!(report.checks.len(), 4);
+        assert!(report.checks.iter().all(|c| c.status == PrereqStatus::Ok));
+    }
+
+    #[test]
+    fn test_run_checks_missing_tmux_fails_required() {
+        let report = run_checks(make_lookup(vec!["git", "claude", "docker"]));
+        assert!(!report.all_required_present);
+        let tmux = report.checks.iter().find(|c| c.name == "tmux").unwrap();
+        assert_eq!(tmux.status, PrereqStatus::Missing);
+    }
+
+    #[test]
+    fn test_run_checks_missing_git_fails_required() {
+        let report = run_checks(make_lookup(vec!["tmux", "claude"]));
+        assert!(!report.all_required_present);
+        let git = report.checks.iter().find(|c| c.name == "git").unwrap();
+        assert_eq!(git.status, PrereqStatus::Missing);
+    }
+
+    #[test]
+    fn test_run_checks_missing_claude_does_not_fail_required() {
+        let report = run_checks(make_lookup(vec!["tmux", "git"]));
+        assert!(report.all_required_present);
+        let claude = report.checks.iter().find(|c| c.name == "claude").unwrap();
+        assert_eq!(claude.status, PrereqStatus::Warning);
+        assert!(!claude.required);
+    }
+
+    #[test]
+    fn test_run_checks_missing_docker_does_not_fail_required() {
+        let report = run_checks(make_lookup(vec!["tmux", "git", "claude"]));
+        assert!(report.all_required_present);
+        let docker = report.checks.iter().find(|c| c.name == "docker").unwrap();
+        assert_eq!(docker.status, PrereqStatus::Warning);
+        assert!(!docker.required);
+    }
+
+    #[test]
+    fn test_run_checks_nothing_installed() {
+        let report = run_checks(make_lookup(vec![]));
+        assert!(!report.all_required_present);
+        let by_name: std::collections::HashMap<&str, &PrereqCheck> =
+            report.checks.iter().map(|c| (c.name.as_str(), c)).collect();
+        assert_eq!(by_name["tmux"].status, PrereqStatus::Missing);
+        assert_eq!(by_name["git"].status, PrereqStatus::Missing);
+        assert_eq!(by_name["claude"].status, PrereqStatus::Warning);
+        assert_eq!(by_name["docker"].status, PrereqStatus::Warning);
+    }
+
+    #[test]
+    fn test_run_checks_required_vs_optional_classification() {
+        let report = run_checks(make_lookup(vec![]));
+        for c in &report.checks {
+            match c.name.as_str() {
+                "tmux" | "git" => assert!(c.required, "{} should be required", c.name),
+                "claude" | "docker" => assert!(!c.required, "{} should be optional", c.name),
+                other => panic!("unexpected check: {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_run_checks_names_contain_all_four() {
+        let report = run_checks(make_lookup(vec![]));
+        let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"tmux"));
+        assert!(names.contains(&"git"));
+        assert!(names.contains(&"claude"));
+        assert!(names.contains(&"docker"));
+    }
+
+    // --- serialization ---
+
+    #[test]
+    fn test_prereq_status_json_rename_all_snake_case() {
+        assert_eq!(serde_json::to_string(&PrereqStatus::Ok).unwrap(), "\"ok\"");
+        assert_eq!(
+            serde_json::to_string(&PrereqStatus::Missing).unwrap(),
+            "\"missing\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PrereqStatus::Warning).unwrap(),
+            "\"warning\""
+        );
+    }
+
+    #[test]
+    fn test_prereq_report_serializes_with_all_required_present_field() {
+        let report = run_checks(make_lookup(vec!["tmux", "git"]));
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["all_required_present"], true);
+        assert_eq!(json["checks"].as_array().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn test_prereq_check_serializes_path_when_ok() {
+        let lookup = make_lookup(vec!["tmux"]);
+        let c = check_prerequisite("tmux", true, "ok", "missing", &lookup);
+        let json = serde_json::to_value(&c).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["path"], "/fake/bin/tmux");
+        assert_eq!(json["required"], true);
+    }
+}

--- a/ainb-tui/src/cli/list.rs
+++ b/ainb-tui/src/cli/list.rs
@@ -151,12 +151,17 @@ fn output_text(sessions: &[SessionInfo]) {
     }
 }
 
-/// Truncate a string to fit in the given width
+/// Truncate a string to fit in the given width (character-aware for UTF-8)
 fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if max_len <= 3 {
+        return ".".repeat(max_len);
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
+        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{truncated}...")
     }
 }
 

--- a/ainb-tui/src/cli/list.rs
+++ b/ainb-tui/src/cli/list.rs
@@ -1,0 +1,252 @@
+// ABOUTME: CLI list command - list all sessions with status
+//
+// Lists sessions from ~/.agents-in-a-box/sessions.json
+// Shows: session ID, workspace, status (Claude running, idle, stopped), tmux session name
+
+use super::{ListArgs, OutputFormat};
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+use crate::tmux::ClaudeProcessDetector;
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+/// Session status as displayed in the list
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStatus {
+    /// Claude is running (tmux exists and Claude status bar detected)
+    ClaudeRunning,
+    /// Tmux session exists but Claude is not running
+    Idle,
+    /// Tmux session does not exist
+    Stopped,
+}
+
+impl SessionStatus {
+    /// Get the display icon for this status
+    #[must_use]
+    pub const fn icon(&self) -> &'static str {
+        match self {
+            Self::ClaudeRunning => "\u{25cf} Claude", // filled circle
+            Self::Idle => "\u{25cb} Idle",            // empty circle
+            Self::Stopped => "\u{23f8} Stopped",      // pause icon
+        }
+    }
+}
+
+/// A session with enriched status information for display
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub tmux_session_name: String,
+    pub workspace_name: String,
+    pub worktree_path: String,
+    pub created_at: DateTime<Utc>,
+    pub is_running: bool,
+    pub claude_active: bool,
+}
+
+impl SessionInfo {
+    /// Create `SessionInfo` from metadata and status
+    #[must_use]
+    pub fn from_metadata(metadata: &SessionMetadata, is_running: bool, claude_active: bool) -> Self {
+        Self {
+            session_id: metadata.session_id.to_string(),
+            tmux_session_name: metadata.tmux_session_name.clone(),
+            workspace_name: metadata.workspace_name.clone(),
+            worktree_path: metadata.worktree_path.display().to_string(),
+            created_at: metadata.created_at,
+            is_running,
+            claude_active,
+        }
+    }
+
+    /// Get the status of this session
+    #[must_use]
+    pub const fn status(&self) -> SessionStatus {
+        if !self.is_running {
+            SessionStatus::Stopped
+        } else if self.claude_active {
+            SessionStatus::ClaudeRunning
+        } else {
+            SessionStatus::Idle
+        }
+    }
+}
+
+/// Execute the list command
+pub async fn execute(args: ListArgs, format: OutputFormat) -> Result<()> {
+    let sessions = list_sessions(&args).await?;
+
+    match format {
+        OutputFormat::Json => output_json(&sessions)?,
+        OutputFormat::Text => output_text(&sessions),
+    }
+
+    Ok(())
+}
+
+/// List sessions with filtering applied
+#[allow(clippy::unused_async)] // Async for consistency with other CLI commands
+pub async fn list_sessions(args: &ListArgs) -> Result<Vec<SessionInfo>> {
+    let store = SessionStore::load();
+    let detector = ClaudeProcessDetector::new();
+
+    let mut sessions = Vec::new();
+
+    for metadata in store.sessions.values() {
+        // Check tmux session existence and Claude status
+        let (is_running, claude_active) = detector
+            .get_session_health(&metadata.tmux_session_name)
+            .unwrap_or((false, false));
+
+        let info = SessionInfo::from_metadata(metadata, is_running, claude_active);
+
+        // Apply filters
+        if args.running && !is_running {
+            continue;
+        }
+
+        if let Some(ref workspace_filter) = args.workspace {
+            if !info.workspace_name.contains(workspace_filter) {
+                continue;
+            }
+        }
+
+        sessions.push(info);
+    }
+
+    // Sort by created_at descending (newest first)
+    sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    Ok(sessions)
+}
+
+/// Output sessions as JSON
+fn output_json(sessions: &[SessionInfo]) -> Result<()> {
+    let json = serde_json::to_string_pretty(sessions)?;
+    println!("{json}");
+    Ok(())
+}
+
+/// Output sessions as a text table
+fn output_text(sessions: &[SessionInfo]) {
+    if sessions.is_empty() {
+        println!("No sessions found.");
+        return;
+    }
+
+    // Print header
+    println!("{:<36} {:<25} {:<10} TMUX SESSION", "ID", "WORKSPACE", "STATUS");
+    let separator = "-".repeat(100);
+    println!("{separator}");
+
+    // Print each session
+    for session in sessions {
+        let status = session.status();
+        let workspace = truncate(&session.workspace_name, 25);
+        println!(
+            "{:<36} {:<25} {:<10} {}",
+            session.session_id, workspace, status.icon(), session.tmux_session_name
+        );
+    }
+}
+
+/// Truncate a string to fit in the given width
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_session_status_icons() {
+        assert_eq!(SessionStatus::ClaudeRunning.icon(), "\u{25cf} Claude");
+        assert_eq!(SessionStatus::Idle.icon(), "\u{25cb} Idle");
+        assert_eq!(SessionStatus::Stopped.icon(), "\u{23f8} Stopped");
+    }
+
+    #[test]
+    fn test_session_info_status_claude_running() {
+        let metadata = SessionMetadata {
+            session_id: Uuid::new_v4(),
+            tmux_session_name: "test_session".to_string(),
+            worktree_path: PathBuf::from("/tmp/test"),
+            workspace_name: "test-workspace".to_string(),
+            created_at: Utc::now(),
+        };
+
+        let info = SessionInfo::from_metadata(&metadata, true, true);
+        assert_eq!(info.status(), SessionStatus::ClaudeRunning);
+    }
+
+    #[test]
+    fn test_session_info_status_idle() {
+        let metadata = SessionMetadata {
+            session_id: Uuid::new_v4(),
+            tmux_session_name: "test_session".to_string(),
+            worktree_path: PathBuf::from("/tmp/test"),
+            workspace_name: "test-workspace".to_string(),
+            created_at: Utc::now(),
+        };
+
+        let info = SessionInfo::from_metadata(&metadata, true, false);
+        assert_eq!(info.status(), SessionStatus::Idle);
+    }
+
+    #[test]
+    fn test_session_info_status_stopped() {
+        let metadata = SessionMetadata {
+            session_id: Uuid::new_v4(),
+            tmux_session_name: "test_session".to_string(),
+            worktree_path: PathBuf::from("/tmp/test"),
+            workspace_name: "test-workspace".to_string(),
+            created_at: Utc::now(),
+        };
+
+        let info = SessionInfo::from_metadata(&metadata, false, false);
+        assert_eq!(info.status(), SessionStatus::Stopped);
+    }
+
+    #[test]
+    fn test_truncate_short_string() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long_string() {
+        assert_eq!(truncate("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn test_truncate_exact_length() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_session_info_serialization() {
+        let metadata = SessionMetadata {
+            session_id: Uuid::parse_str("f79e07da-774d-415c-aedf-a2acd0bee0d3").unwrap(),
+            tmux_session_name: "tmux_my-session".to_string(),
+            worktree_path: PathBuf::from("/tmp/test"),
+            workspace_name: "my-workspace".to_string(),
+            created_at: Utc::now(),
+        };
+
+        let info = SessionInfo::from_metadata(&metadata, true, true);
+        let json = serde_json::to_value(&info).unwrap();
+
+        assert_eq!(json["session_id"], "f79e07da-774d-415c-aedf-a2acd0bee0d3");
+        assert_eq!(json["tmux_session_name"], "tmux_my-session");
+        assert_eq!(json["workspace_name"], "my-workspace");
+        assert_eq!(json["is_running"], true);
+        assert_eq!(json["claude_active"], true);
+    }
+}

--- a/ainb-tui/src/cli/list.rs
+++ b/ainb-tui/src/cli/list.rs
@@ -168,6 +168,7 @@ fn truncate(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::session::SessionAgentType;
     use std::path::PathBuf;
     use uuid::Uuid;
 
@@ -186,6 +187,7 @@ mod tests {
             worktree_path: PathBuf::from("/tmp/test"),
             workspace_name: "test-workspace".to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);
@@ -200,6 +202,7 @@ mod tests {
             worktree_path: PathBuf::from("/tmp/test"),
             workspace_name: "test-workspace".to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, false);
@@ -214,6 +217,7 @@ mod tests {
             worktree_path: PathBuf::from("/tmp/test"),
             workspace_name: "test-workspace".to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         };
 
         let info = SessionInfo::from_metadata(&metadata, false, false);
@@ -243,6 +247,7 @@ mod tests {
             worktree_path: PathBuf::from("/tmp/test"),
             workspace_name: "my-workspace".to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);

--- a/ainb-tui/src/cli/logs.rs
+++ b/ainb-tui/src/cli/logs.rs
@@ -1,0 +1,213 @@
+// ABOUTME: CLI logs command - view session output from tmux panes
+//
+// Captures tmux pane content and displays it to stdout.
+// Supports --follow mode for streaming updates and --lines for limiting output.
+
+use anyhow::{bail, Result};
+use std::time::Duration;
+use tokio::process::Command;
+use uuid::Uuid;
+
+use super::LogsArgs;
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+use crate::tmux::capture::{capture_pane, CaptureOptions};
+
+/// Execute the logs command
+///
+/// Displays the tmux pane content for a session identified by ID or name prefix.
+/// Supports follow mode for streaming updates and line limiting.
+pub async fn execute(args: LogsArgs) -> Result<()> {
+    // Find the session by ID or name prefix
+    let session = find_session(&args.session)?;
+
+    // Verify tmux session exists
+    if !tmux_session_exists(&session.tmux_session_name).await {
+        bail!(
+            "Tmux session '{}' no longer exists (session may have been terminated)",
+            session.tmux_session_name
+        );
+    }
+
+    if args.follow {
+        follow_logs(&session.tmux_session_name).await
+    } else {
+        show_logs(&session.tmux_session_name, args.lines).await
+    }
+}
+
+/// Find a session by ID or name prefix
+///
+/// Searches the session store for a matching session:
+/// 1. First tries to parse as UUID and match by `session_id`
+/// 2. Then tries prefix matching on `workspace_name`, `tmux_session_name`, or `session_id` string
+///
+/// Returns an error if no match is found or if multiple sessions match.
+fn find_session(id_or_name: &str) -> Result<SessionMetadata> {
+    let store = SessionStore::load();
+
+    // Try UUID parse first for exact match
+    if let Ok(uuid) = Uuid::parse_str(id_or_name) {
+        if let Some(session) = store.sessions.values().find(|s| s.session_id == uuid) {
+            return Ok(session.clone());
+        }
+    }
+
+    // Try prefix match on workspace_name, tmux_session_name, or session_id string
+    let matches: Vec<_> = store
+        .sessions
+        .values()
+        .filter(|s| {
+            s.workspace_name.starts_with(id_or_name)
+                || s.tmux_session_name.starts_with(id_or_name)
+                || s.session_id.to_string().starts_with(id_or_name)
+        })
+        .collect();
+
+    match matches.len() {
+        0 => bail!("No session found matching '{id_or_name}'"),
+        1 => Ok(matches[0].clone()),
+        _ => {
+            let names: Vec<_> = matches.iter().map(|s| &s.workspace_name).collect();
+            bail!(
+                "Multiple sessions match '{id_or_name}': {names:?}. Please be more specific."
+            )
+        }
+    }
+}
+
+/// Check if a tmux session exists
+async fn tmux_session_exists(session_name: &str) -> bool {
+    let output = Command::new("tmux")
+        .args(["has-session", "-t", session_name])
+        .output()
+        .await;
+
+    matches!(output, Ok(o) if o.status.success())
+}
+
+/// Display logs in follow mode (continuous updates like tail -f)
+async fn follow_logs(session_name: &str) -> Result<()> {
+    loop {
+        // Clear screen and move cursor to top
+        print!("\x1B[2J\x1B[1;1H");
+
+        // Capture and print current pane content
+        let content = capture_pane(session_name, CaptureOptions::visible()).await?;
+        println!("{content}");
+
+        // Wait before next refresh
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Display logs one-shot (capture and exit)
+async fn show_logs(session_name: &str, lines: usize) -> Result<()> {
+    // Use full history capture for larger line counts, visible for small ones
+    let options = if lines > 100 {
+        CaptureOptions::full_history()
+    } else {
+        CaptureOptions::visible()
+    };
+
+    let content = capture_pane(session_name, options).await?;
+
+    // Take the last N lines
+    let output_lines: Vec<&str> = content.lines().collect();
+    let start_idx = output_lines.len().saturating_sub(lines);
+    let truncated: Vec<&str> = output_lines.into_iter().skip(start_idx).collect();
+
+    println!("{}", truncated.join("\n"));
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    /// Create a test SessionMetadata for testing
+    fn create_test_session(
+        id: Uuid,
+        workspace_name: &str,
+        tmux_name: &str,
+    ) -> SessionMetadata {
+        SessionMetadata {
+            session_id: id,
+            tmux_session_name: tmux_name.to_string(),
+            worktree_path: PathBuf::from("/tmp/test"),
+            workspace_name: workspace_name.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_find_session_by_exact_uuid() {
+        // This test would require mocking SessionStore::load()
+        // For now, we verify the function signature and logic structure
+        let id = Uuid::new_v4();
+        let id_str = id.to_string();
+
+        // Verify UUID parsing works
+        assert_eq!(Uuid::parse_str(&id_str).unwrap(), id);
+    }
+
+    #[test]
+    fn test_find_session_prefix_matching_logic() {
+        // Test the prefix matching logic
+        let workspace = "my-project";
+        let prefix = "my-";
+
+        assert!(workspace.starts_with(prefix));
+        assert!(!workspace.starts_with("other-"));
+    }
+
+    #[test]
+    fn test_session_metadata_creation() {
+        let id = Uuid::new_v4();
+        let session = create_test_session(id, "test-workspace", "tmux_test");
+
+        assert_eq!(session.session_id, id);
+        assert_eq!(session.workspace_name, "test-workspace");
+        assert_eq!(session.tmux_session_name, "tmux_test");
+    }
+
+    #[test]
+    fn test_line_truncation_logic() {
+        let content = "line1\nline2\nline3\nline4\nline5";
+        let lines: Vec<&str> = content.lines().collect();
+        let limit = 3;
+
+        let start_idx = lines.len().saturating_sub(limit);
+        let truncated: Vec<&str> = lines.into_iter().skip(start_idx).collect();
+
+        assert_eq!(truncated, vec!["line3", "line4", "line5"]);
+    }
+
+    #[test]
+    fn test_line_truncation_with_fewer_lines() {
+        let content = "line1\nline2";
+        let lines: Vec<&str> = content.lines().collect();
+        let limit = 10;
+
+        let start_idx = lines.len().saturating_sub(limit);
+        let truncated: Vec<&str> = lines.into_iter().skip(start_idx).collect();
+
+        // Should return all lines when there are fewer than the limit
+        assert_eq!(truncated, vec!["line1", "line2"]);
+    }
+
+    #[test]
+    fn test_capture_options_selection() {
+        // Verify we use full_history for large line counts
+        let lines = 150;
+        let should_use_full = lines > 100;
+        assert!(should_use_full);
+
+        // And visible for small ones
+        let lines = 50;
+        let should_use_full = lines > 100;
+        assert!(!should_use_full);
+    }
+}

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -11,6 +11,7 @@ pub mod list;
 pub mod logs;
 pub mod attach;
 pub mod status;
+pub mod util;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -1,0 +1,165 @@
+// ABOUTME: CLI argument parsing and command routing for ainb
+//
+// Provides command-line interface for:
+// - Spawning AI coding sessions (run)
+// - Managing sessions (list, attach, status, kill)
+// - Viewing session output (logs)
+// - Launching TUI (tui, default)
+
+pub mod run;
+pub mod list;
+pub mod logs;
+pub mod attach;
+pub mod status;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
+
+/// AI agents in a box - spawn and manage AI coding sessions
+#[derive(Parser)]
+#[command(name = "ainb")]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
+    /// Output format
+    #[arg(long, global = true, default_value = "text")]
+    pub format: OutputFormat,
+}
+
+/// Output format for commands
+#[derive(Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+}
+
+/// Available CLI commands
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Launch the TUI (default if no command given)
+    Tui,
+
+    /// Spawn a new AI coding session
+    Run(RunArgs),
+
+    /// List all sessions
+    List(ListArgs),
+
+    /// View session output/logs
+    Logs(LogsArgs),
+
+    /// Attach to a session (drops into tmux)
+    Attach(AttachArgs),
+
+    /// Check session status
+    Status(StatusArgs),
+
+    /// Kill a session
+    Kill(KillArgs),
+
+    /// Set up authentication
+    Auth,
+}
+
+/// Arguments for the run command
+#[derive(clap::Args)]
+pub struct RunArgs {
+    /// Remote repository (e.g., username/repo or full URL)
+    #[arg(long)]
+    pub remote_repo: Option<String>,
+
+    /// Local repository path
+    #[arg(long)]
+    pub repo: Option<PathBuf>,
+
+    /// Create a new branch with this name
+    #[arg(long)]
+    pub create_branch: Option<String>,
+
+    /// Use git worktree for isolation
+    #[arg(long)]
+    pub worktree: bool,
+
+    /// AI tool to use (claude, codex, gemini)
+    #[arg(long, default_value = "claude")]
+    pub tool: String,
+
+    /// Model to use (sonnet, opus, haiku)
+    #[arg(long, default_value = "sonnet")]
+    pub model: String,
+
+    /// Initial prompt to send
+    #[arg(long, short)]
+    pub prompt: Option<String>,
+
+    /// Attach to session after creation
+    #[arg(long, short)]
+    pub attach: bool,
+
+    /// Skip permission prompts (dangerous!)
+    #[arg(long)]
+    pub dangerously_skip_permissions: bool,
+
+    /// Custom session name
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Run in interactive mode (spawn tmux and attach)
+    #[arg(long, short)]
+    pub interactive: bool,
+}
+
+/// Arguments for the list command
+#[derive(clap::Args)]
+pub struct ListArgs {
+    /// Show only running sessions
+    #[arg(long)]
+    pub running: bool,
+
+    /// Show only sessions for a specific workspace
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for the logs command
+#[derive(clap::Args)]
+pub struct LogsArgs {
+    /// Session ID or name
+    pub session: String,
+
+    /// Follow log output (like tail -f)
+    #[arg(long, short)]
+    pub follow: bool,
+
+    /// Number of lines to show
+    #[arg(long, short, default_value = "100")]
+    pub lines: usize,
+}
+
+/// Arguments for the attach command
+#[derive(clap::Args)]
+pub struct AttachArgs {
+    /// Session ID or name
+    pub session: String,
+}
+
+/// Arguments for the status command
+#[derive(clap::Args)]
+pub struct StatusArgs {
+    /// Session ID or name
+    pub session: String,
+}
+
+/// Arguments for the kill command
+#[derive(clap::Args)]
+pub struct KillArgs {
+    /// Session ID or name
+    pub session: String,
+
+    /// Force kill without confirmation
+    #[arg(long, short)]
+    pub force: bool,
+}

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -12,6 +12,12 @@ pub mod logs;
 pub mod attach;
 pub mod status;
 pub mod util;
+pub mod recover;
+pub mod config_cmd;
+pub mod git_cmd;
+pub mod favorites;
+pub mod init;
+pub mod presets;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
@@ -63,6 +69,39 @@ pub enum Commands {
 
     /// Set up authentication
     Auth,
+
+    /// Recover orphaned or crashed sessions
+    Recover {
+        #[command(subcommand)]
+        command: recover::RecoverCommands,
+    },
+
+    /// Manage configuration
+    Config {
+        #[command(subcommand)]
+        command: config_cmd::ConfigCommands,
+    },
+
+    /// Git worktree operations
+    Git {
+        #[command(subcommand)]
+        command: git_cmd::GitCommands,
+    },
+
+    /// Manage favorite repositories
+    Favorites {
+        #[command(subcommand)]
+        command: favorites::FavoritesCommands,
+    },
+
+    /// First-time setup and prerequisite checking
+    Init(init::InitArgs),
+
+    /// Manage session presets
+    Presets {
+        #[command(subcommand)]
+        command: presets::PresetsCommands,
+    },
 }
 
 /// Arguments for the run command

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -22,10 +22,23 @@ pub mod presets;
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+const EXAMPLES: &str = "\
+EXAMPLES:
+  ainb                            Launch the TUI
+  ainb run --repo . --worktree    Start a session in the current repo
+  ainb run --tool codex --repo .  Use Codex instead of Claude
+  ainb list --format json         List all sessions as JSON
+  ainb status my-project          Inspect a session by workspace name
+  ainb attach my-project          Drop into a running session
+  ainb config get authentication.default_model
+  ainb recover list               Find orphaned sessions
+  ainb completion zsh > _ainb     Generate zsh completions";
+
 /// AI agents in a box - spawn and manage AI coding sessions
 #[derive(Parser)]
 #[command(name = "ainb")]
 #[command(author, version, about, long_about = None)]
+#[command(after_help = EXAMPLES)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -33,6 +46,29 @@ pub struct Cli {
     /// Output format
     #[arg(long, global = true, default_value = "text")]
     pub format: OutputFormat,
+}
+
+/// AI CLI provider to use for a session
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum Tool {
+    #[default]
+    Claude,
+    Codex,
+    Gemini,
+    Copilot,
+}
+
+impl Tool {
+    /// Convert to the internal CliProvider type
+    pub fn to_cli_provider(self) -> crate::config::CliProvider {
+        match self {
+            Tool::Claude => crate::config::CliProvider::Claude,
+            Tool::Codex => crate::config::CliProvider::Codex,
+            Tool::Gemini => crate::config::CliProvider::Gemini,
+            Tool::Copilot => crate::config::CliProvider::Copilot,
+        }
+    }
 }
 
 /// Output format for commands
@@ -102,10 +138,25 @@ pub enum Commands {
         #[command(subcommand)]
         command: presets::PresetsCommands,
     },
+
+    /// Generate shell completions (bash, zsh, fish, powershell, elvish)
+    Completion {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
 
 /// Arguments for the run command
 #[derive(clap::Args)]
+#[command(after_help = "\
+EXAMPLES:
+  ainb run --repo .                                 Use current directory
+  ainb run --repo . --worktree                      Isolate in a new worktree
+  ainb run --repo . --create-branch feat/new        Create a branch + worktree
+  ainb run --remote-repo owner/repo                 Clone GitHub repo first
+  ainb run --tool codex --repo .                    Use Codex instead of Claude
+  ainb run --repo . -p \"fix the failing tests\"    Send an initial prompt
+  ainb run --repo . --attach                        Drop into tmux after creating")]
 pub struct RunArgs {
     /// Remote repository (e.g., username/repo or full URL)
     #[arg(long)]
@@ -123,9 +174,9 @@ pub struct RunArgs {
     #[arg(long)]
     pub worktree: bool,
 
-    /// AI tool to use (claude, codex, gemini)
-    #[arg(long, default_value = "claude")]
-    pub tool: String,
+    /// AI tool to use
+    #[arg(long, value_enum, default_value_t = Tool::Claude)]
+    pub tool: Tool,
 
     /// Model to use (sonnet, opus, haiku)
     #[arg(long, default_value = "sonnet")]

--- a/ainb-tui/src/cli/presets.rs
+++ b/ainb-tui/src/cli/presets.rs
@@ -1,0 +1,576 @@
+// ABOUTME: CLI presets command for viewing and managing repository presets
+//
+// Subcommands:
+//   list:   Show all presets (built-in + user custom) with descriptions
+//   show:   Display full preset details (provider, model, skills, permissions, etc.)
+//   create: Create a new custom preset with optional provider/model/description
+//   delete: Remove a custom preset (built-ins cannot be deleted)
+//   apply:  Write the selected preset to `.agents-box/preset.toml` in the CWD
+//
+// Built-in presets come from `create_default_presets()` and exist alongside
+// any user-defined presets saved by `PresetManager` under
+// `~/.agents-in-a-box/presets/`. Built-ins are immutable: creating or
+// deleting a preset with a built-in name is rejected with a clear error.
+
+use anyhow::{Context, Result, anyhow};
+use clap::Subcommand;
+use serde::Serialize;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::OutputFormat;
+use crate::config::presets::{
+    PermissionSet, PresetManager, RepositoryPreset, create_default_presets,
+};
+
+#[derive(Subcommand)]
+pub enum PresetsCommands {
+    /// List all available presets (built-in + custom)
+    List,
+    /// Show full details for a specific preset
+    Show {
+        /// Preset name
+        name: String,
+    },
+    /// Create a new custom preset
+    Create {
+        /// Preset name (must be unique and not collide with built-ins)
+        name: String,
+        /// Agent provider (e.g., claude, codex, gemini)
+        #[arg(long)]
+        provider: Option<String>,
+        /// Model identifier (e.g., sonnet, opus, haiku)
+        #[arg(long)]
+        model: Option<String>,
+        /// Human-readable description
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Delete a custom preset
+    Delete {
+        /// Preset name
+        name: String,
+    },
+    /// Apply a preset to the current repository (writes .agents-box/preset.toml)
+    Apply {
+        /// Preset name
+        name: String,
+    },
+}
+
+/// JSON entry emitted by `presets list --format json`
+#[derive(Debug, Serialize)]
+struct PresetListEntry {
+    name: String,
+    description: String,
+    provider: String,
+    model: String,
+    builtin: bool,
+}
+
+/// Execute a presets subcommand
+#[allow(clippy::unused_async)]
+pub async fn execute(command: PresetsCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        PresetsCommands::List => cmd_list(format),
+        PresetsCommands::Show { name } => cmd_show(&name, format),
+        PresetsCommands::Create {
+            name,
+            provider,
+            model,
+            description,
+        } => cmd_create(&name, provider, model, description),
+        PresetsCommands::Delete { name } => cmd_delete(&name),
+        PresetsCommands::Apply { name } => cmd_apply(&name, &std::env::current_dir()?),
+    }
+}
+
+// --- List ---
+
+fn cmd_list(format: OutputFormat) -> Result<()> {
+    let manager = PresetManager::new().context("Failed to initialize preset manager")?;
+    let entries = build_list_entries(&manager);
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&entries)
+                .context("Failed to serialize presets as JSON")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            println!("Available presets:");
+            println!("{}", "\u{2501}".repeat(60));
+            for entry in &entries {
+                let marker = if entry.builtin { "[built-in]" } else { "[custom]  " };
+                println!(
+                    "  {marker} {}  ({}/{})",
+                    entry.name, entry.provider, entry.model
+                );
+                if !entry.description.is_empty() {
+                    println!("             {}", entry.description);
+                }
+            }
+            if entries.is_empty() {
+                println!("  (no presets found)");
+            }
+            println!();
+            println!("Use 'ainb presets show <name>' to view details.");
+        }
+    }
+
+    Ok(())
+}
+
+fn build_list_entries(manager: &PresetManager) -> Vec<PresetListEntry> {
+    let mut entries: Vec<PresetListEntry> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for preset in create_default_presets() {
+        seen.insert(preset.name.clone());
+        entries.push(to_list_entry(&preset, true));
+    }
+
+    let mut customs: Vec<&RepositoryPreset> = manager
+        .all()
+        .into_iter()
+        .filter(|p| !seen.contains(&p.name))
+        .collect();
+    customs.sort_by(|a, b| a.name.cmp(&b.name));
+    for preset in customs {
+        entries.push(to_list_entry(preset, false));
+    }
+
+    entries
+}
+
+fn to_list_entry(preset: &RepositoryPreset, builtin: bool) -> PresetListEntry {
+    PresetListEntry {
+        name: preset.name.clone(),
+        description: preset.description.clone(),
+        provider: preset.agent_provider.clone(),
+        model: preset.agent_model.clone(),
+        builtin,
+    }
+}
+
+// --- Show ---
+
+fn cmd_show(name: &str, format: OutputFormat) -> Result<()> {
+    let manager = PresetManager::new().context("Failed to initialize preset manager")?;
+    let (preset, builtin) =
+        resolve_preset(&manager, name).ok_or_else(|| anyhow!("Preset '{name}' not found"))?;
+
+    match format {
+        OutputFormat::Json => {
+            let wrapper = serde_json::json!({
+                "name": preset.name,
+                "builtin": builtin,
+                "preset": &preset,
+            });
+            println!("{}", serde_json::to_string_pretty(&wrapper)?);
+        }
+        OutputFormat::Text => {
+            println!("{}", format_preset_text(&preset, builtin));
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_preset(manager: &PresetManager, name: &str) -> Option<(RepositoryPreset, bool)> {
+    if let Some(builtin) = create_default_presets().into_iter().find(|p| p.name == name) {
+        return Some((builtin, true));
+    }
+    manager.get(name).map(|p| (p.clone(), false))
+}
+
+fn format_preset_text(preset: &RepositoryPreset, builtin: bool) -> String {
+    let origin = if builtin { "built-in" } else { "custom" };
+    let mut out = String::new();
+    let _ = writeln!(out, "Preset: {} ({origin})", preset.name);
+    let _ = writeln!(out, "{}", "\u{2501}".repeat(60));
+    if !preset.description.is_empty() {
+        let _ = writeln!(out, "Description: {}", preset.description);
+    }
+    let _ = writeln!(out, "Provider:    {}", preset.agent_provider);
+    let _ = writeln!(out, "Model:       {}", preset.agent_model);
+
+    if preset.skills.is_empty() {
+        out.push_str("Skills:      (none)\n");
+    } else {
+        let _ = writeln!(out, "Skills:      {}", preset.skills.join(", "));
+    }
+
+    if preset.plugins.is_empty() {
+        out.push_str("Plugins:     (none)\n");
+    } else {
+        let _ = writeln!(out, "Plugins:     {}", preset.plugins.join(", "));
+    }
+
+    out.push_str("Permissions:\n");
+    out.push_str(&format_permissions(&preset.permissions));
+
+    if let Some(rules) = &preset.custom_rules {
+        out.push_str("Custom rules:\n");
+        for line in rules.lines() {
+            let _ = writeln!(out, "  {line}");
+        }
+    }
+
+    if !preset.environment.is_empty() {
+        out.push_str("Environment:\n");
+        let mut keys: Vec<&String> = preset.environment.keys().collect();
+        keys.sort();
+        for key in keys {
+            let _ = writeln!(out, "  {key}={}", preset.environment[key]);
+        }
+    }
+
+    out
+}
+
+fn format_permissions(perms: &PermissionSet) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "  file_write: {}", perms.file_write);
+    let _ = writeln!(s, "  shell:      {}", perms.shell);
+    let _ = writeln!(s, "  git:        {}", perms.git);
+    let _ = writeln!(s, "  network:    {}", perms.network);
+    let _ = writeln!(s, "  skip_all:   {}", perms.skip_all);
+    s
+}
+
+// --- Create ---
+
+fn cmd_create(
+    name: &str,
+    provider: Option<String>,
+    model: Option<String>,
+    description: Option<String>,
+) -> Result<()> {
+    if is_builtin_name(name) {
+        return Err(anyhow!(
+            "Cannot create preset '{name}': name is reserved for a built-in preset"
+        ));
+    }
+
+    let manager = PresetManager::new().context("Failed to initialize preset manager")?;
+    if manager.get(name).is_some() {
+        return Err(anyhow!("Preset '{name}' already exists"));
+    }
+
+    let preset = build_new_preset(name, provider, model, description);
+    manager
+        .save_preset(&preset)
+        .context("Failed to save new preset")?;
+
+    println!("Created preset '{name}'");
+    println!("  Provider: {}", preset.agent_provider);
+    println!("  Model:    {}", preset.agent_model);
+    if !preset.description.is_empty() {
+        println!("  Description: {}", preset.description);
+    }
+    Ok(())
+}
+
+fn build_new_preset(
+    name: &str,
+    provider: Option<String>,
+    model: Option<String>,
+    description: Option<String>,
+) -> RepositoryPreset {
+    let defaults = RepositoryPreset::default();
+    RepositoryPreset {
+        name: name.to_string(),
+        description: description.unwrap_or_default(),
+        agent_provider: provider.unwrap_or(defaults.agent_provider),
+        agent_model: model.unwrap_or(defaults.agent_model),
+        skills: Vec::new(),
+        plugins: Vec::new(),
+        permissions: PermissionSet::default(),
+        custom_rules: None,
+        environment: std::collections::HashMap::new(),
+    }
+}
+
+// --- Delete ---
+
+fn cmd_delete(name: &str) -> Result<()> {
+    if is_builtin_name(name) {
+        return Err(anyhow!(
+            "Cannot delete preset '{name}': built-in presets are immutable"
+        ));
+    }
+
+    let mut manager = PresetManager::new().context("Failed to initialize preset manager")?;
+    if manager.get(name).is_none() {
+        return Err(anyhow!("Preset '{name}' not found"));
+    }
+
+    manager.delete(name).context("Failed to delete preset")?;
+    println!("Deleted preset '{name}'");
+    Ok(())
+}
+
+// --- Apply ---
+
+fn cmd_apply(name: &str, cwd: &Path) -> Result<()> {
+    let manager = PresetManager::new().context("Failed to initialize preset manager")?;
+    let (preset, _builtin) =
+        resolve_preset(&manager, name).ok_or_else(|| anyhow!("Preset '{name}' not found"))?;
+
+    let target_path = apply_preset_to_dir(&preset, cwd)?;
+    println!("Applied preset '{name}' to {}", target_path.display());
+    Ok(())
+}
+
+fn apply_preset_to_dir(preset: &RepositoryPreset, cwd: &Path) -> Result<PathBuf> {
+    let dir = cwd.join(".agents-box");
+    fs::create_dir_all(&dir).context("Failed to create .agents-box directory")?;
+
+    let path = dir.join("preset.toml");
+    let content = toml::to_string_pretty(preset).context("Failed to serialize preset to TOML")?;
+    fs::write(&path, content).context("Failed to write preset.toml")?;
+    Ok(path)
+}
+
+// --- Helpers ---
+
+fn is_builtin_name(name: &str) -> bool {
+    create_default_presets().iter().any(|p| p.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // --- is_builtin_name ---
+
+    #[test]
+    fn test_is_builtin_name_matches_defaults() {
+        assert!(is_builtin_name("rust-backend"));
+        assert!(is_builtin_name("typescript-frontend"));
+        assert!(is_builtin_name("fast-iteration"));
+    }
+
+    #[test]
+    fn test_is_builtin_name_rejects_custom() {
+        assert!(!is_builtin_name("my-custom-preset"));
+        assert!(!is_builtin_name(""));
+        assert!(!is_builtin_name("Rust-Backend"));
+    }
+
+    // --- create_default_presets surface ---
+
+    #[test]
+    fn test_default_presets_contain_expected_names() {
+        let names: Vec<String> = create_default_presets()
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        assert!(names.contains(&"rust-backend".to_string()));
+        assert!(names.contains(&"typescript-frontend".to_string()));
+        assert!(names.contains(&"fast-iteration".to_string()));
+    }
+
+    // --- build_new_preset ---
+
+    #[test]
+    fn test_build_new_preset_uses_defaults_when_empty() {
+        let p = build_new_preset("myp", None, None, None);
+        assert_eq!(p.name, "myp");
+        assert_eq!(p.agent_provider, "claude");
+        assert_eq!(p.agent_model, "sonnet");
+        assert_eq!(p.description, "");
+        assert!(p.skills.is_empty());
+    }
+
+    #[test]
+    fn test_build_new_preset_respects_overrides() {
+        let p = build_new_preset(
+            "myp",
+            Some("codex".to_string()),
+            Some("opus".to_string()),
+            Some("hello".to_string()),
+        );
+        assert_eq!(p.agent_provider, "codex");
+        assert_eq!(p.agent_model, "opus");
+        assert_eq!(p.description, "hello");
+    }
+
+    // --- apply_preset_to_dir round trip ---
+
+    #[test]
+    fn test_apply_preset_writes_toml_file() {
+        let dir = tempdir().unwrap();
+        let preset = build_new_preset("scratch", None, None, Some("testing".to_string()));
+
+        let path = apply_preset_to_dir(&preset, dir.path()).unwrap();
+
+        assert!(path.ends_with(".agents-box/preset.toml"));
+        assert!(path.exists());
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("name = \"scratch\""));
+        assert!(content.contains("description = \"testing\""));
+    }
+
+    #[test]
+    fn test_apply_preset_round_trip_via_load_repo_preset() {
+        let dir = tempdir().unwrap();
+        let original = create_default_presets()
+            .into_iter()
+            .find(|p| p.name == "rust-backend")
+            .unwrap();
+
+        apply_preset_to_dir(&original, dir.path()).unwrap();
+
+        let loaded = PresetManager::load_repo_preset(dir.path())
+            .unwrap()
+            .expect("preset.toml should be loadable");
+        assert_eq!(loaded.name, "rust-backend");
+        assert_eq!(loaded.agent_provider, original.agent_provider);
+        assert_eq!(loaded.agent_model, original.agent_model);
+        assert_eq!(loaded.skills, original.skills);
+        assert_eq!(loaded.permissions.file_write, original.permissions.file_write);
+    }
+
+    #[test]
+    fn test_apply_preset_creates_agents_box_dir() {
+        let dir = tempdir().unwrap();
+        assert!(!dir.path().join(".agents-box").exists());
+
+        let preset = build_new_preset("scratch", None, None, None);
+        apply_preset_to_dir(&preset, dir.path()).unwrap();
+
+        assert!(dir.path().join(".agents-box").is_dir());
+        assert!(dir.path().join(".agents-box").join("preset.toml").is_file());
+    }
+
+    #[test]
+    fn test_apply_preset_overwrites_existing() {
+        let dir = tempdir().unwrap();
+
+        let first = build_new_preset("v1", None, None, Some("first".to_string()));
+        apply_preset_to_dir(&first, dir.path()).unwrap();
+
+        let second = build_new_preset("v2", None, None, Some("second".to_string()));
+        apply_preset_to_dir(&second, dir.path()).unwrap();
+
+        let loaded = PresetManager::load_repo_preset(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.name, "v2");
+        assert_eq!(loaded.description, "second");
+    }
+
+    // --- format_preset_text ---
+
+    #[test]
+    fn test_format_preset_text_mentions_builtin_tag() {
+        let preset = create_default_presets()
+            .into_iter()
+            .find(|p| p.name == "rust-backend")
+            .unwrap();
+        let text = format_preset_text(&preset, true);
+        assert!(text.contains("rust-backend"));
+        assert!(text.contains("built-in"));
+        assert!(text.contains("Provider:"));
+        assert!(text.contains("Model:"));
+        assert!(text.contains("Permissions:"));
+    }
+
+    #[test]
+    fn test_format_preset_text_custom_tag() {
+        let preset = build_new_preset("myp", None, None, Some("mine".to_string()));
+        let text = format_preset_text(&preset, false);
+        assert!(text.contains("custom"));
+        assert!(text.contains("mine"));
+    }
+
+    #[test]
+    fn test_format_preset_text_handles_empty_skills() {
+        let preset = build_new_preset("empty", None, None, None);
+        let text = format_preset_text(&preset, false);
+        assert!(text.contains("Skills:      (none)"));
+        assert!(text.contains("Plugins:     (none)"));
+    }
+
+    // --- format_permissions ---
+
+    #[test]
+    fn test_format_permissions_renders_all_fields() {
+        let perms = PermissionSet {
+            file_write: true,
+            shell: true,
+            git: true,
+            network: false,
+            skip_all: false,
+        };
+        let text = format_permissions(&perms);
+        assert!(text.contains("file_write: true"));
+        assert!(text.contains("shell:      true"));
+        assert!(text.contains("git:        true"));
+        assert!(text.contains("network:    false"));
+        assert!(text.contains("skip_all:   false"));
+    }
+
+    // --- PresetListEntry JSON serialization ---
+
+    #[test]
+    fn test_list_entry_json_schema() {
+        let entry = PresetListEntry {
+            name: "rust-backend".to_string(),
+            description: "desc".to_string(),
+            provider: "claude".to_string(),
+            model: "sonnet".to_string(),
+            builtin: true,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"name\":\"rust-backend\""));
+        assert!(json.contains("\"builtin\":true"));
+        assert!(json.contains("\"provider\":\"claude\""));
+    }
+
+    // --- to_list_entry ---
+
+    #[test]
+    fn test_to_list_entry_copies_fields() {
+        let preset = RepositoryPreset {
+            name: "n".to_string(),
+            description: "d".to_string(),
+            agent_provider: "codex".to_string(),
+            agent_model: "opus".to_string(),
+            skills: Vec::new(),
+            plugins: Vec::new(),
+            permissions: PermissionSet::default(),
+            custom_rules: None,
+            environment: std::collections::HashMap::new(),
+        };
+        let entry = to_list_entry(&preset, false);
+        assert_eq!(entry.name, "n");
+        assert_eq!(entry.description, "d");
+        assert_eq!(entry.provider, "codex");
+        assert_eq!(entry.model, "opus");
+        assert!(!entry.builtin);
+    }
+
+    // --- resolve_preset with built-ins (no manager interference) ---
+
+    #[test]
+    fn test_resolve_preset_finds_builtin() {
+        // PresetManager::new() loads real ~/.agents-in-a-box/presets,
+        // but resolve_preset checks built-ins first so this is stable.
+        if let Ok(manager) = PresetManager::new() {
+            let (preset, builtin) = resolve_preset(&manager, "rust-backend").unwrap();
+            assert!(builtin);
+            assert_eq!(preset.name, "rust-backend");
+        }
+    }
+
+    #[test]
+    fn test_resolve_preset_missing_returns_none() {
+        if let Ok(manager) = PresetManager::new() {
+            assert!(resolve_preset(&manager, "definitely-not-a-real-preset-xyz").is_none());
+        }
+    }
+}

--- a/ainb-tui/src/cli/recover.rs
+++ b/ainb-tui/src/cli/recover.rs
@@ -1,0 +1,882 @@
+// ABOUTME: CLI recover command - detect, list, resume, and clean up orphaned sessions
+//
+// Provides recovery tools for sessions that became disconnected:
+// - list:    Scan ~/.claude/agents/ for orphaned JSON files and
+//            ~/.agents-in-a-box/worktrees/by-session/ for broken symlinks.
+//            Cross-reference with SessionStore. Show metadata and age.
+// - resume:  Re-register an orphaned session in SessionStore if tmux is alive.
+// - cleanup: Kill tmux, remove worktree, remove metadata file. --force skips confirmation.
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use uuid::Uuid;
+
+use super::OutputFormat;
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+use crate::models::session::SessionAgentType;
+
+/// Subcommands for the recover command
+#[derive(clap::Subcommand)]
+pub enum RecoverCommands {
+    /// List orphaned sessions and broken worktree symlinks
+    List,
+    /// Resume an orphaned session by re-registering it in the session store
+    Resume {
+        /// Session ID, tmux name, or workspace name prefix
+        session: String,
+    },
+    /// Clean up orphaned sessions and broken worktrees
+    Cleanup {
+        /// Specific session to clean up (all if omitted)
+        session: Option<String>,
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        force: bool,
+    },
+}
+
+/// How an orphaned session was detected
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum OrphanSource {
+    /// Session in store but tmux is dead
+    StaleMetadata,
+    /// JSON file in ~/.claude/agents/ not tracked in store
+    AgentFile,
+    /// Broken or untracked symlink in worktrees/by-session/
+    BrokenSymlink,
+}
+
+impl std::fmt::Display for OrphanSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StaleMetadata => write!(f, "Stale Metadata"),
+            Self::AgentFile => write!(f, "Agent File"),
+            Self::BrokenSymlink => write!(f, "Broken Symlink"),
+        }
+    }
+}
+
+/// An orphaned session detected during recovery scan
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedSession {
+    /// Unique identifier (UUID string, tmux name, or file stem)
+    pub id: String,
+    /// How this orphan was detected
+    pub source: OrphanSource,
+    /// Tmux session name, if known
+    pub tmux_session_name: Option<String>,
+    /// Whether the tmux session is still alive
+    pub is_tmux_alive: bool,
+    /// Worktree path, if known
+    pub worktree_path: Option<String>,
+    /// Workspace name, if known
+    pub workspace_name: Option<String>,
+    /// When the session was created
+    pub created_at: Option<DateTime<Utc>>,
+    /// Path to the source file (agent JSON or symlink)
+    pub file_path: Option<String>,
+}
+
+/// Check if a tmux session exists by name
+fn tmux_session_exists(name: &str) -> bool {
+    Command::new("tmux")
+        .args(["has-session", "-t", name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Scan for orphaned sessions from all sources
+pub fn find_orphaned_sessions() -> Result<Vec<OrphanedSession>> {
+    let store = SessionStore::load();
+    let tracked_tmux: Vec<&str> = store.tracked_tmux_names();
+
+    let mut orphans = Vec::new();
+
+    // Source 1: Sessions in store whose tmux is dead
+    for metadata in store.sessions.values() {
+        if !tmux_session_exists(&metadata.tmux_session_name) {
+            orphans.push(OrphanedSession {
+                id: metadata.session_id.to_string(),
+                source: OrphanSource::StaleMetadata,
+                tmux_session_name: Some(metadata.tmux_session_name.clone()),
+                is_tmux_alive: false,
+                worktree_path: Some(metadata.worktree_path.display().to_string()),
+                workspace_name: Some(metadata.workspace_name.clone()),
+                created_at: Some(metadata.created_at),
+                file_path: Some(SessionStore::storage_path().display().to_string()),
+            });
+        }
+    }
+
+    // Source 2: JSON files in ~/.claude/agents/ not tracked in store
+    if let Ok(agent_orphans) = scan_agent_files(&tracked_tmux) {
+        orphans.extend(agent_orphans);
+    }
+
+    // Source 3: Broken/untracked symlinks in worktrees/by-session/
+    if let Ok(symlink_orphans) = scan_broken_symlinks(&store) {
+        orphans.extend(symlink_orphans);
+    }
+
+    // Deduplicate by id
+    orphans.sort_by(|a, b| a.id.cmp(&b.id));
+    orphans.dedup_by(|a, b| a.id == b.id);
+
+    Ok(orphans)
+}
+
+/// Scan ~/.claude/agents/ for JSON session files not in `SessionStore`
+fn scan_agent_files(tracked_tmux: &[&str]) -> Result<Vec<OrphanedSession>> {
+    let home = dirs::home_dir().context("No home directory")?;
+    let agents_dir = home.join(".claude").join("agents");
+
+    if !agents_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut orphans = Vec::new();
+
+    for entry in std::fs::read_dir(&agents_dir)?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        let file_stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
+
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+
+        let parsed = parse_agent_json(&content, &file_stem);
+
+        // Skip if already tracked in store
+        if let Some(ref tmux) = parsed.tmux_session_name {
+            if tracked_tmux.contains(&tmux.as_str()) {
+                continue;
+            }
+        }
+
+        let tmux_alive = parsed.tmux_session_name.as_deref().is_some_and(tmux_session_exists);
+
+        orphans.push(OrphanedSession {
+            id: parsed.session_id.unwrap_or(file_stem),
+            source: OrphanSource::AgentFile,
+            tmux_session_name: parsed.tmux_session_name,
+            is_tmux_alive: tmux_alive,
+            worktree_path: parsed.worktree_path,
+            workspace_name: parsed.workspace_name,
+            created_at: parsed.created_at,
+            file_path: Some(path.display().to_string()),
+        });
+    }
+
+    Ok(orphans)
+}
+
+/// Fields extracted from an agent JSON file
+struct ParsedAgentJson {
+    tmux_session_name: Option<String>,
+    workspace_name: Option<String>,
+    worktree_path: Option<String>,
+    created_at: Option<DateTime<Utc>>,
+    session_id: Option<String>,
+}
+
+/// Try to extract session info from an agent JSON file
+fn parse_agent_json(content: &str, file_stem: &str) -> ParsedAgentJson {
+    // Try parsing as SessionMetadata first
+    if let Ok(meta) = serde_json::from_str::<SessionMetadata>(content) {
+        return ParsedAgentJson {
+            tmux_session_name: Some(meta.tmux_session_name),
+            workspace_name: Some(meta.workspace_name),
+            worktree_path: Some(meta.worktree_path.display().to_string()),
+            created_at: Some(meta.created_at),
+            session_id: Some(meta.session_id.to_string()),
+        };
+    }
+
+    // Fallback: generic JSON with common field names
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(content) {
+        let tmux = val
+            .get("tmux_session_name")
+            .or_else(|| val.get("tmux_session"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let workspace = val
+            .get("workspace_name")
+            .or_else(|| val.get("workspace"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let worktree = val
+            .get("worktree_path")
+            .or_else(|| val.get("directory"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let session_id = val.get("session_id").and_then(|v| v.as_str()).map(String::from);
+
+        return ParsedAgentJson {
+            tmux_session_name: tmux,
+            workspace_name: workspace,
+            worktree_path: worktree,
+            created_at: None,
+            session_id,
+        };
+    }
+
+    // Unparseable — use file stem as ID
+    ParsedAgentJson {
+        tmux_session_name: None,
+        workspace_name: None,
+        worktree_path: None,
+        created_at: None,
+        session_id: Some(file_stem.to_string()),
+    }
+}
+
+/// Scan ~/.agents-in-a-box/worktrees/by-session/ for broken or untracked symlinks
+fn scan_broken_symlinks(store: &SessionStore) -> Result<Vec<OrphanedSession>> {
+    let home = dirs::home_dir().context("No home directory")?;
+    let by_session_dir = home.join(".agents-in-a-box").join("worktrees").join("by-session");
+
+    if !by_session_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut orphans = Vec::new();
+
+    for entry in std::fs::read_dir(&by_session_dir)?.flatten() {
+        let path = entry.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("").to_string();
+
+        if !path.is_symlink() {
+            continue;
+        }
+
+        // Check if this session is tracked in the store
+        if let Ok(uuid) = Uuid::parse_str(&name) {
+            let is_tracked = store.sessions.values().any(|m| m.session_id == uuid);
+            if is_tracked {
+                continue;
+            }
+        }
+
+        let target_exists = std::fs::metadata(&path).is_ok();
+        let target = std::fs::read_link(&path).ok().map(|t| t.display().to_string());
+
+        orphans.push(OrphanedSession {
+            id: name,
+            source: OrphanSource::BrokenSymlink,
+            tmux_session_name: None,
+            is_tmux_alive: false,
+            worktree_path: target,
+            workspace_name: None,
+            created_at: None,
+            file_path: Some(path.display().to_string()),
+        });
+
+        // If symlink target exists but session is untracked, still mark it
+        // (it's already added above regardless of target_exists)
+        let _ = target_exists;
+    }
+
+    Ok(orphans)
+}
+
+/// Execute the recover command, routing to the appropriate subcommand
+#[allow(clippy::unused_async)]
+pub async fn execute(command: RecoverCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        RecoverCommands::List => execute_list(format),
+        RecoverCommands::Resume { session } => execute_resume(&session),
+        RecoverCommands::Cleanup { session, force } => execute_cleanup(session.as_deref(), force),
+    }
+}
+
+/// List all orphaned sessions in text or JSON format
+fn execute_list(format: OutputFormat) -> Result<()> {
+    let orphans = find_orphaned_sessions()?;
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&orphans)
+                .context("Failed to serialize orphan list")?;
+            println!("{json}");
+        }
+        OutputFormat::Text => {
+            if orphans.is_empty() {
+                println!("No orphaned sessions found. Everything looks clean.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<36} {:<20} {:<8} {:<20} SOURCE",
+                "ID", "WORKSPACE", "ALIVE", "TMUX SESSION"
+            );
+            let separator = "-".repeat(100);
+            println!("{separator}");
+
+            for orphan in &orphans {
+                let alive_text = if orphan.is_tmux_alive {
+                    "\x1b[32myes\x1b[0m"
+                } else {
+                    "\x1b[31mno\x1b[0m"
+                };
+                let workspace = orphan.workspace_name.as_deref().unwrap_or("-");
+                let tmux = orphan.tmux_session_name.as_deref().unwrap_or("-");
+
+                println!(
+                    "{:<36} {:<20} {:<8} {:<20} {}",
+                    truncate(&orphan.id, 36),
+                    truncate(workspace, 20),
+                    alive_text,
+                    truncate(tmux, 20),
+                    orphan.source,
+                );
+            }
+
+            println!();
+            println!("Found {} orphaned session(s).", orphans.len());
+
+            let alive_count = orphans.iter().filter(|o| o.is_tmux_alive).count();
+            if alive_count > 0 {
+                println!("{alive_count} session(s) still have a live tmux and can be resumed.");
+                println!("  Run: ainb recover resume <ID>");
+            }
+            println!("  Run: ainb recover cleanup [--force] to clean up.");
+        }
+    }
+
+    Ok(())
+}
+
+/// Resume an orphaned session by re-registering it in the `SessionStore`
+fn execute_resume(session: &str) -> Result<()> {
+    let orphans = find_orphaned_sessions()?;
+    let matched = find_orphan(session, &orphans)?;
+
+    if !matched.is_tmux_alive {
+        return Err(anyhow!(
+            "Tmux session for '{}' is not alive. Cannot resume.\n\
+             Use 'ainb recover cleanup {}' to remove it instead.",
+            matched.id,
+            matched.id,
+        ));
+    }
+
+    let tmux_name = matched.tmux_session_name.as_ref().ok_or_else(|| {
+        anyhow!(
+            "Orphan '{}' has no tmux session name — cannot resume",
+            matched.id
+        )
+    })?;
+
+    let workspace = matched.workspace_name.clone().unwrap_or_else(|| tmux_name.clone());
+
+    let worktree_path = matched
+        .worktree_path
+        .as_ref()
+        .map_or_else(|| PathBuf::from("/tmp/unknown"), PathBuf::from);
+
+    let session_id = Uuid::parse_str(&matched.id).unwrap_or_else(|_| Uuid::new_v4());
+
+    let metadata = SessionMetadata {
+        session_id,
+        tmux_session_name: tmux_name.clone(),
+        worktree_path,
+        workspace_name: workspace.clone(),
+        created_at: matched.created_at.unwrap_or_else(Utc::now),
+        agent_type: SessionAgentType::default(),
+    };
+
+    let mut store = SessionStore::load();
+    store.upsert(metadata);
+    store.save().context("Failed to save session store")?;
+
+    let short_id = &matched.id[..8.min(matched.id.len())];
+    println!("Resumed session '{workspace}' (tmux: {tmux_name}).");
+    println!("  Attach: ainb attach {short_id}");
+
+    Ok(())
+}
+
+/// Clean up orphaned sessions: kill tmux, remove worktree, remove metadata
+#[allow(clippy::if_not_else)]
+fn execute_cleanup(session: Option<&str>, force: bool) -> Result<()> {
+    let orphans = find_orphaned_sessions()?;
+
+    if orphans.is_empty() {
+        println!("No orphaned sessions to clean up.");
+        return Ok(());
+    }
+
+    let targets: Vec<&OrphanedSession> = if let Some(name) = session {
+        let matched = find_orphan(name, &orphans)?;
+        vec![matched]
+    } else {
+        orphans.iter().collect()
+    };
+
+    if targets.is_empty() {
+        println!("No matching orphans found.");
+        return Ok(());
+    }
+
+    // Show what will be cleaned and prompt for confirmation
+    if !force {
+        println!("Will clean up {} orphaned session(s):", targets.len());
+        for t in &targets {
+            let label =
+                t.workspace_name.as_deref().or(t.tmux_session_name.as_deref()).unwrap_or(&t.id);
+            let alive_tag = if t.is_tmux_alive {
+                " (tmux alive — will be killed)"
+            } else {
+                ""
+            };
+            println!("  - {label}{alive_tag}");
+            if let Some(ref path) = t.worktree_path {
+                println!("    worktree: {path}");
+            }
+        }
+        print!("\nProceed? [y/N] ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let mut cleaned = 0u32;
+    let mut errors = 0u32;
+
+    for target in &targets {
+        match cleanup_single_orphan(target) {
+            Ok(()) => {
+                cleaned += 1;
+                let label = target.workspace_name.as_deref().unwrap_or(&target.id);
+                println!("  Cleaned: {label}");
+            }
+            Err(e) => {
+                errors += 1;
+                eprintln!("  Error cleaning '{}': {e}", target.id);
+            }
+        }
+    }
+
+    println!();
+    println!("Cleanup complete: {cleaned} cleaned, {errors} error(s).");
+    Ok(())
+}
+
+/// Clean up a single orphaned session: kill tmux, remove worktree, remove files
+fn cleanup_single_orphan(orphan: &OrphanedSession) -> Result<()> {
+    // 1. Kill tmux session if alive
+    if orphan.is_tmux_alive {
+        if let Some(ref tmux_name) = orphan.tmux_session_name {
+            let _ = Command::new("tmux").args(["kill-session", "-t", tmux_name]).output();
+        }
+    }
+
+    // 2. Remove worktree via WorktreeManager if session ID is a valid UUID
+    if let Ok(uuid) = Uuid::parse_str(&orphan.id) {
+        if let Ok(wm) = crate::git::WorktreeManager::new() {
+            // Ignore errors — worktree may already be gone
+            let _ = wm.remove_worktree(uuid);
+        }
+    }
+
+    // 3. Remove the source file (agent JSON or broken symlink)
+    if let Some(ref file_path) = orphan.file_path {
+        let p = PathBuf::from(file_path);
+        // For the session store itself, don't delete the whole file — just remove the entry
+        if p.file_name().and_then(|n| n.to_str()) == Some("sessions.json") {
+            // Handled below in step 4
+        } else if p.exists() || p.is_symlink() {
+            std::fs::remove_file(&p)
+                .with_context(|| format!("Failed to remove {}", p.display()))?;
+        }
+    }
+
+    // 4. Remove from session store if present
+    let mut store = SessionStore::load();
+    let mut changed = false;
+
+    if let Ok(uuid) = Uuid::parse_str(&orphan.id) {
+        let before = store.sessions.len();
+        store.remove_by_session_id(uuid);
+        changed = store.sessions.len() != before;
+    }
+
+    if let Some(ref tmux_name) = orphan.tmux_session_name {
+        if store.sessions.remove(tmux_name).is_some() {
+            changed = true;
+        }
+    }
+
+    if changed {
+        store.save().context("Failed to save session store")?;
+    }
+
+    Ok(())
+}
+
+/// Find a matching orphan by ID, tmux name, or workspace name prefix
+fn find_orphan<'a>(needle: &str, orphans: &'a [OrphanedSession]) -> Result<&'a OrphanedSession> {
+    let needle_lower = needle.to_lowercase();
+
+    // Exact ID match
+    if let Some(o) = orphans.iter().find(|o| o.id.to_lowercase() == needle_lower) {
+        return Ok(o);
+    }
+
+    // Prefix match on ID
+    let prefix_matches: Vec<&OrphanedSession> = orphans
+        .iter()
+        .filter(|o| o.id.to_lowercase().starts_with(&needle_lower))
+        .collect();
+
+    match prefix_matches.len() {
+        1 => return Ok(prefix_matches[0]),
+        n if n > 1 => {
+            let ids: Vec<&str> = prefix_matches.iter().map(|o| o.id.as_str()).collect();
+            return Err(anyhow!(
+                "Ambiguous match for '{needle}'. Matches:\n  {}",
+                ids.join("\n  ")
+            ));
+        }
+        _ => {}
+    }
+
+    // Match on tmux session name
+    let tmux_matches: Vec<&OrphanedSession> = orphans
+        .iter()
+        .filter(|o| {
+            o.tmux_session_name
+                .as_deref()
+                .is_some_and(|t| t.to_lowercase().starts_with(&needle_lower))
+        })
+        .collect();
+
+    if tmux_matches.len() == 1 {
+        return Ok(tmux_matches[0]);
+    }
+
+    // Match on workspace name
+    let ws_matches: Vec<&OrphanedSession> = orphans
+        .iter()
+        .filter(|o| {
+            o.workspace_name
+                .as_deref()
+                .is_some_and(|w| w.to_lowercase().starts_with(&needle_lower))
+        })
+        .collect();
+
+    if ws_matches.len() == 1 {
+        return Ok(ws_matches[0]);
+    }
+
+    Err(anyhow!(
+        "No orphaned session found matching '{needle}'.\n\
+         Run 'ainb recover list' to see available orphans."
+    ))
+}
+
+/// Truncate a string to fit in the given width
+fn truncate(s: &str, max_len: usize) -> String {
+    if max_len <= 3 {
+        return ".".repeat(max_len);
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_len {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interactive::session_manager::SessionMetadata;
+    use crate::models::session::SessionAgentType;
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn create_test_session(tmux_name: &str, workspace: &str) -> SessionMetadata {
+        SessionMetadata {
+            session_id: Uuid::new_v4(),
+            tmux_session_name: tmux_name.to_string(),
+            worktree_path: PathBuf::from(format!("/tmp/test-worktree-{tmux_name}")),
+            workspace_name: workspace.to_string(),
+            created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
+        }
+    }
+
+    fn make_test_orphan(id: &str, tmux: &str, workspace: &str) -> OrphanedSession {
+        OrphanedSession {
+            id: id.to_string(),
+            source: OrphanSource::AgentFile,
+            tmux_session_name: Some(tmux.to_string()),
+            is_tmux_alive: false,
+            worktree_path: None,
+            workspace_name: Some(workspace.to_string()),
+            created_at: None,
+            file_path: None,
+        }
+    }
+
+    #[test]
+    fn test_orphan_detection_stale_metadata() {
+        let mut store = SessionStore::default();
+        let session =
+            create_test_session("tmux_nonexistent_test_session_xyzzy_42", "ghost-workspace");
+        store.sessions.insert(session.tmux_session_name.clone(), session.clone());
+
+        let alive = tmux_session_exists(&session.tmux_session_name);
+        assert!(!alive, "Test tmux session should not exist on the host");
+
+        let orphan = OrphanedSession {
+            id: session.session_id.to_string(),
+            source: OrphanSource::StaleMetadata,
+            tmux_session_name: Some(session.tmux_session_name.clone()),
+            is_tmux_alive: alive,
+            worktree_path: Some(session.worktree_path.display().to_string()),
+            workspace_name: Some(session.workspace_name.clone()),
+            created_at: Some(session.created_at),
+            file_path: None,
+        };
+
+        assert!(!orphan.is_tmux_alive);
+        assert!(matches!(orphan.source, OrphanSource::StaleMetadata));
+    }
+
+    #[test]
+    fn test_orphan_source_serialization() {
+        let orphan = OrphanedSession {
+            id: "test-id".to_string(),
+            source: OrphanSource::StaleMetadata,
+            tmux_session_name: Some("tmux_test".to_string()),
+            is_tmux_alive: false,
+            worktree_path: Some("/tmp/test-worktree".to_string()),
+            workspace_name: Some("test-ws".to_string()),
+            created_at: None,
+            file_path: None,
+        };
+
+        let json = serde_json::to_value(&orphan).expect("Serialization should succeed");
+        assert_eq!(json["source"], "StaleMetadata");
+        assert_eq!(json["is_tmux_alive"], false);
+
+        let orphan_agent = OrphanedSession {
+            source: OrphanSource::AgentFile,
+            ..orphan.clone()
+        };
+        let json2 = serde_json::to_value(&orphan_agent).unwrap();
+        assert_eq!(json2["source"], "AgentFile");
+
+        let orphan_sym = OrphanedSession {
+            source: OrphanSource::BrokenSymlink,
+            ..orphan
+        };
+        let json3 = serde_json::to_value(&orphan_sym).unwrap();
+        assert_eq!(json3["source"], "BrokenSymlink");
+    }
+
+    #[test]
+    fn test_find_orphan_exact_id() {
+        let orphans = vec![
+            make_test_orphan("abc123", "tmux_a", "workspace-a"),
+            make_test_orphan("def456", "tmux_b", "workspace-b"),
+        ];
+
+        let found = find_orphan("abc123", &orphans).unwrap();
+        assert_eq!(found.id, "abc123");
+    }
+
+    #[test]
+    fn test_find_orphan_prefix() {
+        let orphans = vec![
+            make_test_orphan("abc12345-full-id", "tmux_a", "workspace-a"),
+            make_test_orphan("def45678-full-id", "tmux_b", "workspace-b"),
+        ];
+
+        let found = find_orphan("abc12", &orphans).unwrap();
+        assert_eq!(found.id, "abc12345-full-id");
+    }
+
+    #[test]
+    fn test_find_orphan_ambiguous() {
+        let orphans = vec![
+            make_test_orphan("abc123-one", "tmux_a", "ws-a"),
+            make_test_orphan("abc123-two", "tmux_b", "ws-b"),
+        ];
+
+        let result = find_orphan("abc123", &orphans);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Ambiguous"));
+    }
+
+    #[test]
+    fn test_find_orphan_by_tmux_name() {
+        let orphans = vec![
+            make_test_orphan("id1", "tmux_project-alpha", "ws"),
+            make_test_orphan("id2", "tmux_project-beta", "ws2"),
+        ];
+
+        let found = find_orphan("tmux_project-a", &orphans).unwrap();
+        assert_eq!(found.id, "id1");
+    }
+
+    #[test]
+    fn test_find_orphan_by_workspace() {
+        let orphans = vec![
+            make_test_orphan("id1", "tmux_a", "my-cool-project"),
+            make_test_orphan("id2", "tmux_b", "another-project"),
+        ];
+
+        let found = find_orphan("my-cool", &orphans).unwrap();
+        assert_eq!(found.id, "id1");
+    }
+
+    #[test]
+    fn test_find_orphan_not_found() {
+        let orphans = vec![make_test_orphan("abc", "tmux_a", "ws-a")];
+
+        let result = find_orphan("nonexistent", &orphans);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No orphaned session"));
+    }
+
+    #[test]
+    fn test_parse_agent_json_session_metadata() {
+        let json = r#"{
+            "session_id": "12345678-1234-1234-1234-123456789abc",
+            "tmux_session_name": "tmux_test",
+            "worktree_path": "/tmp/wt",
+            "workspace_name": "test-ws",
+            "created_at": "2026-01-01T00:00:00Z"
+        }"#;
+
+        let parsed = parse_agent_json(json, "fallback");
+
+        assert_eq!(parsed.tmux_session_name.unwrap(), "tmux_test");
+        assert_eq!(parsed.workspace_name.unwrap(), "test-ws");
+        assert_eq!(parsed.worktree_path.unwrap(), "/tmp/wt");
+        assert!(parsed.created_at.is_some());
+        assert_eq!(
+            parsed.session_id.unwrap(),
+            "12345678-1234-1234-1234-123456789abc"
+        );
+    }
+
+    #[test]
+    fn test_parse_agent_json_generic_fields() {
+        let json = r#"{
+            "tmux_session": "tmux_generic",
+            "workspace": "generic-ws",
+            "directory": "/home/user/project"
+        }"#;
+
+        let parsed = parse_agent_json(json, "fallback-id");
+
+        assert_eq!(parsed.tmux_session_name.unwrap(), "tmux_generic");
+        assert_eq!(parsed.workspace_name.unwrap(), "generic-ws");
+        assert_eq!(parsed.worktree_path.unwrap(), "/home/user/project");
+        assert!(parsed.created_at.is_none());
+    }
+
+    #[test]
+    fn test_parse_agent_json_invalid() {
+        let parsed = parse_agent_json("not json at all", "my-file");
+
+        assert!(parsed.tmux_session_name.is_none());
+        assert!(parsed.workspace_name.is_none());
+        assert!(parsed.worktree_path.is_none());
+        assert!(parsed.created_at.is_none());
+        assert_eq!(parsed.session_id.unwrap(), "my-file");
+    }
+
+    #[test]
+    fn test_find_orphans_empty_store() {
+        let store = SessionStore::default();
+        assert!(store.sessions.is_empty());
+
+        let mut orphans = Vec::new();
+        for metadata in store.sessions.values() {
+            let alive = tmux_session_exists(&metadata.tmux_session_name);
+            if !alive {
+                orphans.push(OrphanedSession {
+                    id: metadata.session_id.to_string(),
+                    source: OrphanSource::StaleMetadata,
+                    tmux_session_name: Some(metadata.tmux_session_name.clone()),
+                    is_tmux_alive: false,
+                    worktree_path: Some(metadata.worktree_path.display().to_string()),
+                    workspace_name: Some(metadata.workspace_name.clone()),
+                    created_at: Some(metadata.created_at),
+                    file_path: None,
+                });
+            }
+        }
+
+        assert!(orphans.is_empty(), "Empty store should produce no orphans");
+    }
+
+    #[test]
+    fn test_tmux_session_exists_nonexistent() {
+        assert!(!tmux_session_exists(
+            "__ainb_test_impossible_session_name_99999__"
+        ));
+    }
+
+    #[test]
+    fn test_orphan_source_display() {
+        assert_eq!(OrphanSource::StaleMetadata.to_string(), "Stale Metadata");
+        assert_eq!(OrphanSource::AgentFile.to_string(), "Agent File");
+        assert_eq!(OrphanSource::BrokenSymlink.to_string(), "Broken Symlink");
+    }
+
+    #[test]
+    fn test_truncate_short() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long() {
+        assert_eq!(truncate("hello world foo", 10), "hello w...");
+    }
+
+    #[test]
+    fn test_truncate_exact() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_orphaned_session_clone() {
+        let orphan = OrphanedSession {
+            id: "clone-test-id".to_string(),
+            source: OrphanSource::StaleMetadata,
+            tmux_session_name: Some("tmux_clone".to_string()),
+            is_tmux_alive: false,
+            worktree_path: Some("/tmp/clone-test".to_string()),
+            workspace_name: Some("clone-ws".to_string()),
+            created_at: None,
+            file_path: None,
+        };
+
+        let cloned = orphan.clone();
+        assert_eq!(cloned.id, "clone-test-id");
+        assert!(!cloned.is_tmux_alive);
+        assert_eq!(cloned.worktree_path, Some("/tmp/clone-test".to_string()));
+    }
+}

--- a/ainb-tui/src/cli/run.rs
+++ b/ainb-tui/src/cli/run.rs
@@ -1,0 +1,357 @@
+// ABOUTME: CLI run command - spawn a new AI coding session
+//
+// Creates a new session with:
+// - Optional git worktree for isolation
+// - Tmux session running Claude CLI
+// - Session metadata persisted for TUI compatibility
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::path::PathBuf;
+use tokio::process::Command;
+use tokio::time::{sleep, Duration};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use super::RunArgs;
+use crate::git::worktree_manager::WorktreeManager;
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+use crate::models::ClaudeModel;
+use crate::tmux::TmuxSession;
+
+/// Execute the run command
+pub async fn execute(args: RunArgs) -> Result<()> {
+    // Step 1: Resolve repository path
+    let repo_path = resolve_repo_path(&args).await?;
+    info!("Using repository: {}", repo_path.display());
+
+    // Step 2: Determine workspace name and working directory
+    let workspace_name = repo_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("workspace")
+        .to_string();
+
+    let work_dir: PathBuf;
+    let branch_name: String;
+    let session_id = Uuid::new_v4();
+
+    // Step 3: Create worktree if requested
+    if args.worktree || args.create_branch.is_some() {
+        let worktree_manager = WorktreeManager::new()
+            .context("Failed to initialize worktree manager")?;
+
+        let branch = args.create_branch.clone().unwrap_or_else(|| {
+            format!("ainb/session-{}", &session_id.to_string()[..8])
+        });
+
+        info!("Creating worktree for branch: {}", branch);
+
+        let worktree_info = worktree_manager
+            .create_worktree(session_id, &repo_path, &branch, None)
+            .context("Failed to create worktree")?;
+
+        work_dir = worktree_info.path;
+        branch_name = branch;
+
+        println!("Created worktree at: {}", work_dir.display());
+    } else {
+        work_dir = repo_path.clone();
+        branch_name = get_current_branch(&repo_path).unwrap_or_else(|| "main".to_string());
+    }
+
+    // Step 4: Generate session name
+    let session_name = args.name.clone().unwrap_or_else(|| {
+        let short_id = &session_id.to_string()[..8];
+        format!("{}-{}", workspace_name, short_id)
+    });
+
+    // Step 5: Parse model
+    let model = parse_model(&args.model);
+
+    // Step 6: Build Claude command
+    let claude_cmd = build_claude_command(&args, model);
+
+    // Step 7: Create tmux session
+    let mut tmux = TmuxSession::new(session_name.clone(), claude_cmd.clone());
+    tmux.start(&work_dir).await.context("Failed to start tmux session")?;
+
+    let tmux_name = tmux.name().to_string();
+    info!("Started tmux session: {}", tmux_name);
+
+    // Step 8: Send initial prompt if provided
+    if let Some(ref prompt) = args.prompt {
+        info!("Sending initial prompt after 2 second delay...");
+        sleep(Duration::from_secs(2)).await;
+        send_prompt_to_tmux(&tmux_name, prompt).await?;
+    }
+
+    // Step 9: Save session to SessionStore (TUI-compatible format)
+    let metadata = SessionMetadata {
+        session_id,
+        tmux_session_name: tmux_name.clone(),
+        worktree_path: work_dir.clone(),
+        workspace_name: workspace_name.clone(),
+        created_at: Utc::now(),
+    };
+
+    let mut store = SessionStore::load();
+    store.upsert(metadata);
+    store.save().context("Failed to save session metadata")?;
+
+    info!("Saved session metadata for TUI discovery");
+
+    // Step 10: Print session info
+    println!();
+    println!("Session created successfully!");
+    println!("  Session ID:   {}", session_id);
+    println!("  Tmux Session: {}", tmux_name);
+    println!("  Working Dir:  {}", work_dir.display());
+    println!("  Branch:       {}", branch_name);
+    println!("  Model:        {}", model.map(|m| m.display_name()).unwrap_or("default"));
+    println!();
+    println!("To attach to this session:");
+    println!("  tmux attach -t {}", tmux_name);
+    println!();
+    println!("Or use:");
+    println!("  ainb attach {}", session_name);
+    println!();
+
+    // Step 11: Attach if requested
+    if args.attach || args.interactive {
+        println!("Attaching to session...");
+        attach_to_session(&tmux_name)?;
+    }
+
+    Ok(())
+}
+
+/// Resolve the repository path from args or current directory
+async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
+    // Priority: --repo > --remote-repo > current directory
+    if let Some(ref repo) = args.repo {
+        let path = if repo.is_absolute() {
+            repo.clone()
+        } else {
+            std::env::current_dir()?.join(repo)
+        };
+
+        if !path.exists() {
+            anyhow::bail!("Repository path does not exist: {}", path.display());
+        }
+
+        return Ok(path.canonicalize()?);
+    }
+
+    if let Some(ref remote) = args.remote_repo {
+        // Clone or fetch remote repository
+        return clone_remote_repo(remote).await;
+    }
+
+    // Use current directory
+    let current_dir = std::env::current_dir()?;
+
+    // Verify it's a git repository
+    if !current_dir.join(".git").exists() {
+        anyhow::bail!(
+            "Current directory is not a git repository. Use --repo or --remote-repo to specify one."
+        );
+    }
+
+    Ok(current_dir)
+}
+
+/// Clone a remote repository to a local cache directory
+async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
+    // Normalize remote URL
+    let url = if remote.starts_with("http") || remote.starts_with("git@") {
+        remote.to_string()
+    } else {
+        // Assume GitHub shorthand: owner/repo
+        format!("https://github.com/{}.git", remote)
+    };
+
+    // Extract repo name for cache directory
+    let repo_name = url
+        .trim_end_matches(".git")
+        .rsplit('/')
+        .next()
+        .unwrap_or("repo");
+
+    let cache_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+        .join(".agents-in-a-box")
+        .join("repo-cache");
+
+    std::fs::create_dir_all(&cache_dir)?;
+
+    let repo_path = cache_dir.join(repo_name);
+
+    if repo_path.exists() {
+        info!("Repository already cached, fetching updates...");
+        let output = Command::new("git")
+            .current_dir(&repo_path)
+            .args(["fetch", "--all"])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            warn!(
+                "Failed to fetch updates: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    } else {
+        println!("Cloning {}...", url);
+        let output = Command::new("git")
+            .args(["clone", &url, repo_path.to_str().unwrap()])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "Failed to clone repository: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    Ok(repo_path)
+}
+
+/// Get the current branch name from a repository
+fn get_current_branch(repo_path: &PathBuf) -> Option<String> {
+    use git2::Repository;
+
+    let repo = Repository::open(repo_path).ok()?;
+    let head = repo.head().ok()?;
+
+    if head.is_branch() {
+        head.shorthand().map(|s| s.to_string())
+    } else {
+        head.target().map(|oid| oid.to_string()[..8].to_string())
+    }
+}
+
+/// Parse model string to ClaudeModel enum
+fn parse_model(model_str: &str) -> Option<ClaudeModel> {
+    match model_str.to_lowercase().as_str() {
+        "sonnet" | "claude-sonnet" | "claude-3-sonnet" => Some(ClaudeModel::Sonnet),
+        "opus" | "claude-opus" | "claude-3-opus" => Some(ClaudeModel::Opus),
+        "haiku" | "claude-haiku" | "claude-3-haiku" => Some(ClaudeModel::Haiku),
+        _ => Some(ClaudeModel::Sonnet), // Default to Sonnet
+    }
+}
+
+/// Build the Claude CLI command with appropriate flags
+fn build_claude_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
+    let mut cmd_parts = vec!["claude".to_string()];
+
+    // Add model flag if specified
+    if let Some(m) = model {
+        cmd_parts.push("--model".to_string());
+        cmd_parts.push(m.cli_value().to_string());
+    }
+
+    // Add permission skip flag (always enabled for CLI usage)
+    if args.dangerously_skip_permissions {
+        cmd_parts.push("--dangerously-skip-permissions".to_string());
+    }
+
+    cmd_parts.join(" ")
+}
+
+/// Send a prompt to the tmux session
+async fn send_prompt_to_tmux(session_name: &str, prompt: &str) -> Result<()> {
+    // Target pane explicitly
+    let target = format!("{}:0", session_name);
+
+    // Send the prompt text
+    let output = Command::new("tmux")
+        .args(["send-keys", "-t", &target, prompt, "C-m"])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        warn!(
+            "Failed to send prompt: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    } else {
+        info!("Sent initial prompt to session");
+    }
+
+    Ok(())
+}
+
+/// Attach to a tmux session (replaces current process)
+fn attach_to_session(session_name: &str) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    // This replaces the current process with tmux attach
+    let err = std::process::Command::new("tmux")
+        .args(["attach-session", "-t", session_name])
+        .exec();
+
+    // If exec returns, it means it failed
+    anyhow::bail!("Failed to attach to session: {}", err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_model() {
+        assert_eq!(parse_model("sonnet"), Some(ClaudeModel::Sonnet));
+        assert_eq!(parse_model("SONNET"), Some(ClaudeModel::Sonnet));
+        assert_eq!(parse_model("opus"), Some(ClaudeModel::Opus));
+        assert_eq!(parse_model("haiku"), Some(ClaudeModel::Haiku));
+        assert_eq!(parse_model("claude-sonnet"), Some(ClaudeModel::Sonnet));
+        assert_eq!(parse_model("unknown"), Some(ClaudeModel::Sonnet)); // Default
+    }
+
+    #[test]
+    fn test_build_claude_command() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "claude".to_string(),
+            model: "sonnet".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: true,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_claude_command(&args, Some(ClaudeModel::Sonnet));
+        assert!(cmd.contains("claude"));
+        assert!(cmd.contains("--model sonnet"));
+        assert!(cmd.contains("--dangerously-skip-permissions"));
+    }
+
+    #[test]
+    fn test_build_claude_command_minimal() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "claude".to_string(),
+            model: "opus".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_claude_command(&args, Some(ClaudeModel::Opus));
+        assert!(cmd.contains("claude"));
+        assert!(cmd.contains("--model opus"));
+        assert!(!cmd.contains("--dangerously-skip-permissions"));
+    }
+}

--- a/ainb-tui/src/cli/run.rs
+++ b/ainb-tui/src/cli/run.rs
@@ -24,7 +24,7 @@ use crate::tmux::TmuxSession;
 /// Execute the run command
 pub async fn execute(args: RunArgs) -> Result<()> {
     // Step 0: Validate provider CLI is installed
-    let provider = CliProvider::from_str(&args.tool);
+    let provider = args.tool.to_cli_provider();
     validate_provider_installed(&provider)?;
 
     // Step 1: Resolve repository path
@@ -93,7 +93,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     }
 
     // Step 9: Save session to SessionStore (TUI-compatible format)
-    let agent_type = match CliProvider::from_str(&args.tool) {
+    let agent_type = match args.tool.to_cli_provider() {
         CliProvider::Claude => SessionAgentType::Claude,
         CliProvider::Codex => SessionAgentType::Codex,
         CliProvider::Gemini => SessionAgentType::Gemini,
@@ -289,7 +289,7 @@ fn validate_provider_installed(provider: &CliProvider) -> Result<()> {
 
 /// Build the agent CLI command with appropriate flags for the selected provider
 fn build_agent_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
-    let provider = CliProvider::from_str(&args.tool);
+    let provider = args.tool.to_cli_provider();
     let mut cmd_parts = vec![provider.command().to_string()];
 
     // Add model flag (Claude-only)
@@ -347,6 +347,7 @@ fn attach_to_session(session_name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::Tool;
 
     #[test]
     fn test_parse_model() {
@@ -365,7 +366,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "claude".to_string(),
+            tool: Tool::Claude,
             model: "sonnet".to_string(),
             prompt: None,
             attach: false,
@@ -387,7 +388,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "claude".to_string(),
+            tool: Tool::Claude,
             model: "opus".to_string(),
             prompt: None,
             attach: false,
@@ -409,7 +410,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "codex".to_string(),
+            tool: Tool::Codex,
             model: "sonnet".to_string(),
             prompt: None,
             attach: false,
@@ -430,7 +431,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "codex".to_string(),
+            tool: Tool::Codex,
             model: "sonnet".to_string(),
             prompt: None,
             attach: false,
@@ -459,7 +460,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "gemini".to_string(),
+            tool: Tool::Gemini,
             model: "sonnet".to_string(),
             prompt: None,
             attach: false,
@@ -480,7 +481,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "copilot".to_string(),
+            tool: Tool::Copilot,
             model: "sonnet".to_string(),
             prompt: None,
             attach: false,
@@ -500,7 +501,7 @@ mod tests {
             repo: None,
             create_branch: None,
             worktree: false,
-            tool: "copilot".to_string(),
+            tool: Tool::Copilot,
             model: "sonnet".to_string(),
             prompt: None,
             attach: false,

--- a/ainb-tui/src/cli/run.rs
+++ b/ainb-tui/src/cli/run.rs
@@ -14,13 +14,19 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::RunArgs;
+use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{SessionMetadata, SessionStore};
 use crate::models::ClaudeModel;
+use crate::models::session::SessionAgentType;
 use crate::tmux::TmuxSession;
 
 /// Execute the run command
 pub async fn execute(args: RunArgs) -> Result<()> {
+    // Step 0: Validate provider CLI is installed
+    let provider = CliProvider::from_str(&args.tool);
+    validate_provider_installed(&provider)?;
+
     // Step 1: Resolve repository path
     let repo_path = resolve_repo_path(&args).await?;
     info!("Using repository: {}", repo_path.display());
@@ -63,14 +69,14 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     // Step 4: Generate session name
     let session_name = args.name.clone().unwrap_or_else(|| {
         let short_id = &session_id.to_string()[..8];
-        format!("{}-{}", workspace_name, short_id)
+        format!("{workspace_name}-{short_id}")
     });
 
     // Step 5: Parse model
     let model = parse_model(&args.model);
 
     // Step 6: Build Claude command
-    let claude_cmd = build_claude_command(&args, model);
+    let claude_cmd = build_agent_command(&args, Some(model));
 
     // Step 7: Create tmux session
     let mut tmux = TmuxSession::new(session_name.clone(), claude_cmd.clone());
@@ -87,12 +93,20 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     }
 
     // Step 9: Save session to SessionStore (TUI-compatible format)
+    let agent_type = match CliProvider::from_str(&args.tool) {
+        CliProvider::Claude => SessionAgentType::Claude,
+        CliProvider::Codex => SessionAgentType::Codex,
+        CliProvider::Gemini => SessionAgentType::Gemini,
+        CliProvider::Copilot => SessionAgentType::Copilot,
+    };
+
     let metadata = SessionMetadata {
         session_id,
         tmux_session_name: tmux_name.clone(),
         worktree_path: work_dir.clone(),
         workspace_name: workspace_name.clone(),
         created_at: Utc::now(),
+        agent_type,
     };
 
     let mut store = SessionStore::load();
@@ -104,17 +118,17 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     // Step 10: Print session info
     println!();
     println!("Session created successfully!");
-    println!("  Session ID:   {}", session_id);
-    println!("  Tmux Session: {}", tmux_name);
+    println!("  Session ID:   {session_id}");
+    println!("  Tmux Session: {tmux_name}");
     println!("  Working Dir:  {}", work_dir.display());
-    println!("  Branch:       {}", branch_name);
-    println!("  Model:        {}", model.map(|m| m.display_name()).unwrap_or("default"));
+    println!("  Branch:       {branch_name}");
+    println!("  Model:        {}", model.display_name());
     println!();
     println!("To attach to this session:");
-    println!("  tmux attach -t {}", tmux_name);
+    println!("  tmux attach -t {tmux_name}");
     println!();
     println!("Or use:");
-    println!("  ainb attach {}", session_name);
+    println!("  ainb attach {session_name}");
     println!();
 
     // Step 11: Attach if requested
@@ -168,7 +182,7 @@ async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
         remote.to_string()
     } else {
         // Assume GitHub shorthand: owner/repo
-        format!("https://github.com/{}.git", remote)
+        format!("https://github.com/{remote}.git")
     };
 
     // Extract repo name for cache directory (sanitized to prevent path traversal)
@@ -178,8 +192,7 @@ async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
         .next()
         .unwrap_or("repo")
         .replace("..", "")
-        .replace('/', "-")
-        .replace('\\', "-");
+        .replace(['/', '\\'], "-");
 
     // Validate repo name is safe
     let repo_name = if repo_name.is_empty() || repo_name == "." {
@@ -212,7 +225,7 @@ async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
             );
         }
     } else {
-        println!("Cloning {}...", url);
+        println!("Cloning {url}...");
         let output = Command::new("git")
             .arg("clone")
             .arg(&url)
@@ -232,42 +245,64 @@ async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
 }
 
 /// Get the current branch name from a repository
-fn get_current_branch(repo_path: &PathBuf) -> Option<String> {
+fn get_current_branch(repo_path: &std::path::Path) -> Option<String> {
     use git2::Repository;
 
     let repo = Repository::open(repo_path).ok()?;
     let head = repo.head().ok()?;
 
     if head.is_branch() {
-        head.shorthand().map(|s| s.to_string())
+        head.shorthand().map(std::string::ToString::to_string)
     } else {
         head.target().map(|oid| oid.to_string()[..8].to_string())
     }
 }
 
-/// Parse model string to ClaudeModel enum
-fn parse_model(model_str: &str) -> Option<ClaudeModel> {
+/// Parse model string to `ClaudeModel` enum
+fn parse_model(model_str: &str) -> ClaudeModel {
     match model_str.to_lowercase().as_str() {
-        "sonnet" | "claude-sonnet" | "claude-3-sonnet" => Some(ClaudeModel::Sonnet),
-        "opus" | "claude-opus" | "claude-3-opus" => Some(ClaudeModel::Opus),
-        "haiku" | "claude-haiku" | "claude-3-haiku" => Some(ClaudeModel::Haiku),
-        _ => Some(ClaudeModel::Sonnet), // Default to Sonnet
+        "opus" | "claude-opus" | "claude-3-opus" => ClaudeModel::Opus,
+        "haiku" | "claude-haiku" | "claude-3-haiku" => ClaudeModel::Haiku,
+        _ => ClaudeModel::Sonnet, // Default to Sonnet
     }
 }
 
-/// Build the Claude CLI command with appropriate flags
-fn build_claude_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
-    let mut cmd_parts = vec!["claude".to_string()];
+/// Validate that the selected provider's CLI binary is installed and on PATH
+fn validate_provider_installed(provider: &CliProvider) -> Result<()> {
+    let cmd = provider.command();
+    if which::which(cmd).is_err() {
+        let install_url = match provider {
+            CliProvider::Claude => "https://docs.anthropic.com/en/docs/claude-code",
+            CliProvider::Codex => "https://github.com/openai/codex",
+            CliProvider::Gemini => "https://github.com/google-gemini/gemini-cli",
+            CliProvider::Copilot => "https://githubnext.com/projects/copilot-cli",
+        };
+        anyhow::bail!(
+            "{} CLI ('{}') not found in PATH. Install it first.\nSee: {}",
+            provider.display_name(),
+            cmd,
+            install_url,
+        );
+    }
+    Ok(())
+}
 
-    // Add model flag if specified
-    if let Some(m) = model {
-        cmd_parts.push("--model".to_string());
-        cmd_parts.push(m.cli_value().to_string());
+/// Build the agent CLI command with appropriate flags for the selected provider
+fn build_agent_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
+    let provider = CliProvider::from_str(&args.tool);
+    let mut cmd_parts = vec![provider.command().to_string()];
+
+    // Add model flag (Claude-only)
+    if provider == CliProvider::Claude {
+        if let Some(m) = model {
+            cmd_parts.push("--model".to_string());
+            cmd_parts.push(m.cli_value().to_string());
+        }
     }
 
-    // Add permission skip flag (always enabled for CLI usage)
+    // Add permission skip flag (provider-specific)
     if args.dangerously_skip_permissions {
-        cmd_parts.push("--dangerously-skip-permissions".to_string());
+        cmd_parts.push(provider.skip_permissions_flag().to_string());
     }
 
     cmd_parts.join(" ")
@@ -276,7 +311,7 @@ fn build_claude_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
 /// Send a prompt to the tmux session
 async fn send_prompt_to_tmux(session_name: &str, prompt: &str) -> Result<()> {
     // Target pane explicitly
-    let target = format!("{}:0", session_name);
+    let target = format!("{session_name}:0");
 
     // Send the prompt text
     let output = Command::new("tmux")
@@ -284,13 +319,13 @@ async fn send_prompt_to_tmux(session_name: &str, prompt: &str) -> Result<()> {
         .output()
         .await?;
 
-    if !output.status.success() {
+    if output.status.success() {
+        info!("Sent initial prompt to session");
+    } else {
         warn!(
             "Failed to send prompt: {}",
             String::from_utf8_lossy(&output.stderr)
         );
-    } else {
-        info!("Sent initial prompt to session");
     }
 
     Ok(())
@@ -306,7 +341,7 @@ fn attach_to_session(session_name: &str) -> Result<()> {
         .exec();
 
     // If exec returns, it means it failed
-    anyhow::bail!("Failed to attach to session: {}", err)
+    anyhow::bail!("Failed to attach to session: {err}")
 }
 
 #[cfg(test)]
@@ -315,16 +350,16 @@ mod tests {
 
     #[test]
     fn test_parse_model() {
-        assert_eq!(parse_model("sonnet"), Some(ClaudeModel::Sonnet));
-        assert_eq!(parse_model("SONNET"), Some(ClaudeModel::Sonnet));
-        assert_eq!(parse_model("opus"), Some(ClaudeModel::Opus));
-        assert_eq!(parse_model("haiku"), Some(ClaudeModel::Haiku));
-        assert_eq!(parse_model("claude-sonnet"), Some(ClaudeModel::Sonnet));
-        assert_eq!(parse_model("unknown"), Some(ClaudeModel::Sonnet)); // Default
+        assert_eq!(parse_model("sonnet"), ClaudeModel::Sonnet);
+        assert_eq!(parse_model("SONNET"), ClaudeModel::Sonnet);
+        assert_eq!(parse_model("opus"), ClaudeModel::Opus);
+        assert_eq!(parse_model("haiku"), ClaudeModel::Haiku);
+        assert_eq!(parse_model("claude-sonnet"), ClaudeModel::Sonnet);
+        assert_eq!(parse_model("unknown"), ClaudeModel::Sonnet); // Default
     }
 
     #[test]
-    fn test_build_claude_command() {
+    fn test_build_agent_command() {
         let args = RunArgs {
             remote_repo: None,
             repo: None,
@@ -339,14 +374,14 @@ mod tests {
             interactive: false,
         };
 
-        let cmd = build_claude_command(&args, Some(ClaudeModel::Sonnet));
+        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
         assert!(cmd.contains("claude"));
         assert!(cmd.contains("--model sonnet"));
         assert!(cmd.contains("--dangerously-skip-permissions"));
     }
 
     #[test]
-    fn test_build_claude_command_minimal() {
+    fn test_build_agent_command_minimal() {
         let args = RunArgs {
             remote_repo: None,
             repo: None,
@@ -361,9 +396,143 @@ mod tests {
             interactive: false,
         };
 
-        let cmd = build_claude_command(&args, Some(ClaudeModel::Opus));
+        let cmd = build_agent_command(&args, Some(ClaudeModel::Opus));
         assert!(cmd.contains("claude"));
         assert!(cmd.contains("--model opus"));
         assert!(!cmd.contains("--dangerously-skip-permissions"));
+    }
+
+    #[test]
+    fn test_build_codex_command() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "codex".to_string(),
+            model: "sonnet".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        assert!(cmd.starts_with("codex"), "Command should start with codex, got: {}", cmd);
+        assert!(!cmd.contains("--model"), "Codex should not have --model flag");
+    }
+
+    #[test]
+    fn test_build_codex_command_with_skip_permissions() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "codex".to_string(),
+            model: "sonnet".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: true,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        assert!(cmd.starts_with("codex"), "Command should start with codex, got: {}", cmd);
+        assert!(
+            cmd.contains("--dangerously-bypass-approvals-and-sandbox"),
+            "Codex skip permissions should use --dangerously-bypass-approvals-and-sandbox, got: {}",
+            cmd,
+        );
+        assert!(
+            !cmd.contains("--dangerously-skip-permissions"),
+            "Codex should not use Claude's skip permissions flag"
+        );
+    }
+
+    #[test]
+    fn test_build_gemini_command() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "gemini".to_string(),
+            model: "sonnet".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        assert!(cmd.starts_with("gemini"), "Command should start with gemini, got: {}", cmd);
+        assert!(!cmd.contains("--model"), "Gemini should not have --model flag");
+    }
+
+    #[test]
+    fn test_build_copilot_command() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "copilot".to_string(),
+            model: "sonnet".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        assert!(cmd.starts_with("copilot"), "Command should start with copilot, got: {}", cmd);
+    }
+
+    #[test]
+    fn test_build_copilot_command_no_skip_permissions() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: "copilot".to_string(),
+            model: "sonnet".to_string(),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+        };
+
+        let cmd = build_agent_command(&args, None);
+        assert_eq!(cmd, "copilot", "Copilot with no flags should just be 'copilot'");
+    }
+
+    #[test]
+    fn test_validate_provider_installed_claude() {
+        // Claude CLI should be installed on this machine
+        let provider = CliProvider::Claude;
+        let result = validate_provider_installed(&provider);
+        assert!(result.is_ok(), "Claude CLI should be found in PATH: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_validate_provider_installed_nonexistent() {
+        // Use a provider struct pointing to a binary that definitely doesn't exist
+        // We test via the function directly with a known-missing binary
+        let result = validate_provider_installed(&CliProvider::Copilot);
+        // Copilot CLI is unlikely to be installed in CI/dev - if it is, that's fine too
+        // The important thing is the function doesn't panic
+        if result.is_err() {
+            let err = result.unwrap_err().to_string();
+            assert!(err.contains("not found in PATH"), "Error should mention PATH, got: {}", err);
+            assert!(err.contains("GitHub Copilot"), "Error should mention provider name, got: {}", err);
+            assert!(err.contains("githubnext.com"), "Error should include install URL, got: {}", err);
+        }
     }
 }

--- a/ainb-tui/src/cli/status.rs
+++ b/ainb-tui/src/cli/status.rs
@@ -1,0 +1,349 @@
+// ABOUTME: CLI status and kill commands for session management
+//
+// status: Show detailed session information (text/JSON output)
+// kill: Terminate a session and its tmux, with confirmation prompt
+
+use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use std::io::{self, Write};
+use std::process::Command;
+use uuid::Uuid;
+
+use super::{KillArgs, OutputFormat, StatusArgs};
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+use crate::tmux::ClaudeProcessDetector;
+
+/// JSON output structure for status command
+#[derive(Debug, Serialize)]
+pub struct StatusOutput {
+    pub session_id: String,
+    pub workspace_name: String,
+    pub tmux_session_name: String,
+    pub worktree_path: String,
+    pub created_at: String,
+    pub is_running: bool,
+    pub claude_active: bool,
+}
+
+/// Find a session by ID (prefix match) or workspace name
+///
+/// Searches in order:
+/// 1. Full UUID match
+/// 2. UUID prefix match (allows short IDs like "f79e07da")
+/// 3. Workspace name match
+fn find_session(id_or_name: &str) -> Result<SessionMetadata> {
+    let store = SessionStore::load();
+
+    if store.sessions.is_empty() {
+        return Err(anyhow!("No sessions found. Use 'ainb run' to create one."));
+    }
+
+    // Try full UUID match first
+    if let Ok(uuid) = Uuid::parse_str(id_or_name) {
+        for session in store.sessions.values() {
+            if session.session_id == uuid {
+                return Ok(session.clone());
+            }
+        }
+    }
+
+    // Try UUID prefix match (e.g., "f79e07da" matches "f79e07da-774d-415c-aedf-a2acd0bee0d3")
+    let id_lower = id_or_name.to_lowercase();
+    let mut prefix_matches: Vec<_> = store
+        .sessions
+        .values()
+        .filter(|s| s.session_id.to_string().to_lowercase().starts_with(&id_lower))
+        .collect();
+
+    if prefix_matches.len() == 1 {
+        return Ok(prefix_matches.remove(0).clone());
+    }
+
+    if prefix_matches.len() > 1 {
+        let matches: Vec<_> = prefix_matches
+            .iter()
+            .map(|s| format!("  {} ({})", s.session_id, s.workspace_name))
+            .collect();
+        return Err(anyhow!(
+            "Ambiguous session ID '{}'. Matches:\n{}",
+            id_or_name,
+            matches.join("\n")
+        ));
+    }
+
+    // Try workspace name match (case-insensitive)
+    let name_lower = id_or_name.to_lowercase();
+    let mut name_matches: Vec<_> = store
+        .sessions
+        .values()
+        .filter(|s| s.workspace_name.to_lowercase() == name_lower)
+        .collect();
+
+    if name_matches.len() == 1 {
+        return Ok(name_matches.remove(0).clone());
+    }
+
+    if name_matches.len() > 1 {
+        let matches: Vec<_> = name_matches
+            .iter()
+            .map(|s| format!("  {} ({})", s.session_id, s.workspace_name))
+            .collect();
+        return Err(anyhow!(
+            "Multiple sessions with workspace '{}'. Specify by ID:\n{}",
+            id_or_name,
+            matches.join("\n")
+        ));
+    }
+
+    // No match found - provide helpful error message
+    let available: Vec<_> = store
+        .sessions
+        .values()
+        .map(|s| format!("  {} ({})", &s.session_id.to_string()[..8], s.workspace_name))
+        .collect();
+
+    if available.is_empty() {
+        Err(anyhow!("No sessions found. Use 'ainb run' to create one."))
+    } else {
+        Err(anyhow!(
+            "Session '{}' not found. Available sessions:\n{}",
+            id_or_name,
+            available.join("\n")
+        ))
+    }
+}
+
+/// Check if a tmux session exists
+fn tmux_session_exists(tmux_session_name: &str) -> bool {
+    Command::new("tmux")
+        .args(["has-session", "-t", tmux_session_name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Execute the status command
+///
+/// Shows detailed information about a session including:
+/// - Session ID, workspace name
+/// - Tmux session status
+/// - Worktree path
+/// - Creation time
+/// - Whether Claude CLI is active
+#[allow(clippy::unused_async)]
+pub async fn execute(args: StatusArgs, format: OutputFormat) -> Result<()> {
+    let session = find_session(&args.session)?;
+
+    // Check tmux session status
+    let is_running = tmux_session_exists(&session.tmux_session_name);
+
+    // Check if Claude is active in the session
+    let claude_active = if is_running {
+        let detector = ClaudeProcessDetector::new();
+        detector
+            .is_claude_running(&session.tmux_session_name)
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let output = StatusOutput {
+                session_id: session.session_id.to_string(),
+                workspace_name: session.workspace_name.clone(),
+                tmux_session_name: session.tmux_session_name.clone(),
+                worktree_path: session.worktree_path.display().to_string(),
+                created_at: session.created_at.to_rfc3339(),
+                is_running,
+                claude_active,
+            };
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).context("Failed to serialize status")?
+            );
+        }
+        OutputFormat::Text => {
+            let status_text = if is_running {
+                if claude_active {
+                    "\x1b[32m●\x1b[0m Running (Claude active)"
+                } else {
+                    "\x1b[33m●\x1b[0m Running (shell)"
+                }
+            } else {
+                "\x1b[31m●\x1b[0m Stopped"
+            };
+
+            let short_id = &session.session_id.to_string()[..8];
+
+            println!("Session: {}", session.session_id);
+            println!("{}", "━".repeat(44));
+            println!("Workspace:    {}", session.workspace_name);
+            println!("Status:       {status_text}");
+            println!("Tmux:         {}", session.tmux_session_name);
+            println!("Worktree:     {}", session.worktree_path.display());
+            println!("Created:      {}", session.created_at.format("%Y-%m-%d %H:%M:%S UTC"));
+            println!();
+            println!("Commands:");
+            println!("  Attach:     ainb attach {short_id}");
+            println!("  Logs:       ainb logs {short_id} --follow");
+            println!("  Kill:       ainb kill {short_id}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute the kill command
+///
+/// Terminates a session by:
+/// 1. Finding the session by ID or name
+/// 2. Prompting for confirmation (unless --force)
+/// 3. Killing the tmux session
+/// 4. Removing the session from `SessionStore`
+#[allow(clippy::unused_async, clippy::if_not_else)]
+pub async fn kill(args: KillArgs) -> Result<()> {
+    let session = find_session(&args.session)?;
+
+    // Check if session is running
+    let is_running = tmux_session_exists(&session.tmux_session_name);
+
+    if !is_running {
+        println!(
+            "Session '{}' is not running (tmux session not found).",
+            session.workspace_name
+        );
+        println!("Removing from session store...");
+
+        // Still remove from store
+        let mut store = SessionStore::load();
+        store.remove_by_session_id(session.session_id);
+        store.save().context("Failed to save session store")?;
+
+        println!("Session removed.");
+        return Ok(());
+    }
+
+    // Prompt for confirmation unless --force
+    if !args.force {
+        print!("Kill session '{}'? [y/N] ", session.workspace_name);
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    // Kill tmux session
+    println!("Killing tmux session '{}'...", session.tmux_session_name);
+
+    let output = Command::new("tmux")
+        .args(["kill-session", "-t", &session.tmux_session_name])
+        .output()
+        .context("Failed to execute tmux kill-session")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!(
+            "Warning: tmux kill-session failed: {}",
+            stderr.trim()
+        );
+        // Continue anyway - might already be dead
+    } else {
+        println!("Tmux session killed.");
+    }
+
+    // Remove from session store
+    let mut store = SessionStore::load();
+    store.remove_by_session_id(session.session_id);
+    store.save().context("Failed to save session store")?;
+
+    println!("Session '{}' removed.", session.workspace_name);
+
+    // Note: We don't remove the worktree by default
+    // The user can manually clean it up or we could add --cleanup-worktree flag
+    println!(
+        "\nNote: Worktree at '{}' was not removed.",
+        session.worktree_path.display()
+    );
+    println!("To clean up, run: rm -rf {}", session.worktree_path.display());
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    fn create_test_session(id: Uuid, workspace: &str, tmux_name: &str) -> SessionMetadata {
+        SessionMetadata {
+            session_id: id,
+            tmux_session_name: tmux_name.to_string(),
+            worktree_path: PathBuf::from(format!("/tmp/test-worktree-{}", id)),
+            workspace_name: workspace.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_find_session_by_full_uuid() {
+        // This test would require mocking SessionStore::load()
+        // For now, we verify the logic flow with a unit test of the search
+        let id = Uuid::new_v4();
+        let id_str = id.to_string();
+
+        // Verify UUID parsing works
+        let parsed = Uuid::parse_str(&id_str);
+        assert!(parsed.is_ok());
+        assert_eq!(parsed.unwrap(), id);
+    }
+
+    #[test]
+    fn test_find_session_by_prefix() {
+        let id = Uuid::new_v4();
+        let full_id = id.to_string();
+        let prefix = &full_id[..8];
+
+        // Verify prefix matching logic
+        assert!(full_id.to_lowercase().starts_with(&prefix.to_lowercase()));
+    }
+
+    #[test]
+    fn test_status_output_json_serialization() {
+        let output = StatusOutput {
+            session_id: "f79e07da-774d-415c-aedf-a2acd0bee0d3".to_string(),
+            workspace_name: "my-workspace".to_string(),
+            tmux_session_name: "tmux_my-session".to_string(),
+            worktree_path: "/path/to/worktree".to_string(),
+            created_at: "2026-01-17T18:25:46Z".to_string(),
+            is_running: true,
+            claude_active: true,
+        };
+
+        let json = serde_json::to_string_pretty(&output);
+        assert!(json.is_ok());
+
+        let json_str = json.unwrap();
+        assert!(json_str.contains("session_id"));
+        assert!(json_str.contains("workspace_name"));
+        assert!(json_str.contains("is_running"));
+        assert!(json_str.contains("claude_active"));
+    }
+
+    #[test]
+    fn test_session_metadata_clone() {
+        let id = Uuid::new_v4();
+        let session = create_test_session(id, "test-workspace", "tmux_test");
+
+        let cloned = session.clone();
+        assert_eq!(cloned.session_id, id);
+        assert_eq!(cloned.workspace_name, "test-workspace");
+        assert_eq!(cloned.tmux_session_name, "tmux_test");
+    }
+}

--- a/ainb-tui/src/cli/status.rs
+++ b/ainb-tui/src/cli/status.rs
@@ -192,6 +192,7 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use crate::interactive::session_manager::SessionMetadata;
+    use crate::models::session::SessionAgentType;
     use std::path::PathBuf;
     use uuid::Uuid;
 
@@ -202,6 +203,7 @@ mod tests {
             worktree_path: PathBuf::from(format!("/tmp/test-worktree-{}", id)),
             workspace_name: workspace.to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         }
     }
 

--- a/ainb-tui/src/cli/util.rs
+++ b/ainb-tui/src/cli/util.rs
@@ -1,0 +1,189 @@
+// ABOUTME: Shared CLI utilities for session lookup and common operations
+//
+// Provides consistent session finding logic across all CLI commands.
+// Uses prefix matching for both UUID and workspace name for user convenience.
+
+use anyhow::{anyhow, Result};
+use uuid::Uuid;
+
+use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+
+/// Find a session by ID (full or partial UUID) or workspace name prefix
+///
+/// Matching priority:
+/// 1. Exact UUID match
+/// 2. UUID prefix match (e.g., "abc" matches "abc12345-...")
+/// 3. Workspace name prefix match (case-insensitive)
+///
+/// Returns an error if no match is found or if multiple sessions match.
+pub fn find_session(id_or_name: &str) -> Result<SessionMetadata> {
+    let store = SessionStore::load();
+    find_session_in_store(id_or_name, &store)
+}
+
+/// Find a session within a given store (testable version)
+///
+/// This function accepts a store reference for easier unit testing.
+pub fn find_session_in_store(id_or_name: &str, store: &SessionStore) -> Result<SessionMetadata> {
+    if store.sessions.is_empty() {
+        return Err(anyhow!("No sessions found. Run 'ainb run' to create a session."));
+    }
+
+    // First, try exact UUID match
+    if let Ok(uuid) = Uuid::parse_str(id_or_name) {
+        for session in store.sessions.values() {
+            if session.session_id == uuid {
+                return Ok(session.clone());
+            }
+        }
+    }
+
+    // Try UUID prefix match (case-insensitive)
+    let id_lower = id_or_name.to_lowercase();
+    let uuid_matches: Vec<&SessionMetadata> = store
+        .sessions
+        .values()
+        .filter(|s| s.session_id.to_string().to_lowercase().starts_with(&id_lower))
+        .collect();
+
+    match uuid_matches.len() {
+        1 => return Ok(uuid_matches[0].clone()),
+        n if n > 1 => {
+            let ids: Vec<String> = uuid_matches
+                .iter()
+                .map(|s| format!("  {} ({})", &s.session_id.to_string()[..8], s.workspace_name))
+                .collect();
+            return Err(anyhow!(
+                "Ambiguous session ID prefix '{id_or_name}'. Matches:\n{}",
+                ids.join("\n")
+            ));
+        }
+        _ => {}
+    }
+
+    // Try workspace name prefix match (case-insensitive)
+    let name_matches: Vec<&SessionMetadata> = store
+        .sessions
+        .values()
+        .filter(|s| s.workspace_name.to_lowercase().starts_with(&id_lower))
+        .collect();
+
+    match name_matches.len() {
+        1 => return Ok(name_matches[0].clone()),
+        n if n > 1 => {
+            let names: Vec<String> = name_matches
+                .iter()
+                .map(|s| format!("  {} ({})", s.workspace_name, &s.session_id.to_string()[..8]))
+                .collect();
+            return Err(anyhow!(
+                "Ambiguous session name prefix '{id_or_name}'. Matches:\n{}",
+                names.join("\n")
+            ));
+        }
+        _ => {}
+    }
+
+    // No match found - provide helpful error message
+    let available: Vec<String> = store
+        .sessions
+        .values()
+        .map(|s| format!("  {} ({})", &s.session_id.to_string()[..8], s.workspace_name))
+        .collect();
+
+    if available.is_empty() {
+        Err(anyhow!("No sessions found. Run 'ainb run' to create a session."))
+    } else {
+        Err(anyhow!(
+            "No session found matching '{id_or_name}'. Available sessions:\n{}",
+            available.join("\n")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    fn create_test_store() -> SessionStore {
+        let mut store = SessionStore::default();
+
+        let session1 = SessionMetadata {
+            session_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+            tmux_session_name: "tmux_project-a".to_string(),
+            worktree_path: PathBuf::from("/tmp/project-a"),
+            workspace_name: "project-alpha".to_string(),
+            created_at: Utc::now(),
+        };
+
+        let session2 = SessionMetadata {
+            session_id: Uuid::parse_str("abcdef12-abcd-abcd-abcd-abcdef123456").unwrap(),
+            tmux_session_name: "tmux_project-b".to_string(),
+            worktree_path: PathBuf::from("/tmp/project-b"),
+            workspace_name: "project-beta".to_string(),
+            created_at: Utc::now(),
+        };
+
+        store.sessions.insert(session1.tmux_session_name.clone(), session1);
+        store.sessions.insert(session2.tmux_session_name.clone(), session2);
+
+        store
+    }
+
+    #[test]
+    fn test_find_by_exact_uuid() {
+        let store = create_test_store();
+        let result = find_session_in_store("12345678-1234-1234-1234-123456789abc", &store);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().workspace_name, "project-alpha");
+    }
+
+    #[test]
+    fn test_find_by_uuid_prefix() {
+        let store = create_test_store();
+        let result = find_session_in_store("12345678", &store);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().workspace_name, "project-alpha");
+    }
+
+    #[test]
+    fn test_find_by_workspace_prefix() {
+        let store = create_test_store();
+        let result = find_session_in_store("project-a", &store);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().workspace_name, "project-alpha");
+    }
+
+    #[test]
+    fn test_find_by_workspace_prefix_case_insensitive() {
+        let store = create_test_store();
+        let result = find_session_in_store("PROJECT-B", &store);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().workspace_name, "project-beta");
+    }
+
+    #[test]
+    fn test_ambiguous_prefix() {
+        let store = create_test_store();
+        let result = find_session_in_store("project-", &store);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Ambiguous"));
+    }
+
+    #[test]
+    fn test_not_found() {
+        let store = create_test_store();
+        let result = find_session_in_store("nonexistent", &store);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No session found"));
+    }
+
+    #[test]
+    fn test_empty_store() {
+        let store = SessionStore::default();
+        let result = find_session_in_store("anything", &store);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No sessions found"));
+    }
+}

--- a/ainb-tui/src/cli/util.rs
+++ b/ainb-tui/src/cli/util.rs
@@ -104,6 +104,7 @@ pub fn find_session_in_store(id_or_name: &str, store: &SessionStore) -> Result<S
 mod tests {
     use super::*;
     use chrono::Utc;
+    use crate::models::session::SessionAgentType;
     use std::path::PathBuf;
 
     fn create_test_store() -> SessionStore {
@@ -115,6 +116,7 @@ mod tests {
             worktree_path: PathBuf::from("/tmp/project-a"),
             workspace_name: "project-alpha".to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         };
 
         let session2 = SessionMetadata {
@@ -123,6 +125,7 @@ mod tests {
             worktree_path: PathBuf::from("/tmp/project-b"),
             workspace_name: "project-beta".to_string(),
             created_at: Utc::now(),
+            agent_type: SessionAgentType::default(),
         };
 
         store.sessions.insert(session1.tmux_session_name.clone(), session1);

--- a/ainb-tui/src/config/mod.rs
+++ b/ainb-tui/src/config/mod.rs
@@ -413,7 +413,7 @@ impl AppConfig {
     }
 
     /// Get configuration file paths in order of precedence
-    fn get_config_paths() -> Vec<PathBuf> {
+    pub fn get_config_paths() -> Vec<PathBuf> {
         let mut paths = vec![];
 
         // 1. Local project config
@@ -433,7 +433,7 @@ impl AppConfig {
     }
 
     /// Get user configuration directory
-    fn get_user_config_dir() -> Result<PathBuf> {
+    pub fn get_user_config_dir() -> Result<PathBuf> {
         let home_dir = dirs::home_dir().context("Failed to get home directory")?;
         let config_dir = home_dir.join(".agents-in-a-box").join("config");
         Ok(config_dir)

--- a/ainb-tui/src/config/mod.rs
+++ b/ainb-tui/src/config/mod.rs
@@ -151,7 +151,7 @@ impl CliProvider {
 }
 
 /// Authentication configuration
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthenticationConfig {
     /// Active CLI provider for agent sessions
     #[serde(default)]
@@ -168,6 +168,17 @@ pub struct AuthenticationConfig {
     /// GitHub authentication method (for future use)
     #[serde(default)]
     pub github_method: Option<String>,
+}
+
+impl Default for AuthenticationConfig {
+    fn default() -> Self {
+        Self {
+            cli_provider: CliProvider::default(),
+            claude_provider: ClaudeAuthProvider::default(),
+            default_model: default_claude_model(),
+            github_method: None,
+        }
+    }
 }
 
 fn default_claude_model() -> String {

--- a/ainb-tui/src/lib.rs
+++ b/ainb-tui/src/lib.rs
@@ -1,4 +1,4 @@
-// ABOUTME: Library crate for Agents-in-a-Box exposing public API for testing and external use
+// ABOUTME: Library crate for ainb (Agents-in-a-Box) exposing public API for testing and external use
 
 #![allow(missing_docs)]
 
@@ -6,6 +6,7 @@ pub mod agent_parsers;
 pub mod app;
 pub mod audit;
 pub mod claude;
+pub mod cli;
 pub mod components;
 pub mod config;
 pub mod credentials;

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -73,6 +73,11 @@ async fn main() -> Result<()> {
 
     let args = cli::Cli::parse();
 
+    // Track whether we entered TUI mode so we only clean up terminal in that case.
+    // CLI commands never touch the alternate screen; emitting LeaveAlternateScreen
+    // would leak raw escape codes into the user's terminal.
+    let mut entered_tui = false;
+
     let result = match args.command {
         // CLI commands
         Some(cli::Commands::Run(run_args)) => cli::run::execute(run_args).await,
@@ -88,9 +93,17 @@ async fn main() -> Result<()> {
         Some(cli::Commands::Favorites { command }) => cli::favorites::execute(command, args.format).await,
         Some(cli::Commands::Init(init_args)) => cli::init::execute(init_args, args.format).await,
         Some(cli::Commands::Presets { command }) => cli::presets::execute(command, args.format).await,
+        Some(cli::Commands::Completion { shell }) => {
+            use clap::CommandFactory;
+            let mut cmd = cli::Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+            Ok(())
+        }
 
         // TUI mode (explicit or default)
         Some(cli::Commands::Tui) | None => {
+            entered_tui = true;
             let mut app = App::new();
             app.init().await;
             let mut layout = LayoutComponent::new();
@@ -114,8 +127,10 @@ async fn main() -> Result<()> {
         }
     };
 
-    // Ensure terminal is cleaned up on any error
-    if result.is_err() {
+    // Only clean up terminal if we entered TUI mode. For CLI commands, calling
+    // cleanup_terminal() would emit terminal escape sequences into the user's
+    // shell, corrupting agent-captured output.
+    if result.is_err() && entered_tui {
         cleanup_terminal();
     }
 

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -82,6 +82,12 @@ async fn main() -> Result<()> {
         Some(cli::Commands::Status(status_args)) => cli::status::execute(status_args, args.format).await,
         Some(cli::Commands::Kill(kill_args)) => cli::status::kill(kill_args).await,
         Some(cli::Commands::Auth) => run_auth_setup().await,
+        Some(cli::Commands::Recover { command }) => cli::recover::execute(command, args.format).await,
+        Some(cli::Commands::Config { command }) => cli::config_cmd::execute(command, args.format).await,
+        Some(cli::Commands::Git { command }) => cli::git_cmd::execute(command, args.format).await,
+        Some(cli::Commands::Favorites { command }) => cli::favorites::execute(command, args.format).await,
+        Some(cli::Commands::Init(init_args)) => cli::init::execute(init_args, args.format).await,
+        Some(cli::Commands::Presets { command }) => cli::presets::execute(command, args.format).await,
 
         // TUI mode (explicit or default)
         Some(cli::Commands::Tui) | None => {

--- a/ainb-tui/tests/behavioral.rs
+++ b/ainb-tui/tests/behavioral.rs
@@ -1,0 +1,30 @@
+// ABOUTME: Behavioral test suite for shared modules (CLI/TUI compatibility)
+//
+// These tests verify behavior, not implementation. They must pass against
+// the current codebase BEFORE any refactoring begins.
+//
+// Priority order:
+// - P0: tmux_lifecycle, worktree_integration (critical for CLI)
+// - P1: session_persistence, git_operations (CLI/TUI compatibility)
+// - P2: session_lifecycle, config_loading (completeness)
+
+#[path = "behavioral/fixtures.rs"]
+pub mod fixtures;
+
+#[path = "behavioral/tmux_lifecycle.rs"]
+mod tmux_lifecycle;
+
+#[path = "behavioral/worktree_integration.rs"]
+mod worktree_integration;
+
+#[path = "behavioral/session_persistence.rs"]
+mod session_persistence;
+
+#[path = "behavioral/git_operations.rs"]
+mod git_operations;
+
+// P2 priority - placeholder modules
+#[path = "behavioral/session_lifecycle.rs"]
+mod session_lifecycle;
+#[path = "behavioral/config_loading.rs"]
+mod config_loading;

--- a/ainb-tui/tests/behavioral/config_loading.rs
+++ b/ainb-tui/tests/behavioral/config_loading.rs
@@ -1,0 +1,237 @@
+// ABOUTME: Behavioral tests for configuration loading and provider enums
+// Verifies config defaults, serialization roundtrips, and enum variant coverage
+
+use ainb::config::{
+    AppConfig, AuthenticationConfig, ClaudeAuthProvider, CliProvider,
+};
+
+/// Test that default config has sensible values for immediate usability
+#[test]
+fn test_default_config_has_sensible_values() {
+    // Create default configuration
+    let config = AppConfig::default();
+
+    // Default CLI provider should be Claude
+    assert_eq!(
+        config.authentication.cli_provider,
+        CliProvider::Claude,
+        "Default CLI provider should be Claude"
+    );
+
+    // Default Claude auth provider should be SystemAuth
+    assert_eq!(
+        config.authentication.claude_provider,
+        ClaudeAuthProvider::SystemAuth,
+        "Default Claude auth provider should be SystemAuth"
+    );
+
+    // Note: default_model uses #[serde(default = "default_claude_model")] which only
+    // applies during deserialization, not Default::default(). The derive(Default) gives
+    // empty string. This tests current behavior - consider if this should be fixed in
+    // AuthenticationConfig by implementing Default manually.
+    assert!(
+        config.authentication.default_model.is_empty() || config.authentication.default_model == "sonnet",
+        "Default model should be empty (from derive) or 'sonnet' (from manual impl)"
+    );
+
+    // Version should match package version
+    assert_eq!(
+        config.version,
+        env!("CARGO_PKG_VERSION"),
+        "Version should match package version"
+    );
+
+    // Default container template should be set
+    assert_eq!(
+        config.default_container_template,
+        "claude-dev",
+        "Default container template should be 'claude-dev'"
+    );
+
+    // Container templates should be loaded (built-in templates)
+    assert!(
+        !config.container_templates.is_empty(),
+        "Default config should have built-in container templates"
+    );
+    assert!(
+        config.container_templates.contains_key("claude-dev"),
+        "Default config should include 'claude-dev' template"
+    );
+}
+
+/// Test that configuration roundtrips through TOML serialization without losing data
+#[test]
+fn test_config_serialization_roundtrip() {
+    // Create config with custom values for each provider setting
+    let mut config = AppConfig::default();
+    config.authentication.cli_provider = CliProvider::Codex;
+    config.authentication.claude_provider = ClaudeAuthProvider::ApiKey;
+    config.authentication.default_model = "opus".to_string();
+    config.workspace_defaults.branch_prefix = "feature/".to_string();
+
+    // Serialize to TOML
+    let toml_str = toml::to_string_pretty(&config)
+        .expect("Config should serialize to TOML");
+
+    // Verify TOML contains expected values
+    assert!(
+        toml_str.contains("cli_provider = \"codex\""),
+        "TOML should contain cli_provider = codex"
+    );
+    assert!(
+        toml_str.contains("claude_provider = \"api_key\""),
+        "TOML should contain claude_provider = api_key"
+    );
+    assert!(
+        toml_str.contains("default_model = \"opus\""),
+        "TOML should contain default_model = opus"
+    );
+
+    // Deserialize back
+    let loaded: AppConfig = toml::from_str(&toml_str)
+        .expect("TOML should deserialize back to AppConfig");
+
+    // Verify all values survived roundtrip
+    assert_eq!(
+        loaded.authentication.cli_provider,
+        CliProvider::Codex,
+        "CLI provider should survive roundtrip"
+    );
+    assert_eq!(
+        loaded.authentication.claude_provider,
+        ClaudeAuthProvider::ApiKey,
+        "Claude auth provider should survive roundtrip"
+    );
+    assert_eq!(
+        loaded.authentication.default_model,
+        "opus",
+        "Default model should survive roundtrip"
+    );
+    assert_eq!(
+        loaded.workspace_defaults.branch_prefix,
+        "feature/",
+        "Branch prefix should survive roundtrip"
+    );
+}
+
+/// Test that all CliProvider variants have display names (coverage for enum completeness)
+#[test]
+fn test_cli_provider_variants() {
+    // All variants should have non-empty display names
+    let variants = [
+        CliProvider::Claude,
+        CliProvider::Codex,
+        CliProvider::Gemini,
+    ];
+
+    for variant in &variants {
+        let display_name = variant.display_name();
+        assert!(
+            !display_name.is_empty(),
+            "CliProvider::{:?} should have a display name",
+            variant
+        );
+
+        let command = variant.command();
+        assert!(
+            !command.is_empty(),
+            "CliProvider::{:?} should have a command",
+            variant
+        );
+
+        let env_var = variant.api_key_env_var();
+        assert!(
+            !env_var.is_empty(),
+            "CliProvider::{:?} should have an API key env var",
+            variant
+        );
+    }
+
+    // Verify specific display names
+    assert_eq!(CliProvider::Claude.display_name(), "Claude Code");
+    assert_eq!(CliProvider::Codex.display_name(), "OpenAI Codex");
+    assert_eq!(CliProvider::Gemini.display_name(), "Google Gemini");
+
+    // Verify commands
+    assert_eq!(CliProvider::Claude.command(), "claude");
+    assert_eq!(CliProvider::Codex.command(), "codex");
+    assert_eq!(CliProvider::Gemini.command(), "gemini");
+
+    // Verify env vars
+    assert_eq!(CliProvider::Claude.api_key_env_var(), "ANTHROPIC_API_KEY");
+    assert_eq!(CliProvider::Codex.api_key_env_var(), "OPENAI_API_KEY");
+    assert_eq!(CliProvider::Gemini.api_key_env_var(), "GEMINI_API_KEY");
+}
+
+/// Test that all ClaudeAuthProvider variants serialize correctly
+#[test]
+fn test_claude_auth_provider_variants() {
+    // All variants with their expected serialized form
+    let variants_and_serialized = [
+        (ClaudeAuthProvider::SystemAuth, "system_auth"),
+        (ClaudeAuthProvider::ApiKey, "api_key"),
+        (ClaudeAuthProvider::AmazonBedrock, "amazon_bedrock"),
+        (ClaudeAuthProvider::GoogleVertex, "google_vertex"),
+        (ClaudeAuthProvider::AzureFoundry, "azure_foundry"),
+        (ClaudeAuthProvider::GlmZai, "glm_zai"),
+        (ClaudeAuthProvider::LlmGateway, "llm_gateway"),
+    ];
+
+    for (variant, expected_str) in &variants_and_serialized {
+        // Test as_str method
+        assert_eq!(
+            variant.as_str(),
+            *expected_str,
+            "ClaudeAuthProvider::{:?}.as_str() should return '{}'",
+            variant,
+            expected_str
+        );
+
+        // Test from_id roundtrip
+        let roundtripped = ClaudeAuthProvider::from_id(expected_str);
+        assert_eq!(
+            &roundtripped,
+            variant,
+            "ClaudeAuthProvider::from_id('{}') should return {:?}",
+            expected_str,
+            variant
+        );
+
+        // Test TOML serialization via AuthenticationConfig
+        let auth_config = AuthenticationConfig {
+            cli_provider: CliProvider::default(),
+            claude_provider: variant.clone(),
+            default_model: "test".to_string(),
+            github_method: None,
+        };
+
+        let toml_str = toml::to_string(&auth_config)
+            .expect("AuthenticationConfig should serialize to TOML");
+
+        assert!(
+            toml_str.contains(expected_str),
+            "TOML serialization of {:?} should contain '{}'",
+            variant,
+            expected_str
+        );
+
+        // Test TOML deserialization
+        let loaded: AuthenticationConfig = toml::from_str(&toml_str)
+            .expect("TOML should deserialize back to AuthenticationConfig");
+
+        assert_eq!(
+            loaded.claude_provider,
+            *variant,
+            "ClaudeAuthProvider::{:?} should survive TOML roundtrip",
+            variant
+        );
+    }
+
+    // Test from_id with unknown value falls back to SystemAuth
+    let fallback = ClaudeAuthProvider::from_id("unknown_provider");
+    assert_eq!(
+        fallback,
+        ClaudeAuthProvider::SystemAuth,
+        "Unknown provider ID should fall back to SystemAuth"
+    );
+}

--- a/ainb-tui/tests/behavioral/fixtures.rs
+++ b/ainb-tui/tests/behavioral/fixtures.rs
@@ -1,0 +1,182 @@
+// ABOUTME: Shared test fixtures and utilities for behavioral tests
+//
+// Provides:
+// - TestRepo: Temporary git repository for testing
+// - tmux_available(): Check if tmux is installed
+// - require_tmux!(): Skip test if tmux unavailable
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Creates a temporary git repository with initial commit
+pub struct TestRepo {
+    pub dir: TempDir,
+    pub path: PathBuf,
+}
+
+impl TestRepo {
+    /// Create a new temporary git repository with initial commit
+    pub fn new() -> Result<Self> {
+        let dir = TempDir::new()?;
+        let path = dir.path().to_path_buf();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&path)
+            .output()?;
+
+        // Configure git user for commits
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&path)
+            .output()?;
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&path)
+            .output()?;
+
+        // Create initial file and commit
+        std::fs::write(path.join("README.md"), "# Test Repo\n")?;
+
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&path)
+            .output()?;
+
+        Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(&path)
+            .output()?;
+
+        Ok(Self { dir, path })
+    }
+
+    /// Get the path to the repository
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Add a file and commit it
+    pub fn add_commit(&self, filename: &str, content: &str, message: &str) -> Result<()> {
+        std::fs::write(self.path.join(filename), content)?;
+
+        Command::new("git")
+            .args(["add", filename])
+            .current_dir(&self.path)
+            .output()?;
+
+        Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(&self.path)
+            .output()?;
+
+        Ok(())
+    }
+
+    /// Get current branch name
+    pub fn current_branch(&self) -> Result<String> {
+        let output = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&self.path)
+            .output()?;
+
+        Ok(String::from_utf8(output.stdout)?.trim().to_string())
+    }
+
+    /// Create and checkout a new branch
+    pub fn create_branch(&self, branch_name: &str) -> Result<()> {
+        Command::new("git")
+            .args(["checkout", "-b", branch_name])
+            .current_dir(&self.path)
+            .output()?;
+        Ok(())
+    }
+
+    /// Checkout an existing branch
+    pub fn checkout(&self, branch_name: &str) -> Result<()> {
+        Command::new("git")
+            .args(["checkout", branch_name])
+            .current_dir(&self.path)
+            .output()?;
+        Ok(())
+    }
+}
+
+/// Check if tmux is available on the system
+pub fn tmux_available() -> bool {
+    Command::new("tmux")
+        .args(["-V"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Macro to skip test if tmux is not available
+#[macro_export]
+macro_rules! require_tmux {
+    () => {
+        if !super::fixtures::tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return Ok(());
+        }
+    };
+}
+
+/// Helper to clean up a tmux session by name
+pub fn cleanup_tmux_session(name: &str) {
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", name])
+        .output();
+}
+
+/// Check if a tmux session exists
+pub fn tmux_session_exists(name: &str) -> bool {
+    Command::new("tmux")
+        .args(["has-session", "-t", name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Capture tmux pane content
+pub fn capture_tmux_pane(session_name: &str) -> Result<String> {
+    let output = Command::new("tmux")
+        .args(["capture-pane", "-t", session_name, "-p"])
+        .output()?;
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// Send keys to a tmux session
+pub fn send_tmux_keys(session_name: &str, keys: &str) -> Result<()> {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session_name, keys])
+        .output()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_repo_creation() -> Result<()> {
+        let repo = TestRepo::new()?;
+        assert!(repo.path().exists());
+        assert!(repo.path().join(".git").exists());
+        assert!(repo.path().join("README.md").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_repo_add_commit() -> Result<()> {
+        let repo = TestRepo::new()?;
+        repo.add_commit("test.txt", "hello", "Add test file")?;
+        assert!(repo.path().join("test.txt").exists());
+        Ok(())
+    }
+}

--- a/ainb-tui/tests/behavioral/fixtures.rs
+++ b/ainb-tui/tests/behavioral/fixtures.rs
@@ -23,34 +23,49 @@ impl TestRepo {
         let path = dir.path().to_path_buf();
 
         // Initialize git repo
-        Command::new("git")
+        let output = Command::new("git")
             .args(["init"])
             .current_dir(&path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git init failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
         // Configure git user for commits
-        Command::new("git")
+        let output = Command::new("git")
             .args(["config", "user.email", "test@test.com"])
             .current_dir(&path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git config email failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
-        Command::new("git")
+        let output = Command::new("git")
             .args(["config", "user.name", "Test User"])
             .current_dir(&path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git config name failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
         // Create initial file and commit
         std::fs::write(path.join("README.md"), "# Test Repo\n")?;
 
-        Command::new("git")
+        let output = Command::new("git")
             .args(["add", "."])
             .current_dir(&path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git add failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
-        Command::new("git")
+        let output = Command::new("git")
             .args(["commit", "-m", "Initial commit"])
             .current_dir(&path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git commit failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
         Ok(Self { dir, path })
     }
@@ -64,15 +79,21 @@ impl TestRepo {
     pub fn add_commit(&self, filename: &str, content: &str, message: &str) -> Result<()> {
         std::fs::write(self.path.join(filename), content)?;
 
-        Command::new("git")
+        let output = Command::new("git")
             .args(["add", filename])
             .current_dir(&self.path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git add failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
-        Command::new("git")
+        let output = Command::new("git")
             .args(["commit", "-m", message])
             .current_dir(&self.path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git commit failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
 
         Ok(())
     }
@@ -84,24 +105,34 @@ impl TestRepo {
             .current_dir(&self.path)
             .output()?;
 
+        if !output.status.success() {
+            anyhow::bail!("git branch failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
+
         Ok(String::from_utf8(output.stdout)?.trim().to_string())
     }
 
     /// Create and checkout a new branch
     pub fn create_branch(&self, branch_name: &str) -> Result<()> {
-        Command::new("git")
+        let output = Command::new("git")
             .args(["checkout", "-b", branch_name])
             .current_dir(&self.path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git checkout -b failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
         Ok(())
     }
 
     /// Checkout an existing branch
     pub fn checkout(&self, branch_name: &str) -> Result<()> {
-        Command::new("git")
+        let output = Command::new("git")
             .args(["checkout", branch_name])
             .current_dir(&self.path)
             .output()?;
+        if !output.status.success() {
+            anyhow::bail!("git checkout failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
         Ok(())
     }
 }

--- a/ainb-tui/tests/behavioral/git_operations.rs
+++ b/ainb-tui/tests/behavioral/git_operations.rs
@@ -1,0 +1,303 @@
+// ABOUTME: Behavioral tests for git repository operations using real temporary repos
+// Tests verify git status detection, branch operations, and change tracking
+
+use anyhow::Result;
+use std::fs;
+use std::process::Command;
+
+use ainb::git::repository::RepositoryManager;
+use ainb::models::GitChanges;
+
+use super::fixtures::TestRepo;
+
+/// Fresh repository should be detected as clean (no uncommitted changes)
+#[test]
+fn test_repository_detects_clean_state() -> Result<()> {
+    // Arrange: Create a fresh repo with initial commit
+    let repo = TestRepo::new()?;
+
+    // Act: Open and check status
+    let manager = RepositoryManager::open(repo.path())?;
+    let is_clean = manager.is_clean()?;
+    let changes = manager.get_status()?;
+
+    // Assert: Should be clean with zero changes
+    assert!(is_clean, "Fresh repository should be clean");
+    assert_eq!(changes.total(), 0, "No changes expected in fresh repo");
+    assert_eq!(changes.added, 0);
+    assert_eq!(changes.modified, 0);
+    assert_eq!(changes.deleted, 0);
+
+    Ok(())
+}
+
+/// Modified file should be detected in repository status
+#[test]
+fn test_repository_detects_modified_files() -> Result<()> {
+    // Arrange: Create repo and modify existing file
+    let repo = TestRepo::new()?;
+    let readme_path = repo.path().join("README.md");
+
+    // Act: Modify the README that was created in initial commit
+    fs::write(&readme_path, "# Modified Content\nThis has been changed.")?;
+
+    let manager = RepositoryManager::open(repo.path())?;
+    let changes = manager.get_status()?;
+
+    // Assert: Should detect one modified file
+    assert!(
+        changes.modified >= 1,
+        "Expected at least 1 modified file, got {}",
+        changes.modified
+    );
+    assert!(
+        !manager.is_clean()?,
+        "Repository should not be clean after modification"
+    );
+
+    Ok(())
+}
+
+/// Untracked (new) files should be counted as added
+#[test]
+fn test_repository_detects_new_files() -> Result<()> {
+    // Arrange: Create repo
+    let repo = TestRepo::new()?;
+
+    // Act: Add new untracked files
+    fs::write(repo.path().join("new_file.txt"), "New content")?;
+    fs::write(repo.path().join("another_new.rs"), "fn main() {}")?;
+
+    let manager = RepositoryManager::open(repo.path())?;
+    let changes = manager.get_status()?;
+
+    // Assert: Should detect new files as added
+    assert!(
+        changes.added >= 2,
+        "Expected at least 2 added files, got {}",
+        changes.added
+    );
+    assert!(
+        changes.total() >= 2,
+        "Total changes should be at least 2"
+    );
+
+    Ok(())
+}
+
+/// Deleted files should be counted in repository status
+#[test]
+fn test_repository_detects_deleted_files() -> Result<()> {
+    // Arrange: Create repo with multiple committed files
+    let repo = TestRepo::new()?;
+    repo.add_commit("to_delete.txt", "This will be deleted", "Add file to delete")?;
+    repo.add_commit("also_delete.txt", "Also going away", "Add another file")?;
+
+    // Verify files exist before deletion
+    assert!(repo.path().join("to_delete.txt").exists());
+    assert!(repo.path().join("also_delete.txt").exists());
+
+    // Act: Delete the committed files
+    fs::remove_file(repo.path().join("to_delete.txt"))?;
+    fs::remove_file(repo.path().join("also_delete.txt"))?;
+
+    let manager = RepositoryManager::open(repo.path())?;
+    let changes = manager.get_status()?;
+
+    // Assert: Should detect deleted files
+    assert!(
+        changes.deleted >= 2,
+        "Expected at least 2 deleted files, got {}",
+        changes.deleted
+    );
+
+    Ok(())
+}
+
+/// Should correctly detect current branch name
+#[test]
+fn test_repository_current_branch_detection() -> Result<()> {
+    // Arrange: Create repo (starts on master or main)
+    let repo = TestRepo::new()?;
+
+    // Act: Get branch from RepositoryManager
+    let manager = RepositoryManager::open(repo.path())?;
+    let branch = manager.get_current_branch()?;
+
+    // Assert: Should match default branch (master or main)
+    let expected_branch = repo.current_branch()?;
+    assert_eq!(
+        branch, expected_branch,
+        "Branch from RepositoryManager should match git branch"
+    );
+    assert!(
+        branch == "master" || branch == "main",
+        "Default branch should be 'master' or 'main', got '{}'",
+        branch
+    );
+
+    // Test with custom branch
+    repo.create_branch("feature/test-branch")?;
+    let manager = RepositoryManager::open(repo.path())?;
+    let new_branch = manager.get_current_branch()?;
+
+    assert_eq!(
+        new_branch, "feature/test-branch",
+        "Should detect switched branch"
+    );
+
+    Ok(())
+}
+
+/// GitChanges total() and format() should work correctly
+#[test]
+fn test_git_changes_total_and_format() -> Result<()> {
+    // Test default (no changes)
+    let empty = GitChanges::default();
+    assert_eq!(empty.total(), 0);
+    assert_eq!(empty.format(), "No changes");
+
+    // Test with values
+    let changes = GitChanges {
+        added: 3,
+        modified: 5,
+        deleted: 2,
+    };
+    assert_eq!(changes.total(), 10, "Total should be 3+5+2=10");
+    assert_eq!(changes.format(), "+3 ~5 -2", "Format should show +added ~modified -deleted");
+
+    // Test with only one type of change
+    let only_added = GitChanges {
+        added: 1,
+        modified: 0,
+        deleted: 0,
+    };
+    assert_eq!(only_added.total(), 1);
+    assert_eq!(only_added.format(), "+1 ~0 -0");
+
+    // Verify real repo produces valid GitChanges
+    let repo = TestRepo::new()?;
+    fs::write(repo.path().join("test.txt"), "test")?;
+
+    let manager = RepositoryManager::open(repo.path())?;
+    let real_changes = manager.get_status()?;
+
+    assert!(
+        real_changes.total() > 0,
+        "Real changes should have positive total"
+    );
+    assert!(
+        real_changes.format().contains('+'),
+        "Format should contain + indicator"
+    );
+
+    Ok(())
+}
+
+/// Status should change after staging files with git add
+#[test]
+fn test_repository_status_after_staging() -> Result<()> {
+    // Arrange: Create repo with new file
+    let repo = TestRepo::new()?;
+    fs::write(repo.path().join("staged_file.txt"), "Will be staged")?;
+
+    // Verify initial state shows as added (untracked)
+    let manager = RepositoryManager::open(repo.path())?;
+    let before_stage = manager.get_status()?;
+    assert!(before_stage.added >= 1, "Should detect untracked file as added");
+
+    // Act: Stage the file
+    Command::new("git")
+        .args(["add", "staged_file.txt"])
+        .current_dir(repo.path())
+        .output()?;
+
+    // Assert: File should still show in status (now as staged/index change)
+    // Note: get_status() counts both working tree and index changes
+    let after_stage = manager.get_status()?;
+    assert!(
+        after_stage.total() >= 1,
+        "Staged file should still appear in status"
+    );
+
+    Ok(())
+}
+
+/// Repository should be clean after committing all changes
+#[test]
+fn test_repository_is_clean_after_commit() -> Result<()> {
+    // Arrange: Create repo and add uncommitted changes
+    let repo = TestRepo::new()?;
+    fs::write(repo.path().join("new_file.txt"), "Content to commit")?;
+    fs::write(repo.path().join("README.md"), "Modified README")?;
+
+    // Verify dirty state
+    let manager = RepositoryManager::open(repo.path())?;
+    let dirty_changes = manager.get_status()?;
+    assert!(dirty_changes.total() > 0, "Should have uncommitted changes");
+    assert!(!manager.is_clean()?, "Should not be clean");
+
+    // Act: Stage and commit all changes
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo.path())
+        .output()?;
+
+    Command::new("git")
+        .args(["commit", "-m", "Commit all changes"])
+        .current_dir(repo.path())
+        .output()?;
+
+    // Assert: Should now be clean
+    let after_commit = manager.get_status()?;
+    assert_eq!(
+        after_commit.total(),
+        0,
+        "Should have no changes after commit"
+    );
+    assert!(manager.is_clean()?, "Should be clean after committing");
+    assert_eq!(after_commit.format(), "No changes");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod additional_coverage {
+    use super::*;
+
+    /// Verify RepositoryManager correctly handles has_uncommitted_changes
+    #[test]
+    fn test_has_uncommitted_changes() -> Result<()> {
+        let repo = TestRepo::new()?;
+        let manager = RepositoryManager::open(repo.path())?;
+
+        // Clean repo should have no uncommitted changes
+        assert!(!manager.has_uncommitted_changes()?);
+
+        // Add untracked file
+        fs::write(repo.path().join("dirty.txt"), "dirty")?;
+        assert!(manager.has_uncommitted_changes()?);
+
+        Ok(())
+    }
+
+    /// Verify commit count tracking
+    #[test]
+    fn test_commit_count() -> Result<()> {
+        let repo = TestRepo::new()?;
+        let manager = RepositoryManager::open(repo.path())?;
+
+        // Initial commit exists
+        let initial_count = manager.get_commit_count()?;
+        assert_eq!(initial_count, 1, "Should have 1 initial commit");
+
+        // Add more commits
+        repo.add_commit("file1.txt", "content1", "Second commit")?;
+        repo.add_commit("file2.txt", "content2", "Third commit")?;
+
+        let new_count = manager.get_commit_count()?;
+        assert_eq!(new_count, 3, "Should have 3 commits total");
+
+        Ok(())
+    }
+}

--- a/ainb-tui/tests/behavioral/session_lifecycle.rs
+++ b/ainb-tui/tests/behavioral/session_lifecycle.rs
@@ -1,0 +1,427 @@
+// ABOUTME: Behavioral tests for session lifecycle state machine, agent types, and model selection
+// Complements test_session_model.rs with state machine and agent type coverage.
+
+use ainb::models::{
+    ClaudeModel, Session, SessionAgentType, SessionMode, SessionStatus, ShellSession,
+};
+use std::path::PathBuf;
+
+// =============================================================================
+// Test 1: Session state machine valid transitions
+// =============================================================================
+
+/// Verifies all valid state transitions in the session lifecycle state machine.
+/// State machine: Stopped -> Running -> Idle -> (Stopped | Running)
+///                       -> Error -> (Stopped | Running)
+#[test]
+fn test_session_state_machine_valid_transitions() {
+    // Arrange: Create session starting in Stopped state
+    let mut session = Session::new("transition-test".to_string(), "/workspace".to_string());
+    assert!(matches!(session.status, SessionStatus::Stopped));
+
+    // Act/Assert: Stopped -> Running (valid: starting session)
+    session.set_status(SessionStatus::Running);
+    assert!(matches!(session.status, SessionStatus::Running));
+
+    // Act/Assert: Running -> Idle (valid: Claude process stops but tmux remains)
+    session.set_status(SessionStatus::Idle);
+    assert!(matches!(session.status, SessionStatus::Idle));
+
+    // Act/Assert: Idle -> Running (valid: restart Claude in existing tmux)
+    session.set_status(SessionStatus::Running);
+    assert!(matches!(session.status, SessionStatus::Running));
+
+    // Act/Assert: Running -> Error (valid: runtime error occurs)
+    session.set_status(SessionStatus::Error("Connection lost".to_string()));
+    assert!(matches!(session.status, SessionStatus::Error(_)));
+
+    // Act/Assert: Error -> Running (valid: recovery after error)
+    session.set_status(SessionStatus::Running);
+    assert!(matches!(session.status, SessionStatus::Running));
+
+    // Act/Assert: Running -> Stopped (valid: full shutdown)
+    session.set_status(SessionStatus::Stopped);
+    assert!(matches!(session.status, SessionStatus::Stopped));
+
+    // Act/Assert: Stopped -> Error (valid: startup failure)
+    session.set_status(SessionStatus::Error("Startup failed".to_string()));
+    assert!(matches!(session.status, SessionStatus::Error(_)));
+
+    // Act/Assert: Error -> Stopped (valid: cleanup after error)
+    session.set_status(SessionStatus::Stopped);
+    assert!(matches!(session.status, SessionStatus::Stopped));
+}
+
+// =============================================================================
+// Test 2: Session serialization roundtrip preserves all fields
+// =============================================================================
+
+/// Verifies that JSON serialization/deserialization preserves all session fields,
+/// including optional fields and newly added fields like agent_type and model.
+#[test]
+fn test_session_serialization_roundtrip_preserves_all_fields() {
+    // Arrange: Create session with all fields populated
+    let original = Session::new_with_options(
+        "full-session".to_string(),
+        "/path/to/workspace".to_string(),
+        true, // skip_permissions
+        SessionMode::Boss,
+        Some("Implement feature X".to_string()), // boss_prompt
+        SessionAgentType::Claude,
+        Some(ClaudeModel::Opus),
+    );
+
+    // Manually set additional fields that new_with_options doesn't set
+    let mut original = original;
+    original.container_id = Some("container-abc123".to_string());
+    original.status = SessionStatus::Idle;
+    original.git_changes.added = 5;
+    original.git_changes.modified = 3;
+    original.git_changes.deleted = 1;
+    original.recent_logs = Some("Last log entry".to_string());
+    original.tmux_session_name = Some("tmux_full-session".to_string());
+    original.preview_content = Some("Preview text".to_string());
+    original.is_attached = true;
+
+    // Act: Serialize and deserialize
+    let json = serde_json::to_string_pretty(&original).expect("serialization failed");
+    let restored: Session = serde_json::from_str(&json).expect("deserialization failed");
+
+    // Assert: All fields preserved
+    assert_eq!(restored.id, original.id);
+    assert_eq!(restored.name, original.name);
+    assert_eq!(restored.workspace_path, original.workspace_path);
+    assert_eq!(restored.branch_name, original.branch_name);
+    assert_eq!(restored.container_id, original.container_id);
+    assert_eq!(restored.status, original.status);
+    assert_eq!(restored.created_at, original.created_at);
+    assert_eq!(restored.last_accessed, original.last_accessed);
+    assert_eq!(restored.git_changes.added, original.git_changes.added);
+    assert_eq!(restored.git_changes.modified, original.git_changes.modified);
+    assert_eq!(restored.git_changes.deleted, original.git_changes.deleted);
+    assert_eq!(restored.recent_logs, original.recent_logs);
+    assert_eq!(restored.skip_permissions, original.skip_permissions);
+    assert_eq!(restored.mode, original.mode);
+    assert_eq!(restored.boss_prompt, original.boss_prompt);
+    assert_eq!(restored.agent_type, original.agent_type);
+    assert_eq!(restored.model, original.model);
+    assert_eq!(restored.tmux_session_name, original.tmux_session_name);
+    assert_eq!(restored.preview_content, original.preview_content);
+    assert_eq!(restored.is_attached, original.is_attached);
+}
+
+// =============================================================================
+// Test 3: Session agent type availability
+// =============================================================================
+
+/// Verifies that only Claude and Shell agents are currently available,
+/// while Codex, Gemini, and Kiro are marked as coming soon.
+#[test]
+fn test_session_agent_type_availability() {
+    // Assert: Available agents
+    assert!(
+        SessionAgentType::Claude.is_available(),
+        "Claude should be available"
+    );
+    assert!(
+        SessionAgentType::Shell.is_available(),
+        "Shell should be available"
+    );
+
+    // Assert: Coming soon agents
+    assert!(
+        !SessionAgentType::Codex.is_available(),
+        "Codex should not yet be available"
+    );
+    assert!(
+        !SessionAgentType::Gemini.is_available(),
+        "Gemini should not yet be available"
+    );
+    assert!(
+        !SessionAgentType::Kiro.is_available(),
+        "Kiro should not yet be available"
+    );
+
+    // Assert: All agent types have proper metadata
+    for agent_type in [
+        SessionAgentType::Claude,
+        SessionAgentType::Shell,
+        SessionAgentType::Codex,
+        SessionAgentType::Gemini,
+        SessionAgentType::Kiro,
+    ] {
+        assert!(!agent_type.icon().is_empty(), "Agent should have an icon");
+        assert!(!agent_type.name().is_empty(), "Agent should have a name");
+        assert!(
+            !agent_type.description().is_empty(),
+            "Agent should have a description"
+        );
+    }
+}
+
+// =============================================================================
+// Test 4: Claude model CLI values
+// =============================================================================
+
+/// Verifies that ClaudeModel CLI values match what the Claude CLI expects
+/// and that all models provide proper display information.
+#[test]
+fn test_claude_model_cli_values() {
+    // Assert: CLI values match expected strings
+    assert_eq!(
+        ClaudeModel::Sonnet.cli_value(),
+        "sonnet",
+        "Sonnet CLI value should be 'sonnet'"
+    );
+    assert_eq!(
+        ClaudeModel::Opus.cli_value(),
+        "opus",
+        "Opus CLI value should be 'opus'"
+    );
+    assert_eq!(
+        ClaudeModel::Haiku.cli_value(),
+        "haiku",
+        "Haiku CLI value should be 'haiku'"
+    );
+
+    // Assert: Display names are capitalized versions
+    assert_eq!(ClaudeModel::Sonnet.display_name(), "Sonnet");
+    assert_eq!(ClaudeModel::Opus.display_name(), "Opus");
+    assert_eq!(ClaudeModel::Haiku.display_name(), "Haiku");
+
+    // Assert: All models have descriptions and icons
+    for model in ClaudeModel::all() {
+        assert!(
+            !model.description().is_empty(),
+            "Model {:?} should have a description",
+            model
+        );
+        assert!(
+            !model.icon().is_empty(),
+            "Model {:?} should have an icon",
+            model
+        );
+    }
+
+    // Assert: Sonnet is the default model
+    assert_eq!(ClaudeModel::default(), ClaudeModel::Sonnet);
+
+    // Assert: all() returns all three models
+    let all_models = ClaudeModel::all();
+    assert_eq!(all_models.len(), 3);
+    assert!(all_models.contains(&ClaudeModel::Sonnet));
+    assert!(all_models.contains(&ClaudeModel::Opus));
+    assert!(all_models.contains(&ClaudeModel::Haiku));
+}
+
+// =============================================================================
+// Test 5: Shell session naming conventions
+// =============================================================================
+
+/// Verifies that ShellSession tmux names follow the expected patterns
+/// for different creation scenarios.
+#[test]
+fn test_shell_session_naming_conventions() {
+    // Scenario 1: Shell session with branch name
+    let session_with_branch = ShellSession::new(
+        PathBuf::from("/workspace"),
+        PathBuf::from("/workspace/worktrees/feature-auth"),
+        Some("feature/auth-refactor".to_string()),
+    );
+
+    // Assert: Name includes "shell-" prefix and sanitized branch
+    assert!(
+        session_with_branch.name.starts_with("shell-"),
+        "Shell session name should start with 'shell-'"
+    );
+    assert!(
+        session_with_branch.name.contains("feature"),
+        "Shell session name should contain branch info"
+    );
+    // Branch slashes should be replaced with dashes
+    assert!(
+        !session_with_branch.name.contains('/'),
+        "Shell session name should not contain slashes"
+    );
+
+    // Assert: Tmux name follows ainb-sh-{short_id} pattern
+    assert!(
+        session_with_branch.tmux_session_name.starts_with("ainb-sh-"),
+        "Tmux session name should start with 'ainb-sh-'"
+    );
+    assert_eq!(
+        session_with_branch.tmux_session_name.len(),
+        "ainb-sh-".len() + 8,
+        "Tmux session name should be 'ainb-sh-' + 8-char UUID"
+    );
+
+    // Scenario 2: Workspace shell
+    let workspace_shell =
+        ShellSession::new_workspace_shell(PathBuf::from("/workspace/my-project"), "my-project");
+
+    // Assert: Workspace shell has $ prefix
+    assert!(
+        workspace_shell.name.starts_with("$ "),
+        "Workspace shell name should start with '$ '"
+    );
+    assert!(
+        workspace_shell.name.contains("my-project"),
+        "Workspace shell name should contain workspace name"
+    );
+
+    // Assert: Tmux name follows ainb-ws-{short_id} pattern
+    assert!(
+        workspace_shell.tmux_session_name.starts_with("ainb-ws-"),
+        "Workspace tmux name should start with 'ainb-ws-'"
+    );
+
+    // Scenario 3: Shell session without branch (falls back to directory name)
+    let session_no_branch = ShellSession::new(
+        PathBuf::from("/workspace"),
+        PathBuf::from("/workspace/worktrees/my-feature"),
+        None,
+    );
+
+    // Assert: Uses directory name when no branch provided
+    assert!(
+        session_no_branch.name.contains("my-feature"),
+        "Shell session should use directory name when no branch provided"
+    );
+}
+
+// =============================================================================
+// Test 6: Session status can_restart logic
+// =============================================================================
+
+/// Verifies the can_restart() method returns true only for states
+/// where restarting makes sense (Idle and Error).
+#[test]
+fn test_session_status_can_restart_logic() {
+    // Assert: Idle sessions can be restarted (Claude stopped but tmux exists)
+    assert!(
+        SessionStatus::Idle.can_restart(),
+        "Idle sessions should be restartable"
+    );
+
+    // Assert: Error sessions can be restarted (recovery attempt)
+    assert!(
+        SessionStatus::Error("Some error".to_string()).can_restart(),
+        "Error sessions should be restartable"
+    );
+    assert!(
+        SessionStatus::Error(String::new()).can_restart(),
+        "Error sessions with empty message should be restartable"
+    );
+
+    // Assert: Running sessions cannot be restarted (already running)
+    assert!(
+        !SessionStatus::Running.can_restart(),
+        "Running sessions should not be restartable"
+    );
+
+    // Assert: Stopped sessions cannot be restarted (need to start fresh)
+    assert!(
+        !SessionStatus::Stopped.can_restart(),
+        "Stopped sessions should not be restartable - they need full startup"
+    );
+}
+
+// =============================================================================
+// Test 7: Session idle status behavior
+// =============================================================================
+
+/// Verifies Idle status specific behavior including indicator and state checks.
+/// Idle represents a state where tmux exists but Claude process has stopped.
+#[test]
+fn test_session_idle_status_behavior() {
+    let idle_status = SessionStatus::Idle;
+
+    // Assert: Idle has its own indicator (empty circle)
+    assert_eq!(
+        idle_status.indicator(),
+        "○",
+        "Idle should have empty circle indicator"
+    );
+
+    // Assert: Idle is not considered "running"
+    assert!(
+        !idle_status.is_running(),
+        "Idle should not be considered running"
+    );
+
+    // Assert: Idle can be restarted
+    assert!(
+        idle_status.can_restart(),
+        "Idle sessions should be restartable"
+    );
+
+    // Assert: Session can transition to and from Idle
+    let mut session = Session::new("idle-test".to_string(), "/workspace".to_string());
+
+    // Simulate: Start -> Run -> Idle -> Restart cycle
+    session.set_status(SessionStatus::Running);
+    assert!(session.status.is_running());
+
+    session.set_status(SessionStatus::Idle);
+    assert!(!session.status.is_running());
+    assert!(session.status.can_restart());
+
+    session.set_status(SessionStatus::Running);
+    assert!(session.status.is_running());
+}
+
+// =============================================================================
+// Test 8: Session error status preserves message
+// =============================================================================
+
+/// Verifies that Error status preserves the error message through serialization
+/// and provides expected behavior.
+#[test]
+fn test_session_error_status_preserves_message() {
+    let error_message = "Connection timeout after 30 seconds";
+
+    // Arrange: Create session with error status
+    let mut session = Session::new("error-test".to_string(), "/workspace".to_string());
+    session.set_status(SessionStatus::Error(error_message.to_string()));
+
+    // Assert: Error message is preserved in status
+    match &session.status {
+        SessionStatus::Error(msg) => {
+            assert_eq!(msg, error_message, "Error message should be preserved");
+        }
+        _ => panic!("Expected Error status"),
+    }
+
+    // Assert: Error has correct indicator
+    assert_eq!(session.status.indicator(), "✗");
+
+    // Assert: Error is not running
+    assert!(!session.status.is_running());
+
+    // Act: Serialize and deserialize
+    let json = serde_json::to_string(&session).expect("serialization failed");
+    let restored: Session = serde_json::from_str(&json).expect("deserialization failed");
+
+    // Assert: Error message preserved through serialization
+    match &restored.status {
+        SessionStatus::Error(msg) => {
+            assert_eq!(
+                msg, error_message,
+                "Error message should survive serialization roundtrip"
+            );
+        }
+        _ => panic!("Expected Error status after deserialization"),
+    }
+
+    // Assert: Different error messages are distinct
+    let error1 = SessionStatus::Error("Error A".to_string());
+    let error2 = SessionStatus::Error("Error B".to_string());
+    assert_ne!(error1, error2, "Different error messages should not be equal");
+
+    // Assert: Same error messages are equal
+    let error3 = SessionStatus::Error("Error A".to_string());
+    assert_eq!(
+        error1, error3,
+        "Same error messages should be equal"
+    );
+}

--- a/ainb-tui/tests/behavioral/session_lifecycle.rs
+++ b/ainb-tui/tests/behavioral/session_lifecycle.rs
@@ -118,7 +118,7 @@ fn test_session_serialization_roundtrip_preserves_all_fields() {
 /// while Codex, Gemini, and Kiro are marked as coming soon.
 #[test]
 fn test_session_agent_type_availability() {
-    // Assert: Available agents
+    // Assert: Available agents (including multi-provider support)
     assert!(
         SessionAgentType::Claude.is_available(),
         "Claude should be available"
@@ -127,16 +127,24 @@ fn test_session_agent_type_availability() {
         SessionAgentType::Shell.is_available(),
         "Shell should be available"
     );
+    assert!(
+        SessionAgentType::Ssh.is_available(),
+        "Ssh should be available"
+    );
+    assert!(
+        SessionAgentType::Codex.is_available(),
+        "Codex should be available"
+    );
+    assert!(
+        SessionAgentType::Gemini.is_available(),
+        "Gemini should be available"
+    );
+    assert!(
+        SessionAgentType::Copilot.is_available(),
+        "Copilot should be available"
+    );
 
-    // Assert: Coming soon agents
-    assert!(
-        !SessionAgentType::Codex.is_available(),
-        "Codex should not yet be available"
-    );
-    assert!(
-        !SessionAgentType::Gemini.is_available(),
-        "Gemini should not yet be available"
-    );
+    // Assert: Still coming soon
     assert!(
         !SessionAgentType::Kiro.is_available(),
         "Kiro should not yet be available"

--- a/ainb-tui/tests/behavioral/session_persistence.rs
+++ b/ainb-tui/tests/behavioral/session_persistence.rs
@@ -1,0 +1,362 @@
+// ABOUTME: Behavioral tests for SessionStore format compatibility between CLI and TUI
+//
+// Verifies JSON format, round-trip persistence, and keyed operations by tmux session name.
+
+use ainb::interactive::session_manager::{SessionMetadata, SessionStore};
+use chrono::{Datelike, Utc};
+use std::path::PathBuf;
+use uuid::Uuid;
+
+/// Helper: Create a SessionMetadata with specified values
+fn create_session_metadata(
+    tmux_name: &str,
+    worktree_path: &str,
+    workspace_name: &str,
+) -> SessionMetadata {
+    SessionMetadata {
+        session_id: Uuid::new_v4(),
+        tmux_session_name: tmux_name.to_string(),
+        worktree_path: PathBuf::from(worktree_path),
+        workspace_name: workspace_name.to_string(),
+        created_at: Utc::now(),
+    }
+}
+
+/// Helper: Create a SessionMetadata with a fixed UUID for deterministic tests
+fn create_session_metadata_with_id(
+    session_id: Uuid,
+    tmux_name: &str,
+    worktree_path: &str,
+    workspace_name: &str,
+) -> SessionMetadata {
+    SessionMetadata {
+        session_id,
+        tmux_session_name: tmux_name.to_string(),
+        worktree_path: PathBuf::from(worktree_path),
+        workspace_name: workspace_name.to_string(),
+        created_at: Utc::now(),
+    }
+}
+
+/// Test 1: Save and load preserves all data (roundtrip)
+#[test]
+fn test_session_store_roundtrip() {
+    // Arrange: Create a store with multiple sessions
+    let mut store = SessionStore::default();
+
+    let session1 = create_session_metadata(
+        "tmux_feature-auth",
+        "/path/to/worktree1",
+        "my-project",
+    );
+    let session2 = create_session_metadata(
+        "tmux_bugfix-123",
+        "/path/to/worktree2",
+        "another-project",
+    );
+
+    let session1_id = session1.session_id;
+    let session2_id = session2.session_id;
+    let session1_path = session1.worktree_path.clone();
+    let session2_path = session2.worktree_path.clone();
+    let session1_created = session1.created_at;
+    let session2_created = session2.created_at;
+
+    store.upsert(session1);
+    store.upsert(session2);
+
+    // Act: Serialize and deserialize
+    let json = serde_json::to_string_pretty(&store).expect("serialize failed");
+    let loaded: SessionStore = serde_json::from_str(&json).expect("deserialize failed");
+
+    // Assert: All data preserved
+    assert_eq!(loaded.sessions.len(), 2);
+
+    let loaded_session1 = loaded.find_by_tmux_name("tmux_feature-auth")
+        .expect("session1 not found");
+    assert_eq!(loaded_session1.session_id, session1_id);
+    assert_eq!(loaded_session1.worktree_path, session1_path);
+    assert_eq!(loaded_session1.workspace_name, "my-project");
+    assert_eq!(loaded_session1.created_at, session1_created);
+
+    let loaded_session2 = loaded.find_by_tmux_name("tmux_bugfix-123")
+        .expect("session2 not found");
+    assert_eq!(loaded_session2.session_id, session2_id);
+    assert_eq!(loaded_session2.worktree_path, session2_path);
+    assert_eq!(loaded_session2.workspace_name, "another-project");
+    assert_eq!(loaded_session2.created_at, session2_created);
+}
+
+/// Test 2: Parse exact TUI JSON format
+#[test]
+fn test_session_store_json_format_matches_tui() {
+    // Arrange: JSON in the exact format the TUI produces
+    let tui_json = r#"{
+  "sessions": {
+    "tmux_session-name": {
+      "session_id": "550e8400-e29b-41d4-a716-446655440000",
+      "tmux_session_name": "tmux_session-name",
+      "worktree_path": "/Users/dev/project/.worktrees/feature-branch",
+      "workspace_name": "my-workspace",
+      "created_at": "2026-01-17T18:25:46.150247Z"
+    }
+  }
+}"#;
+
+    // Act: Parse the JSON
+    let store: SessionStore = serde_json::from_str(tui_json)
+        .expect("failed to parse TUI format");
+
+    // Assert: All fields parsed correctly
+    assert_eq!(store.sessions.len(), 1);
+
+    let session = store.find_by_tmux_name("tmux_session-name")
+        .expect("session not found");
+
+    assert_eq!(
+        session.session_id.to_string(),
+        "550e8400-e29b-41d4-a716-446655440000"
+    );
+    assert_eq!(session.tmux_session_name, "tmux_session-name");
+    assert_eq!(
+        session.worktree_path,
+        PathBuf::from("/Users/dev/project/.worktrees/feature-branch")
+    );
+    assert_eq!(session.workspace_name, "my-workspace");
+
+    // Verify datetime parsing (ISO 8601 format)
+    assert_eq!(session.created_at.year(), 2026);
+    assert_eq!(session.created_at.month(), 1);
+    assert_eq!(session.created_at.day(), 17);
+}
+
+/// Test 3: Sessions are indexed by tmux_session_name
+#[test]
+fn test_session_store_keyed_by_tmux_name() {
+    // Arrange: Create store and add sessions
+    let mut store = SessionStore::default();
+
+    let session = create_session_metadata(
+        "tmux_my-feature",
+        "/path/to/worktree",
+        "workspace",
+    );
+
+    store.upsert(session);
+
+    // Act: Serialize to JSON
+    let json = serde_json::to_string(&store).expect("serialize failed");
+
+    // Assert: JSON uses tmux name as key
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse failed");
+
+    // The sessions object should have the tmux name as key
+    let sessions_obj = parsed.get("sessions").expect("no sessions field");
+    assert!(
+        sessions_obj.get("tmux_my-feature").is_some(),
+        "Session should be keyed by tmux_session_name"
+    );
+
+    // Also verify via the API
+    assert!(store.find_by_tmux_name("tmux_my-feature").is_some());
+    assert!(store.find_by_tmux_name("nonexistent").is_none());
+
+    // Check tracked_tmux_names includes our session
+    let tracked = store.tracked_tmux_names();
+    assert!(tracked.contains(&"tmux_my-feature"));
+}
+
+/// Test 4: Upsert updates existing session (same tmux name)
+#[test]
+fn test_session_store_upsert_updates_existing() {
+    // Arrange: Create store with initial session
+    let mut store = SessionStore::default();
+
+    let original_id = Uuid::new_v4();
+    let original_session = create_session_metadata_with_id(
+        original_id,
+        "tmux_shared-name",
+        "/original/path",
+        "original-workspace",
+    );
+
+    store.upsert(original_session);
+    assert_eq!(store.sessions.len(), 1);
+
+    // Act: Upsert with same tmux name but different data
+    let updated_id = Uuid::new_v4();
+    let updated_session = create_session_metadata_with_id(
+        updated_id,
+        "tmux_shared-name",  // Same tmux name
+        "/updated/path",     // Different path
+        "updated-workspace", // Different workspace
+    );
+
+    store.upsert(updated_session);
+
+    // Assert: Still only one session, but with updated values
+    assert_eq!(store.sessions.len(), 1);
+
+    let session = store.find_by_tmux_name("tmux_shared-name")
+        .expect("session not found");
+
+    // Should have the NEW values
+    assert_eq!(session.session_id, updated_id);
+    assert_eq!(session.worktree_path, PathBuf::from("/updated/path"));
+    assert_eq!(session.workspace_name, "updated-workspace");
+
+    // Should NOT have the old values
+    assert_ne!(session.session_id, original_id);
+}
+
+/// Test 5: Remove by tmux name works
+#[test]
+fn test_session_store_remove_by_tmux_name() {
+    // Arrange: Create store with multiple sessions
+    let mut store = SessionStore::default();
+
+    store.upsert(create_session_metadata(
+        "tmux_to-keep",
+        "/path/keep",
+        "workspace-keep",
+    ));
+    store.upsert(create_session_metadata(
+        "tmux_to-remove",
+        "/path/remove",
+        "workspace-remove",
+    ));
+    store.upsert(create_session_metadata(
+        "tmux_also-keep",
+        "/path/also-keep",
+        "workspace-also-keep",
+    ));
+
+    assert_eq!(store.sessions.len(), 3);
+
+    // Act: Remove by tmux name
+    store.remove_by_tmux_name("tmux_to-remove");
+
+    // Assert: Only the target session removed
+    assert_eq!(store.sessions.len(), 2);
+    assert!(store.find_by_tmux_name("tmux_to-keep").is_some());
+    assert!(store.find_by_tmux_name("tmux_also-keep").is_some());
+    assert!(store.find_by_tmux_name("tmux_to-remove").is_none());
+
+    // Removing non-existent should be a no-op
+    store.remove_by_tmux_name("tmux_nonexistent");
+    assert_eq!(store.sessions.len(), 2);
+}
+
+/// Test 6: Remove by session_id (UUID) works
+#[test]
+fn test_session_store_remove_by_session_id() {
+    // Arrange: Create store with sessions having known UUIDs
+    let mut store = SessionStore::default();
+
+    let id_to_keep = Uuid::new_v4();
+    let id_to_remove = Uuid::new_v4();
+    let id_also_keep = Uuid::new_v4();
+
+    store.upsert(create_session_metadata_with_id(
+        id_to_keep,
+        "tmux_keep-1",
+        "/path/1",
+        "workspace-1",
+    ));
+    store.upsert(create_session_metadata_with_id(
+        id_to_remove,
+        "tmux_remove-me",
+        "/path/2",
+        "workspace-2",
+    ));
+    store.upsert(create_session_metadata_with_id(
+        id_also_keep,
+        "tmux_keep-2",
+        "/path/3",
+        "workspace-3",
+    ));
+
+    assert_eq!(store.sessions.len(), 3);
+
+    // Act: Remove by session_id
+    store.remove_by_session_id(id_to_remove);
+
+    // Assert: Only the target session removed
+    assert_eq!(store.sessions.len(), 2);
+    assert!(store.find_by_tmux_name("tmux_keep-1").is_some());
+    assert!(store.find_by_tmux_name("tmux_keep-2").is_some());
+    assert!(store.find_by_tmux_name("tmux_remove-me").is_none());
+
+    // Verify the remaining sessions have correct IDs
+    let kept_1 = store.find_by_tmux_name("tmux_keep-1").unwrap();
+    assert_eq!(kept_1.session_id, id_to_keep);
+
+    let kept_2 = store.find_by_tmux_name("tmux_keep-2").unwrap();
+    assert_eq!(kept_2.session_id, id_also_keep);
+
+    // Removing non-existent UUID should be a no-op
+    let random_id = Uuid::new_v4();
+    store.remove_by_session_id(random_id);
+    assert_eq!(store.sessions.len(), 2);
+}
+
+/// Additional test: Verify serialized JSON matches expected format exactly
+#[test]
+fn test_session_store_serialization_format() {
+    // Arrange: Create store with known data
+    let mut store = SessionStore::default();
+
+    let fixed_id = Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap();
+    let mut session = create_session_metadata_with_id(
+        fixed_id,
+        "tmux_test-session",
+        "/test/path",
+        "test-workspace",
+    );
+    // Use a fixed timestamp for deterministic output
+    session.created_at = chrono::DateTime::parse_from_rfc3339("2026-01-17T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    store.upsert(session);
+
+    // Act: Serialize
+    let json = serde_json::to_string_pretty(&store).expect("serialize failed");
+
+    // Assert: Parse and verify structure
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse failed");
+
+    // Verify top-level structure
+    assert!(parsed.is_object());
+    assert!(parsed.get("sessions").is_some());
+
+    // Verify session structure
+    let sessions = parsed.get("sessions").unwrap();
+    let session_data = sessions.get("tmux_test-session").unwrap();
+
+    assert_eq!(session_data.get("session_id").unwrap(), "12345678-1234-1234-1234-123456789abc");
+    assert_eq!(session_data.get("tmux_session_name").unwrap(), "tmux_test-session");
+    assert_eq!(session_data.get("worktree_path").unwrap(), "/test/path");
+    assert_eq!(session_data.get("workspace_name").unwrap(), "test-workspace");
+    assert!(session_data.get("created_at").is_some());
+}
+
+/// Test: Empty store serializes correctly
+#[test]
+fn test_empty_session_store() {
+    let store = SessionStore::default();
+
+    // Serialize empty store
+    let json = serde_json::to_string(&store).expect("serialize failed");
+
+    // Parse and verify
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse failed");
+    let sessions = parsed.get("sessions").expect("no sessions field");
+
+    assert!(sessions.is_object());
+    assert_eq!(sessions.as_object().unwrap().len(), 0);
+
+    // Round-trip
+    let loaded: SessionStore = serde_json::from_str(&json).expect("deserialize failed");
+    assert_eq!(loaded.sessions.len(), 0);
+}

--- a/ainb-tui/tests/behavioral/session_persistence.rs
+++ b/ainb-tui/tests/behavioral/session_persistence.rs
@@ -3,6 +3,7 @@
 // Verifies JSON format, round-trip persistence, and keyed operations by tmux session name.
 
 use ainb::interactive::session_manager::{SessionMetadata, SessionStore};
+use ainb::models::session::SessionAgentType;
 use chrono::{Datelike, Utc};
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -19,6 +20,7 @@ fn create_session_metadata(
         worktree_path: PathBuf::from(worktree_path),
         workspace_name: workspace_name.to_string(),
         created_at: Utc::now(),
+        agent_type: SessionAgentType::default(),
     }
 }
 
@@ -35,6 +37,7 @@ fn create_session_metadata_with_id(
         worktree_path: PathBuf::from(worktree_path),
         workspace_name: workspace_name.to_string(),
         created_at: Utc::now(),
+        agent_type: SessionAgentType::default(),
     }
 }
 

--- a/ainb-tui/tests/behavioral/tmux_lifecycle.rs
+++ b/ainb-tui/tests/behavioral/tmux_lifecycle.rs
@@ -1,0 +1,349 @@
+// ABOUTME: Behavioral tests for tmux session lifecycle management
+//
+// Tests verify correct behavior for session creation, cleanup, content capture,
+// and Claude process detection. All tests are conditional on tmux availability.
+
+use super::fixtures::{
+    cleanup_tmux_session, send_tmux_keys, tmux_available, tmux_session_exists,
+};
+use crate::require_tmux;
+use ainb::tmux::{CaptureOptions, ClaudeProcessDetector, TmuxSession};
+use anyhow::Result;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Generate a unique test session name to avoid conflicts
+fn unique_session_name(prefix: &str) -> String {
+    format!("test_{}_{}", prefix, Uuid::new_v4().to_string()[..8].to_string())
+}
+
+/// Test that tmux sessions can be created and cleaned up properly
+#[tokio::test]
+async fn test_tmux_session_create_and_cleanup() -> Result<()> {
+    require_tmux!();
+
+    let session_name = unique_session_name("create");
+    let mut session = TmuxSession::new(session_name.clone(), "bash".to_string());
+
+    // Create a temp directory for the session
+    let temp_dir = tempfile::tempdir()?;
+
+    // Start the session
+    session.start(temp_dir.path()).await?;
+
+    // Verify session exists
+    assert!(
+        session.does_session_exist().await,
+        "Session should exist after start"
+    );
+    assert!(
+        tmux_session_exists(session.name()),
+        "Session should be visible via tmux has-session"
+    );
+
+    // Cleanup the session
+    session.cleanup().await?;
+
+    // Allow tmux to process the kill command
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify session no longer exists
+    assert!(
+        !session.does_session_exist().await,
+        "Session should not exist after cleanup"
+    );
+    assert!(
+        !tmux_session_exists(session.name()),
+        "Session should not be visible after cleanup"
+    );
+
+    Ok(())
+}
+
+/// Test that session names with special characters are properly sanitized
+#[tokio::test]
+async fn test_tmux_session_name_sanitization() -> Result<()> {
+    require_tmux!();
+
+    // Test various special characters that tmux doesn't allow in session names
+    let test_cases = vec![
+        ("my session", "tmux_my_session"),
+        ("test.name", "tmux_test_name"),
+        ("path/to/thing", "tmux_path_to_thing"),
+        ("colon:separated", "tmux_colon_separated"),
+        ("complex.name/with:all chars", "tmux_complex_name_with_all_chars"),
+        // Already prefixed should not double-prefix
+        ("tmux_already_prefixed", "tmux_already_prefixed"),
+    ];
+
+    for (input, expected) in test_cases {
+        let session = TmuxSession::new(input.to_string(), "bash".to_string());
+        assert_eq!(
+            session.name(),
+            expected,
+            "Session name '{}' should sanitize to '{}'",
+            input,
+            expected
+        );
+    }
+
+    // Verify a sanitized name actually works with tmux
+    let session_name = unique_session_name("special.chars/test:name");
+    let mut session = TmuxSession::new(session_name.clone(), "bash".to_string());
+    let temp_dir = tempfile::tempdir()?;
+
+    session.start(temp_dir.path()).await?;
+    assert!(
+        session.does_session_exist().await,
+        "Session with sanitized name should start successfully"
+    );
+
+    // Cleanup
+    session.cleanup().await?;
+
+    Ok(())
+}
+
+/// Test capturing pane content after sending commands
+#[tokio::test]
+async fn test_tmux_session_capture_pane_content() -> Result<()> {
+    require_tmux!();
+
+    let session_name = unique_session_name("capture");
+    let mut session = TmuxSession::new(session_name.clone(), "bash".to_string());
+    let temp_dir = tempfile::tempdir()?;
+
+    session.start(temp_dir.path()).await?;
+
+    // Wait for shell to initialize
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Send a command that produces predictable output
+    send_tmux_keys(session.name(), "echo 'CAPTURE_TEST_OUTPUT_12345'")?;
+    send_tmux_keys(session.name(), "Enter")?;
+
+    // Wait for command to execute
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Capture the pane content
+    let content = session.capture_pane_content().await?;
+
+    // Verify our output is in the captured content
+    assert!(
+        content.contains("CAPTURE_TEST_OUTPUT_12345"),
+        "Captured content should contain our test output. Got: {}",
+        content
+    );
+
+    // Cleanup
+    session.cleanup().await?;
+
+    Ok(())
+}
+
+/// Test that starting a session twice is idempotent (doesn't fail)
+#[tokio::test]
+async fn test_tmux_session_idempotent_start() -> Result<()> {
+    require_tmux!();
+
+    let session_name = unique_session_name("idempotent");
+    let mut session = TmuxSession::new(session_name.clone(), "bash".to_string());
+    let temp_dir = tempfile::tempdir()?;
+
+    // First start
+    session.start(temp_dir.path()).await?;
+    assert!(session.does_session_exist().await, "Session should exist after first start");
+
+    // Second start should not fail (implementation kills and recreates)
+    session.start(temp_dir.path()).await?;
+    assert!(
+        session.does_session_exist().await,
+        "Session should still exist after second start"
+    );
+
+    // Cleanup
+    session.cleanup().await?;
+
+    Ok(())
+}
+
+/// Test that cleanup is idempotent (calling twice doesn't fail)
+#[tokio::test]
+async fn test_tmux_session_cleanup_is_idempotent() -> Result<()> {
+    require_tmux!();
+
+    let session_name = unique_session_name("cleanup_idem");
+    let mut session = TmuxSession::new(session_name.clone(), "bash".to_string());
+    let temp_dir = tempfile::tempdir()?;
+
+    // Start and then cleanup
+    session.start(temp_dir.path()).await?;
+    session.cleanup().await?;
+
+    // Allow tmux to process
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    assert!(
+        !session.does_session_exist().await,
+        "Session should not exist after first cleanup"
+    );
+
+    // Second cleanup should not fail
+    let result = session.cleanup().await;
+    assert!(
+        result.is_ok(),
+        "Second cleanup should not fail, got: {:?}",
+        result.err()
+    );
+
+    Ok(())
+}
+
+/// Test Claude process detector recognizes status bar patterns
+#[tokio::test]
+async fn test_claude_process_detector_status_bar_patterns() -> Result<()> {
+    // Note: This test doesn't require tmux as it tests pattern matching directly
+    let detector = ClaudeProcessDetector::new();
+
+    // Test cases with Claude status bar present (should detect)
+    let positive_cases = vec![
+        // Full status bar
+        "Some output\nModel: Sonnet 4.5  Cost: $0.45  Session: 12m  Ctx: 25k\nMore output",
+        // Partial status bar with 2+ indicators
+        "Model: Opus  Cost: $1.23",
+        "Session: 5m  Ctx: 10k",
+        "Cost: $0.00  Model: Haiku",
+        // Different model names
+        "Model: Claude 3.5 Sonnet  Cost: $2.50",
+        "Model: claude-3-opus-20240229  Session: 1h",
+        // High costs
+        "Model: Opus  Cost: $123.45  Session: 45m",
+        // Long sessions
+        "Model: Sonnet 4.5  Session: 2h15m  Ctx: 150k",
+    ];
+
+    for content in positive_cases {
+        assert!(
+            detector.has_claude_status_bar(content),
+            "Should detect Claude status bar in: {}",
+            content
+        );
+    }
+
+    // Test cases without Claude status bar (should not detect)
+    let negative_cases = vec![
+        // Regular shell output
+        "$ ls -la\ntotal 64\ndrwxr-xr-x",
+        // Only one indicator (not enough)
+        "Some output that mentions Model: Something\nBut no other indicators",
+        "Just mentions Cost: somewhere",
+        // Empty content
+        "",
+        // Random text
+        "Hello world\nThis is just some text",
+        // Similar but not matching patterns
+        "The model was trained on data",
+        "The session lasted 5 minutes",
+    ];
+
+    for content in negative_cases {
+        assert!(
+            !detector.has_claude_status_bar(content),
+            "Should NOT detect Claude status bar in: {}",
+            content
+        );
+    }
+
+    Ok(())
+}
+
+/// Test different capture options: visible vs full history
+#[tokio::test]
+async fn test_tmux_capture_options_visible_vs_full_history() -> Result<()> {
+    require_tmux!();
+
+    let session_name = unique_session_name("capture_opts");
+    let mut session = TmuxSession::new(session_name.clone(), "bash".to_string());
+    let temp_dir = tempfile::tempdir()?;
+
+    session.start(temp_dir.path()).await?;
+
+    // Wait for shell to initialize
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Generate some history by sending multiple commands
+    for i in 1..=5 {
+        send_tmux_keys(session.name(), &format!("echo 'HISTORY_LINE_{}'", i))?;
+        send_tmux_keys(session.name(), "Enter")?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Wait for commands to complete
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Test visible capture options
+    let visible_opts = CaptureOptions::visible();
+    assert!(visible_opts.start_line.is_none(), "Visible capture should have no start line");
+    assert!(visible_opts.end_line.is_none(), "Visible capture should have no end line");
+    assert!(visible_opts.include_escape_sequences, "Should include escape sequences by default");
+    assert!(visible_opts.join_wrapped_lines, "Should join wrapped lines by default");
+
+    // Test full history capture options
+    let history_opts = CaptureOptions::full_history();
+    assert_eq!(
+        history_opts.start_line,
+        Some("-".to_string()),
+        "Full history should have '-' start line"
+    );
+    assert_eq!(
+        history_opts.end_line,
+        Some("-".to_string()),
+        "Full history should have '-' end line"
+    );
+
+    // Capture visible content
+    let visible_content = session.capture_pane_content().await?;
+
+    // Capture full history
+    let full_content = session.capture_full_history().await?;
+
+    // Both should contain our test output
+    assert!(
+        visible_content.contains("HISTORY_LINE") || full_content.contains("HISTORY_LINE"),
+        "At least one capture mode should contain our history lines"
+    );
+
+    // Full history should generally be >= visible content length
+    // (unless screen is very large and history is small)
+    // We check that full_history captures content successfully
+    assert!(
+        !full_content.is_empty(),
+        "Full history capture should return non-empty content"
+    );
+
+    // Cleanup
+    session.cleanup().await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod helper_tests {
+    use super::*;
+
+    #[test]
+    fn test_unique_session_name_generates_different_names() {
+        let name1 = unique_session_name("test");
+        let name2 = unique_session_name("test");
+        assert_ne!(name1, name2, "Each call should generate a unique name");
+    }
+
+    #[test]
+    fn test_unique_session_name_contains_prefix() {
+        let name = unique_session_name("myprefix");
+        assert!(
+            name.contains("myprefix"),
+            "Generated name should contain the prefix"
+        );
+    }
+}

--- a/ainb-tui/tests/behavioral/worktree_integration.rs
+++ b/ainb-tui/tests/behavioral/worktree_integration.rs
@@ -1,0 +1,509 @@
+// ABOUTME: Behavioral tests for git worktree integration verifying worktree creation and removal
+// with real git repositories in temporary directories.
+
+use anyhow::Result;
+use std::path::Path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use ainb::git::worktree_manager::{WorktreeError, WorktreeManager};
+
+use crate::fixtures::TestRepo;
+
+/// Helper to create a WorktreeManager with a temporary base directory
+fn create_test_manager() -> Result<(WorktreeManager, TempDir)> {
+    let worktree_base = TempDir::new()?;
+    let manager = WorktreeManager::with_base_dir(worktree_base.path().to_path_buf())?;
+    Ok((manager, worktree_base))
+}
+
+/// Verify symlink exists and points to expected target
+fn verify_symlink(symlink_path: &Path, expected_target: &Path) -> bool {
+    if !symlink_path.is_symlink() {
+        return false;
+    }
+    match std::fs::read_link(symlink_path) {
+        Ok(target) => target == expected_target,
+        Err(_) => false,
+    }
+}
+
+#[test]
+fn test_worktree_creation_creates_branch_and_symlink() -> Result<()> {
+    // GIVEN: A test git repository and worktree manager
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+    let session_id = Uuid::new_v4();
+    let branch_name = "feature/test-branch";
+
+    // WHEN: Creating a worktree
+    let worktree_info = manager.create_worktree(
+        session_id,
+        repo.path(),
+        branch_name,
+        None, // Use default base branch
+    )?;
+
+    // THEN: Worktree directory exists
+    assert!(
+        worktree_info.path.exists(),
+        "Worktree path should exist: {}",
+        worktree_info.path.display()
+    );
+
+    // THEN: Worktree is a valid git repository
+    assert!(
+        worktree_info.path.join(".git").exists(),
+        "Worktree should have .git file"
+    );
+
+    // THEN: Session symlink exists and points to worktree
+    assert!(
+        worktree_info.session_path.exists(),
+        "Session symlink should exist: {}",
+        worktree_info.session_path.display()
+    );
+    assert!(
+        verify_symlink(&worktree_info.session_path, &worktree_info.path),
+        "Session symlink should point to worktree path"
+    );
+
+    // THEN: Branch name matches
+    assert_eq!(worktree_info.branch_name, branch_name);
+
+    // THEN: Source repository path matches
+    assert_eq!(worktree_info.source_repository, repo.path());
+
+    // THEN: Commit hash is populated
+    assert!(
+        worktree_info.commit_hash.is_some(),
+        "Commit hash should be populated"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_removal_cleans_up_symlink_and_directory() -> Result<()> {
+    // GIVEN: An existing worktree
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+    let session_id = Uuid::new_v4();
+    let branch_name = "feature/to-be-removed";
+
+    let worktree_info = manager.create_worktree(session_id, repo.path(), branch_name, None)?;
+
+    let worktree_path = worktree_info.path.clone();
+    let session_path = worktree_info.session_path.clone();
+
+    // Verify worktree was created
+    assert!(worktree_path.exists(), "Worktree should exist before removal");
+    assert!(
+        session_path.exists(),
+        "Session symlink should exist before removal"
+    );
+
+    // WHEN: Removing the worktree
+    manager.remove_worktree(session_id)?;
+
+    // THEN: Worktree directory is removed
+    assert!(
+        !worktree_path.exists(),
+        "Worktree directory should be removed: {}",
+        worktree_path.display()
+    );
+
+    // THEN: Session symlink is removed
+    assert!(
+        !session_path.exists(),
+        "Session symlink should be removed: {}",
+        session_path.display()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_creation_fails_for_invalid_branch_names() -> Result<()> {
+    // GIVEN: A test repository and worktree manager
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+
+    // List of invalid branch names with reasons
+    let invalid_names = [
+        ("", "empty string"),
+        ("branch with space", "contains space"),
+        ("branch~tilde", "contains tilde"),
+        ("branch^caret", "contains caret"),
+        ("branch:colon", "contains colon"),
+        ("branch?question", "contains question mark"),
+        ("branch*asterisk", "contains asterisk"),
+        ("branch[bracket", "contains bracket"),
+        ("branch\\backslash", "contains backslash"),
+        ("-starts-with-dash", "starts with dash"),
+        ("ends-with-slash/", "ends with slash"),
+        ("contains//double-slash", "contains double slash"),
+    ];
+
+    for (invalid_name, reason) in invalid_names {
+        let session_id = Uuid::new_v4();
+
+        // WHEN: Attempting to create worktree with invalid branch name
+        let result = manager.create_worktree(session_id, repo.path(), invalid_name, None);
+
+        // THEN: Creation fails with InvalidBranchName error
+        assert!(
+            result.is_err(),
+            "Should reject branch name '{}' ({})",
+            invalid_name,
+            reason
+        );
+
+        if let Err(WorktreeError::InvalidBranchName(msg)) = result {
+            assert!(
+                !msg.is_empty(),
+                "Error message should not be empty for '{}'",
+                invalid_name
+            );
+        } else {
+            panic!(
+                "Expected InvalidBranchName error for '{}' ({}), got: {:?}",
+                invalid_name, reason, result
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_creation_accepts_valid_branch_names() -> Result<()> {
+    // GIVEN: A test repository and worktree manager
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+
+    // List of valid branch names
+    let valid_names = [
+        "simple-branch",
+        "feature/nested/path",
+        "UPPERCASE",
+        "MixedCase",
+        "with-numbers-123",
+        "with_underscores",
+        "a", // Single character
+        "feature/ABC-123-add-feature",
+    ];
+
+    for valid_name in valid_names {
+        let session_id = Uuid::new_v4();
+
+        // WHEN: Creating worktree with valid branch name
+        let result = manager.create_worktree(session_id, repo.path(), valid_name, None);
+
+        // THEN: Creation succeeds
+        assert!(
+            result.is_ok(),
+            "Should accept branch name '{}', got error: {:?}",
+            valid_name,
+            result.err()
+        );
+
+        let worktree_info = result.unwrap();
+        assert_eq!(worktree_info.branch_name, valid_name);
+
+        // Cleanup for next iteration
+        manager.remove_worktree(session_id)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_with_custom_base_branch() -> Result<()> {
+    // GIVEN: A repository with a non-default branch
+    let repo = TestRepo::new()?;
+    repo.create_branch("develop")?;
+    repo.add_commit("develop.txt", "develop content", "Add develop file")?;
+
+    // Switch back to main/master for the test
+    repo.checkout(&repo.current_branch()?)?;
+    // Determine the default branch (main or master)
+    let main_branch = repo.current_branch()?;
+    if main_branch != "develop" {
+        repo.checkout(&main_branch)?;
+    }
+
+    let (manager, _worktree_base) = create_test_manager()?;
+    let session_id = Uuid::new_v4();
+    let branch_name = "feature/from-develop";
+
+    // WHEN: Creating worktree with custom base branch
+    let worktree_info = manager.create_worktree(
+        session_id,
+        repo.path(),
+        branch_name,
+        Some("develop"), // Custom base branch
+    )?;
+
+    // THEN: Worktree is created successfully
+    assert!(worktree_info.path.exists());
+    assert_eq!(worktree_info.branch_name, branch_name);
+
+    // THEN: Worktree should contain the file from develop branch
+    assert!(
+        worktree_info.path.join("develop.txt").exists(),
+        "Worktree should contain files from develop branch"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_duplicate_creation_fails() -> Result<()> {
+    // GIVEN: An existing worktree
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+    let session_id = Uuid::new_v4();
+    let branch_name = "feature/duplicate-test";
+
+    // First creation succeeds
+    let first_result = manager.create_worktree(session_id, repo.path(), branch_name, None);
+    assert!(
+        first_result.is_ok(),
+        "First worktree creation should succeed"
+    );
+
+    // WHEN: Attempting to create worktree with same session ID
+    let second_result = manager.create_worktree(session_id, repo.path(), branch_name, None);
+
+    // THEN: Second creation fails with AlreadyExists error
+    assert!(
+        second_result.is_err(),
+        "Duplicate worktree creation should fail"
+    );
+
+    if let Err(WorktreeError::AlreadyExists(path)) = second_result {
+        assert!(
+            !path.is_empty(),
+            "AlreadyExists error should include path"
+        );
+    } else {
+        panic!(
+            "Expected AlreadyExists error, got: {:?}",
+            second_result
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_list_returns_all_worktrees() -> Result<()> {
+    // GIVEN: Multiple worktrees
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+
+    let session_ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
+    let branch_names = ["feature/first", "feature/second", "feature/third"];
+
+    // Create multiple worktrees
+    for (session_id, branch_name) in session_ids.iter().zip(branch_names.iter()) {
+        manager.create_worktree(*session_id, repo.path(), branch_name, None)?;
+    }
+
+    // WHEN: Listing all worktrees
+    let worktrees = manager.list_all_worktrees()?;
+
+    // THEN: All created worktrees are returned
+    assert_eq!(
+        worktrees.len(),
+        session_ids.len(),
+        "Should return all created worktrees"
+    );
+
+    // THEN: Each created session is in the list
+    for session_id in &session_ids {
+        let found = worktrees.iter().any(|(id, _)| id == session_id);
+        assert!(
+            found,
+            "Session {} should be in the worktree list",
+            session_id
+        );
+    }
+
+    // THEN: Each worktree has correct branch name
+    for (_id, info) in &worktrees {
+        assert!(
+            branch_names.contains(&info.branch_name.as_str()),
+            "Branch name '{}' should be one of the created branches",
+            info.branch_name
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_removal_for_nonexistent_session_fails() -> Result<()> {
+    // GIVEN: A worktree manager with no worktrees
+    let (_manager, worktree_base) = create_test_manager()?;
+    let manager = WorktreeManager::with_base_dir(worktree_base.path().to_path_buf())?;
+    let nonexistent_session_id = Uuid::new_v4();
+
+    // WHEN: Attempting to remove a nonexistent worktree
+    let result = manager.remove_worktree(nonexistent_session_id);
+
+    // THEN: Removal fails with NotFound error
+    assert!(result.is_err(), "Removing nonexistent worktree should fail");
+
+    if let Err(WorktreeError::NotFound(msg)) = result {
+        assert!(
+            !msg.is_empty(),
+            "NotFound error should include descriptive message"
+        );
+    } else {
+        panic!("Expected NotFound error, got: {:?}", result);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_path_generation_is_deterministic() -> Result<()> {
+    // GIVEN: A worktree manager and fixed inputs
+    let (manager, _worktree_base) = create_test_manager()?;
+    let session_id = Uuid::parse_str("12345678-1234-1234-1234-123456789abc")?;
+    let branch_name = "feature/test";
+
+    // We need a real repo for full creation
+    let test_repo = TestRepo::new()?;
+
+    // WHEN: Creating a worktree (to test path generation)
+    let worktree_info = manager.create_worktree(
+        session_id,
+        test_repo.path(),
+        branch_name,
+        None,
+    );
+
+    // For path format testing, verify the generated path follows expected pattern
+    // The path should be in: base_dir/by-name/{repo_name}--{branch_name}--{short_uuid}
+    if let Ok(info) = worktree_info {
+        let path_str = info.path.to_string_lossy();
+
+        // THEN: Path contains by-name directory
+        assert!(
+            path_str.contains("by-name"),
+            "Path should contain 'by-name': {}",
+            path_str
+        );
+
+        // THEN: Path contains sanitized branch name (/ becomes -)
+        assert!(
+            path_str.contains("feature-test"),
+            "Path should contain sanitized branch name: {}",
+            path_str
+        );
+
+        // THEN: Path contains short UUID (first 8 chars)
+        let short_uuid = &session_id.to_string()[..8];
+        assert!(
+            path_str.contains(short_uuid),
+            "Path should contain short UUID '{}': {}",
+            short_uuid,
+            path_str
+        );
+
+        // THEN: Session path contains by-session directory
+        let session_path_str = info.session_path.to_string_lossy();
+        assert!(
+            session_path_str.contains("by-session"),
+            "Session path should contain 'by-session': {}",
+            session_path_str
+        );
+
+        // THEN: Session path contains full UUID
+        assert!(
+            session_path_str.contains(&session_id.to_string()),
+            "Session path should contain full UUID: {}",
+            session_path_str
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worktree_info_contains_correct_metadata() -> Result<()> {
+    // GIVEN: A test repository and worktree
+    let repo = TestRepo::new()?;
+    let (manager, _worktree_base) = create_test_manager()?;
+    let session_id = Uuid::new_v4();
+    let branch_name = "feature/metadata-test";
+
+    // WHEN: Creating a worktree
+    let worktree_info = manager.create_worktree(session_id, repo.path(), branch_name, None)?;
+
+    // THEN: ID matches the provided session ID
+    assert_eq!(worktree_info.id, session_id, "ID should match session ID");
+
+    // THEN: Path exists and is a directory
+    assert!(
+        worktree_info.path.is_dir(),
+        "Path should be an existing directory"
+    );
+
+    // THEN: Session path exists and is a symlink
+    assert!(
+        worktree_info.session_path.is_symlink(),
+        "Session path should be a symlink"
+    );
+
+    // THEN: Branch name matches
+    assert_eq!(
+        worktree_info.branch_name, branch_name,
+        "Branch name should match"
+    );
+
+    // THEN: Source repository points to original repo
+    assert_eq!(
+        worktree_info.source_repository,
+        repo.path(),
+        "Source repository should match original repo path"
+    );
+
+    // THEN: Commit hash is a valid git hash (40 hex chars)
+    if let Some(ref hash) = worktree_info.commit_hash {
+        assert_eq!(hash.len(), 40, "Commit hash should be 40 characters");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "Commit hash should be hexadecimal"
+        );
+    } else {
+        panic!("Commit hash should be present");
+    }
+
+    // WHEN: Retrieving worktree info via get_worktree_info
+    let retrieved_info = manager.get_worktree_info(session_id)?;
+
+    // THEN: Retrieved info matches created info
+    assert_eq!(retrieved_info.id, worktree_info.id);
+    assert_eq!(retrieved_info.path, worktree_info.path);
+    assert_eq!(retrieved_info.session_path, worktree_info.session_path);
+    assert_eq!(retrieved_info.branch_name, worktree_info.branch_name);
+
+    // Compare canonicalized paths to handle macOS /var -> /private/var symlink
+    let retrieved_source = retrieved_info.source_repository.canonicalize()
+        .unwrap_or_else(|_| retrieved_info.source_repository.clone());
+    let original_source = worktree_info.source_repository.canonicalize()
+        .unwrap_or_else(|_| worktree_info.source_repository.clone());
+    assert_eq!(
+        retrieved_source,
+        original_source,
+        "Source repository should match (canonicalized)"
+    );
+
+    assert_eq!(retrieved_info.commit_hash, worktree_info.commit_hash);
+
+    Ok(())
+}

--- a/ainb-tui/tests/test_app_state.rs
+++ b/ainb-tui/tests/test_app_state.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Unit tests for AppState to ensure navigation and state management work correctly
 
-use agents_box::app::AppState;
-use agents_box::models::{Session, SessionStatus, Workspace};
+use ainb::app::AppState;
+use ainb::models::{Session, SessionStatus, Workspace};
 use std::path::PathBuf;
 
 fn create_test_state() -> AppState {

--- a/ainb-tui/tests/test_events.rs
+++ b/ainb-tui/tests/test_events.rs
@@ -1,6 +1,6 @@
 // ABOUTME: Unit tests for event handling to ensure keyboard inputs map to correct app actions
 
-use claude_box::app::{AppState, EventHandler};
+use ainb::app::{AppState, EventHandler};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 const fn create_key_event(code: KeyCode) -> KeyEvent {
@@ -51,7 +51,7 @@ fn test_navigation_key_events() {
 
 #[tokio::test]
 async fn test_n_key_triggers_new_session() {
-    use claude_box::app::state::{AsyncAction, View};
+    use ainb::app::state::{AsyncAction, View};
 
     let mut state = AppState::default();
 

--- a/ainb-tui/tests/test_manual_refresh.rs
+++ b/ainb-tui/tests/test_manual_refresh.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Test manual refresh functionality using 'f' key
 
-use claude_box::app::events::{AppEvent, EventHandler};
-use claude_box::app::{
+use ainb::app::events::{AppEvent, EventHandler};
+use ainb::app::{
     App,
     state::{AsyncAction, View},
 };

--- a/ainb-tui/tests/test_session_creation_refresh.rs
+++ b/ainb-tui/tests/test_session_creation_refresh.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Test specifically for session creation UI refresh bug fix
 
-use claude_box::app::events::EventHandler;
-use claude_box::app::{
+use ainb::app::events::EventHandler;
+use ainb::app::{
     App,
     state::{NewSessionStep, View},
 };

--- a/ainb-tui/tests/test_session_model.rs
+++ b/ainb-tui/tests/test_session_model.rs
@@ -1,6 +1,6 @@
 // ABOUTME: Unit tests for Session and related models to ensure data integrity and behavior
 
-use agents_box::models::{GitChanges, Session, SessionStatus};
+use ainb::models::{GitChanges, Session, SessionStatus};
 // Tests don't need chrono::Utc directly
 
 #[test]

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Test UI display components including menu bar and help text
 
-use agents_box::app::{App, state::View};
-use agents_box::components::LayoutComponent;
+use ainb::app::{App, state::View};
+use ainb::components::LayoutComponent;
 use ratatui::{Terminal, backend::TestBackend};
 
 #[tokio::test]

--- a/ainb-tui/tests/test_workspace_model.rs
+++ b/ainb-tui/tests/test_workspace_model.rs
@@ -1,6 +1,6 @@
 // ABOUTME: Unit tests for Workspace model to ensure proper session management and operations
 
-use claude_box::models::{Session, SessionStatus, Workspace};
+use ainb::models::{Session, SessionStatus, Workspace};
 use std::path::PathBuf;
 
 #[test]

--- a/ainb-tui/tests/ui_tests.rs
+++ b/ainb-tui/tests/ui_tests.rs
@@ -5,12 +5,12 @@ use ratatui::{Terminal, backend::TestBackend};
 use std::time::Duration;
 use tokio::time::timeout;
 
-use agents_box::app::events::EventHandler;
-use agents_box::app::{
+use ainb::app::events::EventHandler;
+use ainb::app::{
     App,
     state::{NewSessionStep, View},
 };
-use agents_box::components::LayoutComponent;
+use ainb::components::LayoutComponent;
 
 pub struct UITestFramework {
     app: App,


### PR DESCRIPTION
## Summary

Exposes all major `ainb` TUI capabilities as CLI commands for scripting and automation. Grows the CLI from 7 commands to **15 commands** with full multi-provider support.

## New Commands (this work)

- `ainb run --tool codex|gemini|copilot` — multi-provider with `validate_provider_installed()`
- `ainb recover {list,resume,cleanup}` — detects orphaned sessions and broken worktree symlinks
- `ainb config {show,get,set,reset,path,edit}` — dot-notation keys, multi-level merging
- `ainb git {worktrees,cleanup,status}` — worktree inspection with session association
- `ainb favorites {list,add,remove,use}` — source type detection, usage tracking
- `ainb init {--check,--status,--reset}` — prerequisite checking + onboarding
- `ainb presets {list,show,create,delete,apply}` — built-in + custom TOML presets

All commands support global `--format json`.

## Testing

- **436 library tests passing** (+124 from this work)
- **51 behavioral tests passing**
- **45/45 smoke tests passing** via new isolated harness
- New smoke test script `ainb-tui/scripts/cli-smoke-test.sh` uses `HOME` + `TMUX_TMPDIR` env overrides for zero-risk isolation
- Verified end-to-end against real data: 18 sessions, 13 worktrees, 2 favorites, 3 built-in presets correctly listed

## Highlights

- **Multi-provider wiring**: `--tool codex/gemini/copilot` now fully honoured (previously hardcoded to claude)
- **Session persistence**: CLI and TUI share `~/.agents-in-a-box/sessions.json`
- **Isolated smoke testing**: full lifecycle exercised without touching real user data

## Deferred

- Docker/container session creation via CLI (TUI-only for now)
- SSH session creation via CLI
- MCP server management via CLI

## Test Plan

- [x] `cargo build` clean
- [x] `cargo clippy` no new warnings
- [x] `cargo test --lib` — 436 passing
- [x] `cargo test --test behavioral` — 51 passing
- [x] `./scripts/cli-smoke-test.sh` — 45/45 passing
- [x] Read-only commands smoke-tested against real user data
- [ ] Real-world integration: `ainb run --tool codex` with live codex install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full CLI: run, list, logs, attach, status, kill, init, config, git, favorites, presets, recover, and completion generation.
  * JSON and human-readable text output across commands; follow/log streaming and attach workflows.
  * Worktree, favorites, presets, and recovery tooling; repo/git status reporting.

* **Chores**
  * Package renamed to ainb; CLI entry reorganized.
  * Added an end-to-end CLI smoke test script.

* **Tests**
  * Large behavioral and unit test suite added for CLI, git, tmux, and worktree flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->