### PR TITLE
feat(hooks): TTS opt-in gate via ~/.claude/.tts-on sentinel

### DIFF
--- a/toolkit/packages/utilities/hooks/notification.py
+++ b/toolkit/packages/utilities/hooks/notification.py
@@ -91,6 +91,9 @@ def build_notification_message(input_data):
 
 def announce_notification(notification_message):
     """Announce that the agent needs user input."""
+    # TTS opt-in: stay silent unless ~/.claude/.tts-on exists.
+    if not (Path.home() / ".claude" / ".tts-on").exists():
+        return
     try:
         tts_script = get_tts_script_path()
         if not tts_script:

--- a/toolkit/packages/utilities/hooks/stop.py
+++ b/toolkit/packages/utilities/hooks/stop.py
@@ -88,6 +88,9 @@ def build_completion_message(input_data):
 
 def announce_completion(completion_message):
     """Announce completion using the best available TTS service."""
+    # TTS opt-in: stay silent unless ~/.claude/.tts-on exists.
+    if not (Path.home() / ".claude" / ".tts-on").exists():
+        return
     try:
         tts_script = get_tts_script_path()
         if not tts_script:

--- a/toolkit/packages/utilities/hooks/subagent_stop.py
+++ b/toolkit/packages/utilities/hooks/subagent_stop.py
@@ -72,6 +72,9 @@ def build_subagent_completion_message(input_data):
 
 def announce_subagent_completion(completion_message):
     """Announce subagent completion using the best available TTS service."""
+    # TTS opt-in: stay silent unless ~/.claude/.tts-on exists.
+    if not (Path.home() / ".claude" / ".tts-on").exists():
+        return
     try:
         tts_script = get_tts_script_path()
         if not tts_script:


### PR DESCRIPTION
## Summary
- Three TTS announcement sites (notification, stop, subagent_stop) now gate on a sentinel file `~/.claude/.tts-on`
- File absent = silent (new default). `touch ~/.claude/.tts-on` to enable, `rm` to disable.
- Non-TTS side effects (chat save, Langfuse trace, todo summary extraction) are unaffected — gate sits at the top of each `announce_*` function only.

## Why
Users had no easy way to quickly toggle TTS off for a pairing session / shared office / recording without editing hook source or ripping entries out of `settings.json`. This adds a one-liner with zero state-management surface.

Rationale for the chosen approach:
- **Sentinel file** over env var: survives reboots, requires no shell-rc change, no slash-command infra.
- **Inverted semantics** (`.tts-on` = enabled): combines naturally with "off by default", which is the safer default for users who don't explicitly want audio.

## Breaking change
Default flips from "on" to "off". Anyone currently relying on TTS will need to `touch ~/.claude/.tts-on` once. No other behavior changes.

## Test plan
- [x] `python3 -m py_compile` on all 3 modified files
- [x] Smoke: default path (no sentinel) → `announce_*` returns immediately, no TTS process spawned
- [ ] Smoke: `touch ~/.claude/.tts-on` → TTS speaks as before
- [ ] Smoke: remove sentinel mid-session → next event is silent

## Spec
Full design rationale and alternatives considered in `~/.claude/plans/tts-toggle-spec.md` (user-local, not shipped here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text-to-Speech (TTS) notifications are now opt-in. Voice announcements for notifications, task completion, and sub-agent completion events require creating a `~/.claude/.tts-on` file to enable them. TTS is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->