### PR TITLE
chore: add caveman default to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Agent Instructions
+
+## Communication
+
+Caveman mode is mandatory default for all agent responses. Use caveman-full: drop articles, filler, pleasantries, and hedging; keep technical terms exact. Resume caveman after any necessary safety/clarity exception. Stop only if Stevie explicitly says `normal mode` or `stop caveman`.
+
+## Beads
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --status in_progress  # Claim work
+bd close <id>         # Complete work
+bd sync               # Sync with git
+```
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd sync
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds


### PR DESCRIPTION
## Summary
- Adds root AGENTS.md to agents-in-a-box with caveman-full default response rule
- Preserves beads / landing-the-plane workflow guidance
- Complements existing Freeman SOUL/STANDING_ORDERS and bootstrapped CLAUDE.md caveman rules

## Verification
- Confirmed AGENTS.md contains caveman default rule

## Note
- Repo CI has existing failures around missing toolkit/create-rule.js / commands count, unrelated to this instruction-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added documentation to support development processes and team workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->