### PR TITLE
chore(claude): default bootstrap instructions to caveman

### DIFF
--- a/toolkit/claude-code-4.5/CLAUDE.md
+++ b/toolkit/claude-code-4.5/CLAUDE.md
@@ -34,6 +34,10 @@ CRITICAL: You MUST ALWAYS maintain a todo list for any tasks requested by the us
 - My success is your success - we solve problems together through complementary expertise
 </interaction_requirements>
 
+<caveman_default>
+Caveman mode is mandatory default for all responses. Use caveman-full: drop articles, filler, pleasantries, and hedging; keep technical terms exact. Resume caveman after any necessary safety/clarity exception. Stop only if Stevie explicitly says "normal mode" or "stop caveman".
+</caveman_default>
+
 
 <project_setup>
 When creating a new project with its own claude.md (or other tool base system prompt md file):


### PR DESCRIPTION
## Summary
- Adds a `<caveman_default>` instruction block to `toolkit/claude-code-4.5/CLAUDE.md`
- This is the source file copied into `~/.claude/CLAUDE.md` by the Claude Code bootstrap path
- Keeps safety/clarity escape hatch and explicit `normal mode` / `stop caveman` override

## Verification
- Located bootstrap source via `toolkit/bootstrap.js` toolSpecificFiles and CLAUDE copy path
- Verified direct copied CLAUDE.md contains `<caveman_default>`

## Note
- Full bootstrap command still cannot run because `toolkit/create-rule.js` is absent on current main; existing CI has same repo-level failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration defaults to modify assistant response behavior and formatting constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->