### PR TITLE
feat(ainb-tui): soft-stop and resume actions for stuck sessions

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -32,6 +32,7 @@ pub enum AppEvent {
     ReauthenticateCredentials,
     RestartSession,
     DeleteSession,
+    ResumeSession(String), // Resume a Stopped interactive session (carries trigger key: "Enter" or "r")
     OpenInEditor,    // Open selected session's workspace in preferred editor
     OpenQuickShell,  // Open shell in selected workspace/session directory
     CleanupOrphaned, // Clean up orphaned containers
@@ -145,7 +146,8 @@ pub enum AppEvent {
     SearchWorkspaceInputChar(char),
     SearchWorkspaceBackspace,
     // Confirmation dialog events
-    ConfirmationToggle,  // Switch between Yes/No
+    ConfirmationToggle,  // Switch between Yes/No (binary) or cycle forward (tri-option)
+    ConfirmationPrev,    // Cycle backwards through tri-option dialog
     ConfirmationConfirm, // Confirm action
     ConfirmationCancel,  // Cancel dialog
     // Auth setup events
@@ -478,9 +480,16 @@ impl EventHandler {
         use crate::app::state::View;
 
         // Handle confirmation dialog first (highest priority)
-        if state.confirmation_dialog.is_some() {
+        if let Some(ref dialog) = state.confirmation_dialog {
+            // Tri-option dialogs cycle backwards on Left so users can navigate
+            // both directions; binary dialogs keep the simple Toggle behaviour.
+            let is_tri = dialog.options.is_some();
             match key_event.code {
-                KeyCode::Left | KeyCode::Right | KeyCode::Tab => {
+                KeyCode::Left if is_tri => return Some(AppEvent::ConfirmationPrev),
+                KeyCode::Right | KeyCode::Tab => {
+                    return Some(AppEvent::ConfirmationToggle);
+                }
+                KeyCode::Left => {
                     return Some(AppEvent::ConfirmationToggle);
                 }
                 KeyCode::Enter => {
@@ -678,7 +687,51 @@ impl EventHandler {
                 tracing::info!("[ACTION] 'a' key pressed - AttachTmuxSession requested");
                 Some(AppEvent::AttachTmuxSession)
             }
-            KeyCode::Char('r') => Some(AppEvent::ReauthenticateCredentials),
+            KeyCode::Enter => {
+                // Enter on a Stopped interactive session = resume it.
+                // Enter on a Running session = attach (mirrors 'a').
+                // Other selection types fall through to None to preserve prior behaviour.
+                use crate::models::{SessionAgentType, SessionMode, SessionStatus};
+                if let Some(session) = state.selected_session() {
+                    let is_interactive = matches!(session.mode, SessionMode::Interactive)
+                        && matches!(
+                            session.agent_type,
+                            SessionAgentType::Claude
+                                | SessionAgentType::Codex
+                                | SessionAgentType::Gemini
+                                | SessionAgentType::Copilot
+                        );
+                    if is_interactive && matches!(session.status, SessionStatus::Stopped) {
+                        Some(AppEvent::ResumeSession("Enter".to_string()))
+                    } else {
+                        Some(AppEvent::AttachTmuxSession)
+                    }
+                } else {
+                    None
+                }
+            }
+            KeyCode::Char('r') => {
+                // 'r' resumes a Stopped interactive session; otherwise it falls
+                // back to the existing reauthenticate-credentials shortcut.
+                use crate::models::{SessionAgentType, SessionMode, SessionStatus};
+                if let Some(session) = state.selected_session() {
+                    let is_interactive = matches!(session.mode, SessionMode::Interactive)
+                        && matches!(
+                            session.agent_type,
+                            SessionAgentType::Claude
+                                | SessionAgentType::Codex
+                                | SessionAgentType::Gemini
+                                | SessionAgentType::Copilot
+                        );
+                    if is_interactive && matches!(session.status, SessionStatus::Stopped) {
+                        Some(AppEvent::ResumeSession("r".to_string()))
+                    } else {
+                        Some(AppEvent::ReauthenticateCredentials)
+                    }
+                } else {
+                    Some(AppEvent::ReauthenticateCredentials)
+                }
+            }
             KeyCode::F(2) => {
                 // F2 for rename - works in "SSH Sessions" and "Other tmux" sections
                 if state.is_ssh_session_selected() {
@@ -2432,8 +2485,27 @@ impl EventHandler {
                         }
                     }
                 } else if let Some(session) = state.selected_session() {
-                    // Show confirmation dialog for regular session
-                    state.show_delete_confirmation(session.id);
+                    // Interactive sessions (Claude/Codex/Gemini/Copilot) get the
+                    // tri-option Stop / Delete / Cancel dialog so the user can
+                    // soft-stop without losing the worktree. Boss/Docker, SSH,
+                    // and Shell sessions stick with the binary delete flow.
+                    use crate::models::{SessionAgentType, SessionMode};
+                    let is_interactive_agent = matches!(
+                        session.mode,
+                        SessionMode::Interactive
+                    ) && matches!(
+                        session.agent_type,
+                        SessionAgentType::Claude
+                            | SessionAgentType::Codex
+                            | SessionAgentType::Gemini
+                            | SessionAgentType::Copilot
+                    );
+                    let session_id = session.id;
+                    if is_interactive_agent {
+                        state.show_delete_or_stop_confirmation(session_id);
+                    } else {
+                        state.show_delete_confirmation(session_id);
+                    }
                 } else {
                     tracing::warn!(
                         "[ACTION] DeleteSession: No item to delete (workspace_idx={:?}, session_idx={:?}, shell={}, other_tmux_idx={:?})",
@@ -2469,6 +2541,14 @@ impl EventHandler {
                     ));
                     state.pending_async_action = Some(AsyncAction::BulkDeleteSessions(ids));
                     state.selected_sessions.clear();
+                }
+            }
+            AppEvent::ResumeSession(trigger) => {
+                if let Some(session_id) = state.get_selected_session_id() {
+                    tracing::info!("[ACTION] Resuming stopped session: {} (trigger={})", session_id, trigger);
+                    state.pending_async_action = Some(AsyncAction::ResumeSession(session_id, trigger));
+                } else {
+                    state.add_warning_notification("No session selected to resume".to_string());
                 }
             }
             AppEvent::OpenInEditor => {
@@ -2541,17 +2621,46 @@ impl EventHandler {
             }
             AppEvent::ConfirmationToggle => {
                 if let Some(ref mut dialog) = state.confirmation_dialog {
-                    dialog.selected_option = !dialog.selected_option;
+                    if let Some(ref options) = dialog.options {
+                        let len = options.len().max(1);
+                        dialog.selected_index = (dialog.selected_index + 1) % len;
+                    } else {
+                        dialog.selected_option = !dialog.selected_option;
+                    }
+                }
+            }
+            AppEvent::ConfirmationPrev => {
+                if let Some(ref mut dialog) = state.confirmation_dialog {
+                    if let Some(ref options) = dialog.options {
+                        let len = options.len().max(1);
+                        dialog.selected_index = (dialog.selected_index + len - 1) % len;
+                    } else {
+                        dialog.selected_option = !dialog.selected_option;
+                    }
                 }
             }
             AppEvent::ConfirmationConfirm => {
                 if let Some(dialog) = state.confirmation_dialog.take() {
-                    if dialog.selected_option {
-                        // User confirmed, execute the action
-                        match dialog.confirm_action {
+                    let action = if let Some(options) = dialog.options.as_ref() {
+                        // Tri-option mode: pick the highlighted option's action.
+                        options
+                            .get(dialog.selected_index)
+                            .map(|o| o.action.clone())
+                    } else if dialog.selected_option {
+                        Some(dialog.confirm_action.clone())
+                    } else {
+                        None
+                    };
+
+                    if let Some(action) = action {
+                        match action {
                             crate::app::state::ConfirmAction::DeleteSession(session_id) => {
                                 state.pending_async_action =
                                     Some(AsyncAction::DeleteSession(session_id));
+                            }
+                            crate::app::state::ConfirmAction::StopSession(session_id) => {
+                                state.pending_async_action =
+                                    Some(AsyncAction::StopSession(session_id));
                             }
                             crate::app::state::ConfirmAction::KillOtherTmux(session_name) => {
                                 state.pending_async_action =
@@ -2561,9 +2670,11 @@ impl EventHandler {
                                 state.pending_async_action =
                                     Some(AsyncAction::KillWorkspaceShell(workspace_idx));
                             }
+                            crate::app::state::ConfirmAction::Cancel => {
+                                // Explicit Cancel: dialog already taken; nothing to do.
+                            }
                         }
                     }
-                    // If not confirmed, just close the dialog
                 }
             }
             AppEvent::ConfirmationCancel => {

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -424,15 +424,29 @@ pub struct ConfirmationDialog {
     pub title: String,
     pub message: String,
     pub confirm_action: ConfirmAction,
-    pub selected_option: bool,   // true = Yes, false = No
+    pub selected_option: bool, // true = Yes, false = No (binary mode)
     pub warning: Option<String>, // Optional warning (e.g., uncommitted files in worktree)
+    // Tri-option mode: when `options` is `Some`, the dialog renders one button per
+    // entry and Left/Right cycles `selected_index`. The final-option index is
+    // treated as Cancel by the confirm handler.
+    pub options: Option<Vec<DialogOption>>,
+    pub selected_index: usize,
+}
+
+/// One choice in a tri-option (or n-option) confirmation dialog.
+#[derive(Debug, Clone)]
+pub struct DialogOption {
+    pub label: String,
+    pub action: ConfirmAction,
 }
 
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     DeleteSession(Uuid),
-    KillOtherTmux(String), // Kill a non-agents-in-a-box tmux session by name
+    StopSession(Uuid),         // Soft-stop interactive session (tmux only; preserves worktree)
+    KillOtherTmux(String),     // Kill a non-agents-in-a-box tmux session by name
     KillWorkspaceShell(usize), // Kill workspace shell by workspace index
+    Cancel,                    // No-op terminator for tri-option dialogs
 }
 
 // ============================================================================
@@ -2509,7 +2523,9 @@ pub enum AsyncAction {
     CloneRemoteRepo,         // NEW: Clone remote repo to cache
     FetchRemoteBranches,     // NEW: Get branch list from remote
     CreateNewSession,
-    DeleteSession(Uuid),           // New - delete session with container cleanup
+    DeleteSession(Uuid),         // New - delete session with container cleanup
+    StopSession(Uuid),           // Soft-stop interactive session (kill tmux only)
+    ResumeSession(Uuid, String), // Recreate tmux for a Stopped interactive session; String is the trigger key for audit
     BulkDeleteSessions(Vec<Uuid>), // Bulk delete multiple sessions
     RefreshWorkspaces,             // Manual refresh of workspace data
     FetchContainerLogs(Uuid),      // Fetch container logs for a session
@@ -3574,7 +3590,7 @@ impl AppState {
 
     /// Load Interactive mode sessions from tmux
     async fn load_interactive_mode_sessions(&mut self) {
-        use crate::interactive::InteractiveSessionManager;
+        use crate::interactive::{InteractiveSessionManager, SessionStore};
 
         // Create Interactive session manager (no Docker needed)
         let mut manager = match InteractiveSessionManager::new() {
@@ -3584,6 +3600,11 @@ impl AppState {
                 return;
             }
         };
+
+        // Track tmux names of live sessions so the stopped-detection pass below
+        // does not double-add anything that was already discovered.
+        let mut live_tmux_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         // Discover Interactive sessions from tmux
         match manager.list_sessions().await {
@@ -3595,6 +3616,7 @@ impl AppState {
 
                 // Convert to Session models and add to workspaces
                 for interactive_session in sessions {
+                    live_tmux_names.insert(interactive_session.tmux_session_name.clone());
                     let session = interactive_session.to_session_model();
 
                     // Find or create workspace for this session
@@ -3636,6 +3658,60 @@ impl AppState {
                 warn!("Failed to discover Interactive sessions: {}", e);
             }
         }
+
+        // Second pass: discover Stopped sessions. These are entries persisted in
+        // sessions.json whose tmux session is no longer alive but whose worktree
+        // still exists on disk. Worktree-missing entries fall through to the
+        // existing recovery flow.
+        let store = SessionStore::load();
+        for metadata in store.sessions().values() {
+            if live_tmux_names.contains(&metadata.tmux_session_name) {
+                continue;
+            }
+            if !metadata.worktree_path.exists() {
+                continue;
+            }
+
+            let stopped = Self::stopped_session_from_metadata(metadata);
+            let workspace_path = metadata.worktree_path.parent().unwrap_or(&metadata.worktree_path).to_path_buf();
+
+            if let Some(workspace) = self.workspaces.iter_mut().find(|w| {
+                std::path::Path::new(&w.path).canonicalize().ok()
+                    == workspace_path.canonicalize().ok()
+            }) {
+                if !workspace.sessions.iter().any(|s| s.id == metadata.session_id) {
+                    workspace.sessions.push(stopped);
+                }
+            } else {
+                let mut workspace = crate::models::Workspace::new(
+                    metadata.workspace_name.clone(),
+                    workspace_path,
+                );
+                workspace.sessions.push(stopped);
+                self.workspaces.push(workspace);
+            }
+        }
+    }
+
+    /// Build a `Session` model in `Stopped` state from persisted metadata.
+    /// Used to render sessions whose tmux is dead but whose worktree is alive.
+    pub(crate) fn stopped_session_from_metadata(metadata: &crate::interactive::SessionMetadata) -> crate::models::Session {
+        use crate::models::{Session, SessionMode, SessionStatus};
+
+        let mut session = Session::new_with_options(
+            metadata.workspace_name.clone(),
+            metadata.worktree_path.to_string_lossy().to_string(),
+            false, // skip_permissions — unknown when offline; safe default
+            SessionMode::Interactive,
+            None,
+            metadata.agent_type,
+            None,
+        );
+        session.id = metadata.session_id;
+        session.tmux_session_name = Some(metadata.tmux_session_name.clone());
+        session.status = SessionStatus::Stopped;
+        session.created_at = metadata.created_at;
+        session
     }
 
     /// Discover tmux sessions that are NOT managed by agents-in-a-box
@@ -4505,6 +4581,46 @@ impl AppState {
             confirm_action: ConfirmAction::DeleteSession(session_id),
             selected_option: false, // Default to "No"
             warning,
+            options: None,
+            selected_index: 0,
+        });
+    }
+
+    /// Show a tri-option Stop / Delete / Cancel dialog for an interactive session.
+    ///
+    /// Stop is the default (selected) action: it kills only tmux and keeps the
+    /// worktree, sessions.json entry, and `by-session/<uuid>` symlink intact.
+    /// Delete maps to the existing destructive flow.
+    pub fn show_delete_or_stop_confirmation(&mut self, session_id: Uuid) {
+        info!("Showing Stop/Delete/Cancel dialog for session: {}", session_id);
+
+        let warning = self.check_session_uncommitted_warning(session_id);
+
+        let options = vec![
+            DialogOption {
+                label: "Stop".to_string(),
+                action: ConfirmAction::StopSession(session_id),
+            },
+            DialogOption {
+                label: "Delete".to_string(),
+                action: ConfirmAction::DeleteSession(session_id),
+            },
+            DialogOption {
+                label: "Cancel".to_string(),
+                action: ConfirmAction::Cancel,
+            },
+        ];
+
+        self.confirmation_dialog = Some(ConfirmationDialog {
+            title: "Stop or Delete Session".to_string(),
+            message: "Stop keeps the worktree and resumes later. Delete removes the worktree.".to_string(),
+            // confirm_action mirrors the default (Stop) so the legacy ConfirmationConfirm
+            // handler still has something sensible if it ever runs without options.
+            confirm_action: ConfirmAction::StopSession(session_id),
+            selected_option: true,
+            warning,
+            options: Some(options),
+            selected_index: 0, // Default = Stop (safe option)
         });
     }
 
@@ -4548,6 +4664,8 @@ impl AppState {
             confirm_action: ConfirmAction::KillOtherTmux(session_name),
             selected_option: false, // Default to "No"
             warning: None,
+            options: None,
+            selected_index: 0,
         });
     }
 
@@ -4572,6 +4690,8 @@ impl AppState {
             confirm_action: ConfirmAction::KillOtherTmux(session_name), // Reuse KillOtherTmux since SSH sessions are tmux sessions
             selected_option: false,                                     // Default to "No"
             warning: None,
+            options: None,
+            selected_index: 0,
         });
     }
 
@@ -4603,6 +4723,8 @@ impl AppState {
             confirm_action: ConfirmAction::KillWorkspaceShell(workspace_index),
             selected_option: false, // Default to "No"
             warning: None,
+            options: None,
+            selected_index: 0,
         });
     }
 
@@ -7875,6 +7997,305 @@ impl AppState {
         Ok(())
     }
 
+    /// Soft-stop an interactive session by killing only its tmux session.
+    ///
+    /// Unlike `delete_interactive_session`, this preserves:
+    ///   - the worktree on disk
+    ///   - the `~/.agents-in-a-box/sessions.json` entry
+    ///   - the `by-session/<uuid>` symlink
+    ///
+    /// The session is rediscovered as `Stopped` on the next workspace reload (and
+    /// across TUI restarts) and can be resumed via `resume_interactive_session`.
+    async fn stop_interactive_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
+        use crate::interactive::SessionStore;
+        use crate::models::SessionStatus;
+
+        info!("Soft-stopping interactive session: {}", session_id);
+
+        // Resolve tmux session name preferring the in-memory map, falling back to
+        // sessions.json (handles edge case where the live map is out of sync).
+        let tmux_name = self
+            .tmux_sessions
+            .get(&session_id)
+            .map(|t| t.name().to_string())
+            .or_else(|| {
+                self.find_session(session_id)
+                    .and_then(|s| s.tmux_session_name.clone())
+            })
+            .or_else(|| {
+                let store = SessionStore::load();
+                store
+                    .sessions()
+                    .values()
+                    .find(|m| m.session_id == session_id)
+                    .map(|m| m.tmux_session_name.clone())
+            });
+
+        let worktree_path = self
+            .find_session(session_id)
+            .map(|s| s.workspace_path.clone());
+
+        let result: anyhow::Result<()> = if let Some(ref name) = tmux_name {
+            // Hard constraint: kill only the exact named session. NEVER kill-server.
+            let output = tokio::process::Command::new("tmux")
+                .args(["kill-session", "-t", name])
+                .output()
+                .await?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                // tmux returns non-zero when the session is already gone — treat as success
+                // since the post-condition (no tmux session) is what we care about.
+                if stderr.contains("can't find session") || stderr.contains("no server running") {
+                    info!("tmux session '{}' already gone — proceeding", name);
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Failed to kill tmux session '{}': {}",
+                        name,
+                        stderr
+                    ));
+                }
+            } else {
+                info!("Killed tmux session: {}", name);
+            }
+            Ok(())
+        } else {
+            warn!(
+                "No tmux_session_name for {} — nothing to kill, just marking Stopped",
+                session_id
+            );
+            Ok(())
+        };
+
+        // Drop the live tmux handle but DO NOT touch SessionStore or worktree.
+        self.tmux_sessions.remove(&session_id);
+
+        if let Some(session) = self.find_session_mut(session_id) {
+            session.set_status(SessionStatus::Stopped);
+            session.is_attached = false;
+        }
+
+        let audit_result = match &result {
+            Ok(()) => AuditResult::Success,
+            Err(e) => AuditResult::Failed(e.to_string()),
+        };
+        audit::audit_session_stopped(
+            session_id,
+            tmux_name,
+            worktree_path,
+            AuditTrigger::UserKeypress("D→Stop".to_string()),
+            audit_result,
+        );
+
+        // Mirror delete_session: refresh workspace view so the Stopped indicator is rendered.
+        self.load_real_workspaces().await;
+        self.ui_needs_refresh = true;
+
+        result
+    }
+
+    /// Resume a previously-stopped interactive session.
+    ///
+    /// Recreates the tmux session at the original worktree and re-launches the
+    /// agent CLI. For Claude, attempts to discover the latest transcript and
+    /// pass `--resume <path>` to continue the conversation. Other agents start
+    /// fresh because their CLIs do not support transcript-based resume.
+    async fn resume_interactive_session(
+        &mut self,
+        session_id: Uuid,
+        trigger_key: String,
+    ) -> anyhow::Result<()> {
+        use crate::interactive::{InteractiveSessionManager, SessionStore};
+        use crate::models::SessionStatus;
+
+        info!("Resuming interactive session: {} (trigger={})", session_id, trigger_key);
+
+        // Resolve metadata up-front so we can audit even if subsequent steps fail.
+        let store = SessionStore::load();
+        let metadata = store
+            .sessions()
+            .values()
+            .find(|m| m.session_id == session_id)
+            .cloned();
+
+        // Pull skip_permissions and model from the in-memory Session if available.
+        let (skip_permissions, model) = self
+            .find_session(session_id)
+            .map(|s| (s.skip_permissions, s.model))
+            .unwrap_or((false, None));
+
+        // Capture audit context before any fallible step so we can record both
+        // success and failure with the same fields.
+        let tmux_name_for_audit = metadata.as_ref().map(|m| m.tmux_session_name.clone());
+        let worktree_for_audit = metadata
+            .as_ref()
+            .map(|m| m.worktree_path.display().to_string());
+
+        let mut transcript: Option<PathBuf> = None;
+        let result: anyhow::Result<()> = async {
+            let metadata = metadata.ok_or_else(|| {
+                anyhow::anyhow!("Session {} not found in sessions.json", session_id)
+            })?;
+
+            // Recreate the tmux session at the worktree. If something is already
+            // listening on this name (shouldn't be, since we set Stopped), kill it
+            // first so we get a clean shell — narrow target, never wildcard.
+            let _ = tokio::process::Command::new("tmux")
+                .args(["kill-session", "-t", &metadata.tmux_session_name])
+                .output()
+                .await;
+
+            let new_output = tokio::process::Command::new("tmux")
+                .args([
+                    "new-session",
+                    "-d",
+                    "-s",
+                    &metadata.tmux_session_name,
+                    "-c",
+                    metadata
+                        .worktree_path
+                        .to_str()
+                        .ok_or_else(|| anyhow::anyhow!("Worktree path is not valid UTF-8"))?,
+                    "-x",
+                    "120",
+                    "-y",
+                    "40",
+                ])
+                .output()
+                .await?;
+
+            if !new_output.status.success() {
+                let stderr = String::from_utf8_lossy(&new_output.stderr);
+                return Err(anyhow::anyhow!(
+                    "Failed to create tmux session '{}': {}",
+                    metadata.tmux_session_name,
+                    stderr
+                ));
+            }
+
+            transcript = if metadata.agent_type == SessionAgentType::Claude {
+                Self::find_latest_transcript(&metadata.worktree_path)
+            } else {
+                None
+            };
+
+            let manager = InteractiveSessionManager::new()?;
+            manager
+                .start_cli_in_tmux(
+                    &metadata.tmux_session_name,
+                    skip_permissions,
+                    model,
+                    metadata.agent_type,
+                    transcript.clone(),
+                )
+                .await?;
+
+            // Re-register live tmux handle and flip status to Running.
+            let tmux_session = crate::tmux::TmuxSession::new(
+                metadata.tmux_session_name.clone(),
+                metadata.agent_type.name().to_string(),
+            );
+            self.tmux_sessions.insert(session_id, tmux_session);
+
+            if let Some(session) = self.find_session_mut(session_id) {
+                session.set_status(SessionStatus::Running);
+                session.tmux_session_name = Some(metadata.tmux_session_name.clone());
+            }
+
+            // Inline status banner. Encoded path is shown only on the no-transcript
+            // path so the user can locate (or rule out) Claude's project directory.
+            let banner: String = match (metadata.agent_type, transcript.as_ref()) {
+                (SessionAgentType::Claude, Some(_)) => "Resumed".to_string(),
+                (SessionAgentType::Claude, None) => {
+                    let encoded = Self::encode_claude_project_dir(&metadata.worktree_path);
+                    format!(
+                        "No transcript found at ~/.claude/projects/{} - starting fresh",
+                        encoded
+                    )
+                }
+                (other, _) => format!(
+                    "Resumed (fresh session - {} doesn't support --resume)",
+                    other.name()
+                ),
+            };
+            self.add_info_notification(banner);
+
+            Ok(())
+        }
+        .await;
+
+        let audit_result = match &result {
+            Ok(()) => AuditResult::Success,
+            Err(e) => AuditResult::Failed(e.to_string()),
+        };
+        audit::audit_session_resumed(
+            session_id,
+            tmux_name_for_audit,
+            worktree_for_audit,
+            transcript.as_ref().map(|p| p.display().to_string()),
+            AuditTrigger::UserKeypress(trigger_key),
+            audit_result,
+        );
+
+        if result.is_ok() {
+            self.load_real_workspaces().await;
+            self.ui_needs_refresh = true;
+        }
+
+        result
+    }
+
+    /// Encode an absolute worktree path the same way Claude Code does for its
+    /// `~/.claude/projects/-{encoded}/` transcript directory:
+    ///   - replace `/` with `-`
+    ///   - strip leading slash
+    /// Then prefix with `-` (callers do this).
+    ///
+    /// Mirror of `find_transcript_path()` in
+    /// `toolkit/packages/utilities/utils/spawn-agent-lib.sh:30-69`.
+    pub(crate) fn encode_claude_project_dir(worktree_path: &std::path::Path) -> String {
+        let s = worktree_path.to_string_lossy();
+        let stripped = s.strip_prefix('/').unwrap_or(&s);
+        format!("-{}", stripped.replace('/', "-"))
+    }
+
+    /// Find the most recently modified Claude transcript (`*.jsonl`) for the
+    /// given worktree under `~/.claude/projects/-{encoded}/`.
+    ///
+    /// Returns `None` when the project directory is missing or contains no
+    /// transcripts.
+    pub fn find_latest_transcript(worktree_path: &std::path::Path) -> Option<std::path::PathBuf> {
+        let home = dirs::home_dir()?;
+        Self::find_latest_transcript_in(&home, worktree_path)
+    }
+
+    /// Test-friendly variant: caller supplies the home directory so unit tests
+    /// don't have to mutate process-wide environment.
+    pub(crate) fn find_latest_transcript_in(
+        home: &std::path::Path,
+        worktree_path: &std::path::Path,
+    ) -> Option<std::path::PathBuf> {
+        let project_dir = home
+            .join(".claude")
+            .join("projects")
+            .join(Self::encode_claude_project_dir(worktree_path));
+
+        let read = std::fs::read_dir(&project_dir).ok()?;
+        let mut candidates: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
+        for entry in read.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if let Ok(meta) = entry.metadata() {
+                if let Ok(mtime) = meta.modified() {
+                    candidates.push((path, mtime));
+                }
+            }
+        }
+        candidates.into_iter().max_by_key(|(_, t)| *t).map(|(p, _)| p)
+    }
+
     /// Delete a Boss mode session
     async fn delete_boss_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
         use crate::docker::{ContainerManager, SessionLifecycleManager};
@@ -7988,6 +8409,18 @@ impl AppState {
                 AsyncAction::DeleteSession(session_id) => {
                     if let Err(e) = self.delete_session(session_id).await {
                         error!("Failed to delete session {}: {}", session_id, e);
+                    }
+                }
+                AsyncAction::StopSession(session_id) => {
+                    if let Err(e) = self.stop_interactive_session(session_id).await {
+                        error!("Failed to stop session {}: {}", session_id, e);
+                        self.add_error_notification(format!("Stop failed: {}", e));
+                    }
+                }
+                AsyncAction::ResumeSession(session_id, trigger) => {
+                    if let Err(e) = self.resume_interactive_session(session_id, trigger).await {
+                        error!("Failed to resume session {}: {}", session_id, e);
+                        self.add_error_notification(format!("Resume failed: {}", e));
                     }
                 }
                 AsyncAction::BulkDeleteSessions(session_ids) => {

--- a/ainb-tui/src/app/state_tests.rs
+++ b/ainb-tui/src/app/state_tests.rs
@@ -418,4 +418,199 @@ mod tests {
             "Remote source should not queue StartWorkspaceSearch"
         );
     }
+
+    // ========================================================================
+    // Stop / Resume coverage
+    // ========================================================================
+
+    use crate::app::state::{
+        ConfirmAction, ConfirmationDialog, DialogOption,
+    };
+
+    /// Verify the tri-option dialog defaults to Stop and cycles forward through
+    /// all three options before wrapping back to Stop.
+    #[test]
+    fn test_show_delete_or_stop_confirmation_defaults_to_stop() {
+        let mut state = AppState::new();
+        let session_id = uuid::Uuid::new_v4();
+
+        state.show_delete_or_stop_confirmation(session_id);
+
+        let dialog = state
+            .confirmation_dialog
+            .as_ref()
+            .expect("Dialog should be present");
+        let opts = dialog.options.as_ref().expect("Tri-option dialog");
+        assert_eq!(opts.len(), 3, "Stop / Delete / Cancel");
+        assert_eq!(opts[0].label, "Stop");
+        assert_eq!(opts[1].label, "Delete");
+        assert_eq!(opts[2].label, "Cancel");
+        assert_eq!(dialog.selected_index, 0, "Default = Stop");
+        assert!(
+            matches!(opts[0].action, ConfirmAction::StopSession(id) if id == session_id),
+            "First option must be StopSession for the right uuid"
+        );
+        assert!(
+            matches!(opts[1].action, ConfirmAction::DeleteSession(id) if id == session_id),
+            "Second option must be DeleteSession for the right uuid"
+        );
+        assert!(matches!(opts[2].action, ConfirmAction::Cancel));
+    }
+
+    /// Forward cycling and backwards cycling on a tri-option dialog.
+    #[test]
+    fn test_tri_option_dialog_cycle() {
+        let mut dialog = ConfirmationDialog {
+            title: "T".into(),
+            message: "M".into(),
+            confirm_action: ConfirmAction::Cancel,
+            selected_option: false,
+            warning: None,
+            options: Some(vec![
+                DialogOption { label: "A".into(), action: ConfirmAction::Cancel },
+                DialogOption { label: "B".into(), action: ConfirmAction::Cancel },
+                DialogOption { label: "C".into(), action: ConfirmAction::Cancel },
+            ]),
+            selected_index: 0,
+        };
+
+        // Forward cycle 0 -> 1 -> 2 -> 0
+        let len = dialog.options.as_ref().unwrap().len();
+        dialog.selected_index = (dialog.selected_index + 1) % len;
+        assert_eq!(dialog.selected_index, 1);
+        dialog.selected_index = (dialog.selected_index + 1) % len;
+        assert_eq!(dialog.selected_index, 2);
+        dialog.selected_index = (dialog.selected_index + 1) % len;
+        assert_eq!(dialog.selected_index, 0);
+
+        // Backward cycle 0 -> 2 -> 1 -> 0
+        dialog.selected_index = (dialog.selected_index + len - 1) % len;
+        assert_eq!(dialog.selected_index, 2);
+        dialog.selected_index = (dialog.selected_index + len - 1) % len;
+        assert_eq!(dialog.selected_index, 1);
+        dialog.selected_index = (dialog.selected_index + len - 1) % len;
+        assert_eq!(dialog.selected_index, 0);
+    }
+
+    /// Binary dialog (existing callsites) keeps the legacy yes/no toggle.
+    #[test]
+    fn test_binary_dialog_unchanged() {
+        let session_id = uuid::Uuid::new_v4();
+        let mut state = AppState::new();
+        state.show_delete_confirmation(session_id);
+        let dialog = state.confirmation_dialog.as_ref().unwrap();
+        assert!(dialog.options.is_none(), "Legacy binary dialog");
+        assert!(!dialog.selected_option, "Default = No");
+        assert!(matches!(
+            dialog.confirm_action,
+            ConfirmAction::DeleteSession(_)
+        ));
+    }
+
+    /// Path encoding mirrors `find_transcript_path` in spawn-agent-lib.sh:30-69.
+    #[test]
+    fn test_encode_claude_project_dir() {
+        use std::path::PathBuf;
+        let p = PathBuf::from("/Users/stevie/code/foo-bar");
+        assert_eq!(
+            AppState::encode_claude_project_dir(&p),
+            "-Users-stevie-code-foo-bar"
+        );
+
+        let p = PathBuf::from("/");
+        assert_eq!(AppState::encode_claude_project_dir(&p), "-");
+    }
+
+    /// `find_latest_transcript_in` returns the most recently modified `.jsonl`
+    /// under `<home>/.claude/projects/-{encoded}/`.
+    #[test]
+    fn test_find_latest_transcript_picks_newest_by_mtime() {
+        use std::fs::{self, File};
+        use std::path::PathBuf;
+        use std::time::{Duration, SystemTime};
+
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let fake_home = tmp.path().to_path_buf();
+
+        let worktree = PathBuf::from("/tmp/work-abc-test");
+        let encoded = AppState::encode_claude_project_dir(&worktree);
+        let project_dir = fake_home.join(".claude").join("projects").join(&encoded);
+        fs::create_dir_all(&project_dir).unwrap();
+
+        let older = project_dir.join("2024-01.jsonl");
+        let newer = project_dir.join("2024-02.jsonl");
+        fs::write(&older, "x").unwrap();
+        fs::write(&newer, "y").unwrap();
+
+        let now = SystemTime::now();
+        File::open(&older)
+            .unwrap()
+            .set_modified(now - Duration::from_secs(120))
+            .unwrap();
+        File::open(&newer)
+            .unwrap()
+            .set_modified(now + Duration::from_secs(120))
+            .unwrap();
+
+        // Decoy non-jsonl file should be ignored.
+        fs::write(project_dir.join("ignored.txt"), "z").unwrap();
+
+        let result = AppState::find_latest_transcript_in(&fake_home, &worktree)
+            .expect("Should find a transcript");
+        assert_eq!(result.file_name().unwrap(), "2024-02.jsonl");
+    }
+
+    /// Missing project directory returns None (no transcript = fresh start).
+    #[test]
+    fn test_find_latest_transcript_missing_dir_returns_none() {
+        use std::path::PathBuf;
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let fake_home = tmp.path().to_path_buf();
+
+        let nonexistent = PathBuf::from("/tmp/never-existed-xyz");
+        let result = AppState::find_latest_transcript_in(&fake_home, &nonexistent);
+        assert!(result.is_none());
+    }
+
+    /// Empty project directory (no `.jsonl` files) returns None.
+    #[test]
+    fn test_find_latest_transcript_empty_dir_returns_none() {
+        use std::fs;
+        use std::path::PathBuf;
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let fake_home = tmp.path().to_path_buf();
+        let worktree = PathBuf::from("/tmp/empty-work");
+        let encoded = AppState::encode_claude_project_dir(&worktree);
+        let project_dir = fake_home.join(".claude").join("projects").join(&encoded);
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(project_dir.join("not-a-jsonl.txt"), "z").unwrap();
+
+        let result = AppState::find_latest_transcript_in(&fake_home, &worktree);
+        assert!(result.is_none());
+    }
+
+    /// `stopped_session_from_metadata` produces a Session with status Stopped
+    /// and the right tmux name + worktree path. Backbone of the discovery pass.
+    #[test]
+    fn test_stopped_session_from_metadata_marks_status_stopped() {
+        use crate::interactive::SessionMetadata;
+        use crate::models::{SessionAgentType, SessionStatus};
+        use std::path::PathBuf;
+
+        let metadata = SessionMetadata {
+            session_id: uuid::Uuid::new_v4(),
+            tmux_session_name: "tmux_some_branch".to_string(),
+            worktree_path: PathBuf::from("/tmp/work-stopped"),
+            workspace_name: "ws".to_string(),
+            created_at: chrono::Utc::now(),
+            agent_type: SessionAgentType::Claude,
+        };
+
+        let session = AppState::stopped_session_from_metadata(&metadata);
+        assert_eq!(session.id, metadata.session_id);
+        assert!(matches!(session.status, SessionStatus::Stopped));
+        assert_eq!(session.tmux_session_name.as_deref(), Some("tmux_some_branch"));
+        assert_eq!(session.workspace_path, "/tmp/work-stopped");
+        assert_eq!(session.agent_type, SessionAgentType::Claude);
+    }
 }

--- a/ainb-tui/src/audit.rs
+++ b/ainb-tui/src/audit.rs
@@ -14,6 +14,8 @@ use uuid::Uuid;
 pub enum AuditAction {
     SessionCreated,
     SessionDeleted,
+    SessionStopped,
+    SessionResumed,
     ConfigSaved,
     OrphanedContainersCleanup,
     GitWorktreePrune,
@@ -24,6 +26,8 @@ impl std::fmt::Display for AuditAction {
         match self {
             AuditAction::SessionCreated => write!(f, "SESSION_CREATED"),
             AuditAction::SessionDeleted => write!(f, "SESSION_DELETED"),
+            AuditAction::SessionStopped => write!(f, "SESSION_STOPPED"),
+            AuditAction::SessionResumed => write!(f, "SESSION_RESUMED"),
             AuditAction::ConfigSaved => write!(f, "CONFIG_SAVED"),
             AuditAction::OrphanedContainersCleanup => write!(f, "ORPHANED_CLEANUP"),
             AuditAction::GitWorktreePrune => write!(f, "GIT_WORKTREE_PRUNE"),
@@ -84,6 +88,48 @@ pub fn audit_session_deleted(
         trigger = %trigger,
         result = %result,
         "Session deleted"
+    );
+}
+
+/// Log a soft-stop (tmux killed; worktree, sessions.json, symlink preserved)
+pub fn audit_session_stopped(
+    session_id: Uuid,
+    tmux_session: Option<String>,
+    worktree_path: Option<String>,
+    trigger: AuditTrigger,
+    result: AuditResult,
+) {
+    info!(
+        target: "audit",
+        action = %AuditAction::SessionStopped,
+        session_id = %session_id,
+        tmux_session = ?tmux_session,
+        path = ?worktree_path,
+        trigger = %trigger,
+        result = %result,
+        "Session stopped"
+    );
+}
+
+/// Log a resume (tmux re-created from preserved sessions.json metadata)
+pub fn audit_session_resumed(
+    session_id: Uuid,
+    tmux_session: Option<String>,
+    worktree_path: Option<String>,
+    transcript_path: Option<String>,
+    trigger: AuditTrigger,
+    result: AuditResult,
+) {
+    info!(
+        target: "audit",
+        action = %AuditAction::SessionResumed,
+        session_id = %session_id,
+        tmux_session = ?tmux_session,
+        path = ?worktree_path,
+        transcript = ?transcript_path,
+        trigger = %trigger,
+        result = %result,
+        "Session resumed"
     );
 }
 
@@ -166,6 +212,8 @@ mod tests {
     #[test]
     fn test_action_display() {
         assert_eq!(format!("{}", AuditAction::SessionDeleted), "SESSION_DELETED");
+        assert_eq!(format!("{}", AuditAction::SessionStopped), "SESSION_STOPPED");
+        assert_eq!(format!("{}", AuditAction::SessionResumed), "SESSION_RESUMED");
         assert_eq!(format!("{}", AuditAction::ConfigSaved), "CONFIG_SAVED");
     }
 

--- a/ainb-tui/src/components/confirmation_dialog.rs
+++ b/ainb-tui/src/components/confirmation_dialog.rs
@@ -92,33 +92,59 @@ impl ConfirmationDialogComponent {
 
             frame.render_widget(message, chunks[message_chunk]);
 
-            // Render buttons
-            let button_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(chunks[button_chunk]);
+            // Render buttons. Tri-option mode (e.g. Stop / Delete / Cancel) takes
+            // precedence; binary mode is used by all legacy callsites.
+            if let Some(options) = dialog.options.as_ref() {
+                let n = options.len().max(1);
+                let pct = (100u16 / n as u16).max(1);
+                let constraints: Vec<Constraint> = (0..n).map(|_| Constraint::Percentage(pct)).collect();
+                let button_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(constraints)
+                    .split(chunks[button_chunk]);
 
-            // Yes button
-            let yes_style = if dialog.selected_option {
-                Style::default().fg(Color::Black).bg(Color::White)
+                for (i, opt) in options.iter().enumerate() {
+                    let style = if i == dialog.selected_index {
+                        Style::default().fg(Color::Black).bg(Color::White)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+                    let label = format!("[ {} ]", opt.label);
+                    let button = Paragraph::new(label)
+                        .style(style)
+                        .alignment(Alignment::Center);
+                    if let Some(area) = button_chunks.get(i) {
+                        frame.render_widget(button, *area);
+                    }
+                }
             } else {
-                Style::default().fg(Color::White)
-            };
+                let button_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                    .split(chunks[button_chunk]);
 
-            let yes_button = Paragraph::new("Yes").style(yes_style).alignment(Alignment::Center);
+                // Yes button
+                let yes_style = if dialog.selected_option {
+                    Style::default().fg(Color::Black).bg(Color::White)
+                } else {
+                    Style::default().fg(Color::White)
+                };
 
-            frame.render_widget(yes_button, button_chunks[0]);
+                let yes_button = Paragraph::new("Yes").style(yes_style).alignment(Alignment::Center);
 
-            // No button
-            let no_style = if !dialog.selected_option {
-                Style::default().fg(Color::Black).bg(Color::White)
-            } else {
-                Style::default().fg(Color::White)
-            };
+                frame.render_widget(yes_button, button_chunks[0]);
 
-            let no_button = Paragraph::new("No").style(no_style).alignment(Alignment::Center);
+                // No button
+                let no_style = if !dialog.selected_option {
+                    Style::default().fg(Color::Black).bg(Color::White)
+                } else {
+                    Style::default().fg(Color::White)
+                };
 
-            frame.render_widget(no_button, button_chunks[1]);
+                let no_button = Paragraph::new("No").style(no_style).alignment(Alignment::Center);
+
+                frame.render_widget(no_button, button_chunks[1]);
+            }
         }
     }
 }

--- a/ainb-tui/src/interactive/session_manager.rs
+++ b/ainb-tui/src/interactive/session_manager.rs
@@ -241,7 +241,7 @@ impl InteractiveSessionManager {
         match agent_type {
             SessionAgentType::Claude | SessionAgentType::Codex | SessionAgentType::Gemini | SessionAgentType::Copilot => {
                 info!("Starting {:?} CLI in tmux session (model={:?}, skip_permissions={})", agent_type, model, skip_permissions);
-                self.start_cli_in_tmux(&tmux_session_name, skip_permissions, model, agent_type).await?;
+                self.start_cli_in_tmux(&tmux_session_name, skip_permissions, model, agent_type, None).await?;
             }
             _ => {
                 info!("Skipping CLI for agent type: {:?}", agent_type);
@@ -364,7 +364,7 @@ impl InteractiveSessionManager {
         match agent_type {
             SessionAgentType::Claude | SessionAgentType::Codex | SessionAgentType::Gemini | SessionAgentType::Copilot => {
                 info!("Starting {:?} CLI in tmux session (model={:?}, skip_permissions={})", agent_type, model, skip_permissions);
-                self.start_cli_in_tmux(&tmux_session_name, skip_permissions, model, agent_type).await?;
+                self.start_cli_in_tmux(&tmux_session_name, skip_permissions, model, agent_type, None).await?;
             }
             _ => {
                 info!("Skipping CLI for agent type: {:?}", agent_type);
@@ -916,12 +916,17 @@ impl InteractiveSessionManager {
     }
 
     /// Start AI CLI in the tmux session (Claude, Codex, or Gemini)
-    async fn start_cli_in_tmux(
+    ///
+    /// `resume_transcript`, when supplied for `agent_type == Claude`, appends
+    /// `--resume <path>` to the CLI invocation. Mirrors `spawn-agent-lib.sh:508`.
+    /// Ignored for other agent types since they have no equivalent flag yet.
+    pub async fn start_cli_in_tmux(
         &self,
         session_name: &str,
         skip_permissions: bool,
         model: Option<ClaudeModel>,
         agent_type: SessionAgentType,
+        resume_transcript: Option<PathBuf>,
     ) -> Result<(), InteractiveSessionError> {
         use crate::config::CliProvider;
 
@@ -956,6 +961,23 @@ impl InteractiveSessionManager {
         // Add skip permissions flag if specified (provider-specific)
         if skip_permissions {
             cmd_parts.push(provider.skip_permissions_flag().to_string());
+        }
+
+        // Resume only supported by Claude today; other CLIs simply start fresh.
+        if agent_type == SessionAgentType::Claude {
+            if let Some(path) = resume_transcript.as_ref() {
+                cmd_parts.push("--resume".to_string());
+                cmd_parts.push(
+                    path.to_str()
+                        .ok_or_else(|| {
+                            InteractiveSessionError::Tmux(format!(
+                                "Resume transcript path is not valid UTF-8: {:?}",
+                                path
+                            ))
+                        })?
+                        .to_string(),
+                );
+            }
         }
 
         let cli_cmd = cmd_parts.join(" ");


### PR DESCRIPTION
## Summary

Adds a recoverable escape hatch for when the embedded `claude` (or `codex`/`gemini`/`copilot`) CLI hangs inside its tmux pane. Today the only escape is **D** (delete), which destroys the git worktree and the `sessions.json` entry. This change:

- **D** on an interactive session now opens a tri-option dialog: \`[Stop] [Delete] [Cancel]\` (Stop default — safe).
- **Stop** runs \`tmux kill-session -t <exact-name>\` and nothing else: worktree, \`by-session/<uuid>\` symlink, and \`sessions.json\` entry all survive. Session re-renders with a Stopped indicator.
- **Enter** or **r** on a Stopped interactive session resumes it: tmux is recreated at the same worktree and the CLI relaunches. For Claude, the latest \`.jsonl\` in \`~/.claude/projects/-{encoded-cwd}/\` is discovered and passed via \`--resume\` so the conversation continues. Codex/Gemini/Copilot start fresh with a banner explaining the limitation.
- Boss/Docker, SSH, and shell sessions keep the legacy binary Yes/No dialog — only interactive routes to the tri-option flow.

Three atomic commits, one concern each (audit hooks → CLI flag plumbing → feature wiring + tests). Use \`gh pr merge --merge\` to preserve them on \`main\`.

## Test plan

- [ ] \`cargo build\` — clean (warnings only, all pre-existing)
- [ ] \`cargo test --lib\` — 447 pass; 9 pre-existing \`docker::agents_dev_tests::*\` failures unrelated to this diff
- [ ] **Stop preserves worktree:** \`D → Stop\` on a healthy session → \`tmux has-session\` false; \`~/.agents-in-a-box/worktrees/by-session/<uuid>\` still resolves; \`sessions.json\` entry survives; ⏸ shows in list
- [ ] **Delete still works:** \`D → Delete\` on a healthy session → worktree, symlink, and sessions.json entry all gone (existing behavior unchanged)
- [ ] **Resume restores conversation:** Enter on ⏸ → tmux recreated; Claude boots with prior conversation visible; status flips to ●; banner reads \`Resumed\`
- [ ] **Resume with no transcript:** Delete \`~/.claude/projects/-{encoded}/*.jsonl\`, press Enter → fresh session; banner reads \`No transcript found at … — starting fresh\`
- [ ] **Resume non-Claude agent:** Codex/Gemini/Copilot session resumes fresh; banner reads \`Resumed (fresh session — {agent} doesn't support --resume)\`
- [ ] **Stuck session canary:** \`D → Stop → Enter\` on the existing stuck \`tmux_shotclubhouse_shotclubhouse_temp_debug_temp_debug\` recovers without losing the worktree
- [ ] **Boss-mode unchanged:** D on Boss/Docker session still shows binary Yes/No
- [ ] **Audit trail:** \`grep audit ~/.agents-in-a-box/logs/ainb-tui.log\` shows \`SESSION_STOPPED\` (trigger=\`keypress:D→Stop\`) and \`SESSION_RESUMED\` (trigger=\`keypress:Enter\` or \`keypress:r\`) — both success and failure paths

## Out of scope (deferred)

- Boss/Docker soft-stop (container preservation): not addressed — existing binary D dialog stays for those sessions.
- Shell-escape on the \`--resume\` argv path: pre-existing pattern in \`start_cli_in_tmux\` (\`cmd_parts.join(" ")\`); risk is theoretical for Stevie's cwd but worth a follow-up cleanup.
- The "stuck splash screen, no spinner" tmux-claude hang itself is not fixed — this PR only adds the escape hatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume stopped interactive sessions with new keybindings (Enter resumes and attaches; R resumes or re-authenticates).
  * Enhanced confirmation dialogs now support multiple options with arrow-key navigation.
  * Added stop-session functionality distinct from deletion.

* **Improvements**
  * Better detection of stopped sessions even when external session managers are unavailable.
  * Claude sessions can now resume from previous transcripts, preserving context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->