### PR TITLE
docs(skill): squash→merge commit recovery recipe in git-history-surgery

### DIFF
--- a/toolkit/packages/skills/git-history-surgery/SKILL.md
+++ b/toolkit/packages/skills/git-history-surgery/SKILL.md
@@ -99,3 +99,48 @@ If `--force-with-lease` rejects:
 ## Why this matters
 
 Shared branches with force-push capability are one shell-slip away from catastrophic history loss. The throwaway-worktree + lease + verify-diff pattern makes the operation idempotent: if any step fails, nothing bad has happened yet. Only the final push is destructive, and the lease gates that.
+
+## Recipe: Swap a squash-merge for a true merge commit (post-merge correction)
+
+**Scenario:** A PR was already squash-merged but it should have been a merge commit (e.g., the project prefers to preserve atomic per-concern commits in main's history). The squash commit sits on the default branch.
+
+**Trick:** the squash commit's tree IS the merged result. Reuse it. Build a new commit object that points to the same tree but has two parents (pre-squash main tip + feature branch tip). Force-push to swap. No actual re-merge happens, so there's no chance of conflicts and no working-tree changes.
+
+```bash
+# 1. Identify SHAs
+SQUASH=$(git rev-parse origin/main)              # current main tip (the squash)
+PRE_SQUASH=$(git rev-parse $SQUASH^)             # main before the squash
+FEATURE=$(git rev-parse <feature-branch>)        # feature branch tip (must still exist locally or on remote)
+TREE=$(git rev-parse $SQUASH^{tree})             # merged tree (already correct)
+
+# 2. Build the merge commit object via plumbing — no working tree touched
+MERGE=$(git commit-tree $TREE -p $PRE_SQUASH -p $FEATURE \
+  -m "Merge pull request #N from <branch>" \
+  -m "<body>")
+
+# 3. Sanity check — trees MUST match. If they don't, abort.
+[ "$(git rev-parse $SQUASH^{tree})" = "$(git rev-parse $MERGE^{tree})" ] \
+  || { echo "TREE MISMATCH — abort"; exit 1; }
+
+# 4. Force-push with lease scoped to the squash SHA
+#    Refuses if anyone else has moved main since the squash.
+git push --force-with-lease=main:$SQUASH origin $MERGE:refs/heads/main
+
+# 5. Verify
+git fetch origin main
+git log --pretty=format:"%h %p %s" -1 origin/main   # should show two parents
+```
+
+**Why this works:** `git commit-tree` is plumbing that creates a commit object pointing at any tree with any parents, no merge driver involved. Since the squash already produced the correct merged tree, you're just relabeling that tree as a merge commit with the right parentage. The byte-identical-tree assertion is the safety check that proves you haven't lost or added content.
+
+**When to use:**
+- Project convention is merge-commits, but a squash slipped through.
+- You want to preserve the feature branch's atomic commits as parents reachable from main.
+- The squashed PR landed within the last few commits and nothing else has been built on top.
+
+**When NOT to use:**
+- Other commits have landed on main on top of the squash (`origin/main^` is no longer the pre-squash SHA). The lease will reject anyway, but the operation is no longer simply reversible — you'd need to rebuild the chain.
+- The feature branch was deleted from remote *and* local, with no reflog. You can't reconstitute a merge without parent2.
+- The squash combined changes from multiple feature branches (rare, but the recipe assumes 1:1).
+
+**Branch protection:** Default-branch force-push usually requires admin override. Coordinate or use `gh api` with admin token if needed. Per `feedback_force_push_docs`, in this repo history-surgery on main is acceptable when the trees match and the lease holds.


### PR DESCRIPTION
## Summary

Adds a post-merge correction recipe to the git-history-surgery skill: how to swap a squash-merge for a true merge commit using \`git commit-tree\` plumbing.

The recipe reuses the squash commit's tree as the merged result and creates a new commit object pointing at the same tree with two parents (pre-squash main + feature branch tip), then force-pushes with lease. Byte-identical-tree assertion guarantees no content drift; the lease scoped to the squash SHA refuses concurrent writes.

Captured after using exactly this sequence to convert PR #51's squash into the merge commit currently on \`main\` as \`008e0c3\`.

## Test plan

- [ ] Skill renders correctly
- [ ] Recipe is reproducible from the documented steps (already validated against PR #51)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for a post-merge correction workflow with safety controls to prevent errors
  * Includes verification steps and tree validation checks
  * Provides clear guidance on when to use this approach and operational constraints to consider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->