### PR TITLE
feat(reflect): v3.1.0 retrieval — /reflect:recall + SessionStart auto-inject (#40 phases 1+2)

### DIFF
--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -783,30 +783,52 @@ function copyDirectoryRecursive(source, destination, excludeFiles = [], template
 
 // Deploy the global-learnings CLI to ~/.learnings/cli/ so every tool
 // install (claude, codex, copilot, …) picks up the current CLI from
-// ai-coder-rules. The content repo (learnings-kb) still carries its own
-// CLI copy today, but bootstrap runs after any such clone and wins last
-// — overwriting stale files without touching data dirs (documents/,
-// nano_graphrag_cache/, .venv/). Silent no-op if the toolkit template is
-// missing. Returns number of files copied.
+// ai-coder-rules — the single source of truth. The content repo
+// (learnings-kb) holds only documents/indexes; its cli/ folder is
+// deprecated and being removed.
+//
+// Strategy: copy every file from the template, then prune any file in
+// the destination that isn't in the template. This removes stale CLI
+// files from old learnings-kb clones without touching sibling data
+// dirs (documents/, nano_graphrag_cache/, .venv/) — those live one
+// level up at ~/.learnings/. Silent no-op if the template is missing.
+//
+// Returns {copied, pruned} counts.
 function installLearningsCli() {
     const srcDir = path.join(__dirname, 'packages', 'knowledge', 'global-learnings-template', 'cli');
-    if (!fs.existsSync(srcDir)) return 0;
+    if (!fs.existsSync(srcDir)) return { copied: 0, pruned: 0 };
 
     const destDir = path.join(os.homedir(), '.learnings', 'cli');
     fs.mkdirSync(destDir, { recursive: true });
 
+    // Canonical fileset from the template — top-level files only.
+    const templateFiles = new Set(
+        readdirSync(srcDir).filter(e => !statSync(path.join(srcDir, e)).isDirectory())
+    );
+
+    // Copy canonical files.
     let copied = 0;
-    for (const entry of readdirSync(srcDir)) {
+    for (const entry of templateFiles) {
         const src = path.join(srcDir, entry);
-        // Skip subdirs (__pycache__, etc.) — the wrapper regenerates them.
-        if (statSync(src).isDirectory()) continue;
         const dst = path.join(destDir, entry);
         fs.copyFileSync(src, dst);
-        // Preserve executability for the bash wrapper.
         if (entry === 'learnings') fs.chmodSync(dst, 0o755);
         copied++;
     }
-    return copied;
+
+    // Prune orphan files — anything in destDir not in templateFiles.
+    // Keep subdirectories (__pycache__, etc.) alone; the wrapper
+    // regenerates them.
+    let pruned = 0;
+    for (const entry of readdirSync(destDir)) {
+        if (templateFiles.has(entry)) continue;
+        const victim = path.join(destDir, entry);
+        if (statSync(victim).isDirectory()) continue;
+        fs.unlinkSync(victim);
+        pruned++;
+    }
+
+    return { copied, pruned };
 }
 
 async function handleSharedContentCopy(tool, config, targetFolder) {
@@ -1474,9 +1496,10 @@ async function handlePackagesStructureCopy(tool, config, overrideHomeDir = null,
     // repo (learnings-kb). Runs on every tool install; cheap and idempotent.
     if (shouldUseHome) {
         showProgress('Installing learnings CLI to ~/.learnings/cli/');
-        const cliCount = installLearningsCli();
-        if (cliCount > 0) {
-            completeProgress(`Installed learnings CLI (${cliCount} files) to ~/.learnings/cli/`);
+        const { copied, pruned } = installLearningsCli();
+        if (copied > 0) {
+            const prunedMsg = pruned > 0 ? `, pruned ${pruned} stale` : '';
+            completeProgress(`Installed learnings CLI (${copied} files${prunedMsg}) to ~/.learnings/cli/`);
         } else {
             completeProgress('learnings CLI template not found — skipped');
         }

--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -781,6 +781,34 @@ function copyDirectoryRecursive(source, destination, excludeFiles = [], template
     return files.length;
 }
 
+// Deploy the global-learnings CLI to ~/.learnings/cli/ so every tool
+// install (claude, codex, copilot, …) picks up the current CLI from
+// ai-coder-rules. The content repo (learnings-kb) still carries its own
+// CLI copy today, but bootstrap runs after any such clone and wins last
+// — overwriting stale files without touching data dirs (documents/,
+// nano_graphrag_cache/, .venv/). Silent no-op if the toolkit template is
+// missing. Returns number of files copied.
+function installLearningsCli() {
+    const srcDir = path.join(__dirname, 'packages', 'knowledge', 'global-learnings-template', 'cli');
+    if (!fs.existsSync(srcDir)) return 0;
+
+    const destDir = path.join(os.homedir(), '.learnings', 'cli');
+    fs.mkdirSync(destDir, { recursive: true });
+
+    let copied = 0;
+    for (const entry of readdirSync(srcDir)) {
+        const src = path.join(srcDir, entry);
+        // Skip subdirs (__pycache__, etc.) — the wrapper regenerates them.
+        if (statSync(src).isDirectory()) continue;
+        const dst = path.join(destDir, entry);
+        fs.copyFileSync(src, dst);
+        // Preserve executability for the bash wrapper.
+        if (entry === 'learnings') fs.chmodSync(dst, 0o755);
+        copied++;
+    }
+    return copied;
+}
+
 async function handleSharedContentCopy(tool, config, targetFolder) {
     if (!targetFolder) {
         const answers = await inquirer.prompt([
@@ -1439,6 +1467,19 @@ async function handlePackagesStructureCopy(tool, config, overrideHomeDir = null,
         fs.writeFileSync(scriptPath, config._externalDepsScript);
         fs.chmodSync(scriptPath, 0o755);
         completeProgress(`Generated setup-external.sh (${config._externalDepsCount} external deps)`);
+    }
+
+    // Deploy the learnings CLI so ai-coder-rules is the single source of
+    // truth for the tool, even though the KB content lives in a separate
+    // repo (learnings-kb). Runs on every tool install; cheap and idempotent.
+    if (shouldUseHome) {
+        showProgress('Installing learnings CLI to ~/.learnings/cli/');
+        const cliCount = installLearningsCli();
+        if (cliCount > 0) {
+            completeProgress(`Installed learnings CLI (${cliCount} files) to ~/.learnings/cli/`);
+        } else {
+            completeProgress('learnings CLI template not found — skipped');
+        }
     }
 
     console.log(`\n\x1b[32m🎉 packages setup complete!\x1b[0m`);

--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -793,42 +793,61 @@ function copyDirectoryRecursive(source, destination, excludeFiles = [], template
 // dirs (documents/, nano_graphrag_cache/, .venv/) — those live one
 // level up at ~/.learnings/. Silent no-op if the template is missing.
 //
-// Returns {copied, pruned} counts.
+// Safety: uses lstatSync (not statSync) so we never chase a symlink
+// into user data, and skips non-regular files during prune. Each copy
+// and unlink is guarded — a single permission error warns and moves on
+// rather than aborting bootstrap mid-migration.
+//
+// Returns {copied, pruned, prunedNames, errors} — prunedNames is
+// surfaced in the install log so silent $HOME deletions stay visible.
 function installLearningsCli() {
+    const result = { copied: 0, pruned: 0, prunedNames: [], errors: [] };
     const srcDir = path.join(__dirname, 'packages', 'knowledge', 'global-learnings-template', 'cli');
-    if (!fs.existsSync(srcDir)) return { copied: 0, pruned: 0 };
+    if (!fs.existsSync(srcDir)) return result;
 
     const destDir = path.join(os.homedir(), '.learnings', 'cli');
     fs.mkdirSync(destDir, { recursive: true });
 
-    // Canonical fileset from the template — top-level files only.
-    const templateFiles = new Set(
-        readdirSync(srcDir).filter(e => !statSync(path.join(srcDir, e)).isDirectory())
-    );
-
-    // Copy canonical files.
-    let copied = 0;
-    for (const entry of templateFiles) {
+    // Canonical fileset from the template — top-level regular files only.
+    const templateFiles = new Map();
+    for (const entry of readdirSync(srcDir)) {
         const src = path.join(srcDir, entry);
-        const dst = path.join(destDir, entry);
-        fs.copyFileSync(src, dst);
-        if (entry === 'learnings') fs.chmodSync(dst, 0o755);
-        copied++;
+        const st = fs.lstatSync(src);
+        if (!st.isFile()) continue;
+        templateFiles.set(entry, st.mode & 0o777);
     }
 
-    // Prune orphan files — anything in destDir not in templateFiles.
-    // Keep subdirectories (__pycache__, etc.) alone; the wrapper
-    // regenerates them.
-    let pruned = 0;
+    // Copy canonical files, mirroring each one's source mode bits so any
+    // executable added to the template (not just `learnings`) stays +x.
+    for (const [entry, mode] of templateFiles) {
+        try {
+            const src = path.join(srcDir, entry);
+            const dst = path.join(destDir, entry);
+            fs.copyFileSync(src, dst);
+            fs.chmodSync(dst, mode);
+            result.copied++;
+        } catch (err) {
+            result.errors.push(`copy ${entry}: ${err.message}`);
+        }
+    }
+
+    // Prune orphans — anything in destDir not in templateFiles. Symlinks
+    // and non-regular files (sockets, FIFOs) are left alone so a dev's
+    // symlink to a local checkout doesn't get silently deleted.
     for (const entry of readdirSync(destDir)) {
         if (templateFiles.has(entry)) continue;
         const victim = path.join(destDir, entry);
-        if (statSync(victim).isDirectory()) continue;
-        fs.unlinkSync(victim);
-        pruned++;
+        try {
+            if (!fs.lstatSync(victim).isFile()) continue;
+            fs.unlinkSync(victim);
+            result.pruned++;
+            result.prunedNames.push(entry);
+        } catch (err) {
+            result.errors.push(`prune ${entry}: ${err.message}`);
+        }
     }
 
-    return { copied, pruned };
+    return result;
 }
 
 async function handleSharedContentCopy(tool, config, targetFolder) {
@@ -1496,12 +1515,17 @@ async function handlePackagesStructureCopy(tool, config, overrideHomeDir = null,
     // repo (learnings-kb). Runs on every tool install; cheap and idempotent.
     if (shouldUseHome) {
         showProgress('Installing learnings CLI to ~/.learnings/cli/');
-        const { copied, pruned } = installLearningsCli();
+        const { copied, pruned, prunedNames, errors } = installLearningsCli();
         if (copied > 0) {
-            const prunedMsg = pruned > 0 ? `, pruned ${pruned} stale` : '';
+            const prunedMsg = pruned > 0 ? `, pruned ${pruned} stale (${prunedNames.join(', ')})` : '';
             completeProgress(`Installed learnings CLI (${copied} files${prunedMsg}) to ~/.learnings/cli/`);
         } else {
             completeProgress('learnings CLI template not found — skipped');
+        }
+        // Warn-continue: don't abort the whole install on a single copy/prune
+        // failure, but surface it so the user knows something is off.
+        for (const msg of errors) {
+            console.log(`  ⚠ learnings CLI: ${msg}`);
         }
     }
 

--- a/toolkit/packages/knowledge/global-learnings-template/README.md
+++ b/toolkit/packages/knowledge/global-learnings-template/README.md
@@ -9,6 +9,16 @@ This repository stores learnings that are useful across multiple projects. It us
 
 Fixes to the CLI land here; content changes land in learnings-kb. Never edit `~/.learnings/cli/` directly — it will be overwritten on next bootstrap.
 
+### Migrating from old install paths
+
+Pre-v3.1 installs placed the CLI at `~/.claude/global-learnings/cli/` (Claude-specific). That path is deprecated — the canonical install is now `~/.learnings/cli/` for all tools. If you have the old path, it's safe to delete:
+
+```bash
+rm -rf ~/.claude/global-learnings
+```
+
+New installs (via `bootstrap.js` for any tool) write only to `~/.learnings/`.
+
 ## Philosophy
 
 > "Each solved problem makes future work easier - across ALL projects."

--- a/toolkit/packages/knowledge/global-learnings-template/README.md
+++ b/toolkit/packages/knowledge/global-learnings-template/README.md
@@ -2,6 +2,13 @@
 
 This repository stores learnings that are useful across multiple projects. It uses nano-graphrag for semantic search and graph-based retrieval with local embeddings (no API key required).
 
+## Source-of-truth split
+
+- **This toolkit** (ai-coder-rules) is the canonical source for the **CLI** (`cli/*.py`, `cli/learnings`). `bootstrap.js` deploys it to `~/.learnings/cli/` on every tool install and prunes any stale orphan files.
+- **learnings-kb repo** is the canonical source for **content only** — `documents/`, entity sidecars, GraphRAG cache, QMD indexes. It no longer carries a CLI copy.
+
+Fixes to the CLI land here; content changes land in learnings-kb. Never edit `~/.learnings/cli/` directly — it will be overwritten on next bootstrap.
+
 ## Philosophy
 
 > "Each solved problem makes future work easier - across ALL projects."

--- a/toolkit/packages/knowledge/global-learnings-template/cli/learnings_cli.py
+++ b/toolkit/packages/knowledge/global-learnings-template/cli/learnings_cli.py
@@ -269,11 +269,17 @@ def add(file_path: str, entities: Optional[str]):
     # already tracks, so we MUST run `qmd update` first to rescan the
     # collection for the newly-added file — otherwise new docs are visible
     # to GraphRAG but silently missing from QMD. Graceful if qmd absent.
+    #
+    # Both subprocesses are synchronous and can take ~10s-2min on large
+    # KBs. Echo progress so a user running `learnings add` isn't staring
+    # at a silent terminal.
     if shutil.which("qmd"):
         try:
             import subprocess
 
+            console.print("[dim]QMD: rescanning collection…[/dim]")
             subprocess.run(["qmd", "update"], capture_output=True, timeout=30)
+            console.print("[dim]QMD: embedding new docs (up to 2 min on large KBs)…[/dim]")
             subprocess.run(["qmd", "embed"], capture_output=True, timeout=120)
             console.print("[green]QMD index + embeddings updated[/green]")
         except Exception as e:

--- a/toolkit/packages/knowledge/global-learnings-template/cli/learnings_cli.py
+++ b/toolkit/packages/knowledge/global-learnings-template/cli/learnings_cli.py
@@ -265,6 +265,20 @@ def add(file_path: str, entities: Optional[str]):
         console.print(f"[yellow]Warning: Graph indexing failed: {e}[/yellow]")
         console.print("[dim]Document saved. Run 'learnings reindex' to retry.[/dim]")
 
+    # Keep QMD in sync (if installed). `qmd embed` only embeds files QMD
+    # already tracks, so we MUST run `qmd update` first to rescan the
+    # collection for the newly-added file — otherwise new docs are visible
+    # to GraphRAG but silently missing from QMD. Graceful if qmd absent.
+    if shutil.which("qmd"):
+        try:
+            import subprocess
+
+            subprocess.run(["qmd", "update"], capture_output=True, timeout=30)
+            subprocess.run(["qmd", "embed"], capture_output=True, timeout=120)
+            console.print("[green]QMD index + embeddings updated[/green]")
+        except Exception as e:
+            console.print(f"[yellow]Warning: QMD sync failed: {e}[/yellow]")
+
     console.print(f"[green]Added:[/green] {dest}")
     console.print(f"[dim]Title: {frontmatter['title']}[/dim]")
     console.print(f"[dim]Category: {frontmatter['category']}[/dim]")

--- a/toolkit/packages/plugins/reflect/.claude-plugin/plugin.json
+++ b/toolkit/packages/plugins/reflect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reflect",
-  "version": "3.0.0",
-  "description": "Agent self-improvement through conversation analysis. Extracts behavioral corrections, knowledge learnings, and success patterns. Permanently encodes them into agent definitions and a searchable GraphRAG knowledge base. Philosophy: Correct once, never again.",
+  "version": "3.1.0",
+  "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings at SessionStart via hook. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"
   }

--- a/toolkit/packages/plugins/reflect/hooks/settings-snippet.json
+++ b/toolkit/packages/plugins/reflect/hooks/settings-snippet.json
@@ -1,13 +1,26 @@
 {
-  "_comment": "Copy the relevant sections to your ~/.claude/settings.json",
+  "_comment": "Reflect plugin hook snippets. Copy relevant sections into ~/.claude/settings.json hooks block.",
 
   "hooks": {
+    "SessionStart": [
+      {
+        "_comment": "Phase 2: inject top-3 relevant learnings into new session context",
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run {{HOME_TOOL_DIR}}/skills/recall/hooks/session_start_recall.py"
+          }
+        ]
+      }
+    ],
+
     "PreCompact": [
       {
         "matcher": "",
         "hooks": [
           {
-            "_comment": "Option 1: Just add reminder to run /reflect",
+            "_comment": "Option 1: reminder-only (non-blocking nudge)",
             "type": "command",
             "command": "uv run {{HOME_TOOL_DIR}}/skills/reflect/hooks/precompact_reflect.py --remind"
           }
@@ -20,7 +33,7 @@
         "matcher": "",
         "hooks": [
           {
-            "_comment": "Option 2: Auto-reflect if enabled via /reflect on",
+            "_comment": "Option 2: auto-reflect if /reflect on has been invoked",
             "type": "command",
             "command": "uv run {{HOME_TOOL_DIR}}/skills/reflect/hooks/precompact_reflect.py --auto --verbose"
           }
@@ -33,7 +46,7 @@
         "matcher": "",
         "hooks": [
           {
-            "_comment": "Option 3: Full integration with handover + backup + reflect",
+            "_comment": "Option 3: handover + backup + reflect",
             "type": "command",
             "command": "claude handover && uv run {{HOME_TOOL_DIR}}/hooks/pre_compact.py --backup && uv run {{HOME_TOOL_DIR}}/skills/reflect/hooks/precompact_reflect.py --auto"
           }

--- a/toolkit/packages/plugins/reflect/skills/recall/SKILL.md
+++ b/toolkit/packages/plugins/reflect/skills/recall/SKILL.md
@@ -33,8 +33,9 @@ and tag overlap.
 - When the user references past work ("like we did in Y")
 
 **Also fires automatically** via the SessionStart hook (see
-`hooks/session_start_recall.py`) with a 3-result cap, HIGH confidence only.
-This skill is the explicit, higher-limit path.
+`hooks/session_start_recall.py`) with a 3-result cap, any confidence
+(reranked by confidence/recency/tag-overlap). This skill is the
+explicit, higher-limit path.
 
 ## Quick reference
 
@@ -79,5 +80,5 @@ This skill is the explicit, higher-limit path.
 ## Related
 
 - `/reflect:ingest` — populate the KB
-- `/reflect:status` — KB health, coverage, pending reviews
+- `/reflect-status` — KB health, coverage, pending reviews
 - SessionStart hook — auto-recall on project entry (see `hooks/settings-snippet.json`)

--- a/toolkit/packages/plugins/reflect/skills/recall/SKILL.md
+++ b/toolkit/packages/plugins/reflect/skills/recall/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: reflect:recall
+description: |
+  Retrieve relevant prior learnings from the global knowledge base. Hybrid
+  vector + graph search over 170+ indexed learnings, reranked by confidence,
+  recency, and tag overlap. Use when starting work, debugging a recurring
+  problem, or before implementing a feature that may have prior art.
+version: "3.1.0"
+user-invocable: true
+triggers:
+  - reflect:recall
+  - recall learnings
+  - prior learnings
+  - what have i learned about
+  - have we done this before
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+---
+
+# /reflect:recall — Retrieve relevant prior learnings
+
+Queries the global learnings KB (GraphRAG + vector) and surfaces the top-N
+most relevant learnings for the current work, reranked by confidence, recency,
+and tag overlap.
+
+## When to use
+
+- Starting work in a project or on a new branch — "what do we know about X"
+- Debugging a recurring issue — "have we seen this error before"
+- Before implementing a feature — "has this pattern been tried"
+- When the user references past work ("like we did in Y")
+
+**Also fires automatically** via the SessionStart hook (see
+`hooks/session_start_recall.py`) with a 3-result cap, HIGH confidence only.
+This skill is the explicit, higher-limit path.
+
+## Quick reference
+
+| Invocation | Behavior |
+|---|---|
+| `/reflect:recall <query>` | Default — 10 results, any confidence, markdown out |
+| `/reflect:recall <query> --limit 5 --confidence HIGH` | Tight filter |
+| `/reflect:recall <query> --mode local` | Graph-neighborhood search (finds related concepts) |
+| `/reflect:recall <query> --mode global` | Community-based (broad patterns) |
+| `/reflect:recall <query> --format json` | Structured output for programmatic use |
+| `/reflect:recall <query> --no-cache` | Skip cache, force fresh query |
+
+## Workflow
+
+1. **Build the query** — combine the user's question with project context:
+   current cwd, branch name, any relevant tags the user mentioned.
+2. **Run recall** — invoke `{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py`:
+   ```bash
+   uv run {{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py "$QUERY" --limit 10 --format markdown
+   ```
+3. **Inspect results** — each result has `[lrn-id]`, key insight, and how-to-apply.
+4. **Fetch full docs if needed** — for any interesting learning ID, the user can
+   run `learnings search <id>` or check `~/.learnings/documents/learnings/`.
+
+## Query construction tips
+
+- Short, focused queries beat long sentences (the backend does vector similarity).
+- Include proper nouns: project names, tool names, error snippets.
+- Add tags explicitly with `--tags a,b,c` for reranking boost.
+
+## Backend details
+
+- **Retrieval**: wraps `~/.learnings/cli/learnings search` as subprocess.
+- **Ranking**: `confidence × recency × (1 + tag_overlap_bonus)`.
+  - Confidence: HIGH=1.0, MEDIUM=0.7, LOW=0.4
+  - Recency: exp(-days_ago / 90), half-life ~60 days
+  - Tag bonus: 0.1 × count(query_tags ∩ learning_tags)
+- **Cache**: per-query SHA1 hash at `~/.reflect/recall_cache/`, 1h TTL.
+- **Log**: every recall is appended to `~/.reflect/recall_log.jsonl` for
+  future helpfulness analysis (Phase 6 of the retrieval plan).
+
+## Related
+
+- `/reflect:ingest` — populate the KB
+- `/reflect:status` — KB health, coverage, pending reviews
+- SessionStart hook — auto-recall on project entry (see `hooks/settings-snippet.json`)

--- a/toolkit/packages/plugins/reflect/skills/recall/hooks/session_start_recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/hooks/session_start_recall.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""
+SessionStart Recall Hook (Phase 2 of reflect retrieval).
+
+Fires on SessionStart. Builds a query from the current project context
+(cwd, git branch, recent commits) and injects top-3 HIGH-confidence
+learnings into the agent's context via additionalContext.
+
+Usage in settings.json:
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "uv run {{HOME_TOOL_DIR}}/skills/recall/hooks/session_start_recall.py"
+      }]
+    }]
+  }
+}
+
+Exit behavior (D9): always exit 0 with possibly-empty hookSpecificOutput.
+Never blocks, never errors out.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+# D2: conservative caps for auto-inject
+SESSION_START_LIMIT = 3
+SESSION_START_CONFIDENCE = "ANY"  # relaxed; rely on reranking
+SESSION_START_MAX_CHARS = 1500  # tighter than explicit /reflect:recall
+
+
+# --- Context extraction --------------------------------------------------
+
+STOPWORDS = {
+    "fix", "feat", "chore", "docs", "test", "refactor", "build", "ci", "perf",
+    "the", "a", "an", "of", "to", "for", "on", "in", "at", "and", "or",
+    "add", "remove", "update", "change", "merge", "pull", "request", "pr",
+}
+
+
+def git_capture(args: list[str], cwd: Path) -> str:
+    try:
+        r = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def project_name(cwd: Path) -> str:
+    """Remote origin basename → fall back to cwd basename."""
+    url = git_capture(["remote", "get-url", "origin"], cwd)
+    if url:
+        base = url.rstrip("/").rsplit("/", 1)[-1]
+        return re.sub(r"\.git$", "", base)
+    return cwd.name
+
+
+def current_branch(cwd: Path) -> str:
+    b = git_capture(["branch", "--show-current"], cwd)
+    if b in ("main", "master", ""):
+        return ""
+    return b
+
+
+def recent_commit_tags(cwd: Path, n: int = 5, limit: int = 3) -> list[str]:
+    """Last N commit subjects → top-K alphanumeric tokens excluding stopwords."""
+    log = git_capture(["log", f"-{n}", "--format=%s"], cwd)
+    if not log:
+        return []
+    tokens: dict[str, int] = {}
+    for line in log.splitlines():
+        for tok in re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{2,}", line):
+            low = tok.lower()
+            if low in STOPWORDS:
+                continue
+            tokens[low] = tokens.get(low, 0) + 1
+    # Sort by frequency, stable
+    ranked = sorted(tokens.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [t for t, _ in ranked[:limit]]
+
+
+def build_query(cwd: Path) -> tuple[str, list[str]]:
+    """
+    D3: query = project_name + branch + top-3 commit-derived tags.
+    Returns (query_string, tag_list_for_rerank).
+    """
+    parts = [project_name(cwd)]
+    branch = current_branch(cwd)
+    if branch:
+        # Normalise: "feat/foo-bar" → "foo bar"
+        parts.append(re.sub(r"[/_-]+", " ", branch))
+    tags = recent_commit_tags(cwd)
+    parts.extend(tags)
+    # Dedup, preserving order
+    seen: set[str] = set()
+    dedup: list[str] = []
+    for p in parts:
+        for word in p.split():
+            w = word.lower()
+            if w and w not in seen:
+                seen.add(w)
+                dedup.append(word)
+    return " ".join(dedup), tags
+
+
+# --- Hook main -----------------------------------------------------------
+
+def find_recall_script() -> Path | None:
+    """recall.py may live in scripts/ of this plugin in deployed form."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        here.parent / "scripts" / "recall.py",
+        # fallback: colocated
+        here / "recall.py",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def emit(additional_context: str) -> None:
+    """Always exit 0 with valid JSON."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": additional_context,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+def main() -> None:
+    # Hooks receive JSON on stdin but we don't need it for cwd derivation
+    try:
+        _ = sys.stdin.read()
+    except Exception:
+        pass
+
+    cwd = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
+
+    # Skip for $HOME — no project context there
+    if cwd == Path.home():
+        emit("")
+
+    query, tags = build_query(cwd)
+    if not query:
+        emit("")
+
+    recall = find_recall_script()
+    if not recall:
+        emit("")
+
+    try:
+        r = subprocess.run(
+            [
+                "uv", "run", "--quiet", str(recall),
+                query,
+                "--limit", str(SESSION_START_LIMIT),
+                "--confidence", SESSION_START_CONFIDENCE,
+                "--format", "markdown",
+                "--max-chars", str(SESSION_START_MAX_CHARS),
+                "--tags", ",".join(tags),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=45,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        emit("")
+        return
+
+    if r.returncode != 0:
+        emit("")
+        return
+
+    out = (r.stdout or "").strip()
+    emit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/toolkit/packages/plugins/reflect/skills/recall/hooks/session_start_recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/hooks/session_start_recall.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["pyyaml"]
+# dependencies = []
 # ///
 """
 SessionStart Recall Hook (Phase 2 of reflect retrieval).
 
 Fires on SessionStart. Builds a query from the current project context
-(cwd, git branch, recent commits) and injects top-3 HIGH-confidence
-learnings into the agent's context via additionalContext.
+(cwd, git branch, recent commits) and injects the top-3 learnings
+(any confidence; reranked) into the agent's context via additionalContext.
 
 Usage in settings.json:
 {
@@ -64,7 +64,9 @@ def git_capture(args: list[str], cwd: Path) -> str:
         )
         if r.returncode == 0:
             return r.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (subprocess.TimeoutExpired, OSError):
+        # OSError subsumes FileNotFoundError / PermissionError — never let the
+        # hook crash the session start just because git is missing or blocked.
         pass
     return ""
 
@@ -194,7 +196,8 @@ def main() -> None:
             timeout=45,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (subprocess.TimeoutExpired, OSError):
+        # OSError covers FileNotFoundError (uv missing), PermissionError, etc.
         emit("")
         return
 

--- a/toolkit/packages/plugins/reflect/skills/recall/hooks/session_start_recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/hooks/session_start_recall.py
@@ -32,9 +32,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 
 # D2: conservative caps for auto-inject
@@ -144,8 +146,12 @@ def find_recall_script() -> Path | None:
     return None
 
 
-def emit(additional_context: str) -> None:
-    """Always exit 0 with valid JSON."""
+def emit(additional_context: str) -> NoReturn:
+    """Always exit 0 with valid JSON.
+
+    Typed NoReturn so callers (and linters) know execution stops here —
+    no need for a `return` after `emit(...)` at the call site.
+    """
     print(
         json.dumps(
             {
@@ -159,7 +165,13 @@ def emit(additional_context: str) -> None:
     sys.exit(0)
 
 
-def main() -> None:
+# Resolve `uv` once at module load. SessionStart hooks often run with a
+# trimmed PATH (launchd, IDE subprocesses), so a late lookup can fail even
+# when `uv` is installed. None → fall through to empty emit.
+UV_BIN = shutil.which("uv")
+
+
+def main() -> NoReturn:
     # Hooks receive JSON on stdin but we don't need it for cwd derivation
     try:
         _ = sys.stdin.read()
@@ -177,13 +189,17 @@ def main() -> None:
         emit("")
 
     recall = find_recall_script()
-    if not recall:
+    if not recall or not UV_BIN:
         emit("")
 
+    # D9: SessionStart must feel instant. 10s cap — if recall is slower
+    # than that, prefer empty context over a stalled session boot. The
+    # recall cache makes repeat sessions fast; the first call absorbs
+    # the miss silently.
     try:
         r = subprocess.run(
             [
-                "uv", "run", "--quiet", str(recall),
+                UV_BIN, "run", "--quiet", str(recall),
                 query,
                 "--limit", str(SESSION_START_LIMIT),
                 "--confidence", SESSION_START_CONFIDENCE,
@@ -193,20 +209,16 @@ def main() -> None:
             ],
             capture_output=True,
             text=True,
-            timeout=45,
+            timeout=10,
             check=False,
         )
     except (subprocess.TimeoutExpired, OSError):
-        # OSError covers FileNotFoundError (uv missing), PermissionError, etc.
         emit("")
-        return
 
     if r.returncode != 0:
         emit("")
-        return
 
-    out = (r.stdout or "").strip()
-    emit(out)
+    emit((r.stdout or "").strip())
 
 
 if __name__ == "__main__":

--- a/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
@@ -57,7 +57,7 @@ LEARNINGS_CLI_CANDIDATES = [
 
 CONFIDENCE_WEIGHTS = {"HIGH": 1.0, "MEDIUM": 0.7, "LOW": 0.4}
 CHUNK_SEPARATOR = "--New Chunk--"
-ARCHIVE_HEADER_RE = re.compile(r"<!--\s*archived:\s*([0-9T:\-Z]+)\s*-->")
+ARCHIVE_HEADER_RE = re.compile(r"<!--\s*archived:\s*([0-9T:.+\-Z]+)\s*-->")
 
 
 # --- Data models ---------------------------------------------------------
@@ -88,8 +88,14 @@ class Learning:
 
     @property
     def confidence(self) -> str:
-        raw = self.frontmatter.get("confidence") or "MEDIUM"
-        # Coerce numeric confidence (instinct-style 0.0-1.0) to tier
+        raw = self.frontmatter.get("confidence")
+        if raw is None:
+            return "MEDIUM"
+        # Coerce numeric confidence (instinct-style 0.0-1.0) to tier.
+        # Explicit None check above so `0`/`0.0` reach this branch, not the default.
+        if isinstance(raw, bool):
+            # bool is a subclass of int — treat as a tier string via str().upper()
+            return str(raw).upper()
         if isinstance(raw, (int, float)):
             if raw >= 0.8:
                 return "HIGH"
@@ -100,7 +106,7 @@ class Learning:
 
     @property
     def tags(self) -> list[str]:
-        raw = self.frontmatter.get("tags", [])
+        raw = self.frontmatter.get("tags") or []
         if isinstance(raw, str):
             # yaml sometimes leaves unquoted lists as strings; split tolerantly
             raw = [t.strip() for t in re.split(r"[\[\],]", raw) if t.strip()]
@@ -142,9 +148,13 @@ def find_learnings_cli() -> Path | None:
     return Path(cli_on_path) if cli_on_path else None
 
 
-def cache_path(query: str, mode: str) -> Path:
-    """Per-query cache file. D4: 1-hour TTL."""
-    digest = hashlib.sha1(f"{query}|{mode}".encode()).hexdigest()[:16]
+def cache_path(query: str, mode: str, limit: int) -> Path:
+    """Per-query cache file. D4: 1-hour TTL.
+
+    Limit is part of the key so a small-limit fetch can't poison a
+    subsequent large-limit read with a truncated result set.
+    """
+    digest = hashlib.sha1(f"{query}|{mode}|{limit}".encode()).hexdigest()[:16]
     base = Path(os.environ.get("REFLECT_STATE_DIR", Path.home() / ".reflect"))
     cache_dir = base / "recall_cache"
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -341,7 +351,8 @@ def recall(
     if not cli:
         return RecallResult([], query, mode, error="learnings CLI not found")
 
-    cache_file = cache_path(query, mode)
+    fetched_limit = max(limit * 2, 10)
+    cache_file = cache_path(query, mode, fetched_limit)
     if use_cache:
         cached = read_cache(cache_file, cache_ttl)
         if cached:
@@ -361,7 +372,7 @@ def recall(
     try:
         proc = subprocess.run(
             [str(cli), "search", query, "--mode", mode, "--format", "json",
-             "--limit", str(max(limit * 2, 10))],
+             "--limit", str(fetched_limit)],
             capture_output=True,
             text=True,
             timeout=30,

--- a/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
@@ -150,7 +150,16 @@ class RecallResult:
 # --- Helpers -------------------------------------------------------------
 
 def find_learnings_cli() -> Path | None:
-    """Locate the learnings CLI. D1: subprocess wrapper."""
+    """Locate the learnings CLI. D1: subprocess wrapper.
+
+    Trust boundary: absolute candidates under `~/.learnings/cli/` are
+    tried first (installed by bootstrap.js from the toolkit template),
+    so the canonical install always wins. Only if those are absent do
+    we fall back to `shutil.which("learnings")` — which resolves via
+    `$PATH` and is therefore only as trustworthy as the caller's
+    environment. In practice this only runs as the user in their own
+    session; a hostile `$PATH` would already compromise their shell.
+    """
     for candidate in LEARNINGS_CLI_CANDIDATES:
         if candidate.exists() and os.access(candidate, os.X_OK):
             return candidate
@@ -167,6 +176,11 @@ def cache_path(query: str, mode: str, limit: int) -> Path:
     Limit is part of the key so a small-limit fetch can't poison a
     subsequent large-limit read with a truncated result set. Version tag
     invalidates old caches when the fusion pipeline changes.
+
+    `query_tags` is intentionally NOT part of the key: tags only affect
+    rerank ordering (applied after cache read) and the fetched raw set
+    is tag-independent, so two calls with same (query, mode, limit) but
+    different tags correctly share a cached fetch.
     """
     digest = hashlib.sha1(
         f"{CACHE_VERSION}|{query}|{mode}|{limit}".encode()
@@ -202,8 +216,12 @@ def read_cache(path: Path, ttl: int) -> dict | None:
 def write_cache(path: Path, payload: dict) -> None:
     try:
         path.write_text(json.dumps(payload, default=str))
-    except OSError:
-        pass  # non-fatal
+    except OSError as e:
+        # Disk full / permission / path too long — non-fatal, but surface
+        # in debug mode so silent cache-write failures don't hide real
+        # issues (e.g. $HOME on a read-only volume).
+        if os.environ.get("REFLECT_RECALL_DEBUG"):
+            print(f"recall: cache write failed: {e}", file=sys.stderr)
 
 
 def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
@@ -305,8 +323,8 @@ def rrf_fuse(result_lists: list[list[Learning]], k: int = RRF_K) -> list[Learnin
             # over file-read from qmd when both are present)
             if key not in first_seen:
                 first_seen[key] = learning
-    ordered_keys = sorted(scores, key=lambda k: scores[k], reverse=True)
-    return [first_seen[k] for k in ordered_keys]
+    ordered_keys = sorted(scores, key=lambda key: scores[key], reverse=True)
+    return [first_seen[key] for key in ordered_keys]
 
 
 def parse_learnings_output(json_blob: str) -> list[Learning]:
@@ -356,7 +374,11 @@ def rerank(
                 ts = datetime.fromisoformat(lrn.archived_at.rstrip("Z"))
                 age_days = max(0.0, (now - ts).days)
                 recency = math.exp(-age_days / 90.0)
-            except ValueError:
+            except (ValueError, TypeError):
+                # TypeError: aware-vs-naive datetime subtraction (one side
+                # has +00:00 offset). ValueError: malformed ISO string.
+                # Either way, fall back to neutral recency rather than
+                # crashing the entire rerank over one bad archive header.
                 pass
         lt = set(t.lower() for t in lrn.tags)
         bonus = 0.1 * len(qt & lt) if qt else 0.0
@@ -372,7 +394,7 @@ def filter_by_confidence(learnings: list[Learning], threshold: str) -> list[Lear
         return learnings
     rank = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
     min_rank = rank.get(threshold, 0)
-    return [l for l in learnings if rank.get(l.confidence, 0) >= min_rank]
+    return [lrn for lrn in learnings if rank.get(lrn.confidence, 0) >= min_rank]
 
 
 def render_markdown(
@@ -403,15 +425,15 @@ def render_json(learnings: list[Learning], query: str, mode: str) -> str:
             "count": len(learnings),
             "results": [
                 {
-                    "id": l.id,
-                    "title": l.title,
-                    "key_insight": l.key_insight,
-                    "confidence": l.confidence,
-                    "tags": l.tags,
-                    "how_to_apply": l.how_to_apply,
-                    "archived_at": l.archived_at,
+                    "id": lrn.id,
+                    "title": lrn.title,
+                    "key_insight": lrn.key_insight,
+                    "confidence": lrn.confidence,
+                    "tags": lrn.tags,
+                    "how_to_apply": lrn.how_to_apply,
+                    "archived_at": lrn.archived_at,
                 }
-                for l in learnings
+                for lrn in learnings
             ],
         },
         indent=2,

--- a/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pyyaml",
+# ]
+# ///
+"""
+Reflect Recall — hybrid retrieval from the global learnings KB.
+
+Wraps ~/.learnings/cli/learnings as a subprocess so we inherit GraphRAG +
+embeddings without pulling the nano-graphrag dep chain into this plugin.
+
+Usage:
+    recall.py <query> [--limit N] [--mode naive|local|global]
+                      [--confidence HIGH|MEDIUM|LOW|ANY]
+                      [--format markdown|json]
+                      [--max-chars 2000]
+                      [--no-cache]
+                      [--cache-ttl 3600]
+
+Exit codes:
+    0 = success (including empty results when KB absent — see D9)
+    2 = invalid args
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # graceful degrade; we can still parse most frontmatter
+
+
+# --- Config --------------------------------------------------------------
+
+DEFAULT_LIMIT = 10
+DEFAULT_MODE = "naive"
+DEFAULT_CACHE_TTL = 3600  # 1 hour
+DEFAULT_MAX_CHARS = 2000
+LEARNINGS_CLI_CANDIDATES = [
+    Path.home() / ".learnings" / "cli" / "learnings",
+    Path("/opt/homebrew/bin/learnings"),
+]
+
+CONFIDENCE_WEIGHTS = {"HIGH": 1.0, "MEDIUM": 0.7, "LOW": 0.4}
+CHUNK_SEPARATOR = "--New Chunk--"
+ARCHIVE_HEADER_RE = re.compile(r"<!--\s*archived:\s*([0-9T:\-Z]+)\s*-->")
+
+
+# --- Data models ---------------------------------------------------------
+
+@dataclass
+class Learning:
+    """One parsed chunk from the learnings search output."""
+
+    chunk_text: str
+    frontmatter: dict[str, Any] = field(default_factory=dict)
+    archived_at: str | None = None  # ISO timestamp from the <!-- archived --> comment
+
+    @property
+    def id(self) -> str:
+        return self.frontmatter.get("id") or self.frontmatter.get("name") or "?"
+
+    @property
+    def title(self) -> str:
+        return (
+            self.frontmatter.get("title")
+            or self.frontmatter.get("name")
+            or "(no title)"
+        ).strip().strip('"')
+
+    @property
+    def key_insight(self) -> str:
+        return (self.frontmatter.get("key_insight") or "").strip().strip('"')
+
+    @property
+    def confidence(self) -> str:
+        raw = self.frontmatter.get("confidence") or "MEDIUM"
+        # Coerce numeric confidence (instinct-style 0.0-1.0) to tier
+        if isinstance(raw, (int, float)):
+            if raw >= 0.8:
+                return "HIGH"
+            if raw >= 0.5:
+                return "MEDIUM"
+            return "LOW"
+        return str(raw).upper()
+
+    @property
+    def tags(self) -> list[str]:
+        raw = self.frontmatter.get("tags", [])
+        if isinstance(raw, str):
+            # yaml sometimes leaves unquoted lists as strings; split tolerantly
+            raw = [t.strip() for t in re.split(r"[\[\],]", raw) if t.strip()]
+        return [str(t).strip() for t in raw]
+
+    @property
+    def how_to_apply(self) -> str:
+        """Extract the "How to apply:" paragraph from the chunk body."""
+        m = re.search(
+            r"\*\*How to apply:\*\*\s*\n?(.*?)(?=\n\n|\n\*\*|\Z)",
+            self.chunk_text,
+            re.DOTALL,
+        )
+        if m:
+            text = m.group(1).strip()
+            # Cap at one sentence / 280 chars for SessionStart brevity
+            text = text.split("\n")[0]
+            return text[:280]
+        return ""
+
+
+@dataclass
+class RecallResult:
+    learnings: list[Learning]
+    query: str
+    mode: str
+    cache_hit: bool = False
+    error: str | None = None
+
+
+# --- Helpers -------------------------------------------------------------
+
+def find_learnings_cli() -> Path | None:
+    """Locate the learnings CLI. D1: subprocess wrapper."""
+    for candidate in LEARNINGS_CLI_CANDIDATES:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    cli_on_path = shutil.which("learnings")
+    return Path(cli_on_path) if cli_on_path else None
+
+
+def cache_path(query: str, mode: str) -> Path:
+    """Per-query cache file. D4: 1-hour TTL."""
+    digest = hashlib.sha1(f"{query}|{mode}".encode()).hexdigest()[:16]
+    base = Path(os.environ.get("REFLECT_STATE_DIR", Path.home() / ".reflect"))
+    cache_dir = base / "recall_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{digest}.json"
+
+
+def read_cache(path: Path, ttl: int) -> dict | None:
+    if not path.exists():
+        return None
+    age = time.time() - path.stat().st_mtime
+    if age > ttl:
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def write_cache(path: Path, payload: dict) -> None:
+    try:
+        path.write_text(json.dumps(payload, default=str))
+    except OSError:
+        pass  # non-fatal
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Extract YAML frontmatter if present; return (dict, remaining_body)."""
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    header = text[3:end].strip()
+    body = text[end + 4 :].lstrip("\n")
+    if yaml is None:
+        # fallback: line-by-line k: v (no lists)
+        data: dict[str, Any] = {}
+        for line in header.splitlines():
+            if ":" in line:
+                k, _, v = line.partition(":")
+                data[k.strip()] = v.strip().strip('"')
+        return data, body
+    try:
+        data = yaml.safe_load(header) or {}
+        return (data if isinstance(data, dict) else {}), body
+    except yaml.YAMLError:
+        return {}, body
+
+
+def parse_learnings_output(json_blob: str) -> list[Learning]:
+    """Split a `learnings search --format json` response into Learning objects."""
+    try:
+        envelope = json.loads(json_blob)
+    except json.JSONDecodeError:
+        return []
+    context = envelope.get("context", "")
+    if not context:
+        return []
+    chunks = [c.strip() for c in context.split(CHUNK_SEPARATOR) if c.strip()]
+    results: list[Learning] = []
+    for chunk in chunks:
+        fm, body = parse_frontmatter(chunk)
+        archived = None
+        m = ARCHIVE_HEADER_RE.search(body)
+        if m:
+            archived = m.group(1)
+        results.append(Learning(chunk_text=chunk, frontmatter=fm, archived_at=archived))
+    return results
+
+
+def rerank(
+    learnings: list[Learning],
+    query_tags: list[str] | None = None,
+    now: datetime | None = None,
+) -> list[Learning]:
+    """
+    D8: score = confidence × recency × (1 + tag_bonus).
+    Sorts in-place and returns the same list.
+    """
+    now = now or datetime.now(tz=None)
+    qt = set(t.lower() for t in (query_tags or []))
+
+    def score(lrn: Learning) -> float:
+        c = CONFIDENCE_WEIGHTS.get(lrn.confidence, 0.5)
+        # Recency: half-life 60d via exp(-age / 90)
+        recency = 1.0
+        if lrn.archived_at:
+            try:
+                ts = datetime.fromisoformat(lrn.archived_at.rstrip("Z"))
+                age_days = max(0.0, (now - ts).days)
+                recency = math.exp(-age_days / 90.0)
+            except ValueError:
+                pass
+        lt = set(t.lower() for t in lrn.tags)
+        bonus = 0.1 * len(qt & lt) if qt else 0.0
+        return c * recency * (1 + bonus)
+
+    learnings.sort(key=score, reverse=True)
+    return learnings
+
+
+def filter_by_confidence(learnings: list[Learning], threshold: str) -> list[Learning]:
+    """threshold ∈ {HIGH, MEDIUM, LOW, ANY}"""
+    if threshold == "ANY":
+        return learnings
+    rank = {"HIGH": 3, "MEDIUM": 2, "LOW": 1}
+    min_rank = rank.get(threshold, 0)
+    return [l for l in learnings if rank.get(l.confidence, 0) >= min_rank]
+
+
+def render_markdown(
+    learnings: list[Learning], query: str, max_chars: int = DEFAULT_MAX_CHARS
+) -> str:
+    """D5: compact markdown block for agent context."""
+    if not learnings:
+        return ""
+    lines = [f"## Prior learnings relevant to `{query[:80]}`\n"]
+    used = len(lines[0])
+    for lrn in learnings:
+        header = f"- **[{lrn.id}]** {lrn.key_insight or lrn.title}"
+        how = lrn.how_to_apply
+        entry = header + (f"\n  How to apply: {how}" if how else "") + "\n"
+        if used + len(entry) > max_chars:
+            lines.append(f"- _(…{len(learnings) - (len(lines) - 1)} more truncated)_\n")
+            break
+        lines.append(entry)
+        used += len(entry)
+    return "".join(lines).rstrip() + "\n"
+
+
+def render_json(learnings: list[Learning], query: str, mode: str) -> str:
+    return json.dumps(
+        {
+            "query": query,
+            "mode": mode,
+            "count": len(learnings),
+            "results": [
+                {
+                    "id": l.id,
+                    "title": l.title,
+                    "key_insight": l.key_insight,
+                    "confidence": l.confidence,
+                    "tags": l.tags,
+                    "how_to_apply": l.how_to_apply,
+                    "archived_at": l.archived_at,
+                }
+                for l in learnings
+            ],
+        },
+        indent=2,
+    )
+
+
+def log_recall(query: str, mode: str, count: int, cached: bool) -> None:
+    """D_phase6: append-only jsonl for future helpfulness tracking."""
+    base = Path(os.environ.get("REFLECT_STATE_DIR", Path.home() / ".reflect"))
+    log = base / "recall_log.jsonl"
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+        with log.open("a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "ts": datetime.now().isoformat(timespec="seconds"),
+                        "query": query,
+                        "mode": mode,
+                        "count": count,
+                        "cached": cached,
+                    }
+                )
+                + "\n"
+            )
+    except OSError:
+        pass
+
+
+# --- Core entry ----------------------------------------------------------
+
+def recall(
+    query: str,
+    *,
+    limit: int = DEFAULT_LIMIT,
+    mode: str = DEFAULT_MODE,
+    confidence: str = "ANY",
+    max_chars: int = DEFAULT_MAX_CHARS,
+    use_cache: bool = True,
+    cache_ttl: int = DEFAULT_CACHE_TTL,
+    query_tags: list[str] | None = None,
+) -> RecallResult:
+    """High-level API: query → ranked Learnings. Never raises on KB issues."""
+    cli = find_learnings_cli()
+    if not cli:
+        return RecallResult([], query, mode, error="learnings CLI not found")
+
+    cache_file = cache_path(query, mode)
+    if use_cache:
+        cached = read_cache(cache_file, cache_ttl)
+        if cached:
+            learnings = [
+                Learning(
+                    chunk_text=r.get("chunk_text", ""),
+                    frontmatter=r.get("frontmatter", {}),
+                    archived_at=r.get("archived_at"),
+                )
+                for r in cached.get("results", [])
+            ]
+            learnings = rerank(learnings, query_tags)
+            learnings = filter_by_confidence(learnings, confidence.upper())[:limit]
+            log_recall(query, mode, len(learnings), cached=True)
+            return RecallResult(learnings, query, mode, cache_hit=True)
+
+    try:
+        proc = subprocess.run(
+            [str(cli), "search", query, "--mode", mode, "--format", "json",
+             "--limit", str(max(limit * 2, 10))],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return RecallResult([], query, mode, error=f"subprocess failed: {e}")
+
+    if proc.returncode != 0:
+        return RecallResult([], query, mode, error=f"learnings exit {proc.returncode}")
+
+    learnings = parse_learnings_output(proc.stdout)
+    # persist raw results to cache before filtering (so different confidence/limit
+    # combinations can reuse the same fetch)
+    if use_cache:
+        write_cache(
+            cache_file,
+            {
+                "query": query,
+                "mode": mode,
+                "fetched_at": time.time(),
+                "results": [
+                    {
+                        "chunk_text": l.chunk_text,
+                        "frontmatter": l.frontmatter,
+                        "archived_at": l.archived_at,
+                    }
+                    for l in learnings
+                ],
+            },
+        )
+    learnings = rerank(learnings, query_tags)
+    learnings = filter_by_confidence(learnings, confidence.upper())[:limit]
+    log_recall(query, mode, len(learnings), cached=False)
+    return RecallResult(learnings, query, mode)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("query", nargs="+", help="Search query")
+    ap.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    ap.add_argument("--mode", choices=["naive", "local", "global"], default=DEFAULT_MODE)
+    ap.add_argument("--confidence", choices=["HIGH", "MEDIUM", "LOW", "ANY"], default="ANY")
+    ap.add_argument("--format", choices=["markdown", "json"], default="markdown")
+    ap.add_argument("--max-chars", type=int, default=DEFAULT_MAX_CHARS)
+    ap.add_argument("--no-cache", action="store_true")
+    ap.add_argument("--cache-ttl", type=int, default=DEFAULT_CACHE_TTL)
+    ap.add_argument("--tags", default="",
+                    help="Comma-separated query tags for tag-overlap reranking")
+    args = ap.parse_args()
+
+    query = " ".join(args.query).strip()
+    if not query:
+        print("error: empty query", file=sys.stderr)
+        return 2
+
+    query_tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+
+    result = recall(
+        query,
+        limit=args.limit,
+        mode=args.mode,
+        confidence=args.confidence,
+        max_chars=args.max_chars,
+        use_cache=not args.no_cache,
+        cache_ttl=args.cache_ttl,
+        query_tags=query_tags,
+    )
+
+    if result.error:
+        # D9: silent no-op on KB absence; only print to stderr when diagnostic
+        if os.environ.get("REFLECT_RECALL_DEBUG"):
+            print(f"recall: {result.error}", file=sys.stderr)
+        # Empty output, exit 0
+        return 0
+
+    if args.format == "json":
+        print(render_json(result.learnings, query, args.mode))
+    else:
+        out = render_markdown(result.learnings, query, max_chars=args.max_chars)
+        if out:
+            print(out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
@@ -27,6 +27,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import hashlib
 import json
 import math
@@ -58,6 +59,15 @@ LEARNINGS_CLI_CANDIDATES = [
 CONFIDENCE_WEIGHTS = {"HIGH": 1.0, "MEDIUM": 0.7, "LOW": 0.4}
 CHUNK_SEPARATOR = "--New Chunk--"
 ARCHIVE_HEADER_RE = re.compile(r"<!--\s*archived:\s*([0-9T:.+\-Z]+)\s*-->")
+
+# --- QMD fusion config ---------------------------------------------------
+# QMD provides BM25 lexical search (fast, ~0.5s) as a complement to
+# GraphRAG's vector path. Fusing the two via RRF gives hybrid lex+vec
+# retrieval without changing the learnings CLI.
+QMD_COLLECTION = "learnings"
+QMD_DOCS_ROOT = Path.home() / ".learnings" / "documents"
+QMD_PATH_RE = re.compile(r"qmd://" + re.escape(QMD_COLLECTION) + r"/(\S+?\.md)")
+RRF_K = 60  # standard reciprocal-rank-fusion constant
 
 
 # --- Data models ---------------------------------------------------------
@@ -148,13 +158,19 @@ def find_learnings_cli() -> Path | None:
     return Path(cli_on_path) if cli_on_path else None
 
 
+CACHE_VERSION = "v2-hybrid"  # bump when fusion semantics change
+
+
 def cache_path(query: str, mode: str, limit: int) -> Path:
     """Per-query cache file. D4: 1-hour TTL.
 
     Limit is part of the key so a small-limit fetch can't poison a
-    subsequent large-limit read with a truncated result set.
+    subsequent large-limit read with a truncated result set. Version tag
+    invalidates old caches when the fusion pipeline changes.
     """
-    digest = hashlib.sha1(f"{query}|{mode}|{limit}".encode()).hexdigest()[:16]
+    digest = hashlib.sha1(
+        f"{CACHE_VERSION}|{query}|{mode}|{limit}".encode()
+    ).hexdigest()[:16]
     base = Path(os.environ.get("REFLECT_STATE_DIR", Path.home() / ".reflect"))
     cache_dir = base / "recall_cache"
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -204,6 +220,93 @@ def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
         return (data if isinstance(data, dict) else {}), body
     except yaml.YAMLError:
         return {}, body
+
+
+def find_qmd_cli() -> Path | None:
+    """Locate the `qmd` binary. Returns None if not installed."""
+    cli_on_path = shutil.which("qmd")
+    return Path(cli_on_path) if cli_on_path else None
+
+
+def fetch_qmd(query: str, limit: int, timeout: int = 10) -> list[Learning]:
+    """Fast BM25 retrieval via qmd. Complement to GraphRAG's vector path.
+
+    Returns empty list on any failure (missing CLI, timeout, empty KB) — QMD
+    is strictly a booster, never a blocker.
+    """
+    qmd = find_qmd_cli()
+    if not qmd:
+        return []
+    try:
+        proc = subprocess.run(
+            [str(qmd), "search", query, "-c", QMD_COLLECTION,
+             "--limit", str(limit)],
+            capture_output=True, text=True, timeout=timeout, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if proc.returncode != 0 or not proc.stdout:
+        return []
+    return parse_qmd_output(proc.stdout)
+
+
+def parse_qmd_output(text: str) -> list[Learning]:
+    """Convert qmd's text output to Learning objects by reading each hit's file.
+
+    qmd emits lines like `qmd://learnings/learnings/<file>.md:<line> #hash`
+    for each result. We extract the relative path, resolve it under the QMD
+    collection root, and parse frontmatter + body.
+    """
+    seen: set[str] = set()
+    learnings: list[Learning] = []
+    for m in QMD_PATH_RE.finditer(text):
+        rel = m.group(1)
+        if rel in seen:  # qmd can emit multiple line hits per file
+            continue
+        seen.add(rel)
+        path = QMD_DOCS_ROOT / rel
+        try:
+            content = path.read_text()
+        except OSError:
+            continue
+        fm, body = parse_frontmatter(content)
+        archived = None
+        am = ARCHIVE_HEADER_RE.search(body)
+        if am:
+            archived = am.group(1)
+        learnings.append(Learning(chunk_text=content, frontmatter=fm, archived_at=archived))
+    return learnings
+
+
+def _learning_key(learning: Learning) -> str:
+    """Dedup key stable across backends. Prefers frontmatter id, falls back to
+    a hash of the chunk so distinct chunks don't collapse."""
+    fid = learning.frontmatter.get("id") or learning.frontmatter.get("name")
+    if fid:
+        return str(fid)
+    return hashlib.sha1(learning.chunk_text[:256].encode()).hexdigest()[:12]
+
+
+def rrf_fuse(result_lists: list[list[Learning]], k: int = RRF_K) -> list[Learning]:
+    """Reciprocal Rank Fusion. Standard hybrid-search technique.
+
+    score(doc) = Σ 1 / (k + rank_in_each_source)
+
+    Source-agnostic — doesn't need score normalization across backends.
+    Docs appearing in both get summed scores → fused ranking.
+    """
+    scores: dict[str, float] = {}
+    first_seen: dict[str, Learning] = {}
+    for results in result_lists:
+        for rank, learning in enumerate(results, start=1):
+            key = _learning_key(learning)
+            scores[key] = scores.get(key, 0.0) + 1.0 / (k + rank)
+            # Keep the first occurrence (prefer full-chunk from learnings search
+            # over file-read from qmd when both are present)
+            if key not in first_seen:
+                first_seen[key] = learning
+    ordered_keys = sorted(scores, key=lambda k: scores[k], reverse=True)
+    return [first_seen[k] for k in ordered_keys]
 
 
 def parse_learnings_output(json_blob: str) -> list[Learning]:
@@ -374,22 +477,33 @@ def recall(
             log_recall(query, mode, len(learnings), cached=True)
             return RecallResult(learnings, query, mode, cache_hit=True)
 
-    try:
-        proc = subprocess.run(
-            [str(cli), "search", query, "--mode", mode, "--format", "json",
-             "--limit", str(fetched_limit)],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
-        return RecallResult([], query, mode, error=f"subprocess failed: {e}")
+    # Fan out GraphRAG (via learnings CLI) and QMD (BM25) in parallel.
+    # QMD contributes lexical recall that pure vector search misses; it's a
+    # booster, not a blocker — returns [] on any failure and fusion still works.
+    def _fetch_learnings() -> tuple[list[Learning], str | None]:
+        try:
+            proc = subprocess.run(
+                [str(cli), "search", query, "--mode", mode, "--format", "json",
+                 "--limit", str(fetched_limit)],
+                capture_output=True, text=True, timeout=30, check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            return [], f"subprocess failed: {e}"
+        if proc.returncode != 0:
+            return [], f"learnings exit {proc.returncode}"
+        return parse_learnings_output(proc.stdout), None
 
-    if proc.returncode != 0:
-        return RecallResult([], query, mode, error=f"learnings exit {proc.returncode}")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        learnings_future = pool.submit(_fetch_learnings)
+        qmd_future = pool.submit(fetch_qmd, query, fetched_limit)
+        graph_results, graph_err = learnings_future.result()
+        qmd_results = qmd_future.result()
 
-    learnings = parse_learnings_output(proc.stdout)
+    # If graph path failed but QMD returned results, keep going — still useful.
+    if graph_err and not qmd_results:
+        return RecallResult([], query, mode, error=graph_err)
+
+    learnings = rrf_fuse([graph_results, qmd_results])
     # persist raw results to cache before filtering (so different confidence/limit
     # combinations can reuse the same fetch)
     if use_cache:

--- a/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
@@ -41,10 +41,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-try:
-    import yaml
-except ImportError:
-    yaml = None  # graceful degrade; we can still parse most frontmatter
+import yaml  # declared in PEP 723 header; uv run --script always installs
 
 
 # --- Config --------------------------------------------------------------
@@ -154,11 +151,21 @@ def cache_path(query: str, mode: str) -> Path:
     return cache_dir / f"{digest}.json"
 
 
+def kb_last_modified() -> float:
+    """mtime of the GraphRAG cache dir — proxy for last KB write."""
+    kb = Path.home() / ".learnings" / "nano_graphrag_cache"
+    try:
+        return kb.stat().st_mtime if kb.exists() else 0.0
+    except OSError:
+        return 0.0
+
+
 def read_cache(path: Path, ttl: int) -> dict | None:
     if not path.exists():
         return None
-    age = time.time() - path.stat().st_mtime
-    if age > ttl:
+    cache_mtime = path.stat().st_mtime
+    # Invalidate on TTL or when KB has been written since the cache was created
+    if time.time() - cache_mtime > ttl or kb_last_modified() > cache_mtime:
         return None
     try:
         return json.loads(path.read_text())
@@ -182,14 +189,6 @@ def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
         return {}, text
     header = text[3:end].strip()
     body = text[end + 4 :].lstrip("\n")
-    if yaml is None:
-        # fallback: line-by-line k: v (no lists)
-        data: dict[str, Any] = {}
-        for line in header.splitlines():
-            if ":" in line:
-                k, _, v = line.partition(":")
-                data[k.strip()] = v.strip().strip('"')
-        return data, body
     try:
         data = yaml.safe_load(header) or {}
         return (data if isinstance(data, dict) else {}), body

--- a/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
+++ b/toolkit/packages/plugins/reflect/skills/recall/scripts/recall.py
@@ -212,8 +212,13 @@ def parse_learnings_output(json_blob: str) -> list[Learning]:
         envelope = json.loads(json_blob)
     except json.JSONDecodeError:
         return []
+    # Expected shape is {"context": "...chunks...--New Chunk--..."}.
+    # Guard against list/string/other shapes so a CLI format change can't
+    # crash us — it should just return zero results.
+    if not isinstance(envelope, dict):
+        return []
     context = envelope.get("context", "")
-    if not context:
+    if not isinstance(context, str) or not context:
         return []
     chunks = [c.strip() for c in context.split(CHUNK_SEPARATOR) if c.strip()]
     results: list[Learning] = []

--- a/toolkit/packages/plugins/reflect/skills/reflect/SKILL.md
+++ b/toolkit/packages/plugins/reflect/skills/reflect/SKILL.md
@@ -87,7 +87,13 @@ Analyze the conversation for **two types** of signals:
 
 See `references/signal_patterns.md` for full detection rules.
 
-### Step 2: Classify & Match to Targets
+### Step 2: Classify & Match to Targets (MANDATORY)
+
+**CRITICAL**: Every detected signal MUST be routed to at least one of:
+(a) an existing agent/CLAUDE.md file edit, (b) a new skill proposal, or
+(c) a knowledge note. Knowledge notes are the **fallback**, not the default.
+If a signal has clear behavioral implications, you MUST propose an edit to an
+existing agent target — do not skip straight to knowledge-note output.
 
 **Behavioral signals** map to agent files:
 
@@ -205,14 +211,26 @@ relationships:
 1. Apply each behavioral change using Edit tool
 2. Write knowledge notes to `docs/solutions/{category}/`
 3. Write entity sidecar alongside each knowledge note
-4. Index globally:
+4. Index globally (validates sidecar first to catch schema errors early):
    ```bash
-   LEARNINGS_CLI="$HOME/.claude/global-learnings/cli/learnings"
+   LEARNINGS_CLI="$HOME/.learnings/cli/learnings"
+   SIDECAR="docs/solutions/{category}/{filename}.entities.yaml"
+   DOC="docs/solutions/{category}/{filename}.md"
+   VALIDATE="{{HOME_TOOL_DIR}}/skills/reflect/scripts/validate_sidecar.py"
+
    if [[ -x "$LEARNINGS_CLI" ]]; then
-       "$LEARNINGS_CLI" add docs/solutions/{category}/{filename}.md \
-           --entities docs/solutions/{category}/{filename}.entities.yaml
+       # Validate before ingest — malformed sidecars fail loudly here, not
+       # silently at GraphRAG time
+       uv run "$VALIDATE" --strict "$SIDECAR" || {
+           echo "ERROR: sidecar validation failed for $SIDECAR" >&2
+           exit 1
+       }
+       "$LEARNINGS_CLI" add "$DOC" --entities "$SIDECAR"
    fi
    ```
+   Capture → index is now closed: every accepted learning flows into GraphRAG
+   + QMD immediately, so the next session's SessionStart recall will surface
+   it via the retrieval hook.
 5. Create episode note (auto, no approval needed)
 6. Update metrics:
    ```bash

--- a/toolkit/packages/plugins/reflect/tests/inject_recall_preamble.py
+++ b/toolkit/packages/plugins/reflect/tests/inject_recall_preamble.py
@@ -54,7 +54,6 @@ def build_block(skill: str, tier: int, query_hint: str) -> str:
         "gh-issue": "fixing the issue",
         "find-missing-tests": "identifying test gaps",
         "validate": "validating",
-        "review": "reviewing",
     }[skill]
     return f"""{BEGIN_MARK}
 

--- a/toolkit/packages/plugins/reflect/tests/inject_recall_preamble.py
+++ b/toolkit/packages/plugins/reflect/tests/inject_recall_preamble.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+Inject the Step 0 recall preamble into Tier 1 + 2 skills.
+
+Idempotent: skipped if <!-- recall:begin --> already present.
+Inserts the block immediately before the first H2 heading in the file.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[5]  # repo root
+SKILLS = ROOT / "toolkit" / "packages" / "skills"
+
+# (skill_name, tier, query_hint) — query_hint is skill-specific guidance
+# on how to build the recall query from user input / context.
+TARGETS = [
+    # ─── Tier 1 — mandatory recall preamble ────────────────────────────
+    ("plan", 1, "concatenate the user's task description + any file paths + domain keywords (e.g. `\"user auth OAuth migration\"`)"),
+    ("plan-tdd", 1, "task description + `\"testing strategy\"` + target module name (e.g. `\"payment webhook testing strategy\"`)"),
+    ("plan-gh", 1, "task scope + `\"github issue\"` + repo/project name (e.g. `\"dashboard rewrite github issue frontend\"`)"),
+    ("research", 1, "the research topic verbatim + domain keywords (e.g. `\"redis connection pooling node\"`)"),
+    ("brainstorm", 1, "the topic or problem being brainstormed + any constraint hints from the user (e.g. `\"caching strategy mobile offline\"`)"),
+    ("critique", 1, "a short summary of the approach/code being critiqued + relevant domain keywords (e.g. `\"event-sourced migration rollback strategy\"`)"),
+
+    # ─── Tier 2 — recommended recall preamble ──────────────────────────
+    ("implement", 2, "the plan's current phase name + touched module names (e.g. `\"auth middleware session token storage\"`). Skip if the calling /plan already ran recall and surfaced findings."),
+    ("gh-issue", 2, "issue title + top labels + repo name (e.g. `\"flaky signup test frontend auth\"`)"),
+    ("find-missing-tests", 2, "target module/package name + `\"testing\"` (e.g. `\"payment webhook handler testing\"`)"),
+    ("validate", 2, "the feature/change being validated + relevant verification keywords (e.g. `\"OAuth callback validation edge cases\"`)"),
+    # `review` skill is provided by an external plugin (not in toolkit/packages/skills/) — skipped.
+]
+
+
+BEGIN_MARK = "<!-- recall:begin -->"
+END_MARK = "<!-- recall:end -->"
+
+
+def build_block(skill: str, tier: int, query_hint: str) -> str:
+    tier_word = "MANDATORY" if tier == 1 else "RECOMMENDED"
+    verb = {
+        "plan": "planning",
+        "plan-tdd": "writing the TDD plan",
+        "plan-gh": "generating issues",
+        "research": "researching",
+        "brainstorm": "brainstorming",
+        "critique": "critiquing",
+        "implement": "implementing",
+        "gh-issue": "fixing the issue",
+        "find-missing-tests": "identifying test gaps",
+        "validate": "validating",
+        "review": "reviewing",
+    }[skill]
+    return f"""{BEGIN_MARK}
+
+## Step 0: Prior-art check ({tier_word})
+
+Before {verb}, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{{{HOME_TOOL_DIR}}}}/skills/recall/scripts/recall.py" \\
+  "<QUERY>" \\
+  --limit 5 --format markdown
+```
+
+**Query construction for `/{skill}`**: {query_hint}.
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+{END_MARK}
+
+"""
+
+
+def inject(skill: str, tier: int, query_hint: str) -> str:
+    """Return 'ok' / 'skipped' / 'missing'."""
+    path = SKILLS / skill / "SKILL.md"
+    if not path.exists():
+        return "missing"
+    content = path.read_text()
+    if BEGIN_MARK in content:
+        return "skipped"
+
+    # Insert before the first H2 after the frontmatter.
+    # The frontmatter is a `---` … `---` block at the very top.
+    lines = content.splitlines(keepends=True)
+    insert_at = None
+    in_frontmatter = False
+    seen_frontmatter_close = False
+    for i, line in enumerate(lines):
+        if i == 0 and line.startswith("---"):
+            in_frontmatter = True
+            continue
+        if in_frontmatter and line.startswith("---"):
+            in_frontmatter = False
+            seen_frontmatter_close = True
+            continue
+        if in_frontmatter:
+            continue
+        # After frontmatter, find first H2 (or H1 that starts the body)
+        if line.startswith("## "):
+            insert_at = i
+            break
+        # Or first numbered step (skills that use bare `1. ...` lists)
+        if line.lstrip().startswith("1. ") and i > 0:
+            insert_at = i
+            break
+
+    if insert_at is None:
+        # No H2 found — append after the H1 intro, or at end
+        return "no-insertion-point"
+
+    block = build_block(skill, tier, query_hint)
+    new_content = "".join(lines[:insert_at]) + block + "".join(lines[insert_at:])
+    path.write_text(new_content)
+    return "ok"
+
+
+def main() -> int:
+    results = {}
+    for skill, tier, hint in TARGETS:
+        results[skill] = inject(skill, tier, hint)
+    print(f"{'skill':<20}  {'result':<10}")
+    print("─" * 32)
+    for skill, result in results.items():
+        marker = "✓" if result in ("ok", "skipped") else "✗"
+        print(f"{marker} {skill:<18}  {result}")
+    bad = [s for s, r in results.items() if r not in ("ok", "skipped")]
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/toolkit/packages/plugins/reflect/tests/test_skill_recall_integration.py
+++ b/toolkit/packages/plugins/reflect/tests/test_skill_recall_integration.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pytest",
+# ]
+# ///
+"""
+Integration tests for recall-preamble wiring in Tier 1 + 2 skills.
+
+Two layers:
+
+1. Structural — every tier-1/2 skill's SKILL.md contains a recall block
+   delimited by <!-- recall:begin --> / <!-- recall:end --> with the
+   expected command shape.
+
+2. Sandbox e2e — a fake KB dir is seeded with one distinctive learning;
+   recall.py is invoked with a query aligned to that seed; output must
+   contain the seed's ID. Proves the recall CLI actually retrieves when
+   a skill would call it.
+
+Run:
+    uv run toolkit/packages/plugins/reflect/tests/test_skill_recall_integration.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[5]
+SKILLS = ROOT / "toolkit" / "packages" / "skills"
+RECALL = ROOT / "toolkit" / "packages" / "plugins" / "reflect" / "skills" / "recall" / "scripts" / "recall.py"
+
+# Must match TARGETS in inject_recall_preamble.py
+SKILLS_WITH_RECALL = [
+    "plan", "plan-tdd", "plan-gh", "research", "brainstorm", "critique",
+    "implement", "gh-issue", "find-missing-tests", "validate",
+]
+
+BEGIN = "<!-- recall:begin -->"
+END = "<!-- recall:end -->"
+
+
+# ─── Layer 1: structural ──────────────────────────────────────────────
+
+@pytest.mark.parametrize("skill", SKILLS_WITH_RECALL)
+def test_skill_has_recall_block(skill: str):
+    """Every tier-1/2 skill has the recall preamble block."""
+    path = SKILLS / skill / "SKILL.md"
+    assert path.exists(), f"skill source missing: {path}"
+    content = path.read_text()
+    assert BEGIN in content, f"{skill}: missing {BEGIN}"
+    assert END in content, f"{skill}: missing {END}"
+
+
+@pytest.mark.parametrize("skill", SKILLS_WITH_RECALL)
+def test_skill_recall_block_has_correct_command(skill: str):
+    """The recall block invokes recall.py with the right flags."""
+    content = (SKILLS / skill / "SKILL.md").read_text()
+    block = content.split(BEGIN, 1)[1].split(END, 1)[0]
+    assert "recall.py" in block, f"{skill}: recall.py not referenced"
+    assert "--limit" in block, f"{skill}: missing --limit flag"
+    assert "--format markdown" in block, f"{skill}: missing --format markdown"
+    assert "{{HOME_TOOL_DIR}}" in block, f"{skill}: missing template placeholder"
+
+
+@pytest.mark.parametrize("skill", SKILLS_WITH_RECALL)
+def test_skill_recall_block_has_query_guidance(skill: str):
+    """Each skill has skill-specific guidance on building the query."""
+    content = (SKILLS / skill / "SKILL.md").read_text()
+    block = content.split(BEGIN, 1)[1].split(END, 1)[0]
+    assert f"/{skill}" in block, f"{skill}: block doesn't mention its own name"
+    assert "Query construction" in block, f"{skill}: no query construction hint"
+
+
+def test_recall_preamble_positioned_before_main_flow():
+    """Preamble must precede the first imperative step in every skill."""
+    for skill in SKILLS_WITH_RECALL:
+        content = (SKILLS / skill / "SKILL.md").read_text()
+        preamble_pos = content.find(BEGIN)
+        assert preamble_pos > 0, f"{skill}: preamble not found"
+        # find the first non-preamble imperative marker
+        for marker in ("## Planning Process", "## Workflow", "## Process",
+                       "## Implementation", "## Review"):
+            idx = content.find(marker)
+            if idx > 0:
+                assert preamble_pos < idx, \
+                    f"{skill}: preamble at {preamble_pos} is AFTER '{marker}' at {idx}"
+
+
+# ─── Layer 2: sandbox e2e ─────────────────────────────────────────────
+
+@pytest.fixture
+def sandbox_kb(tmp_path):
+    """Minimal fake KB that the `learnings` CLI can search."""
+    # Return a callable that installs a stub `learnings` binary + seed docs.
+    # We don't exercise nano-graphrag here — we stub the subprocess output.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    # Stub `learnings` CLI that returns a fixed JSON result containing the seed.
+    # Shape matches what real CLI emits: {"context": "<chunks separated by --New Chunk-->"}
+    seed_id = "lrn-test-fixture-abc123"
+    chunk = (
+        "---\n"
+        f"id: {seed_id}\n"
+        "title: Test fixture learning\n"
+        "key_insight: This is the seeded fixture for sandbox e2e testing\n"
+        "confidence: HIGH\n"
+        "tags: [test, fixture, sandbox]\n"
+        "---\n\n"
+        "**How to apply:** If this text appears in recall output, the loop works.\n"
+    )
+    fake_output = json.dumps({"context": chunk})
+
+    stub = bin_dir / "learnings"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "# stub learnings CLI for sandbox tests\n"
+        f"cat <<'EOF'\n{fake_output}\nEOF\n"
+    )
+    stub.chmod(0o755)
+
+    # Fake ~/.learnings/cli/ layout so recall.py finds it via candidate path.
+    home_learnings = tmp_path / "home" / ".learnings" / "cli"
+    home_learnings.mkdir(parents=True)
+    real_stub = home_learnings / "learnings"
+    shutil.copy(stub, real_stub)
+    real_stub.chmod(0o755)
+
+    # Also create the nano_graphrag_cache dir so kb_last_modified() works.
+    (tmp_path / "home" / ".learnings" / "nano_graphrag_cache").mkdir()
+
+    yield {
+        "home": tmp_path / "home",
+        "seed_id": seed_id,
+        "reflect_state": tmp_path / "reflect_state",
+    }
+
+
+UV = shutil.which("uv") or "/opt/homebrew/bin/uv"
+
+
+def test_recall_returns_seeded_learning(sandbox_kb):
+    """With a seeded KB, recall.py surfaces the fixture ID."""
+    env = os.environ.copy()
+    env["HOME"] = str(sandbox_kb["home"])
+    env["REFLECT_STATE_DIR"] = str(sandbox_kb["reflect_state"])
+
+    result = subprocess.run(
+        [
+            UV, "run", "--quiet", str(RECALL),
+            "anything",  # query doesn't matter — stub returns fixed output
+            "--limit", "5",
+            "--format", "markdown",
+            "--no-cache",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+    assert result.returncode == 0, f"recall exited {result.returncode}: {result.stderr}"
+    assert sandbox_kb["seed_id"] in result.stdout, (
+        f"seeded ID {sandbox_kb['seed_id']} not in recall output.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+
+
+def test_recall_graceful_on_missing_kb(tmp_path):
+    """D9: when KB is absent, recall exits 0 with no output."""
+    # Isolate PATH to a dir that ONLY contains uv — no `learnings` binary.
+    isolated_bin = tmp_path / "bin"
+    isolated_bin.mkdir()
+    (isolated_bin / "uv").symlink_to(UV)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)  # empty — no ~/.learnings
+    env["PATH"] = str(isolated_bin)
+
+    result = subprocess.run(
+        [UV, "run", "--quiet", str(RECALL), "anything",
+         "--limit", "3", "--format", "markdown", "--no-cache"],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    assert result.returncode == 0, f"should exit 0, got {result.returncode}"
+    # Output should be empty-ish when KB absent (no "[lrn-...]" entries)
+    assert "[lrn-" not in result.stdout
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/toolkit/packages/plugins/reflect/tests/test_skill_recall_integration.py
+++ b/toolkit/packages/plugins/reflect/tests/test_skill_recall_integration.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "pytest",
+#     "pyyaml",
 # ]
 # ///
 """
@@ -176,14 +177,11 @@ def test_recall_returns_seeded_learning(sandbox_kb):
 
 def test_recall_graceful_on_missing_kb(tmp_path):
     """D9: when KB is absent, recall exits 0 with no output."""
-    # Isolate PATH to a dir that ONLY contains uv — no `learnings` binary.
-    isolated_bin = tmp_path / "bin"
-    isolated_bin.mkdir()
-    (isolated_bin / "uv").symlink_to(UV)
-
+    # HOME-empty hides ~/.learnings; PATH=/bin:/usr/bin hides `qmd`. uv is
+    # invoked by full path so PATH stripping is safe.
     env = os.environ.copy()
     env["HOME"] = str(tmp_path)  # empty — no ~/.learnings
-    env["PATH"] = str(isolated_bin)
+    env["PATH"] = "/bin:/usr/bin"
 
     result = subprocess.run(
         [UV, "run", "--quiet", str(RECALL), "anything",
@@ -193,6 +191,140 @@ def test_recall_graceful_on_missing_kb(tmp_path):
     assert result.returncode == 0, f"should exit 0, got {result.returncode}"
     # Output should be empty-ish when KB absent (no "[lrn-...]" entries)
     assert "[lrn-" not in result.stdout
+
+
+# ─── Layer 3: sandbox e2e — fusion with BOTH stubs ─────────────────────
+# (RRF + QMD parse + parallel fan-out are all exercised by this e2e test —
+# separate unit tests would just be importlib-fragile duplication.)
+
+@pytest.fixture
+def dual_stub_kb(tmp_path):
+    """Install stubs for BOTH `learnings` and `qmd` + seed docs for both.
+
+    learnings stub returns lrn-graph-X (distinct from lrn-qmd-X in QMD).
+    This lets us verify fusion: the output should contain IDs from BOTH.
+    """
+    home = tmp_path / "home"
+    (home / ".learnings" / "cli").mkdir(parents=True)
+    (home / ".learnings" / "nano_graphrag_cache").mkdir(parents=True)
+    docs_root = home / ".learnings" / "documents"
+    (docs_root / "learnings").mkdir(parents=True)
+
+    # Seed docs on disk so QMD stub can point at real files for parsing.
+    for lid in ["lrn-qmd-x", "lrn-qmd-y"]:
+        (docs_root / "learnings" / f"{lid}.md").write_text(
+            f"---\nid: {lid}\ntitle: {lid}\nconfidence: HIGH\n"
+            f"tags: [sandbox]\n---\n\n**How to apply:** qmd hit\n"
+        )
+
+    # learnings stub — emits envelope JSON with 2 distinct chunks.
+    graph_chunks = []
+    for lid in ["lrn-graph-a", "lrn-graph-b"]:
+        graph_chunks.append(
+            f"---\nid: {lid}\ntitle: {lid}\nconfidence: HIGH\n"
+            f"tags: [sandbox]\n---\n\n**How to apply:** graph hit\n"
+        )
+    graph_context = "\n--New Chunk--\n".join(graph_chunks)
+    graph_envelope = json.dumps({"context": graph_context})
+
+    learnings_stub = home / ".learnings" / "cli" / "learnings"
+    learnings_stub.write_text(
+        f"#!/usr/bin/env bash\ncat <<'EOF'\n{graph_envelope}\nEOF\n"
+    )
+    learnings_stub.chmod(0o755)
+
+    # qmd stub — emits text output with paths pointing at our seeded docs.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "uv").symlink_to(UV)
+    qmd_stub = bin_dir / "qmd"
+    qmd_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "cat <<'EOF'\n"
+        "qmd://learnings/learnings/lrn-qmd-x.md:1 #aaa\n"
+        "Title: lrn-qmd-x\n\n"
+        "qmd://learnings/learnings/lrn-qmd-y.md:1 #bbb\n"
+        "Title: lrn-qmd-y\n"
+        "EOF\n"
+    )
+    qmd_stub.chmod(0o755)
+
+    yield {
+        "home": home,
+        "bin": bin_dir,
+        "reflect_state": tmp_path / "reflect_state",
+    }
+
+
+def test_fusion_includes_both_backends(dual_stub_kb):
+    """With both backends stubbed, fused output must contain IDs from EACH."""
+    env = os.environ.copy()
+    env["HOME"] = str(dual_stub_kb["home"])
+    env["REFLECT_STATE_DIR"] = str(dual_stub_kb["reflect_state"])
+    # Prepend stub bin so our qmd stub wins lookup; keep system PATH so uv
+    # can still find bash/coreutils when running the stubs.
+    env["PATH"] = f"{dual_stub_kb['bin']}:{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [UV, "run", "--quiet", str(RECALL), "sandbox",
+         "--limit", "10", "--format", "markdown", "--no-cache"],
+        capture_output=True, text=True, timeout=60, env=env,
+    )
+    assert result.returncode == 0, f"recall failed: {result.stderr}"
+    # Must see at least one ID from each backend → fusion is happening
+    assert "lrn-graph-" in result.stdout, (
+        f"graph backend results missing — recall isn't calling learnings CLI.\n"
+        f"stdout: {result.stdout}"
+    )
+    assert "lrn-qmd-" in result.stdout, (
+        f"qmd backend results missing — fusion isn't happening.\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+# ─── Layer 6: REAL CLI smoke tests (skipped if KB absent) ──────────────
+
+def _real_learnings_available() -> bool:
+    return (Path.home() / ".learnings" / "cli" / "learnings").exists()
+
+
+def _real_qmd_available() -> bool:
+    return shutil.which("qmd") is not None
+
+
+@pytest.mark.skipif(not _real_learnings_available(),
+                    reason="no real ~/.learnings KB on this host")
+def test_real_learnings_cli_returns_results():
+    """Smoke test: the real learnings CLI actually returns something for a
+    generic query. Catches if the local KB is empty or broken."""
+    result = subprocess.run(
+        [str(Path.home() / ".learnings" / "cli" / "learnings"),
+         "search", "the", "--mode", "naive", "--format", "json", "--limit", "3"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"learnings CLI failed: {result.stderr[:500]}"
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), f"expected envelope dict, got {type(payload)}"
+    context = payload.get("context", "")
+    assert context, "empty context — either KB is empty or CLI is broken"
+
+
+@pytest.mark.skipif(not _real_qmd_available(),
+                    reason="qmd CLI not installed on this host")
+def test_real_qmd_cli_returns_results():
+    """Smoke test: the real qmd CLI actually returns something for a
+    generic keyword against the learnings collection."""
+    result = subprocess.run(
+        ["qmd", "search", "the", "-c", "learnings", "--limit", "3"],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, f"qmd failed: {result.stderr[:500]}"
+    # QMD search emits qmd:// path lines for hits, or "No results found." for empty
+    assert "qmd://learnings/" in result.stdout or "No results" in result.stdout, (
+        f"unexpected qmd output: {result.stdout[:500]}"
+    )
 
 
 if __name__ == "__main__":

--- a/toolkit/packages/skills/brainstorm/SKILL.md
+++ b/toolkit/packages/skills/brainstorm/SKILL.md
@@ -8,6 +8,28 @@ Develop a thorough, step-by-step specification for the provided idea: $ARGUMENTS
 
 Follow these steps:
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (MANDATORY)
+
+Before brainstorming, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/brainstorm`**: the topic or problem being brainstormed + any constraint hints from the user (e.g. `"caching strategy mobile offline"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 1. **Ask clarifying questions** one at a time to understand the requirements:
    - What is the core problem this solves?
    - Who are the target users?

--- a/toolkit/packages/skills/critique/SKILL.md
+++ b/toolkit/packages/skills/critique/SKILL.md
@@ -8,6 +8,28 @@ user-invocable: true
 
 Use this command to get a Distinguished Engineer level technical critique of the current approach and implementation.
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (MANDATORY)
+
+Before critiquing, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/critique`**: a short summary of the approach/code being critiqued + relevant domain keywords (e.g. `"event-sourced migration rollback strategy"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 ## Usage
 
 ```

--- a/toolkit/packages/skills/find-missing-tests/SKILL.md
+++ b/toolkit/packages/skills/find-missing-tests/SKILL.md
@@ -8,6 +8,28 @@ Analyze codebase and identify missing test cases, then create GitHub issues for 
 
 Follow these steps:
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (RECOMMENDED)
+
+Before identifying test gaps, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/find-missing-tests`**: target module/package name + `"testing"` (e.g. `"payment webhook handler testing"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 1. **Analyze the codebase**:
    - If $ARGUMENTS specifies files/directories, focus on those areas
    - Otherwise, scan the entire codebase for test coverage gaps

--- a/toolkit/packages/skills/gh-issue/SKILL.md
+++ b/toolkit/packages/skills/gh-issue/SKILL.md
@@ -8,6 +8,28 @@ Analyze and fix the specified GitHub issue: $ARGUMENTS
 
 Follow these steps:
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (RECOMMENDED)
+
+Before fixing the issue, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/gh-issue`**: issue title + top labels + repo name (e.g. `"flaky signup test frontend auth"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 1. **Get issue details**:
    - Use `gh issue view $ARGUMENTS` to get the complete issue information
    - If $ARGUMENTS is not provided, list issues with `gh issue list` and ask which to work on

--- a/toolkit/packages/skills/implement/SKILL.md
+++ b/toolkit/packages/skills/implement/SKILL.md
@@ -8,6 +8,28 @@ user-invocable: true
 
 You are tasked with implementing an approved technical plan from `plans/`. These plans contain phases with specific changes and success criteria.
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (RECOMMENDED)
+
+Before implementing, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/implement`**: the plan's current phase name + touched module names (e.g. `"auth middleware session token storage"`). Skip if the calling /plan already ran recall and surfaced findings..
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 ## Getting Started
 
 When given a plan path:

--- a/toolkit/packages/skills/plan-gh/SKILL.md
+++ b/toolkit/packages/skills/plan-gh/SKILL.md
@@ -8,6 +8,28 @@ Create a detailed development plan and corresponding GitHub issues for the proje
 
 Follow these steps:
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (MANDATORY)
+
+Before generating issues, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/plan-gh`**: task scope + `"github issue"` + repo/project name (e.g. `"dashboard rewrite github issue frontend"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 1. **Read the specification**:
    - Look for the spec file specified in $ARGUMENTS
    - If no file specified, look for `spec.md` or ask for the specification file path

--- a/toolkit/packages/skills/plan-tdd/SKILL.md
+++ b/toolkit/packages/skills/plan-tdd/SKILL.md
@@ -8,6 +8,28 @@ Create a test-driven development plan for the project: $ARGUMENTS
 
 Follow these steps:
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (MANDATORY)
+
+Before writing the TDD plan, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/plan-tdd`**: task description + `"testing strategy"` + target module name (e.g. `"payment webhook testing strategy"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 1. **Read the specification**:
    - Look for the spec file specified in $ARGUMENTS
    - If no file specified, look for `spec.md` or ask for the specification file path

--- a/toolkit/packages/skills/plan/SKILL.md
+++ b/toolkit/packages/skills/plan/SKILL.md
@@ -8,6 +8,28 @@ user-invocable: true
 
 You are tasked with creating detailed implementation plans through an interactive, iterative process. You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (MANDATORY)
+
+Before planning, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/plan`**: concatenate the user's task description + any file paths + domain keywords (e.g. `"user auth OAuth migration"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 ## Initial Response
 
 When this command is invoked:

--- a/toolkit/packages/skills/research/SKILL.md
+++ b/toolkit/packages/skills/research/SKILL.md
@@ -11,6 +11,28 @@ user-invocable: true
 
 You are tasked with conducting comprehensive research across multiple sources - codebase, web, and documentation - by spawning parallel sub-agents and synthesizing their findings.
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (MANDATORY)
+
+Before researching, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/research`**: the research topic verbatim + domain keywords (e.g. `"redis connection pooling node"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 ## Initial Setup
 
 When this command is invoked, respond with:

--- a/toolkit/packages/skills/validate/SKILL.md
+++ b/toolkit/packages/skills/validate/SKILL.md
@@ -8,6 +8,28 @@ user-invocable: true
 
 You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.
 
+<!-- recall:begin -->
+
+## Step 0: Prior-art check (RECOMMENDED)
+
+Before validating, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+
+```bash
+uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
+  "<QUERY>" \
+  --limit 5 --format markdown
+```
+
+**Query construction for `/validate`**: the feature/change being validated + relevant verification keywords (e.g. `"OAuth callback validation edge cases"`).
+
+**What to do with results:**
+
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
+- If nothing relevant returns — proceed silently, no need to mention the check.
+- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+
+<!-- recall:end -->
+
 ## Initial Setup
 
 When invoked:


### PR DESCRIPTION
## Summary

Closes phases **1 and 2** of #40 (retrieval gap). The reflect KB has been capture-only — this PR wires it back into sessions.

- **Phase 1** — new `/reflect:recall` sub-skill. Hybrid vector+graph query against the 178-doc global learnings KB, reranked by confidence × recency × tag overlap. Per-query cache, append-only log for future feedback loop.
- **Phase 2** — SessionStart hook. Builds a query from project name + branch + recent commits, injects top-3 relevant learnings into the first turn's context. Zero user action required once wired into `settings.json`.

Plugin bumped `3.0.0 → 3.1.0`.

## Decisions

Each autonomous decision (D1–D11) made while building this is captured in `.claude/session/DECISIONS-retrieval-2026-04-23.md`. Review and override any you disagree with — behavior is easy to tune (result cap, confidence threshold, query construction).

## Wiring it in

Copy the SessionStart block from `toolkit/packages/plugins/reflect/hooks/settings-snippet.json` into `~/.claude/settings.json`. After that, every new session starts with prior learnings already in context.

## Test plan

- [x] Existing reflect sim test suite: 13/13 passing
- [x] recall.py smoke-tested against live KB (178 docs)
- [x] SessionStart hook tested end-to-end from this repo's cwd — returns 3 relevant learnings in ~1500 chars
- [x] Graceful degradation verified: missing KB / missing CLI / subprocess failure → empty `additionalContext`, exit 0
- [ ] Verify auto-inject in a fresh Claude Code session after merge + settings wire-in

## Follow-ups (remain on #40)

- Phase 3 — recall integration in `/research`, `/plan`, `/critique`, `/commit`, `/implement`
- Phase 4 — PostToolUse passive error-match suggestions
- Phase 5 — temporal filters + commit linkage (`fixes lrn-xxx`) + stale detection
- Phase 6 — helpfulness feedback loop (infra already logging to `recall_log.jsonl`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid recall: fetch, fuse, rerank and format prior learnings; SessionStart injection via a new hook and non-blocking recall behavior.

* **Documentation**
  * Many skills updated with mandatory/recommended prior‑art recall steps and guidance treating recall failures as “no prior art found.” Skill docs include query construction and invocation examples.

* **Tests**
  * Integration tests and an injection utility added to validate recall preambles and dual-backend fusion.

* **Chores**
  * Bootstrap now deploys a local learnings CLI template; CLI sync warnings added; QMD sync attempted when available.

* **Version**
  * Plugin bumped to 3.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->