### PR TITLE
feat(ainb-tui): add Skills browser screen

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -232,6 +232,7 @@ pub enum AppEvent {
     GoToConfig,                  // Navigate to config view
     GoToSessionList,             // Navigate to session list view
     GoToStats,                   // Navigate to stats view
+    GoToSkills,                  // Navigate to skills view
     GoToRecovery,                // Navigate to session recovery view
     // AINB 2.0: Agent selection events
     AgentSelectionBack,          // Return to home screen (Esc)
@@ -341,6 +342,23 @@ pub enum AppEvent {
     UsageToTop,                  // Jump to top (g)
     UsageToBottom,               // Jump to bottom (G)
     UsageRefresh,                // Reload data (r)
+    // Skills browser events
+    SkillsBack,                  // Return to home screen (Esc)
+    SkillsNextProvider,          // Next provider (Right arrow)
+    SkillsPrevProvider,          // Previous provider (Left arrow)
+    SkillsNextTab,               // Next sub-tab (Tab)
+    SkillsPrevTab,               // Previous sub-tab (Shift+Tab)
+    SkillsScrollUp,              // Move selection up (k/Up)
+    SkillsScrollDown,            // Move selection down (j/Down)
+    SkillsPageUp,                // Page up
+    SkillsPageDown,              // Page down
+    SkillsToTop,                 // Jump to top (g)
+    SkillsToBottom,              // Jump to bottom (G)
+    SkillsRefresh,               // Reload data (r)
+    SkillsSearchStart,           // Enter search mode (/)
+    SkillsSearchChar(char),      // Append char to search query
+    SkillsSearchBackspace,       // Remove last char from search query
+    SkillsSearchClose,           // Exit search mode (Esc)
     // Session recovery events
     SessionRecoveryBack,         // Return to home screen (Esc)
     SessionRecoveryNext,         // Navigate to next session (Down/j)
@@ -584,6 +602,12 @@ impl EventHandler {
         if state.current_view == View::Analytics {
             tracing::debug!("In usage analytics view, handling usage keys");
             return Self::handle_usage_keys(key_event, state);
+        }
+
+        // Handle skills browser view
+        if state.current_view == View::Skills {
+            tracing::debug!("In skills view, handling skills keys");
+            return Self::handle_skills_keys(key_event, state);
         }
 
         // Handle session recovery view
@@ -1534,6 +1558,39 @@ impl EventHandler {
         }
     }
 
+    // Skills browser key handling
+    fn handle_skills_keys(key_event: KeyEvent, state: &AppState) -> Option<AppEvent> {
+        tracing::debug!("Skills key handler: {:?}", key_event.code);
+
+        // Search mode eats most keys: typing feeds the query, Esc exits.
+        if state.skills_state.search_active {
+            return match key_event.code {
+                KeyCode::Esc => Some(AppEvent::SkillsSearchClose),
+                KeyCode::Enter => Some(AppEvent::SkillsSearchClose),
+                KeyCode::Backspace => Some(AppEvent::SkillsSearchBackspace),
+                KeyCode::Char(c) => Some(AppEvent::SkillsSearchChar(c)),
+                _ => None,
+            };
+        }
+
+        match key_event.code {
+            KeyCode::Esc => Some(AppEvent::SkillsBack),
+            KeyCode::Right | KeyCode::Char('l') => Some(AppEvent::SkillsNextProvider),
+            KeyCode::Left | KeyCode::Char('h') => Some(AppEvent::SkillsPrevProvider),
+            KeyCode::Tab => Some(AppEvent::SkillsNextTab),
+            KeyCode::BackTab => Some(AppEvent::SkillsPrevTab),
+            KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::SkillsScrollUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::SkillsScrollDown),
+            KeyCode::PageUp => Some(AppEvent::SkillsPageUp),
+            KeyCode::PageDown => Some(AppEvent::SkillsPageDown),
+            KeyCode::Char('g') => Some(AppEvent::SkillsToTop),
+            KeyCode::Char('G') => Some(AppEvent::SkillsToBottom),
+            KeyCode::Char('r') => Some(AppEvent::SkillsRefresh),
+            KeyCode::Char('/') => Some(AppEvent::SkillsSearchStart),
+            _ => None,
+        }
+    }
+
     // Changelog viewer key handling
     fn handle_changelog_keys(key_event: KeyEvent, _state: &AppState) -> Option<AppEvent> {
         tracing::debug!("Changelog key handler: {:?}", key_event.code);
@@ -1590,6 +1647,7 @@ impl EventHandler {
             KeyCode::Char('C') => return Some(AppEvent::GoToConfig),
             KeyCode::Char('s') => return Some(AppEvent::GoToSessionList),
             KeyCode::Char('i') => return Some(AppEvent::GoToStats),
+            KeyCode::Char('k') => return Some(AppEvent::GoToSkills),
             KeyCode::Char('R') => return Some(AppEvent::GoToRecovery),
             KeyCode::Char('v') => return Some(AppEvent::ShowChangelog),
             KeyCode::Char('?') => return Some(AppEvent::ToggleHelp),
@@ -2809,6 +2867,11 @@ impl EventHandler {
                         state.current_view = View::Analytics;
                         state.start_background_usage_load(false);
                     }
+                    SidebarItem::Skills => {
+                        tracing::info!("Navigating to Skills from sidebar");
+                        state.current_view = View::Skills;
+                        state.start_background_skills_load(false);
+                    }
                     SidebarItem::Changelog => {
                         state.current_view = View::Changelog;
                     }
@@ -3010,6 +3073,11 @@ impl EventHandler {
                 tracing::info!("Navigating to Usage Analytics");
                 state.current_view = View::Analytics;
                 state.start_background_usage_load(false);
+            }
+            AppEvent::GoToSkills => {
+                tracing::info!("Navigating to Skills");
+                state.current_view = View::Skills;
+                state.start_background_skills_load(false);
             }
             AppEvent::GoToRecovery => {
                 tracing::info!("Navigating to Session Recovery");
@@ -3678,6 +3746,75 @@ impl EventHandler {
                     "Refresh already in progress"
                 };
                 state.add_success_notification(msg.to_string());
+            }
+            // Skills browser events
+            AppEvent::SkillsBack => {
+                tracing::debug!("Skills back");
+                state.current_view = View::HomeScreen;
+            }
+            AppEvent::SkillsNextProvider => {
+                state.skills_state.next_provider();
+                if state.skills_state.provider.has_data() {
+                    state.start_background_skills_load(false);
+                }
+            }
+            AppEvent::SkillsPrevProvider => {
+                state.skills_state.prev_provider();
+                if state.skills_state.provider.has_data() {
+                    state.start_background_skills_load(false);
+                }
+            }
+            AppEvent::SkillsNextTab => {
+                state.skills_state.next_tab();
+            }
+            AppEvent::SkillsPrevTab => {
+                state.skills_state.prev_tab();
+            }
+            AppEvent::SkillsScrollUp => {
+                state.skills_state.scroll_up();
+            }
+            AppEvent::SkillsScrollDown => {
+                let max = state.skills_state.row_count();
+                state.skills_state.scroll_down(max);
+            }
+            AppEvent::SkillsPageUp => {
+                state.skills_state.page_up(20);
+            }
+            AppEvent::SkillsPageDown => {
+                let max = state.skills_state.row_count();
+                state.skills_state.page_down(max, 20);
+            }
+            AppEvent::SkillsToTop => {
+                state.skills_state.scroll_to_top();
+            }
+            AppEvent::SkillsToBottom => {
+                let max = state.skills_state.row_count();
+                state.skills_state.scroll_to_bottom(max);
+            }
+            AppEvent::SkillsRefresh => {
+                tracing::info!("Refreshing skills data");
+                let msg = if state.start_background_skills_load(true) {
+                    "Refreshing skills data…"
+                } else {
+                    "Refresh already in progress"
+                };
+                state.add_success_notification(msg.to_string());
+            }
+            AppEvent::SkillsSearchStart => {
+                state.skills_state.search_active = true;
+                state.skills_state.search_query.clear();
+                state.skills_state.scroll_offset = 0;
+                state.skills_state.selected_index = 0;
+            }
+            AppEvent::SkillsSearchChar(c) => {
+                state.skills_state.search_push(c);
+            }
+            AppEvent::SkillsSearchBackspace => {
+                state.skills_state.search_pop();
+            }
+            AppEvent::SkillsSearchClose => {
+                state.skills_state.search_active = false;
+                // Query is preserved so the filter stays applied after exit.
             }
             // Session recovery events
             AppEvent::SessionRecoveryBack => {

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -3803,14 +3803,17 @@ impl EventHandler {
             AppEvent::SkillsSearchStart => {
                 state.skills_state.search_active = true;
                 state.skills_state.search_query.clear();
-                state.skills_state.scroll_offset = 0;
                 state.skills_state.selected_index = 0;
             }
             AppEvent::SkillsSearchChar(c) => {
                 state.skills_state.search_push(c);
+                let max = state.skills_state.row_count();
+                state.skills_state.clamp_selection(max);
             }
             AppEvent::SkillsSearchBackspace => {
                 state.skills_state.search_pop();
+                let max = state.skills_state.row_count();
+                state.skills_state.clamp_selection(max);
             }
             AppEvent::SkillsSearchClose => {
                 state.skills_state.search_active = false;

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3337,6 +3337,12 @@ impl AppState {
                 Err(mpsc::error::TryRecvError::Disconnected) => {
                     self.skills_state.loading = false;
                     self.skills_load_receiver = None;
+                    warn!(
+                        "Skills parse task dropped its sender without delivering data"
+                    );
+                    self.add_warning_notification(
+                        "Failed to parse skills; keeping cached data".to_string(),
+                    );
                     true
                 }
             }

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -416,6 +416,7 @@ pub enum View {
     SetupMenu,        // Setup menu with factory reset option
     Changelog,        // Version history viewer
     SessionRecovery,  // Recover orphaned agent sessions after crash/shutdown
+    Skills,           // Per-agent skills + agents browser
 }
 
 #[derive(Debug, Clone)]
@@ -1925,6 +1926,12 @@ pub struct AppState {
     /// Present only while a parse is in flight; `tick()` drains it.
     pub usage_load_receiver: Option<mpsc::UnboundedReceiver<crate::models::UsageData>>,
 
+    // Skills browser state
+    pub skills_state: crate::components::skills::SkillsViewState,
+    /// Channel receiver for background skills+agents scan.
+    /// Present only while a scan is in flight; `tick()` drains it.
+    pub skills_load_receiver: Option<mpsc::UnboundedReceiver<crate::models::SkillsData>>,
+
     // Periodic session snapshot tracking
     pub last_snapshot_time: Option<Instant>,
 
@@ -2468,6 +2475,10 @@ impl Default for AppState {
             // Usage analytics state
             usage_state: crate::components::usage::UsageViewState::default(),
             usage_load_receiver: None,
+
+            // Skills browser state
+            skills_state: crate::components::skills::SkillsViewState::default(),
+            skills_load_receiver: None,
 
             // Periodic session snapshot tracking
             last_snapshot_time: None,
@@ -3276,6 +3287,56 @@ impl AppState {
                 Err(mpsc::error::TryRecvError::Disconnected) => {
                     self.usage_state.loading = false;
                     self.usage_load_receiver = None;
+                    true
+                }
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Kick off a background scan of ~/.claude/skills and ~/.claude/agents.
+    /// Skipped if already in-flight, or data is cached and `force` is false.
+    /// Returns true if a new scan was spawned, false if coalesced.
+    /// Mirrors `start_background_usage_load` so Skills screen navigation
+    /// never blocks the event thread.
+    pub fn start_background_skills_load(&mut self, force: bool) -> bool {
+        if self.skills_load_receiver.is_some() {
+            return false;
+        }
+        if !force && self.skills_state.data.is_some() {
+            return false;
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.skills_load_receiver = Some(rx);
+        self.skills_state.loading = true;
+        tokio::spawn(async move {
+            match tokio::task::spawn_blocking(crate::models::skills::parse_skills).await {
+                Ok(data) => {
+                    let _ = tx.send(data);
+                }
+                Err(e) => {
+                    warn!("Skills parse task failed: {}", e);
+                }
+            }
+        });
+        true
+    }
+
+    /// Poll the background scan. Returns true if data was applied this tick.
+    pub fn check_skills_load_complete(&mut self) -> bool {
+        if let Some(ref mut receiver) = self.skills_load_receiver {
+            match receiver.try_recv() {
+                Ok(data) => {
+                    self.skills_state.data = Some(data);
+                    self.skills_state.loading = false;
+                    self.skills_load_receiver = None;
+                    true
+                }
+                Err(mpsc::error::TryRecvError::Empty) => false,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    self.skills_state.loading = false;
+                    self.skills_load_receiver = None;
                     true
                 }
             }
@@ -8773,6 +8834,11 @@ impl App {
 
         // Check for completed background usage-data parsing
         if self.state.check_usage_load_complete() {
+            self.state.ui_needs_refresh = true;
+        }
+
+        // Check for completed background skills scan
+        if self.state.check_skills_load_complete() {
             self.state.ui_needs_refresh = true;
         }
 

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -202,6 +202,17 @@ impl LayoutComponent {
             return;
         }
 
+        // Skills browser view (full screen)
+        if state.current_view == View::Skills {
+            tracing::debug!("Rendering Skills view");
+            crate::components::skills::render(frame, frame.size(), &state.skills_state);
+            if state.help_visible {
+                tracing::debug!("Rendering help overlay on Skills");
+                self.help.render(frame, frame.size());
+            }
+            return;
+        }
+
         // Session recovery view (full screen)
         if state.current_view == View::SessionRecovery {
             tracing::debug!("Rendering SessionRecovery view");

--- a/ainb-tui/src/components/mod.rs
+++ b/ainb-tui/src/components/mod.rs
@@ -31,6 +31,7 @@ pub mod session_list;
 pub mod session_recovery;
 pub mod setup_menu;
 pub mod sidebar;
+pub mod skills;
 pub mod tmux_preview;
 pub mod usage;
 pub mod welcome_panel;

--- a/ainb-tui/src/components/sidebar.rs
+++ b/ainb-tui/src/components/sidebar.rs
@@ -34,6 +34,7 @@ pub enum SidebarItem {
     Recovery,  // Recover orphaned sessions
     Logs,      // Log history viewer
     Stats,     // Analytics & usage
+    Skills,    // Browse per-agent skills
     Changelog, // Version history
     Setup,     // Setup wizard & factory reset
     Help,      // Docs & guides
@@ -50,6 +51,7 @@ impl SidebarItem {
             Self::Recovery => "🔄",
             Self::Logs => "📋",
             Self::Stats => "📊",
+            Self::Skills => "🧠",
             Self::Changelog => "📝",
             Self::Setup => "🛠️",
             Self::Help => "❓",
@@ -66,6 +68,7 @@ impl SidebarItem {
             Self::Recovery => "Recovery",
             Self::Logs => "Logs",
             Self::Stats => "Stats",
+            Self::Skills => "Skills",
             Self::Changelog => "Changelog",
             Self::Setup => "Setup",
             Self::Help => "Help",
@@ -82,6 +85,7 @@ impl SidebarItem {
             Self::Recovery => "Resume Orphaned",
             Self::Logs => "View Log History",
             Self::Stats => "Usage & Analytics",
+            Self::Skills => "Per-Agent Skills",
             Self::Changelog => "Version History",
             Self::Setup => "Setup & Reset",
             Self::Help => "Docs & Guides",
@@ -98,6 +102,7 @@ impl SidebarItem {
             Self::Recovery => "R",
             Self::Logs => "l",
             Self::Stats => "i",
+            Self::Skills => "k",
             Self::Changelog => "v",
             Self::Setup => "S",
             Self::Help => "?",
@@ -114,6 +119,7 @@ impl SidebarItem {
             Self::Recovery,
             Self::Logs,
             Self::Stats,
+            Self::Skills,
             Self::Changelog,
             Self::Setup,
             Self::Help,
@@ -205,7 +211,7 @@ impl SidebarComponent {
         frame.render_widget(block, area);
 
         // Layout: title + items + flexible space
-        // Using 2 lines per item to fit 10 items in typical terminal heights
+        // Using 2 lines per item to fit 11 items in typical terminal heights
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -218,6 +224,7 @@ impl SidebarComponent {
                 Constraint::Length(2),  // Recovery
                 Constraint::Length(2),  // Logs
                 Constraint::Length(2),  // Stats
+                Constraint::Length(2),  // Skills
                 Constraint::Length(2),  // Changelog
                 Constraint::Length(2),  // Setup
                 Constraint::Length(2),  // Help
@@ -230,7 +237,7 @@ impl SidebarComponent {
 
         let items = SidebarItem::all();
 
-        // Render all 10 items with premium styling
+        // Render all items with premium styling
         for (idx, item) in items.iter().enumerate() {
             let is_selected = state.selected_index == idx;
             let badge = if *item == SidebarItem::Sessions && state.active_sessions_count > 0 {

--- a/ainb-tui/src/components/sidebar.rs
+++ b/ainb-tui/src/components/sidebar.rs
@@ -210,32 +210,24 @@ impl SidebarComponent {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        // Layout: title + items + flexible space
-        // Using 2 lines per item to fit 11 items in typical terminal heights
+        // Layout: title + spacer + one row per SidebarItem + flexible space.
+        // Constraints are derived from SidebarItem::all() so adding a new
+        // entry to the enum automatically reserves a layout slot (instead of
+        // silently rendering into a zero-height row).
+        let items = SidebarItem::all();
+        let mut constraints: Vec<Constraint> = Vec::with_capacity(items.len() + 3);
+        constraints.push(Constraint::Length(2)); // Title area
+        constraints.push(Constraint::Length(1)); // Spacer
+        constraints.extend(items.iter().map(|_| Constraint::Length(2)));
+        constraints.push(Constraint::Min(0)); // Flexible space
+
         let layout = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(2),  // Title area
-                Constraint::Length(1),  // Spacer
-                Constraint::Length(2),  // Agents
-                Constraint::Length(2),  // Catalog
-                Constraint::Length(2),  // Config
-                Constraint::Length(2),  // Sessions
-                Constraint::Length(2),  // Recovery
-                Constraint::Length(2),  // Logs
-                Constraint::Length(2),  // Stats
-                Constraint::Length(2),  // Skills
-                Constraint::Length(2),  // Changelog
-                Constraint::Length(2),  // Setup
-                Constraint::Length(2),  // Help
-                Constraint::Min(0),     // Flexible space
-            ])
+            .constraints(constraints)
             .split(inner);
 
         // Render title
         self.render_title(frame, layout[0], state);
-
-        let items = SidebarItem::all();
 
         // Render all items with premium styling
         for (idx, item) in items.iter().enumerate() {

--- a/ainb-tui/src/components/skills.rs
+++ b/ainb-tui/src/components/skills.rs
@@ -199,14 +199,6 @@ impl SkillsViewState {
         self.selected_index = (self.selected_index + page_size).min(max_rows - 1);
     }
 
-    pub fn toggle_search(&mut self) {
-        self.search_active = !self.search_active;
-        if !self.search_active {
-            self.search_query.clear();
-        }
-        self.selected_index = 0;
-    }
-
     pub fn search_push(&mut self, c: char) {
         self.search_query.push(c);
         self.selected_index = 0;
@@ -214,12 +206,6 @@ impl SkillsViewState {
 
     pub fn search_pop(&mut self) {
         self.search_query.pop();
-        self.selected_index = 0;
-    }
-
-    pub fn search_clear(&mut self) {
-        self.search_active = false;
-        self.search_query.clear();
         self.selected_index = 0;
     }
 

--- a/ainb-tui/src/components/skills.rs
+++ b/ainb-tui/src/components/skills.rs
@@ -119,7 +119,6 @@ pub struct SkillsViewState {
     pub active_tab: SkillsTab,
     pub data: Option<SkillsData>,
     pub loading: bool,
-    pub scroll_offset: usize,
     pub selected_index: usize,
     pub search_active: bool,
     pub search_query: String,
@@ -132,7 +131,6 @@ impl Default for SkillsViewState {
             active_tab: SkillsTab::Skills,
             data: None,
             loading: false,
-            scroll_offset: 0,
             selected_index: 0,
             search_active: false,
             search_query: String::new(),
@@ -145,34 +143,27 @@ impl SkillsViewState {
     // mirroring the fix in UsageViewState.
     pub fn next_provider(&mut self) {
         self.provider = self.provider.next();
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn prev_provider(&mut self) {
         self.provider = self.provider.prev();
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn next_tab(&mut self) {
         self.active_tab = self.active_tab.next();
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn prev_tab(&mut self) {
         self.active_tab = self.active_tab.prev();
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn scroll_up(&mut self) {
         if self.selected_index > 0 {
             self.selected_index -= 1;
-        }
-        if self.scroll_offset > self.selected_index {
-            self.scroll_offset = self.selected_index;
         }
     }
 
@@ -186,14 +177,12 @@ impl SkillsViewState {
     }
 
     pub fn scroll_to_top(&mut self) {
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn scroll_to_bottom(&mut self, max_rows: usize) {
         if max_rows == 0 {
             self.selected_index = 0;
-            self.scroll_offset = 0;
             return;
         }
         self.selected_index = max_rows - 1;
@@ -201,7 +190,6 @@ impl SkillsViewState {
 
     pub fn page_up(&mut self, page_size: usize) {
         self.selected_index = self.selected_index.saturating_sub(page_size);
-        self.scroll_offset = self.scroll_offset.saturating_sub(page_size);
     }
 
     pub fn page_down(&mut self, max_rows: usize, page_size: usize) {
@@ -216,27 +204,33 @@ impl SkillsViewState {
         if !self.search_active {
             self.search_query.clear();
         }
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn search_push(&mut self, c: char) {
         self.search_query.push(c);
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn search_pop(&mut self) {
         self.search_query.pop();
-        self.scroll_offset = 0;
         self.selected_index = 0;
     }
 
     pub fn search_clear(&mut self) {
         self.search_active = false;
         self.search_query.clear();
-        self.scroll_offset = 0;
         self.selected_index = 0;
+    }
+
+    /// Clamp `selected_index` to a shrinking row set (e.g. after a filter
+    /// narrows results or the active provider/tab swaps).
+    pub fn clamp_selection(&mut self, row_count: usize) {
+        if row_count == 0 {
+            self.selected_index = 0;
+        } else if self.selected_index >= row_count {
+            self.selected_index = row_count - 1;
+        }
     }
 
     pub fn row_count(&self) -> usize {

--- a/ainb-tui/src/components/skills.rs
+++ b/ainb-tui/src/components/skills.rs
@@ -1,0 +1,1040 @@
+// ABOUTME: Skills browser screen — shows user-level skills, agents, and the
+// associations between them. Mirrors the Usage Analytics layout and async-load
+// pattern so provider switches never block the event thread.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph, Row, Table, Tabs},
+    Frame,
+};
+
+use crate::models::skills::{AgentDef, Skill, SkillsData};
+
+// Color palette from TUI style guide (mirrors usage.rs)
+const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
+const GOLD: Color = Color::Rgb(255, 215, 0);
+const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
+const DARK_BG: Color = Color::Rgb(25, 25, 35);
+const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
+const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+const LIST_HIGHLIGHT_BG: Color = Color::Rgb(40, 40, 60);
+
+/// Which agent provider's skills to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillsProvider {
+    #[default]
+    Claude,
+    Codex,
+    Gemini,
+    Copilot,
+}
+
+impl SkillsProvider {
+    fn all() -> &'static [SkillsProvider] {
+        &[
+            SkillsProvider::Claude,
+            SkillsProvider::Codex,
+            SkillsProvider::Gemini,
+            SkillsProvider::Copilot,
+        ]
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            SkillsProvider::Claude => "✻ Claude Code",
+            SkillsProvider::Codex => "✦ Codex CLI",
+            SkillsProvider::Gemini => "✨ Gemini CLI",
+            SkillsProvider::Copilot => "🐙 Copilot",
+        }
+    }
+
+    pub fn has_data(&self) -> bool {
+        matches!(self, SkillsProvider::Claude)
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            SkillsProvider::Claude => SkillsProvider::Codex,
+            SkillsProvider::Codex => SkillsProvider::Gemini,
+            SkillsProvider::Gemini => SkillsProvider::Copilot,
+            SkillsProvider::Copilot => SkillsProvider::Claude,
+        }
+    }
+
+    fn prev(&self) -> Self {
+        match self {
+            SkillsProvider::Claude => SkillsProvider::Copilot,
+            SkillsProvider::Codex => SkillsProvider::Claude,
+            SkillsProvider::Gemini => SkillsProvider::Codex,
+            SkillsProvider::Copilot => SkillsProvider::Gemini,
+        }
+    }
+}
+
+/// Which sub-tab is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillsTab {
+    #[default]
+    Skills,
+    Agents,
+    Associations,
+}
+
+impl SkillsTab {
+    fn all() -> &'static [SkillsTab] {
+        &[SkillsTab::Skills, SkillsTab::Agents, SkillsTab::Associations]
+    }
+
+    fn title(&self) -> &'static str {
+        match self {
+            SkillsTab::Skills => "Skills",
+            SkillsTab::Agents => "Agents",
+            SkillsTab::Associations => "Associations",
+        }
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            SkillsTab::Skills => SkillsTab::Agents,
+            SkillsTab::Agents => SkillsTab::Associations,
+            SkillsTab::Associations => SkillsTab::Skills,
+        }
+    }
+
+    fn prev(&self) -> Self {
+        match self {
+            SkillsTab::Skills => SkillsTab::Associations,
+            SkillsTab::Agents => SkillsTab::Skills,
+            SkillsTab::Associations => SkillsTab::Agents,
+        }
+    }
+}
+
+/// View state for the Skills screen.
+#[derive(Debug, Clone)]
+pub struct SkillsViewState {
+    pub provider: SkillsProvider,
+    pub active_tab: SkillsTab,
+    pub data: Option<SkillsData>,
+    pub loading: bool,
+    pub scroll_offset: usize,
+    pub selected_index: usize,
+    pub search_active: bool,
+    pub search_query: String,
+}
+
+impl Default for SkillsViewState {
+    fn default() -> Self {
+        Self {
+            provider: SkillsProvider::Claude,
+            active_tab: SkillsTab::Skills,
+            data: None,
+            loading: false,
+            scroll_offset: 0,
+            selected_index: 0,
+            search_active: false,
+            search_query: String::new(),
+        }
+    }
+}
+
+impl SkillsViewState {
+    // IMPORTANT: do NOT null `data` on provider switch — it stays cached,
+    // mirroring the fix in UsageViewState.
+    pub fn next_provider(&mut self) {
+        self.provider = self.provider.next();
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn prev_provider(&mut self) {
+        self.provider = self.provider.prev();
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn next_tab(&mut self) {
+        self.active_tab = self.active_tab.next();
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn prev_tab(&mut self) {
+        self.active_tab = self.active_tab.prev();
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn scroll_up(&mut self) {
+        if self.selected_index > 0 {
+            self.selected_index -= 1;
+        }
+        if self.scroll_offset > self.selected_index {
+            self.scroll_offset = self.selected_index;
+        }
+    }
+
+    pub fn scroll_down(&mut self, max_rows: usize) {
+        if max_rows == 0 {
+            return;
+        }
+        if self.selected_index + 1 < max_rows {
+            self.selected_index += 1;
+        }
+    }
+
+    pub fn scroll_to_top(&mut self) {
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn scroll_to_bottom(&mut self, max_rows: usize) {
+        if max_rows == 0 {
+            self.selected_index = 0;
+            self.scroll_offset = 0;
+            return;
+        }
+        self.selected_index = max_rows - 1;
+    }
+
+    pub fn page_up(&mut self, page_size: usize) {
+        self.selected_index = self.selected_index.saturating_sub(page_size);
+        self.scroll_offset = self.scroll_offset.saturating_sub(page_size);
+    }
+
+    pub fn page_down(&mut self, max_rows: usize, page_size: usize) {
+        if max_rows == 0 {
+            return;
+        }
+        self.selected_index = (self.selected_index + page_size).min(max_rows - 1);
+    }
+
+    pub fn toggle_search(&mut self) {
+        self.search_active = !self.search_active;
+        if !self.search_active {
+            self.search_query.clear();
+        }
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn search_push(&mut self, c: char) {
+        self.search_query.push(c);
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn search_pop(&mut self) {
+        self.search_query.pop();
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn search_clear(&mut self) {
+        self.search_active = false;
+        self.search_query.clear();
+        self.scroll_offset = 0;
+        self.selected_index = 0;
+    }
+
+    pub fn row_count(&self) -> usize {
+        let Some(data) = &self.data else {
+            return 0;
+        };
+        match self.active_tab {
+            SkillsTab::Skills => filtered_skills(data, &self.search_query).len(),
+            SkillsTab::Agents => filtered_agents(data, &self.search_query).len(),
+            SkillsTab::Associations => association_rows(data, &self.search_query).len(),
+        }
+    }
+}
+
+// ------------- filtering helpers -------------
+
+fn matches_query(name: &str, description: &str, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let q = query.to_lowercase();
+    name.to_lowercase().contains(&q) || description.to_lowercase().contains(&q)
+}
+
+fn filtered_skills<'a>(data: &'a SkillsData, query: &str) -> Vec<&'a Skill> {
+    data.skills
+        .iter()
+        .filter(|s| matches_query(&s.name, &s.description, query))
+        .collect()
+}
+
+fn filtered_agents<'a>(data: &'a SkillsData, query: &str) -> Vec<&'a AgentDef> {
+    data.agents
+        .iter()
+        .filter(|a| matches_query(&a.name, &a.description, query))
+        .collect()
+}
+
+/// Returns (skill_name, agent_names) pairs for skills that have at least one
+/// associated agent, filtered by search query.
+fn association_rows<'a>(data: &'a SkillsData, query: &str) -> Vec<(&'a Skill, Vec<&'a str>)> {
+    let mut out: Vec<(&'a Skill, Vec<&'a str>)> = Vec::new();
+    for skill in &data.skills {
+        let agents = match data.associations.get(&skill.name) {
+            Some(v) if !v.is_empty() => v,
+            _ => continue,
+        };
+        let joined = agents.join(" ");
+        if !matches_query(&skill.name, &joined, query) {
+            continue;
+        }
+        let refs: Vec<&str> = agents.iter().map(String::as_str).collect();
+        out.push((skill, refs));
+    }
+    out
+}
+
+// ------------- top-level render -------------
+
+pub fn render(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Summary bar
+            Constraint::Length(3), // Provider selector
+            Constraint::Length(3), // Tab bar
+            Constraint::Min(0),    // Content area
+            Constraint::Length(2), // Help bar
+        ])
+        .split(area);
+
+    render_summary_bar(frame, layout[0], state);
+    render_provider_bar(frame, layout[1], state);
+    render_tab_bar(frame, layout[2], state);
+
+    if !state.provider.has_data() {
+        render_no_data(frame, layout[3], state);
+    } else if state.loading || state.data.is_none() {
+        render_loading(frame, layout[3]);
+    } else {
+        render_content(frame, layout[3], state);
+    }
+
+    render_help_bar(frame, layout[4], state);
+}
+
+fn render_summary_bar(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let mut spans = vec![
+        Span::styled("🧠 ", Style::default().fg(GOLD)),
+        Span::styled(
+            "Skills",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+    ];
+
+    if let Some(data) = &state.data {
+        let linked = data
+            .associations
+            .values()
+            .filter(|v| !v.is_empty())
+            .count();
+        spans.extend_from_slice(&[
+            Span::styled("  │  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{}", data.skills.len()),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" skills  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{}", data.agents.len()),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" agents  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{}", linked),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" associations", Style::default().fg(MUTED_GRAY)),
+        ]);
+    } else if state.provider.has_data() {
+        spans.push(Span::styled(
+            "  │  Loading...",
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+
+    if state.search_active || !state.search_query.is_empty() {
+        spans.extend_from_slice(&[
+            Span::styled("  │  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("/", Style::default().fg(GOLD)),
+            Span::styled(
+                state.search_query.clone(),
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
+            if state.search_active {
+                Span::styled("▏", Style::default().fg(SELECTION_GREEN))
+            } else {
+                Span::raw("")
+            },
+        ]);
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let paragraph = Paragraph::new(Line::from(spans)).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_provider_bar(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let mut spans: Vec<Span> =
+        vec![Span::styled("  Provider: ", Style::default().fg(MUTED_GRAY))];
+
+    for (i, provider) in SkillsProvider::all().iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled("  │  ", Style::default().fg(MUTED_GRAY)));
+        }
+        let is_active = *provider == state.provider;
+        let style = if is_active {
+            Style::default()
+                .fg(GOLD)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else if provider.has_data() {
+            Style::default().fg(SOFT_WHITE)
+        } else {
+            Style::default().fg(MUTED_GRAY)
+        };
+        spans.push(Span::styled(provider.label(), style));
+    }
+
+    spans.push(Span::styled("    ", Style::default()));
+    spans.push(Span::styled(
+        "◀/▶",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(" switch", Style::default().fg(MUTED_GRAY)));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let paragraph = Paragraph::new(Line::from(spans)).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_tab_bar(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let titles: Vec<Line> = SkillsTab::all()
+        .iter()
+        .map(|t| {
+            let style = if *t == state.active_tab {
+                Style::default()
+                    .fg(GOLD)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                Style::default().fg(MUTED_GRAY)
+            };
+            Line::from(Span::styled(t.title(), style))
+        })
+        .collect();
+
+    let idx = SkillsTab::all()
+        .iter()
+        .position(|t| *t == state.active_tab)
+        .unwrap_or(0);
+    let tabs = Tabs::new(titles)
+        .select(idx)
+        .highlight_style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .divider(Span::styled(" │ ", Style::default().fg(MUTED_GRAY)))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(CORNFLOWER_BLUE))
+                .style(Style::default().bg(DARK_BG)),
+        );
+
+    frame.render_widget(tabs, area);
+}
+
+fn render_no_data(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ", Style::default()),
+            Span::styled(
+                state.provider.label(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " skills browsing is not yet available.",
+                Style::default().fg(MUTED_GRAY),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Skills parsing is currently supported for Claude Code only.",
+            Style::default()
+                .fg(MUTED_GRAY)
+                .add_modifier(Modifier::ITALIC),
+        )),
+        Line::from(Span::styled(
+            "  Other providers will be added as they expose a skills surface.",
+            Style::default()
+                .fg(MUTED_GRAY)
+                .add_modifier(Modifier::ITALIC),
+        )),
+    ];
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+fn render_loading(frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+    let paragraph = Paragraph::new(Line::from(vec![Span::styled(
+        "  ⏳ Scanning ~/.claude/skills and ~/.claude/agents...",
+        Style::default().fg(MUTED_GRAY),
+    )]))
+    .block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_content(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(area);
+
+    match state.active_tab {
+        SkillsTab::Skills => render_skills_tab(frame, chunks[0], chunks[1], state),
+        SkillsTab::Agents => render_agents_tab(frame, chunks[0], chunks[1], state),
+        SkillsTab::Associations => render_associations_tab(frame, chunks[0], chunks[1], state),
+    }
+}
+
+fn list_block() -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG))
+}
+
+fn detail_block(title: &str) -> Block<'_> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG))
+        .title(Span::styled(
+            format!(" {} ", title),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+}
+
+fn render_skills_tab(
+    frame: &mut Frame,
+    list_area: Rect,
+    detail_area: Rect,
+    state: &SkillsViewState,
+) {
+    let data = state.data.as_ref().unwrap();
+    let skills = filtered_skills(data, &state.search_query);
+
+    let list_inner_block = list_block();
+    let list_inner = list_inner_block.inner(list_area);
+    frame.render_widget(list_inner_block, list_area);
+
+    if skills.is_empty() {
+        let p = Paragraph::new("  No skills match.").style(Style::default().fg(MUTED_GRAY));
+        frame.render_widget(p, list_inner);
+        render_empty_detail(frame, detail_area, "Skill");
+        return;
+    }
+
+    let visible_rows = list_inner.height.saturating_sub(2) as usize;
+    let sel = state.selected_index.min(skills.len().saturating_sub(1));
+    let offset = compute_offset(sel, visible_rows, skills.len());
+
+    let header = Row::new(vec!["", "Name", "Description"])
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
+
+    let rows: Vec<Row> = skills
+        .iter()
+        .enumerate()
+        .skip(offset)
+        .take(visible_rows)
+        .map(|(i, s)| {
+            let indicator = if i == sel { "▶" } else { " " };
+            let style = if i == sel {
+                Style::default()
+                    .fg(SOFT_WHITE)
+                    .bg(LIST_HIGHLIGHT_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(SOFT_WHITE)
+            };
+            Row::new(vec![
+                Span::styled(indicator, Style::default().fg(SELECTION_GREEN)).to_string(),
+                truncate_string(&s.name, 24),
+                truncate_string(&one_line(&s.description), 80),
+            ])
+            .style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(1),
+        Constraint::Length(24),
+        Constraint::Min(20),
+    ];
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, list_inner);
+
+    // Detail pane
+    let current = skills.get(sel).copied();
+    render_skill_detail(frame, detail_area, current, data);
+}
+
+fn render_skill_detail(
+    frame: &mut Frame,
+    area: Rect,
+    skill: Option<&Skill>,
+    data: &SkillsData,
+) {
+    let block = detail_block("Skill");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let Some(skill) = skill else {
+        render_empty_detail_inner(frame, inner);
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Name: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            skill.name.clone(),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    if let Some(inv) = skill.user_invocable {
+        lines.push(Line::from(vec![
+            Span::styled("User-invocable: ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                if inv { "yes" } else { "no" },
+                Style::default().fg(SOFT_WHITE),
+            ),
+        ]));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("Source: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            display_path(&skill.source_path.display().to_string()),
+            Style::default().fg(SOFT_WHITE),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Description",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    )));
+    for l in wrap_text(&skill.description, inner.width.saturating_sub(2) as usize) {
+        lines.push(Line::from(Span::styled(l, Style::default().fg(SOFT_WHITE))));
+    }
+    lines.push(Line::from(""));
+
+    let agents_for_skill: &[String] = data
+        .associations
+        .get(&skill.name)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    lines.push(Line::from(Span::styled(
+        format!("Used by {} agent(s)", agents_for_skill.len()),
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    )));
+    if agents_for_skill.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no references found)",
+            Style::default()
+                .fg(MUTED_GRAY)
+                .add_modifier(Modifier::ITALIC),
+        )));
+    } else {
+        for name in agents_for_skill {
+            lines.push(Line::from(vec![
+                Span::styled("  • ", Style::default().fg(SELECTION_GREEN)),
+                Span::styled(name.clone(), Style::default().fg(SOFT_WHITE)),
+            ]));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+fn render_agents_tab(
+    frame: &mut Frame,
+    list_area: Rect,
+    detail_area: Rect,
+    state: &SkillsViewState,
+) {
+    let data = state.data.as_ref().unwrap();
+    let agents = filtered_agents(data, &state.search_query);
+
+    let list_inner_block = list_block();
+    let list_inner = list_inner_block.inner(list_area);
+    frame.render_widget(list_inner_block, list_area);
+
+    if agents.is_empty() {
+        let p = Paragraph::new("  No agents match.").style(Style::default().fg(MUTED_GRAY));
+        frame.render_widget(p, list_inner);
+        render_empty_detail(frame, detail_area, "Agent");
+        return;
+    }
+
+    let visible_rows = list_inner.height.saturating_sub(2) as usize;
+    let sel = state.selected_index.min(agents.len().saturating_sub(1));
+    let offset = compute_offset(sel, visible_rows, agents.len());
+
+    let header = Row::new(vec!["", "Name", "Description"])
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
+
+    let rows: Vec<Row> = agents
+        .iter()
+        .enumerate()
+        .skip(offset)
+        .take(visible_rows)
+        .map(|(i, a)| {
+            let indicator = if i == sel { "▶" } else { " " };
+            let style = if i == sel {
+                Style::default()
+                    .fg(SOFT_WHITE)
+                    .bg(LIST_HIGHLIGHT_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(SOFT_WHITE)
+            };
+            Row::new(vec![
+                Span::styled(indicator, Style::default().fg(SELECTION_GREEN)).to_string(),
+                truncate_string(&a.name, 26),
+                truncate_string(&one_line(&a.description), 80),
+            ])
+            .style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(1),
+        Constraint::Length(26),
+        Constraint::Min(20),
+    ];
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, list_inner);
+
+    let current = agents.get(sel).copied();
+    render_agent_detail(frame, detail_area, current);
+}
+
+fn render_agent_detail(frame: &mut Frame, area: Rect, agent: Option<&AgentDef>) {
+    let block = detail_block("Agent");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let Some(agent) = agent else {
+        render_empty_detail_inner(frame, inner);
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Name: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            agent.name.clone(),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Source: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            display_path(&agent.source_path.display().to_string()),
+            Style::default().fg(SOFT_WHITE),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Description",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    )));
+    for l in wrap_text(&agent.description, inner.width.saturating_sub(2) as usize) {
+        lines.push(Line::from(Span::styled(l, Style::default().fg(SOFT_WHITE))));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        format!("Tools ({})", agent.tools.len()),
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    )));
+    if agent.tools.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (none listed)",
+            Style::default()
+                .fg(MUTED_GRAY)
+                .add_modifier(Modifier::ITALIC),
+        )));
+    } else {
+        for t in &agent.tools {
+            lines.push(Line::from(vec![
+                Span::styled("  • ", Style::default().fg(SELECTION_GREEN)),
+                Span::styled(t.clone(), Style::default().fg(SOFT_WHITE)),
+            ]));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+fn render_associations_tab(
+    frame: &mut Frame,
+    list_area: Rect,
+    detail_area: Rect,
+    state: &SkillsViewState,
+) {
+    let data = state.data.as_ref().unwrap();
+    let rows = association_rows(data, &state.search_query);
+
+    let list_inner_block = list_block();
+    let list_inner = list_inner_block.inner(list_area);
+    frame.render_widget(list_inner_block, list_area);
+
+    if rows.is_empty() {
+        let p = Paragraph::new("  No associations found.")
+            .style(Style::default().fg(MUTED_GRAY));
+        frame.render_widget(p, list_inner);
+        render_empty_detail(frame, detail_area, "Association");
+        return;
+    }
+
+    let visible_rows = list_inner.height.saturating_sub(2) as usize;
+    let sel = state.selected_index.min(rows.len().saturating_sub(1));
+    let offset = compute_offset(sel, visible_rows, rows.len());
+
+    let header = Row::new(vec!["", "Skill", "Agents"])
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
+
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .enumerate()
+        .skip(offset)
+        .take(visible_rows)
+        .map(|(i, (skill, agents))| {
+            let indicator = if i == sel { "▶" } else { " " };
+            let style = if i == sel {
+                Style::default()
+                    .fg(SOFT_WHITE)
+                    .bg(LIST_HIGHLIGHT_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(SOFT_WHITE)
+            };
+            Row::new(vec![
+                Span::styled(indicator, Style::default().fg(SELECTION_GREEN)).to_string(),
+                truncate_string(&skill.name, 24),
+                format!("{} agent(s)", agents.len()),
+            ])
+            .style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(1),
+        Constraint::Length(24),
+        Constraint::Min(10),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, list_inner);
+
+    // Detail pane: skill + the list of agents.
+    let block = detail_block("Association");
+    let inner = block.inner(detail_area);
+    frame.render_widget(block, detail_area);
+
+    let Some((skill, agents)) = rows.get(sel) else {
+        render_empty_detail_inner(frame, inner);
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Skill: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            skill.name.clone(),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Source: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            display_path(&skill.source_path.display().to_string()),
+            Style::default().fg(SOFT_WHITE),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Description",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    )));
+    for l in wrap_text(&skill.description, inner.width.saturating_sub(2) as usize) {
+        lines.push(Line::from(Span::styled(l, Style::default().fg(SOFT_WHITE))));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        format!("Referenced by {} agent(s)", agents.len()),
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    )));
+    for name in agents {
+        lines.push(Line::from(vec![
+            Span::styled("  • ", Style::default().fg(SELECTION_GREEN)),
+            Span::styled((*name).to_string(), Style::default().fg(SOFT_WHITE)),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+fn render_empty_detail(frame: &mut Frame, area: Rect, label: &str) {
+    let block = detail_block(label);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    render_empty_detail_inner(frame, inner);
+}
+
+fn render_empty_detail_inner(frame: &mut Frame, area: Rect) {
+    let p = Paragraph::new(Line::from(Span::styled(
+        "  Nothing selected.",
+        Style::default()
+            .fg(MUTED_GRAY)
+            .add_modifier(Modifier::ITALIC),
+    )));
+    frame.render_widget(p, area);
+}
+
+fn render_help_bar(frame: &mut Frame, area: Rect, state: &SkillsViewState) {
+    let spans = if state.search_active {
+        vec![
+            Span::styled(" /", Style::default().fg(GOLD)),
+            Span::styled(" type to filter  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Enter", Style::default().fg(GOLD)),
+            Span::styled(" apply  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Esc", Style::default().fg(GOLD)),
+            Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
+        ]
+    } else {
+        vec![
+            Span::styled(" ◀/▶", Style::default().fg(GOLD)),
+            Span::styled(" provider  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Tab", Style::default().fg(GOLD)),
+            Span::styled(" view  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("j/k", Style::default().fg(GOLD)),
+            Span::styled(" scroll  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("/", Style::default().fg(GOLD)),
+            Span::styled(" search  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("r", Style::default().fg(GOLD)),
+            Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Esc", Style::default().fg(GOLD)),
+            Span::styled(" back", Style::default().fg(MUTED_GRAY)),
+        ]
+    };
+    let paragraph =
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(DARK_BG));
+    frame.render_widget(paragraph, area);
+}
+
+// ------------- small helpers -------------
+
+fn compute_offset(selected: usize, visible: usize, total: usize) -> usize {
+    if visible == 0 || total == 0 {
+        return 0;
+    }
+    if selected < visible {
+        0
+    } else {
+        let max_offset = total.saturating_sub(visible);
+        (selected + 1).saturating_sub(visible).min(max_offset)
+    }
+}
+
+fn one_line(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_string(s: &str, max_len: usize) -> String {
+    if max_len == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max_len.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+fn display_path(p: &str) -> String {
+    if let Some(home) = dirs::home_dir() {
+        let home_str = home.display().to_string();
+        if let Some(stripped) = p.strip_prefix(&home_str) {
+            return format!("~{}", stripped);
+        }
+    }
+    p.to_string()
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![text.to_string()];
+    }
+    let mut out: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            out.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    if out.is_empty() {
+        out.push(String::new());
+    }
+    out
+}

--- a/ainb-tui/src/models/mod.rs
+++ b/ainb-tui/src/models/mod.rs
@@ -2,10 +2,12 @@
 
 pub mod other_tmux;
 pub mod session;
+pub mod skills;
 pub mod usage;
 pub mod workspace;
 
 pub use other_tmux::OtherTmuxSession;
 pub use session::{ClaudeModel, GitChanges, Session, SessionAgentType, SessionMode, SessionStatus, ShellSession, ShellSessionStatus, SshTarget};
+pub use skills::{AgentDef, Skill, SkillsData};
 pub use usage::{UsageData, format_tokens_short};
 pub use workspace::Workspace;

--- a/ainb-tui/src/models/skills.rs
+++ b/ainb-tui/src/models/skills.rs
@@ -478,7 +478,33 @@ fn parse_tools(s: &str) -> Vec<String> {
     if s.trim().is_empty() {
         return Vec::new();
     }
-    s.split(|c: char| c == ',' || c == '\n')
+    // Quote-aware split: commas and newlines only split entries when we are
+    // NOT inside a single- or double-quoted region. Handles entries like
+    // `"Read,Bash(bd:*)"` where a literal comma lives inside the quotes.
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    for ch in s.chars() {
+        match ch {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                current.push(ch);
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                current.push(ch);
+            }
+            ',' | '\n' if !in_single && !in_double => {
+                parts.push(std::mem::take(&mut current));
+            }
+            _ => current.push(ch),
+        }
+    }
+    parts.push(current);
+
+    parts
+        .into_iter()
         .map(|t| strip_quotes(t.trim().trim_start_matches('-').trim()))
         .filter(|t| !t.is_empty())
         .collect()

--- a/ainb-tui/src/models/skills.rs
+++ b/ainb-tui/src/models/skills.rs
@@ -22,8 +22,16 @@ pub struct AgentDef {
     pub description: String,
     pub tools: Vec<String>,
     pub source_path: PathBuf,
-    /// Body text (post-frontmatter) retained for association scanning.
-    pub body: String,
+}
+
+/// Scanner-internal view of an agent that caches pre-lowercased strings used
+/// during association building. Kept separate from [`AgentDef`] so the public
+/// type stays lean (body text is only needed for matching, never rendered).
+struct ScannedAgent {
+    agent: AgentDef,
+    desc_lower: String,
+    body_lower: String,
+    tools_lower: Vec<String>,
 }
 
 /// Complete parsed skills + agents snapshot.
@@ -47,8 +55,9 @@ pub fn parse_skills() -> SkillsData {
     };
 
     let skills = scan_skills(&home.join(".claude").join("skills"));
-    let agents = scan_agents(&home.join(".claude").join("agents"));
-    let associations = build_associations(&skills, &agents);
+    let scanned = scan_agents(&home.join(".claude").join("agents"));
+    let associations = build_associations(&skills, &scanned);
+    let agents: Vec<AgentDef> = scanned.into_iter().map(|s| s.agent).collect();
 
     debug!(
         "Parsed {} skills, {} agents, {} skill-associations",
@@ -124,8 +133,8 @@ fn scan_skills(root: &Path) -> Vec<Skill> {
     out
 }
 
-fn scan_agents(root: &Path) -> Vec<AgentDef> {
-    let mut out: Vec<AgentDef> = Vec::new();
+fn scan_agents(root: &Path) -> Vec<ScannedAgent> {
+    let mut out: Vec<ScannedAgent> = Vec::new();
     if !root.is_dir() {
         return out;
     }
@@ -155,16 +164,24 @@ fn scan_agents(root: &Path) -> Vec<AgentDef> {
         let description = fm.get("description").cloned().unwrap_or_default();
         let tools = parse_tools(fm.get("tools").map(String::as_str).unwrap_or(""));
 
-        out.push(AgentDef {
-            name,
-            description,
-            tools,
-            source_path: path,
-            body,
+        let desc_lower = description.to_lowercase();
+        let body_lower = body.to_lowercase();
+        let tools_lower = tools.iter().map(|t| t.to_lowercase()).collect();
+
+        out.push(ScannedAgent {
+            agent: AgentDef {
+                name,
+                description,
+                tools,
+                source_path: path,
+            },
+            desc_lower,
+            body_lower,
+            tools_lower,
         });
     }
 
-    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out.sort_by(|a, b| a.agent.name.to_lowercase().cmp(&b.agent.name.to_lowercase()));
     out
 }
 
@@ -201,7 +218,7 @@ fn collect_agent_files(dir: &Path, out: &mut Vec<PathBuf>) {
 
 fn build_associations(
     skills: &[Skill],
-    agents: &[AgentDef],
+    agents: &[ScannedAgent],
 ) -> HashMap<String, Vec<String>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
 
@@ -211,17 +228,14 @@ fn build_associations(
 
         for agent in agents {
             // Tool list match: exact case-insensitive match.
-            let tool_hit = agent
-                .tools
-                .iter()
-                .any(|t| t.to_lowercase() == skill_name_lower);
+            let tool_hit = agent.tools_lower.iter().any(|t| t == &skill_name_lower);
 
             // Text match: whole-word case-insensitive match in description or body.
-            let text_hit = contains_word(&agent.description, &skill_name_lower)
-                || contains_word(&agent.body, &skill_name_lower);
+            let text_hit = contains_word(&agent.desc_lower, &skill_name_lower)
+                || contains_word(&agent.body_lower, &skill_name_lower);
 
             if tool_hit || text_hit {
-                matches.push(agent.name.clone());
+                matches.push(agent.agent.name.clone());
             }
         }
 
@@ -470,13 +484,15 @@ fn parse_tools(s: &str) -> Vec<String> {
         .collect()
 }
 
-fn contains_word(haystack: &str, needle_lower: &str) -> bool {
+/// Whole-word substring match. Caller must pass a pre-lowercased haystack
+/// and pre-lowercased needle; this avoids redundant per-call normalization
+/// when the same haystack is scanned against many needles.
+fn contains_word(haystack_lower: &str, needle_lower: &str) -> bool {
     if needle_lower.is_empty() {
         return false;
     }
-    let hay = haystack.to_lowercase();
     let needle_bytes = needle_lower.as_bytes();
-    let hay_bytes = hay.as_bytes();
+    let hay_bytes = haystack_lower.as_bytes();
     let mut i = 0usize;
     while i + needle_bytes.len() <= hay_bytes.len() {
         if &hay_bytes[i..i + needle_bytes.len()] == needle_bytes {

--- a/ainb-tui/src/models/skills.rs
+++ b/ainb-tui/src/models/skills.rs
@@ -360,31 +360,75 @@ fn split_frontmatter(content: &str) -> (HashMap<String, String>, String) {
             continue;
         }
 
-        // Case 2: value on following lines — collect dash-list or nested keys.
-        // For `tools:` style lists we join entries with commas.
-        let mut collected: Vec<String> = Vec::new();
+        // Case 2: value on following lines.
+        // Peek at the first non-blank indented follow-up line. Only enter
+        // list-collection mode if it starts with `- ` (or bare `-`). Otherwise
+        // the bare key points at a nested map / JSON block (see bitwarden's
+        // `metadata:` block), so skip the whole indented region and resume
+        // at the next column-0 key.
         i += 1;
-        while i < fm_lines.len() {
-            let l = fm_lines[i];
-            let li = l.len() - l.trim_start().len();
-            if li == 0 && !l.trim().is_empty() {
-                break;
-            }
-            let t = l.trim();
-            if t.is_empty() {
-                i += 1;
+        let mut first_non_blank: Option<&str> = None;
+        let mut scan = i;
+        while scan < fm_lines.len() {
+            let l = fm_lines[scan];
+            if l.trim().is_empty() {
+                scan += 1;
                 continue;
             }
-            if let Some(item) = t.strip_prefix('-') {
-                collected.push(strip_quotes(item.trim()));
-            } else {
-                // Some other nested structure — bail out.
+            let li = l.len() - l.trim_start().len();
+            if li == 0 {
                 break;
             }
-            i += 1;
+            first_non_blank = Some(l);
+            break;
         }
-        if !collected.is_empty() {
-            map.insert(key, collected.join(", "));
+
+        let is_list = first_non_blank
+            .map(|l| {
+                let t = l.trim_start();
+                t == "-" || t.starts_with("- ")
+            })
+            .unwrap_or(false);
+
+        if is_list {
+            let mut collected: Vec<String> = Vec::new();
+            while i < fm_lines.len() {
+                let l = fm_lines[i];
+                let li = l.len() - l.trim_start().len();
+                if li == 0 && !l.trim().is_empty() {
+                    break;
+                }
+                let t = l.trim();
+                if t.is_empty() {
+                    i += 1;
+                    continue;
+                }
+                if let Some(item) = t.strip_prefix('-') {
+                    collected.push(strip_quotes(item.trim()));
+                    i += 1;
+                } else {
+                    // Nested descendant of a list item — don't absorb.
+                    break;
+                }
+            }
+            if !collected.is_empty() {
+                map.insert(key, collected.join(", "));
+            }
+        } else {
+            // Nested map / JSON / other block — skip all blank + indented
+            // lines until the next column-0 non-blank line.
+            while i < fm_lines.len() {
+                let l = fm_lines[i];
+                if l.trim().is_empty() {
+                    i += 1;
+                    continue;
+                }
+                let li = l.len() - l.trim_start().len();
+                if li == 0 {
+                    break;
+                }
+                i += 1;
+            }
         }
     }
 

--- a/ainb-tui/src/models/skills.rs
+++ b/ainb-tui/src/models/skills.rs
@@ -449,5 +449,5 @@ fn contains_word(haystack: &str, needle_lower: &str) -> bool {
 }
 
 fn is_word_char(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
+    b.is_ascii_alphanumeric() || b == b'_'
 }

--- a/ainb-tui/src/models/skills.rs
+++ b/ainb-tui/src/models/skills.rs
@@ -1,0 +1,453 @@
+// ABOUTME: Parser and data model for user-level Claude Code skills + agents.
+// Walks ~/.claude/skills/*/SKILL.md and ~/.claude/agents/**/*.md, extracts YAML
+// frontmatter, and builds a skill-to-agents association map for the TUI Skills screen.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tracing::{debug, warn};
+
+/// A single skill parsed from `SKILL.md`.
+#[derive(Debug, Clone, Default)]
+pub struct Skill {
+    pub name: String,
+    pub description: String,
+    pub user_invocable: Option<bool>,
+    pub source_path: PathBuf,
+}
+
+/// An agent definition parsed from an `.md` file under `~/.claude/agents/`.
+#[derive(Debug, Clone, Default)]
+pub struct AgentDef {
+    pub name: String,
+    pub description: String,
+    pub tools: Vec<String>,
+    pub source_path: PathBuf,
+    /// Body text (post-frontmatter) retained for association scanning.
+    pub body: String,
+}
+
+/// Complete parsed skills + agents snapshot.
+#[derive(Debug, Clone, Default)]
+pub struct SkillsData {
+    pub skills: Vec<Skill>,
+    pub agents: Vec<AgentDef>,
+    /// skill name -> list of agent names that reference it.
+    pub associations: HashMap<String, Vec<String>>,
+}
+
+/// Parse all skills + agents installed at the user level and return a snapshot.
+/// This is designed to run off the event thread (blocking I/O).
+pub fn parse_skills() -> SkillsData {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            warn!("Could not determine home directory for skills scan");
+            return SkillsData::default();
+        }
+    };
+
+    let skills = scan_skills(&home.join(".claude").join("skills"));
+    let agents = scan_agents(&home.join(".claude").join("agents"));
+    let associations = build_associations(&skills, &agents);
+
+    debug!(
+        "Parsed {} skills, {} agents, {} skill-associations",
+        skills.len(),
+        agents.len(),
+        associations.len()
+    );
+
+    SkillsData {
+        skills,
+        agents,
+        associations,
+    }
+}
+
+fn scan_skills(root: &Path) -> Vec<Skill> {
+    let mut out: Vec<Skill> = Vec::new();
+    if !root.is_dir() {
+        return out;
+    }
+
+    let entries = match std::fs::read_dir(root) {
+        Ok(rd) => rd,
+        Err(e) => {
+            warn!("Cannot read skills dir {:?}: {}", root, e);
+            return out;
+        }
+    };
+
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_md = path.join("SKILL.md");
+        if !skill_md.is_file() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&skill_md) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let (fm, _body) = split_frontmatter(&content);
+        if fm.is_empty() {
+            continue;
+        }
+        let name = fm
+            .get("name")
+            .cloned()
+            .unwrap_or_else(|| {
+                path.file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .to_string()
+            });
+        if name.is_empty() {
+            continue;
+        }
+        let description = fm.get("description").cloned().unwrap_or_default();
+        let user_invocable = fm
+            .get("user-invocable")
+            .map(|s| parse_bool(s));
+
+        out.push(Skill {
+            name,
+            description,
+            user_invocable,
+            source_path: skill_md,
+        });
+    }
+
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out
+}
+
+fn scan_agents(root: &Path) -> Vec<AgentDef> {
+    let mut out: Vec<AgentDef> = Vec::new();
+    if !root.is_dir() {
+        return out;
+    }
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_agent_files(root, &mut files);
+
+    for path in files {
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let (fm, body) = split_frontmatter(&content);
+        if fm.is_empty() {
+            // Not a frontmatter-style agent file; skip.
+            continue;
+        }
+        let name = fm.get("name").cloned().unwrap_or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string()
+        });
+        if name.is_empty() {
+            continue;
+        }
+        let description = fm.get("description").cloned().unwrap_or_default();
+        let tools = parse_tools(fm.get("tools").map(String::as_str).unwrap_or(""));
+
+        out.push(AgentDef {
+            name,
+            description,
+            tools,
+            source_path: path,
+            body,
+        });
+    }
+
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out
+}
+
+fn collect_agent_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if path.is_dir() {
+            // Skip noisy / non-agent subdirs.
+            if matches!(name.as_str(), "archived" | "swarm") {
+                continue;
+            }
+            collect_agent_files(&path, out);
+        } else if path.is_file() {
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+            if ext == "md" {
+                out.push(path);
+            }
+        }
+    }
+}
+
+fn build_associations(
+    skills: &[Skill],
+    agents: &[AgentDef],
+) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+
+    for skill in skills {
+        let skill_name_lower = skill.name.to_lowercase();
+        let mut matches: Vec<String> = Vec::new();
+
+        for agent in agents {
+            // Tool list match: exact case-insensitive match.
+            let tool_hit = agent
+                .tools
+                .iter()
+                .any(|t| t.to_lowercase() == skill_name_lower);
+
+            // Text match: whole-word case-insensitive match in description or body.
+            let text_hit = contains_word(&agent.description, &skill_name_lower)
+                || contains_word(&agent.body, &skill_name_lower);
+
+            if tool_hit || text_hit {
+                matches.push(agent.name.clone());
+            }
+        }
+
+        if !matches.is_empty() {
+            matches.sort();
+            matches.dedup();
+            map.insert(skill.name.clone(), matches);
+        }
+    }
+
+    map
+}
+
+/// Very small YAML-frontmatter extractor. Returns (key->value map, body).
+/// Supports simple `key: value` lines and block scalars using `>` or `|`,
+/// plus multi-line continuations where subsequent lines are indented.
+/// Good enough for the subset of frontmatter our skills/agents use.
+fn split_frontmatter(content: &str) -> (HashMap<String, String>, String) {
+    let mut map: HashMap<String, String> = HashMap::new();
+    let mut body_start = 0usize;
+
+    let mut lines = content.lines().enumerate();
+    let Some((_, first)) = lines.next() else {
+        return (map, String::new());
+    };
+
+    if first.trim() != "---" {
+        return (map, content.to_string());
+    }
+
+    // Collect frontmatter lines until the next `---`.
+    let mut fm_lines: Vec<&str> = Vec::new();
+    let mut end_idx: Option<usize> = None;
+    for (idx, line) in lines {
+        if line.trim() == "---" {
+            end_idx = Some(idx);
+            break;
+        }
+        fm_lines.push(line);
+    }
+
+    match end_idx {
+        Some(idx) => {
+            // Compute byte offset of body (line idx+1 and onward).
+            let mut seen = 0usize;
+            for (i, l) in content.lines().enumerate() {
+                if i == idx + 1 {
+                    break;
+                }
+                seen += l.len() + 1; // +1 for the newline
+            }
+            body_start = seen.min(content.len());
+        }
+        None => {
+            // Missing closing delimiter — treat whole file as frontmatter-less.
+            return (HashMap::new(), content.to_string());
+        }
+    }
+
+    // Parse frontmatter lines. Top-level keys live at column 0 with `key:`.
+    let mut i = 0usize;
+    while i < fm_lines.len() {
+        let line = fm_lines[i];
+        let trimmed = line.trim_end();
+        // Skip blank lines or comments at top level.
+        if trimmed.trim().is_empty() || trimmed.trim_start().starts_with('#') {
+            i += 1;
+            continue;
+        }
+        // Only treat as top-level key when the line starts in column 0.
+        let indent = line.len() - line.trim_start().len();
+        if indent != 0 {
+            i += 1;
+            continue;
+        }
+        let Some(colon) = trimmed.find(':') else {
+            i += 1;
+            continue;
+        };
+        let key = trimmed[..colon].trim().to_string();
+        let raw_value = trimmed[colon + 1..].trim();
+
+        if key.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        // Case 1: inline value present.
+        if !raw_value.is_empty() {
+            // Handle block scalar folding marker on same line: `key: >` / `key: |`.
+            let folded = raw_value == ">" || raw_value == "|";
+            if folded {
+                let mut collected = String::new();
+                i += 1;
+                while i < fm_lines.len() {
+                    let l = fm_lines[i];
+                    let li = l.len() - l.trim_start().len();
+                    if li == 0 && !l.trim().is_empty() {
+                        break;
+                    }
+                    if !collected.is_empty() {
+                        collected.push(' ');
+                    }
+                    collected.push_str(l.trim());
+                    i += 1;
+                }
+                map.insert(key, strip_quotes(&collected));
+                continue;
+            }
+
+            // Plain value — also absorb any continuation lines that are indented
+            // (so multi-line descriptions without `>` still get captured).
+            let mut buf = strip_quotes(raw_value);
+            i += 1;
+            while i < fm_lines.len() {
+                let l = fm_lines[i];
+                let li = l.len() - l.trim_start().len();
+                let t = l.trim();
+                // Stop at the next top-level key or blank separator.
+                if li == 0 {
+                    break;
+                }
+                // Skip list entries introduced by `-` (they belong to a structured value).
+                if t.starts_with('-') {
+                    i += 1;
+                    continue;
+                }
+                if !buf.is_empty() {
+                    buf.push(' ');
+                }
+                buf.push_str(t);
+                i += 1;
+            }
+            map.insert(key, buf);
+            continue;
+        }
+
+        // Case 2: value on following lines — collect dash-list or nested keys.
+        // For `tools:` style lists we join entries with commas.
+        let mut collected: Vec<String> = Vec::new();
+        i += 1;
+        while i < fm_lines.len() {
+            let l = fm_lines[i];
+            let li = l.len() - l.trim_start().len();
+            if li == 0 && !l.trim().is_empty() {
+                break;
+            }
+            let t = l.trim();
+            if t.is_empty() {
+                i += 1;
+                continue;
+            }
+            if let Some(item) = t.strip_prefix('-') {
+                collected.push(strip_quotes(item.trim()));
+            } else {
+                // Some other nested structure — bail out.
+                break;
+            }
+            i += 1;
+        }
+        if !collected.is_empty() {
+            map.insert(key, collected.join(", "));
+        }
+    }
+
+    let body = if body_start < content.len() {
+        content[body_start..].to_string()
+    } else {
+        String::new()
+    };
+
+    (map, body)
+}
+
+fn strip_quotes(s: &str) -> String {
+    let t = s.trim();
+    if t.len() >= 2
+        && ((t.starts_with('"') && t.ends_with('"'))
+            || (t.starts_with('\'') && t.ends_with('\'')))
+    {
+        t[1..t.len() - 1].to_string()
+    } else {
+        t.to_string()
+    }
+}
+
+fn parse_bool(s: &str) -> bool {
+    matches!(
+        s.trim().to_lowercase().as_str(),
+        "true" | "yes" | "on" | "1"
+    )
+}
+
+fn parse_tools(s: &str) -> Vec<String> {
+    if s.trim().is_empty() {
+        return Vec::new();
+    }
+    s.split(|c: char| c == ',' || c == '\n')
+        .map(|t| strip_quotes(t.trim().trim_start_matches('-').trim()))
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+fn contains_word(haystack: &str, needle_lower: &str) -> bool {
+    if needle_lower.is_empty() {
+        return false;
+    }
+    let hay = haystack.to_lowercase();
+    let needle_bytes = needle_lower.as_bytes();
+    let hay_bytes = hay.as_bytes();
+    let mut i = 0usize;
+    while i + needle_bytes.len() <= hay_bytes.len() {
+        if &hay_bytes[i..i + needle_bytes.len()] == needle_bytes {
+            let before_ok = i == 0 || !is_word_char(hay_bytes[i - 1]);
+            let after_idx = i + needle_bytes.len();
+            let after_ok =
+                after_idx >= hay_bytes.len() || !is_word_char(hay_bytes[after_idx]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn is_word_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
+}

--- a/ainb-tui/src/models/skills.rs
+++ b/ainb-tui/src/models/skills.rs
@@ -265,13 +265,14 @@ fn split_frontmatter(content: &str) -> (HashMap<String, String>, String) {
 
     match end_idx {
         Some(idx) => {
-            // Compute byte offset of body (line idx+1 and onward).
+            // Compute byte offset of body (line idx+1 and onward) using
+            // split_inclusive so CRLF line endings are counted in full.
             let mut seen = 0usize;
-            for (i, l) in content.lines().enumerate() {
+            for (i, l) in content.split_inclusive('\n').enumerate() {
                 if i == idx + 1 {
                     break;
                 }
-                seen += l.len() + 1; // +1 for the newline
+                seen += l.len();
             }
             body_start = seen.min(content.len());
         }


### PR DESCRIPTION
## Summary

New full-screen **Skills** view (sidebar shortcut `k` / 🧠) for browsing installed skills + agents at the user level (`~/.claude/skills/`, `~/.claude/agents/`). Answers "what skills are installed and which agents reference them?" without leaving the TUI.

Layout and async-load pattern mirror the Usage Analytics screen (including the in-flight cache preservation from #42).

## What it does

- **Scanner** (`models/skills.rs`): parses YAML frontmatter from each `SKILL.md` (name, description, user-invocable) and every `.md` agent file under `~/.claude/agents/` (name, description, tools). Skips `archived/`, `swarm/`, and non-`.md` fixtures. Hand-written frontmatter splitter — no new crate deps.
- **Association map**: case-insensitive whole-word match across agent descriptions/bodies + exact match on the `tools:` list → `skill_name → [agent_names]`.
- **View** (`components/skills.rs`): three-row layout (summary / provider switcher / content) matching Usage. Provider switcher: Claude Code / Codex / Gemini / Copilot — only Claude Code returns data in this MVP; the others render the same "not yet available" panel.
- **Three sub-tabs**: Skills, Agents, Associations. Left list + right detail pane. `/` enters live filter (name + description substring match, case-insensitive).
- **Background load**: `tokio::spawn_blocking` + `mpsc`, polled from `tick()`. Cache preserved across provider switches. JoinError panic drops the sender → loading cleared without overwriting cached data. Same contract as the usage loader.

## Wiring

| File | Change |
|---|---|
| `models/skills.rs` | new: scanner + types (`Skill`, `AgentDef`, `SkillsData`) |
| `models/mod.rs` | `pub mod skills;` + re-exports |
| `components/skills.rs` | new: view state + render |
| `components/mod.rs` | `pub mod skills;` |
| `components/sidebar.rs` | `SidebarItem::Skills` (icon 🧠, key `k`), bumped layout constraint array |
| `components/layout.rs` | `View::Skills` routing |
| `app/state.rs` | `View::Skills`, `skills_state`, `skills_load_receiver`, `start_background_skills_load` + `check_skills_load_complete`, polled from `tick()` |
| `app/events.rs` | 16 new `AppEvent` variants, `GoToSkills`, `handle_skills_keys`, full dispatch block |

## Stacked on

This PR targets `fix/usage-async-load` (#42) since it reuses the async-load pattern that fix introduced. Rebase onto `main` once #42 lands.

## Test plan
- [x] `cargo check` clean (101 warnings, 3 new and harmless: two unused spec-mandated methods + one unused re-export)
- [ ] Manual: open Skills, scroll through skills list, `/` + type to filter
- [ ] Manual: Tab cycles Skills → Agents → Associations; detail pane updates
- [ ] Manual: ◀/▶ across providers — Codex/Gemini/Copilot show "not available", data persists on return to Claude
- [ ] Manual: `r` refreshes; in-flight refresh shows "already in progress" notification equivalent
- [ ] Manual: association map accurate for a known skill (e.g., `commit`, `brainstorm`) — verify agents that reference them appear in the right pane

## Out of scope (future follow-ups)
- Codex/Gemini/Copilot scanners
- Enable/disable toggles
- Open skill source in `$EDITOR`
- Fuzzy (not substring) search ranking