### PR TITLE
fix(ainb-tui): stop dead worktrees fabricating phantom workspaces

### DIFF
--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3619,9 +3619,20 @@ impl AppState {
                     live_tmux_names.insert(interactive_session.tmux_session_name.clone());
                     let session = interactive_session.to_session_model();
 
-                    // Find or create workspace for this session
-                    // Use source_repository (the original git repo) not worktree_path parent
-                    let workspace_path = &interactive_session.source_repository;
+                    // Find or create workspace for this session.
+                    // Use source_repository (the original git repo) not worktree_path parent.
+                    // When the worktree is broken (no `.git`), source_repository was
+                    // collapsed onto worktree_path by the discovery fallback — bucket
+                    // every such session under a single sentinel path so they all
+                    // collapse into one "(broken)" workspace row instead of fanning out.
+                    let broken_bucket = std::path::PathBuf::from("__broken_worktrees__");
+                    let is_broken = interactive_session.workspace_name
+                        == crate::interactive::InteractiveSessionManager::BROKEN_WORKSPACE_NAME;
+                    let workspace_path: &std::path::Path = if is_broken {
+                        broken_bucket.as_path()
+                    } else {
+                        interactive_session.source_repository.as_path()
+                    };
 
                     // Remove any stale entries for this session (e.g., added by Boss-mode loader)
                     for workspace in &mut self.workspaces {
@@ -3663,6 +3674,15 @@ impl AppState {
         // sessions.json whose tmux session is no longer alive but whose worktree
         // still exists on disk. Worktree-missing entries fall through to the
         // existing recovery flow.
+        //
+        // Skip "dead-but-not-deleted" worktrees (dir exists but `.git` file is
+        // gone — usually a leftover cache like `.vite/` keeping the dir alive).
+        // Without this guard the loader fabricates a phantom workspace named
+        // after the sanitized worktree-dir basename and bunches every such
+        // session into it, because the previous grouping key was
+        // `worktree_path.parent()` (a single shared dir for every flat
+        // worktree). These entries should be surfaced via /recover-sessions
+        // instead.
         let store = SessionStore::load();
         for metadata in store.sessions().values() {
             if live_tmux_names.contains(&metadata.tmux_session_name) {
@@ -3672,8 +3692,24 @@ impl AppState {
                 continue;
             }
 
+            let Some(source_repo) =
+                crate::interactive::InteractiveSessionManager::get_source_repository(
+                    &metadata.worktree_path,
+                )
+            else {
+                debug!(
+                    "Skipping stopped session {} — worktree {:?} has no `.git` file (broken). Use /recover-sessions to clean up.",
+                    metadata.session_id, metadata.worktree_path
+                );
+                continue;
+            };
+
             let stopped = Self::stopped_session_from_metadata(metadata);
-            let workspace_path = metadata.worktree_path.parent().unwrap_or(&metadata.worktree_path).to_path_buf();
+            // Group by the actual source repository (matches Phase 1's
+            // grouping above). The previous `worktree_path.parent()` key was
+            // always the shared `~/.agents-in-a-box/worktrees/` dir, which
+            // collapsed every stopped session into one bucket.
+            let workspace_path = source_repo.clone();
 
             if let Some(workspace) = self.workspaces.iter_mut().find(|w| {
                 std::path::Path::new(&w.path).canonicalize().ok()
@@ -3683,11 +3719,6 @@ impl AppState {
                     workspace.sessions.push(stopped);
                 }
             } else {
-                let source_repo =
-                    crate::interactive::InteractiveSessionManager::get_source_repository(
-                        &metadata.worktree_path,
-                    )
-                    .unwrap_or_else(|| metadata.worktree_path.clone());
                 let workspace_name =
                     crate::interactive::InteractiveSessionManager::derive_workspace_name(
                         &metadata.worktree_path,

--- a/ainb-tui/src/interactive/session_manager.rs
+++ b/ainb-tui/src/interactive/session_manager.rs
@@ -610,12 +610,23 @@ impl InteractiveSessionManager {
         }
     }
 
+    /// Sentinel workspace name for sessions whose worktree is on disk but
+    /// has no `.git` file (e.g. emptied except for a leftover cache like
+    /// `.vite/`). Callers also use this as the workspace bucket key so
+    /// every broken session collapses into one row instead of fanning out.
+    pub const BROKEN_WORKSPACE_NAME: &'static str = "(broken)";
+
     /// Derive a workspace display name from a worktree path.
     ///
     /// Why: only the legacy `<repo>--<hash>--<session>` worktree layout encodes
     /// the repo in the directory name. Newer flat-format paths (no `--`) made
     /// `path.split("--").next()` return the entire directory, producing bogus
     /// workspace groups like `shotclubhouse_shotclubhouse_temp_debug`.
+    ///
+    /// When the worktree is broken (no `.git` file), callers fall back to
+    /// passing `worktree_path` itself as `source_repository`. Detect that
+    /// collapse and surface `(broken)` instead of the sanitized doubled-prefix
+    /// dir name — otherwise a dead worktree dir appears as a real workspace.
     pub fn derive_workspace_name(worktree_path: &Path, source_repository: &Path) -> String {
         let from_dir = worktree_path
             .file_name()
@@ -623,12 +634,21 @@ impl InteractiveSessionManager {
             .filter(|name| name.contains("--"))
             .and_then(|name| name.split("--").next());
 
-        from_dir
-            .or_else(|| {
-                source_repository
-                    .file_name()
-                    .and_then(|n| n.to_str())
-            })
+        if let Some(name) = from_dir {
+            return name.to_string();
+        }
+
+        // Broken-worktree sentinel: the loaders fall back to
+        // `source_repository = worktree_path` whenever `get_source_repository`
+        // returns None. We only treat that collapse as "broken" when both
+        // paths actually have a basename (so `/` + `/` still yields "unknown").
+        if source_repository == worktree_path && worktree_path.file_name().is_some() {
+            return Self::BROKEN_WORKSPACE_NAME.to_string();
+        }
+
+        source_repository
+            .file_name()
+            .and_then(|n| n.to_str())
             .unwrap_or("unknown")
             .to_string()
     }
@@ -1133,10 +1153,21 @@ mod tests {
             "shotclubhouse"
         );
 
-        // Both unusable → "unknown"
+        // Both unusable → "unknown" (root paths have no `file_name`,
+        // so the broken-sentinel branch is skipped).
         assert_eq!(
             InteractiveSessionManager::derive_workspace_name(Path::new("/"), Path::new("/")),
             "unknown"
+        );
+
+        // Broken worktree: source_repository collapsed onto worktree_path
+        // (caller's get_source_repository() returned None and used the
+        // worktree_path as fallback). Must surface "(broken)" rather than
+        // the doubled-prefix dir name.
+        let dead = Path::new("/wt/shotclubhouse_shotclubhouse_fix_all-bugs");
+        assert_eq!(
+            InteractiveSessionManager::derive_workspace_name(dead, dead),
+            InteractiveSessionManager::BROKEN_WORKSPACE_NAME
         );
     }
 


### PR DESCRIPTION
## Summary

Two compounding bugs caused a phantom workspace named `shotclubhouse_shotclubhouse_fix_all-bugs` (5) to appear in the sessions tree on refresh, with sessions that look like duplicates of those under their real workspaces.

**Trigger**: a worktree dir on disk with no `.git` file — e.g. the worktree was removed but a leftover cache subdir like `.vite/` kept the dir alive.

- **Bug A — fake workspace name.** `get_source_repository()` returns None when there's no `.git` file. Callers (`session_manager.rs:483-484`, `state.rs:3686-3690` pre-fix) fell back to passing `worktree_path` itself as `source_repository`, and `derive_workspace_name` returned the worktree's own dir basename — i.e. the doubled-prefix sanitized name. The 1d14d99 self-heal didn't help because it relies on source_repo basename being *different* from worktree basename.
- **Bug B — sessions all bunched.** The Phase 2 (stopped) loader grouped by `metadata.worktree_path.parent()`, which is the shared `~/.agents-in-a-box/worktrees/` for every flat worktree. The first stopped session created a workspace at that path, every subsequent one merged in.

## Fix

- **`derive_workspace_name`**: detect the `source_repository == worktree_path` collapse and return a `(broken)` sentinel (only when `worktree_path.file_name().is_some()` so root-paths still resolve to `unknown`).
- **Phase 1 live sessions**: if a discovered session arrives with the `(broken)` workspace name, bucket it under a single `__broken_worktrees__` sentinel path — all live broken sessions collapse into one row instead of fanning out one phantom workspace per dead dir.
- **Phase 2 stopped sessions**: if `get_source_repository()` is `None`, skip the metadata entirely (these belong in `/recover-sessions`). Group the rest by the resolved `source_repo`, matching Phase 1 — no more shared-parent collapse.

A `BROKEN_WORKSPACE_NAME` constant is exposed on `InteractiveSessionManager` so the state-level grouping stays in sync with the helper.

## Test plan

- [x] `cargo test --lib derive_workspace_name` — added a test for the broken-collapse case (`(broken)` instead of dir basename); existing legacy / flat / unknown cases still pass.
- [x] `cargo test --lib` — 470 pass, 9 fail (all `docker::agents_dev_tests::*` with `Connection refused`, unrelated).
- [x] `cargo build` — clean, no new warnings introduced near the edits.
- [ ] Manual: reproduce the screenshot scenario by emptying a worktree dir but leaving `.vite/`, then refresh sessions tree — phantom workspace should disappear (stopped) or collapse under `(broken)` (live).

## Follow-ups (not in this PR)

- `worktree_manager::remove_worktree` could `remove_dir_all` after `git worktree remove` so cache leftovers don't keep dead dirs alive past cleanup.
- Stale fan-out in `sessions.json` — multiple `tmux_session_name` keys for the same `session_id` — could be pruned opportunistically on load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of broken and corrupted Git worktrees during session discovery
  * Sessions with missing repositories are now properly identified and directed to recovery options
  * Enhanced workspace grouping organization for damaged worktree instances

* **Tests**
  * Extended test coverage for workspace name derivation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->