### PR TITLE
fix(ainb-tui): move usage parsing off event thread

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -3672,8 +3672,12 @@ impl EventHandler {
             }
             AppEvent::UsageRefresh => {
                 tracing::info!("Refreshing usage data");
-                state.start_background_usage_load(true);
-                state.add_success_notification("Refreshing usage data…".to_string());
+                let msg = if state.start_background_usage_load(true) {
+                    "Refreshing usage data…"
+                } else {
+                    "Refresh already in progress"
+                };
+                state.add_success_notification(msg.to_string());
             }
             // Session recovery events
             AppEvent::SessionRecoveryBack => {

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3233,24 +3233,33 @@ impl AppState {
 
     /// Kick off a background parse of ~/.claude/projects/**/*.jsonl.
     /// Skipped if already in-flight, or data is cached and `force` is false.
+    /// Returns true if a new parse was spawned, false if a call was coalesced.
     /// The parse walks ~1GB of jsonl files; keeping it off the event thread
     /// is what prevents the Stats/Usage screen from hanging on provider switch.
-    pub fn start_background_usage_load(&mut self, force: bool) {
+    pub fn start_background_usage_load(&mut self, force: bool) -> bool {
         if self.usage_load_receiver.is_some() {
-            return;
+            return false;
         }
         if !force && self.usage_state.data.is_some() {
-            return;
+            return false;
         }
         let (tx, rx) = mpsc::unbounded_channel();
         self.usage_load_receiver = Some(rx);
         self.usage_state.loading = true;
         tokio::spawn(async move {
-            let data = tokio::task::spawn_blocking(crate::models::usage::parse_usage)
-                .await
-                .unwrap_or_default();
-            let _ = tx.send(data);
+            match tokio::task::spawn_blocking(crate::models::usage::parse_usage).await {
+                Ok(data) => {
+                    let _ = tx.send(data);
+                }
+                Err(e) => {
+                    // Dropping tx lets check_usage_load_complete observe
+                    // TryRecvError::Disconnected, which clears `loading`
+                    // without overwriting any cached data.
+                    warn!("Usage parse task failed: {}", e);
+                }
+            }
         });
+        true
     }
 
     /// Poll the background parse. Returns true if data was applied this tick.


### PR DESCRIPTION
## Summary

- Fixes the hang + jitter in the Stats/Usage screen when switching providers (Claude → Codex → …).
- Root cause: `parse_usage()` walks `~/.claude/projects/**/*.jsonl` (1.4 GB / 3600+ files on a typical machine) synchronously on the event-handler thread, and `next_provider()` cleared the cache on every switch — so every round-trip back to Claude forced a full re-parse.
- Fix: async background load via `tokio::spawn_blocking` + `mpsc`, polled from `tick()`; cache preserved across provider toggles; in-flight parse de-duplicated; truthful refresh notification.

## Commits in this branch

This branch happens to contain two earlier docs commits from `ops/main` that hadn't been pushed yet:

- `5f4e9a5` docs(assets): add 7 TUI screenshots for README showcase
- `2a70aec` docs(readme): hero screenshot, feature showcase, CLI callout
- `8a771ba` **fix(ainb-tui): move usage parsing off event thread** ← the fix under review

Suggest squash-merging or cherry-picking the fix commit individually if the docs commits should land separately.

## Test plan
- [x] `cargo check` clean (98 pre-existing warnings, none new)
- [ ] Manual smoke: open Stats → toggle Claude→Codex→Gemini→Copilot→Claude repeatedly; screen stays responsive, no re-parse on each switch
- [ ] Press `r` during first parse — expect "Refresh already in progress" notification, not "Refreshing…"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-provider session orchestration (Claude Code, Codex, Gemini, Copilot)
  * Introduced live session dashboard and usage analytics interface
  * Added tmux persistence across disconnects
  * Enhanced CLI with 15 top-level scriptable commands
  * Added guided onboarding

* **Improvements**
  * Usage analytics now load asynchronously for improved UI responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->