### PR TITLE
feat: add CodeBurn-style usage burndown analytics

### DIFF
--- a/ainb-tui/README.md
+++ b/ainb-tui/README.md
@@ -1,0 +1,22 @@
+# AINB TUI
+
+Terminal UI and CLI for Agents-in-a-Box.
+
+## Usage Analytics
+
+Open Stats in the TUI with `i`. The Usage screen includes Daily, Weekly, Project, Burndown, and Optimize tabs. Burndown supports Claude Code and Codex local session histories, period switching, provider filtering, include/exclude project filters, and read-only optimization findings.
+
+Keys: `Tab` changes usage tab, `1`-`5` selects Today/Week/30 days/Month/All, `p` cycles All/Claude/Codex, `/` adds include filter, `x` adds exclude filter, `d` enters custom `YYYY-MM-DD YYYY-MM-DD` range, `c` clears filters, and `r` reloads.
+
+CLI usage:
+
+```bash
+ainb usage report --period week
+ainb usage report --from 2026-04-01 --to 2026-04-10 --format json
+ainb usage export --format csv --output /tmp/ainb-usage.csv
+ainb usage optimize --period 30days
+ainb usage compare --period all
+ainb usage yield --period week
+```
+
+AINB reads `~/.claude/projects/**/*.jsonl` and `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` or `$CODEX_HOME/sessions/...`. Parsing is read-only. Cost values are estimates; unknown model prices are omitted while tokens/calls remain visible.

--- a/ainb-tui/docs/CLI.md
+++ b/ainb-tui/docs/CLI.md
@@ -32,6 +32,7 @@ Run `ainb` with no arguments to launch the TUI, or use any subcommand below for 
   - [`init`](#ainb-init) — first-time setup & factory reset
   - [`presets`](#ainb-presets) — session presets
   - [`completion`](#ainb-completion) — shell completions
+  - [`usage`](#ainb-usage) — local usage analytics and export
 - [Scripting recipes](#scripting-recipes)
 
 ---
@@ -42,7 +43,7 @@ Every command accepts:
 
 | Flag | Values | Default | Purpose |
 |------|--------|---------|---------|
-| `--format` | `text`, `json` | `text` | Switch any command's output to machine-readable JSON. Pair with `jq` for scripting. |
+| `--format` | `text`, `json`, `csv` | `text` | Switch output format. `csv` is mainly for `ainb usage export`. |
 | `-h`, `--help` | — | — | Print help for the command or subcommand. |
 | `-V`, `--version` | — | — | Print `ainb` version (top level only). |
 
@@ -187,6 +188,51 @@ ainb list [OPTIONS]
 ```bash
 ainb list --format json | jq '.[] | {name: .workspace_name, tool: .agent_type, branch}'
 ```
+
+### `ainb usage`
+
+Read-only local usage analytics for Claude Code and Codex session histories. AINB reads `~/.claude/projects/**/*.jsonl` plus `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` or `$CODEX_HOME/sessions/...`. It does not modify session files. Cost values are estimates from built-in model pricing; unknown models still report tokens and calls.
+
+```bash
+ainb usage report --period week
+ainb usage report --from 2026-04-01 --to 2026-04-10 --format json
+ainb usage report --provider codex --include agents-in-a-box
+ainb usage report --exclude scratch --format json
+ainb usage status --format json
+ainb usage today --format json
+ainb usage month --format json
+ainb usage export --format csv --output /tmp/ainb-usage.csv
+ainb usage export --format csv --output /tmp/ainb-usage-export
+ainb usage optimize --period 30days
+ainb usage compare --period all --format json
+ainb usage yield --period week
+```
+
+Usage filters:
+
+| Flag | Values | Purpose |
+|------|--------|---------|
+| `--period` | `today`, `week`, `30days`, `month`, `all` | Select time window. |
+| `--from`, `--to` | `YYYY-MM-DD` | Custom inclusive range. One bound may be omitted. |
+| `--provider` | `all`, `claude`, `codex` | Provider filter. |
+| `--include`, `--project` | repeatable text | Include projects whose name/path contains text. |
+| `--exclude` | repeatable text | Exclude projects whose name/path contains text. Exclusion wins. |
+
+Usage settings:
+
+```bash
+ainb usage plan show --format json
+ainb usage plan set claude-pro --provider claude --reset-day 12
+ainb usage plan set custom --monthly-usd 75 --provider all
+ainb usage plan reset
+ainb usage currency GBP --symbol GBP
+ainb usage currency --reset
+ainb usage model-alias --list
+ainb usage model-alias cursor-auto claude-sonnet-4-5
+ainb usage model-alias --remove cursor-auto
+```
+
+TUI: press `i` to open Stats, `Tab` to reach `Burndown` and `Optimize`, `1`-`5` for periods, `p` for All/Claude/Codex, `/` include filter, `x` exclude filter, `d` custom range, `c` clear filters, and `r` reload.
 
 ---
 

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -16,7 +16,7 @@ const SESSIONS_PANE_WIDTH_PERCENTAGE: f32 = 0.4;
 #[derive(Debug, Clone)]
 pub enum AppEvent {
     Quit,
-    GoToHomeScreen,  // Return to home screen from any view
+    GoToHomeScreen, // Return to home screen from any view
     NextSession,
     PreviousSession,
     NextWorkspace,
@@ -60,33 +60,33 @@ pub enum AppEvent {
     NewSessionInputChar(char),
     NewSessionInputPasteText(String),
     NewSessionBackspace,
-    NewSessionBackspaceWord,  // Delete word backward (Shift+Backspace)
+    NewSessionBackspaceWord, // Delete word backward (Shift+Backspace)
     // Source selection events (Local, Remote, SSH, Favorites)
-    SourceSelectionToggle,        // Toggle forward: Local → Remote → SSH → Favorites → Local
+    SourceSelectionToggle, // Toggle forward: Local → Remote → SSH → Favorites → Local
     SourceSelectionToggleReverse, // Toggle backward: Local → Favorites → SSH → Remote → Local
-    SourceSelectionConfirm,       // Proceed with selected source
-    SourceQuickSelectLocal,       // Quick select Local and proceed
-    SourceQuickSelectRemote,      // Quick select Remote and proceed
-    SourceQuickSelectSsh,         // Quick select SSH and proceed
-    SourceQuickSelectFavorites,   // Quick select Favorites and proceed
+    SourceSelectionConfirm, // Proceed with selected source
+    SourceQuickSelectLocal, // Quick select Local and proceed
+    SourceQuickSelectRemote, // Quick select Remote and proceed
+    SourceQuickSelectSsh,  // Quick select SSH and proceed
+    SourceQuickSelectFavorites, // Quick select Favorites and proceed
     // Favorites picker events (SelectFavorite step)
-    FavoriteSelectNext,           // Navigate to next favorite
-    FavoriteSelectPrev,           // Navigate to previous favorite
-    FavoriteSelectConfirm,        // Confirm selection
-    FavoriteGoBack,               // Go back to source selection
-    FavoriteDelete,               // Delete selected favorite
+    FavoriteSelectNext,    // Navigate to next favorite
+    FavoriteSelectPrev,    // Navigate to previous favorite
+    FavoriteSelectConfirm, // Confirm selection
+    FavoriteGoBack,        // Go back to source selection
+    FavoriteDelete,        // Delete selected favorite
     // Repo input events (URL or path)
     RepoInputChar(char),
     RepoInputBackspace,
     RepoInputBackspaceWord,
     RepoInputPasteText(String),
     RepoInputSubmit,
-    RepoInputFavoriteNext,     // Navigate to next favorite in inline list
-    RepoInputFavoritePrev,     // Navigate to previous favorite in inline list
-    RepoInputSelectFavorite,   // Use selected favorite
-    RepoInputToggleFavorite,   // Star/unstar current input as favorite
+    RepoInputFavoriteNext,   // Navigate to next favorite in inline list
+    RepoInputFavoritePrev,   // Navigate to previous favorite in inline list
+    RepoInputSelectFavorite, // Use selected favorite
+    RepoInputToggleFavorite, // Star/unstar current input as favorite
     // Local repo selection events
-    LocalRepoToggleFavorite,   // Star/unstar currently selected local repo
+    LocalRepoToggleFavorite, // Star/unstar currently selected local repo
     // Branch selection events
     BranchSelectNext,
     BranchSelectPrev,
@@ -121,21 +121,21 @@ pub enum AppEvent {
     NewSessionAgentNext,
     NewSessionAgentPrev,
     NewSessionAgentSelect,
-    NewSessionOpenShell,  // Open shell directly when Shell agent is selected
+    NewSessionOpenShell, // Open shell directly when Shell agent is selected
     // SSH configuration events (new session flow - for SSH agent)
-    NewSessionSshNextField,      // Tab to next SSH input field
-    NewSessionSshPrevField,      // Shift+Tab to previous SSH input field
-    NewSessionSshInputChar(char), // Character input for SSH fields
+    NewSessionSshNextField,         // Tab to next SSH input field
+    NewSessionSshPrevField,         // Shift+Tab to previous SSH input field
+    NewSessionSshInputChar(char),   // Character input for SSH fields
     NewSessionSshPasteText(String), // Paste text into focused SSH field
-    NewSessionSshBackspace,       // Backspace in SSH fields
-    NewSessionSshConfirm,         // Confirm SSH configuration
-    NewSessionSshGoBack,          // Go back to agent selection
+    NewSessionSshBackspace,         // Backspace in SSH fields
+    NewSessionSshConfirm,           // Confirm SSH configuration
+    NewSessionSshGoBack,            // Go back to agent selection
     // Model selection events (new session flow - for Claude agent)
     NewSessionModelNext,
     NewSessionModelPrev,
     NewSessionToggleAgentModelFocus, // Tab to switch between agent and model panels
     // Notification events
-    ShowNotification(String),  // Display a notification message to the user
+    ShowNotification(String), // Display a notification message to the user
     // File finder events for @ symbol trigger
     FileFinderNavigateUp,
     FileFinderNavigateDown,
@@ -159,18 +159,18 @@ pub enum AppEvent {
     AuthSetupRefresh,         // Manual refresh to check auth completion
     AuthSetupShowCommand,     // Show manual CLI command
     // Git view events
-    ShowGitView,       // Show git view for selected session
-    GitViewSwitchTab,  // Switch between Files and Diff tabs
-    GitViewNextFile,   // Navigate to next file
-    GitViewPrevFile,   // Navigate to previous file
-    GitViewScrollUp,   // Scroll diff up
-    GitViewScrollDown, // Scroll diff down
-    GitViewNextCommit, // Navigate to next commit in commits tab
-    GitViewPrevCommit, // Navigate to previous commit in commits tab
+    ShowGitView,           // Show git view for selected session
+    GitViewSwitchTab,      // Switch between Files and Diff tabs
+    GitViewNextFile,       // Navigate to next file
+    GitViewPrevFile,       // Navigate to previous file
+    GitViewScrollUp,       // Scroll diff up
+    GitViewScrollDown,     // Scroll diff down
+    GitViewNextCommit,     // Navigate to next commit in commits tab
+    GitViewPrevCommit,     // Navigate to previous commit in commits tab
     GitViewShowCommitDiff, // Show diff for selected commit (Enter on Commits tab)
-    GitViewCommitPush, // Commit and push changes
-    GitViewBack,       // Return to session list
-    GitCommitAndPush,  // Direct commit and push from main view (p key)
+    GitViewCommitPush,     // Commit and push changes
+    GitViewBack,           // Return to session list
+    GitCommitAndPush,      // Direct commit and push from main view (p key)
     // Quick commit dialog events (for home screen [p] key)
     QuickCommitStart,           // Start quick commit dialog
     QuickCommitInputChar(char), // Character input for quick commit
@@ -189,189 +189,199 @@ pub enum AppEvent {
     GitViewCommitConfirm,         // Confirm and execute commit (Enter)
     GitCommitSuccess(String),     // Commit was successful with message
     // File tree navigation events
-    GitViewToggleFolder,          // Toggle folder expand/collapse
-    GitViewExpandAll,             // Expand all folders
-    GitViewCollapseAll,           // Collapse all folders
+    GitViewToggleFolder, // Toggle folder expand/collapse
+    GitViewExpandAll,    // Expand all folders
+    GitViewCollapseAll,  // Collapse all folders
     // Tmux integration events
-    AttachTmuxSession,            // Attach to tmux session
-    DetachTmuxSession,            // Detach from tmux session
-    EnterScrollMode,              // Enter scroll mode in tmux preview
-    ExitScrollMode,               // Exit scroll mode in tmux preview
-    ScrollPreviewUp,              // Scroll tmux preview up
-    ScrollPreviewDown,            // Scroll tmux preview down
-    ToggleExpandAll,              // Toggle expand/collapse all workspaces
+    AttachTmuxSession, // Attach to tmux session
+    DetachTmuxSession, // Detach from tmux session
+    EnterScrollMode,   // Enter scroll mode in tmux preview
+    ExitScrollMode,    // Exit scroll mode in tmux preview
+    ScrollPreviewUp,   // Scroll tmux preview up
+    ScrollPreviewDown, // Scroll tmux preview down
+    ToggleExpandAll,   // Toggle expand/collapse all workspaces
     // Other tmux rename events
-    OtherTmuxStartRename,         // Start rename mode for selected "Other tmux" session
-    OtherTmuxRenameChar(char),    // Character input for rename
-    OtherTmuxRenameBackspace,     // Backspace in rename
-    OtherTmuxConfirmRename,       // Confirm rename (Enter)
-    OtherTmuxCancelRename,        // Cancel rename (Escape)
+    OtherTmuxStartRename, // Start rename mode for selected "Other tmux" session
+    OtherTmuxRenameChar(char), // Character input for rename
+    OtherTmuxRenameBackspace, // Backspace in rename
+    OtherTmuxConfirmRename, // Confirm rename (Enter)
+    OtherTmuxCancelRename, // Cancel rename (Escape)
     // SSH session rename events
-    SshSessionStartRename,        // Start rename mode for selected SSH session
-    SshSessionRenameChar(char),   // Character input for SSH rename
-    SshSessionRenameBackspace,    // Backspace in SSH rename
-    SshSessionConfirmRename,      // Confirm SSH rename (Enter)
-    SshSessionCancelRename,       // Cancel SSH rename (Escape)
+    SshSessionStartRename,      // Start rename mode for selected SSH session
+    SshSessionRenameChar(char), // Character input for SSH rename
+    SshSessionRenameBackspace,  // Backspace in SSH rename
+    SshSessionConfirmRename,    // Confirm SSH rename (Enter)
+    SshSessionCancelRename,     // Cancel SSH rename (Escape)
     // AINB 2.0: Home screen events
-    HomeScreenSelectTile,        // Select current tile (Enter)
-    HomeScreenNavigateUp,        // Navigate up in tile grid
-    HomeScreenNavigateDown,      // Navigate down in tile grid
-    HomeScreenNavigateLeft,      // Navigate left in tile grid
-    HomeScreenNavigateRight,     // Navigate right in tile grid
+    HomeScreenSelectTile,    // Select current tile (Enter)
+    HomeScreenNavigateUp,    // Navigate up in tile grid
+    HomeScreenNavigateDown,  // Navigate down in tile grid
+    HomeScreenNavigateLeft,  // Navigate left in tile grid
+    HomeScreenNavigateRight, // Navigate right in tile grid
     // AINB 2.0: Home screen V2 events (sidebar navigation)
-    HomeScreenSidebarUp,         // Navigate up in sidebar
-    HomeScreenSidebarDown,       // Navigate down in sidebar
-    HomeScreenSidebarSelect,     // Select current sidebar item (Enter)
-    HomeScreenToggleFocus,       // Toggle focus between sidebar and content panel (Tab)
-    StarSelectedWorkspace,        // Star/unstar the currently selected workspace
+    HomeScreenSidebarUp,     // Navigate up in sidebar
+    HomeScreenSidebarDown,   // Navigate down in sidebar
+    HomeScreenSidebarSelect, // Select current sidebar item (Enter)
+    HomeScreenToggleFocus,   // Toggle focus between sidebar and content panel (Tab)
+    StarSelectedWorkspace,   // Star/unstar the currently selected workspace
     // AINB 2.0: Home screen V2 welcome panel events
-    WelcomePanelScrollUp,        // Scroll welcome panel up
-    WelcomePanelScrollDown,      // Scroll welcome panel down
-    WelcomePanelPageUp,          // Page up in welcome panel
-    WelcomePanelPageDown,        // Page down in welcome panel
-    WelcomePanelCopyContent,     // Copy welcome panel content to clipboard (y)
-    GoToAgentSelection,          // Navigate to agent selection view
-    GoToCatalog,                 // Navigate to catalog view (coming soon)
-    GoToConfig,                  // Navigate to config view
-    GoToSessionList,             // Navigate to session list view
-    GoToStats,                   // Navigate to stats view
-    GoToSkills,                  // Navigate to skills view
-    GoToRecovery,                // Navigate to session recovery view
+    WelcomePanelScrollUp,    // Scroll welcome panel up
+    WelcomePanelScrollDown,  // Scroll welcome panel down
+    WelcomePanelPageUp,      // Page up in welcome panel
+    WelcomePanelPageDown,    // Page down in welcome panel
+    WelcomePanelCopyContent, // Copy welcome panel content to clipboard (y)
+    GoToAgentSelection,      // Navigate to agent selection view
+    GoToCatalog,             // Navigate to catalog view (coming soon)
+    GoToConfig,              // Navigate to config view
+    GoToSessionList,         // Navigate to session list view
+    GoToStats,               // Navigate to stats view
+    GoToSkills,              // Navigate to skills view
+    GoToRecovery,            // Navigate to session recovery view
     // AINB 2.0: Agent selection events
-    AgentSelectionBack,          // Return to home screen (Esc)
-    AgentSelectionNextProvider,  // Navigate to next provider
-    AgentSelectionPrevProvider,  // Navigate to previous provider
-    AgentSelectionNextModel,     // Navigate to next model
-    AgentSelectionPrevModel,     // Navigate to previous model
-    AgentSelectionToggleExpand,  // Toggle provider expand
-    AgentSelectionSelect,        // Select current agent (Enter)
+    AgentSelectionBack,         // Return to home screen (Esc)
+    AgentSelectionNextProvider, // Navigate to next provider
+    AgentSelectionPrevProvider, // Navigate to previous provider
+    AgentSelectionNextModel,    // Navigate to next model
+    AgentSelectionPrevModel,    // Navigate to previous model
+    AgentSelectionToggleExpand, // Toggle provider expand
+    AgentSelectionSelect,       // Select current agent (Enter)
     // AINB 2.0: Config screen events
-    ConfigBack,                  // Return to home screen (Esc)
-    ConfigNextCategory,          // Navigate to next category
-    ConfigPrevCategory,          // Navigate to previous category
-    ConfigNextSetting,           // Navigate to next setting
-    ConfigPrevSetting,           // Navigate to previous setting
-    ConfigSwitchPane,            // Toggle focus between category and settings pane (Tab)
-    ConfigNavigateUp,            // Navigate up within current focused pane
-    ConfigNavigateDown,          // Navigate down within current focused pane
-    ConfigFocusCategories,       // Switch focus to categories pane (Left)
-    ConfigFocusSettings,         // Switch focus to settings pane (Right)
-    ConfigEditSetting,           // Start editing current setting (Enter)
-    ConfigSaveEdit,              // Save current edit (Enter while editing)
-    ConfigCancelEdit,            // Cancel current edit (Esc while editing)
-    ConfigEditChar(char),        // Input character while editing
-    ConfigEditBackspace,         // Backspace while editing
-    ConfigSaveAll,               // Save all settings (S)
+    ConfigBack,            // Return to home screen (Esc)
+    ConfigNextCategory,    // Navigate to next category
+    ConfigPrevCategory,    // Navigate to previous category
+    ConfigNextSetting,     // Navigate to next setting
+    ConfigPrevSetting,     // Navigate to previous setting
+    ConfigSwitchPane,      // Toggle focus between category and settings pane (Tab)
+    ConfigNavigateUp,      // Navigate up within current focused pane
+    ConfigNavigateDown,    // Navigate down within current focused pane
+    ConfigFocusCategories, // Switch focus to categories pane (Left)
+    ConfigFocusSettings,   // Switch focus to settings pane (Right)
+    ConfigEditSetting,     // Start editing current setting (Enter)
+    ConfigSaveEdit,        // Save current edit (Enter while editing)
+    ConfigCancelEdit,      // Cancel current edit (Esc while editing)
+    ConfigEditChar(char),  // Input character while editing
+    ConfigEditBackspace,   // Backspace while editing
+    ConfigSaveAll,         // Save all settings (S)
     // API Key configuration
-    ConfigApiKeyStart,           // Start API key input mode (when on API Key Status)
-    ConfigApiKeySave,            // Save the entered API key to keychain
-    ConfigApiKeyDelete,          // Delete stored API key
+    ConfigApiKeyStart,  // Start API key input mode (when on API Key Status)
+    ConfigApiKeySave,   // Save the entered API key to keychain
+    ConfigApiKeyDelete, // Delete stored API key
     // Auth provider popup
-    AuthProviderPopupOpen,       // Open the auth provider popup
-    AuthProviderPopupClose,      // Close the popup (Esc)
-    AuthProviderPopupNext,       // Navigate to next provider
-    AuthProviderPopupPrev,       // Navigate to previous provider
-    AuthProviderPopupSelect,     // Select current provider (Enter)
+    AuthProviderPopupOpen,            // Open the auth provider popup
+    AuthProviderPopupClose,           // Close the popup (Esc)
+    AuthProviderPopupNext,            // Navigate to next provider
+    AuthProviderPopupPrev,            // Navigate to previous provider
+    AuthProviderPopupSelect,          // Select current provider (Enter)
     AuthProviderPopupInputChar(char), // Input character for API key
-    AuthProviderPopupBackspace,  // Backspace in API key input
-    AuthProviderPopupDeleteKey,  // Delete stored API key (D)
+    AuthProviderPopupBackspace,       // Backspace in API key input
+    AuthProviderPopupDeleteKey,       // Delete stored API key (D)
     // Config popup events (for choice/text input popups)
-    ConfigPopupNavigateUp,       // Navigate up in choice list
-    ConfigPopupNavigateDown,     // Navigate down in choice list
-    ConfigPopupConfirm,          // Confirm selection/save text (Enter)
-    ConfigPopupCancel,           // Cancel popup (Esc)
-    ConfigPopupInputChar(char),  // Input character in text/number input
-    ConfigPopupBackspace,        // Backspace in text/number input
+    ConfigPopupNavigateUp,      // Navigate up in choice list
+    ConfigPopupNavigateDown,    // Navigate down in choice list
+    ConfigPopupConfirm,         // Confirm selection/save text (Enter)
+    ConfigPopupCancel,          // Cancel popup (Esc)
+    ConfigPopupInputChar(char), // Input character in text/number input
+    ConfigPopupBackspace,       // Backspace in text/number input
     // Log history viewer events
-    LogHistoryBack,              // Return to home screen (Esc)
-    LogHistoryNextSession,       // Navigate to next session
-    LogHistoryPrevSession,       // Navigate to previous session
-    LogHistorySelectSession,     // Select/load session logs (Enter)
-    LogHistoryToggleFocus,       // Toggle focus between sessions and logs (Tab)
-    LogHistoryScrollUp,          // Scroll log entries up
-    LogHistoryScrollDown,        // Scroll log entries down
-    LogHistoryPageUp,            // Page up in log entries
-    LogHistoryPageDown,          // Page down in log entries
-    LogHistoryCycleFilter,       // Cycle through filter levels (f)
-    LogHistoryRefresh,           // Refresh session list (r)
-    LogHistoryCopySelection,     // Copy selected text to clipboard (y or Ctrl+c)
-    LogHistoryScrollLeft,        // Scroll log content left (←)
-    LogHistoryScrollRight,       // Scroll log content right (→)
-    LogHistoryScrollHome,        // Reset horizontal scroll to start (Home)
-    LogHistoryCleanup,           // Delete all log files (C)
+    LogHistoryBack,          // Return to home screen (Esc)
+    LogHistoryNextSession,   // Navigate to next session
+    LogHistoryPrevSession,   // Navigate to previous session
+    LogHistorySelectSession, // Select/load session logs (Enter)
+    LogHistoryToggleFocus,   // Toggle focus between sessions and logs (Tab)
+    LogHistoryScrollUp,      // Scroll log entries up
+    LogHistoryScrollDown,    // Scroll log entries down
+    LogHistoryPageUp,        // Page up in log entries
+    LogHistoryPageDown,      // Page down in log entries
+    LogHistoryCycleFilter,   // Cycle through filter levels (f)
+    LogHistoryRefresh,       // Refresh session list (r)
+    LogHistoryCopySelection, // Copy selected text to clipboard (y or Ctrl+c)
+    LogHistoryScrollLeft,    // Scroll log content left (←)
+    LogHistoryScrollRight,   // Scroll log content right (→)
+    LogHistoryScrollHome,    // Reset horizontal scroll to start (Home)
+    LogHistoryCleanup,       // Delete all log files (C)
     // Onboarding wizard events
-    OnboardingNext,              // Go to next step (Enter/Right Arrow)
-    OnboardingBack,              // Go to previous step (Backspace/Left Arrow)
-    OnboardingCancel,            // Cancel onboarding (Esc)
-    OnboardingInputChar(char),   // Input character for git directories
-    OnboardingBackspace,         // Backspace in git directories input
-    OnboardingDelete,            // Delete character in input
-    OnboardingCursorLeft,        // Move cursor left in input
-    OnboardingCursorRight,       // Move cursor right in input
-    OnboardingCursorHome,        // Move cursor to start of input
-    OnboardingCursorEnd,         // Move cursor to end of input
-    OnboardingCheckDeps,         // Run dependency check
-    OnboardingSkipAuth,          // Skip authentication step
-    OnboardingEditorUp,          // Move editor selection up
-    OnboardingEditorDown,        // Move editor selection down
-    OnboardingFinish,            // Complete onboarding
-    OnboardingInstallConfig,     // Install recommended config (I key)
+    OnboardingNext,            // Go to next step (Enter/Right Arrow)
+    OnboardingBack,            // Go to previous step (Backspace/Left Arrow)
+    OnboardingCancel,          // Cancel onboarding (Esc)
+    OnboardingInputChar(char), // Input character for git directories
+    OnboardingBackspace,       // Backspace in git directories input
+    OnboardingDelete,          // Delete character in input
+    OnboardingCursorLeft,      // Move cursor left in input
+    OnboardingCursorRight,     // Move cursor right in input
+    OnboardingCursorHome,      // Move cursor to start of input
+    OnboardingCursorEnd,       // Move cursor to end of input
+    OnboardingCheckDeps,       // Run dependency check
+    OnboardingSkipAuth,        // Skip authentication step
+    OnboardingEditorUp,        // Move editor selection up
+    OnboardingEditorDown,      // Move editor selection down
+    OnboardingFinish,          // Complete onboarding
+    OnboardingInstallConfig,   // Install recommended config (I key)
     // Setup menu events
-    SetupMenuBack,               // Return to home screen (Esc)
-    SetupMenuSelect,             // Select menu item (Enter)
-    SetupMenuUp,                 // Navigate up
-    SetupMenuDown,               // Navigate down
-    StartOnboarding,             // Start onboarding wizard (from setup menu)
-    FactoryReset,                // Factory reset AINB
+    SetupMenuBack,   // Return to home screen (Esc)
+    SetupMenuSelect, // Select menu item (Enter)
+    SetupMenuUp,     // Navigate up
+    SetupMenuDown,   // Navigate down
+    StartOnboarding, // Start onboarding wizard (from setup menu)
+    FactoryReset,    // Factory reset AINB
     // Changelog viewer events
-    ShowChangelog,               // Navigate to changelog view (v key)
-    ChangelogBack,               // Return to home screen (Esc)
-    ChangelogScrollUp,           // Scroll up one line
-    ChangelogScrollDown,         // Scroll down one line
-    ChangelogPageUp,             // Page up
-    ChangelogPageDown,           // Page down
-    ChangelogToTop,              // Jump to top (g)
-    ChangelogToBottom,           // Jump to bottom (G)
+    ShowChangelog,       // Navigate to changelog view (v key)
+    ChangelogBack,       // Return to home screen (Esc)
+    ChangelogScrollUp,   // Scroll up one line
+    ChangelogScrollDown, // Scroll down one line
+    ChangelogPageUp,     // Page up
+    ChangelogPageDown,   // Page down
+    ChangelogToTop,      // Jump to top (g)
+    ChangelogToBottom,   // Jump to bottom (G)
     // Usage analytics events
-    UsageBack,                   // Return to home screen (Esc)
-    UsageNextProvider,           // Next provider (Right arrow)
-    UsagePrevProvider,           // Previous provider (Left arrow)
-    UsageNextTab,                // Next sub-tab (Tab)
-    UsagePrevTab,                // Previous sub-tab (Shift+Tab)
-    UsageScrollUp,               // Scroll up (k)
-    UsageScrollDown,             // Scroll down (j)
-    UsagePageUp,                 // Page up
-    UsagePageDown,               // Page down
-    UsageToTop,                  // Jump to top (g)
-    UsageToBottom,               // Jump to bottom (G)
-    UsageRefresh,                // Reload data (r)
+    UsageBack,                // Return to home screen (Esc)
+    UsageNextProvider,        // Next provider (Right arrow)
+    UsagePrevProvider,        // Previous provider (Left arrow)
+    UsageNextTab,             // Next sub-tab (Tab)
+    UsagePrevTab,             // Previous sub-tab (Shift+Tab)
+    UsageScrollUp,            // Scroll up (k)
+    UsageScrollDown,          // Scroll down (j)
+    UsagePageUp,              // Page up
+    UsagePageDown,            // Page down
+    UsageToTop,               // Jump to top (g)
+    UsageToBottom,            // Jump to bottom (G)
+    UsageRefresh,             // Reload data (r)
+    UsageCycleProviderFilter, // Cycle All/Claude/Codex (p)
+    UsageSetPeriod(u8),       // Period shortcut 1-5
+    UsageStartIncludeFilter,  // Start include project input (/)
+    UsageStartExcludeFilter,  // Start exclude project input (x)
+    UsageStartDateRange,      // Start date range input (d)
+    UsageClearFilters,        // Clear include/exclude filters (c)
+    UsageInputChar(char),     // Input for usage filter/range
+    UsageInputBackspace,      // Backspace in usage input
+    UsageInputSubmit,         // Submit usage input
+    UsageInputCancel,         // Cancel usage input
     // Skills browser events
-    SkillsBack,                  // Return to home screen (Esc)
-    SkillsNextProvider,          // Next provider (Right arrow)
-    SkillsPrevProvider,          // Previous provider (Left arrow)
-    SkillsNextTab,               // Next sub-tab (Tab)
-    SkillsPrevTab,               // Previous sub-tab (Shift+Tab)
-    SkillsScrollUp,              // Move selection up (k/Up)
-    SkillsScrollDown,            // Move selection down (j/Down)
-    SkillsPageUp,                // Page up
-    SkillsPageDown,              // Page down
-    SkillsToTop,                 // Jump to top (g)
-    SkillsToBottom,              // Jump to bottom (G)
-    SkillsRefresh,               // Reload data (r)
-    SkillsSearchStart,           // Enter search mode (/)
-    SkillsSearchChar(char),      // Append char to search query
-    SkillsSearchBackspace,       // Remove last char from search query
-    SkillsSearchClose,           // Exit search mode (Esc)
+    SkillsBack,             // Return to home screen (Esc)
+    SkillsNextProvider,     // Next provider (Right arrow)
+    SkillsPrevProvider,     // Previous provider (Left arrow)
+    SkillsNextTab,          // Next sub-tab (Tab)
+    SkillsPrevTab,          // Previous sub-tab (Shift+Tab)
+    SkillsScrollUp,         // Move selection up (k/Up)
+    SkillsScrollDown,       // Move selection down (j/Down)
+    SkillsPageUp,           // Page up
+    SkillsPageDown,         // Page down
+    SkillsToTop,            // Jump to top (g)
+    SkillsToBottom,         // Jump to bottom (G)
+    SkillsRefresh,          // Reload data (r)
+    SkillsSearchStart,      // Enter search mode (/)
+    SkillsSearchChar(char), // Append char to search query
+    SkillsSearchBackspace,  // Remove last char from search query
+    SkillsSearchClose,      // Exit search mode (Esc)
     // Session recovery events
-    SessionRecoveryBack,         // Return to home screen (Esc)
-    SessionRecoveryNext,         // Navigate to next session (Down/j)
-    SessionRecoveryPrev,         // Navigate to previous session (Up/k)
-    SessionRecoveryResume,       // Resume selected session (r)
-    SessionRecoveryArchive,      // Archive/delete selected item (d)
-    SessionRecoveryRefresh,      // Refresh session list (R)
-    SessionRecoveryToggleView,   // Toggle view mode: Sessions/Worktrees/All (Tab)
-    SessionRecoveryRecoverAll,   // Recover all orphaned worktrees (Shift+A)
-    SessionRecoveryToggleSelect, // Toggle multi-select on current item (Space)
+    SessionRecoveryBack,           // Return to home screen (Esc)
+    SessionRecoveryNext,           // Navigate to next session (Down/j)
+    SessionRecoveryPrev,           // Navigate to previous session (Up/k)
+    SessionRecoveryResume,         // Resume selected session (r)
+    SessionRecoveryArchive,        // Archive/delete selected item (d)
+    SessionRecoveryRefresh,        // Refresh session list (R)
+    SessionRecoveryToggleView,     // Toggle view mode: Sessions/Worktrees/All (Tab)
+    SessionRecoveryRecoverAll,     // Recover all orphaned worktrees (Shift+A)
+    SessionRecoveryToggleSelect,   // Toggle multi-select on current item (Space)
     SessionRecoveryDeleteSelected, // Delete all multi-selected items (Shift+D)
     ToggleSelectSession,           // Toggle multi-select on current session (Space)
     DeleteSelectedSessions,        // Bulk delete all multi-selected sessions (Shift+D)
@@ -659,7 +669,9 @@ impl EventHandler {
                 if state.selected_workspace_index.is_some() {
                     Some(AppEvent::StarSelectedWorkspace)
                 } else {
-                    Some(AppEvent::ShowNotification("Select a workspace first to star it".to_string()))
+                    Some(AppEvent::ShowNotification(
+                        "Select a workspace first to star it".to_string(),
+                    ))
                 }
             }
             KeyCode::Char('a') => {
@@ -674,7 +686,9 @@ impl EventHandler {
                 } else if state.is_other_tmux_selected() {
                     Some(AppEvent::OtherTmuxStartRename)
                 } else {
-                    Some(AppEvent::ShowNotification("F2 rename only works on SSH and 'Other tmux' sessions".to_string()))
+                    Some(AppEvent::ShowNotification(
+                        "F2 rename only works on SSH and 'Other tmux' sessions".to_string(),
+                    ))
                 }
             }
             KeyCode::Char('e') => Some(AppEvent::RestartSession),
@@ -791,9 +805,7 @@ impl EventHandler {
                         KeyCode::Esc => Some(AppEvent::NewSessionCancel),
                         KeyCode::Enter => Some(AppEvent::SourceSelectionConfirm),
                         // Down/j cycles forward: Local → Remote → SSH → Favorites → Local
-                        KeyCode::Down | KeyCode::Char('j') => {
-                            Some(AppEvent::SourceSelectionToggle)
-                        }
+                        KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::SourceSelectionToggle),
                         // Up/k cycles backward: Local → Favorites → SSH → Remote → Local
                         KeyCode::Up | KeyCode::Char('k') => {
                             Some(AppEvent::SourceSelectionToggleReverse)
@@ -833,7 +845,9 @@ impl EventHandler {
                         KeyCode::Esc => Some(AppEvent::NewSessionCancel),
                         KeyCode::Enter => {
                             // If a favorite is selected, use it; otherwise submit input
-                            if state.new_session_state.as_ref()
+                            if state
+                                .new_session_state
+                                .as_ref()
                                 .map(|s| s.selected_favorite_index.is_some())
                                 .unwrap_or(false)
                             {
@@ -844,22 +858,20 @@ impl EventHandler {
                         }
                         KeyCode::Down => Some(AppEvent::RepoInputFavoriteNext),
                         KeyCode::Up => Some(AppEvent::RepoInputFavoritePrev),
-                        KeyCode::Char('s') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                        KeyCode::Char('s')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
                             Some(AppEvent::RepoInputToggleFavorite)
                         }
-                        KeyCode::Char('v') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                            Self::get_clipboard_text()
-                                .ok()
-                                .map(AppEvent::RepoInputPasteText)
+                        KeyCode::Char('v')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            Self::get_clipboard_text().ok().map(AppEvent::RepoInputPasteText)
                         }
                         KeyCode::Insert if key_event.modifiers.contains(KeyModifiers::SHIFT) => {
-                            Self::get_clipboard_text()
-                                .ok()
-                                .map(AppEvent::RepoInputPasteText)
+                            Self::get_clipboard_text().ok().map(AppEvent::RepoInputPasteText)
                         }
-                        KeyCode::Backspace
-                            if key_event.modifiers.contains(KeyModifiers::SHIFT) =>
-                        {
+                        KeyCode::Backspace if key_event.modifiers.contains(KeyModifiers::SHIFT) => {
                             Some(AppEvent::RepoInputBackspaceWord)
                         }
                         KeyCode::Backspace => Some(AppEvent::RepoInputBackspace),
@@ -874,18 +886,16 @@ impl EventHandler {
                         _ => None,
                     }
                 }
-                NewSessionStep::SelectBranch => {
-                    match key_event.code {
-                        KeyCode::Esc => Some(AppEvent::BranchSelectBack),
-                        KeyCode::Enter => Some(AppEvent::BranchSelectConfirm),
-                        KeyCode::Down => Some(AppEvent::BranchSelectNext),
-                        KeyCode::Up => Some(AppEvent::BranchSelectPrev),
-                        KeyCode::Tab => Some(AppEvent::BranchToggleCheckoutMode),
-                        KeyCode::Backspace => Some(AppEvent::BranchFilterBackspace),
-                        KeyCode::Char(c) => Some(AppEvent::BranchFilterInput(c)),
-                        _ => None,
-                    }
-                }
+                NewSessionStep::SelectBranch => match key_event.code {
+                    KeyCode::Esc => Some(AppEvent::BranchSelectBack),
+                    KeyCode::Enter => Some(AppEvent::BranchSelectConfirm),
+                    KeyCode::Down => Some(AppEvent::BranchSelectNext),
+                    KeyCode::Up => Some(AppEvent::BranchSelectPrev),
+                    KeyCode::Tab => Some(AppEvent::BranchToggleCheckoutMode),
+                    KeyCode::Backspace => Some(AppEvent::BranchFilterBackspace),
+                    KeyCode::Char(c) => Some(AppEvent::BranchFilterInput(c)),
+                    _ => None,
+                },
                 NewSessionStep::SelectRepo => {
                     match key_event.code {
                         KeyCode::Esc => Some(AppEvent::NewSessionCancel),
@@ -893,9 +903,7 @@ impl EventHandler {
                         KeyCode::Up => Some(AppEvent::NewSessionPrevRepo),
                         KeyCode::Enter => Some(AppEvent::NewSessionConfirmRepo),
                         // 's' key to star/unstar selected repo
-                        KeyCode::Char('s') => {
-                            Some(AppEvent::LocalRepoToggleFavorite)
-                        }
+                        KeyCode::Char('s') => Some(AppEvent::LocalRepoToggleFavorite),
                         // '$' key to open shell directly at repo (no branch/worktree prompt)
                         KeyCode::Char('$') => Some(AppEvent::NewSessionOpenShell),
                         _ => None,
@@ -911,39 +919,37 @@ impl EventHandler {
                         KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::NewSessionAgentNext),
                         KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::NewSessionAgentPrev),
                         // Model navigation (horizontal) - only when Claude is selected
-                        KeyCode::Right | KeyCode::Char('l') if show_model => Some(AppEvent::NewSessionModelNext),
-                        KeyCode::Left | KeyCode::Char('h') if show_model => Some(AppEvent::NewSessionModelPrev),
+                        KeyCode::Right | KeyCode::Char('l') if show_model => {
+                            Some(AppEvent::NewSessionModelNext)
+                        }
+                        KeyCode::Left | KeyCode::Char('h') if show_model => {
+                            Some(AppEvent::NewSessionModelPrev)
+                        }
                         KeyCode::Enter => Some(AppEvent::NewSessionAgentSelect),
                         _ => None,
                     }
                 }
-                NewSessionStep::ConfigureSsh => {
-                    match key_event.code {
-                        KeyCode::Esc => Some(AppEvent::NewSessionSshGoBack),
-                        KeyCode::Tab => {
-                            if key_event.modifiers.contains(KeyModifiers::SHIFT) {
-                                Some(AppEvent::NewSessionSshPrevField)
-                            } else {
-                                Some(AppEvent::NewSessionSshNextField)
-                            }
+                NewSessionStep::ConfigureSsh => match key_event.code {
+                    KeyCode::Esc => Some(AppEvent::NewSessionSshGoBack),
+                    KeyCode::Tab => {
+                        if key_event.modifiers.contains(KeyModifiers::SHIFT) {
+                            Some(AppEvent::NewSessionSshPrevField)
+                        } else {
+                            Some(AppEvent::NewSessionSshNextField)
                         }
-                        KeyCode::BackTab => Some(AppEvent::NewSessionSshPrevField),
-                        KeyCode::Enter => Some(AppEvent::NewSessionSshConfirm),
-                        KeyCode::Char('v') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                            Self::get_clipboard_text()
-                                .ok()
-                                .map(AppEvent::NewSessionSshPasteText)
-                        }
-                        KeyCode::Insert if key_event.modifiers.contains(KeyModifiers::SHIFT) => {
-                            Self::get_clipboard_text()
-                                .ok()
-                                .map(AppEvent::NewSessionSshPasteText)
-                        }
-                        KeyCode::Backspace => Some(AppEvent::NewSessionSshBackspace),
-                        KeyCode::Char(ch) => Some(AppEvent::NewSessionSshInputChar(ch)),
-                        _ => None,
                     }
-                }
+                    KeyCode::BackTab => Some(AppEvent::NewSessionSshPrevField),
+                    KeyCode::Enter => Some(AppEvent::NewSessionSshConfirm),
+                    KeyCode::Char('v') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                        Self::get_clipboard_text().ok().map(AppEvent::NewSessionSshPasteText)
+                    }
+                    KeyCode::Insert if key_event.modifiers.contains(KeyModifiers::SHIFT) => {
+                        Self::get_clipboard_text().ok().map(AppEvent::NewSessionSshPasteText)
+                    }
+                    KeyCode::Backspace => Some(AppEvent::NewSessionSshBackspace),
+                    KeyCode::Char(ch) => Some(AppEvent::NewSessionSshInputChar(ch)),
+                    _ => None,
+                },
                 NewSessionStep::InputBranch => {
                     // Check if model selection is available (Claude selected)
                     let show_model = session_state.should_show_model_selection();
@@ -958,7 +964,9 @@ impl EventHandler {
                             // Check if selected agent is available
                             if !agent_available {
                                 // Agent not available yet (Coming Soon)
-                                Some(AppEvent::ShowNotification("This agent is coming soon!".to_string()))
+                                Some(AppEvent::ShowNotification(
+                                    "This agent is coming soon!".to_string(),
+                                ))
                             } else if selected_agent == crate::models::SessionAgentType::Shell {
                                 // Shell selected - open shell directly
                                 Some(AppEvent::NewSessionOpenShell)
@@ -981,19 +989,15 @@ impl EventHandler {
                         // Left/Right for model selection (only when Claude is selected)
                         KeyCode::Left if show_model => Some(AppEvent::NewSessionModelPrev),
                         KeyCode::Right if show_model => Some(AppEvent::NewSessionModelNext),
-                        KeyCode::Char('v') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                            Self::get_clipboard_text()
-                                .ok()
-                                .map(AppEvent::NewSessionInputPasteText)
+                        KeyCode::Char('v')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            Self::get_clipboard_text().ok().map(AppEvent::NewSessionInputPasteText)
                         }
                         KeyCode::Insert if key_event.modifiers.contains(KeyModifiers::SHIFT) => {
-                            Self::get_clipboard_text()
-                                .ok()
-                                .map(AppEvent::NewSessionInputPasteText)
+                            Self::get_clipboard_text().ok().map(AppEvent::NewSessionInputPasteText)
                         }
-                        KeyCode::Backspace
-                            if key_event.modifiers.contains(KeyModifiers::SHIFT) =>
-                        {
+                        KeyCode::Backspace if key_event.modifiers.contains(KeyModifiers::SHIFT) => {
                             Some(AppEvent::NewSessionBackspaceWord)
                         }
                         KeyCode::Backspace => Some(AppEvent::NewSessionBackspace),
@@ -1347,43 +1351,39 @@ impl EventHandler {
                             Some(AppEvent::OnboardingBack)
                         }
                         KeyCode::Char('r') => Some(AppEvent::OnboardingCheckDeps), // Re-check
-                        KeyCode::Char('i') | KeyCode::Char('I') => Some(AppEvent::OnboardingInstallConfig), // Install config
+                        KeyCode::Char('i') | KeyCode::Char('I') => {
+                            Some(AppEvent::OnboardingInstallConfig)
+                        } // Install config
                         _ => None,
                     }
                 }
-                OnboardingStep::Authentication => {
-                    match key_event.code {
-                        KeyCode::Enter => Some(AppEvent::OnboardingNext),
-                        KeyCode::Esc => Some(AppEvent::OnboardingCancel),
-                        KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
-                            Some(AppEvent::OnboardingBack)
-                        }
-                        KeyCode::Char('s') | KeyCode::Char('S') => Some(AppEvent::OnboardingSkipAuth),
-                        _ => None,
+                OnboardingStep::Authentication => match key_event.code {
+                    KeyCode::Enter => Some(AppEvent::OnboardingNext),
+                    KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                    KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
+                        Some(AppEvent::OnboardingBack)
                     }
-                }
-                OnboardingStep::EditorSelection => {
-                    match key_event.code {
-                        KeyCode::Enter => Some(AppEvent::OnboardingNext),
-                        KeyCode::Esc => Some(AppEvent::OnboardingCancel),
-                        KeyCode::Left | KeyCode::Backspace => Some(AppEvent::OnboardingBack),
-                        KeyCode::Up => Some(AppEvent::OnboardingEditorUp),
-                        KeyCode::Down => Some(AppEvent::OnboardingEditorDown),
-                        KeyCode::Char('k') => Some(AppEvent::OnboardingEditorUp),
-                        KeyCode::Char('j') => Some(AppEvent::OnboardingEditorDown),
-                        _ => None,
+                    KeyCode::Char('s') | KeyCode::Char('S') => Some(AppEvent::OnboardingSkipAuth),
+                    _ => None,
+                },
+                OnboardingStep::EditorSelection => match key_event.code {
+                    KeyCode::Enter => Some(AppEvent::OnboardingNext),
+                    KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                    KeyCode::Left | KeyCode::Backspace => Some(AppEvent::OnboardingBack),
+                    KeyCode::Up => Some(AppEvent::OnboardingEditorUp),
+                    KeyCode::Down => Some(AppEvent::OnboardingEditorDown),
+                    KeyCode::Char('k') => Some(AppEvent::OnboardingEditorUp),
+                    KeyCode::Char('j') => Some(AppEvent::OnboardingEditorDown),
+                    _ => None,
+                },
+                OnboardingStep::Summary => match key_event.code {
+                    KeyCode::Enter => Some(AppEvent::OnboardingFinish),
+                    KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                    KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
+                        Some(AppEvent::OnboardingBack)
                     }
-                }
-                OnboardingStep::Summary => {
-                    match key_event.code {
-                        KeyCode::Enter => Some(AppEvent::OnboardingFinish),
-                        KeyCode::Esc => Some(AppEvent::OnboardingCancel),
-                        KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
-                            Some(AppEvent::OnboardingBack)
-                        }
-                        _ => None,
-                    }
-                }
+                    _ => None,
+                },
                 _ => {
                     // Welcome and other steps - basic navigation
                     match key_event.code {
@@ -1406,10 +1406,10 @@ impl EventHandler {
         if state.setup_menu_state.showing_confirmation {
             match key_event.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
-                    Some(AppEvent::SetupMenuSelect)  // Confirm
+                    Some(AppEvent::SetupMenuSelect) // Confirm
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                    Some(AppEvent::SetupMenuBack)  // Cancel
+                    Some(AppEvent::SetupMenuBack) // Cancel
                 }
                 _ => None,
             }
@@ -1553,7 +1553,9 @@ impl EventHandler {
             KeyCode::Char('f') => return Some(AppEvent::LogHistoryCycleFilter),
             KeyCode::Char('r') => return Some(AppEvent::LogHistoryRefresh),
             KeyCode::Char('y') => return Some(AppEvent::LogHistoryCopySelection),
-            KeyCode::Char('c') if key_event.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => {
+            KeyCode::Char('c')
+                if key_event.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+            {
                 return Some(AppEvent::LogHistoryCopySelection);
             }
             KeyCode::Char('c') | KeyCode::Char('C') => return Some(AppEvent::LogHistoryCleanup),
@@ -1564,31 +1566,37 @@ impl EventHandler {
 
         // Focus-specific navigation
         match state.log_history_state.focus {
-            LogViewerFocus::SessionList => {
-                match key_event.code {
-                    KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::LogHistoryPrevSession),
-                    KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::LogHistoryNextSession),
-                    KeyCode::Enter => Some(AppEvent::LogHistorySelectSession),
-                    _ => None,
-                }
-            }
-            LogViewerFocus::LogEntries => {
-                match key_event.code {
-                    KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::LogHistoryScrollUp),
-                    KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::LogHistoryScrollDown),
-                    KeyCode::PageUp => Some(AppEvent::LogHistoryPageUp),
-                    KeyCode::PageDown => Some(AppEvent::LogHistoryPageDown),
-                    KeyCode::Left | KeyCode::Char('h') => Some(AppEvent::LogHistoryScrollLeft),
-                    KeyCode::Right | KeyCode::Char('l') => Some(AppEvent::LogHistoryScrollRight),
-                    _ => None,
-                }
-            }
+            LogViewerFocus::SessionList => match key_event.code {
+                KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::LogHistoryPrevSession),
+                KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::LogHistoryNextSession),
+                KeyCode::Enter => Some(AppEvent::LogHistorySelectSession),
+                _ => None,
+            },
+            LogViewerFocus::LogEntries => match key_event.code {
+                KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::LogHistoryScrollUp),
+                KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::LogHistoryScrollDown),
+                KeyCode::PageUp => Some(AppEvent::LogHistoryPageUp),
+                KeyCode::PageDown => Some(AppEvent::LogHistoryPageDown),
+                KeyCode::Left | KeyCode::Char('h') => Some(AppEvent::LogHistoryScrollLeft),
+                KeyCode::Right | KeyCode::Char('l') => Some(AppEvent::LogHistoryScrollRight),
+                _ => None,
+            },
         }
     }
 
     // Usage analytics key handling
-    fn handle_usage_keys(key_event: KeyEvent, _state: &AppState) -> Option<AppEvent> {
+    fn handle_usage_keys(key_event: KeyEvent, state: &AppState) -> Option<AppEvent> {
         tracing::debug!("Usage key handler: {:?}", key_event.code);
+
+        if state.usage_state.input_mode.is_some() {
+            return match key_event.code {
+                KeyCode::Esc => Some(AppEvent::UsageInputCancel),
+                KeyCode::Enter => Some(AppEvent::UsageInputSubmit),
+                KeyCode::Backspace => Some(AppEvent::UsageInputBackspace),
+                KeyCode::Char(ch) => Some(AppEvent::UsageInputChar(ch)),
+                _ => None,
+            };
+        }
 
         match key_event.code {
             KeyCode::Esc => Some(AppEvent::UsageBack),
@@ -1603,6 +1611,16 @@ impl EventHandler {
             KeyCode::Char('g') => Some(AppEvent::UsageToTop),
             KeyCode::Char('G') => Some(AppEvent::UsageToBottom),
             KeyCode::Char('r') => Some(AppEvent::UsageRefresh),
+            KeyCode::Char('p') => Some(AppEvent::UsageCycleProviderFilter),
+            KeyCode::Char('1') => Some(AppEvent::UsageSetPeriod(1)),
+            KeyCode::Char('2') => Some(AppEvent::UsageSetPeriod(2)),
+            KeyCode::Char('3') => Some(AppEvent::UsageSetPeriod(3)),
+            KeyCode::Char('4') => Some(AppEvent::UsageSetPeriod(4)),
+            KeyCode::Char('5') => Some(AppEvent::UsageSetPeriod(5)),
+            KeyCode::Char('/') => Some(AppEvent::UsageStartIncludeFilter),
+            KeyCode::Char('x') => Some(AppEvent::UsageStartExcludeFilter),
+            KeyCode::Char('d') => Some(AppEvent::UsageStartDateRange),
+            KeyCode::Char('c') => Some(AppEvent::UsageClearFilters),
             _ => None,
         }
     }
@@ -1712,24 +1730,20 @@ impl EventHandler {
         // Focus-specific navigation
         let focus = &state.home_screen_v2_state.focus;
         let event = match focus {
-            HomeScreenFocus::Sidebar => {
-                match key_event.code {
-                    KeyCode::Up => Some(AppEvent::HomeScreenSidebarUp),
-                    KeyCode::Down => Some(AppEvent::HomeScreenSidebarDown),
-                    KeyCode::Enter => Some(AppEvent::HomeScreenSidebarSelect),
-                    _ => None,
-                }
-            }
-            HomeScreenFocus::ContentPanel => {
-                match key_event.code {
-                    KeyCode::Up => Some(AppEvent::WelcomePanelScrollUp),
-                    KeyCode::Down => Some(AppEvent::WelcomePanelScrollDown),
-                    KeyCode::PageUp => Some(AppEvent::WelcomePanelPageUp),
-                    KeyCode::PageDown => Some(AppEvent::WelcomePanelPageDown),
-                    KeyCode::Char('y') => Some(AppEvent::WelcomePanelCopyContent),
-                    _ => None,
-                }
-            }
+            HomeScreenFocus::Sidebar => match key_event.code {
+                KeyCode::Up => Some(AppEvent::HomeScreenSidebarUp),
+                KeyCode::Down => Some(AppEvent::HomeScreenSidebarDown),
+                KeyCode::Enter => Some(AppEvent::HomeScreenSidebarSelect),
+                _ => None,
+            },
+            HomeScreenFocus::ContentPanel => match key_event.code {
+                KeyCode::Up => Some(AppEvent::WelcomePanelScrollUp),
+                KeyCode::Down => Some(AppEvent::WelcomePanelScrollDown),
+                KeyCode::PageUp => Some(AppEvent::WelcomePanelPageUp),
+                KeyCode::PageDown => Some(AppEvent::WelcomePanelPageDown),
+                KeyCode::Char('y') => Some(AppEvent::WelcomePanelCopyContent),
+                _ => None,
+            },
         };
 
         tracing::debug!("HomeScreen V2 key handler returning: {:?}", event);
@@ -1797,8 +1811,8 @@ impl EventHandler {
             }
         } else {
             // Navigation mode - check if we're on auth settings
-            let is_auth_category = config_state.selected_category == 0;  // Authentication category
-            let on_claude_auth = is_auth_category && config_state.selected_setting == 0;  // Claude Authentication
+            let is_auth_category = config_state.selected_category == 0; // Authentication category
+            let on_claude_auth = is_auth_category && config_state.selected_setting == 0; // Claude Authentication
 
             match key_event.code {
                 KeyCode::Esc => Some(AppEvent::ConfigBack),
@@ -1907,10 +1921,22 @@ impl EventHandler {
                 // Mark for async processing to reload workspace data
                 state.pending_async_action = Some(AsyncAction::RefreshWorkspaces);
             }
-            AppEvent::NextSession => { state.next_session(); state.last_preview_update = None; },
-            AppEvent::PreviousSession => { state.previous_session(); state.last_preview_update = None; },
-            AppEvent::NextWorkspace => { state.next_workspace(); state.last_preview_update = None; },
-            AppEvent::PreviousWorkspace => { state.previous_workspace(); state.last_preview_update = None; },
+            AppEvent::NextSession => {
+                state.next_session();
+                state.last_preview_update = None;
+            }
+            AppEvent::PreviousSession => {
+                state.previous_session();
+                state.last_preview_update = None;
+            }
+            AppEvent::NextWorkspace => {
+                state.next_workspace();
+                state.last_preview_update = None;
+            }
+            AppEvent::PreviousWorkspace => {
+                state.previous_workspace();
+                state.last_preview_update = None;
+            }
             AppEvent::GoToTop => {
                 if state.selected_workspace_index.is_some() {
                     state.selected_session_index = Some(0);
@@ -2117,16 +2143,15 @@ impl EventHandler {
                             tracing::info!("Opening shell in workspace: {:?}", repo_path);
 
                             // Find the workspace index for this repo
-                            let workspace_idx = state.workspaces.iter()
-                                .position(|w| w.path == repo_path);
+                            let workspace_idx =
+                                state.workspaces.iter().position(|w| w.path == repo_path);
 
                             if let Some(idx) = workspace_idx {
-                                state.pending_async_action = Some(
-                                    AsyncAction::OpenWorkspaceShell {
+                                state.pending_async_action =
+                                    Some(AsyncAction::OpenWorkspaceShell {
                                         workspace_index: idx,
                                         target_dir: None, // Open in workspace root
-                                    }
-                                );
+                                    });
                             } else {
                                 state.add_warning_notification("Workspace not found".to_string());
                             }
@@ -2237,10 +2262,13 @@ impl EventHandler {
                         if let Some(tmux_name) = &ssh_session.tmux_session_name {
                             let session_name = tmux_name.clone();
                             tracing::info!("[ACTION] Attaching to SSH session: {}", session_name);
-                            state.pending_async_action = Some(AsyncAction::AttachToOtherTmux(session_name));
+                            state.pending_async_action =
+                                Some(AsyncAction::AttachToOtherTmux(session_name));
                         } else {
                             tracing::warn!("[ACTION] SSH session has no tmux session name");
-                            state.add_error_notification("SSH session has no tmux session".to_string());
+                            state.add_error_notification(
+                                "SSH session has no tmux session".to_string(),
+                            );
                         }
                     } else {
                         tracing::warn!("[ACTION] SSH session selected but no session found");
@@ -2249,8 +2277,12 @@ impl EventHandler {
                 } else if state.is_other_tmux_selected() {
                     if let Some(other_session) = state.selected_other_tmux_session() {
                         let session_name = other_session.name.clone();
-                        tracing::info!("[ACTION] Attaching to other tmux session: {}", session_name);
-                        state.pending_async_action = Some(AsyncAction::AttachToOtherTmux(session_name));
+                        tracing::info!(
+                            "[ACTION] Attaching to other tmux session: {}",
+                            session_name
+                        );
+                        state.pending_async_action =
+                            Some(AsyncAction::AttachToOtherTmux(session_name));
                     } else {
                         tracing::warn!("[ACTION] Other tmux selected but no session found");
                     }
@@ -2260,10 +2292,16 @@ impl EventHandler {
                         if let Some(workspace) = state.workspaces.get(workspace_idx) {
                             if let Some(shell) = &workspace.shell_session {
                                 let session_name = shell.tmux_session_name.clone();
-                                tracing::info!("[ACTION] Attaching to workspace shell: {}", session_name);
-                                state.pending_async_action = Some(AsyncAction::AttachToOtherTmux(session_name));
+                                tracing::info!(
+                                    "[ACTION] Attaching to workspace shell: {}",
+                                    session_name
+                                );
+                                state.pending_async_action =
+                                    Some(AsyncAction::AttachToOtherTmux(session_name));
                             } else {
-                                tracing::warn!("[ACTION] Shell selected but no shell session found in workspace");
+                                tracing::warn!(
+                                    "[ACTION] Shell selected but no shell session found in workspace"
+                                );
                                 state.add_error_notification("No shell session found".to_string());
                             }
                         }
@@ -2281,8 +2319,11 @@ impl EventHandler {
                     }
                     state.pending_async_action = Some(AsyncAction::AttachToTmuxSession(session_id));
                 } else {
-                    tracing::warn!("[ACTION] AttachTmuxSession: No session selected (workspace_idx={:?}, session_idx={:?})",
-                        state.selected_workspace_index, state.selected_session_index);
+                    tracing::warn!(
+                        "[ACTION] AttachTmuxSession: No session selected (workspace_idx={:?}, session_idx={:?})",
+                        state.selected_workspace_index,
+                        state.selected_session_index
+                    );
                     state.add_error_notification("No session selected to attach".to_string());
                 }
             }
@@ -2347,27 +2388,46 @@ impl EventHandler {
                     if let Some(ssh_session) = state.selected_ssh_session() {
                         // SSH sessions are tmux sessions - use the tmux session name for kill
                         if let Some(tmux_name) = ssh_session.tmux_session_name.clone() {
-                            tracing::info!("[ACTION] Showing kill confirmation for SSH session: {}", tmux_name);
+                            tracing::info!(
+                                "[ACTION] Showing kill confirmation for SSH session: {}",
+                                tmux_name
+                            );
                             state.show_kill_ssh_session_confirmation(tmux_name);
                         } else {
                             tracing::warn!("[ACTION] SSH session has no tmux_session_name");
-                            state.add_warning_notification("Cannot delete SSH session: no tmux session name".to_string());
+                            state.add_warning_notification(
+                                "Cannot delete SSH session: no tmux session name".to_string(),
+                            );
                         }
                     } else {
-                        tracing::warn!("[ACTION] SSH session selected but no session found at index {:?}", state.selected_ssh_session_index);
+                        tracing::warn!(
+                            "[ACTION] SSH session selected but no session found at index {:?}",
+                            state.selected_ssh_session_index
+                        );
                     }
                 // Check if we're in the "Other tmux" section
                 } else if state.is_other_tmux_selected() {
                     if let Some(other_session) = state.selected_other_tmux_session() {
-                        tracing::info!("[ACTION] Showing kill confirmation for other tmux session: {}", other_session.name);
+                        tracing::info!(
+                            "[ACTION] Showing kill confirmation for other tmux session: {}",
+                            other_session.name
+                        );
                         state.show_kill_other_tmux_confirmation(other_session.name.clone());
                     } else {
-                        tracing::warn!("[ACTION] Other tmux selected but no session found at index {:?}", state.selected_other_tmux_index);
+                        tracing::warn!(
+                            "[ACTION] Other tmux selected but no session found at index {:?}",
+                            state.selected_other_tmux_index
+                        );
                     }
                 } else if state.shell_selected {
                     // Shell session selected - show kill shell confirmation
                     if let Some(workspace_idx) = state.selected_workspace_index {
-                        if state.workspaces.get(workspace_idx).and_then(|w| w.shell_session.as_ref()).is_some() {
+                        if state
+                            .workspaces
+                            .get(workspace_idx)
+                            .and_then(|w| w.shell_session.as_ref())
+                            .is_some()
+                        {
                             state.show_kill_shell_confirmation(workspace_idx);
                         }
                     }
@@ -2389,16 +2449,24 @@ impl EventHandler {
                 state.toggle_select_session();
                 let count = state.selected_sessions.len();
                 if count > 0 {
-                    state.add_success_notification(format!("{} session(s) selected — Shift+D to delete", count));
+                    state.add_success_notification(format!(
+                        "{} session(s) selected — Shift+D to delete",
+                        count
+                    ));
                 }
             }
             AppEvent::DeleteSelectedSessions => {
                 let count = state.selected_sessions.len();
                 if count == 0 {
-                    state.add_warning_notification("No sessions selected. Use Space to select sessions first.".to_string());
+                    state.add_warning_notification(
+                        "No sessions selected. Use Space to select sessions first.".to_string(),
+                    );
                 } else {
                     let ids: Vec<uuid::Uuid> = state.selected_sessions.iter().copied().collect();
-                    state.add_success_notification(format!("Deleting {} selected session(s)...", count));
+                    state.add_success_notification(format!(
+                        "Deleting {} selected session(s)...",
+                        count
+                    ));
                     state.pending_async_action = Some(AsyncAction::BulkDeleteSessions(ids));
                     state.selected_sessions.clear();
                 }
@@ -2679,7 +2747,9 @@ impl EventHandler {
                 if let Some(ref mut git_state) = state.git_view_state {
                     match git_state.active_tab {
                         crate::components::git_view::GitTab::Diff => git_state.scroll_diff_up(),
-                        crate::components::git_view::GitTab::Markdown => git_state.scroll_markdown_up(),
+                        crate::components::git_view::GitTab::Markdown => {
+                            git_state.scroll_markdown_up()
+                        }
                         _ => {}
                     }
                 }
@@ -2688,7 +2758,9 @@ impl EventHandler {
                 if let Some(ref mut git_state) = state.git_view_state {
                     match git_state.active_tab {
                         crate::components::git_view::GitTab::Diff => git_state.scroll_diff_down(),
-                        crate::components::git_view::GitTab::Markdown => git_state.scroll_markdown_down(),
+                        crate::components::git_view::GitTab::Markdown => {
+                            git_state.scroll_markdown_down()
+                        }
                         _ => {}
                     }
                 }
@@ -2713,7 +2785,10 @@ impl EventHandler {
                     if let Some(commit) = git_state.commits.get(git_state.selected_commit_index) {
                         let commit_hash = commit.hash_short.clone();
                         // Load the commit diff
-                        match crate::git::operations::get_commit_diff(&git_state.worktree_path, &commit_hash) {
+                        match crate::git::operations::get_commit_diff(
+                            &git_state.worktree_path,
+                            &commit_hash,
+                        ) {
                             Ok(diff_lines) => {
                                 git_state.diff_content = diff_lines;
                                 git_state.diff_scroll_offset = 0;
@@ -2722,7 +2797,10 @@ impl EventHandler {
                             }
                             Err(e) => {
                                 tracing::error!("Failed to get commit diff: {}", e);
-                                state.add_error_notification(format!("Failed to load commit diff: {}", e));
+                                state.add_error_notification(format!(
+                                    "Failed to load commit diff: {}",
+                                    e
+                                ));
                             }
                         }
                     }
@@ -2748,7 +2826,8 @@ impl EventHandler {
             }
             AppEvent::GitViewBack => {
                 // Return to the previous view (where user was before opening Git view)
-                state.current_view = state.previous_view.take().unwrap_or(crate::app::state::View::SessionList);
+                state.current_view =
+                    state.previous_view.take().unwrap_or(crate::app::state::View::SessionList);
                 state.git_view_state = None;
             }
             // Commit message input events
@@ -2958,54 +3037,46 @@ impl EventHandler {
 
                         // Try to get the remote URL from the git repository
                         // This allows favoriting the REMOTE repo, not just the local path
-                        let (source, source_type, display_source) =
-                            if let Ok(git_repo) = crate::git::RepositoryManager::open(&workspace.path) {
-                                if let Ok(Some(remote_url)) = git_repo.get_remote_url() {
-                                    // Parse the remote URL to get owner/repo
-                                    if let Ok(repo_source) =
-                                        crate::git::RepoSource::from_input(&remote_url)
-                                    {
-                                        if let Ok(parsed) = repo_source.parse_components() {
-                                            // Use GitHub shorthand if it's a GitHub repo
-                                            if parsed.host == "github.com" {
-                                                let shorthand =
-                                                    format!("{}/{}", parsed.owner, parsed.repo_name);
-                                                (
-                                                    shorthand.clone(),
-                                                    crate::config::FavoriteSourceType::GithubShorthand,
-                                                    shorthand,
-                                                )
-                                            } else {
-                                                // For other hosts, use the full URL
-                                                let source_type = if remote_url.starts_with("git@") {
-                                                    crate::config::FavoriteSourceType::SshUrl
-                                                } else {
-                                                    crate::config::FavoriteSourceType::HttpsUrl
-                                                };
-                                                let display =
-                                                    format!("{}/{}", parsed.owner, parsed.repo_name);
-                                                (remote_url, source_type, display)
-                                            }
+                        let (source, source_type, display_source) = if let Ok(git_repo) =
+                            crate::git::RepositoryManager::open(&workspace.path)
+                        {
+                            if let Ok(Some(remote_url)) = git_repo.get_remote_url() {
+                                // Parse the remote URL to get owner/repo
+                                if let Ok(repo_source) =
+                                    crate::git::RepoSource::from_input(&remote_url)
+                                {
+                                    if let Ok(parsed) = repo_source.parse_components() {
+                                        // Use GitHub shorthand if it's a GitHub repo
+                                        if parsed.host == "github.com" {
+                                            let shorthand =
+                                                format!("{}/{}", parsed.owner, parsed.repo_name);
+                                            (
+                                                shorthand.clone(),
+                                                crate::config::FavoriteSourceType::GithubShorthand,
+                                                shorthand,
+                                            )
                                         } else {
-                                            // Couldn't parse, use raw URL
+                                            // For other hosts, use the full URL
                                             let source_type = if remote_url.starts_with("git@") {
                                                 crate::config::FavoriteSourceType::SshUrl
                                             } else {
                                                 crate::config::FavoriteSourceType::HttpsUrl
                                             };
-                                            (remote_url.clone(), source_type, remote_url)
+                                            let display =
+                                                format!("{}/{}", parsed.owner, parsed.repo_name);
+                                            (remote_url, source_type, display)
                                         }
                                     } else {
-                                        // Fallback to local path
-                                        let path_str = workspace.path.display().to_string();
-                                        (
-                                            path_str.clone(),
-                                            crate::config::FavoriteSourceType::LocalPath,
-                                            path_str,
-                                        )
+                                        // Couldn't parse, use raw URL
+                                        let source_type = if remote_url.starts_with("git@") {
+                                            crate::config::FavoriteSourceType::SshUrl
+                                        } else {
+                                            crate::config::FavoriteSourceType::HttpsUrl
+                                        };
+                                        (remote_url.clone(), source_type, remote_url)
                                     }
                                 } else {
-                                    // No remote, use local path
+                                    // Fallback to local path
                                     let path_str = workspace.path.display().to_string();
                                     (
                                         path_str.clone(),
@@ -3014,14 +3085,23 @@ impl EventHandler {
                                     )
                                 }
                             } else {
-                                // Not a git repo, use local path
+                                // No remote, use local path
                                 let path_str = workspace.path.display().to_string();
                                 (
                                     path_str.clone(),
                                     crate::config::FavoriteSourceType::LocalPath,
                                     path_str,
                                 )
-                            };
+                            }
+                        } else {
+                            // Not a git repo, use local path
+                            let path_str = workspace.path.display().to_string();
+                            (
+                                path_str.clone(),
+                                crate::config::FavoriteSourceType::LocalPath,
+                                path_str,
+                            )
+                        };
 
                         // Toggle: remove if exists, add if not
                         // Check both source and local path for existing favorites
@@ -3168,8 +3248,16 @@ impl EventHandler {
                     // Store selected agent and proceed to session creation
                     state.add_success_notification(format!(
                         "Selected: {} - {}",
-                        state.agent_selection_state.current_provider().map(|p| p.name.as_str()).unwrap_or("Unknown"),
-                        state.agent_selection_state.current_model().map(|m| m.name.as_str()).unwrap_or("Unknown")
+                        state
+                            .agent_selection_state
+                            .current_provider()
+                            .map(|p| p.name.as_str())
+                            .unwrap_or("Unknown"),
+                        state
+                            .agent_selection_state
+                            .current_model()
+                            .map(|m| m.name.as_str())
+                            .unwrap_or("Unknown")
                     ));
                     // Go to session list or new session
                     state.current_view = View::SessionList;
@@ -3193,15 +3281,17 @@ impl EventHandler {
             AppEvent::ConfigPrevCategory => {
                 let num_categories = state.config_screen_state.categories.len();
                 if num_categories > 0 {
-                    state.config_screen_state.selected_category =
-                        state.config_screen_state.selected_category
-                            .checked_sub(1)
-                            .unwrap_or(num_categories - 1);
+                    state.config_screen_state.selected_category = state
+                        .config_screen_state
+                        .selected_category
+                        .checked_sub(1)
+                        .unwrap_or(num_categories - 1);
                     state.config_screen_state.selected_setting = 0;
                 }
             }
             AppEvent::ConfigNextSetting => {
-                let current_category = &state.config_screen_state.categories[state.config_screen_state.selected_category];
+                let current_category = &state.config_screen_state.categories
+                    [state.config_screen_state.selected_category];
                 if let Some(settings) = state.config_screen_state.settings.get(current_category) {
                     if !settings.is_empty() {
                         state.config_screen_state.selected_setting =
@@ -3210,23 +3300,29 @@ impl EventHandler {
                 }
             }
             AppEvent::ConfigPrevSetting => {
-                let current_category = &state.config_screen_state.categories[state.config_screen_state.selected_category];
+                let current_category = &state.config_screen_state.categories
+                    [state.config_screen_state.selected_category];
                 if let Some(settings) = state.config_screen_state.settings.get(current_category) {
                     if !settings.is_empty() {
-                        state.config_screen_state.selected_setting =
-                            state.config_screen_state.selected_setting
-                                .checked_sub(1)
-                                .unwrap_or(settings.len() - 1);
+                        state.config_screen_state.selected_setting = state
+                            .config_screen_state
+                            .selected_setting
+                            .checked_sub(1)
+                            .unwrap_or(settings.len() - 1);
                     }
                 }
             }
             AppEvent::ConfigSwitchPane => {
                 // Toggle focus between categories and settings panes
-                state.config_screen_state.focused_pane = match state.config_screen_state.focused_pane {
-                    ConfigPane::Categories => ConfigPane::Settings,
-                    ConfigPane::Settings => ConfigPane::Categories,
-                };
-                tracing::debug!("Config switch pane - focus is now on {:?}", state.config_screen_state.focused_pane);
+                state.config_screen_state.focused_pane =
+                    match state.config_screen_state.focused_pane {
+                        ConfigPane::Categories => ConfigPane::Settings,
+                        ConfigPane::Settings => ConfigPane::Categories,
+                    };
+                tracing::debug!(
+                    "Config switch pane - focus is now on {:?}",
+                    state.config_screen_state.focused_pane
+                );
             }
             AppEvent::ConfigNavigateUp => {
                 // Navigate up within the currently focused pane
@@ -3235,22 +3331,27 @@ impl EventHandler {
                         // Navigate to previous category
                         let num_categories = state.config_screen_state.categories.len();
                         if num_categories > 0 {
-                            state.config_screen_state.selected_category =
-                                state.config_screen_state.selected_category
-                                    .checked_sub(1)
-                                    .unwrap_or(num_categories - 1);
+                            state.config_screen_state.selected_category = state
+                                .config_screen_state
+                                .selected_category
+                                .checked_sub(1)
+                                .unwrap_or(num_categories - 1);
                             state.config_screen_state.selected_setting = 0;
                         }
                     }
                     ConfigPane::Settings => {
                         // Navigate to previous setting
-                        let current_category = &state.config_screen_state.categories[state.config_screen_state.selected_category];
-                        if let Some(settings) = state.config_screen_state.settings.get(current_category) {
+                        let current_category = &state.config_screen_state.categories
+                            [state.config_screen_state.selected_category];
+                        if let Some(settings) =
+                            state.config_screen_state.settings.get(current_category)
+                        {
                             if !settings.is_empty() {
-                                state.config_screen_state.selected_setting =
-                                    state.config_screen_state.selected_setting
-                                        .checked_sub(1)
-                                        .unwrap_or(settings.len() - 1);
+                                state.config_screen_state.selected_setting = state
+                                    .config_screen_state
+                                    .selected_setting
+                                    .checked_sub(1)
+                                    .unwrap_or(settings.len() - 1);
                             }
                         }
                     }
@@ -3270,11 +3371,15 @@ impl EventHandler {
                     }
                     ConfigPane::Settings => {
                         // Navigate to next setting
-                        let current_category = &state.config_screen_state.categories[state.config_screen_state.selected_category];
-                        if let Some(settings) = state.config_screen_state.settings.get(current_category) {
+                        let current_category = &state.config_screen_state.categories
+                            [state.config_screen_state.selected_category];
+                        if let Some(settings) =
+                            state.config_screen_state.settings.get(current_category)
+                        {
                             if !settings.is_empty() {
                                 state.config_screen_state.selected_setting =
-                                    (state.config_screen_state.selected_setting + 1) % settings.len();
+                                    (state.config_screen_state.selected_setting + 1)
+                                        % settings.len();
                             }
                         }
                     }
@@ -3289,9 +3394,11 @@ impl EventHandler {
                 tracing::debug!("Config focus switched to Settings pane");
             }
             AppEvent::ConfigEditSetting => {
-                let current_category = state.config_screen_state.categories[state.config_screen_state.selected_category];
+                let current_category = state.config_screen_state.categories
+                    [state.config_screen_state.selected_category];
                 if let Some(settings) = state.config_screen_state.settings.get(&current_category) {
-                    if let Some(setting) = settings.get(state.config_screen_state.selected_setting) {
+                    if let Some(setting) = settings.get(state.config_screen_state.selected_setting)
+                    {
                         // Open popup based on setting type
                         let title = setting.label.clone();
                         let description = setting.description.clone();
@@ -3317,12 +3424,7 @@ impl EventHandler {
                             }
                             crate::app::state::ConfigValue::Secret(_) => {
                                 // For secrets, show empty input (don't reveal existing value)
-                                state.config_popup_state.open_text(
-                                    &title,
-                                    &description,
-                                    &key,
-                                    "",
-                                );
+                                state.config_popup_state.open_text(&title, &description, &key, "");
                             }
                             crate::app::state::ConfigValue::Bool(value) => {
                                 state.config_popup_state.open_boolean(
@@ -3346,23 +3448,44 @@ impl EventHandler {
                 }
             }
             AppEvent::ConfigSaveEdit => {
-                let current_category = state.config_screen_state.categories[state.config_screen_state.selected_category];
-                if let Some(settings) = state.config_screen_state.settings.get_mut(&current_category) {
-                    if let Some(setting) = settings.get_mut(state.config_screen_state.selected_setting) {
+                let current_category = state.config_screen_state.categories
+                    [state.config_screen_state.selected_category];
+                if let Some(settings) =
+                    state.config_screen_state.settings.get_mut(&current_category)
+                {
+                    if let Some(setting) =
+                        settings.get_mut(state.config_screen_state.selected_setting)
+                    {
                         let new_value = state.config_screen_state.edit_buffer.clone();
                         // Update the value based on the type
                         setting.value = match &setting.value {
-                            crate::app::state::ConfigValue::Text(_) => crate::app::state::ConfigValue::Text(new_value),
-                            crate::app::state::ConfigValue::Secret(_) => crate::app::state::ConfigValue::Secret(new_value),
-                            crate::app::state::ConfigValue::Bool(_) => crate::app::state::ConfigValue::Bool(new_value.to_lowercase() == "true"),
-                            crate::app::state::ConfigValue::Number(_) => crate::app::state::ConfigValue::Number(new_value.parse().unwrap_or(0)),
+                            crate::app::state::ConfigValue::Text(_) => {
+                                crate::app::state::ConfigValue::Text(new_value)
+                            }
+                            crate::app::state::ConfigValue::Secret(_) => {
+                                crate::app::state::ConfigValue::Secret(new_value)
+                            }
+                            crate::app::state::ConfigValue::Bool(_) => {
+                                crate::app::state::ConfigValue::Bool(
+                                    new_value.to_lowercase() == "true",
+                                )
+                            }
+                            crate::app::state::ConfigValue::Number(_) => {
+                                crate::app::state::ConfigValue::Number(
+                                    new_value.parse().unwrap_or(0),
+                                )
+                            }
                             crate::app::state::ConfigValue::Choice(options, _) => {
                                 // Try to find the index of the entered value
                                 let idx = options.iter().position(|o| o == &new_value).unwrap_or(0);
                                 crate::app::state::ConfigValue::Choice(options.clone(), idx)
                             }
                         };
-                        tracing::info!("Saved setting: {} = {}", setting.label, setting.value.display());
+                        tracing::info!(
+                            "Saved setting: {} = {}",
+                            setting.label,
+                            setting.value.display()
+                        );
                     }
                 }
                 state.config_screen_state.editing = false;
@@ -3402,7 +3525,9 @@ impl EventHandler {
                 tracing::info!("Starting API key input mode");
                 state.config_screen_state.api_key_input_mode = true;
                 state.config_screen_state.edit_buffer.clear();
-                state.add_info_notification("Enter your Anthropic API key (starts with sk-ant-)".to_string());
+                state.add_info_notification(
+                    "Enter your Anthropic API key (starts with sk-ant-)".to_string(),
+                );
             }
             AppEvent::ConfigApiKeySave => {
                 let api_key = state.config_screen_state.edit_buffer.clone();
@@ -3410,15 +3535,21 @@ impl EventHandler {
 
                 match credentials::store_anthropic_api_key(&api_key) {
                     Ok(()) => {
-                        state.add_success_notification("API key saved to system keychain".to_string());
+                        state.add_success_notification(
+                            "API key saved to system keychain".to_string(),
+                        );
                         tracing::info!("API key successfully stored in keychain");
 
                         // Update auth status to show API key configured
                         let masked = credentials::get_anthropic_api_key_masked();
                         let status = format!("API Key ({})", masked);
                         let auth_category = crate::app::state::ConfigCategory::Authentication;
-                        if let Some(settings) = state.config_screen_state.settings.get_mut(&auth_category) {
-                            if let Some(status_setting) = settings.iter_mut().find(|s| s.key == "claude_auth") {
+                        if let Some(settings) =
+                            state.config_screen_state.settings.get_mut(&auth_category)
+                        {
+                            if let Some(status_setting) =
+                                settings.iter_mut().find(|s| s.key == "claude_auth")
+                            {
                                 status_setting.value = crate::app::state::ConfigValue::Text(status);
                             }
                         }
@@ -3437,15 +3568,21 @@ impl EventHandler {
 
                 match credentials::delete_anthropic_api_key() {
                     Ok(()) => {
-                        state.add_success_notification("API key removed from system keychain".to_string());
+                        state.add_success_notification(
+                            "API key removed from system keychain".to_string(),
+                        );
                         tracing::info!("API key successfully deleted from keychain");
 
                         // Update auth status to show system auth
                         let auth_category = crate::app::state::ConfigCategory::Authentication;
-                        if let Some(settings) = state.config_screen_state.settings.get_mut(&auth_category) {
-                            if let Some(status_setting) = settings.iter_mut().find(|s| s.key == "claude_auth") {
+                        if let Some(settings) =
+                            state.config_screen_state.settings.get_mut(&auth_category)
+                        {
+                            if let Some(status_setting) =
+                                settings.iter_mut().find(|s| s.key == "claude_auth")
+                            {
                                 status_setting.value = crate::app::state::ConfigValue::Text(
-                                    "System Auth (Pro/Max Plan)".to_string()
+                                    "System Auth (Pro/Max Plan)".to_string(),
                                 );
                             }
                         }
@@ -3484,20 +3621,28 @@ impl EventHandler {
 
                     match credentials::store_anthropic_api_key(&api_key) {
                         Ok(()) => {
-                            state.add_success_notification("API key saved to system keychain".to_string());
+                            state.add_success_notification(
+                                "API key saved to system keychain".to_string(),
+                            );
 
                             // Update config screen status
                             let masked = credentials::get_anthropic_api_key_masked();
                             let status = format!("API Key ({})", masked);
                             let auth_category = crate::app::state::ConfigCategory::Authentication;
-                            if let Some(settings) = state.config_screen_state.settings.get_mut(&auth_category) {
-                                if let Some(status_setting) = settings.iter_mut().find(|s| s.key == "claude_auth") {
-                                    status_setting.value = crate::app::state::ConfigValue::Text(status);
+                            if let Some(settings) =
+                                state.config_screen_state.settings.get_mut(&auth_category)
+                            {
+                                if let Some(status_setting) =
+                                    settings.iter_mut().find(|s| s.key == "claude_auth")
+                                {
+                                    status_setting.value =
+                                        crate::app::state::ConfigValue::Text(status);
                                 }
                             }
 
                             // Persist auth provider to config.toml
-                            state.app_config.authentication.claude_provider = crate::config::ClaudeAuthProvider::ApiKey;
+                            state.app_config.authentication.claude_provider =
+                                crate::config::ClaudeAuthProvider::ApiKey;
                             if let Err(e) = state.app_config.save() {
                                 tracing::warn!("Failed to save config: {}", e);
                             }
@@ -3516,29 +3661,37 @@ impl EventHandler {
                     // Check what's selected
                     if let Some(provider) = popup_state.current_provider() {
                         if !provider.available {
-                            state.add_info_notification(format!("{} - Coming Soon!", provider.name));
+                            state
+                                .add_info_notification(format!("{} - Coming Soon!", provider.name));
                         } else if provider.id == "api_key" {
                             // Start API key input mode
                             state.auth_provider_popup_state.start_key_input();
                         } else if provider.id == "system" {
                             // System auth - just close and confirm
-                            state.add_success_notification("Using system authentication (Pro/Max plan)".to_string());
+                            state.add_success_notification(
+                                "Using system authentication (Pro/Max plan)".to_string(),
+                            );
 
                             // Delete any stored API key to switch to system auth
                             let _ = credentials::delete_anthropic_api_key();
 
                             // Update config screen status
                             let auth_category = crate::app::state::ConfigCategory::Authentication;
-                            if let Some(settings) = state.config_screen_state.settings.get_mut(&auth_category) {
-                                if let Some(status_setting) = settings.iter_mut().find(|s| s.key == "claude_auth") {
+                            if let Some(settings) =
+                                state.config_screen_state.settings.get_mut(&auth_category)
+                            {
+                                if let Some(status_setting) =
+                                    settings.iter_mut().find(|s| s.key == "claude_auth")
+                                {
                                     status_setting.value = crate::app::state::ConfigValue::Text(
-                                        "System Auth (Pro/Max Plan)".to_string()
+                                        "System Auth (Pro/Max Plan)".to_string(),
                                     );
                                 }
                             }
 
                             // Persist auth provider to config.toml
-                            state.app_config.authentication.claude_provider = crate::config::ClaudeAuthProvider::SystemAuth;
+                            state.app_config.authentication.claude_provider =
+                                crate::config::ClaudeAuthProvider::SystemAuth;
                             if let Err(e) = state.app_config.save() {
                                 tracing::warn!("Failed to save config: {}", e);
                             }
@@ -3569,16 +3722,21 @@ impl EventHandler {
 
                         // Update config screen
                         let auth_category = crate::app::state::ConfigCategory::Authentication;
-                        if let Some(settings) = state.config_screen_state.settings.get_mut(&auth_category) {
-                            if let Some(status_setting) = settings.iter_mut().find(|s| s.key == "claude_auth") {
+                        if let Some(settings) =
+                            state.config_screen_state.settings.get_mut(&auth_category)
+                        {
+                            if let Some(status_setting) =
+                                settings.iter_mut().find(|s| s.key == "claude_auth")
+                            {
                                 status_setting.value = crate::app::state::ConfigValue::Text(
-                                    "System Auth (Pro/Max Plan)".to_string()
+                                    "System Auth (Pro/Max Plan)".to_string(),
                                 );
                             }
                         }
 
                         // Persist switch to system auth in config.toml
-                        state.app_config.authentication.claude_provider = crate::config::ClaudeAuthProvider::SystemAuth;
+                        state.app_config.authentication.claude_provider =
+                            crate::config::ClaudeAuthProvider::SystemAuth;
                         if let Err(e) = state.app_config.save() {
                             tracing::warn!("Failed to save config: {}", e);
                         }
@@ -3600,29 +3758,54 @@ impl EventHandler {
 
                 if let Some(value) = state.config_popup_state.get_value() {
                     let setting_key = state.config_popup_state.setting_key.clone();
-                    let current_category = state.config_screen_state.categories[state.config_screen_state.selected_category];
+                    let current_category = state.config_screen_state.categories
+                        [state.config_screen_state.selected_category];
 
                     // Update the setting value
-                    if let Some(settings) = state.config_screen_state.settings.get_mut(&current_category) {
+                    if let Some(settings) =
+                        state.config_screen_state.settings.get_mut(&current_category)
+                    {
                         if let Some(setting) = settings.iter_mut().find(|s| s.key == setting_key) {
                             match value {
                                 ConfigPopupValue::Choice(text, idx) => {
-                                    if let crate::app::state::ConfigValue::Choice(opts, _) = &setting.value {
-                                        setting.value = crate::app::state::ConfigValue::Choice(opts.clone(), idx);
+                                    if let crate::app::state::ConfigValue::Choice(opts, _) =
+                                        &setting.value
+                                    {
+                                        setting.value = crate::app::state::ConfigValue::Choice(
+                                            opts.clone(),
+                                            idx,
+                                        );
                                     }
-                                    tracing::info!("Config setting {} changed to: {}", setting_key, text);
+                                    tracing::info!(
+                                        "Config setting {} changed to: {}",
+                                        setting_key,
+                                        text
+                                    );
                                 }
                                 ConfigPopupValue::Text(text) => {
-                                    setting.value = crate::app::state::ConfigValue::Text(text.clone());
-                                    tracing::info!("Config setting {} changed to: {}", setting_key, text);
+                                    setting.value =
+                                        crate::app::state::ConfigValue::Text(text.clone());
+                                    tracing::info!(
+                                        "Config setting {} changed to: {}",
+                                        setting_key,
+                                        text
+                                    );
                                 }
                                 ConfigPopupValue::Boolean(b) => {
                                     setting.value = crate::app::state::ConfigValue::Bool(b);
-                                    tracing::info!("Config setting {} changed to: {}", setting_key, b);
+                                    tracing::info!(
+                                        "Config setting {} changed to: {}",
+                                        setting_key,
+                                        b
+                                    );
                                 }
                                 ConfigPopupValue::Number(n) => {
                                     setting.value = crate::app::state::ConfigValue::Number(n);
-                                    tracing::info!("Config setting {} changed to: {}", setting_key, n);
+                                    tracing::info!(
+                                        "Config setting {} changed to: {}",
+                                        setting_key,
+                                        n
+                                    );
                                 }
                             }
                         }
@@ -3807,6 +3990,53 @@ impl EventHandler {
                 };
                 state.add_success_notification(msg.to_string());
             }
+            AppEvent::UsageCycleProviderFilter => {
+                state.usage_state.cycle_provider_filter();
+                state.start_background_usage_load(true);
+            }
+            AppEvent::UsageSetPeriod(period) => {
+                use crate::models::usage::UsagePeriod;
+                let selected = match period {
+                    1 => UsagePeriod::Today,
+                    2 => UsagePeriod::Week,
+                    3 => UsagePeriod::ThirtyDays,
+                    4 => UsagePeriod::Month,
+                    5 => UsagePeriod::All,
+                    _ => state.usage_state.period.clone(),
+                };
+                state.usage_state.set_period(selected);
+                state.start_background_usage_load(true);
+            }
+            AppEvent::UsageStartIncludeFilter => {
+                state.usage_state.begin_input(crate::components::usage::UsageInputMode::Include);
+            }
+            AppEvent::UsageStartExcludeFilter => {
+                state.usage_state.begin_input(crate::components::usage::UsageInputMode::Exclude);
+            }
+            AppEvent::UsageStartDateRange => {
+                state
+                    .usage_state
+                    .begin_input(crate::components::usage::UsageInputMode::DateRange);
+            }
+            AppEvent::UsageClearFilters => {
+                state.usage_state.clear_filters();
+                state.start_background_usage_load(true);
+            }
+            AppEvent::UsageInputChar(ch) => {
+                state.usage_state.input_char(ch);
+            }
+            AppEvent::UsageInputBackspace => {
+                state.usage_state.input_backspace();
+            }
+            AppEvent::UsageInputCancel => {
+                state.usage_state.cancel_input();
+            }
+            AppEvent::UsageInputSubmit => match state.usage_state.submit_input() {
+                Ok(()) => {
+                    state.start_background_usage_load(true);
+                }
+                Err(e) => state.add_error_notification(e),
+            },
             // Skills browser events
             AppEvent::SkillsBack => {
                 tracing::debug!("Skills back");
@@ -3907,28 +4137,39 @@ impl EventHandler {
                         state.add_success_notification(format!("Resumed {} sessions", resumed));
                     } else {
                         state.add_info_notification(format!(
-                            "Resumed {}, failed {}", resumed, failed
+                            "Resumed {}, failed {}",
+                            resumed, failed
                         ));
                     }
                 } else {
                     // Single item resume (worktree or session)
                     let (name, result) = if state.session_recovery_state.is_worktree_selected() {
-                        let name = state.session_recovery_state.selected_worktree()
-                            .map(|w| w.name.clone()).unwrap_or_default();
+                        let name = state
+                            .session_recovery_state
+                            .selected_worktree()
+                            .map(|w| w.name.clone())
+                            .unwrap_or_default();
                         (name, state.session_recovery_state.resume_worktree())
                     } else {
-                        let name = state.session_recovery_state.selected()
-                            .map(|s| s.session.clone()).unwrap_or_default();
+                        let name = state
+                            .session_recovery_state
+                            .selected()
+                            .map(|s| s.session.clone())
+                            .unwrap_or_default();
                         (name, state.session_recovery_state.resume_selected())
                     };
 
                     let overlay_result = match result {
-                        Ok(ref tmux_name) => crate::components::session_recovery::RecoveryResultLine {
-                            name: name.clone(), success: true,
-                            detail: format!("→ {}", tmux_name),
-                        },
+                        Ok(ref tmux_name) => {
+                            crate::components::session_recovery::RecoveryResultLine {
+                                name: name.clone(),
+                                success: true,
+                                detail: format!("→ {}", tmux_name),
+                            }
+                        }
                         Err(ref e) => crate::components::session_recovery::RecoveryResultLine {
-                            name: name.clone(), success: false,
+                            name: name.clone(),
+                            success: false,
                             detail: e.clone(),
                         },
                     };
@@ -3938,13 +4179,12 @@ impl EventHandler {
                         Err(e) => (format!("Failed: {}", e), false),
                     };
 
-                    state.session_recovery_state.recovery_overlay = Some(
-                        crate::components::session_recovery::RecoveryOverlay {
+                    state.session_recovery_state.recovery_overlay =
+                        Some(crate::components::session_recovery::RecoveryOverlay {
                             title,
                             results: vec![overlay_result],
                             scroll_offset: 0,
-                        }
-                    );
+                        });
 
                     if succeeded {
                         state.add_success_notification("Session resumed".to_string());
@@ -3992,7 +4232,9 @@ impl EventHandler {
                 } else {
                     state.add_info_notification(format!(
                         "Recovered {}/{} sessions ({} failed)",
-                        result.succeeded.len(), total, result.failed.len()
+                        result.succeeded.len(),
+                        total,
+                        result.failed.len()
                     ));
                 }
             }
@@ -4006,7 +4248,9 @@ impl EventHandler {
             AppEvent::SessionRecoveryDeleteSelected => {
                 let count = state.session_recovery_state.selected_items.len();
                 if count == 0 {
-                    state.add_info_notification("No items selected. Use Space to select items first.".to_string());
+                    state.add_info_notification(
+                        "No items selected. Use Space to select items first.".to_string(),
+                    );
                 } else {
                     tracing::info!("Session recovery: deleting {} selected items", count);
                     let (deleted, failed) = state.session_recovery_state.delete_multi_selected();
@@ -4015,7 +4259,9 @@ impl EventHandler {
                     } else {
                         state.add_info_notification(format!(
                             "Deleted {}/{} items ({} failed)",
-                            deleted, deleted + failed, failed
+                            deleted,
+                            deleted + failed,
+                            failed
                         ));
                     }
                 }
@@ -4238,10 +4484,10 @@ impl EventHandler {
                 }
             }
             // Mouse events are handled directly in the main event loop
-            AppEvent::MouseClick { .. } |
-            AppEvent::MouseDragStart { .. } |
-            AppEvent::MouseDragEnd { .. } |
-            AppEvent::MouseDragging { .. } => {
+            AppEvent::MouseClick { .. }
+            | AppEvent::MouseDragStart { .. }
+            | AppEvent::MouseDragEnd { .. }
+            | AppEvent::MouseDragging { .. } => {
                 // These are processed by handle_mouse_event
             }
         }

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -12,8 +12,8 @@ use crate::components::home_screen_v2::HomeScreenV2State;
 use crate::components::live_logs_stream::LogEntry;
 use crate::config::{AppConfig, SshDisplayNameStore, WorktreeCollisionBehavior};
 use crate::credentials;
-use crate::editors;
 use crate::docker::LogStreamingCoordinator;
+use crate::editors;
 use crate::git::{ParsedRepo, RemoteBranch, RepoSource};
 use crate::models::{ClaudeModel, Session, SessionAgentType, Workspace};
 use std::collections::{HashMap, HashSet};
@@ -395,28 +395,28 @@ pub enum FocusedPane {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum View {
-    HomeScreen,       // Default landing page with tile navigation
-    AgentSelection,   // Choose agent provider and model
-    Config,           // Settings and configuration
-    Catalog,          // Browse marketplace/catalog
-    Analytics,        // Usage statistics and cost tracking
+    HomeScreen,     // Default landing page with tile navigation
+    AgentSelection, // Choose agent provider and model
+    Config,         // Settings and configuration
+    Catalog,        // Browse marketplace/catalog
+    Analytics,      // Usage statistics and cost tracking
     SessionList,
     Logs,
-    LogHistory,       // Historical JSONL log viewer
+    LogHistory, // Historical JSONL log viewer
     Terminal,
     Help,
     NewSession,
     SearchWorkspace,
     NonGitNotification,
     AttachedTerminal,
-    AuthSetup,        // New view for authentication setup
-    ClaudeChat,       // Claude chat popup overlay
-    GitView,          // Git status and diff view
-    Onboarding,       // First-time setup wizard
-    SetupMenu,        // Setup menu with factory reset option
-    Changelog,        // Version history viewer
-    SessionRecovery,  // Recover orphaned agent sessions after crash/shutdown
-    Skills,           // Per-agent skills + agents browser
+    AuthSetup,       // New view for authentication setup
+    ClaudeChat,      // Claude chat popup overlay
+    GitView,         // Git status and diff view
+    Onboarding,      // First-time setup wizard
+    SetupMenu,       // Setup menu with factory reset option
+    Changelog,       // Version history viewer
+    SessionRecovery, // Recover orphaned agent sessions after crash/shutdown
+    Skills,          // Per-agent skills + agents browser
 }
 
 #[derive(Debug, Clone)]
@@ -424,15 +424,15 @@ pub struct ConfirmationDialog {
     pub title: String,
     pub message: String,
     pub confirm_action: ConfirmAction,
-    pub selected_option: bool, // true = Yes, false = No
+    pub selected_option: bool,   // true = Yes, false = No
     pub warning: Option<String>, // Optional warning (e.g., uncommitted files in worktree)
 }
 
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     DeleteSession(Uuid),
-    KillOtherTmux(String),        // Kill a non-agents-in-a-box tmux session by name
-    KillWorkspaceShell(usize),    // Kill workspace shell by workspace index
+    KillOtherTmux(String), // Kill a non-agents-in-a-box tmux session by name
+    KillWorkspaceShell(usize), // Kill workspace shell by workspace index
 }
 
 // ============================================================================
@@ -441,13 +441,13 @@ pub enum ConfirmAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HomeTile {
-    Agents,    // Agent selection
-    Catalog,   // Browse catalog/marketplace
-    Config,    // Settings & presets
-    Sessions,  // Session manager
-    Recovery,  // Recover orphaned sessions
-    Stats,     // Analytics & usage
-    Help,      // Docs & guides
+    Agents,   // Agent selection
+    Catalog,  // Browse catalog/marketplace
+    Config,   // Settings & presets
+    Sessions, // Session manager
+    Recovery, // Recover orphaned sessions
+    Stats,    // Analytics & usage
+    Help,     // Docs & guides
 }
 
 impl HomeTile {
@@ -602,19 +602,40 @@ pub enum CostTier {
 #[derive(Debug, Clone)]
 pub struct SessionAgentOption {
     pub agent_type: SessionAgentType,
-    pub is_current: bool,  // Is this the currently selected agent for the app?
+    pub is_current: bool, // Is this the currently selected agent for the app?
 }
 
 impl SessionAgentOption {
     pub fn all() -> Vec<Self> {
         vec![
-            Self { agent_type: SessionAgentType::Claude, is_current: true },  // Claude is default
-            Self { agent_type: SessionAgentType::Shell, is_current: false },
-            Self { agent_type: SessionAgentType::Ssh, is_current: false },    // SSH sessions
-            Self { agent_type: SessionAgentType::Codex, is_current: false },
-            Self { agent_type: SessionAgentType::Gemini, is_current: false },
-            Self { agent_type: SessionAgentType::Copilot, is_current: false },
-            Self { agent_type: SessionAgentType::Kiro, is_current: false },
+            Self {
+                agent_type: SessionAgentType::Claude,
+                is_current: true,
+            }, // Claude is default
+            Self {
+                agent_type: SessionAgentType::Shell,
+                is_current: false,
+            },
+            Self {
+                agent_type: SessionAgentType::Ssh,
+                is_current: false,
+            }, // SSH sessions
+            Self {
+                agent_type: SessionAgentType::Codex,
+                is_current: false,
+            },
+            Self {
+                agent_type: SessionAgentType::Gemini,
+                is_current: false,
+            },
+            Self {
+                agent_type: SessionAgentType::Copilot,
+                is_current: false,
+            },
+            Self {
+                agent_type: SessionAgentType::Kiro,
+                is_current: false,
+            },
         ]
     }
 }
@@ -652,7 +673,12 @@ impl AgentProvider {
             name: "Claude Code".to_string(),
             vendor: "Anthropic".to_string(),
             models: vec![
-                AgentModel::new("Opus 4.5", "Best reasoning, complex tasks", CostTier::Premium, false),
+                AgentModel::new(
+                    "Opus 4.5",
+                    "Best reasoning, complex tasks",
+                    CostTier::Premium,
+                    false,
+                ),
                 AgentModel::new("Sonnet 4.5", "Balanced (Recommended)", CostTier::High, true),
                 AgentModel::new("Haiku 4.5", "Fast, lightweight", CostTier::Medium, false),
             ],
@@ -665,10 +691,30 @@ impl AgentProvider {
             name: "Codex CLI".to_string(),
             vendor: "OpenAI".to_string(),
             models: vec![
-                AgentModel::new("gpt-5.2-codex", "Latest frontier agentic coding model", CostTier::Premium, true),
-                AgentModel::new("gpt-5.1-codex-max", "Deep and fast reasoning flagship", CostTier::High, false),
-                AgentModel::new("gpt-5.1-codex-mini", "Cheaper, faster, less capable", CostTier::Medium, false),
-                AgentModel::new("gpt-5.2", "Frontier model, reasoning & coding", CostTier::Premium, false),
+                AgentModel::new(
+                    "gpt-5.2-codex",
+                    "Latest frontier agentic coding model",
+                    CostTier::Premium,
+                    true,
+                ),
+                AgentModel::new(
+                    "gpt-5.1-codex-max",
+                    "Deep and fast reasoning flagship",
+                    CostTier::High,
+                    false,
+                ),
+                AgentModel::new(
+                    "gpt-5.1-codex-mini",
+                    "Cheaper, faster, less capable",
+                    CostTier::Medium,
+                    false,
+                ),
+                AgentModel::new(
+                    "gpt-5.2",
+                    "Frontier model, reasoning & coding",
+                    CostTier::Premium,
+                    false,
+                ),
             ],
             status: ProviderStatus::Available,
         }
@@ -679,11 +725,36 @@ impl AgentProvider {
             name: "Gemini CLI".to_string(),
             vendor: "Google".to_string(),
             models: vec![
-                AgentModel::new("gemini-3-pro", "Latest reasoning model (preview)", CostTier::Premium, false),
-                AgentModel::new("gemini-3-flash", "Fast agentic model (preview)", CostTier::High, false),
-                AgentModel::new("gemini-2.5-pro", "1M context, adaptive thinking", CostTier::High, true),
-                AgentModel::new("gemini-2.5-flash", "Fast multimodal model", CostTier::Medium, false),
-                AgentModel::new("gemini-2.5-flash-lite", "Ultra-efficient, low cost", CostTier::Low, false),
+                AgentModel::new(
+                    "gemini-3-pro",
+                    "Latest reasoning model (preview)",
+                    CostTier::Premium,
+                    false,
+                ),
+                AgentModel::new(
+                    "gemini-3-flash",
+                    "Fast agentic model (preview)",
+                    CostTier::High,
+                    false,
+                ),
+                AgentModel::new(
+                    "gemini-2.5-pro",
+                    "1M context, adaptive thinking",
+                    CostTier::High,
+                    true,
+                ),
+                AgentModel::new(
+                    "gemini-2.5-flash",
+                    "Fast multimodal model",
+                    CostTier::Medium,
+                    false,
+                ),
+                AgentModel::new(
+                    "gemini-2.5-flash-lite",
+                    "Ultra-efficient, low cost",
+                    CostTier::Low,
+                    false,
+                ),
             ],
             status: ProviderStatus::Available,
         }
@@ -694,13 +765,38 @@ impl AgentProvider {
             name: "GitHub Copilot".to_string(),
             vendor: "GitHub".to_string(),
             models: vec![
-                AgentModel::new("claude-sonnet-4.6", "Claude Sonnet 4.6 (default)", CostTier::High, true),
-                AgentModel::new("claude-opus-4.6", "Claude Opus 4.6 (premium)", CostTier::Premium, false),
-                AgentModel::new("claude-haiku-4.5", "Claude Haiku 4.5 (fast)", CostTier::Low, false),
+                AgentModel::new(
+                    "claude-sonnet-4.6",
+                    "Claude Sonnet 4.6 (default)",
+                    CostTier::High,
+                    true,
+                ),
+                AgentModel::new(
+                    "claude-opus-4.6",
+                    "Claude Opus 4.6 (premium)",
+                    CostTier::Premium,
+                    false,
+                ),
+                AgentModel::new(
+                    "claude-haiku-4.5",
+                    "Claude Haiku 4.5 (fast)",
+                    CostTier::Low,
+                    false,
+                ),
                 AgentModel::new("gpt-5.2", "GPT-5.2", CostTier::High, false),
-                AgentModel::new("gpt-5.1-codex", "GPT-5.1 Codex (coding)", CostTier::High, false),
+                AgentModel::new(
+                    "gpt-5.1-codex",
+                    "GPT-5.1 Codex (coding)",
+                    CostTier::High,
+                    false,
+                ),
                 AgentModel::new("gpt-4.1", "GPT-4.1 (stable)", CostTier::Medium, false),
-                AgentModel::new("gemini-3-pro-preview", "Gemini 3 Pro (preview)", CostTier::High, false),
+                AgentModel::new(
+                    "gemini-3-pro-preview",
+                    "Gemini 3 Pro (preview)",
+                    CostTier::High,
+                    false,
+                ),
             ],
             status: ProviderStatus::Available,
         }
@@ -710,9 +806,12 @@ impl AgentProvider {
         Self {
             name: "Local Models".to_string(),
             vendor: "Ollama".to_string(),
-            models: vec![
-                AgentModel::new("Configurable", "Self-hosted models", CostTier::Low, true),
-            ],
+            models: vec![AgentModel::new(
+                "Configurable",
+                "Self-hosted models",
+                CostTier::Low,
+                true,
+            )],
             status: ProviderStatus::ComingSoon,
         }
     }
@@ -757,8 +856,7 @@ impl AgentSelectionState {
     }
 
     pub fn current_model(&self) -> Option<&AgentModel> {
-        self.current_provider()
-            .and_then(|p| p.models.get(self.selected_model))
+        self.current_provider().and_then(|p| p.models.get(self.selected_model))
     }
 
     pub fn select_next_provider(&mut self) {
@@ -902,7 +1000,7 @@ pub struct ConfigSetting {
 #[derive(Debug, Clone)]
 pub enum ConfigValue {
     Text(String),
-    Secret(String),      // Masked display
+    Secret(String), // Masked display
     Bool(bool),
     Choice(Vec<String>, usize), // Options and selected index
     Number(i64),
@@ -968,171 +1066,206 @@ impl Default for ConfigScreenState {
             _ => "System Auth (Pro/Max Plan)".to_string(),
         };
 
-        settings.insert(ConfigCategory::Authentication, vec![
-            ConfigSetting {
-                key: "claude_auth".to_string(),
-                label: "Claude Authentication".to_string(),
-                value: ConfigValue::Text(auth_status),
-                description: "Press Enter to configure authentication provider".to_string(),
-            },
-            ConfigSetting {
-                key: "github_auth".to_string(),
-                label: "GitHub Credentials".to_string(),
-                value: ConfigValue::Text("System Default".to_string()),
-                description: "Uses git credential helper. PAT support coming soon.".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::Authentication,
+            vec![
+                ConfigSetting {
+                    key: "claude_auth".to_string(),
+                    label: "Claude Authentication".to_string(),
+                    value: ConfigValue::Text(auth_status),
+                    description: "Press Enter to configure authentication provider".to_string(),
+                },
+                ConfigSetting {
+                    key: "github_auth".to_string(),
+                    label: "GitHub Credentials".to_string(),
+                    value: ConfigValue::Text("System Default".to_string()),
+                    description: "Uses git credential helper. PAT support coming soon.".to_string(),
+                },
+            ],
+        );
 
         // Workspace settings
-        settings.insert(ConfigCategory::Workspace, vec![
-            ConfigSetting {
-                key: "default_workspace".to_string(),
-                label: "Default Workspace".to_string(),
-                value: ConfigValue::Text("~/projects".to_string()),
-                description: "Default directory for new sessions".to_string(),
-            },
-            ConfigSetting {
-                key: "branch_prefix".to_string(),
-                label: "Branch Prefix".to_string(),
-                value: ConfigValue::Text("agents/".to_string()),
-                description: "Prefix for auto-created branch names".to_string(),
-            },
-            ConfigSetting {
-                key: "exclude_paths".to_string(),
-                label: "Exclude Paths".to_string(),
-                value: ConfigValue::Text("node_modules, .git, target".to_string()),
-                description: "Patterns to exclude from repo scanning (comma-separated)".to_string(),
-            },
-            ConfigSetting {
-                key: "max_repositories".to_string(),
-                label: "Max Repositories".to_string(),
-                value: ConfigValue::Number(500),
-                description: "Maximum repositories to show in search results".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::Workspace,
+            vec![
+                ConfigSetting {
+                    key: "default_workspace".to_string(),
+                    label: "Default Workspace".to_string(),
+                    value: ConfigValue::Text("~/projects".to_string()),
+                    description: "Default directory for new sessions".to_string(),
+                },
+                ConfigSetting {
+                    key: "branch_prefix".to_string(),
+                    label: "Branch Prefix".to_string(),
+                    value: ConfigValue::Text("agents/".to_string()),
+                    description: "Prefix for auto-created branch names".to_string(),
+                },
+                ConfigSetting {
+                    key: "exclude_paths".to_string(),
+                    label: "Exclude Paths".to_string(),
+                    value: ConfigValue::Text("node_modules, .git, target".to_string()),
+                    description: "Patterns to exclude from repo scanning (comma-separated)"
+                        .to_string(),
+                },
+                ConfigSetting {
+                    key: "max_repositories".to_string(),
+                    label: "Max Repositories".to_string(),
+                    value: ConfigValue::Number(500),
+                    description: "Maximum repositories to show in search results".to_string(),
+                },
+            ],
+        );
 
         // Docker settings
-        settings.insert(ConfigCategory::Docker, vec![
-            ConfigSetting {
-                key: "docker_host".to_string(),
-                label: "Docker Host".to_string(),
-                value: ConfigValue::Text("Auto-detect".to_string()),
-                description: "Docker daemon connection (auto-detect, unix socket, or TCP)".to_string(),
-            },
-            ConfigSetting {
-                key: "docker_timeout".to_string(),
-                label: "Connection Timeout".to_string(),
-                value: ConfigValue::Number(60),
-                description: "Docker connection timeout in seconds".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::Docker,
+            vec![
+                ConfigSetting {
+                    key: "docker_host".to_string(),
+                    label: "Docker Host".to_string(),
+                    value: ConfigValue::Text("Auto-detect".to_string()),
+                    description: "Docker daemon connection (auto-detect, unix socket, or TCP)"
+                        .to_string(),
+                },
+                ConfigSetting {
+                    key: "docker_timeout".to_string(),
+                    label: "Connection Timeout".to_string(),
+                    value: ConfigValue::Number(60),
+                    description: "Docker connection timeout in seconds".to_string(),
+                },
+            ],
+        );
 
         // Agent defaults
-        settings.insert(ConfigCategory::AgentDefaults, vec![
-            ConfigSetting {
-                key: "default_model".to_string(),
-                label: "Default Model".to_string(),
-                value: ConfigValue::Choice(
-                    vec!["Opus 4.5".to_string(), "Sonnet 4.5".to_string(), "Haiku 4.5".to_string()],
-                    1, // Sonnet default
-                ),
-                description: "Default Claude model for new sessions".to_string(),
-            },
-            ConfigSetting {
-                key: "auto_approve".to_string(),
-                label: "Auto-Approve Actions".to_string(),
-                value: ConfigValue::Bool(false),
-                description: "Automatically approve file writes and commands".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::AgentDefaults,
+            vec![
+                ConfigSetting {
+                    key: "default_model".to_string(),
+                    label: "Default Model".to_string(),
+                    value: ConfigValue::Choice(
+                        vec![
+                            "Opus 4.5".to_string(),
+                            "Sonnet 4.5".to_string(),
+                            "Haiku 4.5".to_string(),
+                        ],
+                        1, // Sonnet default
+                    ),
+                    description: "Default Claude model for new sessions".to_string(),
+                },
+                ConfigSetting {
+                    key: "auto_approve".to_string(),
+                    label: "Auto-Approve Actions".to_string(),
+                    value: ConfigValue::Bool(false),
+                    description: "Automatically approve file writes and commands".to_string(),
+                },
+            ],
+        );
 
         // Permissions
-        settings.insert(ConfigCategory::Permissions, vec![
-            ConfigSetting {
-                key: "allow_file_write".to_string(),
-                label: "Allow File Write".to_string(),
-                value: ConfigValue::Bool(true),
-                description: "Allow agents to write files".to_string(),
-            },
-            ConfigSetting {
-                key: "allow_shell".to_string(),
-                label: "Allow Shell Commands".to_string(),
-                value: ConfigValue::Bool(true),
-                description: "Allow agents to run shell commands".to_string(),
-            },
-            ConfigSetting {
-                key: "allow_git".to_string(),
-                label: "Allow Git Operations".to_string(),
-                value: ConfigValue::Bool(true),
-                description: "Allow agents to perform git operations".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::Permissions,
+            vec![
+                ConfigSetting {
+                    key: "allow_file_write".to_string(),
+                    label: "Allow File Write".to_string(),
+                    value: ConfigValue::Bool(true),
+                    description: "Allow agents to write files".to_string(),
+                },
+                ConfigSetting {
+                    key: "allow_shell".to_string(),
+                    label: "Allow Shell Commands".to_string(),
+                    value: ConfigValue::Bool(true),
+                    description: "Allow agents to run shell commands".to_string(),
+                },
+                ConfigSetting {
+                    key: "allow_git".to_string(),
+                    label: "Allow Git Operations".to_string(),
+                    value: ConfigValue::Bool(true),
+                    description: "Allow agents to perform git operations".to_string(),
+                },
+            ],
+        );
 
         // Editor
         // Detect available editors for the editor preference setting
         let available_editors = editors::get_editor_options();
-        let editor_names: Vec<String> = available_editors.iter().map(|(name, _)| name.clone()).collect();
-        let default_editor_index = available_editors.iter().position(|(_, avail)| *avail).unwrap_or(0);
+        let editor_names: Vec<String> =
+            available_editors.iter().map(|(name, _)| name.clone()).collect();
+        let default_editor_index =
+            available_editors.iter().position(|(_, avail)| *avail).unwrap_or(0);
 
-        settings.insert(ConfigCategory::Editor, vec![
-            ConfigSetting {
+        settings.insert(
+            ConfigCategory::Editor,
+            vec![ConfigSetting {
                 key: "preferred_editor".to_string(),
                 label: "Preferred Editor".to_string(),
                 value: ConfigValue::Choice(editor_names, default_editor_index),
                 description: "Editor for opening sessions (o key)".to_string(),
-            },
-        ]);
+            }],
+        );
 
         // Appearance
-        settings.insert(ConfigCategory::Appearance, vec![
-            ConfigSetting {
-                key: "theme".to_string(),
-                label: "Theme".to_string(),
-                value: ConfigValue::Choice(
-                    vec!["Dark".to_string(), "Light".to_string(), "System".to_string()],
-                    0,
-                ),
-                description: "Color theme for the TUI".to_string(),
-            },
-            ConfigSetting {
-                key: "show_container_status".to_string(),
-                label: "Show Container Status".to_string(),
-                value: ConfigValue::Bool(true),
-                description: "Show container mode icons in session list".to_string(),
-            },
-            ConfigSetting {
-                key: "show_git_status".to_string(),
-                label: "Show Git Status".to_string(),
-                value: ConfigValue::Bool(true),
-                description: "Show git changes in session list".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::Appearance,
+            vec![
+                ConfigSetting {
+                    key: "theme".to_string(),
+                    label: "Theme".to_string(),
+                    value: ConfigValue::Choice(
+                        vec![
+                            "Dark".to_string(),
+                            "Light".to_string(),
+                            "System".to_string(),
+                        ],
+                        0,
+                    ),
+                    description: "Color theme for the TUI".to_string(),
+                },
+                ConfigSetting {
+                    key: "show_container_status".to_string(),
+                    label: "Show Container Status".to_string(),
+                    value: ConfigValue::Bool(true),
+                    description: "Show container mode icons in session list".to_string(),
+                },
+                ConfigSetting {
+                    key: "show_git_status".to_string(),
+                    label: "Show Git Status".to_string(),
+                    value: ConfigValue::Bool(true),
+                    description: "Show git changes in session list".to_string(),
+                },
+            ],
+        );
 
         // Plugins (empty for now)
-        settings.insert(ConfigCategory::Plugins, vec![
-            ConfigSetting {
+        settings.insert(
+            ConfigCategory::Plugins,
+            vec![ConfigSetting {
                 key: "installed_plugins".to_string(),
                 label: "Installed Plugins".to_string(),
                 value: ConfigValue::Text("None installed".to_string()),
                 description: "Manage installed plugins from the Catalog".to_string(),
-            },
-        ]);
+            }],
+        );
 
         // Analytics
-        settings.insert(ConfigCategory::Analytics, vec![
-            ConfigSetting {
-                key: "track_usage".to_string(),
-                label: "Track Usage".to_string(),
-                value: ConfigValue::Bool(true),
-                description: "Track session duration and token usage".to_string(),
-            },
-            ConfigSetting {
-                key: "cost_alerts".to_string(),
-                label: "Cost Alerts".to_string(),
-                value: ConfigValue::Bool(false),
-                description: "Alert when spending exceeds threshold".to_string(),
-            },
-        ]);
+        settings.insert(
+            ConfigCategory::Analytics,
+            vec![
+                ConfigSetting {
+                    key: "track_usage".to_string(),
+                    label: "Track Usage".to_string(),
+                    value: ConfigValue::Bool(true),
+                    description: "Track session duration and token usage".to_string(),
+                },
+                ConfigSetting {
+                    key: "cost_alerts".to_string(),
+                    label: "Cost Alerts".to_string(),
+                    value: ConfigValue::Bool(false),
+                    description: "Alert when spending exceeds threshold".to_string(),
+                },
+            ],
+        );
 
         Self {
             selected_category: 0,
@@ -1239,9 +1372,15 @@ impl ConfigScreenState {
                             }
                         }
                         ClaudeAuthProvider::SystemAuth => "System Auth (Pro/Max Plan)".to_string(),
-                        ClaudeAuthProvider::AmazonBedrock => "Amazon Bedrock [Coming Soon]".to_string(),
-                        ClaudeAuthProvider::GoogleVertex => "Google Vertex [Coming Soon]".to_string(),
-                        ClaudeAuthProvider::AzureFoundry => "Azure Foundry [Coming Soon]".to_string(),
+                        ClaudeAuthProvider::AmazonBedrock => {
+                            "Amazon Bedrock [Coming Soon]".to_string()
+                        }
+                        ClaudeAuthProvider::GoogleVertex => {
+                            "Google Vertex [Coming Soon]".to_string()
+                        }
+                        ClaudeAuthProvider::AzureFoundry => {
+                            "Azure Foundry [Coming Soon]".to_string()
+                        }
                         ClaudeAuthProvider::GlmZai => "GLM on ZAI [Coming Soon]".to_string(),
                         ClaudeAuthProvider::LlmGateway => "LLM Gateway [Coming Soon]".to_string(),
                     };
@@ -1256,14 +1395,17 @@ impl ConfigScreenState {
                 match setting.key.as_str() {
                     "default_workspace" => {
                         // Use first scan path or default
-                        let path = config.workspace_defaults.workspace_scan_paths
+                        let path = config
+                            .workspace_defaults
+                            .workspace_scan_paths
                             .first()
                             .map(|p| p.display().to_string())
                             .unwrap_or_else(|| "~/projects".to_string());
                         setting.value = ConfigValue::Text(path);
                     }
                     "branch_prefix" => {
-                        setting.value = ConfigValue::Text(config.workspace_defaults.branch_prefix.clone());
+                        setting.value =
+                            ConfigValue::Text(config.workspace_defaults.branch_prefix.clone());
                     }
                     "exclude_paths" => {
                         let paths = config.workspace_defaults.exclude_paths.join(", ");
@@ -1274,7 +1416,8 @@ impl ConfigScreenState {
                         });
                     }
                     "max_repositories" => {
-                        setting.value = ConfigValue::Number(config.workspace_defaults.max_repositories as i64);
+                        setting.value =
+                            ConfigValue::Number(config.workspace_defaults.max_repositories as i64);
                     }
                     _ => {}
                 }
@@ -1286,8 +1429,8 @@ impl ConfigScreenState {
             for setting in settings.iter_mut() {
                 match setting.key.as_str() {
                     "docker_host" => {
-                        let host_display = config.docker.host.clone()
-                            .unwrap_or_else(|| "Auto-detect".to_string());
+                        let host_display =
+                            config.docker.host.clone().unwrap_or_else(|| "Auto-detect".to_string());
                         setting.value = ConfigValue::Text(host_display);
                     }
                     "docker_timeout" => {
@@ -1351,12 +1494,17 @@ impl ConfigScreenState {
                             _ => 0,
                         };
                         setting.value = ConfigValue::Choice(
-                            vec!["Dark".to_string(), "Light".to_string(), "System".to_string()],
+                            vec![
+                                "Dark".to_string(),
+                                "Light".to_string(),
+                                "System".to_string(),
+                            ],
                             theme_idx,
                         );
                     }
                     "show_container_status" => {
-                        setting.value = ConfigValue::Bool(config.ui_preferences.show_container_status);
+                        setting.value =
+                            ConfigValue::Bool(config.ui_preferences.show_container_status);
                     }
                     "show_git_status" => {
                         setting.value = ConfigValue::Bool(config.ui_preferences.show_git_status);
@@ -1544,9 +1692,8 @@ pub struct AuthProviderPopupState {
 impl Default for AuthProviderPopupState {
     fn default() -> Self {
         // Check current API key status to mark current provider
-        let has_api_key = credentials::get_anthropic_api_key()
-            .map(|opt| opt.is_some())
-            .unwrap_or(false);
+        let has_api_key =
+            credentials::get_anthropic_api_key().map(|opt| opt.is_some()).unwrap_or(false);
 
         let mut providers = vec![
             AuthProviderOption::new(
@@ -1691,15 +1838,12 @@ impl AuthProviderPopupState {
 
     /// Get the current provider ID (the one marked as is_current)
     pub fn get_current_provider_id(&self) -> Option<&str> {
-        self.providers.iter()
-            .find(|p| p.is_current)
-            .map(|p| p.id.as_str())
+        self.providers.iter().find(|p| p.is_current).map(|p| p.id.as_str())
     }
 
     pub fn refresh_providers(&mut self) {
-        let has_api_key = credentials::get_anthropic_api_key()
-            .map(|opt| opt.is_some())
-            .unwrap_or(false);
+        let has_api_key =
+            credentials::get_anthropic_api_key().map(|opt| opt.is_some()).unwrap_or(false);
 
         for p in &mut self.providers {
             p.is_current = false;
@@ -1969,19 +2113,26 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
     if AppState::is_docker_available_sync() {
         info!("load_workspaces_async: Docker available, loading Boss mode sessions");
         match SessionLoader::new().await {
-            Ok(loader) => {
-                match loader.load_active_sessions().await {
-                    Ok(mut docker_workspaces) => {
-                        info!("load_workspaces_async: Loaded {} Boss mode workspaces", docker_workspaces.len());
-                        workspaces.append(&mut docker_workspaces);
-                    }
-                    Err(e) => {
-                        warn!("load_workspaces_async: Failed to load Boss mode sessions: {}", e);
-                    }
+            Ok(loader) => match loader.load_active_sessions().await {
+                Ok(mut docker_workspaces) => {
+                    info!(
+                        "load_workspaces_async: Loaded {} Boss mode workspaces",
+                        docker_workspaces.len()
+                    );
+                    workspaces.append(&mut docker_workspaces);
                 }
-            }
+                Err(e) => {
+                    warn!(
+                        "load_workspaces_async: Failed to load Boss mode sessions: {}",
+                        e
+                    );
+                }
+            },
             Err(e) => {
-                warn!("load_workspaces_async: Failed to create session loader: {}", e);
+                warn!(
+                    "load_workspaces_async: Failed to create session loader: {}",
+                    e
+                );
             }
         }
     } else {
@@ -1994,7 +2145,10 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
         Ok(mut manager) => {
             match manager.list_sessions().await {
                 Ok(interactive_sessions) => {
-                    info!("load_workspaces_async: Found {} Interactive sessions", interactive_sessions.len());
+                    info!(
+                        "load_workspaces_async: Found {} Interactive sessions",
+                        interactive_sessions.len()
+                    );
                     // Group sessions by workspace
                     for interactive_session in interactive_sessions {
                         let session = interactive_session.to_session_model();
@@ -2005,9 +2159,10 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
                         // This prevents duplicates when paths differ only by normalization
                         // (e.g., symlinks, ".." components, trailing slashes)
                         let canonical_workspace_path = workspace_path.canonicalize().ok();
-                        if let Some(workspace) = workspaces.iter_mut().find(|w| {
-                            w.path.canonicalize().ok() == canonical_workspace_path
-                        }) {
+                        if let Some(workspace) = workspaces
+                            .iter_mut()
+                            .find(|w| w.path.canonicalize().ok() == canonical_workspace_path)
+                        {
                             workspace.add_session(session);
                         } else {
                             let mut workspace = Workspace::new(workspace_name, workspace_path);
@@ -2017,18 +2172,27 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
                     }
                 }
                 Err(e) => {
-                    warn!("load_workspaces_async: Failed to list Interactive sessions: {}", e);
+                    warn!(
+                        "load_workspaces_async: Failed to list Interactive sessions: {}",
+                        e
+                    );
                 }
             }
         }
         Err(e) => {
-            warn!("load_workspaces_async: Failed to create Interactive session manager: {}", e);
+            warn!(
+                "load_workspaces_async: Failed to create Interactive session manager: {}",
+                e
+            );
         }
     }
 
     // Load other tmux sessions (not managed by agents-in-a-box)
     // This is quick and doesn't involve Docker, so we include it
-    info!("load_workspaces_async: Complete with {} workspaces", workspaces.len());
+    info!(
+        "load_workspaces_async: Complete with {} workspaces",
+        workspaces.len()
+    );
     Ok(workspaces)
 }
 
@@ -2044,7 +2208,7 @@ pub enum AgentModelFocus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BranchCheckoutMode {
     #[default]
-    CreateNew,        // Create ainb/{uuid} branch from selected (default)
+    CreateNew, // Create ainb/{uuid} branch from selected (default)
     CheckoutExisting, // Use the remote branch directly
 }
 
@@ -2065,35 +2229,35 @@ pub struct NewSessionState {
     pub file_finder: FuzzyFileFinderState, // Fuzzy file finder for @ symbol
     pub restart_session_id: Option<Uuid>, // If set, this is a restart operation
     // Agent selection
-    pub selected_agent: SessionAgentType,       // The selected agent for this session
+    pub selected_agent: SessionAgentType, // The selected agent for this session
     pub agent_options: Vec<SessionAgentOption>, // List of available agents
-    pub selected_agent_index: usize,            // Index in agent_options list
+    pub selected_agent_index: usize,      // Index in agent_options list
     // Model selection (for Claude agent)
-    pub selected_model: ClaudeModel,     // The selected model for this session
+    pub selected_model: ClaudeModel, // The selected model for this session
     pub model_options: Vec<ClaudeModel>, // List of available models
-    pub selected_model_index: usize,     // Index in model_options list
+    pub selected_model_index: usize, // Index in model_options list
     pub agent_model_focus: AgentModelFocus, // Which panel has focus (Agent or Model)
 
     // Remote repository support
-    pub repo_input: String,                    // URL or path input from user
-    pub repo_source: Option<RepoSource>,       // Parsed repo source
-    pub remote_branches: Vec<RemoteBranch>,    // Available branches from remote
+    pub repo_input: String,                 // URL or path input from user
+    pub repo_source: Option<RepoSource>,    // Parsed repo source
+    pub remote_branches: Vec<RemoteBranch>, // Available branches from remote
     pub filtered_branches: Vec<(usize, RemoteBranch)>, // (original_index, branch) after filter
-    pub branch_filter_text: String,            // Filter text for fuzzy branch search
-    pub selected_branch_index: usize,          // Selected index in filtered branch list
-    pub selected_base_branch: Option<String>,  // The base branch to create worktree from
-    pub cached_repo_path: Option<PathBuf>,     // Path to cached bare clone
+    pub branch_filter_text: String,         // Filter text for fuzzy branch search
+    pub selected_branch_index: usize,       // Selected index in filtered branch list
+    pub selected_base_branch: Option<String>, // The base branch to create worktree from
+    pub cached_repo_path: Option<PathBuf>,  // Path to cached bare clone
     pub repo_validation_error: Option<String>, // Error message for UI display
-    pub is_validating: bool,                   // Show loading indicator
-    pub recent_repos: Vec<ParsedRepo>,         // Recently used repos for suggestions
+    pub is_validating: bool,                // Show loading indicator
+    pub recent_repos: Vec<ParsedRepo>,      // Recently used repos for suggestions
     pub branch_checkout_mode: BranchCheckoutMode, // Toggle: create new vs checkout existing
 
     // SSH configuration (only used when agent_type == Ssh)
-    pub ssh_host: String,                      // SSH host (e.g., "server.example.com")
-    pub ssh_port: String,                      // SSH port (string for input, parsed to u16)
-    pub ssh_user: String,                      // SSH username (optional)
-    pub ssh_identity_file: String,             // Path to SSH identity file (optional)
-    pub ssh_input_focus: SshInputFocus,        // Which SSH field has focus
+    pub ssh_host: String,               // SSH host (e.g., "server.example.com")
+    pub ssh_port: String,               // SSH port (string for input, parsed to u16)
+    pub ssh_user: String,               // SSH username (optional)
+    pub ssh_identity_file: String,      // Path to SSH identity file (optional)
+    pub ssh_input_focus: SshInputFocus, // Which SSH field has focus
 
     // Favorites (shown inline in InputRepoSource for quick selection)
     pub favorites_store: crate::config::FavoritesStore, // Cached favorites
@@ -2209,9 +2373,7 @@ impl NewSessionState {
     }
 
     pub fn current_agent_type(&self) -> SessionAgentType {
-        self.current_agent_option()
-            .map(|o| o.agent_type)
-            .unwrap_or_default()
+        self.current_agent_option().map(|o| o.agent_type).unwrap_or_default()
     }
 
     pub fn is_current_agent_available(&self) -> bool {
@@ -2265,10 +2427,7 @@ impl NewSessionState {
 
     /// Get the currently selected model
     pub fn current_model(&self) -> ClaudeModel {
-        self.model_options
-            .get(self.selected_model_index)
-            .copied()
-            .unwrap_or_default()
+        self.model_options.get(self.selected_model_index).copied().unwrap_or_default()
     }
 
     /// Toggle focus between Agent and Model panels
@@ -2333,7 +2492,7 @@ pub enum SshInputFocus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RepoSourceChoice {
     #[default]
-    Local,     // Browse local repos
+    Local, // Browse local repos
     Remote,    // Clone from URL
     Ssh,       // SSH connection to remote server
     Favorites, // Quick access to saved favorites
@@ -2341,37 +2500,37 @@ pub enum RepoSourceChoice {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AsyncAction {
-    StartNewSession,        // Old - will be removed
-    StartWorkspaceSearch,   // New - search all workspaces
-    NewSessionInCurrentDir, // New - create session in current directory
-    NewSessionNormal,       // New - create normal new session with mode selection
+    StartNewSession,         // Old - will be removed
+    StartWorkspaceSearch,    // New - search all workspaces
+    NewSessionInCurrentDir,  // New - create session in current directory
+    NewSessionNormal,        // New - create normal new session with mode selection
     NewSessionWithRepoInput, // NEW: Start with URL/path input
     ValidateRepoSource,      // NEW: Parse and validate repo input
     CloneRemoteRepo,         // NEW: Clone remote repo to cache
     FetchRemoteBranches,     // NEW: Get branch list from remote
     CreateNewSession,
-    DeleteSession(Uuid),       // New - delete session with container cleanup
+    DeleteSession(Uuid),           // New - delete session with container cleanup
     BulkDeleteSessions(Vec<Uuid>), // Bulk delete multiple sessions
-    RefreshWorkspaces,         // Manual refresh of workspace data
-    FetchContainerLogs(Uuid),  // Fetch container logs for a session
-    AttachToContainer(Uuid),   // Attach to a container session
-    AttachToTmuxSession(Uuid), // Attach to a tmux session
-    KillContainer(Uuid),       // Kill container for a session
-    AuthSetupOAuth,            // Run OAuth authentication setup
-    AuthSetupApiKey,           // Save API key authentication
-    ReauthenticateCredentials, // Re-authenticate Claude credentials
-    RestartSession(Uuid),      // Restart a stopped session with new container
-    CleanupOrphaned,           // Clean up orphaned containers without worktrees
-    AttachToOtherTmux(String), // Attach to a non-agents-in-a-box tmux session by name
-    KillOtherTmux(String),     // Kill a non-agents-in-a-box tmux session by name
-    ConfirmOtherTmuxRename,    // Confirm and execute rename for "Other tmux" session
+    RefreshWorkspaces,             // Manual refresh of workspace data
+    FetchContainerLogs(Uuid),      // Fetch container logs for a session
+    AttachToContainer(Uuid),       // Attach to a container session
+    AttachToTmuxSession(Uuid),     // Attach to a tmux session
+    KillContainer(Uuid),           // Kill container for a session
+    AuthSetupOAuth,                // Run OAuth authentication setup
+    AuthSetupApiKey,               // Save API key authentication
+    ReauthenticateCredentials,     // Re-authenticate Claude credentials
+    RestartSession(Uuid),          // Restart a stopped session with new container
+    CleanupOrphaned,               // Clean up orphaned containers without worktrees
+    AttachToOtherTmux(String),     // Attach to a non-agents-in-a-box tmux session by name
+    KillOtherTmux(String),         // Kill a non-agents-in-a-box tmux session by name
+    ConfirmOtherTmuxRename,        // Confirm and execute rename for "Other tmux" session
     // Shell session actions (one shell per workspace)
     OpenWorkspaceShell {
-        workspace_index: usize,                      // Index of workspace to open shell for
-        target_dir: Option<std::path::PathBuf>,      // Optional: cd to this directory (worktree)
+        workspace_index: usize,                 // Index of workspace to open shell for
+        target_dir: Option<std::path::PathBuf>, // Optional: cd to this directory (worktree)
     },
     OpenShellAtPath(std::path::PathBuf), // Open shell directly at a path (no workspace required)
-    KillWorkspaceShell(usize), // Kill workspace shell by workspace index
+    KillWorkspaceShell(usize),           // Kill workspace shell by workspace index
     // SSH session actions
     CreateSshSession, // Create a new SSH session with configured target
     // Editor action
@@ -2862,7 +3021,10 @@ impl AppState {
             }
 
             if let Err(e) = self.app_config.save() {
-                warn!("Failed to save app config during onboarding completion: {}", e);
+                warn!(
+                    "Failed to save app config during onboarding completion: {}",
+                    e
+                );
             }
         }
 
@@ -3002,7 +3164,10 @@ impl AppState {
 
         // Preserve shell_sessions before clearing workspaces
         // Map workspace path -> shell_session for restoration after reload
-        let preserved_shells: std::collections::HashMap<std::path::PathBuf, crate::models::ShellSession> = self
+        let preserved_shells: std::collections::HashMap<
+            std::path::PathBuf,
+            crate::models::ShellSession,
+        > = self
             .workspaces
             .iter()
             .filter_map(|w| w.shell_session.clone().map(|s| (w.path.clone(), s)))
@@ -3049,7 +3214,10 @@ impl AppState {
 
         // Restore preserved shell_sessions to matching workspaces
         if !preserved_shells.is_empty() {
-            info!("Restoring {} preserved shell sessions", preserved_shells.len());
+            info!(
+                "Restoring {} preserved shell sessions",
+                preserved_shells.len()
+            );
             for workspace in &mut self.workspaces {
                 if let Some(shell) = preserved_shells.get(&workspace.path) {
                     // Only restore if the tmux session still exists
@@ -3059,12 +3227,16 @@ impl AppState {
                         .await;
 
                     if check.map(|o| o.status.success()).unwrap_or(false) {
-                        info!("Restored shell session '{}' for workspace '{}'",
-                              shell.tmux_session_name, workspace.name);
+                        info!(
+                            "Restored shell session '{}' for workspace '{}'",
+                            shell.tmux_session_name, workspace.name
+                        );
                         workspace.set_shell_session(shell.clone());
                     } else {
-                        info!("Shell session '{}' no longer exists, not restoring",
-                              shell.tmux_session_name);
+                        info!(
+                            "Shell session '{}' no longer exists, not restoring",
+                            shell.tmux_session_name
+                        );
                     }
                 }
             }
@@ -3112,7 +3284,9 @@ impl AppState {
 
     /// Start loading workspaces in the background (non-blocking)
     /// Returns a channel receiver that will receive the result
-    pub fn start_background_workspace_loading(&mut self) -> mpsc::UnboundedSender<WorkspaceLoadResult> {
+    pub fn start_background_workspace_loading(
+        &mut self,
+    ) -> mpsc::UnboundedSender<WorkspaceLoadResult> {
         let (tx, rx) = mpsc::unbounded_channel();
         self.workspace_load_receiver = Some(rx);
         self.is_loading_workspaces = true;
@@ -3132,21 +3306,25 @@ impl AppState {
 
                     match result {
                         WorkspaceLoadResult::Success(mut workspaces) => {
-                            info!("Background workspace loading completed: {} workspaces", workspaces.len());
+                            info!(
+                                "Background workspace loading completed: {} workspaces",
+                                workspaces.len()
+                            );
 
                             // Extract SSH sessions from workspaces into their own section
                             let mut ssh_sessions = Vec::new();
                             for workspace in &mut workspaces {
-                                let (ssh, non_ssh): (Vec<_>, Vec<_>) = workspace
-                                    .sessions
-                                    .drain(..)
-                                    .partition(|s| s.agent_type == crate::models::SessionAgentType::Ssh);
+                                let (ssh, non_ssh): (Vec<_>, Vec<_>) =
+                                    workspace.sessions.drain(..).partition(|s| {
+                                        s.agent_type == crate::models::SessionAgentType::Ssh
+                                    });
                                 workspace.sessions = non_ssh;
                                 ssh_sessions.extend(ssh);
                             }
 
                             // Remove empty workspaces (those that only had SSH sessions)
-                            workspaces.retain(|w| !w.sessions.is_empty() || w.shell_session.is_some());
+                            workspaces
+                                .retain(|w| !w.sessions.is_empty() || w.shell_session.is_some());
 
                             info!(
                                 "Separated {} SSH sessions from {} workspaces",
@@ -3164,18 +3342,26 @@ impl AppState {
                                 for session in &workspace.sessions {
                                     if session.mode == crate::models::SessionMode::Interactive {
                                         // Use tmux_session_name if available, otherwise generate from session name
-                                        let tmux_name = session.tmux_session_name.clone()
+                                        let tmux_name = session
+                                            .tmux_session_name
+                                            .clone()
                                             .unwrap_or_else(|| session.get_tmux_name());
                                         let tmux_session = crate::tmux::TmuxSession::new(
                                             tmux_name,
                                             "claude".to_string(),
                                         );
                                         self.tmux_sessions.insert(session.id, tmux_session);
-                                        debug!("Populated tmux_sessions for session {}: {}", session.id, session.name);
+                                        debug!(
+                                            "Populated tmux_sessions for session {}: {}",
+                                            session.id, session.name
+                                        );
                                     }
                                 }
                             }
-                            info!("Populated tmux_sessions with {} entries", self.tmux_sessions.len());
+                            info!(
+                                "Populated tmux_sessions with {} entries",
+                                self.tmux_sessions.len()
+                            );
 
                             // Set initial selection
                             self.selected_workspace_index = None;
@@ -3205,13 +3391,19 @@ impl AppState {
                         WorkspaceLoadResult::Error(err) => {
                             warn!("Background workspace loading failed: {}", err);
                             self.workspace_load_error = Some(err.clone());
-                            self.add_warning_notification(format!("Failed to load sessions: {}", err));
+                            self.add_warning_notification(format!(
+                                "Failed to load sessions: {}",
+                                err
+                            ));
                             return true;
                         }
                         WorkspaceLoadResult::Timeout => {
                             warn!("Background workspace loading timed out");
-                            self.workspace_load_error = Some("Docker operation timed out".to_string());
-                            self.add_warning_notification("Docker is slow - sessions may be incomplete".to_string());
+                            self.workspace_load_error =
+                                Some("Docker operation timed out".to_string());
+                            self.add_warning_notification(
+                                "Docker is slow - sessions may be incomplete".to_string(),
+                            );
                             return true;
                         }
                     }
@@ -3225,7 +3417,9 @@ impl AppState {
                             self.is_loading_workspaces = false;
                             self.workspace_load_receiver = None;
                             self.workspace_load_error = Some("Loading timed out".to_string());
-                            self.add_warning_notification("Session loading timed out - using cached data".to_string());
+                            self.add_warning_notification(
+                                "Session loading timed out - using cached data".to_string(),
+                            );
                             return true;
                         }
                     }
@@ -3257,8 +3451,11 @@ impl AppState {
         let (tx, rx) = mpsc::unbounded_channel();
         self.usage_load_receiver = Some(rx);
         self.usage_state.loading = true;
+        let query = self.usage_state.query();
         tokio::spawn(async move {
-            match tokio::task::spawn_blocking(crate::models::usage::parse_usage).await {
+            match tokio::task::spawn_blocking(move || crate::models::usage::parse_usage_for(query))
+                .await
+            {
                 Ok(data) => {
                     let _ = tx.send(data);
                 }
@@ -3337,9 +3534,7 @@ impl AppState {
                 Err(mpsc::error::TryRecvError::Disconnected) => {
                     self.skills_state.loading = false;
                     self.skills_load_receiver = None;
-                    warn!(
-                        "Skills parse task dropped its sender without delivering data"
-                    );
+                    warn!("Skills parse task dropped its sender without delivering data");
                     self.add_warning_notification(
                         "Failed to parse skills; keeping cached data".to_string(),
                     );
@@ -3393,7 +3588,10 @@ impl AppState {
         // Discover Interactive sessions from tmux
         match manager.list_sessions().await {
             Ok(sessions) => {
-                info!("Discovered {} Interactive sessions from tmux", sessions.len());
+                info!(
+                    "Discovered {} Interactive sessions from tmux",
+                    sessions.len()
+                );
 
                 // Convert to Session models and add to workspaces
                 for interactive_session in sessions {
@@ -3443,21 +3641,28 @@ impl AppState {
     /// Discover tmux sessions that are NOT managed by agents-in-a-box
     /// Also includes orphaned `tmux_` sessions whose worktrees no longer exist
     pub async fn load_other_tmux_sessions(&mut self) {
-        use tokio::process::Command;
-        use crate::models::OtherTmuxSession;
         use crate::interactive::SessionStore;
+        use crate::models::OtherTmuxSession;
+        use tokio::process::Command;
 
         info!("Discovering other tmux sessions");
 
         // Get all tmux sessions with format: name:attached:windows
         let output = match Command::new("tmux")
-            .args(["list-sessions", "-F", "#{session_name}:#{session_attached}:#{session_windows}"])
+            .args([
+                "list-sessions",
+                "-F",
+                "#{session_name}:#{session_attached}:#{session_windows}",
+            ])
             .output()
             .await
         {
             Ok(o) => o,
             Err(e) => {
-                debug!("Failed to list tmux sessions: {} (tmux might not be running)", e);
+                debug!(
+                    "Failed to list tmux sessions: {} (tmux might not be running)",
+                    e
+                );
                 self.other_tmux_sessions.clear();
                 return;
             }
@@ -3473,7 +3678,8 @@ impl AppState {
         let session_store = SessionStore::load();
 
         // Collect tmux names that appear in loaded workspaces (successfully matched)
-        let matched_tmux_names: std::collections::HashSet<&str> = self.workspaces
+        let matched_tmux_names: std::collections::HashSet<&str> = self
+            .workspaces
             .iter()
             .flat_map(|ws| ws.sessions.iter())
             .filter_map(|s| s.tmux_session_name.as_deref())
@@ -3492,13 +3698,17 @@ impl AppState {
                 // Skip shell sessions (ainb-ws-*, ainb-sh-*, ainb-shell-*)
                 if name.starts_with("ainb-ws-")
                     || name.starts_with("ainb-sh-")
-                    || name.starts_with("ainb-shell-") {
+                    || name.starts_with("ainb-shell-")
+                {
                     continue;
                 }
 
                 let attached = parts[parts.len() - 2] == "1";
                 let windows = parts[parts.len() - 1].parse().unwrap_or_else(|e| {
-                    warn!("Failed to parse window count for tmux session '{}': {}. Defaulting to 1.", name, e);
+                    warn!(
+                        "Failed to parse window count for tmux session '{}': {}. Defaulting to 1.",
+                        name, e
+                    );
                     1
                 });
 
@@ -3520,12 +3730,14 @@ impl AppState {
 
                     // Try to parse host info from session name
                     // Expected format: ssh-{host}-{port} or ssh-{host}-{user}-{port}
-                    let parts: Vec<&str> = name.strip_prefix("ssh-").unwrap_or(&name).split('-').collect();
+                    let parts: Vec<&str> =
+                        name.strip_prefix("ssh-").unwrap_or(&name).split('-').collect();
                     if parts.len() >= 2 {
                         // Last part should be port or timestamp
                         if let Ok(port) = parts[parts.len() - 1].parse::<u16>() {
                             let host = parts[..parts.len() - 1].join("-");
-                            ssh_session.ssh_target = Some(crate::models::SshTarget::new(host).with_port(port));
+                            ssh_session.ssh_target =
+                                Some(crate::models::SshTarget::new(host).with_port(port));
                         } else {
                             // Couldn't parse port, use name as-is
                             let host = parts.join("-");
@@ -3554,12 +3766,21 @@ impl AppState {
                         // If worktree exists, session should have been discovered by normal flow
                         // If we're here, something went wrong - show as orphaned
                         if metadata.worktree_path.exists() {
-                            debug!("tmux_ session {} has valid worktree but wasn't matched - adding to Other", name);
+                            debug!(
+                                "tmux_ session {} has valid worktree but wasn't matched - adding to Other",
+                                name
+                            );
                         } else {
-                            debug!("tmux_ session {} is orphaned (worktree deleted) - adding to Other", name);
+                            debug!(
+                                "tmux_ session {} is orphaned (worktree deleted) - adding to Other",
+                                name
+                            );
                         }
                     } else {
-                        debug!("tmux_ session {} not in sessions.json - adding to Other", name);
+                        debug!(
+                            "tmux_ session {} not in sessions.json - adding to Other",
+                            name
+                        );
                     }
                     // Fall through to add as "other" session
                 }
@@ -3568,7 +3789,11 @@ impl AppState {
             }
         }
 
-        info!("Discovered {} other tmux sessions and {} SSH sessions", other_sessions.len(), ssh_sessions.len());
+        info!(
+            "Discovered {} other tmux sessions and {} SSH sessions",
+            other_sessions.len(),
+            ssh_sessions.len()
+        );
         self.other_tmux_sessions = other_sessions;
         self.ssh_sessions = ssh_sessions;
     }
@@ -3576,8 +3801,8 @@ impl AppState {
     /// Auto-detect workspace shell sessions from tmux
     /// Finds ainb-ws-* sessions and matches them to workspaces
     pub async fn auto_detect_workspace_shells(&mut self) {
-        use tokio::process::Command;
         use crate::models::{ShellSession, ShellSessionStatus};
+        use tokio::process::Command;
 
         info!("Auto-detecting workspace shell sessions from tmux");
 
@@ -3586,17 +3811,14 @@ impl AppState {
         // Note: #{...} is tmux format syntax, not Rust format
         #[allow(clippy::literal_string_with_formatting_args)]
         let tmux_format = "#{session_name}:#{pane_current_path}";
-        let output = match Command::new("tmux")
-            .args(["list-sessions", "-F", tmux_format])
-            .output()
-            .await
-        {
-            Ok(o) => o,
-            Err(e) => {
-                debug!("Failed to list tmux sessions for shell detection: {}", e);
-                return;
-            }
-        };
+        let output =
+            match Command::new("tmux").args(["list-sessions", "-F", tmux_format]).output().await {
+                Ok(o) => o,
+                Err(e) => {
+                    debug!("Failed to list tmux sessions for shell detection: {}", e);
+                    return;
+                }
+            };
 
         if !output.status.success() {
             debug!("No tmux sessions found for shell detection");
@@ -4084,8 +4306,7 @@ impl AppState {
 
     /// Get the currently selected other tmux session, if any
     pub fn selected_other_tmux_session(&self) -> Option<&crate::models::OtherTmuxSession> {
-        self.selected_other_tmux_index
-            .and_then(|idx| self.other_tmux_sessions.get(idx))
+        self.selected_other_tmux_index.and_then(|idx| self.other_tmux_sessions.get(idx))
     }
 
     /// Check if the selection is in the "Other tmux" section
@@ -4137,10 +4358,7 @@ impl AppState {
                 let old_name = session.name.clone();
 
                 // Sanitize new name (tmux compatible)
-                let sanitized_name = new_name
-                    .replace(' ', "_")
-                    .replace('.', "_")
-                    .replace(':', "_");
+                let sanitized_name = new_name.replace(' ', "_").replace('.', "_").replace(':', "_");
 
                 // Execute tmux rename-session
                 let output = tokio::process::Command::new("tmux")
@@ -4178,8 +4396,7 @@ impl AppState {
 
     /// Get the currently selected SSH session, if any
     pub fn selected_ssh_session(&self) -> Option<&crate::models::Session> {
-        self.selected_ssh_session_index
-            .and_then(|idx| self.ssh_sessions.get(idx))
+        self.selected_ssh_session_index.and_then(|idx| self.ssh_sessions.get(idx))
     }
 
     /// Check if the selection is in the "SSH Sessions" section
@@ -4193,12 +4410,13 @@ impl AppState {
     pub fn start_ssh_session_rename(&mut self) {
         if let Some(session) = self.selected_ssh_session() {
             // Start with existing display_name or ssh_target display
-            self.ssh_session_rename_buffer = session.display_name.clone()
-                .unwrap_or_else(|| {
-                    session.ssh_target.as_ref()
-                        .map(|t| t.display_name())
-                        .unwrap_or_else(|| session.name.clone())
-                });
+            self.ssh_session_rename_buffer = session.display_name.clone().unwrap_or_else(|| {
+                session
+                    .ssh_target
+                    .as_ref()
+                    .map(|t| t.display_name())
+                    .unwrap_or_else(|| session.name.clone())
+            });
             self.ssh_session_rename_mode = true;
         }
     }
@@ -4273,7 +4491,10 @@ impl AppState {
     }
 
     pub fn show_delete_confirmation(&mut self, session_id: Uuid) {
-        info!("!!! SHOWING DELETE CONFIRMATION DIALOG for session: {}", session_id);
+        info!(
+            "!!! SHOWING DELETE CONFIRMATION DIALOG for session: {}",
+            session_id
+        );
 
         // Check for uncommitted changes in worktree (only for non-Shell sessions)
         let warning = self.check_session_uncommitted_warning(session_id);
@@ -4314,10 +4535,16 @@ impl AppState {
 
     /// Show confirmation dialog for killing an "other" tmux session
     pub fn show_kill_other_tmux_confirmation(&mut self, session_name: String) {
-        info!("Showing kill confirmation for other tmux session: {}", session_name);
+        info!(
+            "Showing kill confirmation for other tmux session: {}",
+            session_name
+        );
         self.confirmation_dialog = Some(ConfirmationDialog {
             title: "Kill tmux Session".to_string(),
-            message: format!("Are you sure you want to kill tmux session '{}'?", session_name),
+            message: format!(
+                "Are you sure you want to kill tmux session '{}'?",
+                session_name
+            ),
             confirm_action: ConfirmAction::KillOtherTmux(session_name),
             selected_option: false, // Default to "No"
             warning: None,
@@ -4327,37 +4554,52 @@ impl AppState {
     /// Show confirmation dialog for killing an SSH session (which is a tmux session)
     pub fn show_kill_ssh_session_confirmation(&mut self, session_name: String) {
         // Get the display name if available for a friendlier message
-        let display_text = self.selected_ssh_session()
+        let display_text = self
+            .selected_ssh_session()
             .and_then(|s| s.display_name.clone())
             .unwrap_or_else(|| session_name.clone());
 
-        info!("Showing kill confirmation for SSH session: {} (display: {})", session_name, display_text);
+        info!(
+            "Showing kill confirmation for SSH session: {} (display: {})",
+            session_name, display_text
+        );
         self.confirmation_dialog = Some(ConfirmationDialog {
             title: "Kill SSH Session".to_string(),
-            message: format!("Are you sure you want to kill SSH session '{}'?", display_text),
+            message: format!(
+                "Are you sure you want to kill SSH session '{}'?",
+                display_text
+            ),
             confirm_action: ConfirmAction::KillOtherTmux(session_name), // Reuse KillOtherTmux since SSH sessions are tmux sessions
-            selected_option: false, // Default to "No"
+            selected_option: false,                                     // Default to "No"
             warning: None,
         });
     }
 
     /// Show confirmation dialog for killing a workspace shell session
     pub fn show_kill_shell_confirmation(&mut self, workspace_index: usize) {
-        let shell_name = self.workspaces
+        let shell_name = self
+            .workspaces
             .get(workspace_index)
             .and_then(|w| w.shell_session.as_ref())
             .map(|s| s.name.clone())
             .unwrap_or_else(|| "shell".to_string());
 
-        let workspace_name = self.workspaces
+        let workspace_name = self
+            .workspaces
             .get(workspace_index)
             .map(|w| w.name.clone())
             .unwrap_or_else(|| "workspace".to_string());
 
-        info!("Showing kill confirmation for workspace shell: {} in {}", shell_name, workspace_name);
+        info!(
+            "Showing kill confirmation for workspace shell: {} in {}",
+            shell_name, workspace_name
+        );
         self.confirmation_dialog = Some(ConfirmationDialog {
             title: "Kill Shell Session".to_string(),
-            message: format!("Are you sure you want to kill shell '{}' in workspace '{}'?", shell_name, workspace_name),
+            message: format!(
+                "Are you sure you want to kill shell '{}' in workspace '{}'?",
+                shell_name, workspace_name
+            ),
             confirm_action: ConfirmAction::KillWorkspaceShell(workspace_index),
             selected_option: false, // Default to "No"
             warning: None,
@@ -4725,7 +4967,11 @@ impl AppState {
             }
         };
 
-        info!("Parsed repo source: {:?}, is_remote: {}", source, source.is_remote());
+        info!(
+            "Parsed repo source: {:?}, is_remote: {}",
+            source,
+            source.is_remote()
+        );
 
         if source.is_remote() {
             // Remote URL - try to fetch branches
@@ -4745,7 +4991,8 @@ impl AppState {
             Err(e) => {
                 if let Some(ref mut state) = self.new_session_state {
                     state.is_validating = false;
-                    state.repo_validation_error = Some(format!("Failed to init repo manager: {}", e));
+                    state.repo_validation_error =
+                        Some(format!("Failed to init repo manager: {}", e));
                 }
                 return;
             }
@@ -4806,7 +5053,8 @@ impl AppState {
             if !path.exists() {
                 if let Some(ref mut state) = self.new_session_state {
                     state.is_validating = false;
-                    state.repo_validation_error = Some(format!("Path not found: {}", path.display()));
+                    state.repo_validation_error =
+                        Some(format!("Path not found: {}", path.display()));
                 }
                 return;
             }
@@ -4815,7 +5063,8 @@ impl AppState {
             if !WorkspaceScanner::validate_workspace(path).unwrap_or(false) {
                 if let Some(ref mut state) = self.new_session_state {
                     state.is_validating = false;
-                    state.repo_validation_error = Some(format!("Not a git repository: {}", path.display()));
+                    state.repo_validation_error =
+                        Some(format!("Not a git repository: {}", path.display()));
                 }
                 return;
             }
@@ -4845,12 +5094,17 @@ impl AppState {
 
         let (source, base_branch, checkout_mode) = if let Some(ref state) = self.new_session_state {
             // Get branch from filtered list (which stores (original_idx, branch) tuples)
-            let branch = state.filtered_branches
+            let branch = state
+                .filtered_branches
                 .get(state.selected_branch_index)
                 .map(|(_, b)| b.name.clone())
                 .or_else(|| state.selected_base_branch.clone())
                 .unwrap_or_else(|| "main".to_string());
-            (state.repo_source.clone(), branch, state.branch_checkout_mode)
+            (
+                state.repo_source.clone(),
+                branch,
+                state.branch_checkout_mode,
+            )
         } else {
             error!("clone_remote_repo called but no state");
             return;
@@ -4872,7 +5126,8 @@ impl AppState {
             Err(e) => {
                 if let Some(ref mut state) = self.new_session_state {
                     state.is_validating = false;
-                    state.repo_validation_error = Some(format!("Failed to init repo manager: {}", e));
+                    state.repo_validation_error =
+                        Some(format!("Failed to init repo manager: {}", e));
                     state.step = NewSessionStep::SelectBranch;
                 }
                 return;
@@ -4999,7 +5254,8 @@ impl AppState {
             state.filtered_branches = state.remote_branches.iter().cloned().enumerate().collect();
         } else {
             // Fuzzy filter - match if filter chars appear in order
-            state.filtered_branches = state.remote_branches
+            state.filtered_branches = state
+                .remote_branches
                 .iter()
                 .enumerate()
                 .filter(|(_, branch)| {
@@ -5212,11 +5468,8 @@ impl AppState {
         );
 
         // Initialize filtered repos with all repos (even if empty)
-        let filtered_repos: Vec<(usize, std::path::PathBuf)> = repos
-            .iter()
-            .enumerate()
-            .map(|(idx, path)| (idx, path.clone()))
-            .collect();
+        let filtered_repos: Vec<(usize, std::path::PathBuf)> =
+            repos.iter().enumerate().map(|(idx, path)| (idx, path.clone())).collect();
 
         // Check if user has already cancelled (e.g., pressed escape while loading)
         if self.async_operation_cancelled {
@@ -5255,12 +5508,7 @@ impl AppState {
                 match scanner.scan() {
                     Ok(scan_result) => {
                         let max_repos = config.workspace_defaults.max_repositories;
-                        scan_result
-                            .workspaces
-                            .into_iter()
-                            .map(|w| w.path)
-                            .take(max_repos)
-                            .collect()
+                        scan_result.workspaces.into_iter().map(|w| w.path).take(max_repos).collect()
                     }
                     Err(e) => {
                         warn!("Failed to scan for repositories: {}", e);
@@ -5392,7 +5640,9 @@ impl AppState {
     pub fn new_session_next_agent(&mut self) {
         if let Some(ref mut state) = self.new_session_state {
             // Allow agent selection on both SelectAgent and InputBranch steps
-            if state.step == NewSessionStep::SelectAgent || state.step == NewSessionStep::InputBranch {
+            if state.step == NewSessionStep::SelectAgent
+                || state.step == NewSessionStep::InputBranch
+            {
                 state.next_agent();
             }
         }
@@ -5402,7 +5652,9 @@ impl AppState {
     pub fn new_session_prev_agent(&mut self) {
         if let Some(ref mut state) = self.new_session_state {
             // Allow agent selection on both SelectAgent and InputBranch steps
-            if state.step == NewSessionStep::SelectAgent || state.step == NewSessionStep::InputBranch {
+            if state.step == NewSessionStep::SelectAgent
+                || state.step == NewSessionStep::InputBranch
+            {
                 state.prev_agent();
             }
         }
@@ -5412,7 +5664,9 @@ impl AppState {
     pub fn new_session_next_model(&mut self) {
         if let Some(ref mut state) = self.new_session_state {
             // Allow model selection on both SelectAgent and InputBranch steps
-            if state.step == NewSessionStep::SelectAgent || state.step == NewSessionStep::InputBranch {
+            if state.step == NewSessionStep::SelectAgent
+                || state.step == NewSessionStep::InputBranch
+            {
                 state.next_model();
             }
         }
@@ -5422,7 +5676,9 @@ impl AppState {
     pub fn new_session_prev_model(&mut self) {
         if let Some(ref mut state) = self.new_session_state {
             // Allow model selection on both SelectAgent and InputBranch steps
-            if state.step == NewSessionStep::SelectAgent || state.step == NewSessionStep::InputBranch {
+            if state.step == NewSessionStep::SelectAgent
+                || state.step == NewSessionStep::InputBranch
+            {
                 state.prev_model();
             }
         }
@@ -5431,7 +5687,9 @@ impl AppState {
     /// Toggle focus between agent and model panels
     pub fn new_session_toggle_agent_model_focus(&mut self) {
         if let Some(ref mut state) = self.new_session_state {
-            if state.step == NewSessionStep::SelectAgent || state.step == NewSessionStep::InputBranch {
+            if state.step == NewSessionStep::SelectAgent
+                || state.step == NewSessionStep::InputBranch
+            {
                 state.toggle_agent_model_focus();
             }
         }
@@ -5482,7 +5740,8 @@ impl AppState {
 
             // For AI agents, check if we should skip branch input
             // In CheckoutExisting mode for remote repos, the branch name is already set
-            let skip_branch_input = state.branch_checkout_mode == BranchCheckoutMode::CheckoutExisting
+            let skip_branch_input = state.branch_checkout_mode
+                == BranchCheckoutMode::CheckoutExisting
                 && state.cached_repo_path.is_some()
                 && !state.branch_name.is_empty();
 
@@ -5535,13 +5794,15 @@ impl AppState {
                 // Find the last word boundary (space, slash, dash, underscore)
                 let s = &state.branch_name;
                 // First, skip any trailing delimiters
-                let trimmed_end = s.trim_end_matches(|c: char| c == ' ' || c == '/' || c == '-' || c == '_');
+                let trimmed_end =
+                    s.trim_end_matches(|c: char| c == ' ' || c == '/' || c == '-' || c == '_');
                 if trimmed_end.is_empty() {
                     state.branch_name.clear();
                     return;
                 }
                 // Find the last word boundary
-                let last_boundary = trimmed_end.rfind(|c: char| c == ' ' || c == '/' || c == '-' || c == '_');
+                let last_boundary =
+                    trimmed_end.rfind(|c: char| c == ' ' || c == '/' || c == '-' || c == '_');
                 match last_boundary {
                     Some(idx) => {
                         // Keep up to and including the delimiter
@@ -5624,10 +5885,18 @@ impl AppState {
         if let Some(ref mut state) = self.new_session_state {
             if state.step == NewSessionStep::ConfigureSsh {
                 match state.ssh_input_focus {
-                    SshInputFocus::Host => { state.ssh_host.pop(); }
-                    SshInputFocus::Port => { state.ssh_port.pop(); }
-                    SshInputFocus::User => { state.ssh_user.pop(); }
-                    SshInputFocus::IdentityFile => { state.ssh_identity_file.pop(); }
+                    SshInputFocus::Host => {
+                        state.ssh_host.pop();
+                    }
+                    SshInputFocus::Port => {
+                        state.ssh_port.pop();
+                    }
+                    SshInputFocus::User => {
+                        state.ssh_user.pop();
+                    }
+                    SshInputFocus::IdentityFile => {
+                        state.ssh_identity_file.pop();
+                    }
                 }
             }
         }
@@ -5655,7 +5924,11 @@ impl AppState {
 
             tracing::info!(
                 "SSH configuration confirmed: {}@{}:{}",
-                if state.ssh_user.is_empty() { "(no user)" } else { &state.ssh_user },
+                if state.ssh_user.is_empty() {
+                    "(no user)"
+                } else {
+                    &state.ssh_user
+                },
                 state.ssh_host,
                 port
             );
@@ -5802,7 +6075,10 @@ impl AppState {
                     RepoSourceChoice::Ssh => RepoSourceChoice::Remote,
                     RepoSourceChoice::Favorites => RepoSourceChoice::Ssh,
                 };
-                tracing::info!("Source choice toggled (reverse) to: {:?}", state.source_choice);
+                tracing::info!(
+                    "Source choice toggled (reverse) to: {:?}",
+                    state.source_choice
+                );
             }
         }
     }
@@ -5821,7 +6097,9 @@ impl AppState {
                         self.pending_async_action = Some(AsyncAction::StartWorkspaceSearch);
                     }
                     RepoSourceChoice::Remote => {
-                        tracing::info!("Proceeding with Remote source - showing URL input with favorites");
+                        tracing::info!(
+                            "Proceeding with Remote source - showing URL input with favorites"
+                        );
                         // Load favorites for quick selection in InputRepoSource
                         state.favorites_store = crate::config::FavoritesStore::load();
                         state.selected_favorite_index = None; // Start with URL input focused
@@ -5840,7 +6118,9 @@ impl AppState {
                         state.ssh_input_focus = SshInputFocus::Host;
                     }
                     RepoSourceChoice::Favorites => {
-                        tracing::info!("Proceeding with Favorites source - showing favorites picker");
+                        tracing::info!(
+                            "Proceeding with Favorites source - showing favorites picker"
+                        );
                         // Load favorites and go to favorites picker
                         state.favorites_store = crate::config::FavoritesStore::load();
                         state.selected_favorite_index = if state.favorites_store.is_empty() {
@@ -6049,7 +6329,9 @@ impl AppState {
             if !state.repo_input.is_empty() {
                 let source = state.repo_input.clone();
                 // Check if already a favorite
-                if let Some(existing) = state.favorites_store.favorites.iter().find(|f| f.source == source) {
+                if let Some(existing) =
+                    state.favorites_store.favorites.iter().find(|f| f.source == source)
+                {
                     let alias = existing.alias.clone();
                     state.favorites_store.remove(&alias);
                     tracing::info!("Removed from favorites: {}", source);
@@ -6057,7 +6339,8 @@ impl AppState {
                     // Add as new favorite with auto-generated alias
                     let alias = Self::generate_favorite_alias(&source);
                     let source_type = Self::detect_source_type(&source);
-                    let favorite = crate::config::Favorite::new(alias.clone(), source.clone(), source_type);
+                    let favorite =
+                        crate::config::Favorite::new(alias.clone(), source.clone(), source_type);
                     let _ = state.favorites_store.add(favorite);
                     tracing::info!("Added to favorites: {} as {}", source, alias);
                 }
@@ -6098,7 +6381,11 @@ impl AppState {
     pub fn is_repo_input_favorite(&self) -> bool {
         if let Some(ref state) = self.new_session_state {
             if !state.repo_input.is_empty() {
-                return state.favorites_store.favorites.iter().any(|f| f.source == state.repo_input);
+                return state
+                    .favorites_store
+                    .favorites
+                    .iter()
+                    .any(|f| f.source == state.repo_input);
             }
         }
         false
@@ -6113,7 +6400,9 @@ impl AppState {
                     let source = repo_path.display().to_string();
 
                     // Check if already a favorite
-                    if let Some(existing) = state.favorites_store.favorites.iter().find(|f| f.source == source) {
+                    if let Some(existing) =
+                        state.favorites_store.favorites.iter().find(|f| f.source == source)
+                    {
                         let alias = existing.alias.clone();
                         state.favorites_store.remove(&alias);
                         tracing::info!("Removed local repo from favorites: {}", source);
@@ -6121,7 +6410,11 @@ impl AppState {
                         // Add as new favorite with auto-generated alias
                         let alias = Self::generate_favorite_alias(&source);
                         let source_type = crate::config::FavoriteSourceType::LocalPath;
-                        let favorite = crate::config::Favorite::new(alias.clone(), source.clone(), source_type);
+                        let favorite = crate::config::Favorite::new(
+                            alias.clone(),
+                            source.clone(),
+                            source_type,
+                        );
                         let _ = state.favorites_store.add(favorite);
                         tracing::info!("Added local repo to favorites: {} as {}", source, alias);
                     }
@@ -6399,7 +6692,9 @@ impl AppState {
 
             // Then check if authentication is set up
             if Self::is_first_time_setup() {
-                info!("Boss mode selected but authentication not set up, switching to auth setup view");
+                info!(
+                    "Boss mode selected but authentication not set up, switching to auth setup view"
+                );
                 self.current_view = View::AuthSetup;
                 self.auth_setup_state = Some(AuthSetupState {
                     selected_method: AuthMethod::OAuth,
@@ -6413,7 +6708,9 @@ impl AppState {
                 return;
             }
         } else {
-            info!("Interactive mode selected - skipping Docker auth check (will use host ~/.claude)");
+            info!(
+                "Interactive mode selected - skipping Docker auth check (will use host ~/.claude)"
+            );
         }
 
         let (
@@ -6449,8 +6746,11 @@ impl AppState {
                     // Check if this is a remote repo flow (cached_repo_path is set)
                     // For remote repos, we create worktree here and pass it to session creation
                     // For local repos, session creation will create the worktree
-                    let (repo_path, existing_worktree, worktree_notice) =
-                        if let Some(ref cached_path) = state.cached_repo_path {
+                    let (repo_path, existing_worktree, worktree_notice) = if let Some(
+                        ref cached_path,
+                    ) =
+                        state.cached_repo_path
+                    {
                         // Remote repo flow - create worktree from bare cache
                         use crate::git::RemoteRepoManager;
 
@@ -6462,14 +6762,16 @@ impl AppState {
                             Some(dir) => dir.join(".agents-in-a-box").join("worktrees"),
                             None => {
                                 tracing::error!("Home directory not found, cannot create worktree");
-                                state.repo_validation_error = Some("Home directory not found".to_string());
+                                state.repo_validation_error =
+                                    Some("Home directory not found".to_string());
                                 state.step = NewSessionStep::InputRepoSource;
                                 return;
                             }
                         };
 
                         // Create unique worktree path using repo name and branch
-                        let repo_name = state.repo_source
+                        let repo_name = state
+                            .repo_source
                             .as_ref()
                             .map(|s| s.display_name().replace('/', "_"))
                             .unwrap_or_else(|| "unknown".to_string());
@@ -6483,8 +6785,8 @@ impl AppState {
                                 WorktreeCollisionBehavior::AutoRename => {
                                     let mut suffix = Uuid::new_v4().to_string();
                                     suffix.truncate(8);
-                                    let mut candidate =
-                                        worktree_base.join(format!("{}-{}", base_worktree_name, suffix));
+                                    let mut candidate = worktree_base
+                                        .join(format!("{}-{}", base_worktree_name, suffix));
                                     while candidate.exists() {
                                         let mut next_suffix = Uuid::new_v4().to_string();
                                         next_suffix.truncate(8);
@@ -6548,7 +6850,8 @@ impl AppState {
                                     Ok(()) => worktree_path.clone(),
                                     Err(e) => {
                                         tracing::error!("Failed to create worktree: {}", e);
-                                        state.repo_validation_error = Some(format!("Failed to create worktree: {}", e));
+                                        state.repo_validation_error =
+                                            Some(format!("Failed to create worktree: {}", e));
                                         state.step = NewSessionStep::InputRepoSource;
                                         return;
                                     }
@@ -6577,7 +6880,8 @@ impl AppState {
                                     }
                                     Err(e) => {
                                         tracing::error!("Failed to create worktree: {}", e);
-                                        state.repo_validation_error = Some(format!("Failed to create worktree: {}", e));
+                                        state.repo_validation_error =
+                                            Some(format!("Failed to create worktree: {}", e));
                                         state.step = NewSessionStep::InputRepoSource;
                                         return;
                                     }
@@ -6631,10 +6935,10 @@ impl AppState {
                         } else {
                             None
                         },
-                        state.restart_session_id, // Pass restart session ID
-                        state.selected_agent,     // Agent type for session
+                        state.restart_session_id,  // Pass restart session ID
+                        state.selected_agent,      // Agent type for session
                         state.get_session_model(), // Model (only for Claude agent)
-                        existing_worktree,        // Existing worktree for remote repos
+                        existing_worktree,         // Existing worktree for remote repos
                         worktree_notice,
                     )
                 } else {
@@ -6869,18 +7173,21 @@ impl AppState {
         if let Ok(ref session_state) = result {
             if mode_clone == crate::models::SessionMode::Interactive {
                 if let Some(ref worktree_info) = session_state.worktree_info {
-                    info!("Creating tmux session for restarted Interactive mode session {}", session_id);
+                    info!(
+                        "Creating tmux session for restarted Interactive mode session {}",
+                        session_id
+                    );
 
                     // Send log message about tmux session creation
-                    let _ = log_sender.send("Creating tmux session for interactive mode...".to_string());
+                    let _ = log_sender
+                        .send("Creating tmux session for interactive mode...".to_string());
 
                     // Create tmux session name from session info
-                    let tmux_name = format!("tmux_{}", branch_name.replace('/', "_").replace(' ', "_"));
+                    let tmux_name =
+                        format!("tmux_{}", branch_name.replace('/', "_").replace(' ', "_"));
 
-                    let mut tmux_session = crate::tmux::TmuxSession::new(
-                        tmux_name.clone(),
-                        "claude".to_string()
-                    );
+                    let mut tmux_session =
+                        crate::tmux::TmuxSession::new(tmux_name.clone(), "claude".to_string());
                     let tmux_session_name = tmux_session.name().to_string();
 
                     // Start tmux session in the worktree directory
@@ -6896,11 +7203,13 @@ impl AppState {
                             // Store tmux session in our map
                             self.tmux_sessions.insert(session_id, tmux_session);
 
-                            let _ = log_sender.send("Tmux session created successfully!".to_string());
+                            let _ =
+                                log_sender.send("Tmux session created successfully!".to_string());
                         }
                         Err(e) => {
                             warn!("Failed to start tmux session: {}", e);
-                            let _ = log_sender.send(format!("Warning: Failed to create tmux session: {}", e));
+                            let _ = log_sender
+                                .send(format!("Warning: Failed to create tmux session: {}", e));
                             // Don't fail the whole session creation if tmux fails
                         }
                     }
@@ -6908,7 +7217,10 @@ impl AppState {
                     warn!("Session state has no worktree info, skipping tmux creation");
                 }
             } else {
-                info!("Skipping tmux creation for Boss mode session {}", session_id);
+                info!(
+                    "Skipping tmux creation for Boss mode session {}",
+                    session_id
+                );
             }
         }
 
@@ -6979,14 +7291,20 @@ impl AppState {
 
         info!(
             "Creating Interactive mode session {} for branch '{}' (skip_permissions={}, existing_worktree={})",
-            session_id, branch_name, skip_permissions, existing_worktree.is_some()
+            session_id,
+            branch_name,
+            skip_permissions,
+            existing_worktree.is_some()
         );
 
         // Create a channel for logs
         let (log_sender, mut log_receiver) = mpsc::unbounded_channel::<String>();
 
         // Initialize logs for this session
-        self.logs.insert(session_id, vec!["Starting Interactive session creation...".to_string()]);
+        self.logs.insert(
+            session_id,
+            vec!["Starting Interactive session creation...".to_string()],
+        );
 
         // Create a shared vector for logs
         let session_logs = Arc::new(Mutex::new(Vec::new()));
@@ -6999,15 +7317,15 @@ impl AppState {
                 if let Ok(mut logs) = logs_clone.lock() {
                     logs.push(log_message.clone());
                 }
-                info!("Interactive session log for {}: {}", session_id_clone, log_message);
+                info!(
+                    "Interactive session log for {}: {}",
+                    session_id_clone, log_message
+                );
             }
         });
 
-        let workspace_name = repo_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown")
-            .to_string();
+        let workspace_name =
+            repo_path.file_name().and_then(|n| n.to_str()).unwrap_or("unknown").to_string();
 
         // Create Interactive session manager (NO Docker dependency)
         let mut manager = InteractiveSessionManager::new()?;
@@ -7066,20 +7384,20 @@ impl AppState {
                 let session = interactive_session.to_session_model();
 
                 // Find or create workspace for this repo
-                if let Some((ws_idx, workspace)) = self.workspaces.iter_mut().enumerate().find(|(_, w)| {
-                    std::path::Path::new(&w.path).canonicalize().ok()
-                        == repo_path.canonicalize().ok()
-                }) {
+                if let Some((ws_idx, workspace)) =
+                    self.workspaces.iter_mut().enumerate().find(|(_, w)| {
+                        std::path::Path::new(&w.path).canonicalize().ok()
+                            == repo_path.canonicalize().ok()
+                    })
+                {
                     workspace.sessions.push(session);
                     // Auto-select the new session so the list scrolls to show it
                     self.selected_workspace_index = Some(ws_idx);
                     self.selected_session_index = Some(workspace.sessions.len() - 1);
                 } else {
                     // Create new workspace
-                    let mut workspace = crate::models::Workspace::new(
-                        workspace_name,
-                        repo_path.to_path_buf(),
-                    );
+                    let mut workspace =
+                        crate::models::Workspace::new(workspace_name, repo_path.to_path_buf());
                     workspace.sessions.push(session);
                     self.workspaces.push(workspace);
                     // Auto-select the new workspace and session
@@ -7129,7 +7447,10 @@ impl AppState {
         let (log_sender, mut log_receiver) = mpsc::unbounded_channel::<String>();
 
         // Initialize logs for this session
-        self.logs.insert(session_id, vec!["Starting Boss session creation...".to_string()]);
+        self.logs.insert(
+            session_id,
+            vec!["Starting Boss session creation...".to_string()],
+        );
 
         // Create a shared vector for logs
         let session_logs = Arc::new(Mutex::new(Vec::new()));
@@ -7236,10 +7557,7 @@ impl AppState {
                                 );
                             } else {
                                 cleaned_up += 1;
-                                info!(
-                                    "Successfully removed orphaned container {}",
-                                    container_id
-                                );
+                                info!("Successfully removed orphaned container {}", container_id);
                             }
                         }
                     }
@@ -7260,7 +7578,10 @@ impl AppState {
                 } else {
                     // Also check if the worktree actually exists
                     if let Err(_) = worktree_manager.get_worktree_info(session.id) {
-                        info!("Found session without worktree: {} ({})", session.name, session.id);
+                        info!(
+                            "Found session without worktree: {} ({})",
+                            session.name, session.id
+                        );
                         orphaned_sessions.push(session.id);
                     }
                 }
@@ -7285,20 +7606,15 @@ impl AppState {
         // Step 3: Prune git worktrees (removes stale git references for deleted worktrees)
         info!("Pruning git worktrees to remove stale references");
         use tokio::process::Command;
-        match Command::new("git")
-            .arg("worktree")
-            .arg("prune")
-            .arg("-v")
-            .output()
-            .await
-        {
+        match Command::new("git").arg("worktree").arg("prune").arg("-v").output().await {
             Ok(output) => {
                 if output.status.success() {
                     let stdout = String::from_utf8_lossy(&output.stdout);
                     if !stdout.trim().is_empty() {
                         info!("Git worktree prune output: {}", stdout.trim());
                         // Count lines that start with "Removing" to track pruned worktrees
-                        let pruned_count = stdout.lines().filter(|line| line.contains("Removing")).count();
+                        let pruned_count =
+                            stdout.lines().filter(|line| line.contains("Removing")).count();
                         if pruned_count > 0 {
                             info!("Pruned {} stale git worktree references", pruned_count);
                             cleaned_up += pruned_count;
@@ -7343,11 +7659,11 @@ impl AppState {
         cleaned_up += shells_cleaned;
 
         if cleaned_up > 0 {
-            info!("Cleaned up {} orphaned items (containers + state + git refs + tmux shells)", cleaned_up);
-            self.add_success_notification(format!(
-                "🧹 Cleaned up {} orphaned items",
+            info!(
+                "Cleaned up {} orphaned items (containers + state + git refs + tmux shells)",
                 cleaned_up
-            ));
+            );
+            self.add_success_notification(format!("🧹 Cleaned up {} orphaned items", cleaned_up));
 
             // Reload workspaces to reflect changes
             self.load_real_workspaces().await;
@@ -7357,7 +7673,10 @@ impl AppState {
             audit::audit_orphaned_cleanup(
                 AuditTrigger::UserKeypress("Ctrl+X".to_string()),
                 AuditResult::Success,
-                format!("Cleaned up {} orphaned items (containers + state + git refs + tmux shells)", cleaned_up),
+                format!(
+                    "Cleaned up {} orphaned items (containers + state + git refs + tmux shells)",
+                    cleaned_up
+                ),
             );
         } else {
             info!("No orphaned containers or sessions found");
@@ -7405,16 +7724,15 @@ impl AppState {
             return 0;
         }
 
-        info!("Found {} orphaned tmux shell sessions to clean up", orphaned_shells.len());
+        info!(
+            "Found {} orphaned tmux shell sessions to clean up",
+            orphaned_shells.len()
+        );
         let mut killed_count = 0;
 
         for session_name in &orphaned_shells {
             info!("Killing orphaned tmux shell session: {}", session_name);
-            match Command::new("tmux")
-                .args(["kill-session", "-t", session_name])
-                .output()
-                .await
-            {
+            match Command::new("tmux").args(["kill-session", "-t", session_name]).output().await {
                 Ok(output) if output.status.success() => {
                     killed_count += 1;
                     info!("Successfully killed tmux session: {}", session_name);
@@ -7424,7 +7742,10 @@ impl AppState {
                     warn!("Failed to kill tmux session {}: {}", session_name, stderr);
                 }
                 Err(e) => {
-                    warn!("Failed to run tmux kill-session for {}: {}", session_name, e);
+                    warn!(
+                        "Failed to run tmux kill-session for {}: {}",
+                        session_name, e
+                    );
                 }
             }
         }
@@ -7459,13 +7780,14 @@ impl AppState {
                 crate::models::SessionMode::Interactive => {
                     self.delete_interactive_session(session_id).await
                 }
-                crate::models::SessionMode::Boss => {
-                    self.delete_boss_session(session_id).await
-                }
+                crate::models::SessionMode::Boss => self.delete_boss_session(session_id).await,
             }
         } else {
             // Session not found in UI, try both cleanup methods
-            warn!("Session {} not found in UI, attempting cleanup anyway", session_id);
+            warn!(
+                "Session {} not found in UI, attempting cleanup anyway",
+                session_id
+            );
 
             // Try Interactive cleanup first (no Docker needed)
             if let Err(e) = self.delete_interactive_session(session_id).await {
@@ -7532,7 +7854,10 @@ impl AppState {
         }
 
         // Use Interactive session manager to remove session
-        info!("Creating InteractiveSessionManager for session: {}", session_id);
+        info!(
+            "Creating InteractiveSessionManager for session: {}",
+            session_id
+        );
         let mut manager = InteractiveSessionManager::new()?;
         info!("Calling manager.remove_session() for: {}", session_id);
         match manager.remove_session(session_id).await {
@@ -7543,7 +7868,10 @@ impl AppState {
             }
         }
 
-        info!("=== DELETE INTERACTIVE SESSION COMPLETE: {} ===", session_id);
+        info!(
+            "=== DELETE INTERACTIVE SESSION COMPLETE: {} ===",
+            session_id
+        );
         Ok(())
     }
 
@@ -7614,7 +7942,10 @@ impl AppState {
 
     pub async fn process_async_action(&mut self) -> anyhow::Result<()> {
         if let Some(action) = self.pending_async_action.take() {
-            info!(">>> process_async_action() called with action: {:?}", action);
+            info!(
+                ">>> process_async_action() called with action: {:?}",
+                action
+            );
             match action {
                 AsyncAction::StartNewSession => {
                     self.start_new_session().await;
@@ -7674,7 +8005,10 @@ impl AppState {
                     // Refresh once after all deletions
                     self.load_real_workspaces().await;
                     if failed > 0 {
-                        self.add_warning_notification(format!("Deleted {}/{} sessions ({} failed)", deleted, total, failed));
+                        self.add_warning_notification(format!(
+                            "Deleted {}/{} sessions ({} failed)",
+                            deleted, total, failed
+                        ));
                     } else {
                         self.add_success_notification(format!("Deleted {} session(s)", deleted));
                     }
@@ -7776,7 +8110,9 @@ impl AppState {
                     info!("Executing Other tmux rename");
                     match self.confirm_other_tmux_rename().await {
                         Ok(()) => {
-                            self.add_success_notification("Session renamed successfully".to_string());
+                            self.add_success_notification(
+                                "Session renamed successfully".to_string(),
+                            );
                             self.ui_needs_refresh = true;
                         }
                         Err(e) => {
@@ -8019,8 +8355,10 @@ impl AppState {
                 // Wrap in tokio timeout
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(3),
-                    tokio::task::spawn_blocking(move || child.wait_with_output())
-                ).await {
+                    tokio::task::spawn_blocking(move || child.wait_with_output()),
+                )
+                .await
+                {
                     Ok(Ok(Ok(output))) => {
                         if output.status.success() {
                             let version = String::from_utf8_lossy(&output.stdout);
@@ -8245,11 +8583,11 @@ impl AppState {
 
                     // For Idle sessions, we restart Claude within the existing tmux session
                     if let Err(e) = self.restart_claude_in_tmux(session_id).await {
-                        error!("Failed to restart Claude in tmux for session {}: {}", session_id, e);
-                        self.add_error_notification(format!(
-                            "❌ Failed to restart Claude: {}",
-                            e
-                        ));
+                        error!(
+                            "Failed to restart Claude in tmux for session {}: {}",
+                            session_id, e
+                        );
+                        self.add_error_notification(format!("❌ Failed to restart Claude: {}", e));
                     } else {
                         self.add_success_notification(
                             "✓ Claude restarted successfully".to_string(),
@@ -8490,7 +8828,7 @@ impl AppState {
     /// Update preview content for all tmux sessions (called from main update loop)
     pub async fn update_tmux_previews(&mut self) -> anyhow::Result<()> {
         use crate::tmux::ClaudeProcessDetector;
-        use crate::tmux::capture::{capture_pane, CaptureOptions};
+        use crate::tmux::capture::{CaptureOptions, capture_pane};
 
         // THROTTLE: Only update previews every 5 seconds (not every 250ms tick)
         // This prevents spawning N tmux capture-pane subprocesses per tick
@@ -8600,7 +8938,9 @@ impl AppState {
         // Update shell session preview (only the selected workspace's shell)
         let selected_workspace_idx = self.selected_workspace_index;
         if let Some(ws_idx) = selected_workspace_idx {
-            if let Some(tmux_name) = self.workspaces.get(ws_idx)
+            if let Some(tmux_name) = self
+                .workspaces
+                .get(ws_idx)
                 .and_then(|w| w.shell_session.as_ref())
                 .map(|s| s.tmux_session_name.clone())
             {
@@ -8620,7 +8960,10 @@ impl AppState {
                         }
                     }
                     Err(e) => {
-                        debug!("Failed to capture shell session content for {}: {}", tmux_name, e);
+                        debug!(
+                            "Failed to capture shell session content for {}: {}",
+                            tmux_name, e
+                        );
                     }
                 }
             }
@@ -8683,7 +9026,10 @@ impl AppState {
             session.set_status(crate::models::SessionStatus::Running);
         }
 
-        info!("Successfully sent Claude restart command to tmux session '{}'", tmux_session_name);
+        info!(
+            "Successfully sent Claude restart command to tmux session '{}'",
+            tmux_session_name
+        );
         Ok(())
     }
 
@@ -8700,7 +9046,10 @@ impl AppState {
     }
 
     /// Helper to find a mutable session by ID across all workspaces
-    fn find_session_mut(&mut self, session_id: uuid::Uuid) -> Option<&mut crate::models::session::Session> {
+    fn find_session_mut(
+        &mut self,
+        session_id: uuid::Uuid,
+    ) -> Option<&mut crate::models::session::Session> {
         for workspace in &mut self.workspaces {
             for session in &mut workspace.sessions {
                 if session.id == session_id {
@@ -8760,7 +9109,9 @@ impl App {
                         Err(e) => warn!("Failed to refresh OAuth tokens: {}", e),
                     }
                 } else {
-                    info!("Docker not available - skipping OAuth token refresh (Boss mode will require Docker)");
+                    info!(
+                        "Docker not available - skipping OAuth token refresh (Boss mode will require Docker)"
+                    );
                     // Don't show error - user might only use Interactive mode which doesn't need Docker
                 }
             }
@@ -8790,14 +9141,14 @@ impl App {
             let timeout_duration = Duration::from_secs(AppState::DOCKER_TIMEOUT_SECS);
 
             // Load workspaces with timeout
-            let load_result = tokio::time::timeout(
-                timeout_duration,
-                load_workspaces_async()
-            ).await;
+            let load_result = tokio::time::timeout(timeout_duration, load_workspaces_async()).await;
 
             let result = match load_result {
                 Ok(Ok(workspaces)) => {
-                    info!("Background workspace loading succeeded: {} workspaces", workspaces.len());
+                    info!(
+                        "Background workspace loading succeeded: {} workspaces",
+                        workspaces.len()
+                    );
                     WorkspaceLoadResult::Success(workspaces)
                 }
                 Ok(Err(e)) => {
@@ -8805,7 +9156,10 @@ impl App {
                     WorkspaceLoadResult::Error(e.to_string())
                 }
                 Err(_) => {
-                    warn!("Background workspace loading timed out after {}s", AppState::DOCKER_TIMEOUT_SECS);
+                    warn!(
+                        "Background workspace loading timed out after {}s",
+                        AppState::DOCKER_TIMEOUT_SECS
+                    );
                     WorkspaceLoadResult::Timeout
                 }
             };
@@ -8958,9 +9312,13 @@ impl App {
             tokio::spawn(async {
                 match crate::app::snapshot::SnapshotManager::take_snapshot().await {
                     Ok(snapshot) => {
-                        if let Err(e) = crate::app::snapshot::SnapshotManager::save_snapshot(&snapshot).await {
+                        if let Err(e) =
+                            crate::app::snapshot::SnapshotManager::save_snapshot(&snapshot).await
+                        {
                             tracing::warn!("Failed to save session snapshot: {}", e);
-                        } else if let Err(e) = crate::app::snapshot::SnapshotManager::prune_snapshots(48).await {
+                        } else if let Err(e) =
+                            crate::app::snapshot::SnapshotManager::prune_snapshots(48).await
+                        {
                             tracing::warn!("Failed to prune old snapshots: {}", e);
                         }
                     }
@@ -8993,12 +9351,18 @@ impl App {
 
         // Process any pending async actions
         if self.state.pending_async_action.is_some() {
-            info!(">>> tick() detected pending_async_action: {:?}", self.state.pending_async_action);
+            info!(
+                ">>> tick() detected pending_async_action: {:?}",
+                self.state.pending_async_action
+            );
         }
         match self.state.process_async_action().await {
             Ok(()) => {
                 if self.state.pending_async_action.is_some() {
-                    info!(">>> After process_async_action, still pending: {:?}", self.state.pending_async_action);
+                    info!(
+                        ">>> After process_async_action, still pending: {:?}",
+                        self.state.pending_async_action
+                    );
                 }
             }
             Err(e) => {

--- a/ainb-tui/src/cli/config_cmd.rs
+++ b/ainb-tui/src/cli/config_cmd.rs
@@ -77,7 +77,7 @@ fn cmd_show(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize config as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             let toml_str =
                 toml::to_string_pretty(&config).context("Failed to serialize config as TOML")?;
             println!("{toml_str}");
@@ -101,7 +101,7 @@ fn cmd_get(key: &str, format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize value as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             print_toml_value(value);
         }
     }
@@ -186,7 +186,7 @@ fn cmd_path(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize config paths")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             let labels = ["Project config", "User config", "System config"];
 
             println!("Configuration file locations (highest precedence first):");

--- a/ainb-tui/src/cli/favorites.rs
+++ b/ainb-tui/src/cli/favorites.rs
@@ -95,14 +95,17 @@ fn cmd_list(format: OutputFormat) -> Result<()> {
 
     match format {
         OutputFormat::Json => {
-            let entries: Vec<FavoriteJson<'_>> = sorted.iter().map(|f| FavoriteJson::from(*f)).collect();
-            let json =
-                serde_json::to_string_pretty(&entries).context("Failed to serialize favorites as JSON")?;
+            let entries: Vec<FavoriteJson<'_>> =
+                sorted.iter().map(|f| FavoriteJson::from(*f)).collect();
+            let json = serde_json::to_string_pretty(&entries)
+                .context("Failed to serialize favorites as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             if sorted.is_empty() {
-                println!("No favorites yet. Add one with 'ainb favorites add <source> --alias <name>'.");
+                println!(
+                    "No favorites yet. Add one with 'ainb favorites add <source> --alias <name>'."
+                );
                 return Ok(());
             }
 
@@ -116,11 +119,8 @@ fn cmd_list(format: OutputFormat) -> Result<()> {
                     format!(" [{}]", fav.tags.join(", "))
                 };
 
-                let desc = fav
-                    .description
-                    .as_deref()
-                    .map(|d| format!(" — {d}"))
-                    .unwrap_or_default();
+                let desc =
+                    fav.description.as_deref().map(|d| format!(" — {d}")).unwrap_or_default();
 
                 println!(
                     "  {alias} ({kind})  uses={count}{tags}",
@@ -157,9 +157,7 @@ fn cmd_add(source: &str, alias: &str, description: Option<&str>, tags: Option<&s
     fav.description = description.map(str::to_string);
     fav.tags = parse_tags(tags);
 
-    store
-        .add(fav)
-        .map_err(|e| anyhow!("Failed to add favorite '{alias}': {e}"))?;
+    store.add(fav).map_err(|e| anyhow!("Failed to add favorite '{alias}': {e}"))?;
 
     store.save().context("Failed to save favorites store")?;
 
@@ -242,7 +240,11 @@ fn is_github_shorthand(input: &str) -> bool {
     if input.contains(char::is_whitespace) {
         return false;
     }
-    if input.contains("://") || input.starts_with('/') || input.starts_with('.') || input.starts_with('~') {
+    if input.contains("://")
+        || input.starts_with('/')
+        || input.starts_with('.')
+        || input.starts_with('~')
+    {
         return false;
     }
 
@@ -306,7 +308,10 @@ mod tests {
             detect_source_type("anthropics/claude-code"),
             SourceType::GithubShorthand
         );
-        assert_eq!(detect_source_type("rust-lang/rust"), SourceType::GithubShorthand);
+        assert_eq!(
+            detect_source_type("rust-lang/rust"),
+            SourceType::GithubShorthand
+        );
     }
 
     #[test]
@@ -328,10 +333,7 @@ mod tests {
     #[test]
     fn test_detect_three_segments_not_shorthand() {
         // Three slashes is not GitHub shorthand. Falls through to local path.
-        assert_eq!(
-            detect_source_type("a/b/c"),
-            SourceType::LocalPath
-        );
+        assert_eq!(detect_source_type("a/b/c"), SourceType::LocalPath);
     }
 
     #[test]
@@ -374,7 +376,11 @@ mod tests {
     fn test_parse_tags_multiple_with_whitespace() {
         assert_eq!(
             parse_tags(Some("frontend, react ,  ui")),
-            vec!["frontend".to_string(), "react".to_string(), "ui".to_string()]
+            vec![
+                "frontend".to_string(),
+                "react".to_string(),
+                "ui".to_string()
+            ]
         );
     }
 

--- a/ainb-tui/src/cli/git_cmd.rs
+++ b/ainb-tui/src/cli/git_cmd.rs
@@ -118,7 +118,7 @@ fn cmd_worktrees(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize worktree entries")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             if entries.is_empty() {
                 println!("No managed worktrees found.");
                 return Ok(());
@@ -178,7 +178,9 @@ fn cmd_cleanup(force: bool, dry_run: bool, format: OutputFormat) -> Result<()> {
     if orphans.is_empty() {
         match format {
             OutputFormat::Json => println!("[]"),
-            OutputFormat::Text => println!("No orphaned worktrees to clean up."),
+            OutputFormat::Text | OutputFormat::Csv => {
+                println!("No orphaned worktrees to clean up.")
+            }
         }
         return Ok(());
     }
@@ -190,7 +192,7 @@ fn cmd_cleanup(force: bool, dry_run: bool, format: OutputFormat) -> Result<()> {
                     .context("Failed to serialize orphan entries")?;
                 println!("{json}");
             }
-            OutputFormat::Text => {
+            OutputFormat::Text | OutputFormat::Csv => {
                 println!(
                     "Dry run - {} orphaned worktree(s) would be removed:",
                     orphans.len()
@@ -258,7 +260,7 @@ fn cmd_status(session: &str, format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize git status report")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             let short_id = short_session_id(&report.session_id);
             println!("Session: {} ({})", report.workspace_name, short_id);
             println!("Branch:  {}", report.branch);
@@ -371,7 +373,10 @@ fn build_status_report(
             unstaged += 1;
         }
 
-        files.push(FileStatus { path, status: status_str });
+        files.push(FileStatus {
+            path,
+            status: status_str,
+        });
     }
 
     Ok(GitStatusReport {
@@ -471,7 +476,10 @@ mod tests {
     fn make_worktree_info(id: Uuid, branch: &str) -> WorktreeInfo {
         WorktreeInfo {
             id,
-            path: PathBuf::from(format!("/tmp/worktrees/by-name/repo--{branch}--{}", &id.to_string()[..8])),
+            path: PathBuf::from(format!(
+                "/tmp/worktrees/by-name/repo--{branch}--{}",
+                &id.to_string()[..8]
+            )),
             session_path: PathBuf::from(format!("/tmp/worktrees/by-session/{id}")),
             branch_name: branch.to_string(),
             source_repository: PathBuf::from("/tmp/source-repo"),
@@ -578,8 +586,14 @@ mod tests {
         let json = serde_json::to_value(&entry).unwrap();
         assert!(json["session_id"].is_string());
         assert!(json["path"].is_string());
-        assert_eq!(json["branch"], serde_json::Value::String("main".to_string()));
-        assert_eq!(json["status"], serde_json::Value::String("orphaned".to_string()));
+        assert_eq!(
+            json["branch"],
+            serde_json::Value::String("main".to_string())
+        );
+        assert_eq!(
+            json["status"],
+            serde_json::Value::String("orphaned".to_string())
+        );
         assert!(json["commit"].is_string());
     }
 
@@ -668,23 +682,38 @@ mod tests {
             unstaged: 1,
             untracked: 0,
             files: vec![
-                FileStatus { path: "a.rs".to_string(), status: "M".to_string() },
-                FileStatus { path: "b.rs".to_string(), status: "m".to_string() },
+                FileStatus {
+                    path: "a.rs".to_string(),
+                    status: "M".to_string(),
+                },
+                FileStatus {
+                    path: "b.rs".to_string(),
+                    status: "m".to_string(),
+                },
             ],
         };
 
         let json = serde_json::to_value(&report).unwrap();
         assert_eq!(json["files_changed"], serde_json::json!(2));
         assert_eq!(json["staged"], serde_json::json!(1));
-        assert_eq!(json["branch"], serde_json::Value::String("main".to_string()));
+        assert_eq!(
+            json["branch"],
+            serde_json::Value::String("main".to_string())
+        );
         assert_eq!(json["files"].as_array().unwrap().len(), 2);
     }
 
     #[test]
     fn test_file_status_serialize() {
-        let fs = FileStatus { path: "src/main.rs".to_string(), status: "M".to_string() };
+        let fs = FileStatus {
+            path: "src/main.rs".to_string(),
+            status: "M".to_string(),
+        };
         let json = serde_json::to_value(&fs).unwrap();
-        assert_eq!(json["path"], serde_json::Value::String("src/main.rs".to_string()));
+        assert_eq!(
+            json["path"],
+            serde_json::Value::String("src/main.rs".to_string())
+        );
         assert_eq!(json["status"], serde_json::Value::String("M".to_string()));
     }
 

--- a/ainb-tui/src/cli/init.rs
+++ b/ainb-tui/src/cli/init.rs
@@ -182,9 +182,7 @@ where
         ),
     ];
 
-    let all_required_present = checks
-        .iter()
-        .all(|c| !c.required || c.status == PrereqStatus::Ok);
+    let all_required_present = checks.iter().all(|c| !c.required || c.status == PrereqStatus::Ok);
 
     PrereqReport {
         checks,
@@ -230,7 +228,7 @@ fn cmd_check(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize prerequisite report")?;
             println!("{json}");
         }
-        OutputFormat::Text => print_report_text(&report),
+        OutputFormat::Text | OutputFormat::Csv => print_report_text(&report),
     }
 
     if !report.all_required_present {
@@ -281,9 +279,7 @@ fn cmd_setup(format: OutputFormat) -> Result<()> {
     // Mark onboarding as complete and persist
     let mut onboarding = OnboardingConfig::load().context("Failed to load onboarding config")?;
     onboarding.mark_completed();
-    onboarding
-        .save()
-        .context("Failed to save onboarding config")?;
+    onboarding.save().context("Failed to save onboarding config")?;
 
     match format {
         OutputFormat::Json => {
@@ -299,7 +295,7 @@ fn cmd_setup(format: OutputFormat) -> Result<()> {
                 serde_json::to_string_pretty(&output).context("Failed to serialize output")?
             );
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             println!("Setup complete.");
             println!("  Base dir:    {}", base_dir.display());
             println!("  Config file: {}", config_path.display());
@@ -339,7 +335,7 @@ fn cmd_status(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize status report")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             println!("Onboarding status:");
             println!("{}", "\u{2501}".repeat(60));
             let marker = if report.completed {
@@ -390,7 +386,7 @@ fn cmd_reset(force: bool, format: OutputFormat) -> Result<()> {
                 });
                 println!("{}", serde_json::to_string_pretty(&out)?);
             }
-            OutputFormat::Text => {
+            OutputFormat::Text | OutputFormat::Csv => {
                 println!("Nothing to reset: {} does not exist", base_dir.display());
             }
         }
@@ -423,7 +419,7 @@ fn cmd_reset(force: bool, format: OutputFormat) -> Result<()> {
             });
             println!("{}", serde_json::to_string_pretty(&out)?);
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             println!("Factory reset complete.");
             println!("  Removed: {}", base_dir.display());
         }

--- a/ainb-tui/src/cli/list.rs
+++ b/ainb-tui/src/cli/list.rs
@@ -48,7 +48,11 @@ pub struct SessionInfo {
 impl SessionInfo {
     /// Create `SessionInfo` from metadata and status
     #[must_use]
-    pub fn from_metadata(metadata: &SessionMetadata, is_running: bool, claude_active: bool) -> Self {
+    pub fn from_metadata(
+        metadata: &SessionMetadata,
+        is_running: bool,
+        claude_active: bool,
+    ) -> Self {
         Self {
             session_id: metadata.session_id.to_string(),
             tmux_session_name: metadata.tmux_session_name.clone(),
@@ -79,7 +83,7 @@ pub async fn execute(args: ListArgs, format: OutputFormat) -> Result<()> {
 
     match format {
         OutputFormat::Json => output_json(&sessions)?,
-        OutputFormat::Text => output_text(&sessions),
+        OutputFormat::Text | OutputFormat::Csv => output_text(&sessions),
     }
 
     Ok(())
@@ -136,7 +140,10 @@ fn output_text(sessions: &[SessionInfo]) {
     }
 
     // Print header
-    println!("{:<36} {:<25} {:<10} TMUX SESSION", "ID", "WORKSPACE", "STATUS");
+    println!(
+        "{:<36} {:<25} {:<10} TMUX SESSION",
+        "ID", "WORKSPACE", "STATUS"
+    );
     let separator = "-".repeat(100);
     println!("{separator}");
 
@@ -146,7 +153,10 @@ fn output_text(sessions: &[SessionInfo]) {
         let workspace = truncate(&session.workspace_name, 25);
         println!(
             "{:<36} {:<25} {:<10} {}",
-            session.session_id, workspace, status.icon(), session.tmux_session_name
+            session.session_id,
+            workspace,
+            status.icon(),
+            session.tmux_session_name
         );
     }
 }

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -6,18 +6,19 @@
 // - Viewing session output (logs)
 // - Launching TUI (tui, default)
 
-pub mod run;
+pub mod attach;
+pub mod config_cmd;
+pub mod favorites;
+pub mod git_cmd;
+pub mod init;
 pub mod list;
 pub mod logs;
-pub mod attach;
-pub mod status;
-pub mod util;
-pub mod recover;
-pub mod config_cmd;
-pub mod git_cmd;
-pub mod favorites;
-pub mod init;
 pub mod presets;
+pub mod recover;
+pub mod run;
+pub mod status;
+pub mod usage;
+pub mod util;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
@@ -77,6 +78,7 @@ pub enum OutputFormat {
     #[default]
     Text,
     Json,
+    Csv,
 }
 
 /// Available CLI commands
@@ -137,6 +139,12 @@ pub enum Commands {
     Presets {
         #[command(subcommand)]
         command: presets::PresetsCommands,
+    },
+
+    /// Usage analytics, reports, export, and optimization
+    Usage {
+        #[command(subcommand)]
+        command: usage::UsageCommands,
     },
 
     /// Generate shell completions (bash, zsh, fish, powershell, elvish)

--- a/ainb-tui/src/cli/presets.rs
+++ b/ainb-tui/src/cli/presets.rs
@@ -98,11 +98,15 @@ fn cmd_list(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize presets as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             println!("Available presets:");
             println!("{}", "\u{2501}".repeat(60));
             for entry in &entries {
-                let marker = if entry.builtin { "[built-in]" } else { "[custom]  " };
+                let marker = if entry.builtin {
+                    "[built-in]"
+                } else {
+                    "[custom]  "
+                };
                 println!(
                     "  {marker} {}  ({}/{})",
                     entry.name, entry.provider, entry.model
@@ -131,11 +135,8 @@ fn build_list_entries(manager: &PresetManager) -> Vec<PresetListEntry> {
         entries.push(to_list_entry(&preset, true));
     }
 
-    let mut customs: Vec<&RepositoryPreset> = manager
-        .all()
-        .into_iter()
-        .filter(|p| !seen.contains(&p.name))
-        .collect();
+    let mut customs: Vec<&RepositoryPreset> =
+        manager.all().into_iter().filter(|p| !seen.contains(&p.name)).collect();
     customs.sort_by(|a, b| a.name.cmp(&b.name));
     for preset in customs {
         entries.push(to_list_entry(preset, false));
@@ -170,7 +171,7 @@ fn cmd_show(name: &str, format: OutputFormat) -> Result<()> {
             });
             println!("{}", serde_json::to_string_pretty(&wrapper)?);
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             println!("{}", format_preset_text(&preset, builtin));
         }
     }
@@ -260,9 +261,7 @@ fn cmd_create(
     }
 
     let preset = build_new_preset(name, provider, model, description);
-    manager
-        .save_preset(&preset)
-        .context("Failed to save new preset")?;
+    manager.save_preset(&preset).context("Failed to save new preset")?;
 
     println!("Created preset '{name}'");
     println!("  Provider: {}", preset.agent_provider);
@@ -365,10 +364,7 @@ mod tests {
 
     #[test]
     fn test_default_presets_contain_expected_names() {
-        let names: Vec<String> = create_default_presets()
-            .into_iter()
-            .map(|p| p.name)
-            .collect();
+        let names: Vec<String> = create_default_presets().into_iter().map(|p| p.name).collect();
         assert!(names.contains(&"rust-backend".to_string()));
         assert!(names.contains(&"typescript-frontend".to_string()));
         assert!(names.contains(&"fast-iteration".to_string()));
@@ -419,10 +415,8 @@ mod tests {
     #[test]
     fn test_apply_preset_round_trip_via_load_repo_preset() {
         let dir = tempdir().unwrap();
-        let original = create_default_presets()
-            .into_iter()
-            .find(|p| p.name == "rust-backend")
-            .unwrap();
+        let original =
+            create_default_presets().into_iter().find(|p| p.name == "rust-backend").unwrap();
 
         apply_preset_to_dir(&original, dir.path()).unwrap();
 
@@ -433,7 +427,10 @@ mod tests {
         assert_eq!(loaded.agent_provider, original.agent_provider);
         assert_eq!(loaded.agent_model, original.agent_model);
         assert_eq!(loaded.skills, original.skills);
-        assert_eq!(loaded.permissions.file_write, original.permissions.file_write);
+        assert_eq!(
+            loaded.permissions.file_write,
+            original.permissions.file_write
+        );
     }
 
     #[test]
@@ -467,10 +464,8 @@ mod tests {
 
     #[test]
     fn test_format_preset_text_mentions_builtin_tag() {
-        let preset = create_default_presets()
-            .into_iter()
-            .find(|p| p.name == "rust-backend")
-            .unwrap();
+        let preset =
+            create_default_presets().into_iter().find(|p| p.name == "rust-backend").unwrap();
         let text = format_preset_text(&preset, true);
         assert!(text.contains("rust-backend"));
         assert!(text.contains("built-in"));

--- a/ainb-tui/src/cli/recover.rs
+++ b/ainb-tui/src/cli/recover.rs
@@ -308,7 +308,7 @@ fn execute_list(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize orphan list")?;
             println!("{json}");
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             if orphans.is_empty() {
                 println!("No orphaned sessions found. Everything looks clean.");
                 return Ok(());

--- a/ainb-tui/src/cli/status.rs
+++ b/ainb-tui/src/cli/status.rs
@@ -52,9 +52,7 @@ pub async fn execute(args: StatusArgs, format: OutputFormat) -> Result<()> {
     // Check if Claude is active in the session
     let claude_active = if is_running {
         let detector = ClaudeProcessDetector::new();
-        detector
-            .is_claude_running(&session.tmux_session_name)
-            .unwrap_or(false)
+        detector.is_claude_running(&session.tmux_session_name).unwrap_or(false)
     } else {
         false
     };
@@ -75,7 +73,7 @@ pub async fn execute(args: StatusArgs, format: OutputFormat) -> Result<()> {
                 serde_json::to_string_pretty(&output).context("Failed to serialize status")?
             );
         }
-        OutputFormat::Text => {
+        OutputFormat::Text | OutputFormat::Csv => {
             let status_text = if is_running {
                 if claude_active {
                     "\x1b[32m●\x1b[0m Running (Claude active)"
@@ -94,7 +92,10 @@ pub async fn execute(args: StatusArgs, format: OutputFormat) -> Result<()> {
             println!("Status:       {status_text}");
             println!("Tmux:         {}", session.tmux_session_name);
             println!("Worktree:     {}", session.worktree_path.display());
-            println!("Created:      {}", session.created_at.format("%Y-%m-%d %H:%M:%S UTC"));
+            println!(
+                "Created:      {}",
+                session.created_at.format("%Y-%m-%d %H:%M:%S UTC")
+            );
             println!();
             println!("Commands:");
             println!("  Attach:     ainb attach {short_id}");
@@ -160,10 +161,7 @@ pub async fn kill(args: KillArgs) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!(
-            "Warning: tmux kill-session failed: {}",
-            stderr.trim()
-        );
+        eprintln!("Warning: tmux kill-session failed: {}", stderr.trim());
         // Continue anyway - might already be dead
     } else {
         println!("Tmux session killed.");
@@ -182,7 +180,10 @@ pub async fn kill(args: KillArgs) -> Result<()> {
         "\nNote: Worktree at '{}' was not removed.",
         session.worktree_path.display()
     );
-    println!("To clean up, run: rm -rf {}", session.worktree_path.display());
+    println!(
+        "To clean up, run: rm -rf {}",
+        session.worktree_path.display()
+    );
 
     Ok(())
 }
@@ -190,9 +191,9 @@ pub async fn kill(args: KillArgs) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use crate::interactive::session_manager::SessionMetadata;
     use crate::models::session::SessionAgentType;
+    use chrono::Utc;
     use std::path::PathBuf;
     use uuid::Uuid;
 

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -1,0 +1,815 @@
+// ABOUTME: Non-interactive usage analytics commands.
+// Provides CodeBurn-style reports, exports, plans, optimization, compare, and yield.
+
+use crate::cli::OutputFormat;
+use crate::config::{AppConfig, CurrencyConfig, UsagePlan, UsagePlanId, UsagePlanProvider};
+use crate::models::usage::{
+    ActivityUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsagePeriod,
+    UsageProviderFilter, UsageQuery, analyze_yield, compare_models, optimize_usage,
+    parse_usage_for,
+};
+use anyhow::{Result, anyhow, bail};
+use chrono::{Local, NaiveDate};
+use clap::{Args, Subcommand, ValueEnum};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Subcommand)]
+pub enum UsageCommands {
+    /// Print a compact burndown report
+    Report(UsageReportArgs),
+    /// Print current usage status
+    Status(UsageReportArgs),
+    /// Print today's usage
+    Today(UsageReportArgs),
+    /// Print current month's usage
+    Month(UsageReportArgs),
+    /// Export usage data as CSV or JSON
+    Export(UsageExportArgs),
+    /// Manage usage plan
+    Plan {
+        #[command(subcommand)]
+        command: UsagePlanCommands,
+    },
+    /// Set or reset display currency
+    Currency(UsageCurrencyArgs),
+    /// Manage model aliases
+    ModelAlias(UsageModelAliasArgs),
+    /// Show read-only optimization findings
+    Optimize(UsageReportArgs),
+    /// Compare models
+    Compare(UsageReportArgs),
+    /// Estimate usage yield from session signals
+    Yield(UsageReportArgs),
+}
+
+#[derive(Args, Clone, Default)]
+pub struct UsageReportArgs {
+    /// Period: today, week, 30days, month, all
+    #[arg(long, value_enum, default_value_t = PeriodArg::Week)]
+    pub period: PeriodArg,
+    /// Start date YYYY-MM-DD
+    #[arg(long)]
+    pub from: Option<String>,
+    /// End date YYYY-MM-DD
+    #[arg(long)]
+    pub to: Option<String>,
+    /// Provider: all, claude, codex
+    #[arg(long, value_enum, default_value_t = ProviderArg::All)]
+    pub provider: ProviderArg,
+    /// Include projects matching substring
+    #[arg(long, alias = "project")]
+    pub include: Vec<String>,
+    /// Exclude projects matching substring
+    #[arg(long)]
+    pub exclude: Vec<String>,
+}
+
+#[derive(Args, Clone, Default)]
+pub struct UsageExportArgs {
+    #[command(flatten)]
+    pub report: UsageReportArgs,
+    /// Output file or directory
+    #[arg(long, short)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Subcommand)]
+pub enum UsagePlanCommands {
+    /// Show configured plan and current projection
+    Show(UsageReportArgs),
+    /// Set a known or custom plan
+    Set {
+        plan: PlanArg,
+        #[arg(long)]
+        monthly_usd: Option<f64>,
+        #[arg(long, value_enum, default_value_t = PlanProviderArg::All)]
+        provider: PlanProviderArg,
+        #[arg(long, default_value_t = 1)]
+        reset_day: u8,
+    },
+    /// Remove plan
+    Reset,
+    /// Attempt to detect plan from Claude CLI
+    Detect,
+}
+
+#[derive(Args)]
+pub struct UsageCurrencyArgs {
+    /// Currency code, for example USD, GBP, EUR
+    pub code: Option<String>,
+    /// Display symbol
+    #[arg(long)]
+    pub symbol: Option<String>,
+    /// Reset to USD
+    #[arg(long)]
+    pub reset: bool,
+}
+
+#[derive(Args)]
+pub struct UsageModelAliasArgs {
+    /// List aliases
+    #[arg(long)]
+    pub list: bool,
+    /// Remove alias by source model name
+    #[arg(long)]
+    pub remove: Option<String>,
+    /// Source model name
+    pub from: Option<String>,
+    /// Alias target model name
+    pub to: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum PeriodArg {
+    Today,
+    #[default]
+    Week,
+    #[clap(name = "30days")]
+    ThirtyDays,
+    Month,
+    All,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum ProviderArg {
+    #[default]
+    All,
+    Claude,
+    Codex,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum PlanArg {
+    ClaudePro,
+    ClaudeMax,
+    ClaudeMax5x,
+    CursorPro,
+    Custom,
+    None,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum PlanProviderArg {
+    #[default]
+    All,
+    Claude,
+    Codex,
+    Cursor,
+}
+
+pub async fn execute(command: UsageCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        UsageCommands::Report(args) => print_report(&args, format, "Usage Report"),
+        UsageCommands::Status(args) => print_status(&args, format),
+        UsageCommands::Today(mut args) => {
+            args.period = PeriodArg::Today;
+            print_report(&args, format, "Today")
+        }
+        UsageCommands::Month(mut args) => {
+            args.period = PeriodArg::Month;
+            print_report(&args, format, "Month")
+        }
+        UsageCommands::Export(args) => export_usage(&args, format),
+        UsageCommands::Plan { command } => plan_command(command, format),
+        UsageCommands::Currency(args) => currency_command(args),
+        UsageCommands::ModelAlias(args) => model_alias_command(args),
+        UsageCommands::Optimize(args) => print_optimize(&args, format),
+        UsageCommands::Compare(args) => print_compare(&args, format),
+        UsageCommands::Yield(args) => print_yield(&args, format),
+    }
+}
+
+fn print_report(args: &UsageReportArgs, format: OutputFormat, title: &str) -> Result<()> {
+    let data = load_usage(args)?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report_json(&data))?);
+        }
+        OutputFormat::Csv => {
+            print!("{}", combined_csv(&data));
+        }
+        OutputFormat::Text => {
+            print_text_report(title, &data);
+        }
+    }
+    Ok(())
+}
+
+fn print_status(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let config = AppConfig::load().unwrap_or_default();
+    let projection = config.usage.plan.as_ref().map(|plan| {
+        crate::models::usage::project_plan_usage(&data, plan, Local::now().date_naive())
+    });
+    match format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "overview": data.overview(),
+                "plan": projection,
+            }))?
+        ),
+        OutputFormat::Csv => print!("{}", combined_csv(&data)),
+        OutputFormat::Text => {
+            print_text_report("Usage Status", &data);
+            if let Some(projection) = projection {
+                println!(
+                    "Plan: ${:.2} / ${:.2} ({:.0}%) {:?}",
+                    projection.spent_usd,
+                    projection.monthly_usd,
+                    projection.percent_used * 100.0,
+                    projection.status
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_optimize(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let result = optimize_usage(&data);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Optimize Findings");
+    println!("Health: {:?} ({}/100)", result.grade, result.score);
+    println!(
+        "Potential savings: {} tokens",
+        result.potential_tokens_saved
+    );
+    for finding in &result.findings {
+        println!(
+            "- {:?}: {} ({})",
+            finding.impact, finding.title, finding.details
+        );
+        for action in &finding.actions {
+            match &action.command {
+                Some(command) => println!("  Suggestion: {} -> {}", action.label, command),
+                None => println!("  Suggestion: {}", action.label),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_compare(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let result = compare_models(&data);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Model Compare");
+    if let Some(winner) = &result.winner {
+        println!("Leader: {winner}");
+    }
+    if result.low_data {
+        println!("Low data: compare results need more sessions.");
+    }
+    for row in &result.models {
+        println!(
+            "- {}: {} calls, {} tokens/call, {} one-shot, {} retries",
+            row.model, row.calls, row.tokens_per_call, row.one_shot_turns, row.retries
+        );
+    }
+    Ok(())
+}
+
+fn print_yield(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let result = analyze_yield(&data);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Usage Yield");
+    println!(
+        "Productive: {} sessions (${:.2})",
+        result.productive_sessions, result.productive_usd
+    );
+    println!(
+        "Reverted: {} sessions (${:.2})",
+        result.reverted_sessions, result.reverted_usd
+    );
+    println!(
+        "Abandoned: {} sessions (${:.2})",
+        result.abandoned_sessions, result.abandoned_usd
+    );
+    Ok(())
+}
+
+fn export_usage(args: &UsageExportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(&args.report)?;
+    match format {
+        OutputFormat::Json => {
+            let text = serde_json::to_string_pretty(&json!({
+                "schema": "ainb.usage.v1",
+                "generated_at": Local::now().to_rfc3339(),
+                "currency": "USD",
+                "report": report_json(&data),
+            }))?;
+            write_or_print(args.output.as_deref(), &text)
+        }
+        OutputFormat::Text => {
+            let text = serde_json::to_string_pretty(&report_json(&data))?;
+            write_or_print(args.output.as_deref(), &text)
+        }
+        OutputFormat::Csv => {
+            if let Some(path) = &args.output {
+                if path.extension().is_some() {
+                    fs::write(path, combined_csv(&data))?;
+                } else {
+                    fs::create_dir_all(path)?;
+                    fs::write(path.join("README.md"), "AINB usage export\n")?;
+                    fs::write(path.join("summary.csv"), summary_csv(&data))?;
+                    fs::write(path.join("daily.csv"), daily_csv(&data))?;
+                    fs::write(path.join("projects.csv"), projects_csv(&data.projects))?;
+                    fs::write(path.join("sessions.csv"), sessions_csv(&data.sessions))?;
+                    fs::write(
+                        path.join("activities.csv"),
+                        activities_csv(&data.activities),
+                    )?;
+                    fs::write(path.join("models.csv"), models_csv(&data))?;
+                    fs::write(path.join("tools.csv"), named_csv("tool", &data.tools))?;
+                    fs::write(
+                        path.join("shell_commands.csv"),
+                        named_csv("command", &data.shell_commands),
+                    )?;
+                    fs::write(
+                        path.join("mcp_servers.csv"),
+                        named_csv("server", &data.mcp_servers),
+                    )?;
+                }
+                Ok(())
+            } else {
+                print!("{}", combined_csv(&data));
+                Ok(())
+            }
+        }
+    }
+}
+
+fn plan_command(command: UsagePlanCommands, format: OutputFormat) -> Result<()> {
+    let mut config = AppConfig::load().unwrap_or_default();
+    match command {
+        UsagePlanCommands::Show(args) => {
+            let data = load_usage(&args)?;
+            let projection = config.usage.plan.as_ref().map(|plan| {
+                crate::models::usage::project_plan_usage(&data, plan, Local::now().date_naive())
+            });
+            if matches!(format, OutputFormat::Json) {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "plan": config.usage.plan,
+                        "projection": projection,
+                    }))?
+                );
+            } else if let Some(plan) = &config.usage.plan {
+                println!(
+                    "Plan: {:?} ${:.2}/month reset day {}",
+                    plan.id, plan.monthly_usd, plan.reset_day
+                );
+                if let Some(projection) = projection {
+                    println!(
+                        "Spend: ${:.2}, projected ${:.2}, {:?}",
+                        projection.spent_usd, projection.projected_usd, projection.status
+                    );
+                }
+            } else {
+                println!("No usage plan configured.");
+            }
+        }
+        UsagePlanCommands::Set {
+            plan,
+            monthly_usd,
+            provider,
+            reset_day,
+        } => {
+            let id = plan_id(plan);
+            let monthly_usd = monthly_usd
+                .or_else(|| id.monthly_usd())
+                .ok_or_else(|| anyhow!("custom plan requires --monthly-usd"))?;
+            config.usage.plan = Some(UsagePlan {
+                id,
+                monthly_usd,
+                provider: plan_provider(provider),
+                reset_day: reset_day.clamp(1, 28),
+                set_at: Local::now().to_rfc3339(),
+            });
+            config.save()?;
+            println!("Usage plan saved.");
+        }
+        UsagePlanCommands::Reset => {
+            config.usage.plan = None;
+            config.save()?;
+            println!("Usage plan reset.");
+        }
+        UsagePlanCommands::Detect => {
+            bail!("Plan detection unavailable. Use `ainb usage plan set <plan>`.");
+        }
+    }
+    Ok(())
+}
+
+fn currency_command(args: UsageCurrencyArgs) -> Result<()> {
+    let mut config = AppConfig::load().unwrap_or_default();
+    if args.reset {
+        config.usage.currency = CurrencyConfig::default();
+    } else {
+        let Some(code) = args.code else {
+            println!(
+                "{} {}",
+                config.usage.currency.symbol, config.usage.currency.code
+            );
+            return Ok(());
+        };
+        let code = code.to_uppercase();
+        if code.len() != 3 || !code.chars().all(|ch| ch.is_ascii_uppercase()) {
+            bail!("Currency code must be a 3-letter ISO-style code");
+        }
+        config.usage.currency.code = code.clone();
+        config.usage.currency.symbol = args.symbol.unwrap_or(code);
+    }
+    config.save()?;
+    println!("Currency saved.");
+    Ok(())
+}
+
+fn model_alias_command(args: UsageModelAliasArgs) -> Result<()> {
+    let mut config = AppConfig::load().unwrap_or_default();
+    if args.list {
+        for (from, to) in &config.usage.model_aliases {
+            println!("{from} -> {to}");
+        }
+        return Ok(());
+    }
+    if let Some(remove) = args.remove {
+        config.usage.model_aliases.remove(&remove);
+        config.save()?;
+        println!("Model alias removed.");
+        return Ok(());
+    }
+    match (args.from, args.to) {
+        (Some(from), Some(to)) => {
+            config.usage.model_aliases.insert(from, to);
+            config.save()?;
+            println!("Model alias saved.");
+            Ok(())
+        }
+        _ => bail!("Use --list, --remove <model>, or <from> <to>"),
+    }
+}
+
+fn load_usage(args: &UsageReportArgs) -> Result<UsageData> {
+    Ok(parse_usage_for(query_from_args(args)?))
+}
+
+fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
+    let period = if args.from.is_some() || args.to.is_some() {
+        let from = match &args.from {
+            Some(value) => parse_date(value)?,
+            None => NaiveDate::from_ymd_opt(1970, 1, 1).expect("valid date"),
+        };
+        let to = match &args.to {
+            Some(value) => parse_date(value)?,
+            None => Local::now().date_naive(),
+        };
+        if from > to {
+            bail!("from date must be before or equal to to date");
+        }
+        UsagePeriod::Custom { from, to }
+    } else {
+        match args.period {
+            PeriodArg::Today => UsagePeriod::Today,
+            PeriodArg::Week => UsagePeriod::Week,
+            PeriodArg::ThirtyDays => UsagePeriod::ThirtyDays,
+            PeriodArg::Month => UsagePeriod::Month,
+            PeriodArg::All => UsagePeriod::All,
+        }
+    };
+
+    Ok(UsageQuery {
+        period,
+        provider_filter: match args.provider {
+            ProviderArg::All => UsageProviderFilter::All,
+            ProviderArg::Claude => UsageProviderFilter::Claude,
+            ProviderArg::Codex => UsageProviderFilter::Codex,
+        },
+        include_projects: args.include.clone(),
+        exclude_projects: args.exclude.clone(),
+    })
+}
+
+fn parse_date(value: &str) -> Result<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| anyhow!("invalid date `{value}`, expected YYYY-MM-DD"))
+}
+
+fn print_text_report(title: &str, data: &UsageData) {
+    println!("{title}");
+    println!(
+        "Overview: {} calls, {} sessions, {} projects, {} tokens, {}",
+        data.grand_total.call_count,
+        data.grand_total.session_count,
+        data.grand_total.project_count,
+        data.grand_total.total(),
+        format_cost(data.grand_total.cost_usd)
+    );
+    println!();
+    print_top_projects(data);
+    print_top_activities(data);
+    print_top_models(data);
+}
+
+fn print_top_projects(data: &UsageData) {
+    println!("By Project");
+    for project in data.projects.iter().take(8) {
+        println!(
+            "- {}: {} calls, {} tokens, {}",
+            project.name,
+            project.bucket.call_count,
+            project.bucket.total(),
+            format_cost(project.bucket.cost_usd)
+        );
+    }
+}
+
+fn print_top_activities(data: &UsageData) {
+    println!("By Activity");
+    for activity in data.activities.iter().take(8) {
+        println!(
+            "- {}: {} turns, {} retries, {} tokens",
+            activity.category.label(),
+            activity.turns,
+            activity.retries,
+            activity.bucket.total()
+        );
+    }
+}
+
+fn print_top_models(data: &UsageData) {
+    println!("By Model");
+    for model in data.models.iter().take(8) {
+        println!(
+            "- {}: {} calls, {} tokens, {}",
+            model.model,
+            model.bucket.call_count,
+            model.bucket.total(),
+            format_cost(model.bucket.cost_usd)
+        );
+    }
+}
+
+fn report_json(data: &UsageData) -> serde_json::Value {
+    json!({
+        "overview": data.overview(),
+        "daily": data.daily,
+        "projects": data.projects,
+        "models": data.models,
+        "activities": data.activities,
+        "sessions": data.sessions,
+        "tools": data.tools,
+        "shell_commands": data.shell_commands,
+        "mcp_servers": data.mcp_servers,
+    })
+}
+
+fn write_or_print(path: Option<&Path>, text: &str) -> Result<()> {
+    if let Some(path) = path {
+        fs::write(path, text)?;
+    } else {
+        println!("{text}");
+    }
+    Ok(())
+}
+
+fn combined_csv(data: &UsageData) -> String {
+    [
+        summary_csv(data),
+        daily_csv(data),
+        projects_csv(&data.projects),
+        sessions_csv(&data.sessions),
+        activities_csv(&data.activities),
+        models_csv(data),
+        named_csv("tool", &data.tools),
+        named_csv("command", &data.shell_commands),
+        named_csv("server", &data.mcp_servers),
+    ]
+    .join("\n")
+}
+
+fn summary_csv(data: &UsageData) -> String {
+    format!(
+        "section,metric,value\nsummary,calls,{}\nsummary,sessions,{}\nsummary,projects,{}\nsummary,tokens,{}\nsummary,cost_usd,{}\n",
+        data.grand_total.call_count,
+        data.grand_total.session_count,
+        data.grand_total.project_count,
+        data.grand_total.total(),
+        data.grand_total.cost_usd.unwrap_or(0.0)
+    )
+}
+
+fn daily_csv(data: &UsageData) -> String {
+    let mut out = "date,calls,sessions,projects,tokens,cost_usd\n".to_string();
+    for (date, bucket) in &data.daily {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            date,
+            bucket.call_count,
+            bucket.session_count,
+            bucket.project_count,
+            bucket.total(),
+            bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn projects_csv(projects: &[ProjectUsage]) -> String {
+    let mut out = "project,path,calls,sessions,tokens,cost_usd\n".to_string();
+    for project in projects {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            csv_cell(&project.name),
+            csv_cell(&project.path),
+            project.bucket.call_count,
+            project.bucket.session_count,
+            project.bucket.total(),
+            project.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn sessions_csv(sessions: &[SessionUsage]) -> String {
+    let mut out = "provider,project,session_id,first,last,calls,tokens,cost_usd\n".to_string();
+    for session in sessions {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{}\n",
+            csv_cell(&session.provider),
+            csv_cell(&session.project),
+            csv_cell(&session.session_id),
+            session.first_timestamp.to_rfc3339(),
+            session.last_timestamp.to_rfc3339(),
+            session.bucket.call_count,
+            session.bucket.total(),
+            session.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn activities_csv(activities: &[ActivityUsage]) -> String {
+    let mut out = "activity,turns,retries,edit_turns,one_shot_turns,tokens,cost_usd\n".to_string();
+    for activity in activities {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{}\n",
+            activity.category.label(),
+            activity.turns,
+            activity.retries,
+            activity.edit_turns,
+            activity.one_shot_turns,
+            activity.bucket.total(),
+            activity.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn models_csv(data: &UsageData) -> String {
+    let mut out = "model,calls,tokens,cost_usd\n".to_string();
+    for model in &data.models {
+        out.push_str(&format!(
+            "{},{},{},{}\n",
+            csv_cell(&model.model),
+            model.bucket.call_count,
+            model.bucket.total(),
+            model.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn named_csv(name_header: &str, rows: &[NamedUsage]) -> String {
+    let mut out = format!("{name_header},calls\n");
+    for row in rows {
+        out.push_str(&format!("{},{}\n", csv_cell(&row.name), row.calls));
+    }
+    out
+}
+
+fn csv_cell(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    let protected = if escaped
+        .chars()
+        .next()
+        .is_some_and(|ch| matches!(ch, '\t' | '\r' | '=' | '+' | '-' | '@'))
+    {
+        format!("'{escaped}")
+    } else {
+        escaped
+    };
+    format!("\"{protected}\"")
+}
+
+fn format_cost(cost: Option<f64>) -> String {
+    cost.map(|value| format!("${value:.2}"))
+        .unwrap_or_else(|| "cost unavailable".to_string())
+}
+
+fn plan_id(plan: PlanArg) -> UsagePlanId {
+    match plan {
+        PlanArg::ClaudePro => UsagePlanId::ClaudePro,
+        PlanArg::ClaudeMax => UsagePlanId::ClaudeMax,
+        PlanArg::ClaudeMax5x => UsagePlanId::ClaudeMax5x,
+        PlanArg::CursorPro => UsagePlanId::CursorPro,
+        PlanArg::Custom => UsagePlanId::Custom,
+        PlanArg::None => UsagePlanId::None,
+    }
+}
+
+fn plan_provider(provider: PlanProviderArg) -> UsagePlanProvider {
+    match provider {
+        PlanProviderArg::All => UsagePlanProvider::All,
+        PlanProviderArg::Claude => UsagePlanProvider::Claude,
+        PlanProviderArg::Codex => UsagePlanProvider::Codex,
+        PlanProviderArg::Cursor => UsagePlanProvider::Cursor,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn csv_cell_escapes_formula_starts() {
+        assert_eq!(csv_cell("=cmd"), "\"'=cmd\"");
+        assert_eq!(csv_cell("@user"), "\"'@user\"");
+        assert_eq!(csv_cell("safe"), "\"safe\"");
+    }
+
+    #[test]
+    fn report_json_keeps_expected_top_level_sections() {
+        let data = UsageData::default();
+        let json = report_json(&data);
+
+        for key in [
+            "overview",
+            "daily",
+            "projects",
+            "models",
+            "activities",
+            "sessions",
+            "tools",
+            "shell_commands",
+            "mcp_servers",
+        ] {
+            assert!(json.get(key).is_some(), "missing {key}");
+        }
+    }
+
+    #[test]
+    fn combined_csv_includes_export_section_headers() {
+        let csv = combined_csv(&UsageData::default());
+
+        for header in [
+            "section,metric,value",
+            "date,calls,sessions,projects,tokens,cost_usd",
+            "project,path,calls,sessions,tokens,cost_usd",
+            "provider,project,session_id,first,last,calls,tokens,cost_usd",
+            "activity,turns,retries,edit_turns,one_shot_turns,tokens,cost_usd",
+            "model,calls,tokens,cost_usd",
+            "tool,calls",
+            "command,calls",
+            "server,calls",
+        ] {
+            assert!(csv.contains(header), "missing {header}");
+        }
+    }
+
+    #[test]
+    fn invalid_date_returns_clear_error() {
+        let args = UsageReportArgs {
+            from: Some("2026/04/01".to_string()),
+            ..UsageReportArgs::default()
+        };
+        let err = query_from_args(&args).unwrap_err().to_string();
+        assert!(err.contains("expected YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn inverted_date_range_errors() {
+        let args = UsageReportArgs {
+            from: Some("2026-04-02".to_string()),
+            to: Some("2026-04-01".to_string()),
+            ..UsageReportArgs::default()
+        };
+        let err = query_from_args(&args).unwrap_err().to_string();
+        assert!(err.contains("from date"));
+    }
+}

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -5,7 +5,7 @@ use crate::cli::OutputFormat;
 use crate::config::{AppConfig, CurrencyConfig, UsagePlan, UsagePlanId, UsagePlanProvider};
 use crate::models::usage::{
     ActivityUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsagePeriod,
-    UsageProviderFilter, UsageQuery, analyze_yield, compare_models, optimize_usage,
+    UsageProviderFilter, UsageQuery, analyze_yield, billing_period, compare_models, optimize_usage,
     parse_usage_for,
 };
 use anyhow::{Result, anyhow, bail};
@@ -357,10 +357,17 @@ fn plan_command(command: UsagePlanCommands, format: OutputFormat) -> Result<()> 
     let mut config = AppConfig::load().unwrap_or_default();
     match command {
         UsagePlanCommands::Show(args) => {
-            let data = load_usage(&args)?;
-            let projection = config.usage.plan.as_ref().map(|plan| {
-                crate::models::usage::project_plan_usage(&data, plan, Local::now().date_naive())
-            });
+            let today = Local::now().date_naive();
+            let data = if let Some(plan) = config.usage.plan.as_ref() {
+                load_usage(&plan_show_args_for_plan(&args, plan, today))?
+            } else {
+                load_usage(&args)?
+            };
+            let projection = config
+                .usage
+                .plan
+                .as_ref()
+                .map(|plan| crate::models::usage::project_plan_usage(&data, plan, today));
             if matches!(format, OutputFormat::Json) {
                 println!(
                     "{}",
@@ -742,6 +749,28 @@ fn plan_provider(provider: PlanProviderArg) -> UsagePlanProvider {
     }
 }
 
+fn provider_arg_for_plan(provider: UsagePlanProvider) -> ProviderArg {
+    match provider {
+        UsagePlanProvider::All | UsagePlanProvider::Cursor => ProviderArg::All,
+        UsagePlanProvider::Claude => ProviderArg::Claude,
+        UsagePlanProvider::Codex => ProviderArg::Codex,
+    }
+}
+
+fn plan_show_args_for_plan(
+    args: &UsageReportArgs,
+    plan: &UsagePlan,
+    today: NaiveDate,
+) -> UsageReportArgs {
+    let (from, to) = billing_period(today, plan.reset_day);
+    let mut scoped_args = args.clone();
+    scoped_args.period = PeriodArg::All;
+    scoped_args.from = Some(from.to_string());
+    scoped_args.to = Some(to.to_string());
+    scoped_args.provider = provider_arg_for_plan(plan.provider);
+    scoped_args
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -811,5 +840,23 @@ mod tests {
         };
         let err = query_from_args(&args).unwrap_err().to_string();
         assert!(err.contains("from date"));
+    }
+
+    #[test]
+    fn plan_show_uses_billing_window_and_plan_provider() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let plan = UsagePlan {
+            id: UsagePlanId::ClaudePro,
+            monthly_usd: 20.0,
+            provider: UsagePlanProvider::Claude,
+            reset_day: 12,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        };
+
+        let scoped = plan_show_args_for_plan(&UsageReportArgs::default(), &plan, today);
+
+        assert_eq!(scoped.from.as_deref(), Some("2026-04-12"));
+        assert_eq!(scoped.to.as_deref(), Some("2026-05-11"));
+        assert!(matches!(scoped.provider, ProviderArg::Claude));
     }
 }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -358,18 +358,20 @@ pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
     render_provider_bar(frame, layout[1], state);
     render_tab_bar(frame, layout[2], state);
 
-    if !state.provider.has_data() {
-        render_no_data(frame, layout[3], state);
-    } else if state.loading || state.data.is_none() {
+    if state.loading || state.data.is_none() {
         render_loading(frame, layout[3]);
     } else {
         let data = state.data.as_ref().unwrap();
-        match state.active_tab {
-            UsageTab::Daily => render_daily(frame, layout[3], data, state.scroll_offset),
-            UsageTab::Weekly => render_weekly(frame, layout[3], data, state.scroll_offset),
-            UsageTab::Projects => render_projects(frame, layout[3], data, state.scroll_offset),
-            UsageTab::Burndown => render_burndown(frame, layout[3], data, state),
-            UsageTab::Optimize => render_optimize(frame, layout[3], data),
+        if data.calls.is_empty() && !state.provider.has_data() {
+            render_no_data(frame, layout[3], state);
+        } else {
+            match state.active_tab {
+                UsageTab::Daily => render_daily(frame, layout[3], data, state.scroll_offset),
+                UsageTab::Weekly => render_weekly(frame, layout[3], data, state.scroll_offset),
+                UsageTab::Projects => render_projects(frame, layout[3], data, state.scroll_offset),
+                UsageTab::Burndown => render_burndown(frame, layout[3], data, state),
+                UsageTab::Optimize => render_optimize(frame, layout[3], data),
+            }
         }
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -2,14 +2,17 @@
 // Accessible via 'i' key from home screen or Stats sidebar item.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Paragraph, Row, Table, Tabs},
-    Frame,
 };
 
-use crate::models::{UsageData, format_tokens_short};
+use crate::models::{
+    ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsagePeriod,
+    UsageProviderFilter, UsageQuery, format_tokens_short, optimize_usage,
+};
 
 // Color palette from TUI style guide
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
@@ -35,7 +38,12 @@ pub enum UsageProvider {
 
 impl UsageProvider {
     fn all() -> &'static [UsageProvider] {
-        &[UsageProvider::Claude, UsageProvider::Codex, UsageProvider::Gemini, UsageProvider::Copilot]
+        &[
+            UsageProvider::Claude,
+            UsageProvider::Codex,
+            UsageProvider::Gemini,
+            UsageProvider::Copilot,
+        ]
     }
 
     fn label(&self) -> &'static str {
@@ -57,7 +65,7 @@ impl UsageProvider {
     }
 
     pub fn has_data(&self) -> bool {
-        matches!(self, UsageProvider::Claude)
+        matches!(self, UsageProvider::Claude | UsageProvider::Codex)
     }
 
     fn next(&self) -> Self {
@@ -86,11 +94,19 @@ pub enum UsageTab {
     Daily,
     Weekly,
     Projects,
+    Burndown,
+    Optimize,
 }
 
 impl UsageTab {
     fn all() -> &'static [UsageTab] {
-        &[UsageTab::Daily, UsageTab::Weekly, UsageTab::Projects]
+        &[
+            UsageTab::Daily,
+            UsageTab::Weekly,
+            UsageTab::Projects,
+            UsageTab::Burndown,
+            UsageTab::Optimize,
+        ]
     }
 
     fn title(&self) -> &'static str {
@@ -98,6 +114,8 @@ impl UsageTab {
             UsageTab::Daily => "Daily",
             UsageTab::Weekly => "Weekly",
             UsageTab::Projects => "By Project",
+            UsageTab::Burndown => "Burndown",
+            UsageTab::Optimize => "Optimize",
         }
     }
 
@@ -105,17 +123,28 @@ impl UsageTab {
         match self {
             UsageTab::Daily => UsageTab::Weekly,
             UsageTab::Weekly => UsageTab::Projects,
-            UsageTab::Projects => UsageTab::Daily,
+            UsageTab::Projects => UsageTab::Burndown,
+            UsageTab::Burndown => UsageTab::Optimize,
+            UsageTab::Optimize => UsageTab::Daily,
         }
     }
 
     fn prev(&self) -> Self {
         match self {
-            UsageTab::Daily => UsageTab::Projects,
+            UsageTab::Daily => UsageTab::Optimize,
             UsageTab::Weekly => UsageTab::Daily,
             UsageTab::Projects => UsageTab::Weekly,
+            UsageTab::Burndown => UsageTab::Projects,
+            UsageTab::Optimize => UsageTab::Burndown,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageInputMode {
+    Include,
+    Exclude,
+    DateRange,
 }
 
 /// View state for the usage analytics screen
@@ -126,6 +155,12 @@ pub struct UsageViewState {
     pub data: Option<UsageData>,
     pub loading: bool,
     pub scroll_offset: usize,
+    pub period: UsagePeriod,
+    pub provider_filter: UsageProviderFilter,
+    pub include_projects: Vec<String>,
+    pub exclude_projects: Vec<String>,
+    pub input_mode: Option<UsageInputMode>,
+    pub input_buffer: String,
 }
 
 impl Default for UsageViewState {
@@ -136,6 +171,12 @@ impl Default for UsageViewState {
             data: None,
             loading: false,
             scroll_offset: 0,
+            period: UsagePeriod::Week,
+            provider_filter: UsageProviderFilter::All,
+            include_projects: Vec::new(),
+            exclude_projects: Vec::new(),
+            input_mode: None,
+            input_buffer: String::new(),
         }
     }
 }
@@ -143,11 +184,35 @@ impl Default for UsageViewState {
 impl UsageViewState {
     pub fn next_provider(&mut self) {
         self.provider = self.provider.next();
+        self.provider_filter = match self.provider {
+            UsageProvider::Claude => UsageProviderFilter::Claude,
+            UsageProvider::Codex => UsageProviderFilter::Codex,
+            UsageProvider::Gemini | UsageProvider::Copilot => UsageProviderFilter::All,
+        };
         self.scroll_offset = 0;
     }
 
     pub fn prev_provider(&mut self) {
         self.provider = self.provider.prev();
+        self.provider_filter = match self.provider {
+            UsageProvider::Claude => UsageProviderFilter::Claude,
+            UsageProvider::Codex => UsageProviderFilter::Codex,
+            UsageProvider::Gemini | UsageProvider::Copilot => UsageProviderFilter::All,
+        };
+        self.scroll_offset = 0;
+    }
+
+    pub fn cycle_provider_filter(&mut self) {
+        self.provider_filter = match self.provider_filter {
+            UsageProviderFilter::All => UsageProviderFilter::Claude,
+            UsageProviderFilter::Claude => UsageProviderFilter::Codex,
+            UsageProviderFilter::Codex => UsageProviderFilter::All,
+        };
+        self.scroll_offset = 0;
+    }
+
+    pub fn set_period(&mut self, period: UsagePeriod) {
+        self.period = period;
         self.scroll_offset = 0;
     }
 
@@ -194,8 +259,84 @@ impl UsageViewState {
                 UsageTab::Daily => data.daily.len(),
                 UsageTab::Weekly => data.weekly.len(),
                 UsageTab::Projects => data.projects.len(),
+                UsageTab::Burndown => {
+                    data.daily.len()
+                        + data.projects.len()
+                        + data.sessions.len()
+                        + data.activities.len()
+                        + data.models.len()
+                }
+                UsageTab::Optimize => optimize_usage(data).findings.len(),
             },
         }
+    }
+
+    pub fn query(&self) -> UsageQuery {
+        UsageQuery {
+            period: self.period.clone(),
+            provider_filter: self.provider_filter,
+            include_projects: self.include_projects.clone(),
+            exclude_projects: self.exclude_projects.clone(),
+        }
+    }
+
+    pub fn begin_input(&mut self, mode: UsageInputMode) {
+        self.input_mode = Some(mode);
+        self.input_buffer.clear();
+    }
+
+    pub fn input_char(&mut self, ch: char) {
+        self.input_buffer.push(ch);
+    }
+
+    pub fn input_backspace(&mut self) {
+        self.input_buffer.pop();
+    }
+
+    pub fn cancel_input(&mut self) {
+        self.input_mode = None;
+        self.input_buffer.clear();
+    }
+
+    pub fn submit_input(&mut self) -> Result<(), String> {
+        let value = self.input_buffer.trim().to_string();
+        match self.input_mode {
+            Some(UsageInputMode::Include) => {
+                if !value.is_empty() {
+                    self.include_projects.push(value);
+                }
+            }
+            Some(UsageInputMode::Exclude) => {
+                if !value.is_empty() {
+                    self.exclude_projects.push(value);
+                }
+            }
+            Some(UsageInputMode::DateRange) => {
+                let parts: Vec<_> = value
+                    .split(|ch| ch == '.' || ch == ',' || ch == ' ')
+                    .filter(|part| !part.is_empty())
+                    .collect();
+                if parts.len() != 2 {
+                    return Err("Use YYYY-MM-DD YYYY-MM-DD".to_string());
+                }
+                let from = chrono::NaiveDate::parse_from_str(parts[0], "%Y-%m-%d")
+                    .map_err(|_| "Invalid from date".to_string())?;
+                let to = chrono::NaiveDate::parse_from_str(parts[1], "%Y-%m-%d")
+                    .map_err(|_| "Invalid to date".to_string())?;
+                if from > to {
+                    return Err("From date must be before to date".to_string());
+                }
+                self.period = UsagePeriod::Custom { from, to };
+            }
+            None => {}
+        }
+        self.cancel_input();
+        Ok(())
+    }
+
+    pub fn clear_filters(&mut self) {
+        self.include_projects.clear();
+        self.exclude_projects.clear();
     }
 }
 
@@ -208,7 +349,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
             Constraint::Length(3), // Summary bar
             Constraint::Length(3), // Provider selector
             Constraint::Length(3), // Tab bar
-            Constraint::Min(0),   // Table content
+            Constraint::Min(0),    // Table content
             Constraint::Length(2), // Help bar
         ])
         .split(area);
@@ -227,6 +368,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
             UsageTab::Daily => render_daily(frame, layout[3], data, state.scroll_offset),
             UsageTab::Weekly => render_weekly(frame, layout[3], data, state.scroll_offset),
             UsageTab::Projects => render_projects(frame, layout[3], data, state.scroll_offset),
+            UsageTab::Burndown => render_burndown(frame, layout[3], data, state),
+            UsageTab::Optimize => render_optimize(frame, layout[3], data),
         }
     }
 
@@ -236,7 +379,10 @@ pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
 fn render_summary_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
     let mut spans = vec![
         Span::styled("📊 ", Style::default().fg(GOLD)),
-        Span::styled("Usage Analytics", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "Usage Analytics",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
     ];
 
     if let Some(data) = &state.data {
@@ -244,18 +390,33 @@ fn render_summary_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         spans.extend_from_slice(&[
             Span::styled("  │  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("Total: ", Style::default().fg(MUTED_GRAY)),
-            Span::styled(format_tokens_short(gt.total()), Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                format_tokens_short(gt.total()),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" tokens", Style::default().fg(MUTED_GRAY)),
             Span::styled("  │  ", Style::default().fg(MUTED_GRAY)),
-            Span::styled(format!("{}", data.daily.len()), Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                format!("{}", data.daily.len()),
+                Style::default().fg(SOFT_WHITE),
+            ),
             Span::styled(" days  ", Style::default().fg(MUTED_GRAY)),
-            Span::styled(format!("{}", data.projects.len()), Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                format!("{}", data.projects.len()),
+                Style::default().fg(SOFT_WHITE),
+            ),
             Span::styled(" projects  ", Style::default().fg(MUTED_GRAY)),
-            Span::styled(format!("{}", gt.session_count), Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                format!("{}", gt.session_count),
+                Style::default().fg(SOFT_WHITE),
+            ),
             Span::styled(" sessions", Style::default().fg(MUTED_GRAY)),
         ]);
     } else if state.provider.has_data() {
-        spans.push(Span::styled("  │  Loading...", Style::default().fg(MUTED_GRAY)));
+        spans.push(Span::styled(
+            "  │  Loading...",
+            Style::default().fg(MUTED_GRAY),
+        ));
     }
 
     let block = Block::default()
@@ -269,7 +430,10 @@ fn render_summary_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
 }
 
 fn render_provider_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
-    let mut spans: Vec<Span> = vec![Span::styled("  Provider: ", Style::default().fg(MUTED_GRAY))];
+    let mut spans: Vec<Span> = vec![Span::styled(
+        "  Provider: ",
+        Style::default().fg(MUTED_GRAY),
+    )];
 
     for (i, provider) in UsageProvider::all().iter().enumerate() {
         if i > 0 {
@@ -289,8 +453,34 @@ fn render_provider_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
     }
 
     spans.push(Span::styled("    ", Style::default()));
-    spans.push(Span::styled("◀/▶", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)));
+    spans.push(Span::styled(
+        "◀/▶",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
     spans.push(Span::styled(" switch", Style::default().fg(MUTED_GRAY)));
+    spans.push(Span::styled("  │  p ", Style::default().fg(GOLD)));
+    spans.push(Span::styled(
+        format!("filter: {}", provider_filter_label(state.provider_filter)),
+        Style::default().fg(MUTED_GRAY),
+    ));
+    spans.push(Span::styled("  │  ", Style::default().fg(MUTED_GRAY)));
+    spans.push(Span::styled(
+        period_label(&state.period),
+        Style::default().fg(SOFT_WHITE),
+    ));
+    if !state.include_projects.is_empty() || !state.exclude_projects.is_empty() {
+        spans.push(Span::styled(
+            "  │  filters active",
+            Style::default().fg(GOLD),
+        ));
+    }
+    if let Some(mode) = state.input_mode {
+        spans.push(Span::styled("  │  ", Style::default().fg(MUTED_GRAY)));
+        spans.push(Span::styled(
+            format!("{}: {}", input_label(mode), state.input_buffer),
+            Style::default().fg(GOLD),
+        ));
+    }
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -317,12 +507,18 @@ fn render_no_data(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         Line::from(""),
         Line::from(vec![
             Span::styled("  ", Style::default()),
-            Span::styled(state.provider.label(), Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)),
-            Span::styled(" usage tracking is not yet available.", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                state.provider.label(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " usage tracking is not yet available.",
+                Style::default().fg(MUTED_GRAY),
+            ),
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            "  Usage data parsing is currently supported for Claude Code only.",
+            "  Usage data parsing is currently supported for Claude Code and Codex.",
             Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
         )),
         Line::from(Span::styled(
@@ -371,9 +567,10 @@ fn render_loading(frame: &mut Frame, area: Rect) {
         .border_style(Style::default().fg(CORNFLOWER_BLUE))
         .style(Style::default().bg(DARK_BG));
 
-    let paragraph = Paragraph::new(Line::from(vec![
-        Span::styled("  ⏳ Scanning session files...", Style::default().fg(MUTED_GRAY)),
-    ]))
+    let paragraph = Paragraph::new(Line::from(vec![Span::styled(
+        "  ⏳ Scanning session files...",
+        Style::default().fg(MUTED_GRAY),
+    )]))
     .block(block);
     frame.render_widget(paragraph, area);
 }
@@ -401,9 +598,11 @@ fn render_daily(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offset: 
         .split(inner);
 
     // Table
-    let header = Row::new(vec!["Date", "Total", "Input", "Cache", "Output", "Sessions"])
-        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
-        .bottom_margin(1);
+    let header = Row::new(vec![
+        "Date", "Total", "Input", "Cache", "Output", "Sessions",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
 
     let visible_rows = chunks[0].height.saturating_sub(2) as usize;
     let total_rows = data.daily.len();
@@ -414,7 +613,9 @@ fn render_daily(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offset: 
         scroll_offset
     };
 
-    let rows: Vec<Row> = data.daily.iter()
+    let rows: Vec<Row> = data
+        .daily
+        .iter()
         .skip(effective_offset)
         .take(visible_rows)
         .map(|(date, bucket)| {
@@ -439,9 +640,7 @@ fn render_daily(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offset: 
         Constraint::Length(8),
     ];
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .column_spacing(1);
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
 
     frame.render_widget(table, chunks[0]);
 
@@ -465,9 +664,17 @@ fn render_weekly(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offset:
         return;
     }
 
-    let header = Row::new(vec!["Week Start", "Total", "Input", "Cache", "Output", "Sessions", "Projects"])
-        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
-        .bottom_margin(1);
+    let header = Row::new(vec![
+        "Week Start",
+        "Total",
+        "Input",
+        "Cache",
+        "Output",
+        "Sessions",
+        "Projects",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
 
     let visible_rows = inner.height.saturating_sub(2) as usize;
     let total_rows = data.weekly.len();
@@ -477,7 +684,9 @@ fn render_weekly(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offset:
         scroll_offset
     };
 
-    let rows: Vec<Row> = data.weekly.iter()
+    let rows: Vec<Row> = data
+        .weekly
+        .iter()
         .skip(effective_offset)
         .take(visible_rows)
         .map(|(date, bucket)| {
@@ -504,9 +713,7 @@ fn render_weekly(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offset:
         Constraint::Length(8),
     ];
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .column_spacing(1);
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
 
     frame.render_widget(table, inner);
 }
@@ -527,13 +734,17 @@ fn render_projects(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offse
         return;
     }
 
-    let header = Row::new(vec!["#", "Project", "Total", "Input", "Cache", "Output", "Sessions"])
-        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
-        .bottom_margin(1);
+    let header = Row::new(vec![
+        "#", "Project", "Total", "Input", "Cache", "Output", "Sessions",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
 
     let visible_rows = inner.height.saturating_sub(2) as usize;
 
-    let rows: Vec<Row> = data.projects.iter()
+    let rows: Vec<Row> = data
+        .projects
+        .iter()
         .enumerate()
         .skip(scroll_offset)
         .take(visible_rows)
@@ -562,11 +773,308 @@ fn render_projects(frame: &mut Frame, area: Rect, data: &UsageData, scroll_offse
         Constraint::Length(8),
     ];
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .column_spacing(1);
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
 
     frame.render_widget(table, inner);
+}
+
+fn render_burndown(frame: &mut Frame, area: Rect, data: &UsageData, state: &UsageViewState) {
+    let block = Block::default()
+        .title(" Burndown ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if data.calls.is_empty() {
+        let p = Paragraph::new("  No usage data found for selected period/provider/filter.")
+            .style(Style::default().fg(MUTED_GRAY));
+        frame.render_widget(p, inner);
+        return;
+    }
+
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    render_burndown_header(frame, vertical[0], data);
+    render_period_row(frame, vertical[1], state);
+
+    let body = if vertical[2].width >= 110 {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(vertical[2])
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(vertical[2])
+    };
+
+    let left = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
+        .split(body[0]);
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
+        .split(body[1]);
+
+    render_daily_activity_panel(frame, left[0], data);
+    render_project_panel(frame, left[1], &data.projects);
+    render_session_panel(frame, left[2], &data.sessions);
+    render_activity_panel(frame, right[0], &data.activities);
+    render_model_panel(frame, right[1], &data.models);
+
+    let tool_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
+        .split(right[2]);
+    render_named_panel(frame, tool_chunks[0], "Core Tools", &data.tools);
+    render_named_panel(
+        frame,
+        tool_chunks[1],
+        "Shell Commands",
+        &data.shell_commands,
+    );
+    render_named_panel(frame, tool_chunks[2], "MCP Servers", &data.mcp_servers);
+}
+
+fn render_burndown_header(frame: &mut Frame, area: Rect, data: &UsageData) {
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Calls ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.grand_total.call_count.to_string(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Sessions ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.grand_total.session_count.to_string(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Projects ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.grand_total.project_count.to_string(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Cost ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_cost(data.grand_total.cost_usd),
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Tokens ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(data.grand_total.total()),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled("  Cache ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(
+                    data.grand_total.cache_creation_tokens + data.grand_total.cache_read_tokens,
+                ),
+                Style::default().fg(SOFT_WHITE),
+            ),
+        ]),
+    ];
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn render_period_row(frame: &mut Frame, area: Rect, state: &UsageViewState) {
+    let text = Line::from(vec![
+        Span::styled(
+            "1 Today  2 Week  3 30d  4 Month  5 All  d Custom  / Include  x Exclude  c Clear  r Reload",
+            Style::default().fg(MUTED_GRAY),
+        ),
+        Span::styled("   Active: ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(period_label(&state.period), Style::default().fg(GOLD)),
+    ]);
+    frame.render_widget(Paragraph::new(text), area);
+}
+
+fn render_daily_activity_panel(frame: &mut Frame, area: Rect, data: &UsageData) {
+    let max = data.daily.iter().map(|(_, bucket)| bucket.total()).max().unwrap_or(1);
+    let rows: Vec<_> = data
+        .daily
+        .iter()
+        .rev()
+        .take(area.height.saturating_sub(2) as usize)
+        .map(|(date, bucket)| {
+            format!(
+                "{} {} {}",
+                date.format("%m-%d"),
+                bar(bucket.total(), max, 18),
+                format_tokens_short(bucket.total())
+            )
+        })
+        .collect();
+    render_panel(frame, area, "Daily Activity", rows);
+}
+
+fn render_project_panel(frame: &mut Frame, area: Rect, rows: &[ProjectUsage]) {
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let lines = rows
+        .iter()
+        .take(area.height.saturating_sub(2) as usize)
+        .map(|row| {
+            format!(
+                "{} {} {}",
+                truncate_string(&row.name, 22),
+                bar(row.bucket.total(), max, 12),
+                format_cost(row.bucket.cost_usd)
+            )
+        })
+        .collect();
+    render_panel(frame, area, "By Project", lines);
+}
+
+fn render_session_panel(frame: &mut Frame, area: Rect, rows: &[SessionUsage]) {
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let lines = rows
+        .iter()
+        .take(area.height.saturating_sub(2) as usize)
+        .map(|row| {
+            format!(
+                "{} {} {}",
+                truncate_string(&row.project, 18),
+                bar(row.bucket.total(), max, 12),
+                format_tokens_short(row.bucket.total())
+            )
+        })
+        .collect();
+    render_panel(frame, area, "Top Sessions", lines);
+}
+
+fn render_activity_panel(frame: &mut Frame, area: Rect, rows: &[ActivityUsage]) {
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let lines = rows
+        .iter()
+        .take(area.height.saturating_sub(2) as usize)
+        .map(|row| {
+            format!(
+                "{} {} {}t {}r",
+                row.category.label(),
+                bar(row.bucket.total(), max, 10),
+                row.turns,
+                row.retries
+            )
+        })
+        .collect();
+    render_panel(frame, area, "By Activity", lines);
+}
+
+fn render_model_panel(frame: &mut Frame, area: Rect, rows: &[ModelUsage]) {
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let lines = rows
+        .iter()
+        .take(area.height.saturating_sub(2) as usize)
+        .map(|row| {
+            format!(
+                "{} {} {}",
+                truncate_string(&row.model, 18),
+                bar(row.bucket.total(), max, 10),
+                format_tokens_short(row.bucket.total())
+            )
+        })
+        .collect();
+    render_panel(frame, area, "By Model", lines);
+}
+
+fn render_named_panel(frame: &mut Frame, area: Rect, title: &str, rows: &[NamedUsage]) {
+    let max = rows.iter().map(|row| row.calls as u64).max().unwrap_or(1);
+    let lines = rows
+        .iter()
+        .take(area.height.saturating_sub(2) as usize)
+        .map(|row| {
+            format!(
+                "{} {} {}",
+                truncate_string(&row.name, 14),
+                bar(row.calls as u64, max, 8),
+                row.calls
+            )
+        })
+        .collect();
+    render_panel(frame, area, title, lines);
+}
+
+fn render_optimize(frame: &mut Frame, area: Rect, data: &UsageData) {
+    let result = optimize_usage(data);
+    let mut lines = vec![
+        format!("Health {:?} ({}/100)", result.grade, result.score),
+        format!(
+            "Potential savings {} tokens",
+            format_tokens_short(result.potential_tokens_saved)
+        ),
+        String::new(),
+    ];
+    for finding in result.findings.iter().take(area.height.saturating_sub(5) as usize) {
+        lines.push(format!("{:?}: {}", finding.impact, finding.title));
+        lines.push(format!("  {}", truncate_string(&finding.details, 80)));
+        if let Some(action) = finding.actions.first() {
+            lines.push(format!(
+                "  Suggestion: {}",
+                truncate_string(&action.label, 80)
+            ));
+        }
+    }
+    render_panel(frame, area, "Optimize Findings", lines);
+}
+
+fn render_panel(frame: &mut Frame, area: Rect, title: &str, rows: Vec<String>) {
+    let block = Block::default()
+        .title(format!(" {title} "))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+    let lines = if rows.is_empty() {
+        vec![Line::from(Span::styled(
+            "No data",
+            Style::default().fg(MUTED_GRAY),
+        ))]
+    } else {
+        rows.into_iter()
+            .map(|row| Line::from(Span::styled(row, Style::default().fg(SOFT_WHITE))))
+            .collect()
+    };
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn bar(value: u64, max: u64, width: usize) -> String {
+    let filled = if max == 0 {
+        0
+    } else {
+        ((value as f64 / max as f64) * width as f64).round() as usize
+    }
+    .min(width);
+    format!(
+        "{}{}",
+        "█".repeat(filled),
+        "░".repeat(width.saturating_sub(filled))
+    )
 }
 
 fn render_bar_chart(frame: &mut Frame, area: Rect, data: &UsageData) {
@@ -637,6 +1145,12 @@ fn render_help_bar(frame: &mut Frame, area: Rect) {
     let spans = vec![
         Span::styled(" ◀/▶", Style::default().fg(GOLD)),
         Span::styled(" provider  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("p", Style::default().fg(GOLD)),
+        Span::styled(" filter  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("1-5", Style::default().fg(GOLD)),
+        Span::styled(" period  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("/ x d c", Style::default().fg(GOLD)),
+        Span::styled(" filters  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("Tab", Style::default().fg(GOLD)),
         Span::styled(" view  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("j/k", Style::default().fg(GOLD)),
@@ -648,8 +1162,7 @@ fn render_help_bar(frame: &mut Frame, area: Rect) {
         Span::styled("Esc", Style::default().fg(GOLD)),
         Span::styled(" back", Style::default().fg(MUTED_GRAY)),
     ];
-    let paragraph = Paragraph::new(Line::from(spans))
-        .style(Style::default().bg(DARK_BG));
+    let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(DARK_BG));
     frame.render_widget(paragraph, area);
 }
 
@@ -659,4 +1172,36 @@ fn truncate_string(s: &str, max_len: usize) -> String {
     } else {
         format!("{}…", &s[..max_len - 1])
     }
+}
+
+fn provider_filter_label(filter: UsageProviderFilter) -> &'static str {
+    match filter {
+        UsageProviderFilter::All => "All",
+        UsageProviderFilter::Claude => "Claude",
+        UsageProviderFilter::Codex => "Codex",
+    }
+}
+
+fn period_label(period: &UsagePeriod) -> String {
+    match period {
+        UsagePeriod::Today => "Today".to_string(),
+        UsagePeriod::Week => "Week".to_string(),
+        UsagePeriod::ThirtyDays => "30 days".to_string(),
+        UsagePeriod::Month => "Month".to_string(),
+        UsagePeriod::All => "All".to_string(),
+        UsagePeriod::Custom { from, to } => format!("{from} to {to}"),
+    }
+}
+
+fn input_label(mode: UsageInputMode) -> &'static str {
+    match mode {
+        UsageInputMode::Include => "include",
+        UsageInputMode::Exclude => "exclude",
+        UsageInputMode::DateRange => "date range",
+    }
+}
+
+fn format_cost(cost: Option<f64>) -> String {
+    cost.map(|value| format!("${value:.2}"))
+        .unwrap_or_else(|| "cost n/a".to_string())
 }

--- a/ainb-tui/src/config/mod.rs
+++ b/ainb-tui/src/config/mod.rs
@@ -3,8 +3,8 @@
 
 #![allow(dead_code)]
 
-use anyhow::{Context, Result};
 use crate::audit::{self, AuditResult, AuditTrigger};
+use anyhow::{Context, Result};
 use dirs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -218,6 +218,109 @@ pub struct AppConfig {
     /// Docker configuration
     #[serde(default)]
     pub docker: DockerConfig,
+
+    /// Usage analytics configuration.
+    #[serde(default)]
+    pub usage: UsageConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UsageConfig {
+    #[serde(default)]
+    pub plan: Option<UsagePlan>,
+    #[serde(default)]
+    pub currency: CurrencyConfig,
+    #[serde(default)]
+    pub model_aliases: HashMap<String, String>,
+}
+
+impl Default for UsageConfig {
+    fn default() -> Self {
+        Self {
+            plan: None,
+            currency: CurrencyConfig::default(),
+            model_aliases: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UsagePlan {
+    pub id: UsagePlanId,
+    pub monthly_usd: f64,
+    pub provider: UsagePlanProvider,
+    pub reset_day: u8,
+    pub set_at: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum UsagePlanId {
+    ClaudePro,
+    ClaudeMax,
+    ClaudeMax5x,
+    CursorPro,
+    Custom,
+    None,
+}
+
+impl UsagePlanId {
+    pub fn monthly_usd(self) -> Option<f64> {
+        match self {
+            Self::ClaudePro => Some(20.0),
+            Self::ClaudeMax => Some(100.0),
+            Self::ClaudeMax5x => Some(200.0),
+            Self::CursorPro => Some(20.0),
+            Self::Custom | Self::None => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UsagePlanProvider {
+    All,
+    Claude,
+    Codex,
+    Cursor,
+}
+
+impl Default for UsagePlanProvider {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CurrencyConfig {
+    #[serde(default = "default_currency_code")]
+    pub code: String,
+    #[serde(default = "default_currency_symbol")]
+    pub symbol: String,
+    #[serde(default = "default_exchange_rate")]
+    pub usd_rate: f64,
+}
+
+impl Default for CurrencyConfig {
+    fn default() -> Self {
+        Self {
+            code: default_currency_code(),
+            symbol: default_currency_symbol(),
+            usd_rate: default_exchange_rate(),
+        }
+    }
+}
+
+fn default_currency_code() -> String {
+    "USD".to_string()
+}
+
+fn default_currency_symbol() -> String {
+    "$".to_string()
+}
+
+fn default_exchange_rate() -> f64 {
+    1.0
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -508,6 +611,8 @@ impl AppConfig {
         if other.docker.timeout != 0 && other.docker.timeout != default_docker_timeout() {
             self.docker.timeout = other.docker.timeout;
         }
+
+        self.usage = other.usage;
     }
 
     /// Load built-in container templates
@@ -549,6 +654,7 @@ impl Default for AppConfig {
             workspace_defaults: WorkspaceDefaults::default(),
             ui_preferences: UiPreferences::default(),
             docker: DockerConfig::default(),
+            usage: UsageConfig::default(),
         };
 
         // Load built-in templates
@@ -686,31 +792,79 @@ mod tests {
         config.ui_preferences.show_container_status = false;
         config.ui_preferences.show_git_status = false;
         config.ui_preferences.preferred_editor = Some("nvim".to_string());
+        config.usage.plan = Some(UsagePlan {
+            id: UsagePlanId::ClaudePro,
+            monthly_usd: 20.0,
+            provider: UsagePlanProvider::Claude,
+            reset_day: 12,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        });
+        config.usage.currency = CurrencyConfig {
+            code: "GBP".to_string(),
+            symbol: "GBP".to_string(),
+            usd_rate: 1.0,
+        };
+        config
+            .usage
+            .model_aliases
+            .insert("cursor-auto".to_string(), "claude-sonnet-4-5".to_string());
 
         // Serialize to TOML
         let toml_str = toml::to_string_pretty(&config).expect("Failed to serialize config");
 
         // Verify TOML contains our settings
-        assert!(toml_str.contains("branch_prefix = \"custom/\""), "branch_prefix not in TOML");
+        assert!(
+            toml_str.contains("branch_prefix = \"custom/\""),
+            "branch_prefix not in TOML"
+        );
         assert!(toml_str.contains("vendor"), "exclude_paths not in TOML");
-        assert!(toml_str.contains("max_repositories = 1000"), "max_repositories not in TOML");
+        assert!(
+            toml_str.contains("max_repositories = 1000"),
+            "max_repositories not in TOML"
+        );
         assert!(
             toml_str.contains("worktree_collision_behavior = \"error\""),
             "worktree_collision_behavior not in TOML"
         );
-        assert!(toml_str.contains("tcp://localhost:2376"), "docker.host not in TOML");
-        assert!(toml_str.contains("timeout = 120"), "docker.timeout not in TOML");
+        assert!(
+            toml_str.contains("tcp://localhost:2376"),
+            "docker.host not in TOML"
+        );
+        assert!(
+            toml_str.contains("timeout = 120"),
+            "docker.timeout not in TOML"
+        );
         assert!(toml_str.contains("theme = \"light\""), "theme not in TOML");
-        assert!(toml_str.contains("show_container_status = false"), "show_container_status not in TOML");
-        assert!(toml_str.contains("show_git_status = false"), "show_git_status not in TOML");
-        assert!(toml_str.contains("preferred_editor = \"nvim\""), "preferred_editor not in TOML");
+        assert!(
+            toml_str.contains("show_container_status = false"),
+            "show_container_status not in TOML"
+        );
+        assert!(
+            toml_str.contains("show_git_status = false"),
+            "show_git_status not in TOML"
+        );
+        assert!(
+            toml_str.contains("preferred_editor = \"nvim\""),
+            "preferred_editor not in TOML"
+        );
+        assert!(
+            toml_str.contains("[usage.plan]") && toml_str.contains("[usage.currency]"),
+            "usage config not in TOML"
+        );
+        assert!(
+            toml_str.contains("claude-sonnet-4-5"),
+            "model alias not in TOML"
+        );
 
         // Deserialize back
         let loaded: AppConfig = toml::from_str(&toml_str).expect("Failed to deserialize config");
 
         // Verify all fields match
         assert_eq!(loaded.workspace_defaults.branch_prefix, "custom/");
-        assert_eq!(loaded.workspace_defaults.exclude_paths, vec!["vendor", "dist"]);
+        assert_eq!(
+            loaded.workspace_defaults.exclude_paths,
+            vec!["vendor", "dist"]
+        );
         assert_eq!(loaded.workspace_defaults.max_repositories, 1000);
         assert_eq!(
             loaded.workspace_defaults.worktree_collision_behavior,
@@ -721,7 +875,16 @@ mod tests {
         assert_eq!(loaded.ui_preferences.theme, "light");
         assert_eq!(loaded.ui_preferences.show_container_status, false);
         assert_eq!(loaded.ui_preferences.show_git_status, false);
-        assert_eq!(loaded.ui_preferences.preferred_editor, Some("nvim".to_string()));
+        assert_eq!(
+            loaded.ui_preferences.preferred_editor,
+            Some("nvim".to_string())
+        );
+        assert_eq!(loaded.usage.plan.unwrap().reset_day, 12);
+        assert_eq!(loaded.usage.currency.code, "GBP");
+        assert_eq!(
+            loaded.usage.model_aliases.get("cursor-auto"),
+            Some(&"claude-sonnet-4-5".to_string())
+        );
     }
 
     #[test]
@@ -737,7 +900,10 @@ mod tests {
         base.merge(other);
 
         // Verify docker settings were merged
-        assert_eq!(base.docker.host, Some("unix:///custom/docker.sock".to_string()));
+        assert_eq!(
+            base.docker.host,
+            Some("unix:///custom/docker.sock".to_string())
+        );
         assert_eq!(base.docker.timeout, 90);
     }
 }
@@ -750,8 +916,14 @@ mod old_config_tests {
     fn test_old_config_merge_keeps_default_true_for_booleans() {
         // Start with defaults (which have true for show_container_status and show_git_status)
         let mut defaults = AppConfig::default();
-        assert!(defaults.ui_preferences.show_container_status, "Default should be true");
-        assert!(defaults.ui_preferences.show_git_status, "Default should be true");
+        assert!(
+            defaults.ui_preferences.show_container_status,
+            "Default should be true"
+        );
+        assert!(
+            defaults.ui_preferences.show_git_status,
+            "Default should be true"
+        );
 
         // Simulate an "old config" with empty theme and false values
         let old_config = AppConfig {

--- a/ainb-tui/src/config/mod.rs
+++ b/ainb-tui/src/config/mod.rs
@@ -268,8 +268,8 @@ impl UsagePlanId {
     pub fn monthly_usd(self) -> Option<f64> {
         match self {
             Self::ClaudePro => Some(20.0),
-            Self::ClaudeMax => Some(100.0),
-            Self::ClaudeMax5x => Some(200.0),
+            Self::ClaudeMax => Some(200.0),
+            Self::ClaudeMax5x => Some(100.0),
             Self::CursorPro => Some(20.0),
             Self::Custom | Self::None => None,
         }
@@ -468,10 +468,16 @@ impl AppConfig {
                 let content = fs::read_to_string(&path)
                     .with_context(|| format!("Failed to read config from {}", path.display()))?;
 
+                let usage_present = content
+                    .parse::<toml::Value>()
+                    .ok()
+                    .and_then(|value| value.as_table().cloned())
+                    .is_some_and(|table| table.contains_key("usage"));
+
                 let file_config: AppConfig = toml::from_str(&content)
                     .with_context(|| format!("Failed to parse config from {}", path.display()))?;
 
-                config.merge(file_config);
+                config.merge_loaded(file_config, usage_present);
             }
         }
 
@@ -544,6 +550,11 @@ impl AppConfig {
 
     /// Merge another config into this one
     fn merge(&mut self, other: AppConfig) {
+        self.merge_loaded(other, true);
+    }
+
+    /// Merge another config into this one, preserving defaulted tables omitted from config files.
+    fn merge_loaded(&mut self, other: AppConfig, usage_present: bool) {
         // Don't override version
 
         // Merge authentication config
@@ -612,7 +623,9 @@ impl AppConfig {
             self.docker.timeout = other.docker.timeout;
         }
 
-        self.usage = other.usage;
+        if usage_present {
+            self.usage = other.usage;
+        }
     }
 
     /// Load built-in container templates
@@ -905,6 +918,45 @@ mod tests {
             Some("unix:///custom/docker.sock".to_string())
         );
         assert_eq!(base.docker.timeout, 90);
+    }
+
+    #[test]
+    fn usage_built_in_plan_budgets_match_spec() {
+        assert_eq!(UsagePlanId::ClaudeMax.monthly_usd(), Some(200.0));
+        assert_eq!(UsagePlanId::ClaudeMax5x.monthly_usd(), Some(100.0));
+    }
+
+    #[test]
+    fn layered_merge_preserves_usage_when_higher_layer_omits_usage() {
+        let mut base = AppConfig::default();
+        base.usage.plan = Some(UsagePlan {
+            id: UsagePlanId::ClaudePro,
+            monthly_usd: 20.0,
+            provider: UsagePlanProvider::Claude,
+            reset_day: 12,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        });
+        base.usage.currency = CurrencyConfig {
+            code: "GBP".to_string(),
+            symbol: "GBP".to_string(),
+            usd_rate: 1.0,
+        };
+        base.usage
+            .model_aliases
+            .insert("cursor-auto".to_string(), "claude-sonnet-4-5".to_string());
+
+        let mut higher = AppConfig::default();
+        higher.ui_preferences.theme = "light".to_string();
+
+        base.merge_loaded(higher, false);
+
+        assert_eq!(base.ui_preferences.theme, "light");
+        assert_eq!(base.usage.plan.as_ref().unwrap().reset_day, 12);
+        assert_eq!(base.usage.currency.code, "GBP");
+        assert_eq!(
+            base.usage.model_aliases.get("cursor-auto"),
+            Some(&"claude-sonnet-4-5".to_string())
+        );
     }
 }
 

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -37,8 +37,8 @@ mod cli;
 mod components;
 mod config;
 mod credentials;
-mod editors;
 mod docker;
+mod editors;
 mod git;
 mod interactive;
 mod models;
@@ -93,15 +93,26 @@ async fn main() -> Result<()> {
         Some(cli::Commands::List(list_args)) => cli::list::execute(list_args, args.format).await,
         Some(cli::Commands::Logs(logs_args)) => cli::logs::execute(logs_args).await,
         Some(cli::Commands::Attach(attach_args)) => cli::attach::execute(attach_args).await,
-        Some(cli::Commands::Status(status_args)) => cli::status::execute(status_args, args.format).await,
+        Some(cli::Commands::Status(status_args)) => {
+            cli::status::execute(status_args, args.format).await
+        }
         Some(cli::Commands::Kill(kill_args)) => cli::status::kill(kill_args).await,
         Some(cli::Commands::Auth) => run_auth_setup().await,
-        Some(cli::Commands::Recover { command }) => cli::recover::execute(command, args.format).await,
-        Some(cli::Commands::Config { command }) => cli::config_cmd::execute(command, args.format).await,
+        Some(cli::Commands::Recover { command }) => {
+            cli::recover::execute(command, args.format).await
+        }
+        Some(cli::Commands::Config { command }) => {
+            cli::config_cmd::execute(command, args.format).await
+        }
         Some(cli::Commands::Git { command }) => cli::git_cmd::execute(command, args.format).await,
-        Some(cli::Commands::Favorites { command }) => cli::favorites::execute(command, args.format).await,
+        Some(cli::Commands::Favorites { command }) => {
+            cli::favorites::execute(command, args.format).await
+        }
         Some(cli::Commands::Init(init_args)) => cli::init::execute(init_args, args.format).await,
-        Some(cli::Commands::Presets { command }) => cli::presets::execute(command, args.format).await,
+        Some(cli::Commands::Presets { command }) => {
+            cli::presets::execute(command, args.format).await
+        }
+        Some(cli::Commands::Usage { command }) => cli::usage::execute(command, args.format).await,
         Some(cli::Commands::Completion { shell }) => {
             use clap::CommandFactory;
             let mut cmd = cli::Cli::command();
@@ -409,13 +420,16 @@ async fn run_tui_loop(
                             AppEvent::ExitScrollMode => {
                                 layout.tmux_preview_mut().exit_scroll_mode();
                             }
-                            AppEvent::NewSession | AppEvent::SearchWorkspace | AppEvent::NewSessionCreate | AppEvent::ConfirmationConfirm => {
+                            AppEvent::NewSession
+                            | AppEvent::SearchWorkspace
+                            | AppEvent::NewSessionCreate
+                            | AppEvent::ConfirmationConfirm => {
                                 // Process the event to queue the async action
                                 EventHandler::process_event(app_event, &mut app.state);
 
                                 // IMMEDIATELY process the async action for responsive UI
                                 // This ensures dialogs appear without delay and session creation/deletion starts immediately
-                                use tracing::{info, error};
+                                use tracing::{error, info};
                                 info!(">>> Immediately processing async action for responsive UI");
                                 match app.tick().await {
                                     Ok(()) => {
@@ -439,8 +453,8 @@ async fn run_tui_loop(
                     }
                 }
                 Event::Mouse(mouse_event) => {
-                    use crossterm::event::{MouseEventKind, MouseButton};
                     use crate::app::events::AppEvent;
+                    use crossterm::event::{MouseButton, MouseEventKind};
 
                     match mouse_event.kind {
                         MouseEventKind::Down(MouseButton::Left) => {
@@ -453,7 +467,7 @@ async fn run_tui_loop(
                                 app.state.log_history_state.handle_click(col, row, 0, 0);
                             } else if let Some(app_event) = EventHandler::handle_mouse_event(
                                 AppEvent::MouseClick { x: col, y: row },
-                                &mut app.state
+                                &mut app.state,
                             ) {
                                 EventHandler::process_event(app_event, &mut app.state);
                             }
@@ -501,7 +515,10 @@ async fn run_tui_loop(
                             } else if app.state.current_view == View::LogHistory {
                                 // Scroll log history viewer
                                 // Shift+Scroll = horizontal, normal scroll = vertical
-                                if mouse_event.modifiers.contains(crossterm::event::KeyModifiers::SHIFT) {
+                                if mouse_event
+                                    .modifiers
+                                    .contains(crossterm::event::KeyModifiers::SHIFT)
+                                {
                                     // Horizontal scroll
                                     if is_down {
                                         app.state.log_history_state.scroll_right(SCROLL_LINES * 4);
@@ -519,8 +536,12 @@ async fn run_tui_loop(
                             } else {
                                 // Default: scroll live logs
                                 if is_down {
-                                    let total_logs =
-                                        app.state.live_logs.values().map(|v| v.len()).sum::<usize>();
+                                    let total_logs = app
+                                        .state
+                                        .live_logs
+                                        .values()
+                                        .map(|v| v.len())
+                                        .sum::<usize>();
                                     layout.live_logs_mut().scroll_down(total_logs);
                                 } else {
                                     layout.live_logs_mut().scroll_up();
@@ -535,7 +556,7 @@ async fn run_tui_loop(
                                 app.state.log_history_state.update_selection(col, row);
                             } else if let Some(app_event) = EventHandler::handle_mouse_event(
                                 AppEvent::MouseDragging { x: col, y: row },
-                                &mut app.state
+                                &mut app.state,
                             ) {
                                 EventHandler::process_event(app_event, &mut app.state);
                             }
@@ -548,7 +569,7 @@ async fn run_tui_loop(
                                 app.state.log_history_state.end_selection();
                             } else if let Some(app_event) = EventHandler::handle_mouse_event(
                                 AppEvent::MouseDragEnd { x: col, y: row },
-                                &mut app.state
+                                &mut app.state,
                             ) {
                                 EventHandler::process_event(app_event, &mut app.state);
                             }
@@ -585,25 +606,38 @@ async fn run_tui_loop(
             // IMPORTANT: Use match instead of multiple if-let with .take() to avoid dropping unmatched actions
             if let Some(action) = app.state.pending_async_action.take() {
                 use crate::app::state::AsyncAction;
-                use tracing::{info, error, warn, debug};
+                use tracing::{debug, error, info, warn};
 
                 match action {
                     AsyncAction::AttachToOtherTmux(session_name) => {
                         use crate::app::AttachHandler;
 
-                        info!("[ACTION] Handling AttachToOtherTmux for session '{}'", session_name);
+                        info!(
+                            "[ACTION] Handling AttachToOtherTmux for session '{}'",
+                            session_name
+                        );
 
                         // Create attach handler and attach directly using the session name
-                        info!("[ACTION] Creating attach handler for other tmux session '{}'", session_name);
+                        info!(
+                            "[ACTION] Creating attach handler for other tmux session '{}'",
+                            session_name
+                        );
                         let mut attach_handler = AttachHandler::new_from_terminal(terminal)?;
                         info!("[ACTION] Attach handler created, calling attach_to_session...");
                         match attach_handler.attach_to_session(&session_name).await {
                             Ok(()) => {
-                                info!("[ACTION] Successfully attached and detached from other tmux session '{}'", session_name);
+                                info!(
+                                    "[ACTION] Successfully attached and detached from other tmux session '{}'",
+                                    session_name
+                                );
                             }
                             Err(e) => {
-                                error!("[ACTION] Failed to attach to other tmux session '{}': {}", session_name, e);
-                                app.state.add_error_notification(format!("Failed to attach: {}", e));
+                                error!(
+                                    "[ACTION] Failed to attach to other tmux session '{}': {}",
+                                    session_name, e
+                                );
+                                app.state
+                                    .add_error_notification(format!("Failed to attach: {}", e));
                             }
                         }
 
@@ -625,20 +659,31 @@ async fn run_tui_loop(
                         match output {
                             Ok(o) if o.status.success() => {
                                 info!("Successfully killed tmux session '{}'", session_name);
-                                app.state.add_success_notification(format!("Killed tmux session '{}'", session_name));
+                                app.state.add_success_notification(format!(
+                                    "Killed tmux session '{}'",
+                                    session_name
+                                ));
                                 // Clear selection if we just killed the selected session
-                                if app.state.selected_other_tmux_session().map(|s| s.name.as_str()) == Some(&session_name) {
+                                if app.state.selected_other_tmux_session().map(|s| s.name.as_str())
+                                    == Some(&session_name)
+                                {
                                     app.state.selected_other_tmux_index = None;
                                 }
                             }
                             Ok(o) => {
                                 let stderr = String::from_utf8_lossy(&o.stderr);
                                 warn!("Failed to kill tmux session '{}': {}", session_name, stderr);
-                                app.state.add_error_notification(format!("Failed to kill session: {}", stderr));
+                                app.state.add_error_notification(format!(
+                                    "Failed to kill session: {}",
+                                    stderr
+                                ));
                             }
                             Err(e) => {
                                 warn!("Failed to kill tmux session '{}': {}", session_name, e);
-                                app.state.add_error_notification(format!("Failed to kill session: {}", e));
+                                app.state.add_error_notification(format!(
+                                    "Failed to kill session: {}",
+                                    e
+                                ));
                             }
                         }
 
@@ -657,21 +702,22 @@ async fn run_tui_loop(
                             Some(cmd) => {
                                 info!("Opening {} in {}", workspace_path.display(), cmd);
 
-                                let result = std::process::Command::new(&cmd)
-                                    .arg(&workspace_path)
-                                    .spawn();
+                                let result =
+                                    std::process::Command::new(&cmd).arg(&workspace_path).spawn();
 
                                 match result {
                                     Ok(_) => {
-                                        app.state.add_success_notification(
-                                            format!("📝 Opened in {}", cmd)
-                                        );
+                                        app.state.add_success_notification(format!(
+                                            "📝 Opened in {}",
+                                            cmd
+                                        ));
                                     }
                                     Err(e) => {
                                         error!("Failed to open editor: {}", e);
-                                        app.state.add_error_notification(
-                                            format!("❌ Failed to open editor: {}", e)
-                                        );
+                                        app.state.add_error_notification(format!(
+                                            "❌ Failed to open editor: {}",
+                                            e
+                                        ));
                                     }
                                 }
                             }
@@ -685,14 +731,20 @@ async fn run_tui_loop(
                     }
 
                     // Workspace shell handling (one shell per workspace, cd to switch directories)
-                    AsyncAction::OpenWorkspaceShell { workspace_index, target_dir } => {
+                    AsyncAction::OpenWorkspaceShell {
+                        workspace_index,
+                        target_dir,
+                    } => {
                         use crate::app::AttachHandler;
                         use crate::models::ShellSession;
                         use shell_escape::escape;
                         use std::borrow::Cow;
                         use tokio::process::Command;
 
-                        info!("[ACTION] Opening workspace shell, index: {}, target_dir: {:?}", workspace_index, target_dir);
+                        info!(
+                            "[ACTION] Opening workspace shell, index: {}, target_dir: {:?}",
+                            workspace_index, target_dir
+                        );
 
                         // Get workspace info
                         let (workspace_path, workspace_name, existing_shell) = {
@@ -700,7 +752,10 @@ async fn run_tui_loop(
                                 (
                                     workspace.path.clone(),
                                     workspace.name.clone(),
-                                    workspace.shell_session.as_ref().map(|s| s.tmux_session_name.clone()),
+                                    workspace
+                                        .shell_session
+                                        .as_ref()
+                                        .map(|s| s.tmux_session_name.clone()),
                                 )
                             } else {
                                 app.state.add_error_notification("Workspace not found".to_string());
@@ -713,7 +768,10 @@ async fn run_tui_loop(
                         let (tmux_name, is_new_shell) = if let Some(existing) = existing_shell {
                             (existing, false)
                         } else {
-                            let shell = ShellSession::new_workspace_shell(workspace_path.clone(), &workspace_name);
+                            let shell = ShellSession::new_workspace_shell(
+                                workspace_path.clone(),
+                                &workspace_name,
+                            );
                             let name = shell.tmux_session_name.clone();
                             // Store the new shell in workspace
                             if let Some(workspace) = app.state.workspaces.get_mut(workspace_index) {
@@ -727,8 +785,8 @@ async fn run_tui_loop(
                         let workspace_path_str = workspace_path.to_str().unwrap_or(".");
                         let create_result = Command::new("tmux")
                             .arg("new-session")
-                            .arg("-A")  // Atomic: attach if exists, create if not
-                            .arg("-d")  // Detached (we'll attach separately for TUI handling)
+                            .arg("-A") // Atomic: attach if exists, create if not
+                            .arg("-d") // Detached (we'll attach separately for TUI handling)
                             .arg("-s")
                             .arg(&tmux_name)
                             .arg("-c")
@@ -745,9 +803,10 @@ async fn run_tui_loop(
 
                                 if is_new_shell {
                                     info!("[ACTION] Created new workspace shell: {}", tmux_name);
-                                    app.state.add_success_notification(
-                                        format!("$ Created workspace shell: {}", workspace_name)
-                                    );
+                                    app.state.add_success_notification(format!(
+                                        "$ Created workspace shell: {}",
+                                        workspace_name
+                                    ));
                                 } else {
                                     info!("[ACTION] Reusing workspace shell: {}", tmux_name);
                                 }
@@ -755,13 +814,19 @@ async fn run_tui_loop(
                             Ok(output) => {
                                 let stderr = String::from_utf8_lossy(&output.stderr);
                                 error!("[ACTION] Failed to create/attach tmux session: {}", stderr);
-                                app.state.add_error_notification(format!("Failed to create shell: {}", stderr));
+                                app.state.add_error_notification(format!(
+                                    "Failed to create shell: {}",
+                                    stderr
+                                ));
                                 app.state.ui_needs_refresh = true;
                                 continue;
                             }
                             Err(e) => {
                                 error!("[ACTION] Failed to create tmux session: {}", e);
-                                app.state.add_error_notification(format!("Failed to create shell: {}", e));
+                                app.state.add_error_notification(format!(
+                                    "Failed to create shell: {}",
+                                    e
+                                ));
                                 app.state.ui_needs_refresh = true;
                                 continue;
                             }
@@ -785,7 +850,9 @@ async fn run_tui_loop(
                             match cd_result {
                                 Ok(output) if output.status.success() => {
                                     // Update stored working_dir for state consistency
-                                    if let Some(workspace) = app.state.workspaces.get_mut(workspace_index) {
+                                    if let Some(workspace) =
+                                        app.state.workspaces.get_mut(workspace_index)
+                                    {
                                         if let Some(shell) = workspace.get_shell_session_mut() {
                                             shell.set_working_dir(dir.clone());
                                         }
@@ -794,15 +861,17 @@ async fn run_tui_loop(
                                 Ok(output) => {
                                     let stderr = String::from_utf8_lossy(&output.stderr);
                                     warn!("[ACTION] tmux send-keys may have failed: {}", stderr);
-                                    app.state.add_warning_notification(
-                                        format!("May have failed to cd to: {}", dir_str)
-                                    );
+                                    app.state.add_warning_notification(format!(
+                                        "May have failed to cd to: {}",
+                                        dir_str
+                                    ));
                                 }
                                 Err(e) => {
                                     error!("[ACTION] tmux send-keys error: {}", e);
-                                    app.state.add_error_notification(
-                                        format!("Shell command error: {}", e)
-                                    );
+                                    app.state.add_error_notification(format!(
+                                        "Shell command error: {}",
+                                        e
+                                    ));
                                 }
                             }
                         }
@@ -822,7 +891,8 @@ async fn run_tui_loop(
                             }
                             Err(e) => {
                                 error!("[ACTION] Failed to attach to shell: {}", e);
-                                app.state.add_error_notification(format!("Failed to attach: {}", e));
+                                app.state
+                                    .add_error_notification(format!("Failed to attach: {}", e));
                             }
                         }
 
@@ -837,12 +907,13 @@ async fn run_tui_loop(
 
                         // Generate a simple tmux session name based on repo directory
                         // Sanitize repo name: periods are tmux session.window delimiters
-                        let repo_name = repo_path.file_name()
+                        let repo_name = repo_path
+                            .file_name()
                             .and_then(|n| n.to_str())
                             .unwrap_or("shell")
-                            .replace('.', "-")    // Periods break tmux (session.window delimiter)
-                            .replace(':', "-")    // Colons are special in tmux
-                            .replace('/', "-");   // Slashes for safety
+                            .replace('.', "-") // Periods break tmux (session.window delimiter)
+                            .replace(':', "-") // Colons are special in tmux
+                            .replace('/', "-"); // Slashes for safety
                         let timestamp = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .map(|d| d.as_secs())
@@ -864,9 +935,11 @@ async fn run_tui_loop(
                             let create_result = Command::new("tmux")
                                 .args([
                                     "new-session",
-                                    "-d",           // Start detached
-                                    "-s", &tmux_name,
-                                    "-c", repo_path_str,  // Set working directory
+                                    "-d", // Start detached
+                                    "-s",
+                                    &tmux_name,
+                                    "-c",
+                                    repo_path_str, // Set working directory
                                 ])
                                 .output()
                                 .await;
@@ -874,7 +947,9 @@ async fn run_tui_loop(
                             match create_result {
                                 Ok(output) if output.status.success() => {
                                     // Configure clipboard for the tmux session
-                                    if let Err(e) = crate::tmux::configure_clipboard(&tmux_name).await {
+                                    if let Err(e) =
+                                        crate::tmux::configure_clipboard(&tmux_name).await
+                                    {
                                         warn!("[ACTION] Failed to configure clipboard: {}", e);
                                     }
                                     info!("[ACTION] Created tmux session: {}", tmux_name);
@@ -882,7 +957,10 @@ async fn run_tui_loop(
                                 Ok(output) => {
                                     let stderr = String::from_utf8_lossy(&output.stderr);
                                     error!("[ACTION] tmux session creation failed: {}", stderr);
-                                    app.state.add_error_notification(format!("Shell creation failed: {}", stderr));
+                                    app.state.add_error_notification(format!(
+                                        "Shell creation failed: {}",
+                                        stderr
+                                    ));
                                     app.state.ui_needs_refresh = true;
                                     continue;
                                 }
@@ -906,11 +984,15 @@ async fn run_tui_loop(
                         match attach_handler.attach_to_session(&tmux_name).await {
                             Ok(()) => {
                                 info!("[ACTION] Successfully attached to shell at {:?}", repo_path);
-                                app.state.add_success_notification(format!("Shell opened at: {}", repo_name));
+                                app.state.add_success_notification(format!(
+                                    "Shell opened at: {}",
+                                    repo_name
+                                ));
                             }
                             Err(e) => {
                                 error!("[ACTION] Failed to attach to shell: {}", e);
-                                app.state.add_error_notification(format!("Failed to attach: {}", e));
+                                app.state
+                                    .add_error_notification(format!("Failed to attach: {}", e));
                             }
                         }
 
@@ -925,7 +1007,10 @@ async fn run_tui_loop(
 
                         // Get SSH target from state
                         let ssh_target = app.state.build_ssh_target();
-                        let repo_path = app.state.new_session_state.as_ref()
+                        let repo_path = app
+                            .state
+                            .new_session_state
+                            .as_ref()
                             .and_then(|s| s.get_selected_repo_path());
 
                         // Clear new session state
@@ -941,25 +1026,16 @@ async fn run_tui_loop(
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map(|d| d.as_secs())
                                 .unwrap_or(0);
-                            let sanitized_host = target.host
-                                .replace('.', "-")
-                                .replace(':', "-");
+                            let sanitized_host = target.host.replace('.', "-").replace(':', "-");
                             let tmux_name = format!("ssh-{}-{}", sanitized_host, timestamp % 10000);
 
                             // Determine working directory (use repo path if available, else home)
-                            let work_dir = repo_path
-                                .as_ref()
-                                .and_then(|p| p.to_str())
-                                .unwrap_or("~");
+                            let work_dir =
+                                repo_path.as_ref().and_then(|p| p.to_str()).unwrap_or("~");
 
                             // Create tmux session first (detached)
                             let create_result = Command::new("tmux")
-                                .args([
-                                    "new-session",
-                                    "-d",
-                                    "-s", &tmux_name,
-                                    "-c", work_dir,
-                                ])
+                                .args(["new-session", "-d", "-s", &tmux_name, "-c", work_dir])
                                 .output()
                                 .await;
 
@@ -968,18 +1044,15 @@ async fn run_tui_loop(
                                     info!("[ACTION] Created tmux session for SSH: {}", tmux_name);
 
                                     // Configure clipboard
-                                    if let Err(e) = crate::tmux::configure_clipboard(&tmux_name).await {
+                                    if let Err(e) =
+                                        crate::tmux::configure_clipboard(&tmux_name).await
+                                    {
                                         warn!("[ACTION] Failed to configure clipboard: {}", e);
                                     }
 
                                     // Send SSH command to the tmux session
                                     let send_result = Command::new("tmux")
-                                        .args([
-                                            "send-keys",
-                                            "-t", &tmux_name,
-                                            &ssh_cmd,
-                                            "Enter",
-                                        ])
+                                        .args(["send-keys", "-t", &tmux_name, &ssh_cmd, "Enter"])
                                         .output()
                                         .await;
 
@@ -988,22 +1061,38 @@ async fn run_tui_loop(
                                     }
 
                                     // Attach to the SSH session
-                                    let mut attach_handler = AttachHandler::new_from_terminal(terminal)?;
+                                    let mut attach_handler =
+                                        AttachHandler::new_from_terminal(terminal)?;
                                     match attach_handler.attach_to_session(&tmux_name).await {
                                         Ok(()) => {
-                                            info!("[ACTION] Successfully attached to SSH session: {}", display_name);
-                                            app.state.add_success_notification(format!("SSH: {}", display_name));
+                                            info!(
+                                                "[ACTION] Successfully attached to SSH session: {}",
+                                                display_name
+                                            );
+                                            app.state.add_success_notification(format!(
+                                                "SSH: {}",
+                                                display_name
+                                            ));
                                         }
                                         Err(e) => {
-                                            error!("[ACTION] Failed to attach to SSH session: {}", e);
-                                            app.state.add_error_notification(format!("SSH attach failed: {}", e));
+                                            error!(
+                                                "[ACTION] Failed to attach to SSH session: {}",
+                                                e
+                                            );
+                                            app.state.add_error_notification(format!(
+                                                "SSH attach failed: {}",
+                                                e
+                                            ));
                                         }
                                     }
                                 }
                                 Ok(output) => {
                                     let stderr = String::from_utf8_lossy(&output.stderr);
                                     error!("[ACTION] SSH tmux session creation failed: {}", stderr);
-                                    app.state.add_error_notification(format!("SSH session failed: {}", stderr));
+                                    app.state.add_error_notification(format!(
+                                        "SSH session failed: {}",
+                                        stderr
+                                    ));
                                 }
                                 Err(e) => {
                                     error!("[ACTION] tmux command error for SSH: {}", e);
@@ -1011,7 +1100,8 @@ async fn run_tui_loop(
                                 }
                             }
                         } else {
-                            app.state.add_error_notification("SSH target not configured".to_string());
+                            app.state
+                                .add_error_notification("SSH target not configured".to_string());
                         }
 
                         app.state.ui_needs_refresh = true;
@@ -1020,10 +1110,15 @@ async fn run_tui_loop(
                     AsyncAction::KillWorkspaceShell(workspace_index) => {
                         use tokio::process::Command;
 
-                        info!("[ACTION] Killing workspace shell, index: {}", workspace_index);
+                        info!(
+                            "[ACTION] Killing workspace shell, index: {}",
+                            workspace_index
+                        );
 
                         // Extract info first to avoid borrow issues
-                        let shell_info = if let Some(workspace) = app.state.workspaces.get_mut(workspace_index) {
+                        let shell_info = if let Some(workspace) =
+                            app.state.workspaces.get_mut(workspace_index)
+                        {
                             if let Some(shell) = workspace.shell_session.take() {
                                 Some((shell.tmux_session_name.clone(), workspace.name.clone()))
                             } else {
@@ -1040,9 +1135,10 @@ async fn run_tui_loop(
                                 .output()
                                 .await;
 
-                            app.state.add_success_notification(
-                                format!("Killed workspace shell: {}", workspace_name)
-                            );
+                            app.state.add_success_notification(format!(
+                                "Killed workspace shell: {}",
+                                workspace_name
+                            ));
                         }
 
                         // Refresh workspace list to ensure UI reflects the actual state
@@ -1053,23 +1149,39 @@ async fn run_tui_loop(
                     AsyncAction::AttachToTmuxSession(session_id) => {
                         use crate::app::AttachHandler;
 
-                        info!("[ACTION] Handling AttachToTmuxSession for session {}", session_id);
-                        debug!("[ACTION] Looking for session in {} workspaces", app.state.workspaces.len());
+                        info!(
+                            "[ACTION] Handling AttachToTmuxSession for session {}",
+                            session_id
+                        );
+                        debug!(
+                            "[ACTION] Looking for session in {} workspaces",
+                            app.state.workspaces.len()
+                        );
 
                         // Get session to find tmux session name
-                        let tmux_session_name = if let Some(session) = app.state.workspaces
+                        let tmux_session_name = if let Some(session) = app
+                            .state
+                            .workspaces
                             .iter()
                             .flat_map(|w| &w.sessions)
                             .find(|s| s.id == session_id)
                         {
-                            debug!("[ACTION] Found session: name='{}', status={:?}, tmux_name={:?}",
-                                session.name, session.status, session.tmux_session_name);
+                            debug!(
+                                "[ACTION] Found session: name='{}', status={:?}, tmux_name={:?}",
+                                session.name, session.status, session.tmux_session_name
+                            );
                             if let Some(ref name) = session.tmux_session_name {
                                 info!("[ACTION] Using tmux session name: {}", name);
                                 Some(name.clone())
                             } else {
-                                error!("[ACTION] No tmux session name found for session {} (name={})", session_id, session.name);
-                                app.state.add_error_notification(format!("Session '{}' has no tmux session", session.name));
+                                error!(
+                                    "[ACTION] No tmux session name found for session {} (name={})",
+                                    session_id, session.name
+                                );
+                                app.state.add_error_notification(format!(
+                                    "Session '{}' has no tmux session",
+                                    session.name
+                                ));
                                 app.state.ui_needs_refresh = true;
                                 None
                             }
@@ -1092,16 +1204,26 @@ async fn run_tui_loop(
                             }
 
                             // Create attach handler and attach directly
-                            info!("[ACTION] Creating attach handler for tmux session '{}'", tmux_session_name);
+                            info!(
+                                "[ACTION] Creating attach handler for tmux session '{}'",
+                                tmux_session_name
+                            );
                             let mut attach_handler = AttachHandler::new_from_terminal(terminal)?;
                             info!("[ACTION] Attach handler created, calling attach_to_session...");
                             match attach_handler.attach_to_session(&tmux_session_name).await {
                                 Ok(()) => {
-                                    info!("[ACTION] Successfully attached and detached from tmux session '{}'", tmux_session_name);
+                                    info!(
+                                        "[ACTION] Successfully attached and detached from tmux session '{}'",
+                                        tmux_session_name
+                                    );
                                 }
                                 Err(e) => {
-                                    error!("[ACTION] Failed to attach to tmux session '{}': {}", tmux_session_name, e);
-                                    app.state.add_error_notification(format!("Failed to attach: {}", e));
+                                    error!(
+                                        "[ACTION] Failed to attach to tmux session '{}': {}",
+                                        tmux_session_name, e
+                                    );
+                                    app.state
+                                        .add_error_notification(format!("Failed to attach: {}", e));
                                 }
                             }
 
@@ -1121,7 +1243,10 @@ async fn run_tui_loop(
 
                     // Put back any other actions we don't handle here
                     other => {
-                        debug!("[ACTION] Passing through unhandled action in main loop: {:?}", std::any::type_name_of_val(&other));
+                        debug!(
+                            "[ACTION] Passing through unhandled action in main loop: {:?}",
+                            std::any::type_name_of_val(&other)
+                        );
                         app.state.pending_async_action = Some(other);
                     }
                 }
@@ -1184,8 +1309,8 @@ fn setup_logging() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .json()             // Output in JSON Lines format
-                .with_target(true)  // Include target module in JSON
+                .json() // Output in JSON Lines format
+                .with_target(true) // Include target module in JSON
                 .with_writer(file)
                 .with_ansi(false),
         )

--- a/ainb-tui/src/models/mod.rs
+++ b/ainb-tui/src/models/mod.rs
@@ -7,7 +7,15 @@ pub mod usage;
 pub mod workspace;
 
 pub use other_tmux::OtherTmuxSession;
-pub use session::{ClaudeModel, GitChanges, Session, SessionAgentType, SessionMode, SessionStatus, ShellSession, ShellSessionStatus, SshTarget};
+pub use session::{
+    ClaudeModel, GitChanges, Session, SessionAgentType, SessionMode, SessionStatus, ShellSession,
+    ShellSessionStatus, SshTarget,
+};
 pub use skills::{AgentDef, Skill, SkillsData};
-pub use usage::{UsageData, format_tokens_short};
+pub use usage::{
+    ActivityCategory, ActivityUsage, CompareResult, HealthGrade, ModelComparison, ModelUsage,
+    NamedUsage, OptimizeResult, PlanProjection, PlanStatus, ProjectUsage, ProviderCall,
+    SessionUsage, TokenBucket, UsageData, UsagePeriod, UsageProviderFilter, UsageQuery,
+    WasteFinding, YieldResult, format_tokens_short, optimize_usage,
+};
 pub use workspace::Workspace;

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -731,12 +731,25 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
 
         let (input_tokens, cached_tokens, output_tokens, reasoning_tokens) =
             if let Some(last) = info.last_token_usage {
-                (
-                    last.input_tokens.unwrap_or(0),
-                    last.cached_input_tokens.unwrap_or(0),
-                    last.output_tokens.unwrap_or(0),
-                    last.reasoning_output_tokens.unwrap_or(0),
-                )
+                let input = last.input_tokens.unwrap_or(0);
+                let cached = last.cached_input_tokens.unwrap_or(0);
+                let output = last.output_tokens.unwrap_or(0);
+                let reasoning = last.reasoning_output_tokens.unwrap_or(0);
+
+                if let Some(total) = info.total_token_usage {
+                    previous_input = total.input_tokens.unwrap_or(previous_input + input);
+                    previous_cached = total.cached_input_tokens.unwrap_or(previous_cached + cached);
+                    previous_output = total.output_tokens.unwrap_or(previous_output + output);
+                    previous_reasoning =
+                        total.reasoning_output_tokens.unwrap_or(previous_reasoning + reasoning);
+                } else {
+                    previous_input += input;
+                    previous_cached += cached;
+                    previous_output += output;
+                    previous_reasoning += reasoning;
+                }
+
+                (input, cached, output, reasoning)
             } else if let Some(total) = info.total_token_usage {
                 let input = total.input_tokens.unwrap_or(0).saturating_sub(previous_input);
                 let cached = total.cached_input_tokens.unwrap_or(0).saturating_sub(previous_cached);
@@ -1169,29 +1182,20 @@ pub fn project_plan_usage(
     today: NaiveDate,
 ) -> PlanProjection {
     let (period_start, period_end) = billing_period(today, plan.reset_day);
-    let spent_usd = data
-        .daily
-        .iter()
-        .filter(|(date, _)| *date >= period_start && *date <= period_end)
-        .filter_map(|(_, bucket)| bucket.cost_usd)
-        .sum::<f64>();
+    let spent_usd = plan_cost_for_range(data, plan.provider, period_start, period_end);
     let percent_used = if plan.monthly_usd > 0.0 {
         spent_usd / plan.monthly_usd
     } else {
         0.0
     };
-    let mut last_week: Vec<f64> = data
-        .daily
-        .iter()
-        .filter(|(date, _)| *date >= today - Duration::days(6) && *date <= today)
-        .map(|(_, bucket)| bucket.cost_usd.unwrap_or(0.0))
+    let mut last_week: Vec<f64> = (0..7)
+        .map(|offset| {
+            let date = today - Duration::days(offset);
+            plan_cost_for_range(data, plan.provider, date, date)
+        })
         .collect();
     last_week.sort_by(f64::total_cmp);
-    let median_daily = if last_week.is_empty() {
-        0.0
-    } else {
-        last_week[last_week.len() / 2]
-    };
+    let median_daily = last_week[last_week.len() / 2];
     let remaining_days = (period_end - today).num_days().max(0);
     let projected_usd = spent_usd + median_daily * remaining_days as f64;
     let status = if percent_used > 1.0 {
@@ -1214,7 +1218,43 @@ pub fn project_plan_usage(
     }
 }
 
-fn billing_period(today: NaiveDate, reset_day: u8) -> (NaiveDate, NaiveDate) {
+fn plan_cost_for_range(
+    data: &UsageData,
+    provider: crate::config::UsagePlanProvider,
+    start: NaiveDate,
+    end: NaiveDate,
+) -> f64 {
+    let call_cost = data
+        .calls
+        .iter()
+        .filter(|call| {
+            let date = call.timestamp.date_naive();
+            date >= start && date <= end && plan_provider_includes(provider, &call.provider)
+        })
+        .filter_map(|call| call.cost_usd)
+        .sum::<f64>();
+
+    if call_cost > 0.0 || provider != crate::config::UsagePlanProvider::All {
+        return call_cost;
+    }
+
+    data.daily
+        .iter()
+        .filter(|(date, _)| *date >= start && *date <= end)
+        .filter_map(|(_, bucket)| bucket.cost_usd)
+        .sum::<f64>()
+}
+
+fn plan_provider_includes(provider: crate::config::UsagePlanProvider, call_provider: &str) -> bool {
+    match provider {
+        crate::config::UsagePlanProvider::All => true,
+        crate::config::UsagePlanProvider::Claude => call_provider == "claude",
+        crate::config::UsagePlanProvider::Codex => call_provider == "codex",
+        crate::config::UsagePlanProvider::Cursor => call_provider == "cursor",
+    }
+}
+
+pub fn billing_period(today: NaiveDate, reset_day: u8) -> (NaiveDate, NaiveDate) {
     let reset_day = reset_day.clamp(1, 28) as u32;
     let current_reset =
         NaiveDate::from_ymd_opt(today.year(), today.month(), reset_day).unwrap_or(today);
@@ -1577,9 +1617,9 @@ fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Local>, DateT
     match period {
         UsagePeriod::All => None,
         UsagePeriod::Today => Some(day_bounds(today)),
-        UsagePeriod::Week => Some((start_of_day(today - Duration::days(7)), end_of_day(today))),
+        UsagePeriod::Week => Some((start_of_day(today - Duration::days(6)), end_of_day(today))),
         UsagePeriod::ThirtyDays => {
-            Some((start_of_day(today - Duration::days(30)), end_of_day(today)))
+            Some((start_of_day(today - Duration::days(29)), end_of_day(today)))
         }
         UsagePeriod::Month => {
             let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today);
@@ -1992,6 +2032,38 @@ mod tests {
     }
 
     #[test]
+    fn codex_last_usage_advances_total_delta_baseline() {
+        let temp = tempdir().unwrap();
+        let codex_dir = temp.path().join(".codex");
+        let rollout = codex_dir.join("sessions/2026/04/10/rollout-1.jsonl");
+        write_file(
+            &rollout,
+            r#"{"type":"session_meta","payload":{"originator":"codex_cli","session_id":"codex-1","cwd":"/Users/stevie/work/project","model":"gpt-5"}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}}
+{"type":"event_msg","timestamp":"2026-04-10T10:00:01Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":200,"reasoning_output_tokens":50},"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1650}}}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:02Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}}
+{"type":"event_msg","timestamp":"2026-04-10T10:00:03Z","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1300,"cached_input_tokens":450,"output_tokens":260,"reasoning_output_tokens":70,"total_tokens":2080}}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Codex,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+            },
+            &roots(None, Some(codex_dir)),
+        );
+
+        assert_eq!(data.calls.len(), 2);
+        assert_eq!(data.grand_total.input_tokens, 850);
+        assert_eq!(data.grand_total.cache_read_tokens, 450);
+        assert_eq!(data.grand_total.output_tokens, 260);
+        assert_eq!(data.grand_total.reasoning_tokens, 70);
+    }
+
+    #[test]
     fn date_filter_uses_assistant_call_timestamp() {
         let temp = tempdir().unwrap();
         let claude_projects = temp.path().join(".claude/projects");
@@ -2394,6 +2466,77 @@ mod tests {
         assert_eq!(
             project_plan_usage(&data, &plan, today).status,
             PlanStatus::Over
+        );
+    }
+
+    #[test]
+    fn plan_projection_scopes_provider_and_counts_missing_days_as_zero() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let mut data = UsageData::default();
+        data.calls = vec![
+            ProviderCall {
+                provider: "claude".to_string(),
+                model: "claude-sonnet-4-5".to_string(),
+                session_id: "s1".to_string(),
+                project: "alpha".to_string(),
+                project_path: "/work/alpha".to_string(),
+                timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+                cost_usd: Some(70.0),
+                ..provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-29T10:00:00+01:00",
+                    "build",
+                    &[],
+                    &[],
+                    1,
+                )
+            },
+            ProviderCall {
+                provider: "codex".to_string(),
+                model: "gpt-5".to_string(),
+                session_id: "s2".to_string(),
+                project: "alpha".to_string(),
+                project_path: "/work/alpha".to_string(),
+                timestamp: Local.with_ymd_and_hms(2026, 4, 29, 11, 0, 0).unwrap(),
+                cost_usd: Some(30.0),
+                ..provider_call(
+                    "codex",
+                    "s2",
+                    "2026-04-29T11:00:00+01:00",
+                    "build",
+                    &[],
+                    &[],
+                    1,
+                )
+            },
+        ];
+        let plan = crate::config::UsagePlan {
+            id: crate::config::UsagePlanId::Custom,
+            monthly_usd: 100.0,
+            provider: crate::config::UsagePlanProvider::Claude,
+            reset_day: 1,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        };
+
+        let projection = project_plan_usage(&data, &plan, today);
+
+        assert_eq!(projection.spent_usd, 70.0);
+        assert_eq!(projection.projected_usd, 70.0);
+    }
+
+    #[test]
+    fn fixed_periods_cover_labeled_calendar_days() {
+        let week = date_range_for_period(&UsagePeriod::Week).unwrap();
+        let thirty = date_range_for_period(&UsagePeriod::ThirtyDays).unwrap();
+
+        assert_eq!(
+            (week.1.date_naive() - week.0.date_naive()).num_days() + 1,
+            7
+        );
+        assert_eq!(
+            (thirty.1.date_naive() - thirty.0.date_naive()).num_days() + 1,
+            30
         );
     }
 

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -2,7 +2,7 @@
 // Parses Claude and Codex JSONL histories into reusable aggregates for TUI and CLI views.
 
 use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -10,7 +10,8 @@ use tracing::{debug, warn};
 
 /// Usage period selector shared by TUI and CLI report queries.
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum UsagePeriod {
     Today,
     Week,
@@ -28,7 +29,8 @@ impl Default for UsagePeriod {
 
 /// Provider filter shared by TUI and CLI report queries.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum UsageProviderFilter {
     #[default]
     All,
@@ -48,7 +50,8 @@ impl UsageProviderFilter {
 
 /// Deterministic activity categories. Phase 2 fills these from turn classification.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ActivityCategory {
     Coding,
     Debugging,
@@ -65,6 +68,26 @@ pub enum ActivityCategory {
     General,
 }
 
+impl ActivityCategory {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Coding => "Coding",
+            Self::Debugging => "Debugging",
+            Self::Feature => "Feature",
+            Self::Refactoring => "Refactoring",
+            Self::Testing => "Testing",
+            Self::Exploration => "Exploration",
+            Self::Planning => "Planning",
+            Self::Delegation => "Delegation",
+            Self::Git => "Git",
+            Self::BuildDeploy => "Build/Deploy",
+            Self::Brainstorming => "Brainstorming",
+            Self::Conversation => "Conversation",
+            Self::General => "General",
+        }
+    }
+}
+
 /// Query used to parse and aggregate usage.
 #[derive(Debug, Clone, Default)]
 pub struct UsageQuery {
@@ -75,7 +98,7 @@ pub struct UsageQuery {
 }
 
 /// Token counts for a single usage bucket, provider call, or aggregate row.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
 pub struct TokenBucket {
     pub input_tokens: u64,
     pub cache_creation_tokens: u64,
@@ -110,7 +133,7 @@ impl TokenBucket {
 
 /// Per-provider API call parsed from a local session file.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ProviderCall {
     pub provider: String,
     pub model: String,
@@ -147,7 +170,7 @@ impl ProviderCall {
 
 /// Daily dashboard row.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DailyUsage {
     pub date: NaiveDate,
     pub bucket: TokenBucket,
@@ -155,7 +178,7 @@ pub struct DailyUsage {
 
 /// Per-project summary.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ProjectUsage {
     pub name: String,
     pub path: String,
@@ -164,7 +187,7 @@ pub struct ProjectUsage {
 
 /// Per-session summary.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SessionUsage {
     pub provider: String,
     pub project: String,
@@ -176,7 +199,7 @@ pub struct SessionUsage {
 
 /// Per-model summary.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ModelUsage {
     pub model: String,
     pub bucket: TokenBucket,
@@ -184,7 +207,7 @@ pub struct ModelUsage {
 
 /// Activity summary with classified turns and retry counts.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ActivityUsage {
     pub category: ActivityCategory,
     pub bucket: TokenBucket,
@@ -196,7 +219,7 @@ pub struct ActivityUsage {
 
 /// Tool/MCP/shell breakdown row.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct NamedUsage {
     pub name: String,
     pub calls: usize,
@@ -204,7 +227,7 @@ pub struct NamedUsage {
 
 /// Complete parsed usage data.
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct UsageData {
     pub daily: Vec<(NaiveDate, TokenBucket)>,
     pub weekly: Vec<(NaiveDate, TokenBucket)>,
@@ -217,6 +240,27 @@ pub struct UsageData {
     pub tools: Vec<NamedUsage>,
     pub mcp_servers: Vec<NamedUsage>,
     pub shell_commands: Vec<NamedUsage>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageOverview {
+    pub calls: usize,
+    pub sessions: usize,
+    pub projects: usize,
+    pub tokens: u64,
+    pub cost_usd: Option<f64>,
+}
+
+impl UsageData {
+    pub fn overview(&self) -> UsageOverview {
+        UsageOverview {
+            calls: self.grand_total.call_count,
+            sessions: self.grand_total.session_count,
+            projects: self.grand_total.project_count,
+            tokens: self.grand_total.total(),
+            cost_usd: self.grand_total.cost_usd,
+        }
+    }
 }
 
 impl Default for UsageData {
@@ -1099,6 +1143,365 @@ fn activity_rank(category: ActivityCategory) -> usize {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStatus {
+    Under,
+    Near,
+    Over,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PlanProjection {
+    pub period_start: NaiveDate,
+    pub period_end: NaiveDate,
+    pub monthly_usd: f64,
+    pub spent_usd: f64,
+    pub percent_used: f64,
+    pub projected_usd: f64,
+    pub status: PlanStatus,
+    pub remaining_days: i64,
+}
+
+pub fn project_plan_usage(
+    data: &UsageData,
+    plan: &crate::config::UsagePlan,
+    today: NaiveDate,
+) -> PlanProjection {
+    let (period_start, period_end) = billing_period(today, plan.reset_day);
+    let spent_usd = data
+        .daily
+        .iter()
+        .filter(|(date, _)| *date >= period_start && *date <= period_end)
+        .filter_map(|(_, bucket)| bucket.cost_usd)
+        .sum::<f64>();
+    let percent_used = if plan.monthly_usd > 0.0 {
+        spent_usd / plan.monthly_usd
+    } else {
+        0.0
+    };
+    let mut last_week: Vec<f64> = data
+        .daily
+        .iter()
+        .filter(|(date, _)| *date >= today - Duration::days(6) && *date <= today)
+        .map(|(_, bucket)| bucket.cost_usd.unwrap_or(0.0))
+        .collect();
+    last_week.sort_by(f64::total_cmp);
+    let median_daily = if last_week.is_empty() {
+        0.0
+    } else {
+        last_week[last_week.len() / 2]
+    };
+    let remaining_days = (period_end - today).num_days().max(0);
+    let projected_usd = spent_usd + median_daily * remaining_days as f64;
+    let status = if percent_used > 1.0 {
+        PlanStatus::Over
+    } else if percent_used >= 0.8 {
+        PlanStatus::Near
+    } else {
+        PlanStatus::Under
+    };
+
+    PlanProjection {
+        period_start,
+        period_end,
+        monthly_usd: plan.monthly_usd,
+        spent_usd,
+        percent_used,
+        projected_usd,
+        status,
+        remaining_days,
+    }
+}
+
+fn billing_period(today: NaiveDate, reset_day: u8) -> (NaiveDate, NaiveDate) {
+    let reset_day = reset_day.clamp(1, 28) as u32;
+    let current_reset =
+        NaiveDate::from_ymd_opt(today.year(), today.month(), reset_day).unwrap_or(today);
+    let start = if today >= current_reset {
+        current_reset
+    } else {
+        add_months(current_reset, -1)
+    };
+    let end = add_months(start, 1) - Duration::days(1);
+    (start, end)
+}
+
+fn add_months(date: NaiveDate, months: i32) -> NaiveDate {
+    let month_index = date.year() * 12 + date.month() as i32 - 1 + months;
+    let year = month_index.div_euclid(12);
+    let month = month_index.rem_euclid(12) as u32 + 1;
+    NaiveDate::from_ymd_opt(year, month, date.day()).unwrap_or(date)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Impact {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum HealthGrade {
+    A,
+    B,
+    C,
+    D,
+    F,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WasteAction {
+    pub label: String,
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WasteFinding {
+    pub id: String,
+    pub title: String,
+    pub impact: Impact,
+    pub tokens_saved: u64,
+    pub details: String,
+    pub actions: Vec<WasteAction>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OptimizeResult {
+    pub score: u8,
+    pub grade: HealthGrade,
+    pub potential_tokens_saved: u64,
+    pub findings: Vec<WasteFinding>,
+}
+
+pub fn optimize_usage(data: &UsageData) -> OptimizeResult {
+    let mut findings = Vec::new();
+    let read_calls =
+        data.tools.iter().find(|tool| tool.name == "Read").map_or(0, |tool| tool.calls);
+    let edit_calls =
+        data.tools.iter().find(|tool| tool.name == "Edit").map_or(0, |tool| tool.calls);
+    let bash_calls =
+        data.tools.iter().find(|tool| tool.name == "Bash").map_or(0, |tool| tool.calls);
+
+    if read_calls > edit_calls.saturating_mul(8).max(8) {
+        findings.push(WasteFinding {
+            id: "low-read-edit-ratio".to_string(),
+            title: "Heavy reading before edits".to_string(),
+            impact: Impact::Medium,
+            tokens_saved: data.grand_total.input_tokens / 10,
+            details: format!("{read_calls} reads for {edit_calls} edits"),
+            actions: vec![WasteAction {
+                label: "Prefer targeted file reads and ripgrep before broad scans".to_string(),
+                command: None,
+            }],
+        });
+    }
+
+    let cache_tokens = data.grand_total.cache_creation_tokens + data.grand_total.cache_read_tokens;
+    if cache_tokens > data.grand_total.input_tokens.saturating_mul(2) {
+        findings.push(WasteFinding {
+            id: "cache-bloat".to_string(),
+            title: "Large cache footprint".to_string(),
+            impact: Impact::Low,
+            tokens_saved: cache_tokens / 20,
+            details: format!("{} cached tokens", format_tokens_short(cache_tokens)),
+            actions: vec![WasteAction {
+                label: "Keep prompts and context focused for long sessions".to_string(),
+                command: None,
+            }],
+        });
+    }
+
+    if bash_calls > data.grand_total.call_count.saturating_mul(3).max(10) {
+        findings.push(WasteFinding {
+            id: "bash-output-bloat".to_string(),
+            title: "Frequent shell output".to_string(),
+            impact: Impact::Medium,
+            tokens_saved: data.grand_total.output_tokens / 12,
+            details: format!("{bash_calls} shell calls"),
+            actions: vec![WasteAction {
+                label: "Pipe large command output through focused filters".to_string(),
+                command: Some("rg <pattern> <path>".to_string()),
+            }],
+        });
+    }
+
+    let agent_calls =
+        data.tools.iter().find(|tool| tool.name == "Agent").map_or(0, |tool| tool.calls);
+    if agent_calls > data.sessions.len().saturating_mul(5).max(5) {
+        findings.push(WasteFinding {
+            id: "ghost-agents".to_string(),
+            title: "High agent delegation count".to_string(),
+            impact: Impact::High,
+            tokens_saved: data.grand_total.total() / 8,
+            details: format!(
+                "{agent_calls} agent calls across {} sessions",
+                data.sessions.len()
+            ),
+            actions: vec![WasteAction {
+                label: "Close unused agent tasks and keep delegated scope narrow".to_string(),
+                command: None,
+            }],
+        });
+    }
+
+    findings.sort_by(|a, b| {
+        impact_weight(b.impact)
+            .cmp(&impact_weight(a.impact))
+            .then_with(|| b.tokens_saved.cmp(&a.tokens_saved))
+    });
+    let penalties: u8 = findings
+        .iter()
+        .map(|finding| match finding.impact {
+            Impact::High => 15,
+            Impact::Medium => 7,
+            Impact::Low => 3,
+        })
+        .sum();
+    let score = 100_u8.saturating_sub(penalties).max(20);
+    let grade = health_grade(score);
+    let potential_tokens_saved = findings.iter().map(|finding| finding.tokens_saved).sum();
+
+    OptimizeResult {
+        score,
+        grade,
+        potential_tokens_saved,
+        findings,
+    }
+}
+
+fn impact_weight(impact: Impact) -> u8 {
+    match impact {
+        Impact::High => 3,
+        Impact::Medium => 2,
+        Impact::Low => 1,
+    }
+}
+
+fn health_grade(score: u8) -> HealthGrade {
+    match score {
+        90..=100 => HealthGrade::A,
+        75..=89 => HealthGrade::B,
+        55..=74 => HealthGrade::C,
+        30..=54 => HealthGrade::D,
+        _ => HealthGrade::F,
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelComparison {
+    pub model: String,
+    pub bucket: TokenBucket,
+    pub calls: usize,
+    pub edit_turns: usize,
+    pub one_shot_turns: usize,
+    pub retries: usize,
+    pub cost_per_call: Option<f64>,
+    pub tokens_per_call: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompareResult {
+    pub models: Vec<ModelComparison>,
+    pub winner: Option<String>,
+    pub low_data: bool,
+}
+
+pub fn compare_models(data: &UsageData) -> CompareResult {
+    let mut rows: Vec<ModelComparison> = data
+        .models
+        .iter()
+        .map(|model| {
+            let calls = model.bucket.call_count.max(1);
+            let edit_turns = data
+                .calls
+                .iter()
+                .filter(|call| call.model == model.model && has_edit_tool(&call.tools))
+                .count();
+            let retries = data
+                .calls
+                .iter()
+                .filter(|call| call.model == model.model)
+                .filter(|call| call.user_message.to_lowercase().contains("fix"))
+                .count();
+            let one_shot_turns = edit_turns.saturating_sub(retries);
+            ModelComparison {
+                model: model.model.clone(),
+                bucket: model.bucket.clone(),
+                calls,
+                edit_turns,
+                one_shot_turns,
+                retries,
+                cost_per_call: model.bucket.cost_usd.map(|cost| cost / calls as f64),
+                tokens_per_call: model.bucket.total() / calls as u64,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.one_shot_turns
+            .cmp(&a.one_shot_turns)
+            .then_with(|| a.retries.cmp(&b.retries))
+            .then_with(|| {
+                a.cost_per_call
+                    .unwrap_or(f64::MAX)
+                    .total_cmp(&b.cost_per_call.unwrap_or(f64::MAX))
+            })
+    });
+    let low_data = rows.iter().map(|row| row.calls).sum::<usize>() < 5 || rows.len() < 2;
+    let winner = rows.first().map(|row| row.model.clone());
+    CompareResult {
+        models: rows,
+        winner,
+        low_data,
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct YieldResult {
+    pub productive_usd: f64,
+    pub reverted_usd: f64,
+    pub abandoned_usd: f64,
+    pub productive_sessions: usize,
+    pub reverted_sessions: usize,
+    pub abandoned_sessions: usize,
+}
+
+pub fn analyze_yield(data: &UsageData) -> YieldResult {
+    let mut result = YieldResult {
+        productive_usd: 0.0,
+        reverted_usd: 0.0,
+        abandoned_usd: 0.0,
+        productive_sessions: 0,
+        reverted_sessions: 0,
+        abandoned_sessions: 0,
+    };
+
+    for session in &data.sessions {
+        let cost = session.bucket.cost_usd.unwrap_or(0.0);
+        let has_git = data.calls.iter().any(|call| {
+            call.session_id == session.session_id
+                && call.bash_commands.iter().any(|cmd| cmd.trim_start().starts_with("git "))
+        });
+        let reverted = data.calls.iter().any(|call| {
+            call.session_id == session.session_id
+                && call.user_message.to_lowercase().contains("revert")
+        });
+        if reverted {
+            result.reverted_sessions += 1;
+            result.reverted_usd += cost;
+        } else if has_git {
+            result.productive_sessions += 1;
+            result.productive_usd += cost;
+        } else {
+            result.abandoned_sessions += 1;
+            result.abandoned_usd += cost;
+        }
+    }
+
+    result
+}
+
 struct SessionUsageAccumulator {
     provider: String,
     project: String,
@@ -1955,5 +2358,77 @@ mod tests {
             .unwrap();
         assert_eq!(exploration.turns, 1);
         assert_eq!(exploration.bucket.input_tokens, 200);
+    }
+
+    #[test]
+    fn plan_projection_covers_under_near_and_over_status() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let mut data = UsageData::default();
+        data.daily = vec![(
+            today,
+            TokenBucket {
+                cost_usd: Some(10.0),
+                ..TokenBucket::default()
+            },
+        )];
+        let mut plan = crate::config::UsagePlan {
+            id: crate::config::UsagePlanId::Custom,
+            monthly_usd: 100.0,
+            provider: crate::config::UsagePlanProvider::All,
+            reset_day: 12,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        };
+
+        assert_eq!(
+            project_plan_usage(&data, &plan, today).status,
+            PlanStatus::Under
+        );
+
+        plan.monthly_usd = 12.0;
+        assert_eq!(
+            project_plan_usage(&data, &plan, today).status,
+            PlanStatus::Near
+        );
+
+        plan.monthly_usd = 5.0;
+        assert_eq!(
+            project_plan_usage(&data, &plan, today).status,
+            PlanStatus::Over
+        );
+    }
+
+    #[test]
+    fn optimize_compare_and_yield_return_stable_summaries() {
+        let calls = vec![
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:00:00+01:00",
+                "implement feature",
+                &["Read", "Edit", "Bash"],
+                &["git status"],
+                100,
+            ),
+            provider_call(
+                "codex",
+                "s2",
+                "2026-04-10T10:00:00+01:00",
+                "research parser",
+                &["Read"],
+                &[],
+                200,
+            ),
+        ];
+        let data = aggregate_calls(calls);
+
+        let optimize = optimize_usage(&data);
+        assert!(optimize.score <= 100);
+
+        let compare = compare_models(&data);
+        assert_eq!(compare.models.len(), 2);
+
+        let yield_result = analyze_yield(&data);
+        assert_eq!(yield_result.productive_sessions, 1);
+        assert_eq!(yield_result.abandoned_sessions, 1);
     }
 }

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1,26 +1,100 @@
-// ABOUTME: Token usage data model and JSONL parser for Claude Code session analytics.
-// Parses ~/.claude/projects/**/*.jsonl to extract per-day, per-week, per-project token usage.
+// ABOUTME: Token usage data model and local session parsers for usage analytics.
+// Parses Claude and Codex JSONL histories into reusable aggregates for TUI and CLI views.
 
-use chrono::{Datelike, NaiveDate};
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone};
 use serde::Deserialize;
-use std::collections::HashMap;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
-/// Token counts for a single usage bucket (day, week, project, etc.)
+/// Usage period selector shared by TUI and CLI report queries.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UsagePeriod {
+    Today,
+    Week,
+    ThirtyDays,
+    Month,
+    All,
+    Custom { from: NaiveDate, to: NaiveDate },
+}
+
+impl Default for UsagePeriod {
+    fn default() -> Self {
+        Self::Week
+    }
+}
+
+/// Provider filter shared by TUI and CLI report queries.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum UsageProviderFilter {
+    #[default]
+    All,
+    Claude,
+    Codex,
+}
+
+impl UsageProviderFilter {
+    fn includes(self, provider: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Claude => provider == "claude",
+            Self::Codex => provider == "codex",
+        }
+    }
+}
+
+/// Deterministic activity categories. Phase 2 fills these from turn classification.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ActivityCategory {
+    Coding,
+    Debugging,
+    Feature,
+    Refactoring,
+    Testing,
+    Exploration,
+    Planning,
+    Delegation,
+    Git,
+    BuildDeploy,
+    Brainstorming,
+    Conversation,
+    General,
+}
+
+/// Query used to parse and aggregate usage.
 #[derive(Debug, Clone, Default)]
+pub struct UsageQuery {
+    pub period: UsagePeriod,
+    pub provider_filter: UsageProviderFilter,
+    pub include_projects: Vec<String>,
+    pub exclude_projects: Vec<String>,
+}
+
+/// Token counts for a single usage bucket, provider call, or aggregate row.
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct TokenBucket {
     pub input_tokens: u64,
     pub cache_creation_tokens: u64,
     pub cache_read_tokens: u64,
     pub output_tokens: u64,
+    pub reasoning_tokens: u64,
     pub session_count: usize,
     pub project_count: usize,
+    pub call_count: usize,
+    pub cost_usd: Option<f64>,
 }
 
 impl TokenBucket {
     pub fn total(&self) -> u64 {
-        self.input_tokens + self.cache_creation_tokens + self.cache_read_tokens + self.output_tokens
+        self.input_tokens
+            + self.cache_creation_tokens
+            + self.cache_read_tokens
+            + self.output_tokens
+            + self.reasoning_tokens
     }
 
     fn merge(&mut self, other: &TokenBucket) {
@@ -28,23 +102,121 @@ impl TokenBucket {
         self.cache_creation_tokens += other.cache_creation_tokens;
         self.cache_read_tokens += other.cache_read_tokens;
         self.output_tokens += other.output_tokens;
+        self.reasoning_tokens += other.reasoning_tokens;
+        self.call_count += other.call_count;
+        self.cost_usd = merge_cost(self.cost_usd, other.cost_usd);
     }
 }
 
-/// Per-project summary
+/// Per-provider API call parsed from a local session file.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub struct ProjectUsage {
-    pub name: String,
+pub struct ProviderCall {
+    pub provider: String,
+    pub model: String,
+    pub session_id: String,
+    pub project: String,
+    pub project_path: String,
+    pub timestamp: DateTime<Local>,
+    pub input_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub output_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub cost_usd: Option<f64>,
+    pub tools: Vec<String>,
+    pub bash_commands: Vec<String>,
+    pub user_message: String,
+}
+
+impl ProviderCall {
+    fn bucket(&self) -> TokenBucket {
+        TokenBucket {
+            input_tokens: self.input_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            output_tokens: self.output_tokens,
+            reasoning_tokens: self.reasoning_tokens,
+            session_count: 0,
+            project_count: 0,
+            call_count: 1,
+            cost_usd: self.cost_usd,
+        }
+    }
+}
+
+/// Daily dashboard row.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DailyUsage {
+    pub date: NaiveDate,
     pub bucket: TokenBucket,
 }
 
-/// Complete parsed usage data
+/// Per-project summary.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct ProjectUsage {
+    pub name: String,
+    pub path: String,
+    pub bucket: TokenBucket,
+}
+
+/// Per-session summary.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct SessionUsage {
+    pub provider: String,
+    pub project: String,
+    pub session_id: String,
+    pub first_timestamp: DateTime<Local>,
+    pub last_timestamp: DateTime<Local>,
+    pub bucket: TokenBucket,
+}
+
+/// Per-model summary.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct ModelUsage {
+    pub model: String,
+    pub bucket: TokenBucket,
+}
+
+/// Activity summary with classified turns and retry counts.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct ActivityUsage {
+    pub category: ActivityCategory,
+    pub bucket: TokenBucket,
+    pub turns: usize,
+    pub retries: usize,
+    pub edit_turns: usize,
+    pub one_shot_turns: usize,
+}
+
+/// Tool/MCP/shell breakdown row.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct NamedUsage {
+    pub name: String,
+    pub calls: usize,
+}
+
+/// Complete parsed usage data.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct UsageData {
     pub daily: Vec<(NaiveDate, TokenBucket)>,
     pub weekly: Vec<(NaiveDate, TokenBucket)>,
     pub projects: Vec<ProjectUsage>,
     pub grand_total: TokenBucket,
+    pub calls: Vec<ProviderCall>,
+    pub sessions: Vec<SessionUsage>,
+    pub models: Vec<ModelUsage>,
+    pub activities: Vec<ActivityUsage>,
+    pub tools: Vec<NamedUsage>,
+    pub mcp_servers: Vec<NamedUsage>,
+    pub shell_commands: Vec<NamedUsage>,
 }
 
 impl Default for UsageData {
@@ -54,208 +226,1096 @@ impl Default for UsageData {
             weekly: Vec::new(),
             projects: Vec::new(),
             grand_total: TokenBucket::default(),
+            calls: Vec::new(),
+            sessions: Vec::new(),
+            models: Vec::new(),
+            activities: Vec::new(),
+            tools: Vec::new(),
+            mcp_servers: Vec::new(),
+            shell_commands: Vec::new(),
         }
     }
 }
 
-// Minimal JSON structures we need from the JSONL files
+#[derive(Debug, Clone)]
+pub struct UsageSourceRoots {
+    pub claude_projects_dir: Option<PathBuf>,
+    pub codex_dir: Option<PathBuf>,
+}
+
+impl Default for UsageSourceRoots {
+    fn default() -> Self {
+        let home = dirs::home_dir();
+        let claude_projects_dir = std::env::var_os("CLAUDE_CONFIG_DIR")
+            .map(PathBuf::from)
+            .map(|path| path.join("projects"))
+            .or_else(|| home.as_ref().map(|path| path.join(".claude").join("projects")));
+
+        let codex_dir = std::env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|path| path.join(".codex")));
+
+        Self {
+            claude_projects_dir,
+            codex_dir,
+        }
+    }
+}
+
 #[derive(Deserialize)]
-struct JLine {
+struct ClaudeLine {
     #[serde(rename = "type")]
     msg_type: Option<String>,
     timestamp: Option<String>,
     #[serde(rename = "sessionId")]
     session_id: Option<String>,
-    message: Option<JMessage>,
+    cwd: Option<String>,
+    message: Option<ClaudeMessage>,
 }
 
 #[derive(Deserialize)]
-struct JMessage {
-    usage: Option<JUsage>,
+struct ClaudeMessage {
+    content: Option<Value>,
+    model: Option<String>,
+    usage: Option<ClaudeUsage>,
 }
 
 #[derive(Deserialize)]
-struct JUsage {
+struct ClaudeUsage {
     input_tokens: Option<u64>,
     cache_creation_input_tokens: Option<u64>,
     cache_read_input_tokens: Option<u64>,
     output_tokens: Option<u64>,
 }
 
-/// Parse all Claude Code JSONL session files and return aggregated usage data.
-/// This is designed to run in a background thread (blocking I/O).
-pub fn parse_usage() -> UsageData {
-    let projects_dir = dirs::home_dir()
-        .map(|h| h.join(".claude").join("projects"))
-        .unwrap_or_default();
+#[derive(Deserialize)]
+struct CodexEntry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    timestamp: Option<String>,
+    payload: Option<CodexPayload>,
+}
 
-    if !projects_dir.is_dir() {
-        warn!("Claude projects directory not found: {:?}", projects_dir);
-        return UsageData::default();
+#[derive(Deserialize)]
+struct CodexPayload {
+    #[serde(rename = "type")]
+    payload_type: Option<String>,
+    role: Option<String>,
+    cwd: Option<String>,
+    originator: Option<String>,
+    session_id: Option<String>,
+    model: Option<String>,
+    name: Option<String>,
+    content: Option<Vec<CodexContent>>,
+    info: Option<CodexInfo>,
+}
+
+#[derive(Deserialize)]
+struct CodexContent {
+    #[serde(rename = "type")]
+    content_type: Option<String>,
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CodexInfo {
+    model: Option<String>,
+    model_name: Option<String>,
+    last_token_usage: Option<CodexTokenUsage>,
+    total_token_usage: Option<CodexTokenUsage>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+struct CodexTokenUsage {
+    input_tokens: Option<u64>,
+    cached_input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    reasoning_output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+/// Parse all known local session files using the legacy Claude-only query.
+/// This is designed to run in a background thread.
+pub fn parse_usage() -> UsageData {
+    parse_usage_for(UsageQuery {
+        provider_filter: UsageProviderFilter::Claude,
+        period: UsagePeriod::All,
+        include_projects: Vec::new(),
+        exclude_projects: Vec::new(),
+    })
+}
+
+/// Parse local session files for a query using default user data roots.
+pub fn parse_usage_for(query: UsageQuery) -> UsageData {
+    parse_usage_for_with_roots(query, &UsageSourceRoots::default())
+}
+
+/// Parse local session files for a query using explicit roots.
+pub fn parse_usage_for_with_roots(query: UsageQuery, roots: &UsageSourceRoots) -> UsageData {
+    let range = date_range_for_period(&query.period);
+    let mut calls = Vec::new();
+
+    if query.provider_filter.includes("claude") {
+        calls.extend(parse_claude_sources(roots.claude_projects_dir.as_deref()));
+    }
+    if query.provider_filter.includes("codex") {
+        calls.extend(parse_codex_sources(roots.codex_dir.as_deref()));
     }
 
-    // day -> (project_set, session_set, bucket)
-    let mut daily_map: HashMap<NaiveDate, (std::collections::HashSet<String>, std::collections::HashSet<String>, TokenBucket)> = HashMap::new();
-    // project -> bucket
-    let mut project_map: HashMap<String, (std::collections::HashSet<String>, TokenBucket)> = HashMap::new();
+    let filtered = calls
+        .into_iter()
+        .filter(|call| {
+            range.as_ref().map_or(true, |(start, end)| {
+                call.timestamp >= *start && call.timestamp <= *end
+            })
+        })
+        .filter(|call| project_matches(call, &query.include_projects, &query.exclude_projects))
+        .collect();
 
-    let project_dirs: Vec<_> = match std::fs::read_dir(&projects_dir) {
-        Ok(rd) => rd.filter_map(|e| e.ok()).collect(),
-        Err(e) => {
-            warn!("Cannot read projects dir: {}", e);
-            return UsageData::default();
-        }
+    aggregate_calls(filtered)
+}
+
+fn parse_claude_sources(projects_dir: Option<&Path>) -> Vec<ProviderCall> {
+    let Some(projects_dir) = projects_dir else {
+        return Vec::new();
     };
+    if !projects_dir.is_dir() {
+        warn!("Claude projects directory not found: {:?}", projects_dir);
+        return Vec::new();
+    }
 
     let username = whoami_username();
+    let mut calls = Vec::new();
+    let Ok(project_dirs) = std::fs::read_dir(projects_dir) else {
+        return calls;
+    };
 
-    for entry in project_dirs {
+    for entry in project_dirs.filter_map(Result::ok) {
         let path = entry.path();
         if !path.is_dir() {
             continue;
         }
-        let project_name = clean_project_name(path.file_name().unwrap_or_default().to_str().unwrap_or(""), &username);
 
-        let jsonl_files: Vec<PathBuf> = match std::fs::read_dir(&path) {
-            Ok(rd) => rd
-                .filter_map(|e| e.ok())
-                .map(|e| e.path())
-                .filter(|p| p.extension().map_or(false, |ext| ext == "jsonl"))
-                .collect(),
-            Err(_) => continue,
-        };
+        let raw_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+        let project = clean_project_name(raw_name, &username);
+        let project_path = unsanitize_project_path(raw_name);
 
-        for jsonl_path in &jsonl_files {
-            parse_jsonl_file(jsonl_path, &project_name, &mut daily_map, &mut project_map);
+        for jsonl_path in collect_claude_jsonl_files(&path) {
+            calls.extend(parse_claude_source(&jsonl_path, &project, &project_path));
         }
     }
 
-    // Build daily sorted vec
-    let mut daily: Vec<(NaiveDate, TokenBucket)> = daily_map
+    calls
+}
+
+fn collect_claude_jsonl_files(project_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(project_dir) else {
+        return files;
+    };
+
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "jsonl") {
+            files.push(path);
+            continue;
+        }
+
+        let subagents = path.join("subagents");
+        let Ok(sub_entries) = std::fs::read_dir(subagents) else {
+            continue;
+        };
+        for sub_entry in sub_entries.filter_map(Result::ok) {
+            let sub_path = sub_entry.path();
+            if sub_path.extension().is_some_and(|ext| ext == "jsonl") {
+                files.push(sub_path);
+            }
+        }
+    }
+
+    files
+}
+
+fn parse_claude_source(path: &Path, project: &str, project_path: &str) -> Vec<ProviderCall> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut calls = Vec::new();
+    let mut current_user_message = String::new();
+
+    for line in content.lines() {
+        let parsed: ClaudeLine = match serde_json::from_str(line) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
+
+        match parsed.msg_type.as_deref() {
+            Some("user") => {
+                if let Some(message) = parsed.message {
+                    current_user_message = extract_claude_user_text(message.content.as_ref());
+                }
+            }
+            Some("assistant") => {
+                let Some(message) = parsed.message else {
+                    continue;
+                };
+                let Some(usage) = message.usage else {
+                    continue;
+                };
+                let Some(timestamp) = parsed.timestamp.as_deref().and_then(parse_timestamp) else {
+                    continue;
+                };
+
+                let model = message.model.unwrap_or_else(|| "claude-unknown".to_string());
+                let tools = extract_claude_tools(message.content.as_ref());
+                let bash_commands =
+                    extract_bash_commands_from_claude_content(message.content.as_ref());
+                let input_tokens = usage.input_tokens.unwrap_or(0);
+                let output_tokens = usage.output_tokens.unwrap_or(0);
+                let cache_creation_tokens = usage.cache_creation_input_tokens.unwrap_or(0);
+                let cache_read_tokens = usage.cache_read_input_tokens.unwrap_or(0);
+                let cost_usd = estimate_cost_usd(
+                    &model,
+                    input_tokens,
+                    output_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    0,
+                );
+
+                calls.push(ProviderCall {
+                    provider: "claude".to_string(),
+                    model,
+                    session_id: parsed.session_id.unwrap_or_else(|| {
+                        path.file_stem()
+                            .and_then(|stem| stem.to_str())
+                            .unwrap_or("unknown")
+                            .to_string()
+                    }),
+                    project: project.to_string(),
+                    project_path: parsed.cwd.unwrap_or_else(|| project_path.to_string()),
+                    timestamp,
+                    input_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    output_tokens,
+                    reasoning_tokens: 0,
+                    cost_usd,
+                    tools,
+                    bash_commands,
+                    user_message: current_user_message.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    calls
+}
+
+fn parse_codex_sources(codex_dir: Option<&Path>) -> Vec<ProviderCall> {
+    let Some(codex_dir) = codex_dir else {
+        return Vec::new();
+    };
+    let sessions_dir = codex_dir.join("sessions");
+    if !sessions_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut calls = Vec::new();
+    for file in discover_codex_sources(&sessions_dir) {
+        calls.extend(parse_codex_source(&file));
+    }
+    calls
+}
+
+fn discover_codex_sources(sessions_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(years) = std::fs::read_dir(sessions_dir) else {
+        return files;
+    };
+
+    for year in years.filter_map(Result::ok) {
+        let year_path = year.path();
+        if !year_path.is_dir() || !is_date_component(&year_path, 4) {
+            continue;
+        }
+        let Ok(months) = std::fs::read_dir(year_path) else {
+            continue;
+        };
+        for month in months.filter_map(Result::ok) {
+            let month_path = month.path();
+            if !month_path.is_dir() || !is_date_component(&month_path, 2) {
+                continue;
+            }
+            let Ok(days) = std::fs::read_dir(month_path) else {
+                continue;
+            };
+            for day in days.filter_map(Result::ok) {
+                let day_path = day.path();
+                if !day_path.is_dir() || !is_date_component(&day_path, 2) {
+                    continue;
+                }
+                let Ok(entries) = std::fs::read_dir(day_path) else {
+                    continue;
+                };
+                for entry in entries.filter_map(Result::ok) {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                        continue;
+                    };
+                    if name.starts_with("rollout-")
+                        && name.ends_with(".jsonl")
+                        && is_valid_codex_session(&path)
+                    {
+                        files.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    files
+}
+
+fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut calls = Vec::new();
+    let mut session_id =
+        path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("unknown").to_string();
+    let mut session_model: Option<String> = None;
+    let mut cwd = "unknown".to_string();
+    let mut project = "unknown".to_string();
+    let mut previous_cumulative_total = 0_u64;
+    let mut previous_input = 0_u64;
+    let mut previous_cached = 0_u64;
+    let mut previous_output = 0_u64;
+    let mut previous_reasoning = 0_u64;
+    let mut pending_tools: Vec<String> = Vec::new();
+    let mut pending_user_message = String::new();
+
+    for line in content.lines() {
+        let entry: CodexEntry = match serde_json::from_str(line) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+
+        let payload = entry.payload.as_ref();
+
+        if entry.entry_type == "session_meta" {
+            if let Some(payload) = payload {
+                if let Some(id) = &payload.session_id {
+                    session_id = id.clone();
+                }
+                if let Some(model) = &payload.model {
+                    session_model = Some(model.clone());
+                }
+                if let Some(session_cwd) = &payload.cwd {
+                    cwd = session_cwd.clone();
+                    project = sanitize_codex_project(session_cwd);
+                }
+            }
+            continue;
+        }
+
+        if entry.entry_type == "turn_context" {
+            if let Some(model) = payload.and_then(|payload| payload.model.as_ref()) {
+                session_model = Some(model.clone());
+            }
+            continue;
+        }
+
+        if entry.entry_type == "response_item"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("function_call")
+        {
+            if let Some(raw_name) = payload.and_then(|p| p.name.as_deref()) {
+                pending_tools.push(normalize_codex_tool(raw_name).to_string());
+            }
+            continue;
+        }
+
+        if entry.entry_type == "event_msg"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("patch_apply_end")
+        {
+            pending_tools.push("Edit".to_string());
+            continue;
+        }
+
+        if entry.entry_type == "response_item"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("message")
+            && payload.and_then(|p| p.role.as_deref()) == Some("user")
+        {
+            let texts = payload
+                .and_then(|p| p.content.as_ref())
+                .map(|content| {
+                    content
+                        .iter()
+                        .filter(|item| item.content_type.as_deref() == Some("input_text"))
+                        .filter_map(|item| item.text.as_deref())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            if !texts.is_empty() {
+                pending_user_message = texts;
+            }
+            continue;
+        }
+
+        if entry.entry_type != "event_msg"
+            || payload.and_then(|p| p.payload_type.as_deref()) != Some("token_count")
+        {
+            continue;
+        }
+
+        let Some(info) = payload.and_then(|p| p.info.as_ref()) else {
+            continue;
+        };
+
+        let cumulative_total =
+            info.total_token_usage.and_then(|usage| usage.total_tokens).unwrap_or(0);
+        if cumulative_total > 0 && cumulative_total == previous_cumulative_total {
+            continue;
+        }
+        previous_cumulative_total = cumulative_total;
+
+        let (input_tokens, cached_tokens, output_tokens, reasoning_tokens) =
+            if let Some(last) = info.last_token_usage {
+                (
+                    last.input_tokens.unwrap_or(0),
+                    last.cached_input_tokens.unwrap_or(0),
+                    last.output_tokens.unwrap_or(0),
+                    last.reasoning_output_tokens.unwrap_or(0),
+                )
+            } else if let Some(total) = info.total_token_usage {
+                let input = total.input_tokens.unwrap_or(0).saturating_sub(previous_input);
+                let cached = total.cached_input_tokens.unwrap_or(0).saturating_sub(previous_cached);
+                let output = total.output_tokens.unwrap_or(0).saturating_sub(previous_output);
+                let reasoning =
+                    total.reasoning_output_tokens.unwrap_or(0).saturating_sub(previous_reasoning);
+
+                previous_input = total.input_tokens.unwrap_or(0);
+                previous_cached = total.cached_input_tokens.unwrap_or(0);
+                previous_output = total.output_tokens.unwrap_or(0);
+                previous_reasoning = total.reasoning_output_tokens.unwrap_or(0);
+
+                (input, cached, output, reasoning)
+            } else {
+                continue;
+            };
+
+        if input_tokens + cached_tokens + output_tokens + reasoning_tokens == 0 {
+            continue;
+        }
+
+        let Some(timestamp) = entry.timestamp.as_deref().and_then(parse_timestamp) else {
+            continue;
+        };
+
+        let uncached_input_tokens = input_tokens.saturating_sub(cached_tokens);
+        let model = resolve_codex_model(payload, session_model.as_deref());
+        let cost_usd = estimate_cost_usd(
+            &model,
+            uncached_input_tokens,
+            output_tokens + reasoning_tokens,
+            0,
+            cached_tokens,
+            0,
+        );
+
+        calls.push(ProviderCall {
+            provider: "codex".to_string(),
+            model,
+            session_id: session_id.clone(),
+            project: project.clone(),
+            project_path: cwd.clone(),
+            timestamp,
+            input_tokens: uncached_input_tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens: cached_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cost_usd,
+            tools: std::mem::take(&mut pending_tools),
+            bash_commands: Vec::new(),
+            user_message: std::mem::take(&mut pending_user_message),
+        });
+    }
+
+    calls
+}
+
+fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
+    if calls.is_empty() {
+        return UsageData::default();
+    }
+
+    calls.sort_by_key(|call| call.timestamp);
+    let turn_analysis = analyze_turns(&calls);
+
+    let mut daily_map: HashMap<NaiveDate, (HashSet<String>, HashSet<String>, TokenBucket)> =
+        HashMap::new();
+    let mut project_map: HashMap<String, (String, HashSet<String>, TokenBucket)> = HashMap::new();
+    let mut session_map: HashMap<String, SessionUsageAccumulator> = HashMap::new();
+    let mut model_map: HashMap<String, TokenBucket> = HashMap::new();
+    let mut activity_map: HashMap<ActivityCategory, ActivityAccumulator> = HashMap::new();
+    let mut tool_map: HashMap<String, usize> = HashMap::new();
+    let mut mcp_map: HashMap<String, usize> = HashMap::new();
+    let mut shell_map: HashMap<String, usize> = HashMap::new();
+
+    for (idx, call) in calls.iter().enumerate() {
+        let bucket = call.bucket();
+        let day = call.timestamp.date_naive();
+        let session_key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
+
+        let daily = daily_map.entry(day).or_default();
+        daily.0.insert(call.project.clone());
+        daily.1.insert(session_key.clone());
+        daily.2.merge(&bucket);
+
+        let project = project_map.entry(call.project.clone()).or_insert_with(|| {
+            (
+                call.project_path.clone(),
+                HashSet::new(),
+                TokenBucket::default(),
+            )
+        });
+        project.0 = call.project_path.clone();
+        project.1.insert(session_key.clone());
+        project.2.merge(&bucket);
+
+        let session = session_map.entry(session_key).or_insert_with(|| SessionUsageAccumulator {
+            provider: call.provider.clone(),
+            project: call.project.clone(),
+            session_id: call.session_id.clone(),
+            first_timestamp: call.timestamp,
+            last_timestamp: call.timestamp,
+            bucket: TokenBucket::default(),
+        });
+        if call.timestamp < session.first_timestamp {
+            session.first_timestamp = call.timestamp;
+        }
+        if call.timestamp > session.last_timestamp {
+            session.last_timestamp = call.timestamp;
+        }
+        session.bucket.merge(&bucket);
+
+        model_map.entry(call.model.clone()).or_default().merge(&bucket);
+
+        let analysis = turn_analysis.get(&idx).copied().unwrap_or_else(|| TurnAnalysis {
+            category: classify_activity(call),
+            retries: 0,
+            has_edits: has_edit_tool(&call.tools),
+        });
+        let activity = activity_map.entry(analysis.category).or_default();
+        activity.bucket.merge(&bucket);
+        activity.turns += 1;
+        activity.retries += analysis.retries;
+        if analysis.has_edits {
+            activity.edit_turns += 1;
+            if analysis.retries == 0 {
+                activity.one_shot_turns += 1;
+            }
+        }
+
+        for tool in &call.tools {
+            if let Some(server) =
+                tool.strip_prefix("mcp__").and_then(|rest| rest.split("__").next())
+            {
+                *mcp_map.entry(server.to_string()).or_default() += 1;
+            } else {
+                *tool_map.entry(tool.clone()).or_default() += 1;
+            }
+        }
+        for command in &call.bash_commands {
+            *shell_map.entry(command.clone()).or_default() += 1;
+        }
+    }
+
+    let mut daily: Vec<_> = daily_map
         .into_iter()
         .map(|(date, (projects, sessions, mut bucket))| {
-            bucket.session_count = sessions.len();
             bucket.project_count = projects.len();
-            (date, bucket)
-        })
-        .collect();
-    daily.sort_by_key(|(d, _)| *d);
-
-    // Build weekly from daily
-    let mut weekly_map: HashMap<NaiveDate, TokenBucket> = HashMap::new();
-    let mut weekly_sessions: HashMap<NaiveDate, usize> = HashMap::new();
-    let mut weekly_projects: HashMap<NaiveDate, usize> = HashMap::new();
-    for (date, bucket) in &daily {
-        let week_start = week_start_date(*date);
-        let w = weekly_map.entry(week_start).or_default();
-        w.merge(bucket);
-        *weekly_sessions.entry(week_start).or_default() += bucket.session_count;
-        *weekly_projects.entry(week_start).or_default() += bucket.project_count;
-    }
-    let mut weekly: Vec<(NaiveDate, TokenBucket)> = weekly_map
-        .into_iter()
-        .map(|(date, mut bucket)| {
-            bucket.session_count = weekly_sessions.get(&date).copied().unwrap_or(0);
-            bucket.project_count = weekly_projects.get(&date).copied().unwrap_or(0);
-            (date, bucket)
-        })
-        .collect();
-    weekly.sort_by_key(|(d, _)| *d);
-
-    // Build projects sorted by total desc
-    let mut projects: Vec<ProjectUsage> = project_map
-        .into_iter()
-        .map(|(name, (sessions, mut bucket))| {
             bucket.session_count = sessions.len();
-            ProjectUsage { name, bucket }
+            (date, bucket)
         })
         .collect();
-    projects.sort_by(|a, b| b.bucket.total().cmp(&a.bucket.total()));
+    daily.sort_by_key(|(date, _)| *date);
 
-    // Grand total
+    let mut weekly = aggregate_weekly(&daily);
+
+    let mut projects: Vec<_> = project_map
+        .into_iter()
+        .map(|(name, (path, sessions, mut bucket))| {
+            bucket.session_count = sessions.len();
+            ProjectUsage { name, path, bucket }
+        })
+        .collect();
+    projects.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+
+    let mut sessions: Vec<_> =
+        session_map.into_values().map(SessionUsageAccumulator::into_usage).collect();
+    sessions.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+
+    let mut models: Vec<_> = model_map
+        .into_iter()
+        .map(|(model, bucket)| ModelUsage { model, bucket })
+        .collect();
+    models.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+
+    let tools = sorted_named_usage(tool_map);
+    let mcp_servers = sorted_named_usage(mcp_map);
+    let shell_commands = sorted_named_usage(shell_map);
+    let activities = sorted_activities(activity_map);
+
     let mut grand_total = TokenBucket::default();
     for (_, bucket) in &daily {
         grand_total.merge(bucket);
-        grand_total.session_count += bucket.session_count;
     }
+    grand_total.session_count = sessions.len();
     grand_total.project_count = projects.len();
 
     debug!(
-        "Parsed usage: {} days, {} weeks, {} projects, {} total tokens",
+        "Parsed usage: {} days, {} weeks, {} projects, {} calls, {} total tokens",
         daily.len(),
         weekly.len(),
         projects.len(),
+        calls.len(),
         grand_total.total()
     );
 
     UsageData {
         daily,
-        weekly,
+        weekly: {
+            weekly.sort_by_key(|(date, _)| *date);
+            weekly
+        },
         projects,
         grand_total,
+        calls,
+        sessions,
+        models,
+        activities,
+        tools,
+        mcp_servers,
+        shell_commands,
     }
 }
 
-fn parse_jsonl_file(
-    path: &Path,
-    project_name: &str,
-    daily_map: &mut HashMap<NaiveDate, (std::collections::HashSet<String>, std::collections::HashSet<String>, TokenBucket)>,
-    project_map: &mut HashMap<String, (std::collections::HashSet<String>, TokenBucket)>,
-) {
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return,
+#[derive(Debug, Clone, Copy)]
+struct TurnAnalysis {
+    category: ActivityCategory,
+    retries: usize,
+    has_edits: bool,
+}
+
+#[derive(Debug, Default)]
+struct ActivityAccumulator {
+    bucket: TokenBucket,
+    turns: usize,
+    retries: usize,
+    edit_turns: usize,
+    one_shot_turns: usize,
+}
+
+fn analyze_turns(calls: &[ProviderCall]) -> HashMap<usize, TurnAnalysis> {
+    let mut sessions: HashMap<String, Vec<usize>> = HashMap::new();
+    for (idx, call) in calls.iter().enumerate() {
+        let key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
+        sessions.entry(key).or_default().push(idx);
+    }
+
+    let mut analysis = HashMap::new();
+    for mut indices in sessions.into_values() {
+        indices.sort_by_key(|idx| calls[*idx].timestamp);
+
+        let mut edit_seen = false;
+        let mut bash_after_edit = false;
+        for idx in indices {
+            let call = &calls[idx];
+            let has_edits = has_edit_tool(&call.tools);
+            let has_bash = has_bash_tool(call);
+            let retries = usize::from(has_edits && bash_after_edit);
+
+            if has_edits {
+                edit_seen = true;
+                bash_after_edit = false;
+            }
+            if has_bash && edit_seen {
+                bash_after_edit = true;
+            }
+
+            analysis.insert(
+                idx,
+                TurnAnalysis {
+                    category: classify_activity(call),
+                    retries,
+                    has_edits,
+                },
+            );
+        }
+    }
+
+    analysis
+}
+
+fn classify_activity(call: &ProviderCall) -> ActivityCategory {
+    let base = if has_tool(&call.tools, &["EnterPlanMode", "TodoWrite", "Plan"]) {
+        ActivityCategory::Planning
+    } else if has_tool(&call.tools, &["Agent", "Task"]) {
+        ActivityCategory::Delegation
+    } else if call.bash_commands.iter().any(|command| command_matches(command, &["git"])) {
+        ActivityCategory::Git
+    } else if call.bash_commands.iter().any(|command| {
+        command_matches(
+            command,
+            &["cargo", "npm", "pnpm", "yarn", "docker", "kubectl", "make"],
+        )
+    }) {
+        ActivityCategory::BuildDeploy
+    } else if has_edit_tool(&call.tools) {
+        ActivityCategory::Coding
+    } else if has_tool(
+        &call.tools,
+        &[
+            "Read",
+            "Glob",
+            "Grep",
+            "LS",
+            "Search",
+            "WebSearch",
+            "Fetch",
+            "ReadFile",
+        ],
+    ) || call.tools.iter().any(|tool| tool.starts_with("mcp__"))
+    {
+        ActivityCategory::Exploration
+    } else if call.user_message.trim().is_empty() && !has_any_tool(call) {
+        ActivityCategory::General
+    } else {
+        ActivityCategory::Conversation
     };
 
-    for line in content.lines() {
-        let jline: JLine = match serde_json::from_str(line) {
-            Ok(j) => j,
-            Err(_) => continue,
-        };
+    refine_activity_with_message(base, &call.user_message)
+}
 
-        if jline.msg_type.as_deref() != Some("assistant") {
-            continue;
-        }
-
-        let usage = match jline.message.and_then(|m| m.usage) {
-            Some(u) => u,
-            None => continue,
-        };
-
-        let ts = match &jline.timestamp {
-            Some(t) if t.len() >= 10 => t,
-            _ => continue,
-        };
-
-        let date = match NaiveDate::parse_from_str(&ts[..10], "%Y-%m-%d") {
-            Ok(d) => d,
-            Err(_) => continue,
-        };
-
-        let session_id = jline.session_id.unwrap_or_default();
-
-        let input = usage.input_tokens.unwrap_or(0);
-        let cache_create = usage.cache_creation_input_tokens.unwrap_or(0);
-        let cache_read = usage.cache_read_input_tokens.unwrap_or(0);
-        let output = usage.output_tokens.unwrap_or(0);
-
-        // Daily
-        let daily_entry = daily_map.entry(date).or_default();
-        daily_entry.0.insert(project_name.to_string());
-        daily_entry.1.insert(session_id.clone());
-        daily_entry.2.input_tokens += input;
-        daily_entry.2.cache_creation_tokens += cache_create;
-        daily_entry.2.cache_read_tokens += cache_read;
-        daily_entry.2.output_tokens += output;
-
-        // Project
-        let proj_entry = project_map.entry(project_name.to_string()).or_default();
-        proj_entry.0.insert(session_id);
-        proj_entry.1.input_tokens += input;
-        proj_entry.1.cache_creation_tokens += cache_create;
-        proj_entry.1.cache_read_tokens += cache_read;
-        proj_entry.1.output_tokens += output;
+fn refine_activity_with_message(base: ActivityCategory, message: &str) -> ActivityCategory {
+    let text = message.to_lowercase();
+    if contains_any(&text, &["debug", "bug", "error", "fail", "failing", "fix"]) {
+        ActivityCategory::Debugging
+    } else if contains_any(&text, &["test", "spec", "coverage", "assert"]) {
+        ActivityCategory::Testing
+    } else if contains_any(&text, &["refactor", "cleanup", "rename", "simplify"]) {
+        ActivityCategory::Refactoring
+    } else if contains_any(&text, &["feature", "implement", "add support", "build"]) {
+        ActivityCategory::Feature
+    } else if contains_any(&text, &["brainstorm", "ideas", "options"]) {
+        ActivityCategory::Brainstorming
+    } else if contains_any(&text, &["research", "investigate", "look into", "explore"]) {
+        ActivityCategory::Exploration
+    } else {
+        base
     }
+}
+
+fn has_any_tool(call: &ProviderCall) -> bool {
+    !call.tools.is_empty() || !call.bash_commands.is_empty()
+}
+
+fn has_edit_tool(tools: &[String]) -> bool {
+    has_tool(
+        tools,
+        &[
+            "Edit",
+            "Write",
+            "MultiEdit",
+            "NotebookEdit",
+            "FileEditTool",
+            "FileWriteTool",
+        ],
+    )
+}
+
+fn has_bash_tool(call: &ProviderCall) -> bool {
+    has_tool(&call.tools, &["Bash", "Shell", "exec_command"]) || !call.bash_commands.is_empty()
+}
+
+fn has_tool(tools: &[String], names: &[&str]) -> bool {
+    tools.iter().any(|tool| names.iter().any(|name| tool == name))
+}
+
+fn command_matches(command: &str, names: &[&str]) -> bool {
+    let trimmed = command.trim_start();
+    names
+        .iter()
+        .any(|name| trimmed == *name || trimmed.starts_with(&format!("{name} ")))
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn sorted_activities(map: HashMap<ActivityCategory, ActivityAccumulator>) -> Vec<ActivityUsage> {
+    let mut rows: Vec<_> = map
+        .into_iter()
+        .map(|(category, activity)| ActivityUsage {
+            category,
+            bucket: activity.bucket,
+            turns: activity.turns,
+            retries: activity.retries,
+            edit_turns: activity.edit_turns,
+            one_shot_turns: activity.one_shot_turns,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        bucket_sort_value(&b.bucket)
+            .total_cmp(&bucket_sort_value(&a.bucket))
+            .then_with(|| activity_rank(a.category).cmp(&activity_rank(b.category)))
+    });
+    rows
+}
+
+fn activity_rank(category: ActivityCategory) -> usize {
+    match category {
+        ActivityCategory::Coding => 0,
+        ActivityCategory::Debugging => 1,
+        ActivityCategory::Feature => 2,
+        ActivityCategory::Refactoring => 3,
+        ActivityCategory::Testing => 4,
+        ActivityCategory::Exploration => 5,
+        ActivityCategory::Planning => 6,
+        ActivityCategory::Delegation => 7,
+        ActivityCategory::Git => 8,
+        ActivityCategory::BuildDeploy => 9,
+        ActivityCategory::Brainstorming => 10,
+        ActivityCategory::Conversation => 11,
+        ActivityCategory::General => 12,
+    }
+}
+
+struct SessionUsageAccumulator {
+    provider: String,
+    project: String,
+    session_id: String,
+    first_timestamp: DateTime<Local>,
+    last_timestamp: DateTime<Local>,
+    bucket: TokenBucket,
+}
+
+impl SessionUsageAccumulator {
+    fn into_usage(mut self) -> SessionUsage {
+        self.bucket.session_count = 1;
+        SessionUsage {
+            provider: self.provider,
+            project: self.project,
+            session_id: self.session_id,
+            first_timestamp: self.first_timestamp,
+            last_timestamp: self.last_timestamp,
+            bucket: self.bucket,
+        }
+    }
+}
+
+fn aggregate_weekly(daily: &[(NaiveDate, TokenBucket)]) -> Vec<(NaiveDate, TokenBucket)> {
+    let mut weekly_map: HashMap<NaiveDate, TokenBucket> = HashMap::new();
+
+    for (date, bucket) in daily {
+        let week_start = week_start_date(*date);
+        weekly_map.entry(week_start).or_default().merge(bucket);
+    }
+
+    weekly_map.into_iter().collect()
+}
+
+fn sorted_named_usage(map: HashMap<String, usize>) -> Vec<NamedUsage> {
+    let mut rows: Vec<_> =
+        map.into_iter().map(|(name, calls)| NamedUsage { name, calls }).collect();
+    rows.sort_by(|a, b| b.calls.cmp(&a.calls).then_with(|| a.name.cmp(&b.name)));
+    rows
+}
+
+fn project_matches(call: &ProviderCall, include: &[String], exclude: &[String]) -> bool {
+    let name = call.project.to_lowercase();
+    let path = call.project_path.to_lowercase();
+
+    if !include.is_empty() {
+        let matched = include
+            .iter()
+            .map(|pattern| pattern.to_lowercase())
+            .any(|pattern| name.contains(&pattern) || path.contains(&pattern));
+        if !matched {
+            return false;
+        }
+    }
+
+    if !exclude.is_empty() {
+        let matched = exclude
+            .iter()
+            .map(|pattern| pattern.to_lowercase())
+            .any(|pattern| name.contains(&pattern) || path.contains(&pattern));
+        if matched {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Local>, DateTime<Local>)> {
+    let now = Local::now();
+    let today = now.date_naive();
+
+    match period {
+        UsagePeriod::All => None,
+        UsagePeriod::Today => Some(day_bounds(today)),
+        UsagePeriod::Week => Some((start_of_day(today - Duration::days(7)), end_of_day(today))),
+        UsagePeriod::ThirtyDays => {
+            Some((start_of_day(today - Duration::days(30)), end_of_day(today)))
+        }
+        UsagePeriod::Month => {
+            let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today);
+            Some((start_of_day(first), end_of_day(today)))
+        }
+        UsagePeriod::Custom { from, to } => Some((start_of_day(*from), end_of_day(*to))),
+    }
+}
+
+fn day_bounds(date: NaiveDate) -> (DateTime<Local>, DateTime<Local>) {
+    (start_of_day(date), end_of_day(date))
+}
+
+fn start_of_day(date: NaiveDate) -> DateTime<Local> {
+    Local
+        .from_local_datetime(&date.and_hms_opt(0, 0, 0).expect("valid start of day"))
+        .single()
+        .unwrap_or_else(|| {
+            Local.from_utc_datetime(&date.and_hms_opt(0, 0, 0).expect("valid start of day"))
+        })
+}
+
+fn end_of_day(date: NaiveDate) -> DateTime<Local> {
+    Local
+        .from_local_datetime(&date.and_hms_milli_opt(23, 59, 59, 999).expect("valid end of day"))
+        .single()
+        .unwrap_or_else(|| {
+            Local.from_utc_datetime(
+                &date.and_hms_milli_opt(23, 59, 59, 999).expect("valid end of day"),
+            )
+        })
+}
+
+fn parse_timestamp(timestamp: &str) -> Option<DateTime<Local>> {
+    DateTime::parse_from_rfc3339(timestamp).map(|dt| dt.with_timezone(&Local)).ok()
+}
+
+fn extract_claude_user_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    }
+}
+
+fn extract_claude_tools(content: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(items)) = content else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+        .filter_map(|item| item.get("name").and_then(Value::as_str))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn extract_bash_commands_from_claude_content(content: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(items)) = content else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter(|item| {
+            item.get("type").and_then(Value::as_str) == Some("tool_use")
+                && matches!(
+                    item.get("name").and_then(Value::as_str),
+                    Some("Bash" | "Shell")
+                )
+        })
+        .filter_map(|item| {
+            item.get("input").and_then(|input| input.get("command")).and_then(Value::as_str)
+        })
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn is_valid_codex_session(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Some(first_line) = content.lines().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+    let Ok(entry) = serde_json::from_str::<CodexEntry>(first_line) else {
+        return false;
+    };
+
+    entry.entry_type == "session_meta"
+        && entry
+            .payload
+            .and_then(|payload| payload.originator)
+            .is_some_and(|originator| originator.to_lowercase().starts_with("codex"))
+}
+
+fn is_date_component(path: &Path, len: usize) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.len() == len && name.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn sanitize_codex_project(cwd: &str) -> String {
+    cwd.trim_start_matches('/').replace('/', "-")
+}
+
+fn normalize_codex_tool(raw: &str) -> &str {
+    match raw {
+        "exec_command" => "Bash",
+        "read_file" => "Read",
+        "write_file" | "apply_diff" | "apply_patch" => "Edit",
+        "spawn_agent" | "close_agent" | "wait_agent" => "Agent",
+        "read_dir" => "Glob",
+        _ => raw,
+    }
+}
+
+fn resolve_codex_model(payload: Option<&CodexPayload>, session_model: Option<&str>) -> String {
+    payload
+        .and_then(|payload| payload.model.as_deref())
+        .or_else(|| {
+            payload
+                .and_then(|payload| payload.info.as_ref())
+                .and_then(|info| info.model.as_deref())
+        })
+        .or_else(|| {
+            payload
+                .and_then(|payload| payload.info.as_ref())
+                .and_then(|info| info.model_name.as_deref())
+        })
+        .or(session_model)
+        .unwrap_or("gpt-5")
+        .to_string()
 }
 
 fn clean_project_name(raw: &str, username: &str) -> String {
@@ -270,7 +1330,6 @@ fn clean_project_name(raw: &str, username: &str) -> String {
             break;
         }
     }
-    // Shorten long worktree names
     if name.starts_with("-agents-in-a-box-worktrees-") {
         name = name.replacen("-agents-in-a-box-worktrees-", "worktree/", 1);
     }
@@ -281,9 +1340,13 @@ fn clean_project_name(raw: &str, username: &str) -> String {
     }
 }
 
+fn unsanitize_project_path(raw: &str) -> String {
+    raw.replace('-', "/")
+}
+
 fn week_start_date(date: NaiveDate) -> NaiveDate {
     let days_since_monday = date.weekday().num_days_from_monday();
-    date - chrono::Duration::days(i64::from(days_since_monday))
+    date - Duration::days(i64::from(days_since_monday))
 }
 
 fn whoami_username() -> String {
@@ -292,7 +1355,93 @@ fn whoami_username() -> String {
         .unwrap_or_else(|_| "unknown".to_string())
 }
 
-/// Format a token count in human-readable form (e.g., "1.2B", "456M", "12K")
+fn merge_cost(left: Option<f64>, right: Option<f64>) -> Option<f64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left + right),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn bucket_sort_value(bucket: &TokenBucket) -> f64 {
+    bucket.cost_usd.unwrap_or(bucket.total() as f64)
+}
+
+fn estimate_cost_usd(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    reasoning_tokens: u64,
+) -> Option<f64> {
+    let rates = model_rates(model)?;
+    Some(
+        input_tokens as f64 * rates.input
+            + (output_tokens + reasoning_tokens) as f64 * rates.output
+            + cache_creation_tokens as f64 * rates.cache_write
+            + cache_read_tokens as f64 * rates.cache_read,
+    )
+}
+
+struct ModelRates {
+    input: f64,
+    output: f64,
+    cache_write: f64,
+    cache_read: f64,
+}
+
+fn model_rates(model: &str) -> Option<ModelRates> {
+    let canonical = canonical_model_name(model);
+    let (input_per_million, output_per_million) = if canonical.starts_with("claude-opus") {
+        (15.0, 75.0)
+    } else if canonical.starts_with("claude-sonnet") || canonical.starts_with("claude-3-5-sonnet") {
+        (3.0, 15.0)
+    } else if canonical.starts_with("claude-haiku") || canonical.starts_with("claude-3-5-haiku") {
+        (0.8, 4.0)
+    } else if canonical.starts_with("gpt-5")
+        || canonical.starts_with("gpt-4.1")
+        || canonical.starts_with("gpt-4o")
+    {
+        (1.25, 10.0)
+    } else {
+        return None;
+    };
+
+    let input = input_per_million / 1_000_000.0;
+    let output = output_per_million / 1_000_000.0;
+    Some(ModelRates {
+        input,
+        output,
+        cache_write: input * 1.25,
+        cache_read: input * 0.1,
+    })
+}
+
+fn canonical_model_name(model: &str) -> String {
+    let without_prefix = model
+        .split('@')
+        .next()
+        .unwrap_or(model)
+        .trim_start_matches("anthropic/")
+        .trim_start_matches("openai/")
+        .to_string();
+
+    if without_prefix
+        .rsplit('-')
+        .next()
+        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        without_prefix
+            .rsplit_once('-')
+            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
+    } else {
+        without_prefix
+    }
+}
+
+/// Format a token count in human-readable form (e.g., "1.2B", "456M", "12K").
 pub fn format_tokens_short(n: u64) -> String {
     if n >= 1_000_000_000 {
         format!("{:.1}B", n as f64 / 1_000_000_000.0)
@@ -305,7 +1454,8 @@ pub fn format_tokens_short(n: u64) -> String {
     }
 }
 
-/// Format a token count with commas
+/// Format a token count with commas.
+#[allow(dead_code)]
 pub fn format_tokens_commas(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::with_capacity(s.len() + s.len() / 3);
@@ -316,4 +1466,494 @@ pub fn format_tokens_commas(n: u64) -> String {
         result.push(c);
     }
     result.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    fn roots(claude_projects_dir: Option<PathBuf>, codex_dir: Option<PathBuf>) -> UsageSourceRoots {
+        UsageSourceRoots {
+            claude_projects_dir,
+            codex_dir,
+        }
+    }
+
+    fn provider_call(
+        provider: &str,
+        session_id: &str,
+        timestamp: &str,
+        message: &str,
+        tools: &[&str],
+        bash_commands: &[&str],
+        input_tokens: u64,
+    ) -> ProviderCall {
+        ProviderCall {
+            provider: provider.to_string(),
+            model: if provider == "codex" {
+                "gpt-5".to_string()
+            } else {
+                "claude-sonnet-4-5".to_string()
+            },
+            session_id: session_id.to_string(),
+            project: "alpha".to_string(),
+            project_path: "/work/alpha".to_string(),
+            timestamp: parse_timestamp(timestamp).unwrap(),
+            input_tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 10,
+            reasoning_tokens: 0,
+            cost_usd: None,
+            tools: tools.iter().map(|tool| tool.to_string()).collect(),
+            bash_commands: bash_commands.iter().map(|command| command.to_string()).collect(),
+            user_message: message.to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_claude_fixture_and_preserves_daily_project_totals() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("-Users-stevie-agents-in-a-box");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","message":{"role":"user","content":"fix parser"}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:05Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"tool_use","name":"Read","input":{"file_path":"src/lib.rs"}},{"type":"tool_use","name":"Bash","input":{"command":"cargo test"}}],"usage":{"input_tokens":1000,"cache_creation_input_tokens":200,"cache_read_input_tokens":300,"output_tokens":400}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.daily.len(), 1);
+        assert_eq!(data.projects.len(), 1);
+        assert_eq!(data.grand_total.input_tokens, 1000);
+        assert_eq!(data.grand_total.cache_creation_tokens, 200);
+        assert_eq!(data.grand_total.cache_read_tokens, 300);
+        assert_eq!(data.grand_total.output_tokens, 400);
+        assert_eq!(data.grand_total.call_count, 1);
+        assert_eq!(data.grand_total.session_count, 1);
+        assert!(data.tools.iter().any(|tool| tool.name == "Read" && tool.calls == 1));
+        assert!(data.shell_commands.iter().any(|cmd| cmd.name == "cargo test" && cmd.calls == 1));
+    }
+
+    #[test]
+    fn parses_codex_fixture_and_normalizes_cached_input_tokens() {
+        let temp = tempdir().unwrap();
+        let codex_dir = temp.path().join(".codex");
+        let rollout = codex_dir.join("sessions/2026/04/10/rollout-1.jsonl");
+        write_file(
+            &rollout,
+            r#"{"type":"session_meta","payload":{"originator":"codex_cli","session_id":"codex-1","cwd":"/Users/stevie/work/project","model":"gpt-5"}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"implement thing"}]}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:01Z","payload":{"type":"function_call","name":"exec_command"}}
+{"type":"event_msg","timestamp":"2026-04-10T10:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":200,"reasoning_output_tokens":50},"total_token_usage":{"total_tokens":1650}}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Codex,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+            },
+            &roots(None, Some(codex_dir)),
+        );
+
+        assert_eq!(data.calls.len(), 1);
+        let call = &data.calls[0];
+        assert_eq!(call.input_tokens, 600);
+        assert_eq!(call.cache_read_tokens, 400);
+        assert_eq!(call.output_tokens, 200);
+        assert_eq!(call.reasoning_tokens, 50);
+        assert_eq!(call.tools, vec!["Bash"]);
+        assert_eq!(call.user_message, "implement thing");
+    }
+
+    #[test]
+    fn date_filter_uses_assistant_call_timestamp() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("proj");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-09T23:59:00Z","sessionId":"s1","message":{"role":"user","content":"late ask"}}
+{"type":"assistant","timestamp":"2026-04-10T00:00:05Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":2}}}
+"#,
+        );
+
+        let day = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::Custom { from: day, to: day },
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.grand_total.call_count, 1);
+        assert_eq!(data.daily[0].0, day);
+    }
+
+    #[test]
+    fn custom_ranges_are_inclusive() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("proj");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T23:59:59+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"assistant","timestamp":"2026-04-11T00:00:00+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":10}}}
+"#,
+        );
+
+        let day = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::Custom { from: day, to: day },
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.grand_total.call_count, 1);
+        assert_eq!(data.grand_total.input_tokens, 1);
+    }
+
+    #[test]
+    fn inverted_custom_ranges_return_no_usage() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("proj");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T12:00:00+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#,
+        );
+
+        let from = NaiveDate::from_ymd_opt(2026, 4, 11).unwrap();
+        let to = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::Custom { from, to },
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.grand_total.call_count, 0);
+        assert!(data.calls.is_empty());
+    }
+
+    #[test]
+    fn include_and_exclude_filters_apply_before_aggregation() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        write_file(
+            &claude_projects.join("alpha-keep/session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#,
+        );
+        write_file(
+            &claude_projects.join("alpha-scratch/session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s2","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":10}}}
+"#,
+        );
+        write_file(
+            &claude_projects.join("beta/session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s3","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":100,"output_tokens":100}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: vec!["alpha".to_string()],
+                exclude_projects: vec!["scratch".to_string()],
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.projects.len(), 1);
+        assert_eq!(data.projects[0].name, "alpha-keep");
+        assert_eq!(data.grand_total.input_tokens, 1);
+    }
+
+    #[test]
+    fn classifier_covers_core_tool_and_keyword_categories() {
+        let cases = [
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:00:00+01:00",
+                    "change code",
+                    &["Edit"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Coding,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:01:00+01:00",
+                    "fix parser bug",
+                    &["Edit"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Debugging,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:02:00+01:00",
+                    "implement feature",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Feature,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:03:00+01:00",
+                    "refactor usage cleanup",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Refactoring,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:04:00+01:00",
+                    "add test coverage",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Testing,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:05:00+01:00",
+                    "",
+                    &["Read"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Exploration,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:06:00+01:00",
+                    "",
+                    &["TodoWrite"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Planning,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:07:00+01:00",
+                    "",
+                    &["Agent"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Delegation,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:08:00+01:00",
+                    "",
+                    &["Bash"],
+                    &["git status"],
+                    1,
+                ),
+                ActivityCategory::Git,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:09:00+01:00",
+                    "",
+                    &["Bash"],
+                    &["cargo test usage"],
+                    1,
+                ),
+                ActivityCategory::BuildDeploy,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:10:00+01:00",
+                    "brainstorm options",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Brainstorming,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:11:00+01:00",
+                    "sounds reasonable",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Conversation,
+            ),
+            (
+                provider_call("claude", "s1", "2026-04-10T09:12:00+01:00", "", &[], &[], 1),
+                ActivityCategory::General,
+            ),
+        ];
+
+        for (call, expected) in cases {
+            assert_eq!(classify_activity(&call), expected);
+        }
+    }
+
+    #[test]
+    fn retry_analysis_counts_edit_only_and_edit_bash_edit_cycle() {
+        let calls = vec![
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:00:00+01:00",
+                "implement feature",
+                &["Edit"],
+                &[],
+                10,
+            ),
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:01:00+01:00",
+                "",
+                &["Bash"],
+                &["cargo test usage"],
+                10,
+            ),
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:02:00+01:00",
+                "fix failing test",
+                &["Edit"],
+                &[],
+                10,
+            ),
+        ];
+
+        let analysis = analyze_turns(&calls);
+        assert_eq!(analysis.get(&0).unwrap().retries, 0);
+        assert!(analysis.get(&0).unwrap().has_edits);
+        assert_eq!(analysis.get(&2).unwrap().retries, 1);
+
+        let data = aggregate_calls(calls);
+        let edit_turns: usize = data.activities.iter().map(|activity| activity.edit_turns).sum();
+        let retries: usize = data.activities.iter().map(|activity| activity.retries).sum();
+        let one_shot_turns: usize =
+            data.activities.iter().map(|activity| activity.one_shot_turns).sum();
+
+        assert_eq!(edit_turns, 2);
+        assert_eq!(retries, 1);
+        assert_eq!(one_shot_turns, 1);
+    }
+
+    #[test]
+    fn aggregation_tracks_activity_totals_from_mixed_provider_calls() {
+        let data = aggregate_calls(vec![
+            provider_call(
+                "claude",
+                "claude-1",
+                "2026-04-10T09:00:00+01:00",
+                "implement feature",
+                &["Edit"],
+                &[],
+                100,
+            ),
+            provider_call(
+                "codex",
+                "codex-1",
+                "2026-04-10T10:00:00+01:00",
+                "research parser",
+                &["Read"],
+                &[],
+                200,
+            ),
+        ]);
+
+        assert_eq!(data.grand_total.call_count, 2);
+        assert_eq!(data.grand_total.input_tokens, 300);
+        assert_eq!(data.models.len(), 2);
+        assert!(data.projects.iter().any(|project| project.name == "alpha"));
+        assert!(data.tools.iter().any(|tool| tool.name == "Edit"));
+        assert!(data.tools.iter().any(|tool| tool.name == "Read"));
+
+        let feature = data
+            .activities
+            .iter()
+            .find(|activity| activity.category == ActivityCategory::Feature)
+            .unwrap();
+        assert_eq!(feature.turns, 1);
+        assert_eq!(feature.bucket.input_tokens, 100);
+
+        let exploration = data
+            .activities
+            .iter()
+            .find(|activity| activity.category == ActivityCategory::Exploration)
+            .unwrap();
+        assert_eq!(exploration.turns, 1);
+        assert_eq!(exploration.bucket.input_tokens, 200);
+    }
 }

--- a/ainb-tui/tests/test_app_state.rs
+++ b/ainb-tui/tests/test_app_state.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Unit tests for AppState to ensure navigation and state management work correctly
 
 use ainb::app::AppState;
-use ainb::models::{Session, SessionStatus, Workspace};
+use ainb::models::{Session, SessionStatus, UsagePeriod, UsageProviderFilter, Workspace};
 use std::path::PathBuf;
 
 fn create_test_state() -> AppState {
@@ -157,4 +157,26 @@ fn test_navigation_with_empty_workspace() {
 
     state.previous_session();
     assert_eq!(state.selected_session_index, None);
+}
+
+#[test]
+fn test_usage_query_reflects_selected_controls() {
+    let mut state = AppState::default();
+    state.usage_state.period = UsagePeriod::Month;
+    state.usage_state.provider_filter = UsageProviderFilter::Codex;
+    state.usage_state.include_projects = vec!["agents".to_string()];
+    state.usage_state.exclude_projects = vec!["scratch".to_string()];
+
+    let query = state.usage_state.query();
+    assert!(matches!(query.period, UsagePeriod::Month));
+    assert_eq!(query.provider_filter, UsageProviderFilter::Codex);
+    assert_eq!(query.include_projects, vec!["agents"]);
+    assert_eq!(query.exclude_projects, vec!["scratch"]);
+}
+
+#[tokio::test]
+async fn test_usage_duplicate_loads_are_coalesced() {
+    let mut state = AppState::default();
+    assert!(state.start_background_usage_load(true));
+    assert!(!state.start_background_usage_load(true));
 }

--- a/ainb-tui/tests/test_events.rs
+++ b/ainb-tui/tests/test_events.rs
@@ -1,6 +1,11 @@
 // ABOUTME: Unit tests for event handling to ensure keyboard inputs map to correct app actions
 
+use ainb::app::events::AppEvent;
+use ainb::app::state::View;
 use ainb::app::{AppState, EventHandler};
+use ainb::components::usage::UsageInputMode;
+use ainb::models::{UsagePeriod, UsageProviderFilter};
+use chrono::NaiveDate;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 const fn create_key_event(code: KeyCode) -> KeyEvent {
@@ -219,4 +224,77 @@ fn test_process_help_toggle_event() {
     }
 
     assert!(state.help_visible);
+}
+
+#[tokio::test]
+async fn test_usage_period_provider_and_filters_events() {
+    let mut state = AppState::default();
+    state.current_view = View::Analytics;
+
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('p')), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageCycleProviderFilter)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert_eq!(
+        state.usage_state.provider_filter,
+        UsageProviderFilter::Claude
+    );
+
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('3')), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageSetPeriod(3))));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert!(matches!(state.usage_state.period, UsagePeriod::ThirtyDays));
+
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('/')), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageStartIncludeFilter)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    for ch in "agents".chars() {
+        let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char(ch)), &mut state);
+        EventHandler::process_event(event.unwrap(), &mut state);
+    }
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Enter), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageInputSubmit)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert_eq!(state.usage_state.include_projects, vec!["agents"]);
+
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('x')), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageStartExcludeFilter)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert!(matches!(
+        state.usage_state.input_mode,
+        Some(UsageInputMode::Exclude)
+    ));
+    for ch in "scratch".chars() {
+        let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char(ch)), &mut state);
+        EventHandler::process_event(event.unwrap(), &mut state);
+    }
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Backspace), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageInputBackspace)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('h')), &mut state);
+    EventHandler::process_event(event.unwrap(), &mut state);
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Enter), &mut state);
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert_eq!(state.usage_state.exclude_projects, vec!["scratch"]);
+
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('d')), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageStartDateRange)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    for ch in "2026-04-01..2026-04-10".chars() {
+        let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char(ch)), &mut state);
+        EventHandler::process_event(event.unwrap(), &mut state);
+    }
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Enter), &mut state);
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert!(matches!(
+        state.usage_state.period,
+        UsagePeriod::Custom { from, to }
+            if from == NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()
+                && to == NaiveDate::from_ymd_opt(2026, 4, 10).unwrap()
+    ));
+
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('c')), &mut state);
+    assert!(matches!(event, Some(AppEvent::UsageClearFilters)));
+    EventHandler::process_event(event.unwrap(), &mut state);
+    assert!(state.usage_state.include_projects.is_empty());
+    assert!(state.usage_state.exclude_projects.is_empty());
 }

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -2,7 +2,91 @@
 
 use ainb::app::{App, state::View};
 use ainb::components::LayoutComponent;
+use ainb::components::usage::UsageTab;
+use ainb::models::{
+    ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
+    TokenBucket, UsageData,
+};
+use chrono::{Local, TimeZone};
 use ratatui::{Terminal, backend::TestBackend};
+
+fn sample_usage_data() -> UsageData {
+    let bucket = TokenBucket {
+        input_tokens: 100,
+        output_tokens: 50,
+        call_count: 2,
+        session_count: 1,
+        project_count: 1,
+        cost_usd: Some(0.42),
+        ..TokenBucket::default()
+    };
+    UsageData {
+        calls: vec![ProviderCall {
+            provider: "claude".to_string(),
+            model: "claude-sonnet-4-5".to_string(),
+            session_id: "s1".to_string(),
+            project: "agents-in-a-box".to_string(),
+            project_path: "/tmp/agents-in-a-box".to_string(),
+            timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+            input_tokens: 100,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 50,
+            reasoning_tokens: 0,
+            cost_usd: Some(0.42),
+            tools: vec!["Edit".to_string()],
+            bash_commands: vec!["cargo test".to_string()],
+            user_message: "implement burndown".to_string(),
+        }],
+        daily: vec![(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+            bucket.clone(),
+        )],
+        weekly: vec![(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 27).unwrap(),
+            bucket.clone(),
+        )],
+        projects: vec![ProjectUsage {
+            name: "agents-in-a-box".to_string(),
+            path: "/tmp/agents-in-a-box".to_string(),
+            bucket: bucket.clone(),
+        }],
+        grand_total: bucket.clone(),
+        sessions: vec![ainb::models::SessionUsage {
+            provider: "claude".to_string(),
+            project: "agents-in-a-box".to_string(),
+            session_id: "s1".to_string(),
+            first_timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+            last_timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 10, 0).unwrap(),
+            bucket: bucket.clone(),
+        }],
+        models: vec![ModelUsage {
+            model: "claude-sonnet-4-5".to_string(),
+            bucket: bucket.clone(),
+        }],
+        activities: vec![ActivityUsage {
+            category: ActivityCategory::Feature,
+            bucket: bucket.clone(),
+            turns: 2,
+            retries: 0,
+            edit_turns: 1,
+            one_shot_turns: 1,
+        }],
+        tools: vec![NamedUsage {
+            name: "Edit".to_string(),
+            calls: 1,
+        }],
+        shell_commands: vec![NamedUsage {
+            name: "cargo test".to_string(),
+            calls: 1,
+        }],
+        mcp_servers: vec![NamedUsage {
+            name: "github".to_string(),
+            calls: 1,
+        }],
+        ..UsageData::default()
+    }
+}
 
 #[tokio::test]
 async fn test_bottom_menu_bar_shows_refresh_key() {
@@ -57,6 +141,67 @@ async fn test_bottom_menu_bar_shows_refresh_key() {
         "Should contain '[q]uit' but content was: {}",
         printable_content
     );
+}
+
+#[tokio::test]
+async fn test_usage_burndown_render_contains_core_panels() {
+    let mut app = App::new();
+    app.state.current_view = View::Analytics;
+    app.state.usage_state.active_tab = UsageTab::Burndown;
+    app.state.usage_state.data = Some(sample_usage_data());
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut layout = LayoutComponent::new();
+
+    terminal
+        .draw(|frame| {
+            layout.render(frame, &mut app.state);
+        })
+        .unwrap();
+
+    let content: String = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(ratatui::buffer::Cell::symbol)
+        .collect();
+
+    assert!(content.contains("Burndown"));
+    assert!(content.contains("Daily Activity"));
+    assert!(content.contains("By Project"));
+    assert!(content.contains("By Activity"));
+    assert!(content.contains("By Model"));
+}
+
+#[tokio::test]
+async fn test_usage_burndown_narrow_render_does_not_panic() {
+    let mut app = App::new();
+    app.state.current_view = View::Analytics;
+    app.state.usage_state.active_tab = UsageTab::Burndown;
+    app.state.usage_state.data = Some(sample_usage_data());
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut layout = LayoutComponent::new();
+
+    terminal
+        .draw(|frame| {
+            layout.render(frame, &mut app.state);
+        })
+        .unwrap();
+
+    let content: String = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(ratatui::buffer::Cell::symbol)
+        .collect();
+
+    assert!(content.contains("Burndown"));
+    assert!(content.contains("Daily Activity"));
 }
 
 #[tokio::test]

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -2,7 +2,7 @@
 
 use ainb::app::{App, state::View};
 use ainb::components::LayoutComponent;
-use ainb::components::usage::UsageTab;
+use ainb::components::usage::{UsageProvider, UsageTab};
 use ainb::models::{
     ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
     TokenBucket, UsageData,
@@ -202,6 +202,37 @@ async fn test_usage_burndown_narrow_render_does_not_panic() {
 
     assert!(content.contains("Burndown"));
     assert!(content.contains("Daily Activity"));
+}
+
+#[tokio::test]
+async fn test_usage_render_uses_loaded_data_before_legacy_provider_gate() {
+    let mut app = App::new();
+    app.state.current_view = View::Analytics;
+    app.state.usage_state.active_tab = UsageTab::Burndown;
+    app.state.usage_state.provider = UsageProvider::Gemini;
+    app.state.usage_state.data = Some(sample_usage_data());
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut layout = LayoutComponent::new();
+
+    terminal
+        .draw(|frame| {
+            layout.render(frame, &mut app.state);
+        })
+        .unwrap();
+
+    let content: String = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(ratatui::buffer::Cell::symbol)
+        .collect();
+
+    assert!(content.contains("Burndown"));
+    assert!(content.contains("Daily Activity"));
+    assert!(!content.contains("No Data"));
 }
 
 #[tokio::test]

--- a/plans/codeburn-burndown-ainb-tui.md
+++ b/plans/codeburn-burndown-ainb-tui.md
@@ -162,16 +162,18 @@ Add simple built-in pricing lookup for known Claude and GPT model names. Return 
 ### Success Criteria
 
 #### Automated Verification
-- [ ] Unit tests parse small Claude fixture and preserve daily/project totals.
-- [ ] Unit tests parse small Codex fixture and normalize cached input tokens.
-- [ ] Unit tests validate date filtering uses assistant-call timestamp.
-- [ ] Unit tests validate custom from/to ranges are inclusive and reject inverted ranges.
-- [ ] Unit tests validate include and exclude filters apply after provider parsing and before aggregation.
-- [ ] `cargo test usage --all-targets` passes from `ainb-tui`.
+- [x] Unit tests parse small Claude fixture and preserve daily/project totals.
+- [x] Unit tests parse small Codex fixture and normalize cached input tokens.
+- [x] Unit tests validate date filtering uses assistant-call timestamp.
+- [x] Unit tests validate custom from/to ranges are inclusive and reject inverted ranges.
+- [x] Unit tests validate include and exclude filters apply after provider parsing and before aggregation.
+- [x] `cargo test usage --all-targets` passes from `ainb-tui`.
 
 #### Manual Verification
 - [ ] Opening Stats still shows existing Daily/Weekly/Projects data.
 - [ ] Codex provider no longer shows "not yet available" when local Codex sessions exist.
+
+Phase 1 implementation note: Codex parsing exists behind `parse_usage_for`, but TUI provider wiring is intentionally deferred to Phase 3/4 because Phase 1 only owns `ainb-tui/src/models/usage.rs` and `ainb-tui/src/models/mod.rs`.
 
 ## Phase 2: Activity Classifier And Burndown Aggregation
 <!-- wave: 2 | depends_on: [Phase 1] | files: [ainb-tui/src/models/usage.rs] -->
@@ -209,9 +211,9 @@ Aggregate:
 ### Success Criteria
 
 #### Automated Verification
-- [ ] Classifier tests cover coding, debugging, feature, refactoring, testing, exploration, planning, delegation, git, build/deploy, brainstorming, conversation, general.
-- [ ] Retry tests cover edit-only one-shot and edit -> bash -> edit retry.
-- [ ] Aggregation tests verify project/model/activity/tool totals from mixed Claude/Codex fixture calls.
+- [x] Classifier tests cover coding, debugging, feature, refactoring, testing, exploration, planning, delegation, git, build/deploy, brainstorming, conversation, general.
+- [x] Retry tests cover edit-only one-shot and edit -> bash -> edit retry.
+- [x] Aggregation tests verify project/model/activity/tool totals from mixed Claude/Codex fixture calls.
 
 #### Manual Verification
 - [ ] Generated summary values are plausible compared with a known small fixture.

--- a/plans/codeburn-burndown-ainb-tui.md
+++ b/plans/codeburn-burndown-ainb-tui.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Add a CodeBurn-inspired `Burndown` sub-tab to AINB's existing `Usage Analytics` screen. The first release should show local AI coding usage by period, provider, project, model, activity, tool, shell command, and MCP server while keeping parsing read-only and off the UI thread.
+Add a CodeBurn-inspired `Burndown` sub-tab to AINB's existing `Usage Analytics` screen, plus report/export CLI support for the same data. The first release should show local AI coding usage by period, provider, project, model, activity, tool, shell command, and MCP server while keeping parsing read-only and off the UI thread.
 
 ## Current State Analysis
 
@@ -22,9 +22,12 @@ CodeBurn shows a richer usage dashboard: period tabs, provider switching, cost/c
 AINB's Stats screen includes a `Burndown` tab that looks and behaves like a native AINB Ratatui screen while borrowing CodeBurn's information architecture:
 
 - Period selector: Today, 7 Days, 30 Days, Month, All.
+- Custom date range support: inclusive `from` / `to` dates in `YYYY-MM-DD` format.
 - Provider selector: All, Claude, Codex for MVP; existing unsupported providers remain visibly unavailable.
+- Include/exclude project filters by case-insensitive substring.
 - Overview metrics: estimated cost, calls, sessions, cache hit, input/output/cache tokens.
 - Panels: Daily Activity, By Project, Top Sessions, By Activity, By Model, Core Tools, Shell Commands, MCP Servers.
+- CLI report/export commands for text, JSON, and CSV output using the same summary model as the TUI.
 - Existing Daily/Weekly/Projects tabs keep working.
 - Parsing remains local, read-only, asynchronous, and safe for large history folders.
 
@@ -40,7 +43,7 @@ AINB's Stats screen includes a `Burndown` tab that looks and behaves like a nati
 - Not adding a new top-level `Burndown` screen for MVP.
 - Not writing to Claude, Codex, Cursor, Copilot, or other agent session files.
 - Not implementing Cursor/OpenCode/Gemini/Copilot parsing in the first pass unless the provider abstraction makes it trivial later.
-- Not implementing CodeBurn optimize findings, subscription plan tracking, CSV/JSON export, or model comparison in MVP.
+- Not implementing CodeBurn optimize findings, subscription plan tracking, model comparison, model aliases, currency conversion, menubar, or yield analysis in MVP.
 - Not adding API calls to price usage. MVP can use built-in/fallback pricing and show token-only values when price is unknown.
 
 ## Implementation Approach
@@ -69,6 +72,7 @@ pub enum UsagePeriod {
     ThirtyDays,
     Month,
     All,
+    Custom { from: chrono::NaiveDate, to: chrono::NaiveDate },
 }
 
 pub enum UsageProviderFilter {
@@ -109,6 +113,13 @@ pub struct ProviderCall {
     pub bash_commands: Vec<String>,
     pub user_message: String,
 }
+
+pub struct UsageQuery {
+    pub period: UsagePeriod,
+    pub provider_filter: UsageProviderFilter,
+    pub include_projects: Vec<String>,
+    pub exclude_projects: Vec<String>,
+}
 ```
 
 Add dashboard summary structs for daily, project, session, model, activity, tool, shell, and MCP panels. Keep or derive current `daily`, `weekly`, `projects`, and `grand_total` so old tabs remain backed by the new summary.
@@ -123,7 +134,7 @@ Split the current Claude parser into:
 - `parse_claude_source()`
 - `discover_codex_sources()`
 - `parse_codex_source()`
-- `parse_usage_for(period, provider_filter)`
+- `parse_usage_for(query: UsageQuery)`
 
 For Codex, read `CODEX_HOME` or `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, validate `session_meta`, extract token count events, normalize cached tokens, and map tools:
 
@@ -145,6 +156,8 @@ Add simple built-in pricing lookup for known Claude and GPT model names. Return 
 - [ ] Unit tests parse small Claude fixture and preserve daily/project totals.
 - [ ] Unit tests parse small Codex fixture and normalize cached input tokens.
 - [ ] Unit tests validate date filtering uses assistant-call timestamp.
+- [ ] Unit tests validate custom from/to ranges are inclusive and reject inverted ranges.
+- [ ] Unit tests validate include and exclude filters apply after provider parsing and before aggregation.
 - [ ] `cargo test usage --all-targets` passes from `ainb-tui`.
 
 #### Manual Verification
@@ -257,12 +270,12 @@ Render clear empty states for:
 - [ ] Text fits at 80x24 and 120x40.
 - [ ] Tab cycling reaches Burndown and returns to Daily.
 
-## Phase 4: Period And Provider Controls
+## Phase 4: Period, Range, Provider, And Filter Controls
 <!-- wave: 4 | depends_on: [Phase 3] | files: [ainb-tui/src/components/usage.rs, ainb-tui/src/app/events.rs, ainb-tui/src/app/state.rs] -->
 
 ### Overview
 
-Add CodeBurn-like period and provider interaction without disrupting existing Usage keys.
+Add CodeBurn-like period, custom range, provider, and project filter interaction without disrupting existing Usage keys.
 
 ### Changes Required
 
@@ -275,6 +288,8 @@ Add period and provider filter state:
 ```rust
 pub period: UsagePeriod,
 pub provider_filter: UsageProviderFilter,
+pub include_projects: Vec<String>,
+pub exclude_projects: Vec<String>,
 ```
 
 Keep existing `provider` behavior if needed for compatibility, or replace it with the richer filter if all call sites can move cleanly.
@@ -288,6 +303,10 @@ Add or reuse events for:
 - Left/right: period switch while Burndown is active.
 - `p`: provider filter cycle while Burndown is active.
 - `1`-`5`: direct period shortcuts.
+- `/`: open project include filter input.
+- `x`: open project exclude filter input.
+- `c`: clear include/exclude filters.
+- `d`: open custom date range input.
 - `r`: reload current period/provider.
 
 Preserve current left/right provider switching on Daily/Weekly/Projects if changing it would be too disruptive; otherwise make provider cycling consistently use `p`.
@@ -296,20 +315,86 @@ Preserve current left/right provider switching on Daily/Weekly/Projects if chang
 **File**: `ainb-tui/src/app/state.rs`
 **Changes**:
 
-Update background usage loading to pass selected period/provider filter into the parser. Cache results by `(period, provider_filter)` for the current process.
+Update background usage loading to pass selected period, custom range, provider filter, and project filters into the parser. Cache raw parsed provider calls by provider/range where possible, then apply include/exclude filters cheaply in memory.
 
 ### Success Criteria
 
 #### Automated Verification
-- [ ] Event tests cover `1`-`5`, `p`, tab cycling, and refresh in Analytics.
-- [ ] State tests verify reloads use selected period/provider and do not spawn duplicate loads.
+- [ ] Event tests cover `1`-`5`, custom range entry, `p`, include filter, exclude filter, tab cycling, filter clearing, and refresh in Analytics.
+- [ ] State tests verify reloads use selected period/provider/filter query and do not spawn duplicate loads.
+- [ ] Filter tests verify include/exclude can be combined and exclusion wins when both match.
 
 #### Manual Verification
 - [ ] Period changes update data and loading state visibly.
+- [ ] Custom from/to dates update the dashboard and reject invalid or inverted dates.
 - [ ] Provider cycling works for All, Claude, and Codex.
+- [ ] Include/exclude project filters visibly change project, daily, and overview totals.
 
-## Phase 5: Quality Gates And Documentation
-<!-- wave: 5 | depends_on: [Phase 4] | files: [ainb-tui/tests/test_ui_display.rs, ainb-tui/tests/test_events.rs, ainb-tui/tests/test_app_state.rs, ainb-tui/docs/CLI.md, ainb-tui/README.md] -->
+## Phase 5: Report And Export CLI
+<!-- wave: 5 | depends_on: [Phase 2] | files: [ainb-tui/src/cli/mod.rs, ainb-tui/src/cli/usage.rs, ainb-tui/src/main.rs, ainb-tui/src/models/usage.rs] -->
+
+### Overview
+
+Add non-interactive usage report/export commands powered by the same parser and summary types as the TUI.
+
+### Changes Required
+
+#### 1. CLI Command Shape
+**File**: `ainb-tui/src/cli/mod.rs`
+**Changes**:
+
+Add usage commands:
+
+```rust
+Usage(UsageArgs),
+Export(ExportArgs),
+```
+
+Recommended CLI:
+
+```bash
+ainb usage report --period week
+ainb usage report --from 2026-04-01 --to 2026-04-10
+ainb usage report --provider codex --include agents-in-a-box
+ainb usage report --exclude scratch --format json
+ainb usage export --period 30days --format csv --output usage.csv
+ainb usage export --from 2026-04-01 --to 2026-04-10 --format json
+```
+
+Support repeatable `--include` and `--exclude` flags. `--from` and `--to` must accept `YYYY-MM-DD`; either flag alone is valid, with missing bound defaulting to earliest data or today.
+
+#### 2. CLI Implementation
+**File**: `ainb-tui/src/cli/usage.rs`
+**Changes**:
+
+Implement:
+
+- Text report: same high-level sections as Burndown, compact for terminal output.
+- JSON report: complete structured summary for automation.
+- CSV export: stable rows for daily, project, model, activity, tool, shell, and MCP sections.
+- `--output` support. Without `--output`, write to stdout.
+
+#### 3. Main Routing
+**File**: `ainb-tui/src/main.rs`
+**Changes**:
+
+Route `Commands::Usage` and `Commands::Export` to the new implementation without entering TUI mode.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] CLI argument tests cover period, custom dates, provider, include/exclude, format, and output path.
+- [ ] JSON output test validates stable keys for overview, daily, projects, models, activities, tools, shell commands, and MCP servers.
+- [ ] CSV output test validates headers and row sections.
+- [ ] Invalid date format and inverted range return clear errors.
+
+#### Manual Verification
+- [ ] `ainb usage report --period week` prints useful text.
+- [ ] `ainb usage report --from 2026-04-01 --to 2026-04-10 --format json | jq '.overview'` works.
+- [ ] `ainb usage export --format csv --output /tmp/ainb-usage.csv` creates a usable CSV.
+
+## Phase 6: Quality Gates And Documentation
+<!-- wave: 6 | depends_on: [Phase 4, Phase 5] | files: [ainb-tui/tests/test_ui_display.rs, ainb-tui/tests/test_events.rs, ainb-tui/tests/test_app_state.rs, ainb-tui/docs/CLI.md, ainb-tui/README.md] -->
 
 ### Overview
 
@@ -327,6 +412,7 @@ Add tests for:
 - Usage tab/state navigation.
 - Analytics event routing.
 - Parser fixture behavior.
+- CLI report/export behavior.
 
 #### 2. Docs
 **Files**: `ainb-tui/docs/CLI.md`, `ainb-tui/README.md`
@@ -337,6 +423,9 @@ Document:
 - Stats screen shortcut.
 - Burndown tab.
 - Supported providers and session locations.
+- Periods and custom `--from` / `--to` ranges.
+- Include/exclude project filters.
+- Text, JSON, and CSV export.
 - Read-only local parsing.
 - Cost estimate caveat.
 
@@ -374,13 +463,17 @@ Document:
 4. Press `Tab` until Burndown is active.
 5. Press `1`, `2`, `3`, `4`, `5` and confirm period labels/data update.
 6. Press `p` and confirm provider filter cycles.
-7. Press `r` and confirm reload notification/loading state.
+7. Enter custom date range and confirm dashboard updates.
+8. Add include/exclude project filters and confirm totals change.
+9. Press `r` and confirm reload notification/loading state.
+10. Run `ainb usage report --from 2026-04-01 --to 2026-04-10 --format json`.
+11. Run `ainb usage export --format csv --output /tmp/ainb-usage.csv`.
 
 ## Performance Considerations
 
 - Keep all filesystem scans in `spawn_blocking`, matching existing usage load behavior.
 - Use file mtime to skip files older than selected date range where safe.
-- Cache parsed summaries by period/provider for the process lifetime.
+- Cache parsed raw calls by date range/provider where possible; apply include/exclude filters without reparsing.
 - Consider a daily cache only after MVP if local histories are too large.
 
 ## Migration Notes

--- a/plans/codeburn-burndown-ainb-tui.md
+++ b/plans/codeburn-burndown-ainb-tui.md
@@ -1,0 +1,398 @@
+# CodeBurn-Style Burndown Implementation Plan
+
+## Overview
+
+Add a CodeBurn-inspired `Burndown` sub-tab to AINB's existing `Usage Analytics` screen. The first release should show local AI coding usage by period, provider, project, model, activity, tool, shell command, and MCP server while keeping parsing read-only and off the UI thread.
+
+## Current State Analysis
+
+AINB already has a full-screen usage route: `View::Analytics` in `ainb-tui/src/app/state.rs:397`, sidebar `Stats` in `ainb-tui/src/components/sidebar.rs:27`, and layout dispatch in `ainb-tui/src/components/layout.rs:193`.
+
+Current usage support is narrow:
+
+- `UsageViewState` tracks provider, sub-tab, data, loading, and scroll offset in `ainb-tui/src/components/usage.rs:121`.
+- Existing sub-tabs are only `Daily`, `Weekly`, and `Projects` in `ainb-tui/src/components/usage.rs:82`.
+- `UsageProvider` lists Claude, Codex, Gemini, and Copilot, but `has_data()` only enables Claude in `ainb-tui/src/components/usage.rs:59`.
+- `parse_usage()` reads `~/.claude/projects/**/*.jsonl` and produces token totals only in `ainb-tui/src/models/usage.rs:85`.
+
+CodeBurn shows a richer usage dashboard: period tabs, provider switching, cost/calls/sessions/cache-hit overview, daily/project/model/activity/tool/shell/MCP panels, deterministic activity classification, and one-shot edit-cycle rates.
+
+## Desired End State
+
+AINB's Stats screen includes a `Burndown` tab that looks and behaves like a native AINB Ratatui screen while borrowing CodeBurn's information architecture:
+
+- Period selector: Today, 7 Days, 30 Days, Month, All.
+- Provider selector: All, Claude, Codex for MVP; existing unsupported providers remain visibly unavailable.
+- Overview metrics: estimated cost, calls, sessions, cache hit, input/output/cache tokens.
+- Panels: Daily Activity, By Project, Top Sessions, By Activity, By Model, Core Tools, Shell Commands, MCP Servers.
+- Existing Daily/Weekly/Projects tabs keep working.
+- Parsing remains local, read-only, asynchronous, and safe for large history folders.
+
+### Key Discoveries
+
+- `start_background_usage_load()` already keeps expensive JSONL parsing off the event thread in `ainb-tui/src/app/state.rs:3245`.
+- Usage keyboard handling already supports tab switching, provider switching, scroll, and refresh in `ainb-tui/src/app/events.rs:1540`.
+- CodeBurn's normalized model and deterministic classifier are portable: `/tmp/codeburn-research/src/parser.ts:359` and `/tmp/codeburn-research/src/classifier.ts:56`.
+
+## What We're NOT Doing
+
+- Not vendoring CodeBurn's TypeScript implementation into AINB.
+- Not adding a new top-level `Burndown` screen for MVP.
+- Not writing to Claude, Codex, Cursor, Copilot, or other agent session files.
+- Not implementing Cursor/OpenCode/Gemini/Copilot parsing in the first pass unless the provider abstraction makes it trivial later.
+- Not implementing CodeBurn optimize findings, subscription plan tracking, CSV/JSON export, or model comparison in MVP.
+- Not adding API calls to price usage. MVP can use built-in/fallback pricing and show token-only values when price is unknown.
+
+## Implementation Approach
+
+Build the data model first, then render it inside the existing Usage screen. Keep the current `UsageData` fields or equivalent adapters so existing Daily/Weekly/Projects tables do not regress. Add richer summaries behind the same background load path and only then add the `Burndown` tab UI.
+
+## Phase 1: Domain Model And Provider Adapters
+<!-- wave: 1 | depends_on: [] | files: [ainb-tui/src/models/usage.rs, ainb-tui/src/models/mod.rs] -->
+
+### Overview
+
+Reshape usage parsing around normalized provider events while preserving the existing token aggregates.
+
+### Changes Required
+
+#### 1. Usage Domain Types
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Add types equivalent to:
+
+```rust
+pub enum UsagePeriod {
+    Today,
+    Week,
+    ThirtyDays,
+    Month,
+    All,
+}
+
+pub enum UsageProviderFilter {
+    All,
+    Claude,
+    Codex,
+}
+
+pub enum ActivityCategory {
+    Coding,
+    Debugging,
+    Feature,
+    Refactoring,
+    Testing,
+    Exploration,
+    Planning,
+    Delegation,
+    Git,
+    BuildDeploy,
+    Brainstorming,
+    Conversation,
+    General,
+}
+
+pub struct ProviderCall {
+    pub provider: String,
+    pub model: String,
+    pub session_id: String,
+    pub project: String,
+    pub timestamp: chrono::DateTime<chrono::Local>,
+    pub input_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub output_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub cost_usd: f64,
+    pub tools: Vec<String>,
+    pub bash_commands: Vec<String>,
+    pub user_message: String,
+}
+```
+
+Add dashboard summary structs for daily, project, session, model, activity, tool, shell, and MCP panels. Keep or derive current `daily`, `weekly`, `projects`, and `grand_total` so old tabs remain backed by the new summary.
+
+#### 2. Provider Parsing
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Split the current Claude parser into:
+
+- `discover_claude_sources()`
+- `parse_claude_source()`
+- `discover_codex_sources()`
+- `parse_codex_source()`
+- `parse_usage_for(period, provider_filter)`
+
+For Codex, read `CODEX_HOME` or `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, validate `session_meta`, extract token count events, normalize cached tokens, and map tools:
+
+- `exec_command` -> `Bash`
+- `apply_patch` / `apply_diff` / `write_file` -> `Edit`
+- `spawn_agent` / `wait_agent` / `close_agent` -> `Agent`
+- `read_file` -> `Read`
+- `read_dir` -> `Glob`
+
+#### 3. Cost Formatting
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Add simple built-in pricing lookup for known Claude and GPT model names. Return `None` for unknown pricing and render token/call metrics without claiming exact cost.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Unit tests parse small Claude fixture and preserve daily/project totals.
+- [ ] Unit tests parse small Codex fixture and normalize cached input tokens.
+- [ ] Unit tests validate date filtering uses assistant-call timestamp.
+- [ ] `cargo test usage --all-targets` passes from `ainb-tui`.
+
+#### Manual Verification
+- [ ] Opening Stats still shows existing Daily/Weekly/Projects data.
+- [ ] Codex provider no longer shows "not yet available" when local Codex sessions exist.
+
+## Phase 2: Activity Classifier And Burndown Aggregation
+<!-- wave: 2 | depends_on: [Phase 1] | files: [ainb-tui/src/models/usage.rs] -->
+
+### Overview
+
+Port CodeBurn's deterministic classifier and aggregate normalized calls into burndown panels.
+
+### Changes Required
+
+#### 1. Classifier
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Implement deterministic classification:
+
+- Tool-first categories: edit -> coding, agent -> delegation, plan/todo -> planning, read/search -> exploration.
+- Keyword refinement for debugging, feature, refactoring, testing, git, build/deploy, brainstorming.
+- One-shot metric via edit -> bash -> edit retry count inside a turn/session window.
+
+#### 2. Aggregation
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Aggregate:
+
+- Overview totals.
+- Daily cost/calls/session/token rows.
+- Project totals, average cost per session, session count.
+- Top sessions.
+- Model totals with calls, cost, cache hit.
+- Activity totals with turns, cost, one-shot percent.
+- Tool, shell, and MCP call counts.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Classifier tests cover coding, debugging, feature, refactoring, testing, exploration, planning, delegation, git, build/deploy, brainstorming, conversation, general.
+- [ ] Retry tests cover edit-only one-shot and edit -> bash -> edit retry.
+- [ ] Aggregation tests verify project/model/activity/tool totals from mixed Claude/Codex fixture calls.
+
+#### Manual Verification
+- [ ] Generated summary values are plausible compared with a known small fixture.
+
+## Phase 3: Burndown UI Tab
+<!-- wave: 3 | depends_on: [Phase 2] | files: [ainb-tui/src/components/usage.rs] -->
+
+### Overview
+
+Add `UsageTab::Burndown` and render a CodeBurn-style Ratatui dashboard inside the existing Usage screen.
+
+### Changes Required
+
+#### 1. State And Tab Wiring
+**File**: `ainb-tui/src/components/usage.rs`
+**Changes**:
+
+Add:
+
+```rust
+pub enum UsageTab {
+    Daily,
+    Weekly,
+    Projects,
+    Burndown,
+}
+```
+
+Extend `all()`, `title()`, `next()`, `prev()`, `row_count()`, and render branching.
+
+#### 2. Burndown Panels
+**File**: `ainb-tui/src/components/usage.rs`
+**Changes**:
+
+Add `render_burndown()` with responsive layout:
+
+- Header summary.
+- Period selector row.
+- Two-column panels when width allows; stacked panels on narrow terminals.
+- Reusable horizontal bar renderer with stable width and gradient-like thresholds.
+- Panels: Daily Activity, By Project, Top Sessions, By Activity, By Model, Core Tools, Shell Commands, MCP Servers.
+
+Use AINB palette, restrained borders, and no nested cards.
+
+#### 3. Empty And Partial States
+**File**: `ainb-tui/src/components/usage.rs`
+**Changes**:
+
+Render clear empty states for:
+
+- No usage data.
+- Provider unsupported.
+- Costs unavailable but tokens/calls available.
+- Narrow terminal fallback.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Render test with `TestBackend` sees `Burndown`, `Daily Activity`, `By Project`, `By Activity`, and `By Model`.
+- [ ] Narrow render test confirms no panic and shows stacked fallback content.
+- [ ] Existing usage render tests still pass.
+
+#### Manual Verification
+- [ ] Stats screen feels like one coherent screen, not a bolted-on clone.
+- [ ] Text fits at 80x24 and 120x40.
+- [ ] Tab cycling reaches Burndown and returns to Daily.
+
+## Phase 4: Period And Provider Controls
+<!-- wave: 4 | depends_on: [Phase 3] | files: [ainb-tui/src/components/usage.rs, ainb-tui/src/app/events.rs, ainb-tui/src/app/state.rs] -->
+
+### Overview
+
+Add CodeBurn-like period and provider interaction without disrupting existing Usage keys.
+
+### Changes Required
+
+#### 1. Usage State
+**File**: `ainb-tui/src/components/usage.rs`
+**Changes**:
+
+Add period and provider filter state:
+
+```rust
+pub period: UsagePeriod,
+pub provider_filter: UsageProviderFilter,
+```
+
+Keep existing `provider` behavior if needed for compatibility, or replace it with the richer filter if all call sites can move cleanly.
+
+#### 2. Events
+**File**: `ainb-tui/src/app/events.rs`
+**Changes**:
+
+Add or reuse events for:
+
+- Left/right: period switch while Burndown is active.
+- `p`: provider filter cycle while Burndown is active.
+- `1`-`5`: direct period shortcuts.
+- `r`: reload current period/provider.
+
+Preserve current left/right provider switching on Daily/Weekly/Projects if changing it would be too disruptive; otherwise make provider cycling consistently use `p`.
+
+#### 3. Background Load Parameters
+**File**: `ainb-tui/src/app/state.rs`
+**Changes**:
+
+Update background usage loading to pass selected period/provider filter into the parser. Cache results by `(period, provider_filter)` for the current process.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Event tests cover `1`-`5`, `p`, tab cycling, and refresh in Analytics.
+- [ ] State tests verify reloads use selected period/provider and do not spawn duplicate loads.
+
+#### Manual Verification
+- [ ] Period changes update data and loading state visibly.
+- [ ] Provider cycling works for All, Claude, and Codex.
+
+## Phase 5: Quality Gates And Documentation
+<!-- wave: 5 | depends_on: [Phase 4] | files: [ainb-tui/tests/test_ui_display.rs, ainb-tui/tests/test_events.rs, ainb-tui/tests/test_app_state.rs, ainb-tui/docs/CLI.md, ainb-tui/README.md] -->
+
+### Overview
+
+Lock in behavior and document the new view.
+
+### Changes Required
+
+#### 1. Tests
+**Files**: `ainb-tui/tests/test_ui_display.rs`, `ainb-tui/tests/test_events.rs`, `ainb-tui/tests/test_app_state.rs`
+**Changes**:
+
+Add tests for:
+
+- Burndown render smoke.
+- Usage tab/state navigation.
+- Analytics event routing.
+- Parser fixture behavior.
+
+#### 2. Docs
+**Files**: `ainb-tui/docs/CLI.md`, `ainb-tui/README.md`
+**Changes**:
+
+Document:
+
+- Stats screen shortcut.
+- Burndown tab.
+- Supported providers and session locations.
+- Read-only local parsing.
+- Cost estimate caveat.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `cargo fmt --check` passes.
+- [ ] `cargo test --all-targets` passes from `ainb-tui`.
+- [ ] `cargo clippy --all-targets -- -D warnings` passes or known existing warnings are documented.
+
+#### Manual Verification
+- [ ] Launch `ainb`, open Stats with `i`, tab to Burndown, switch periods/providers, refresh.
+- [ ] Verify no session files are modified.
+
+## Testing Strategy
+
+### Unit Tests
+
+- Parser fixture tests for Claude and Codex.
+- Classifier category tests.
+- Aggregation tests for dashboard panels.
+- Usage state tests for tab, period, provider, and scroll behavior.
+
+### Integration Tests
+
+- Event routing from `View::Analytics`.
+- Background load coalescing.
+- Ratatui render smoke tests at 80x24 and 120x40.
+
+### Manual Testing Steps
+
+1. Run `cargo test --all-targets` inside `ainb-tui`.
+2. Launch `ainb`.
+3. Press `i` to open Stats.
+4. Press `Tab` until Burndown is active.
+5. Press `1`, `2`, `3`, `4`, `5` and confirm period labels/data update.
+6. Press `p` and confirm provider filter cycles.
+7. Press `r` and confirm reload notification/loading state.
+
+## Performance Considerations
+
+- Keep all filesystem scans in `spawn_blocking`, matching existing usage load behavior.
+- Use file mtime to skip files older than selected date range where safe.
+- Cache parsed summaries by period/provider for the process lifetime.
+- Consider a daily cache only after MVP if local histories are too large.
+
+## Migration Notes
+
+No data migration. The feature is read-only and derives summaries from local session files.
+
+## References
+
+- Research: `research/2026-04-28_22-39-40_codeburn-burndown-ainb-tui.md`
+- CodeBurn dashboard composition: `/tmp/codeburn-research/src/dashboard.tsx:602`
+- CodeBurn parser aggregation: `/tmp/codeburn-research/src/parser.ts:167`
+- CodeBurn classifier: `/tmp/codeburn-research/src/classifier.ts:56`
+- AINB Analytics view: `ainb-tui/src/app/state.rs:397`
+- AINB Usage UI state: `ainb-tui/src/components/usage.rs:121`
+- AINB usage parser: `ainb-tui/src/models/usage.rs:85`

--- a/plans/codeburn-burndown-ainb-tui.md
+++ b/plans/codeburn-burndown-ainb-tui.md
@@ -1,8 +1,8 @@
-# CodeBurn-Style Burndown Implementation Plan
+# CodeBurn-Style Usage Analytics Implementation Plan
 
 ## Overview
 
-Add a CodeBurn-inspired `Burndown` sub-tab to AINB's existing `Usage Analytics` screen, plus report/export CLI support for the same data. The first release should show local AI coding usage by period, provider, project, model, activity, tool, shell command, and MCP server while keeping parsing read-only and off the UI thread.
+Add a CodeBurn-inspired usage analytics subsystem to AINB in Rust. This now covers the comprehensive CodeBurn CLI feature set except macOS menubar install/app support: reports, status, export, optimize findings, plan/budget tracking, currency, model aliases, model comparison, yield analysis, and a native TUI Burndown/analytics view.
 
 ## Current State Analysis
 
@@ -15,11 +15,11 @@ Current usage support is narrow:
 - `UsageProvider` lists Claude, Codex, Gemini, and Copilot, but `has_data()` only enables Claude in `ainb-tui/src/components/usage.rs:59`.
 - `parse_usage()` reads `~/.claude/projects/**/*.jsonl` and produces token totals only in `ainb-tui/src/models/usage.rs:85`.
 
-CodeBurn shows a richer usage dashboard: period tabs, provider switching, cost/calls/sessions/cache-hit overview, daily/project/model/activity/tool/shell/MCP panels, deterministic activity classification, and one-shot edit-cycle rates.
+CodeBurn shows a richer usage dashboard and CLI: period tabs, provider switching, cost/calls/sessions/cache-hit overview, daily/project/model/activity/tool/shell/MCP panels, deterministic activity classification, one-shot edit-cycle rates, export/report/status commands, subscription plan tracking, setup optimization findings, model comparison, and git-correlated yield analysis.
 
 ## Desired End State
 
-AINB's Stats screen includes a `Burndown` tab that looks and behaves like a native AINB Ratatui screen while borrowing CodeBurn's information architecture:
+AINB gets a new `ainb usage ...` CLI namespace and an expanded Stats screen that looks and behaves like native AINB while borrowing CodeBurn's information architecture:
 
 - Period selector: Today, 7 Days, 30 Days, Month, All.
 - Custom date range support: inclusive `from` / `to` dates in `YYYY-MM-DD` format.
@@ -27,7 +27,12 @@ AINB's Stats screen includes a `Burndown` tab that looks and behaves like a nati
 - Include/exclude project filters by case-insensitive substring.
 - Overview metrics: estimated cost, calls, sessions, cache hit, input/output/cache tokens.
 - Panels: Daily Activity, By Project, Top Sessions, By Activity, By Model, Core Tools, Shell Commands, MCP Servers.
-- CLI report/export commands for text, JSON, and CSV output using the same summary model as the TUI.
+- CLI report/status/today/month/export commands for text, JSON, and CSV output using the same summary model as the TUI.
+- Read-only optimize findings equivalent to CodeBurn's waste analyzer.
+- Plan/budget settings with presets, custom monthly USD, provider scope, reset day, and projection.
+- Currency and model-alias settings used by cost display and pricing lookup.
+- Model comparison metrics by cost, one-shot rate, retry rate, self-correction rate, cache hit, and working style.
+- Yield analysis that correlates usage spend with git commits and categorizes productive, reverted, and abandoned spend.
 - Existing Daily/Weekly/Projects tabs keep working.
 - Parsing remains local, read-only, asynchronous, and safe for large history folders.
 
@@ -36,19 +41,23 @@ AINB's Stats screen includes a `Burndown` tab that looks and behaves like a nati
 - `start_background_usage_load()` already keeps expensive JSONL parsing off the event thread in `ainb-tui/src/app/state.rs:3245`.
 - Usage keyboard handling already supports tab switching, provider switching, scroll, and refresh in `ainb-tui/src/app/events.rs:1540`.
 - CodeBurn's normalized model and deterministic classifier are portable: `/tmp/codeburn-research/src/parser.ts:359` and `/tmp/codeburn-research/src/classifier.ts:56`.
+- CodeBurn's `optimize` command is read-only: it scans Claude sessions/config, ranks findings, and prints copy-paste fixes without applying changes.
+- CodeBurn does not appear to call `claude -p /usage`; it stores plan settings and compares local API-equivalent spend against budget.
+- Existing top-level `ainb status` is session status, so CodeBurn-style status should live at `ainb usage status`.
 
 ## What We're NOT Doing
 
 - Not vendoring CodeBurn's TypeScript implementation into AINB.
-- Not adding a new top-level `Burndown` screen for MVP.
+- Not adding a new top-level `Burndown` screen for the first TUI integration; use existing Stats/Usage surface.
 - Not writing to Claude, Codex, Cursor, Copilot, or other agent session files.
-- Not implementing Cursor/OpenCode/Gemini/Copilot parsing in the first pass unless the provider abstraction makes it trivial later.
-- Not implementing CodeBurn optimize findings, subscription plan tracking, model comparison, model aliases, currency conversion, menubar, or yield analysis in MVP.
-- Not adding API calls to price usage. MVP can use built-in/fallback pricing and show token-only values when price is unknown.
+- Not implementing macOS menubar install/app behavior.
+- Not executing optimize fixes. Findings produce text/actions only.
+- Not depending on `claude -p /usage` for correct plan data. Manual plan config is required; optional detect/import can be added only if Claude CLI output is stable and parseable.
+- Not promising exact costs for unknown models. Unknown pricing must be visible.
 
 ## Implementation Approach
 
-Build the data model first, then render it inside the existing Usage screen. Keep the current `UsageData` fields or equivalent adapters so existing Daily/Weekly/Projects tables do not regress. Add richer summaries behind the same background load path and only then add the `Burndown` tab UI.
+Build the shared usage domain first, then layer CLI commands and TUI views over the same summaries. Keep the current `UsageData` fields or equivalent adapters so existing Daily/Weekly/Projects tables do not regress. Add richer summaries behind the same background load path, then add CLI parity, then add optimize/plan/compare/yield.
 
 ## Phase 1: Domain Model And Provider Adapters
 <!-- wave: 1 | depends_on: [] | files: [ainb-tui/src/models/usage.rs, ainb-tui/src/models/mod.rs] -->
@@ -122,7 +131,7 @@ pub struct UsageQuery {
 }
 ```
 
-Add dashboard summary structs for daily, project, session, model, activity, tool, shell, and MCP panels. Keep or derive current `daily`, `weekly`, `projects`, and `grand_total` so old tabs remain backed by the new summary.
+Add dashboard summary structs for overview, daily, project, session, model, activity, tool, shell, MCP, plan, optimize, compare, and yield. Keep or derive current `daily`, `weekly`, `projects`, and `grand_total` so old tabs remain backed by the new summary.
 
 #### 2. Provider Parsing
 **File**: `ainb-tui/src/models/usage.rs`
@@ -335,7 +344,7 @@ Update background usage loading to pass selected period, custom range, provider 
 
 ### Overview
 
-Add non-interactive usage report/export commands powered by the same parser and summary types as the TUI.
+Add non-interactive usage report/status/today/month/export commands powered by the same parser and summary types as the TUI.
 
 ### Changes Required
 
@@ -343,11 +352,13 @@ Add non-interactive usage report/export commands powered by the same parser and 
 **File**: `ainb-tui/src/cli/mod.rs`
 **Changes**:
 
-Add usage commands:
+Add one namespaced command:
 
 ```rust
-Usage(UsageArgs),
-Export(ExportArgs),
+Usage {
+    #[command(subcommand)]
+    command: usage::UsageCommands,
+}
 ```
 
 Recommended CLI:
@@ -357,11 +368,14 @@ ainb usage report --period week
 ainb usage report --from 2026-04-01 --to 2026-04-10
 ainb usage report --provider codex --include agents-in-a-box
 ainb usage report --exclude scratch --format json
-ainb usage export --period 30days --format csv --output usage.csv
+ainb usage status --format json
+ainb usage today --format json
+ainb usage month --format json
+ainb usage export --format csv --output ./usage-export
 ainb usage export --from 2026-04-01 --to 2026-04-10 --format json
 ```
 
-Support repeatable `--include` and `--exclude` flags. `--from` and `--to` must accept `YYYY-MM-DD`; either flag alone is valid, with missing bound defaulting to earliest data or today.
+Support repeatable `--include`/`--project` and `--exclude` flags. `--from` and `--to` must accept `YYYY-MM-DD`; either flag alone is valid, with missing bound defaulting to earliest data or today.
 
 #### 2. CLI Implementation
 **File**: `ainb-tui/src/cli/usage.rs`
@@ -370,15 +384,18 @@ Support repeatable `--include` and `--exclude` flags. `--from` and `--to` must a
 Implement:
 
 - Text report: same high-level sections as Burndown, compact for terminal output.
+- Status report: today/month cost and calls, with optional plan.
 - JSON report: complete structured summary for automation.
-- CSV export: stable rows for daily, project, model, activity, tool, shell, and MCP sections.
+- CSV export: CodeBurn-style folder export with README, summary, daily, activity, models, projects, sessions, tools, and shell command CSVs.
+- JSON export: schema, generated timestamp, currency, summary, periods, projects, sessions, tools, and shell commands.
 - `--output` support. Without `--output`, write to stdout.
+- CSV formula-injection protection for cells starting with tab, carriage return, `=`, `+`, `-`, or `@`.
 
 #### 3. Main Routing
 **File**: `ainb-tui/src/main.rs`
 **Changes**:
 
-Route `Commands::Usage` and `Commands::Export` to the new implementation without entering TUI mode.
+Route `Commands::Usage` to the new implementation without entering TUI mode.
 
 ### Success Criteria
 
@@ -386,6 +403,8 @@ Route `Commands::Usage` and `Commands::Export` to the new implementation without
 - [ ] CLI argument tests cover period, custom dates, provider, include/exclude, format, and output path.
 - [ ] JSON output test validates stable keys for overview, daily, projects, models, activities, tools, shell commands, and MCP servers.
 - [ ] CSV output test validates headers and row sections.
+- [ ] CSV output test validates formula-injection escaping.
+- [ ] JSON export test validates schema and core keys.
 - [ ] Invalid date format and inverted range return clear errors.
 
 #### Manual Verification
@@ -393,8 +412,229 @@ Route `Commands::Usage` and `Commands::Export` to the new implementation without
 - [ ] `ainb usage report --from 2026-04-01 --to 2026-04-10 --format json | jq '.overview'` works.
 - [ ] `ainb usage export --format csv --output /tmp/ainb-usage.csv` creates a usable CSV.
 
-## Phase 6: Quality Gates And Documentation
-<!-- wave: 6 | depends_on: [Phase 4, Phase 5] | files: [ainb-tui/tests/test_ui_display.rs, ainb-tui/tests/test_events.rs, ainb-tui/tests/test_app_state.rs, ainb-tui/docs/CLI.md, ainb-tui/README.md] -->
+## Phase 6: Plan, Currency, And Model Alias CLI
+<!-- wave: 6 | depends_on: [Phase 1, Phase 5] | files: [ainb-tui/src/config/mod.rs, ainb-tui/src/cli/usage.rs, ainb-tui/src/models/usage.rs] -->
+
+### Overview
+
+Port CodeBurn's persisted settings for budget, currency display, and model aliasing into AINB config.
+
+### Changes Required
+
+#### 1. Config
+**File**: `ainb-tui/src/config/mod.rs`
+**Changes**:
+
+Add `UsageConfig` under `AppConfig`:
+
+```rust
+pub struct UsageConfig {
+    pub plan: Option<UsagePlan>,
+    pub currency: CurrencyConfig,
+    pub model_aliases: HashMap<String, String>,
+}
+```
+
+Plan fields:
+
+- `id`: `claude-pro`, `claude-max`, `claude-max-5x`, `cursor-pro`, `custom`, `none`.
+- `monthly_usd`
+- `provider`: `all`, `claude`, `codex`, `cursor`
+- `reset_day`: 1-28
+- `set_at`
+
+#### 2. CLI
+**File**: `ainb-tui/src/cli/usage.rs`
+**Changes**:
+
+Implement:
+
+```bash
+ainb usage plan show --format text|json
+ainb usage plan set claude-pro --provider claude --reset-day 12
+ainb usage plan set custom --monthly-usd 75 --provider all
+ainb usage plan reset
+ainb usage plan detect
+ainb usage currency GBP
+ainb usage currency --reset
+ainb usage currency EUR --symbol EUR
+ainb usage model-alias --list
+ainb usage model-alias cursor-auto claude-sonnet-4-5
+ainb usage model-alias --remove cursor-auto
+```
+
+`plan detect` may attempt `claude -p /usage` only if available and parseable. Failure must be non-fatal and instruct manual `plan set`.
+
+#### 3. Projection
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Implement CodeBurn plan math:
+
+- Current billing period from reset day.
+- Spend is parsed API-equivalent cost in the plan period.
+- Percent = spend / monthly budget.
+- Status: `under`, `near` at >=80%, `over` at >100%.
+- Projection = spent + trailing 7-day median daily spend * remaining days.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Config serialization/deserialization preserves plan, currency, and aliases.
+- [ ] Plan reset-day tests cover beginning, middle, and end of month.
+- [ ] Plan projection tests cover under, near, and over status.
+- [ ] CLI tests cover plan show/set/reset/custom/detect failure path.
+- [ ] Currency validation rejects invalid codes and caches/falls back safely.
+- [ ] Alias tests verify user aliases override built-ins.
+
+#### Manual Verification
+- [ ] `ainb usage plan set claude-pro --reset-day 12` persists.
+- [ ] `ainb usage plan show --format json` includes usage and projection.
+- [ ] `ainb usage currency GBP` changes displayed report costs.
+
+## Phase 7: Optimize Findings CLI And TUI Panel
+<!-- wave: 7 | depends_on: [Phase 1, Phase 2, Phase 5] | files: [ainb-tui/src/models/usage.rs, ainb-tui/src/cli/usage.rs, ainb-tui/src/components/usage.rs] -->
+
+### Overview
+
+Port CodeBurn's read-only waste analyzer into Rust.
+
+### Changes Required
+
+#### 1. Findings Model
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Add:
+
+- `WasteFinding`
+- `WasteAction`
+- `Impact`
+- `HealthGrade`
+- `OptimizeResult`
+
+#### 2. Detectors
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Implement detectors:
+
+- Junk reads.
+- Duplicate reads.
+- Unused MCP servers.
+- Bloated `CLAUDE.md` with `@` import expansion.
+- Low read/edit ratio.
+- Cache bloat.
+- Ghost agents.
+- Ghost skills.
+- Ghost commands.
+- Bash output bloat.
+
+Port scoring:
+
+- Health score starts at 100.
+- Penalties: high 15, medium 7, low 3.
+- Minimum score 20.
+- Grades: A >=90, B >=75, C >=55, D >=30, F below 30.
+- Urgency sort weights impact and token savings.
+- Recent 48h trend can mark findings improving or suppress resolved issues.
+
+#### 3. CLI / TUI
+**Files**: `ainb-tui/src/cli/usage.rs`, `ainb-tui/src/components/usage.rs`
+**Changes**:
+
+Add:
+
+```bash
+ainb usage optimize --period 30days --provider claude
+ainb usage optimize --period 30days --format json
+```
+
+TUI can render an Optimize tab/panel with health, total potential savings, and top findings. Actions must be text only.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Detector fixture tests cover each finding type.
+- [ ] Health scoring and urgency sort match CodeBurn behavior.
+- [ ] Trend tests cover improving and resolved suppression.
+- [ ] CLI JSON output includes health, findings, token savings, and actions.
+
+#### Manual Verification
+- [ ] `ainb usage optimize --period 30days` prints actionable findings without modifying files.
+- [ ] Suggested commands are clearly labeled as suggestions.
+
+## Phase 8: Compare And Yield
+<!-- wave: 8 | depends_on: [Phase 1, Phase 2, Phase 5] | files: [ainb-tui/src/models/usage.rs, ainb-tui/src/cli/usage.rs, ainb-tui/src/components/usage.rs] -->
+
+### Overview
+
+Port CodeBurn's model comparison and git yield logic.
+
+### Changes Required
+
+#### 1. Compare
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Aggregate by primary model per turn:
+
+- Calls, cost, token totals.
+- Edit turns, one-shot turns, retries.
+- Self-correction count from assistant text.
+- Cost/call, cost/edit, output tokens/call, cache hit.
+- Category head-to-head.
+- Working style: delegation rate, planning rate, average tools/turn, fast-mode usage.
+
+**File**: `ainb-tui/src/cli/usage.rs`
+**Changes**:
+
+Add:
+
+```bash
+ainb usage compare --period all
+ainb usage compare --period all --provider claude --format json
+```
+
+For TTY, show interactive selector if practical; for non-TTY, JSON/text summary is more useful than CodeBurn's interactive-only guard.
+
+#### 2. Yield
+**File**: `ainb-tui/src/models/usage.rs`
+**Changes**:
+
+Implement git correlation:
+
+- Detect repo from cwd/project path.
+- Resolve main branch from `origin/HEAD`, `main`, then `master`.
+- Read commits from all branches in selected period.
+- Mark revert commits.
+- Match session window from first timestamp to last timestamp + 1 hour.
+- Categorize spend as productive, reverted, abandoned.
+
+**File**: `ainb-tui/src/cli/usage.rs`
+**Changes**:
+
+Add:
+
+```bash
+ainb usage yield --period week
+ainb usage yield --period week --format json
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Compare aggregation tests cover winner logic and low-data handling.
+- [ ] Self-correction regex tests cover correction/apology phrases.
+- [ ] Yield tests use temporary git repo fixtures for productive, reverted, abandoned sessions.
+- [ ] CLI output tests cover text and JSON.
+
+#### Manual Verification
+- [ ] `ainb usage compare --period all` gives model-level tradeoffs.
+- [ ] `ainb usage yield --period week` categorizes spend in a real repo.
+
+## Phase 9: Quality Gates And Documentation
+<!-- wave: 9 | depends_on: [Phase 4, Phase 5, Phase 6, Phase 7, Phase 8] | files: [ainb-tui/tests/test_ui_display.rs, ainb-tui/tests/test_events.rs, ainb-tui/tests/test_app_state.rs, ainb-tui/docs/CLI.md, ainb-tui/README.md] -->
 
 ### Overview
 
@@ -412,7 +652,7 @@ Add tests for:
 - Usage tab/state navigation.
 - Analytics event routing.
 - Parser fixture behavior.
-- CLI report/export behavior.
+- CLI report/status/export/plan/optimize/compare/yield behavior.
 
 #### 2. Docs
 **Files**: `ainb-tui/docs/CLI.md`, `ainb-tui/README.md`
@@ -426,6 +666,9 @@ Document:
 - Periods and custom `--from` / `--to` ranges.
 - Include/exclude project filters.
 - Text, JSON, and CSV export.
+- Plan, currency, and model alias settings.
+- Optimize findings.
+- Model comparison and yield analysis.
 - Read-only local parsing.
 - Cost estimate caveat.
 
@@ -468,6 +711,10 @@ Document:
 9. Press `r` and confirm reload notification/loading state.
 10. Run `ainb usage report --from 2026-04-01 --to 2026-04-10 --format json`.
 11. Run `ainb usage export --format csv --output /tmp/ainb-usage.csv`.
+12. Run `ainb usage plan set claude-pro --reset-day 12`.
+13. Run `ainb usage optimize --period 30days`.
+14. Run `ainb usage compare --period all --format json`.
+15. Run `ainb usage yield --period week`.
 
 ## Performance Considerations
 
@@ -483,9 +730,15 @@ No data migration. The feature is read-only and derives summaries from local ses
 ## References
 
 - Research: `research/2026-04-28_22-39-40_codeburn-burndown-ainb-tui.md`
+- Comprehensive CLI parity research: `research/2026-04-28_23-31-36_codeburn-cli-parity.md`
 - CodeBurn dashboard composition: `/tmp/codeburn-research/src/dashboard.tsx:602`
 - CodeBurn parser aggregation: `/tmp/codeburn-research/src/parser.ts:167`
 - CodeBurn classifier: `/tmp/codeburn-research/src/classifier.ts:56`
+- CodeBurn optimize: `/tmp/codeburn-research/src/optimize.ts:373`
+- CodeBurn plan usage: `/tmp/codeburn-research/src/plan-usage.ts:107`
+- CodeBurn export: `/tmp/codeburn-research/src/export.ts:280`
+- CodeBurn compare: `/tmp/codeburn-research/src/compare-stats.ts:26`
+- CodeBurn yield: `/tmp/codeburn-research/src/yield.ts:116`
 - AINB Analytics view: `ainb-tui/src/app/state.rs:397`
 - AINB Usage UI state: `ainb-tui/src/components/usage.rs:121`
 - AINB usage parser: `ainb-tui/src/models/usage.rs:85`

--- a/research/2026-04-28_22-39-40_codeburn-burndown-ainb-tui.md
+++ b/research/2026-04-28_22-39-40_codeburn-burndown-ainb-tui.md
@@ -12,12 +12,13 @@ Investigate `https://github.com/getagentseal/codeburn` and plan how to bake the 
 
 ## Executive Summary
 
-AINB already has a full-screen `Usage Analytics` view, so the lowest-risk path is to extend that screen with a new `Burndown` sub-tab rather than add a separate top-level view. CodeBurn's highest-value ideas are a provider-normalized usage model, deterministic activity classification, period/provider switching, and compact Ratatui panels for daily, project, model, activity, tool, shell, and MCP breakdowns.
+AINB already has a full-screen `Usage Analytics` view, so the lowest-risk path is to extend that screen with a new `Burndown` sub-tab rather than add a separate top-level view. CodeBurn's highest-value ideas are a provider-normalized usage model, deterministic activity classification, period/provider switching, custom date ranges, project include/exclude filters, export/report output, and compact Ratatui panels for daily, project, model, activity, tool, shell, and MCP breakdowns.
 
 ## Key Findings
 
 - CodeBurn is a local-session reader, not a wrapper or proxy. Its README says it reads data from disk and uses LiteLLM pricing, with no API keys or proxy flow required.
 - CodeBurn's dashboard is a multi-panel terminal dashboard: overview, daily activity, project, top sessions, activity, model, core tools, shell commands, and MCP servers.
+- CodeBurn also provides custom `--from` / `--to` ranges, project include/exclude filters, JSON report output, and CSV/JSON exports; these should be required scope, not follow-up.
 - AINB has `View::Analytics`, a `Stats` sidebar entry, `UsageViewState`, async usage parsing, and existing usage keyboard handling.
 - AINB's current usage parser only supports Claude Code token totals from `~/.claude/projects/**/*.jsonl`; Codex/Gemini/Copilot providers are listed in UI but have no data implementation.
 - Implementation should start by reshaping `UsageData` into a richer normalized summary while preserving the current daily/weekly/project table behavior.
@@ -45,6 +46,8 @@ Important README details:
 - Dashboard navigation uses arrows for periods, `1`-`5` for direct periods, `p` for provider, `o` for optimize, and `c` for model comparison.
 - JSON output includes overview, daily breakdown, project summaries, model counts, activities with one-shot rates, core tools, MCP servers, and shell commands.
 - Provider paths include `~/.claude/projects/` and `~/.codex/sessions/`.
+- Custom `--from` and `--to` dates use `YYYY-MM-DD`, local-time inclusive windows.
+- Project filters use repeatable include and exclude flags by case-insensitive substring.
 
 ### CodeBurn UI Layout
 
@@ -137,10 +140,11 @@ UI rendering tests already use `ratatui::backend::TestBackend` and buffer assert
 2. Introduce richer usage-domain types before UI work: normalized provider calls, classified turns, session summaries, project summaries, daily summaries, and dashboard totals.
 3. Keep provider adapters isolated. Start with Claude and Codex because AINB already exposes those providers in the UI and both have disk-backed session logs.
 4. Preserve the current async parse pathway and add lightweight cache/incremental scan later if parsing grows expensive.
-5. Implement the Burndown view as a compact CodeBurn-style panel dashboard first, then add optimize/plan/model-compare as later tabs or overlays.
-6. Add behavioral tests at model, state, event, and Ratatui render layers.
+5. Treat custom date ranges, include/exclude filters, JSON reports, and CSV/JSON export as required scope for first delivery.
+6. Implement the Burndown view as a compact CodeBurn-style panel dashboard first, then add optimize/plan/model-compare as later tabs or overlays.
+7. Add behavioral tests at model, CLI, state, event, and Ratatui render layers.
 
 ## Open Questions
 
 - No blocking questions. Assumption: `Burndown` should live inside existing `Usage Analytics` as a sub-tab and reuse shortcut `i`, with `Tab` cycling through Daily, Weekly, Projects, and Burndown.
-- Later product decision: whether to copy CodeBurn's subscription plan tracking and optimize findings into the first release or defer them after basic burndown parity.
+- Later product decision: whether to copy CodeBurn's subscription plan tracking, optimize findings, model comparison, currency conversion, model aliases, menubar, and yield analysis after first delivery.

--- a/research/2026-04-28_22-39-40_codeburn-burndown-ainb-tui.md
+++ b/research/2026-04-28_22-39-40_codeburn-burndown-ainb-tui.md
@@ -1,0 +1,146 @@
+# Research: CodeBurn-Style Burndown In AINB TUI
+
+**Date**: 2026-04-28 22:39:40 Europe/London
+**Repository**: agents-in-a-box
+**Branch**: feat/codeburn
+**Commit**: 8ac34152c726b5ccb025ed32eabc642929eae165
+**Research Type**: Comprehensive
+
+## Research Question
+
+Investigate `https://github.com/getagentseal/codeburn` and plan how to bake the same kind of usage observability, similar views, and burndown/dashboard construct into the `ainb-tui` usage area.
+
+## Executive Summary
+
+AINB already has a full-screen `Usage Analytics` view, so the lowest-risk path is to extend that screen with a new `Burndown` sub-tab rather than add a separate top-level view. CodeBurn's highest-value ideas are a provider-normalized usage model, deterministic activity classification, period/provider switching, and compact Ratatui panels for daily, project, model, activity, tool, shell, and MCP breakdowns.
+
+## Key Findings
+
+- CodeBurn is a local-session reader, not a wrapper or proxy. Its README says it reads data from disk and uses LiteLLM pricing, with no API keys or proxy flow required.
+- CodeBurn's dashboard is a multi-panel terminal dashboard: overview, daily activity, project, top sessions, activity, model, core tools, shell commands, and MCP servers.
+- AINB has `View::Analytics`, a `Stats` sidebar entry, `UsageViewState`, async usage parsing, and existing usage keyboard handling.
+- AINB's current usage parser only supports Claude Code token totals from `~/.claude/projects/**/*.jsonl`; Codex/Gemini/Copilot providers are listed in UI but have no data implementation.
+- Implementation should start by reshaping `UsageData` into a richer normalized summary while preserving the current daily/weekly/project table behavior.
+
+## Prior Learnings
+
+### Relevant Past Solutions
+
+| Learning | Key Insight | Confidence |
+|----------|-------------|------------|
+| project-cli-integration | Reuse existing AINB integration points and avoid parallel feature plumbing where the CLI/TUI already has a route. | medium |
+| tui-bulk-delete-fix | TUI additions need explicit state/event/render tests because visual navigation regressions are easy to miss. | medium |
+
+No dedicated prior learning was found for CodeBurn itself.
+
+## Detailed Findings
+
+### External CodeBurn Behavior
+
+The live GitHub README describes CodeBurn as an AI coding cost observability dashboard supporting Claude Code, Codex, Cursor, Gemini CLI, Kiro, OpenCode, Pi, OMP, and GitHub Copilot with a provider plugin system. It tracks task type, tool, model, MCP server, project, and one-shot success rate, and provides an interactive dashboard with gradient charts and keyboard navigation. Source: https://github.com/getagentseal/codeburn
+
+Important README details:
+
+- Dashboard commands include `codeburn`, `today`, `month`, `report -p 30days`, `report -p all`, JSON report output, status output, export, optimize, and yield.
+- Dashboard navigation uses arrows for periods, `1`-`5` for direct periods, `p` for provider, `o` for optimize, and `c` for model comparison.
+- JSON output includes overview, daily breakdown, project summaries, model counts, activities with one-shot rates, core tools, MCP servers, and shell commands.
+- Provider paths include `~/.claude/projects/` and `~/.codex/sessions/`.
+
+### CodeBurn UI Layout
+
+CodeBurn period tabs are `today`, `week`, `30days`, `month`, and `all` in `/tmp/codeburn-research/src/dashboard.tsx:18`. It switches to a wide two-column layout at 90 columns and caps dashboard width at 160 columns in `/tmp/codeburn-research/src/dashboard.tsx:120`.
+
+The overview panel computes total cost, API calls, sessions, token totals, cache hit, and optional plan status in `/tmp/codeburn-research/src/dashboard.tsx:171`. The dashboard content renders overview, daily/project, top sessions, activity/model, tools/shell, and MCP sections in `/tmp/codeburn-research/src/dashboard.tsx:602`.
+
+Panel-level concepts worth porting first:
+
+- Period tabs: Today, 7 Days, 30 Days, This Month, All Time.
+- Overview: cost, calls, sessions, cache hit, token totals.
+- Daily activity: horizontal bars plus cost/calls.
+- By project: cost, average per session, session count.
+- By activity: cost, turns, one-shot percentage.
+- By model: cost, cache hit, call count.
+- Core tools, shell commands, MCP servers: call counts with bars.
+
+### CodeBurn Data Model
+
+CodeBurn normalizes session data into project/session/turn/API-call summaries. Claude parsing extracts usage, model, cache tokens, web search requests, tool names, MCP tools, bash commands, and cost in `/tmp/codeburn-research/src/parser.ts:77`. Session aggregation totals cost, tokens, model/tool/MCP/bash/category breakdowns in `/tmp/codeburn-research/src/parser.ts:167`.
+
+Non-Claude providers emit normalized provider calls and then reuse the same summary/classifier flow in `/tmp/codeburn-research/src/parser.ts:359`.
+
+The Codex provider reads `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, validates `session_meta`, maps tool names like `exec_command` to `Bash`, and normalizes OpenAI cached-input semantics in `/tmp/codeburn-research/src/providers/codex.ts:21`, `/tmp/codeburn-research/src/providers/codex.ts:92`, and `/tmp/codeburn-research/src/providers/codex.ts:241`.
+
+### CodeBurn Classification
+
+CodeBurn classification is deterministic and does not call an LLM. It first classifies by tool patterns, then refines with user-message keywords in `/tmp/codeburn-research/src/classifier.ts:56`. It counts edit/test/fix retry cycles with an edit -> bash -> edit pattern in `/tmp/codeburn-research/src/classifier.ts:120`.
+
+Categories:
+
+- Coding
+- Debugging
+- Feature Dev
+- Refactoring
+- Testing
+- Exploration
+- Planning
+- Delegation
+- Git Ops
+- Build/Deploy
+- Brainstorming
+- Conversation
+- General
+
+### AINB Existing Usage Screen
+
+AINB screens are `View` enum variants; `View::Analytics` is the current usage statistics route in `ainb-tui/src/app/state.rs:397`. Home sidebar `Stats` maps to usage analytics with shortcut `i` in `ainb-tui/src/components/sidebar.rs:27`, `ainb-tui/src/components/sidebar.rs:87`, and `ainb-tui/src/components/sidebar.rs:104`.
+
+`LayoutComponent::render` dispatches `View::Analytics` to `crate::components::usage::render` in `ainb-tui/src/components/layout.rs:193`. `AppState` owns `usage_state` plus an async receiver for usage parsing in `ainb-tui/src/app/state.rs:1923`.
+
+The usage UI already has provider state, sub-tabs, loading state, and scroll offset in `ainb-tui/src/components/usage.rs:121`. Current sub-tabs are `Daily`, `Weekly`, and `Projects` in `ainb-tui/src/components/usage.rs:82`, and render branching happens in `ainb-tui/src/components/usage.rs:226`.
+
+### AINB Usage Parser
+
+AINB's current parser is token-only. `TokenBucket` tracks input, cache creation, cache read, output, session count, and project count in `ainb-tui/src/models/usage.rs:10`. `UsageData` only carries daily, weekly, project, and grand total aggregates in `ainb-tui/src/models/usage.rs:41`.
+
+`parse_usage()` reads Claude Code JSONL files from `~/.claude/projects`, aggregates by day/week/project, and sorts projects by token total in `ainb-tui/src/models/usage.rs:85`.
+
+AINB correctly keeps this scan off the UI thread. `start_background_usage_load()` spawns blocking parse work in `ainb-tui/src/app/state.rs:3245`, and completion is drained through `check_usage_load_complete()`.
+
+### AINB Keyboard/Event Flow
+
+Usage events are already first-class `AppEvent` variants in `ainb-tui/src/app/events.rs:332`. Analytics key routing handles `Esc`, left/right, `Tab`, `BackTab`, `j/k`, page keys, `g/G`, and `r` in `ainb-tui/src/app/events.rs:1540`.
+
+The sidebar `Stats` entry enters Analytics and starts background loading in `ainb-tui/src/app/events.rs:2865`. The direct `i` shortcut maps to `GoToStats`, which also enters Analytics and starts loading in `ainb-tui/src/app/events.rs:3072`.
+
+### Tests
+
+UI rendering tests already use `ratatui::backend::TestBackend` and buffer assertions in `ainb-tui/tests/test_ui_display.rs:7`. App state tests exist in `ainb-tui/tests/test_app_state.rs:39`. No direct tests currently cover `UsageViewState`, `models::usage`, `UsageTab`, or Analytics-specific event behavior.
+
+## Code References
+
+- `ainb-tui/src/app/state.rs:397` - `View` enum includes `Analytics`.
+- `ainb-tui/src/components/sidebar.rs:27` - sidebar navigation items include `Stats`.
+- `ainb-tui/src/components/layout.rs:193` - Analytics layout dispatch.
+- `ainb-tui/src/components/usage.rs:82` - current usage sub-tabs.
+- `ainb-tui/src/components/usage.rs:121` - current usage UI state.
+- `ainb-tui/src/models/usage.rs:10` - current token bucket model.
+- `ainb-tui/src/models/usage.rs:85` - current Claude-only usage parser.
+- `ainb-tui/src/app/state.rs:3245` - background usage parsing.
+- `/tmp/codeburn-research/src/dashboard.tsx:602` - CodeBurn dashboard panel composition.
+- `/tmp/codeburn-research/src/parser.ts:167` - CodeBurn session aggregation.
+- `/tmp/codeburn-research/src/classifier.ts:56` - deterministic activity classifier.
+- `/tmp/codeburn-research/src/providers/codex.ts:92` - Codex session discovery.
+
+## Recommendations
+
+1. Extend the existing AINB `Stats` / `Usage Analytics` screen with `UsageTab::Burndown` instead of adding a new top-level view.
+2. Introduce richer usage-domain types before UI work: normalized provider calls, classified turns, session summaries, project summaries, daily summaries, and dashboard totals.
+3. Keep provider adapters isolated. Start with Claude and Codex because AINB already exposes those providers in the UI and both have disk-backed session logs.
+4. Preserve the current async parse pathway and add lightweight cache/incremental scan later if parsing grows expensive.
+5. Implement the Burndown view as a compact CodeBurn-style panel dashboard first, then add optimize/plan/model-compare as later tabs or overlays.
+6. Add behavioral tests at model, state, event, and Ratatui render layers.
+
+## Open Questions
+
+- No blocking questions. Assumption: `Burndown` should live inside existing `Usage Analytics` as a sub-tab and reuse shortcut `i`, with `Tab` cycling through Daily, Weekly, Projects, and Burndown.
+- Later product decision: whether to copy CodeBurn's subscription plan tracking and optimize findings into the first release or defer them after basic burndown parity.

--- a/research/2026-04-28_23-31-36_codeburn-cli-parity.md
+++ b/research/2026-04-28_23-31-36_codeburn-cli-parity.md
@@ -1,0 +1,365 @@
+# CodeBurn CLI Parity Research
+
+## Question
+
+What does CodeBurn provide at the CLI layer, what does `optimize` do, and what must AINB implement in Rust to cover the same behavior while skipping only macOS menubar install/app support?
+
+## Sources
+
+- CodeBurn repository clone: `/tmp/codeburn-research`
+- Main CLI: `/tmp/codeburn-research/src/cli.ts`
+- Parser and providers: `/tmp/codeburn-research/src/parser.ts`, `/tmp/codeburn-research/src/providers`
+- Optimize: `/tmp/codeburn-research/src/optimize.ts`
+- Export: `/tmp/codeburn-research/src/export.ts`
+- Plan and config: `/tmp/codeburn-research/src/config.ts`, `/tmp/codeburn-research/src/plans.ts`, `/tmp/codeburn-research/src/plan-usage.ts`
+- Compare and yield: `/tmp/codeburn-research/src/compare-stats.ts`, `/tmp/codeburn-research/src/compare.tsx`, `/tmp/codeburn-research/src/yield.ts`
+- AINB CLI/TUI: `ainb-tui/src/cli/mod.rs`, `ainb-tui/src/main.rs`, `ainb-tui/src/models/usage.rs`, `ainb-tui/src/components/usage.rs`, `ainb-tui/src/config/mod.rs`
+
+## Executive Summary
+
+Full CLI parity means more than a Burndown tab. CodeBurn provides a local analytics CLI with:
+
+- Reports: interactive dashboard and JSON report.
+- Status: compact terminal and JSON summaries.
+- Export: CSV folder export and JSON export.
+- Usage periods: today, last 7 days, last 30 days, current month, and all.
+- Custom date range flags on report: `--from YYYY-MM-DD`, `--to YYYY-MM-DD`.
+- Provider and project filters.
+- Plan/budget tracking.
+- Currency and model alias settings.
+- Optimize findings.
+- Model comparison.
+- Git-correlated yield analysis.
+
+Menubar install/app support is the only explicit exclusion. For AINB, the clean command shape is a new `ainb usage ...` namespace so existing top-level `ainb status <workspace>` keeps its current session-management meaning.
+
+## CodeBurn CLI Surface
+
+### Global
+
+- Binary: `codeburn`.
+- Global `--verbose` enables warning output through `CODEBURN_VERBOSE=1`.
+- Startup loads config, model aliases, pricing, and currency before command execution.
+
+### Periods
+
+Preset periods:
+
+- `today`
+- `week` / "Last 7 Days"
+- `30days`
+- `month`
+- `all`
+
+CLI `all` is last six months in `cli.ts`. Dashboard internal `all` uses epoch/all-time. Rust implementation should choose one intentionally; for parity with CLI commands, use last six months for CLI and document TUI all-time if AINB wants the richer view.
+
+### Filters
+
+- `--provider <provider>` exact provider ID match.
+- `--project <name>` repeatable include filter.
+- `--exclude <name>` repeatable exclude filter.
+- Project matching is case-insensitive substring against sanitized project name and raw path.
+- Include is applied before exclude; exclude wins when both match.
+- `--from` and `--to` accept local `YYYY-MM-DD`; missing `from` means earliest data, missing `to` means today; `to` is inclusive through `23:59:59.999`.
+
+### Commands To Port
+
+Recommended AINB namespace:
+
+```bash
+ainb usage report
+ainb usage status
+ainb usage today
+ainb usage month
+ainb usage export
+ainb usage optimize
+ainb usage compare
+ainb usage yield
+ainb usage plan
+ainb usage currency
+ainb usage model-alias
+```
+
+CodeBurn command inventory:
+
+- `report`: dashboard by default, `--format json` for structured output. Supports period, custom range, provider, project include/exclude, refresh.
+- `today`: dashboard pinned to today. Supports provider, project include/exclude, refresh, JSON.
+- `month`: dashboard pinned to current month. Supports provider, project include/exclude, refresh, JSON.
+- `status`: compact terminal/JSON summary for today and month. CodeBurn also has `menubar-json`; AINB can omit menubar schema unless useful for automation.
+- `export`: writes Today, 7 Days, and 30 Days exports in CSV or JSON. Supports provider and project include/exclude.
+- `plan`: show/set/reset budget plan. Supports JSON show output, provider scope, custom monthly USD, reset day 1-28.
+- `currency`: show/set/reset display currency and optional symbol override.
+- `model-alias`: list/add/remove pricing aliases.
+- `optimize`: read-only waste analysis.
+- `compare`: interactive model comparison; non-TTY prints an explanatory message.
+- `yield`: experimental git correlation between AI spend and commits.
+- `menubar`: excluded by request.
+
+## Output Schemas
+
+### Report JSON
+
+`report|today|month --format json` outputs:
+
+- `generated`
+- `currency`
+- `period`
+- `periodKey`
+- `overview`
+- `daily`
+- `projects`
+- `models`
+- `activities`
+- `tools`
+- `mcpServers`
+- `shellCommands`
+- `topSessions`
+- optional `plan`
+
+Overview includes cost, calls, sessions, cache hit, and input/output/cache token totals. Activity rows include turns, cost, edit turns, one-shot turns, and one-shot rate.
+
+### Status JSON
+
+`status --format json` outputs:
+
+- `currency`
+- `today { cost, calls }`
+- `month { cost, calls }`
+- optional `plan`
+
+### Export
+
+CSV export writes a directory, not one flat CSV. Files:
+
+- `.codeburn-export`
+- `README.txt`
+- `summary.csv`
+- `daily.csv`
+- `activity.csv`
+- `models.csv`
+- `projects.csv`
+- `sessions.csv`
+- `tools.csv`
+- `shell-commands.csv`
+
+CSV escapes formula-injection prefixes by adding a leading apostrophe for cells starting with tab, carriage return, `=`, `+`, `-`, or `@`.
+
+JSON export writes:
+
+- `schema: "codeburn.export.v2"`
+- `generated`
+- `currency`
+- `summary`
+- `periods`
+- `projects`
+- `sessions`
+- `tools`
+- `shellCommands`
+
+AINB should port the shape but can use `ainb.export.v1` if exact CodeBurn schema compatibility is not a goal.
+
+## Usage Derivation
+
+CodeBurn parses local provider histories and normalizes them into projects, sessions, turns, calls, tools, shell commands, MCP calls, model stats, and cost.
+
+Core providers in registry include Claude, Codex, Copilot, Droid, Gemini, Kilo Code, Kiro, OpenClaw, Pi, OMP, Qwen, Roo Code, plus lazy Cursor/OpenCode/Cursor Agent providers.
+
+AINB already shows Claude/Codex/Gemini/Copilot provider labels, but only Claude currently has real data. A practical Rust port should implement Claude and Codex first, then add other providers behind the same trait.
+
+Important parse behavior:
+
+- Claude reads `~/.claude/projects` or `CLAUDE_CONFIG_DIR`.
+- Codex reads `CODEX_HOME` or `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+- Codex sources are validated by `session_meta` and `originator` starting with `codex`.
+- Codex tool normalization maps shell/file/agent operations into CodeBurn's common tool names.
+- Codex token counts may be cumulative; when `last_token_usage` exists use it, otherwise diff cumulative totals and skip duplicates.
+- OpenAI cached tokens are included in input; CodeBurn subtracts cached tokens from input for cost math.
+
+Activity classification is deterministic:
+
+- Tool-first categories: planning, delegation, coding, exploration, git, build/deploy, MCP, task management.
+- Prompt keyword refinement detects debugging, feature work, refactoring, testing, brainstorming, research, and conversation.
+- Retry counting treats edit -> bash -> edit cycles as retries.
+- One-shot rate is edit turns with zero retries.
+
+## Optimize Findings
+
+`codeburn optimize` is a read-only waste analyzer. It scans Claude Code sessions and local Claude configuration, emits ranked findings, estimates token/USD savings, and prints copy-paste fixes. It does not mutate files or run fixes.
+
+### Inputs
+
+- Parsed project summaries for period cost, calls, sessions, cache-write totals, and MCP usage.
+- Claude JSONL sessions discovered through `discoverAllSessions('claude')`.
+- `.mcp.json`, user/project Claude settings, `CLAUDE.md` and `.claude/CLAUDE.md`, `~/.claude/agents`, `~/.claude/skills`, `~/.claude/commands`, and shell profiles.
+
+Important caveat: CodeBurn's optimize scanner is Claude-only even when `--provider` filters the project summary data. AINB should either keep that explicit or fix it by adding provider-specific optimize detectors.
+
+### Findings
+
+- Junk reads: flags reads in `node_modules`, `.git`, `dist`, `build`, `.next`, `coverage`, caches, virtualenvs, and similar generated paths.
+- Duplicate reads: flags repeated reads of the same non-junk file in the same project/session.
+- Unused MCP servers: flags configured MCP servers with no matching `mcp__server__tool` usage and no session MCP breakdown usage, ignoring configs modified in last 24h.
+- Bloated `CLAUDE.md`: expands `@./...` imports to depth 5 and flags expanded memory over 200 lines.
+- Low read/edit ratio: flags edit-heavy sessions with fewer than 4 read/search tools per edit once there are at least 10 edits.
+- Cache bloat: compares median cache creation tokens to a budget-aware baseline and flags high excess.
+- Ghost agents: flags `~/.claude/agents/*.md` files not invoked by Agent/Task tool metadata.
+- Ghost skills: flags `~/.claude/skills/*/SKILL.md` directories not invoked by the Skill tool.
+- Ghost commands: flags `~/.claude/commands/*.md` files not referenced by slash command/user-message markers.
+- Bash output bloat: flags unset/default or high `BASH_MAX_OUTPUT_LENGTH`, recommends 15000.
+
+### Ranking And Health
+
+- Each finding has `impact` high/medium/low, explanation, estimated tokens saved, fix action, optional trend.
+- Trend compares recent 48h waste against older baseline. Recent zero suppresses resolved findings; <50% recent rate marks improving.
+- Health score starts at 100. Penalties: high 15, medium 7, low 3; minimum score 20.
+- Grades: A >=90, B >=75, C >=55, D >=30, F below 30.
+- Urgency sort weights impact 70% and normalized token savings 30%.
+
+### Rust Port Shape
+
+Port `optimize` as pure detectors with injected scan/config data:
+
+- `usage::optimize::detectors::*`
+- `usage::optimize::scanner`
+- `usage::optimize::render`
+
+Keep all actions as strings. Do not execute `mv`, `claude mcp remove`, or file edits.
+
+## Plan / Usage Budget
+
+CodeBurn does not appear to call `claude -p /usage`. It stores plan settings in `~/.config/codeburn/config.json` and compares API-equivalent local spend against a monthly budget.
+
+Plan IDs:
+
+- `claude-pro`: $20/month, provider `claude`
+- `claude-max`: $200/month, provider `claude`
+- `claude-max-5x`: $100/month, provider `claude`
+- `cursor-pro`: $20/month, provider `cursor`
+- `custom`: caller supplies `--monthly-usd`
+- `none`: disabled
+
+Plan usage:
+
+- Billing period comes from reset day 1-28.
+- Spend is summed from parsed project cost.
+- Status is `under`, `near` at >=80%, or `over` at >100%.
+- Projection uses trailing 7-day median daily cost times remaining days.
+
+AINB should support manual plan settings first. A `plan detect` or `plan import-claude` command can run `claude -p /usage` only if the installed Claude CLI returns stable parseable output. That path must be optional; manual config remains authoritative.
+
+## Compare
+
+CodeBurn compare is model-centric and interactive.
+
+Metrics:
+
+- Calls
+- Cost
+- Input/output/cache tokens
+- Total turns
+- Edit turns
+- One-shot turns/rate
+- Retries/rate
+- Self-corrections/rate
+- Cost per call
+- Cost per edit
+- Output tokens per call
+- Cache hit rate
+- Category head-to-head one-shot rate
+- Working style: delegation rate, planning rate, average tools per turn, fast-mode usage
+
+Self-corrections are scanned from assistant text with correction/apology regexes. Non-TTY compare exits with a message. AINB can offer both an interactive TUI subview and a non-interactive `--format json` enhancement if desired, but CodeBurn itself is interactive-only.
+
+## Yield
+
+CodeBurn yield correlates session spend to git commits in the current repo.
+
+Flow:
+
+- Detect git repo.
+- Resolve main branch from `origin/HEAD`, then `main`, then `master`.
+- Read commits from all branches in selected period.
+- Mark revert commits by subject containing `revert`.
+- For each session, look for commits between first session timestamp and last timestamp + 1 hour.
+- Categorize session spend:
+  - Productive: commit landed on main.
+  - Reverted: revert commits are at least half of in-main commits.
+  - Abandoned: no commits or no in-main commits.
+
+Output prints Productive/Reverted/Abandoned cost, percent of total, session counts, and total. CodeBurn hardcodes `$` here instead of active currency.
+
+## Currency And Model Aliases
+
+Currency:
+
+- Stored config field: `currency { code, symbol? }`.
+- Validated through ISO 4217 formatting.
+- Exchange rates fetched from Frankfurter, cached 24h under `~/.cache/codeburn/exchange-rate.json`.
+- Invalid/fetch failure falls back to USD rate 1.
+
+Model aliases:
+
+- Stored as `modelAliases`.
+- User aliases override built-ins.
+- Used to map provider-emitted names to LiteLLM pricing keys and display short names.
+
+Pricing:
+
+- LiteLLM model price snapshot is bundled.
+- Live LiteLLM price JSON is fetched and cached 24h under `~/.cache/codeburn/litellm-pricing.json`.
+- Unknown model costs are zero in CodeBurn; AINB should make unknown pricing explicit in UI.
+
+## AINB Integration
+
+Current AINB:
+
+- CLI commands live in `ainb-tui/src/cli/mod.rs`; dispatch is manual in `ainb-tui/src/main.rs`.
+- Top-level `Status` already means session status, so CodeBurn status belongs under `ainb usage status`.
+- Usage model is currently token-only Claude JSONL parsing in `ainb-tui/src/models/usage.rs`.
+- Usage UI has provider labels but only Claude data, and only Daily/Weekly/Projects tabs.
+- Config is layered TOML through `AppConfig` and user config path `~/.agents-in-a-box/config/config.toml`.
+
+Recommended Rust modules:
+
+- `ainb-tui/src/models/usage/mod.rs`
+- `ainb-tui/src/models/usage/query.rs`
+- `ainb-tui/src/models/usage/providers/{claude,codex}.rs`
+- `ainb-tui/src/models/usage/pricing.rs`
+- `ainb-tui/src/models/usage/report.rs`
+- `ainb-tui/src/models/usage/export.rs`
+- `ainb-tui/src/models/usage/optimize.rs`
+- `ainb-tui/src/models/usage/compare.rs`
+- `ainb-tui/src/models/usage/yield_analysis.rs`
+- `ainb-tui/src/cli/usage.rs`
+
+Recommended command shape keeps existing session commands stable:
+
+```bash
+ainb usage report --period week --format text
+ainb usage report --from 2026-04-01 --to 2026-04-10 --provider codex --format json
+ainb usage status --format json
+ainb usage export --format csv --output ./usage-export
+ainb usage optimize --period 30days
+ainb usage compare --period all
+ainb usage yield --period week
+ainb usage plan show --format json
+ainb usage plan set claude-pro --reset-day 12
+ainb usage plan set custom --monthly-usd 75 --provider claude
+ainb usage currency GBP
+ainb usage model-alias cursor-auto claude-sonnet-4-5
+```
+
+## Gaps In Existing Plan
+
+The previous local plan intentionally excluded optimize, plan tracking, compare, yield, currency, and model aliases. Stevie now requested comprehensive CLI coverage except menubar. The implementation plan must be expanded from Burndown MVP to a usage analytics subsystem.
+
+## Interview Need
+
+No interview needed for scope. Stevie clarified:
+
+- Comprehensive CLI parity.
+- No menubar.
+- Rust port of the logic.
+- Plan setting required.
+- Optional `claude -p /usage` can be researched/attempted later, but CodeBurn itself uses local plan config and parsed spend.
+


### PR DESCRIPTION
## Summary
- add CodeBurn-style usage analytics under `ainb usage`
- add Burndown and Optimize views in the AINB Analytics TUI
- support custom date ranges, provider filters, include/exclude filters, JSON/CSV export, plan settings, currency settings, model aliases, optimize findings, model comparison, and yield analysis
- parse Claude and Codex local usage data read-only

## Validation
- `cargo test usage --all-targets`
- `cargo test test_usage_period_provider_and_filters_events --test test_events`
- `cargo test usage_burndown --test test_ui_display`
- `cargo test test_usage_query_reflects_selected_controls --test test_app_state`
- `cargo test test_usage_duplicate_loads_are_coalesced --test test_app_state`

## Notes
- Full `cargo test --all-targets` is blocked locally by Docker connection refused in existing Docker tests.
- Non-Docker full run also exposes existing unrelated `test_previous_session` expectation mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "usage" CLI (ainb usage) with report, export (CSV/JSON/text), optimize, compare, yield and plan commands; CSV export protects against spreadsheet formula injection.
  * TUI: Burndown and Optimize tabs, period/provider/project filters, custom date ranges, keybindings for filters/periods/providers, and read-only session-history parsing (Claude + Codex).
  * Persisted usage plan/currency/model-alias settings and projections.

* **Documentation**
  * Added README, CLI docs, usage examples, and configuration guidance for analytics features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->