### PR TITLE
feat(ainb-tui): persistent SQLite cache for usage analytics scan

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -71,6 +71,11 @@ pulldown-cmark = "0.9"  # Markdown parsing
 syntect = "5.0"  # Syntax highlighting for code blocks
 ansi-to-tui = "4"
 
+# Persistent usage analytics cache
+rusqlite = { version = "0.31", features = ["bundled", "blob"] }
+blake3 = "1"
+bincode = "1.3"
+
 [features]
 default = []
 visual-debug = []  # Enable live terminal during tests

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -346,7 +346,8 @@ pub enum AppEvent {
     UsagePageDown,            // Page down
     UsageToTop,               // Jump to top (g)
     UsageToBottom,            // Jump to bottom (G)
-    UsageRefresh,             // Reload data (r)
+    UsageRefresh,             // Reload data (r) — cache-respecting
+    UsageForceRefresh,        // Force-refresh bypassing the persistent cache (Shift+R)
     UsageCycleProviderFilter, // Cycle All/Claude/Codex (p)
     UsageSetPeriod(u8),       // Period shortcut 1-5
     UsageStartIncludeFilter,  // Start include project input (/)
@@ -1664,6 +1665,7 @@ impl EventHandler {
             KeyCode::Char('g') => Some(AppEvent::UsageToTop),
             KeyCode::Char('G') => Some(AppEvent::UsageToBottom),
             KeyCode::Char('r') => Some(AppEvent::UsageRefresh),
+            KeyCode::Char('R') => Some(AppEvent::UsageForceRefresh),
             KeyCode::Char('p') => Some(AppEvent::UsageCycleProviderFilter),
             KeyCode::Char('1') => Some(AppEvent::UsageSetPeriod(1)),
             KeyCode::Char('2') => Some(AppEvent::UsageSetPeriod(2)),
@@ -4096,6 +4098,15 @@ impl EventHandler {
                 tracing::info!("Refreshing usage data");
                 let msg = if state.start_background_usage_load(true) {
                     "Refreshing usage data…"
+                } else {
+                    "Refresh already in progress"
+                };
+                state.add_success_notification(msg.to_string());
+            }
+            AppEvent::UsageForceRefresh => {
+                tracing::info!("Force-refreshing usage data (bypass cache)");
+                let msg = if state.start_background_usage_load_with_options(true, true) {
+                    "Force-refreshing usage data (cache cleared)…"
                 } else {
                     "Refresh already in progress"
                 };

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3458,6 +3458,17 @@ impl AppState {
     /// The parse walks ~1GB of jsonl files; keeping it off the event thread
     /// is what prevents the Stats/Usage screen from hanging on provider switch.
     pub fn start_background_usage_load(&mut self, force: bool) -> bool {
+        self.start_background_usage_load_with_options(force, false)
+    }
+
+    /// Variant with explicit cache control. `bypass_cache = true` clears the
+    /// persistent usage cache before parsing — used by `Shift+R` (force
+    /// refresh) and the CLI `--no-cache` flag.
+    pub fn start_background_usage_load_with_options(
+        &mut self,
+        force: bool,
+        bypass_cache: bool,
+    ) -> bool {
         if self.usage_load_receiver.is_some() {
             return false;
         }
@@ -3469,8 +3480,15 @@ impl AppState {
         self.usage_state.loading = true;
         let query = self.usage_state.query();
         tokio::spawn(async move {
-            match tokio::task::spawn_blocking(move || crate::models::usage::parse_usage_for(query))
-                .await
+            match tokio::task::spawn_blocking(move || {
+                if bypass_cache {
+                    if let Err(err) = crate::models::usage::shared_cache().clear() {
+                        warn!("Usage cache clear failed during force-refresh: {err}");
+                    }
+                }
+                crate::models::usage::parse_usage_for(query)
+            })
+            .await
             {
                 Ok(data) => {
                     let _ = tx.send(data);

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3482,11 +3482,25 @@ impl AppState {
         tokio::spawn(async move {
             match tokio::task::spawn_blocking(move || {
                 if bypass_cache {
-                    if let Err(err) = crate::models::usage::shared_cache().clear() {
-                        warn!("Usage cache clear failed during force-refresh: {err}");
+                    // Wipe persisted rows so future runs start fresh, but
+                    // also bypass the singleton for THIS parse — clear()
+                    // failure (locked DB, IO error) must not silently
+                    // degrade force-refresh into a regular cached refresh.
+                    let clear_failed = crate::models::usage::shared_cache().clear().is_err();
+                    if clear_failed {
+                        warn!(
+                            "Usage cache clear failed during force-refresh; \
+                             parsing with disabled cache to honour bypass"
+                        );
                     }
+                    crate::models::usage::parse_usage_for_with_roots_and_cache(
+                        query,
+                        &crate::models::usage::UsageSourceRoots::default(),
+                        crate::models::usage::disabled_cache(),
+                    )
+                } else {
+                    crate::models::usage::parse_usage_for(query)
                 }
-                crate::models::usage::parse_usage_for(query)
             })
             .await
             {

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -5,8 +5,9 @@ use crate::cli::OutputFormat;
 use crate::config::{AppConfig, CurrencyConfig, UsagePlan, UsagePlanId, UsagePlanProvider};
 use crate::models::usage::{
     ActivityUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsagePeriod,
-    UsageProviderFilter, UsageQuery, analyze_yield, billing_period, compare_models, optimize_usage,
-    parse_usage_for,
+    UsageProviderFilter, UsageQuery, UsageSourceRoots, analyze_yield, billing_period,
+    compare_models, disabled_cache, optimize_usage, parse_usage_for,
+    parse_usage_for_with_roots_and_cache,
 };
 use anyhow::{Result, anyhow, bail};
 use chrono::{Local, NaiveDate};
@@ -64,6 +65,9 @@ pub struct UsageReportArgs {
     /// Exclude projects matching substring
     #[arg(long)]
     pub exclude: Vec<String>,
+    /// Bypass the persistent usage cache and force a full re-parse.
+    #[arg(long)]
+    pub no_cache: bool,
 }
 
 #[derive(Args, Clone, Default)]
@@ -473,7 +477,16 @@ fn model_alias_command(args: UsageModelAliasArgs) -> Result<()> {
 }
 
 fn load_usage(args: &UsageReportArgs) -> Result<UsageData> {
-    Ok(parse_usage_for(query_from_args(args)?))
+    let query = query_from_args(args)?;
+    if args.no_cache {
+        Ok(parse_usage_for_with_roots_and_cache(
+            query,
+            &UsageSourceRoots::default(),
+            disabled_cache(),
+        ))
+    } else {
+        Ok(parse_usage_for(query))
+    }
 }
 
 fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -7,7 +7,7 @@ use crate::models::usage::{
     ActivityUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsagePeriod,
     UsageProviderFilter, UsageQuery, UsageSourceRoots, analyze_yield, billing_period,
     compare_models, disabled_cache, optimize_usage, parse_usage_for,
-    parse_usage_for_with_roots_and_cache,
+    parse_usage_for_with_roots_and_cache, shared_cache,
 };
 use anyhow::{Result, anyhow, bail};
 use chrono::{Local, NaiveDate};
@@ -43,6 +43,19 @@ pub enum UsageCommands {
     Compare(UsageReportArgs),
     /// Estimate usage yield from session signals
     Yield(UsageReportArgs),
+    /// Inspect or wipe the persistent usage cache
+    Cache {
+        #[command(subcommand)]
+        command: UsageCacheCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UsageCacheCommands {
+    /// Show cache DB path, on-disk size, file count, oldest entry timestamp
+    Info,
+    /// Drop all cached file rows (schema_version row preserved)
+    Clear,
 }
 
 #[derive(Args, Clone, Default)]
@@ -182,6 +195,62 @@ pub async fn execute(command: UsageCommands, format: OutputFormat) -> Result<()>
         UsageCommands::Optimize(args) => print_optimize(&args, format),
         UsageCommands::Compare(args) => print_compare(&args, format),
         UsageCommands::Yield(args) => print_yield(&args, format),
+        UsageCommands::Cache { command } => cache_command(command, format),
+    }
+}
+
+fn cache_command(command: UsageCacheCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        UsageCacheCommands::Info => {
+            let cache = shared_cache();
+            let info = cache
+                .info()
+                .map_err(|e| anyhow!("usage cache info failed: {e}"))?;
+            match format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "db_path": info.db_path,
+                            "size_bytes": info.size_bytes,
+                            "file_count": info.file_count,
+                            "oldest_updated_at": info.oldest_updated_at,
+                            "enabled": cache.is_enabled(),
+                        }))?
+                    );
+                }
+                _ => {
+                    println!("Usage cache");
+                    println!("  Path:           {}", info.db_path.display());
+                    println!("  Size on disk:   {} bytes", info.size_bytes);
+                    println!("  File count:     {}", info.file_count);
+                    println!(
+                        "  Oldest entry:   {}",
+                        info.oldest_updated_at
+                            .map(|t| t.to_string())
+                            .unwrap_or_else(|| "—".to_string())
+                    );
+                    println!(
+                        "  Enabled:        {}",
+                        if cache.is_enabled() { "yes" } else { "no" }
+                    );
+                }
+            }
+            Ok(())
+        }
+        UsageCacheCommands::Clear => {
+            let cache = shared_cache();
+            cache
+                .clear()
+                .map_err(|e| anyhow!("usage cache clear failed: {e}"))?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&json!({"cleared": true}))?);
+                }
+                _ => println!("Usage cache cleared."),
+            }
+            Ok(())
+        }
     }
 }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1811,6 +1811,8 @@ fn render_help_bar(frame: &mut Frame, area: Rect) {
         Span::styled(" top/bottom  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("r", Style::default().fg(GOLD)),
         Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("R", Style::default().fg(GOLD)),
+        Span::styled(" force refresh  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("Esc", Style::default().fg(GOLD)),
         Span::styled(" back", Style::default().fg(MUTED_GRAY)),
     ];

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1004,7 +1004,7 @@ fn render_burndown_header(frame: &mut Frame, area: Rect, data: &UsageData, perio
 fn render_period_row(frame: &mut Frame, area: Rect, state: &UsageViewState) {
     let text = Line::from(vec![
         Span::styled(
-            "[1 Today]  [2 7d]  [3 30d]  [4 Month]  [5 All]  [d Custom]  [/] filter  [x] exclude  [r] reload",
+            "[1 Today]  [2 7d]  [3 30d]  [4 Month]  [5 All]  [d Custom]  [/] filter  [x] exclude  [r] reload  [R] force refresh",
             Style::default().fg(MUTED_GRAY),
         ),
         Span::styled("   Active: ", Style::default().fg(MUTED_GRAY)),

--- a/ainb-tui/src/lib.rs
+++ b/ainb-tui/src/lib.rs
@@ -16,4 +16,5 @@ pub mod git;
 pub mod interactive;
 pub mod models;
 pub mod tmux;
+pub mod usage_cache;
 pub mod widgets;

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -43,6 +43,7 @@ mod git;
 mod interactive;
 mod models;
 mod tmux;
+mod usage_cache;
 mod widgets;
 
 use app::{App, EventHandler};

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -139,6 +139,21 @@ impl TokenBucket {
 ///
 /// `Deserialize` is required for bincode round-trip in the persistent
 /// usage cache (`usage_cache::store`).
+///
+/// **WARNING — bincode layout stability.** Bincode v1 with default options
+/// encodes positionally with no field tags. Any change to the field set or
+/// order of this struct (or any nested type it owns) silently invalidates
+/// every cached blob written under the current `BLOB_FORMAT_BINCODE_V1`.
+/// Wrong-shape decodes can either panic (caught — falls through to a full
+/// re-parse) or, much worse, succeed with mis-aligned bytes and return
+/// wrong analytics from the cache.
+///
+/// **If you change this struct or any nested type, you MUST:**
+/// 1. Bump `usage_cache::db::BLOB_FORMAT_BINCODE_V1` to a new value, and
+/// 2. Update the layout-stability tripwire test in `usage_cache::tests`.
+///
+/// The tripwire test asserts a fixed serialized byte length for a known
+/// fixture and will fail CI if the layout drifts without an explicit bump.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderCall {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -132,8 +132,11 @@ impl TokenBucket {
 }
 
 /// Per-provider API call parsed from a local session file.
+///
+/// `Deserialize` is required for bincode round-trip in the persistent
+/// usage cache (`usage_cache::store`).
 #[allow(dead_code)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderCall {
     pub provider: String,
     pub model: String,

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -409,12 +409,9 @@ fn default_cache() -> Arc<Cache> {
     static CACHE: OnceLock<Arc<Cache>> = OnceLock::new();
     CACHE
         .get_or_init(|| {
-            let path = match crate::usage_cache::store::default_db_path() {
-                Some(p) => p,
-                None => {
-                    debug!("usage_cache: no home dir; running with cache disabled");
-                    return Arc::new(Cache::disabled());
-                }
+            let Some(path) = crate::usage_cache::store::default_db_path() else {
+                debug!("usage_cache: no home dir; running with cache disabled");
+                return Arc::new(Cache::disabled());
             };
             match Cache::open(path.clone()) {
                 Ok(c) => Arc::new(c),

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -5,8 +5,12 @@ use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tracing::{debug, warn};
+
+use crate::usage_cache::{Cache, ParseHint, ParseResult};
 
 /// Usage period selector shared by TUI and CLI report queries.
 #[allow(dead_code)]
@@ -397,16 +401,67 @@ pub fn parse_usage_for(query: UsageQuery) -> UsageData {
     parse_usage_for_with_roots(query, &UsageSourceRoots::default())
 }
 
+/// Process-wide singleton cache handle. Constructed lazily; on open
+/// failure (eg. read-only home dir) we fall back to a disabled cache so
+/// analytics remain functional.
+fn default_cache() -> Arc<Cache> {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<Arc<Cache>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let path = match crate::usage_cache::store::default_db_path() {
+                Some(p) => p,
+                None => {
+                    debug!("usage_cache: no home dir; running with cache disabled");
+                    return Arc::new(Cache::disabled());
+                }
+            };
+            match Cache::open(path.clone()) {
+                Ok(c) => Arc::new(c),
+                Err(err) => {
+                    warn!("usage_cache: failed to open {:?} ({err}); cache disabled", path);
+                    Arc::new(Cache::disabled())
+                }
+            }
+        })
+        .clone()
+}
+
+/// Public helper for callers (CLI `--no-cache`, tests) to get a fresh
+/// disabled cache without going through the singleton.
+pub fn disabled_cache() -> Arc<Cache> {
+    Arc::new(Cache::disabled())
+}
+
+/// Public helper for callers that want the process-wide cache (eg. CLI
+/// `cache info` / `cache clear`).
+pub fn shared_cache() -> Arc<Cache> {
+    default_cache()
+}
+
 /// Parse local session files for a query using explicit roots.
 pub fn parse_usage_for_with_roots(query: UsageQuery, roots: &UsageSourceRoots) -> UsageData {
+    parse_usage_for_with_roots_and_cache(query, roots, default_cache())
+}
+
+/// Parse local session files for a query, using an explicit cache. Pass
+/// `Cache::disabled()` to bypass the cache entirely.
+pub fn parse_usage_for_with_roots_and_cache(
+    query: UsageQuery,
+    roots: &UsageSourceRoots,
+    cache: Arc<Cache>,
+) -> UsageData {
     let range = date_range_for_period(&query.period);
     let mut calls = Vec::new();
 
     if query.provider_filter.includes("claude") {
-        calls.extend(parse_claude_sources(roots.claude_projects_dir.as_deref()));
+        calls.extend(parse_claude_sources(
+            roots.claude_projects_dir.as_deref(),
+            cache.as_ref(),
+        ));
     }
     if query.provider_filter.includes("codex") {
-        calls.extend(parse_codex_sources(roots.codex_dir.as_deref()));
+        calls.extend(parse_codex_sources(roots.codex_dir.as_deref(), cache.as_ref()));
     }
 
     let filtered = calls
@@ -422,7 +477,7 @@ pub fn parse_usage_for_with_roots(query: UsageQuery, roots: &UsageSourceRoots) -
     aggregate_calls(filtered)
 }
 
-fn parse_claude_sources(projects_dir: Option<&Path>) -> Vec<ProviderCall> {
+fn parse_claude_sources(projects_dir: Option<&Path>, cache: &Cache) -> Vec<ProviderCall> {
     let Some(projects_dir) = projects_dir else {
         return Vec::new();
     };
@@ -448,7 +503,19 @@ fn parse_claude_sources(projects_dir: Option<&Path>) -> Vec<ProviderCall> {
         let project_path = unsanitize_project_path(raw_name);
 
         for jsonl_path in collect_claude_jsonl_files(&path) {
-            calls.extend(parse_claude_source(&jsonl_path, &project, &project_path));
+            let project = project.clone();
+            let project_path = project_path.clone();
+            let parsed = cache.get_or_parse(&jsonl_path, |path, hint| match hint {
+                ParseHint::Full => parse_claude_source_full(path, &project, &project_path),
+                ParseHint::Append { from_offset, existing } => parse_claude_source_append(
+                    path,
+                    &project,
+                    &project_path,
+                    from_offset,
+                    existing,
+                ),
+            });
+            calls.extend(parsed);
         }
     }
 
@@ -483,86 +550,164 @@ fn collect_claude_jsonl_files(project_dir: &Path) -> Vec<PathBuf> {
     files
 }
 
-fn parse_claude_source(path: &Path, project: &str, project_path: &str) -> Vec<ProviderCall> {
-    let content = match std::fs::read_to_string(path) {
-        Ok(content) => content,
-        Err(_) => return Vec::new(),
+/// Full parse of a Claude JSONL session file. Returns the complete
+/// `Vec<ProviderCall>` and the byte offset where parsing stopped (typically
+/// the file size at open time — note this is best-effort: if the file is
+/// being appended to concurrently we may stop short, which the cache will
+/// recover from on the next call via append-only).
+fn parse_claude_source_full(
+    path: &Path,
+    project: &str,
+    project_path: &str,
+) -> ParseResult {
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => {
+            return ParseResult {
+                calls: Vec::new(),
+                end_offset: 0,
+            };
+        }
     };
+    let mut content = String::new();
+    if file.read_to_string(&mut content).is_err() {
+        return ParseResult {
+            calls: Vec::new(),
+            end_offset: 0,
+        };
+    }
+    let end_offset = content.len() as u64;
 
     let mut calls = Vec::new();
     let mut current_user_message = String::new();
-
     for line in content.lines() {
-        let parsed: ClaudeLine = match serde_json::from_str(line) {
-            Ok(parsed) => parsed,
-            Err(_) => continue,
-        };
-
-        match parsed.msg_type.as_deref() {
-            Some("user") => {
-                if let Some(message) = parsed.message {
-                    current_user_message = extract_claude_user_text(message.content.as_ref());
-                }
-            }
-            Some("assistant") => {
-                let Some(message) = parsed.message else {
-                    continue;
-                };
-                let Some(usage) = message.usage else {
-                    continue;
-                };
-                let Some(timestamp) = parsed.timestamp.as_deref().and_then(parse_timestamp) else {
-                    continue;
-                };
-
-                let model = message.model.unwrap_or_else(|| "claude-unknown".to_string());
-                let tools = extract_claude_tools(message.content.as_ref());
-                let bash_commands =
-                    extract_bash_commands_from_claude_content(message.content.as_ref());
-                let input_tokens = usage.input_tokens.unwrap_or(0);
-                let output_tokens = usage.output_tokens.unwrap_or(0);
-                let cache_creation_tokens = usage.cache_creation_input_tokens.unwrap_or(0);
-                let cache_read_tokens = usage.cache_read_input_tokens.unwrap_or(0);
-                let cost_usd = estimate_cost_usd(
-                    &model,
-                    input_tokens,
-                    output_tokens,
-                    cache_creation_tokens,
-                    cache_read_tokens,
-                    0,
-                );
-
-                calls.push(ProviderCall {
-                    provider: "claude".to_string(),
-                    model,
-                    session_id: parsed.session_id.unwrap_or_else(|| {
-                        path.file_stem()
-                            .and_then(|stem| stem.to_str())
-                            .unwrap_or("unknown")
-                            .to_string()
-                    }),
-                    project: project.to_string(),
-                    project_path: parsed.cwd.unwrap_or_else(|| project_path.to_string()),
-                    timestamp,
-                    input_tokens,
-                    cache_creation_tokens,
-                    cache_read_tokens,
-                    output_tokens,
-                    reasoning_tokens: 0,
-                    cost_usd,
-                    tools,
-                    bash_commands,
-                    user_message: current_user_message.clone(),
-                });
-            }
-            _ => {}
+        if let Some(call) =
+            parse_claude_line(line, path, project, project_path, &mut current_user_message)
+        {
+            calls.push(call);
         }
     }
-
-    calls
+    ParseResult { calls, end_offset }
 }
 
-fn parse_codex_sources(codex_dir: Option<&Path>) -> Vec<ProviderCall> {
+/// Append-only parse: re-open the file, seek to `from_offset`, and parse
+/// only the new bytes. The returned `Vec<ProviderCall>` is `existing`
+/// concatenated with the new calls, so the cache can persist a complete
+/// blob for the file.
+///
+/// Trade-off: `current_user_message` state from before `from_offset` is
+/// not restored. New assistant rows that appear *before* the next user
+/// line in the appended tail will get an empty `user_message`. This is
+/// rare in practice and cheap to fix in a follow-up by persisting parser
+/// state alongside the row.
+fn parse_claude_source_append(
+    path: &Path,
+    project: &str,
+    project_path: &str,
+    from_offset: u64,
+    existing: &[ProviderCall],
+) -> ParseResult {
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => {
+            return ParseResult {
+                calls: existing.to_vec(),
+                end_offset: from_offset,
+            };
+        }
+    };
+    let total_len = file.metadata().map(|m| m.len()).unwrap_or(from_offset);
+    if file.seek(SeekFrom::Start(from_offset)).is_err() {
+        return ParseResult {
+            calls: existing.to_vec(),
+            end_offset: from_offset,
+        };
+    }
+    let reader = BufReader::new(file);
+    let mut calls = existing.to_vec();
+    let mut current_user_message = String::new();
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        if let Some(call) =
+            parse_claude_line(&line, path, project, project_path, &mut current_user_message)
+        {
+            calls.push(call);
+        }
+    }
+    ParseResult {
+        calls,
+        end_offset: total_len,
+    }
+}
+
+/// Parse a single Claude JSONL line. Returns `Some(call)` for assistant
+/// lines that carry usage data; mutates `current_user_message` when a
+/// user line is encountered. None for unrecognized / unparseable lines.
+fn parse_claude_line(
+    line: &str,
+    path: &Path,
+    project: &str,
+    project_path: &str,
+    current_user_message: &mut String,
+) -> Option<ProviderCall> {
+    let parsed: ClaudeLine = serde_json::from_str(line).ok()?;
+    match parsed.msg_type.as_deref() {
+        Some("user") => {
+            if let Some(message) = parsed.message {
+                *current_user_message = extract_claude_user_text(message.content.as_ref());
+            }
+            None
+        }
+        Some("assistant") => {
+            let message = parsed.message?;
+            let usage = message.usage?;
+            let timestamp = parsed.timestamp.as_deref().and_then(parse_timestamp)?;
+
+            let model = message.model.unwrap_or_else(|| "claude-unknown".to_string());
+            let tools = extract_claude_tools(message.content.as_ref());
+            let bash_commands =
+                extract_bash_commands_from_claude_content(message.content.as_ref());
+            let input_tokens = usage.input_tokens.unwrap_or(0);
+            let output_tokens = usage.output_tokens.unwrap_or(0);
+            let cache_creation_tokens = usage.cache_creation_input_tokens.unwrap_or(0);
+            let cache_read_tokens = usage.cache_read_input_tokens.unwrap_or(0);
+            let cost_usd = estimate_cost_usd(
+                &model,
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                0,
+            );
+
+            Some(ProviderCall {
+                provider: "claude".to_string(),
+                model,
+                session_id: parsed.session_id.unwrap_or_else(|| {
+                    path.file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .unwrap_or("unknown")
+                        .to_string()
+                }),
+                project: project.to_string(),
+                project_path: parsed.cwd.unwrap_or_else(|| project_path.to_string()),
+                timestamp,
+                input_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                output_tokens,
+                reasoning_tokens: 0,
+                cost_usd,
+                tools,
+                bash_commands,
+                user_message: current_user_message.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_codex_sources(codex_dir: Option<&Path>, cache: &Cache) -> Vec<ProviderCall> {
     let Some(codex_dir) = codex_dir else {
         return Vec::new();
     };
@@ -573,7 +718,16 @@ fn parse_codex_sources(codex_dir: Option<&Path>) -> Vec<ProviderCall> {
 
     let mut calls = Vec::new();
     for file in discover_codex_sources(&sessions_dir) {
-        calls.extend(parse_codex_source(&file));
+        // Codex sessions accumulate cumulative token totals across the file,
+        // so an append-only parse would need replayed state. For PR-A we
+        // ignore the append hint and always full-parse on change. The cache
+        // still serves the unchanged-fingerprint path.
+        let parsed = cache.get_or_parse(&file, |path, _hint| {
+            let calls = parse_codex_source(path);
+            let end_offset = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+            ParseResult { calls, end_offset }
+        });
+        calls.extend(parsed);
     }
     calls
 }

--- a/ainb-tui/src/usage_cache/db.rs
+++ b/ainb-tui/src/usage_cache/db.rs
@@ -47,12 +47,12 @@ pub fn open(path: &Path) -> Result<Connection, CacheError> {
 
 /// Ensure the cache DB matches `SCHEMA_VERSION`. Drops & recreates on mismatch.
 fn ensure_schema(conn: &Connection) -> Result<(), CacheError> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)",
-    )?;
+    conn.execute_batch("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)")?;
 
     let current: Option<i64> = conn
-        .query_row("SELECT version FROM schema_version LIMIT 1", [], |row| row.get(0))
+        .query_row("SELECT version FROM schema_version LIMIT 1", [], |row| {
+            row.get(0)
+        })
         .ok();
 
     if current == Some(SCHEMA_VERSION) {

--- a/ainb-tui/src/usage_cache/db.rs
+++ b/ainb-tui/src/usage_cache/db.rs
@@ -1,0 +1,89 @@
+// ABOUTME: SQLite connection + schema management for the usage cache.
+// Schema is content-addressable by version; bumping `SCHEMA_VERSION` drops &
+// rebuilds the DB. Acceptable because this is a derived cache, never source of
+// truth.
+
+//! Sqlite connection + schema lifecycle for the persistent usage cache.
+
+use rusqlite::{Connection, OpenFlags, params};
+use std::path::Path;
+
+use super::store::CacheError;
+
+/// Bumping this drops & rebuilds the DB on next open.
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// `files.blob_format` value for bincode v1 (`bincode::serialize` of
+/// `Vec<ProviderCall>` with default options).
+pub const BLOB_FORMAT_BINCODE_V1: i64 = 1;
+
+/// Open (or create) the usage-cache sqlite DB at `path`, applying schema and
+/// performance pragmas. Caller owns the resulting connection — wrap in a
+/// `Mutex` for cross-thread access.
+pub fn open(path: &Path) -> Result<Connection, CacheError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(CacheError::Io)?;
+    }
+
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+
+    // WAL gives us non-blocking readers + a single durable writer, which is
+    // exactly the cache's access pattern (TUI reads, occasional background
+    // writes). `synchronous=NORMAL` is the WAL-recommended balance: durable
+    // across crashes, not across power loss — fine for a derived cache.
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    conn.pragma_update(None, "temp_store", "MEMORY")?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+
+    ensure_schema(&conn)?;
+    Ok(conn)
+}
+
+/// Ensure the cache DB matches `SCHEMA_VERSION`. Drops & recreates on mismatch.
+fn ensure_schema(conn: &Connection) -> Result<(), CacheError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)",
+    )?;
+
+    let current: Option<i64> = conn
+        .query_row("SELECT version FROM schema_version LIMIT 1", [], |row| row.get(0))
+        .ok();
+
+    if current == Some(SCHEMA_VERSION) {
+        return Ok(());
+    }
+
+    // Drop everything but `schema_version` itself, then recreate.
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS files;
+         DELETE FROM schema_version;",
+    )?;
+
+    conn.execute_batch(
+        "CREATE TABLE files (
+             path           TEXT    PRIMARY KEY,
+             size_bytes     INTEGER NOT NULL,
+             mtime_nanos    INTEGER NOT NULL,
+             last_offset    INTEGER NOT NULL,
+             suffix_blake3  BLOB    NOT NULL,
+             row_count      INTEGER NOT NULL,
+             calls_blob     BLOB    NOT NULL,
+             blob_format    INTEGER NOT NULL,
+             updated_at     INTEGER NOT NULL
+         );
+         CREATE INDEX idx_files_updated_at ON files(updated_at);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_version (version) VALUES (?1)",
+        params![SCHEMA_VERSION],
+    )?;
+
+    Ok(())
+}

--- a/ainb-tui/src/usage_cache/fingerprint.rs
+++ b/ainb-tui/src/usage_cache/fingerprint.rs
@@ -1,0 +1,152 @@
+// ABOUTME: Per-file fingerprint + change-detection for the usage cache.
+// (size, mtime, suffix-hash) tuple; suffix hash catches the truncate+
+// rewrite-to-same-size case the (mtime,size) tuple alone misses.
+
+//! File fingerprinting for the persistent usage cache.
+
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use super::store::CacheError;
+
+/// How many trailing bytes feed into the suffix hash. 4 KiB is enough to
+/// catch nearly all in-place rewrites without paying for a full re-hash.
+pub const SUFFIX_HASH_BYTES: u64 = 4096;
+
+/// Per-file change-detection record stored in the cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileFingerprint {
+    /// Total size of the file at last parse, in bytes.
+    pub size_bytes: u64,
+    /// File mtime at last parse, in nanos since UNIX epoch.
+    pub mtime_nanos: i64,
+    /// `blake3` over the trailing [`SUFFIX_HASH_BYTES`] bytes of the file
+    /// (or the full file if smaller).
+    pub suffix_blake3: [u8; 32],
+}
+
+impl FileFingerprint {
+    /// Compute a fresh fingerprint for `path`.
+    pub fn from_path(path: &Path) -> Result<Self, CacheError> {
+        let mut file = File::open(path).map_err(CacheError::Io)?;
+        let meta = file.metadata().map_err(CacheError::Io)?;
+        Self::from_open_file(&mut file, &meta)
+    }
+
+    /// Compute fingerprint from an already-open file + its metadata.
+    pub fn from_open_file(file: &mut File, meta: &Metadata) -> Result<Self, CacheError> {
+        let size_bytes = meta.len();
+        let mtime_nanos = mtime_nanos_from_meta(meta);
+        let suffix_blake3 = hash_suffix(file, size_bytes)?;
+        Ok(Self {
+            size_bytes,
+            mtime_nanos,
+            suffix_blake3,
+        })
+    }
+
+    /// Build a fingerprint from raw column values (for sqlite reads). The
+    /// blob must be exactly 32 bytes; on size mismatch we return `Schema`.
+    pub fn from_columns(
+        size_bytes: u64,
+        mtime_nanos: i64,
+        suffix_bytes: &[u8],
+    ) -> Result<Self, CacheError> {
+        let suffix_blake3: [u8; 32] = suffix_bytes
+            .try_into()
+            .map_err(|_| CacheError::Schema("suffix_blake3 column not 32 bytes".into()))?;
+        Ok(Self {
+            size_bytes,
+            mtime_nanos,
+            suffix_blake3,
+        })
+    }
+}
+
+/// What action the caller should take on the next parse for this file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FingerprintAction {
+    /// File is byte-identical to last parse. Return cached blob.
+    Unchanged,
+    /// File grew. Caller should verify the prior tail still matches via
+    /// [`verify_append_safe`] and, if so, parse from `from_offset` only.
+    Append { from_offset: u64 },
+    /// Anything else (size shrank, suffix mismatch, no prior fingerprint).
+    /// Caller must full-re-parse.
+    FullReparse,
+}
+
+/// Decide what to do given the prior cached fingerprint + the file's current
+/// state on disk.
+///
+/// Pragmatic choices:
+/// * Same `size_bytes` and same suffix hash → `Unchanged`. mtime is
+///   ignored to tolerate sync tools that bump mtime without altering bytes,
+///   and clock skew that makes mtime appear to regress.
+/// * Size shrank → `FullReparse`. JSONL is append-only; truncation means
+///   the file was rewritten and prior offsets are meaningless.
+/// * Size grew → tentative `Append`. The byte-equality verification of the
+///   prior tail happens in [`verify_append_safe`] because it needs disk I/O.
+pub fn classify(
+    prior: &FileFingerprint,
+    current: &FileFingerprint,
+    prior_offset: u64,
+) -> FingerprintAction {
+    if prior.size_bytes == current.size_bytes && prior.suffix_blake3 == current.suffix_blake3 {
+        return FingerprintAction::Unchanged;
+    }
+
+    if current.size_bytes < prior.size_bytes {
+        return FingerprintAction::FullReparse;
+    }
+
+    FingerprintAction::Append {
+        from_offset: prior_offset,
+    }
+}
+
+/// Verify that, given a candidate `Append` action, the bytes that *were*
+/// present at `prior_size_bytes - SUFFIX_HASH_BYTES .. prior_size_bytes` in
+/// the prior parse still hash to `prior_suffix_blake3` in the current file.
+///
+/// Returns `true` if append is safe; `false` means the prior tail was
+/// rewritten and the caller must downgrade to `FullReparse`.
+pub fn verify_append_safe(
+    file: &mut File,
+    prior_size_bytes: u64,
+    prior_suffix_blake3: &[u8; 32],
+) -> Result<bool, CacheError> {
+    if prior_size_bytes == 0 {
+        return Ok(true);
+    }
+
+    let window = SUFFIX_HASH_BYTES.min(prior_size_bytes);
+    let start = prior_size_bytes - window;
+    file.seek(SeekFrom::Start(start)).map_err(CacheError::Io)?;
+    let mut buf = vec![0u8; window as usize];
+    file.read_exact(&mut buf).map_err(CacheError::Io)?;
+    let hash = blake3::hash(&buf);
+    Ok(hash.as_bytes() == prior_suffix_blake3)
+}
+
+fn hash_suffix(file: &mut File, size_bytes: u64) -> Result<[u8; 32], CacheError> {
+    if size_bytes == 0 {
+        return Ok(*blake3::hash(&[]).as_bytes());
+    }
+    let window = SUFFIX_HASH_BYTES.min(size_bytes);
+    let start = size_bytes - window;
+    file.seek(SeekFrom::Start(start)).map_err(CacheError::Io)?;
+    let mut buf = vec![0u8; window as usize];
+    file.read_exact(&mut buf).map_err(CacheError::Io)?;
+    Ok(*blake3::hash(&buf).as_bytes())
+}
+
+fn mtime_nanos_from_meta(meta: &Metadata) -> i64 {
+    use std::time::UNIX_EPOCH;
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .and_then(|d| i64::try_from(d.as_nanos()).ok())
+        .unwrap_or(0)
+}

--- a/ainb-tui/src/usage_cache/fingerprint.rs
+++ b/ainb-tui/src/usage_cache/fingerprint.rs
@@ -28,6 +28,7 @@ pub struct FileFingerprint {
 
 impl FileFingerprint {
     /// Compute a fresh fingerprint for `path`.
+    #[allow(dead_code)]
     pub fn from_path(path: &Path) -> Result<Self, CacheError> {
         let mut file = File::open(path).map_err(CacheError::Io)?;
         let meta = file.metadata().map_err(CacheError::Io)?;

--- a/ainb-tui/src/usage_cache/fingerprint.rs
+++ b/ainb-tui/src/usage_cache/fingerprint.rs
@@ -85,6 +85,8 @@ pub enum FingerprintAction {
 /// * Same `size_bytes` and same suffix hash → `Unchanged`. mtime is
 ///   ignored to tolerate sync tools that bump mtime without altering bytes,
 ///   and clock skew that makes mtime appear to regress.
+/// * Same `size_bytes` but different suffix → `FullReparse`. The trailing
+///   bytes were rewritten in place; we can't trust any prior offset.
 /// * Size shrank → `FullReparse`. JSONL is append-only; truncation means
 ///   the file was rewritten and prior offsets are meaningless.
 /// * Size grew → tentative `Append`. The byte-equality verification of the
@@ -94,8 +96,11 @@ pub fn classify(
     current: &FileFingerprint,
     prior_offset: u64,
 ) -> FingerprintAction {
-    if prior.size_bytes == current.size_bytes && prior.suffix_blake3 == current.suffix_blake3 {
-        return FingerprintAction::Unchanged;
+    if prior.size_bytes == current.size_bytes {
+        if prior.suffix_blake3 == current.suffix_blake3 {
+            return FingerprintAction::Unchanged;
+        }
+        return FingerprintAction::FullReparse;
     }
 
     if current.size_bytes < prior.size_bytes {
@@ -108,22 +113,24 @@ pub fn classify(
 }
 
 /// Verify that, given a candidate `Append` action, the bytes that *were*
-/// present at `prior_size_bytes - SUFFIX_HASH_BYTES .. prior_size_bytes` in
-/// the prior parse still hash to `prior_suffix_blake3` in the current file.
+/// present at `prior_offset_bytes - SUFFIX_HASH_BYTES .. prior_offset_bytes`
+/// in the prior parse still hash to `prior_suffix_blake3` in the current
+/// file. `prior_offset_bytes` is the byte position where the previous parse
+/// stopped — equal to the file size at that time (JSONL is append-only).
 ///
 /// Returns `true` if append is safe; `false` means the prior tail was
 /// rewritten and the caller must downgrade to `FullReparse`.
 pub fn verify_append_safe(
     file: &mut File,
-    prior_size_bytes: u64,
+    prior_offset_bytes: u64,
     prior_suffix_blake3: &[u8; 32],
 ) -> Result<bool, CacheError> {
-    if prior_size_bytes == 0 {
+    if prior_offset_bytes == 0 {
         return Ok(true);
     }
 
-    let window = SUFFIX_HASH_BYTES.min(prior_size_bytes);
-    let start = prior_size_bytes - window;
+    let window = SUFFIX_HASH_BYTES.min(prior_offset_bytes);
+    let start = prior_offset_bytes - window;
     file.seek(SeekFrom::Start(start)).map_err(CacheError::Io)?;
     let mut buf = vec![0u8; window as usize];
     file.read_exact(&mut buf).map_err(CacheError::Io)?;

--- a/ainb-tui/src/usage_cache/mod.rs
+++ b/ainb-tui/src/usage_cache/mod.rs
@@ -13,9 +13,11 @@
 //! * [`store::default_db_path`] — resolve the standard cache location.
 
 pub mod db;
+pub mod fingerprint;
 pub mod store;
 
 #[cfg(test)]
 mod tests;
 
-pub use store::{BlobFormat, Cache, CacheError, CacheInfo};
+pub use fingerprint::{FileFingerprint, FingerprintAction, SUFFIX_HASH_BYTES};
+pub use store::{BlobFormat, Cache, CacheError, CacheInfo, ParseHint, ParseResult};

--- a/ainb-tui/src/usage_cache/mod.rs
+++ b/ainb-tui/src/usage_cache/mod.rs
@@ -1,0 +1,21 @@
+// ABOUTME: Persistent SQLite-backed cache for parsed usage analytics.
+// Per-file fingerprint + append-only incremental parse so unchanged Claude/Codex
+// JSONL sessions are served instantly and changed files only re-parse new bytes.
+
+//! Usage analytics cache.
+//!
+//! Refer to `~/.claude/projects/.../reference_codeburn_caching.md` for the
+//! competitive analysis that motivates this module — codeburn re-parses every
+//! Claude JSONL on every invocation; ainb-tui does not.
+//!
+//! Public surface:
+//! * [`Cache`] — open, query, write, clear the on-disk cache.
+//! * [`store::default_db_path`] — resolve the standard cache location.
+
+pub mod db;
+pub mod store;
+
+#[cfg(test)]
+mod tests;
+
+pub use store::{BlobFormat, Cache, CacheError, CacheInfo};

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -3,10 +3,9 @@
 
 //! High-level cache API surface.
 //!
-//! This commit lands the lifecycle primitives: open/disabled, clear,
-//! clear_path, info, default_db_path. The fingerprint-aware
-//! `get_or_parse` is added in the next commit together with
-//! [`super::fingerprint`].
+//! Lifecycle primitives: open / disabled / clear / `clear_path` / info /
+//! `default_db_path`, plus the fingerprint-aware `get_or_parse` hot path
+//! that drives the analytics scan.
 
 use std::fs::File;
 use std::io::Seek;
@@ -31,7 +30,7 @@ pub enum BlobFormat {
 }
 
 impl BlobFormat {
-    pub(crate) fn from_i64(v: i64) -> Option<Self> {
+    pub(crate) const fn from_i64(v: i64) -> Option<Self> {
         match v {
             1 => Some(Self::Bincode),
             _ => None,
@@ -100,7 +99,7 @@ impl Cache {
     }
 
     /// Whether cache writes are enabled.
-    pub fn is_enabled(&self) -> bool {
+    pub const fn is_enabled(&self) -> bool {
         matches!(self.inner, CacheInner::Open(_))
     }
 
@@ -187,9 +186,7 @@ impl Cache {
                 };
                 file.rewind().map_err(CacheError::Io)?;
                 drop(file);
-                if !safe {
-                    parse(path, ParseHint::Full)
-                } else {
+                if safe {
                     let existing = prior_calls.as_deref().unwrap_or(&[]);
                     parse(
                         path,
@@ -198,6 +195,8 @@ impl Cache {
                             existing,
                         },
                     )
+                } else {
+                    parse(path, ParseHint::Full)
                 }
             }
             FingerprintAction::FullReparse => {

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -237,6 +237,7 @@ impl Cache {
     }
 
     /// Drop a single cache row by path.
+    #[allow(dead_code)]
     pub fn clear_path(&self, path: &Path) -> Result<(), CacheError> {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -8,6 +8,8 @@
 //! `get_or_parse` is added in the next commit together with
 //! [`super::fingerprint`].
 
+use std::fs::File;
+use std::io::Seek;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
@@ -15,7 +17,10 @@ use std::time::SystemTime;
 use rusqlite::{Connection, OptionalExtension, params};
 use thiserror::Error;
 
+use crate::models::usage::ProviderCall;
+
 use super::db;
+use super::fingerprint::{FileFingerprint, FingerprintAction, classify, verify_append_safe};
 
 /// Versioned blob encoding for `files.calls_blob`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,6 +109,123 @@ impl Cache {
         &self.db_path
     }
 
+    /// Get cached calls for `path` if the file is unchanged; otherwise call
+    /// `parse` with the appropriate [`ParseHint`] and persist the result.
+    ///
+    /// On any cache error we fall back to a full parse with `ParseHint::Full`
+    /// — the cache is never allowed to break analytics.
+    pub fn get_or_parse<F>(&self, path: &Path, mut parse: F) -> Vec<ProviderCall>
+    where
+        F: FnMut(&Path, ParseHint<'_>) -> ParseResult,
+    {
+        match self.try_get_or_parse(path, &mut parse) {
+            Ok(calls) => calls,
+            Err(err) => {
+                tracing::warn!(
+                    "usage_cache fallback to full re-parse for {:?}: {err}",
+                    path
+                );
+                parse(path, ParseHint::Full).calls
+            }
+        }
+    }
+
+    fn try_get_or_parse<F>(
+        &self,
+        path: &Path,
+        parse: &mut F,
+    ) -> Result<Vec<ProviderCall>, CacheError>
+    where
+        F: FnMut(&Path, ParseHint<'_>) -> ParseResult,
+    {
+        let CacheInner::Open(conn) = &self.inner else {
+            return Ok(parse(path, ParseHint::Full).calls);
+        };
+
+        let prior = {
+            let lock = conn.lock().expect("usage_cache mutex poisoned");
+            load_row(&lock, path)?
+        };
+
+        let mut file = match File::open(path) {
+            Ok(f) => f,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                if prior.is_some() {
+                    let lock = conn.lock().expect("usage_cache mutex poisoned");
+                    let _ = lock
+                        .execute("DELETE FROM files WHERE path = ?1", params![path.to_string_lossy().into_owned()]);
+                }
+                return Ok(Vec::new());
+            }
+            Err(err) => return Err(CacheError::Io(err)),
+        };
+        let meta = file.metadata().map_err(CacheError::Io)?;
+        let current = FileFingerprint::from_open_file(&mut file, &meta)?;
+
+        let (action, prior_calls, prior_suffix, _prior_offset) = match prior {
+            Some(row) => {
+                let action = classify(&row.fingerprint, &current, row.last_offset);
+                (
+                    action,
+                    Some(row.calls),
+                    Some(row.fingerprint.suffix_blake3),
+                    row.last_offset,
+                )
+            }
+            None => (FingerprintAction::FullReparse, None, None, 0),
+        };
+
+        let result = match action {
+            FingerprintAction::Unchanged => {
+                return Ok(prior_calls.unwrap_or_default());
+            }
+            FingerprintAction::Append { from_offset } => {
+                let safe = match prior_suffix {
+                    Some(suffix) => verify_append_safe(&mut file, from_offset, &suffix)?,
+                    None => false,
+                };
+                file.rewind().map_err(CacheError::Io)?;
+                drop(file);
+                if !safe {
+                    parse(path, ParseHint::Full)
+                } else {
+                    let existing = prior_calls.as_deref().unwrap_or(&[]);
+                    parse(
+                        path,
+                        ParseHint::Append {
+                            from_offset,
+                            existing,
+                        },
+                    )
+                }
+            }
+            FingerprintAction::FullReparse => {
+                drop(file);
+                parse(path, ParseHint::Full)
+            }
+        };
+
+        let row = StoredRow {
+            fingerprint: current,
+            last_offset: result.end_offset,
+            calls: result.calls,
+        };
+        if let Err(err) = self.write_row(path, &row) {
+            tracing::warn!("usage_cache row write failed for {:?}: {err}", path);
+        }
+        Ok(row.calls)
+    }
+
+    fn write_row(&self, path: &Path, row: &StoredRow) -> Result<(), CacheError> {
+        let CacheInner::Open(conn) = &self.inner else {
+            return Ok(());
+        };
+        let blob = bincode::serialize(&row.calls)?;
+        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        upsert_row(&lock, path, row, &blob)?;
+        Ok(())
+    }
+
     /// Drop all cached rows. Schema row is preserved.
     pub fn clear(&self) -> Result<(), CacheError> {
         let CacheInner::Open(conn) = &self.inner else {
@@ -159,6 +281,127 @@ pub fn default_db_path() -> Option<PathBuf> {
         return Some(PathBuf::from(p));
     }
     dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("cache").join("usage.db"))
+}
+
+/// Hint passed to user parsers. The parser gets to decide what to do — the
+/// cache merely tells it what's safe.
+#[derive(Debug, Clone)]
+pub enum ParseHint<'a> {
+    /// No cache row, or fingerprint forced a full re-parse.
+    Full,
+    /// Append-only parse: skip the first `from_offset` bytes; existing calls
+    /// from the prior run are in `existing` (parser must extend, not
+    /// replace).
+    Append {
+        from_offset: u64,
+        existing: &'a [crate::models::usage::ProviderCall],
+    },
+}
+
+/// Result the caller's parser must produce: the complete `Vec<ProviderCall>`
+/// for the file plus the offset at which it stopped reading.
+pub struct ParseResult {
+    pub calls: Vec<crate::models::usage::ProviderCall>,
+    /// Byte offset in the file where parsing stopped. Almost always
+    /// `metadata().len()`; used to drive the next append-only parse.
+    pub end_offset: u64,
+}
+
+#[derive(Debug)]
+struct StoredRow {
+    fingerprint: FileFingerprint,
+    last_offset: u64,
+    calls: Vec<crate::models::usage::ProviderCall>,
+}
+
+#[derive(Debug)]
+struct LoadedRow {
+    fingerprint: FileFingerprint,
+    last_offset: u64,
+    calls: Vec<crate::models::usage::ProviderCall>,
+}
+
+fn load_row(conn: &Connection, path: &Path) -> Result<Option<LoadedRow>, CacheError> {
+    let path_str = path.to_string_lossy().into_owned();
+    let row = conn
+        .query_row(
+            "SELECT size_bytes, mtime_nanos, last_offset, suffix_blake3, calls_blob, blob_format
+             FROM files WHERE path = ?1",
+            params![path_str],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Vec<u8>>(3)?,
+                    row.get::<_, Vec<u8>>(4)?,
+                    row.get::<_, i64>(5)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    let Some((size_i, mtime, offset, suffix, blob, fmt)) = row else {
+        return Ok(None);
+    };
+
+    let Some(format) = BlobFormat::from_i64(fmt) else {
+        return Ok(None);
+    };
+    let calls: Vec<crate::models::usage::ProviderCall> = match format {
+        BlobFormat::Bincode => bincode::deserialize(&blob)?,
+    };
+    let fingerprint = FileFingerprint::from_columns(
+        u64::try_from(size_i).unwrap_or(0),
+        mtime,
+        &suffix,
+    )?;
+
+    Ok(Some(LoadedRow {
+        fingerprint,
+        last_offset: u64::try_from(offset).unwrap_or(0),
+        calls,
+    }))
+}
+
+fn upsert_row(
+    conn: &Connection,
+    path: &Path,
+    row: &StoredRow,
+    blob: &[u8],
+) -> Result<(), CacheError> {
+    let path_str = path.to_string_lossy().into_owned();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    conn.execute(
+        "INSERT INTO files
+            (path, size_bytes, mtime_nanos, last_offset, suffix_blake3,
+             row_count, calls_blob, blob_format, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(path) DO UPDATE SET
+            size_bytes    = excluded.size_bytes,
+            mtime_nanos   = excluded.mtime_nanos,
+            last_offset   = excluded.last_offset,
+            suffix_blake3 = excluded.suffix_blake3,
+            row_count     = excluded.row_count,
+            calls_blob    = excluded.calls_blob,
+            blob_format   = excluded.blob_format,
+            updated_at    = excluded.updated_at",
+        params![
+            path_str,
+            i64::try_from(row.fingerprint.size_bytes).unwrap_or(i64::MAX),
+            row.fingerprint.mtime_nanos,
+            i64::try_from(row.last_offset).unwrap_or(i64::MAX),
+            row.fingerprint.suffix_blake3.to_vec(),
+            i64::try_from(row.calls.len()).unwrap_or(i64::MAX),
+            blob,
+            db::BLOB_FORMAT_BINCODE_V1,
+            now,
+        ],
+    )?;
+    Ok(())
 }
 
 /// Internal helper for tests / diagnostics: stamp `updated_at` into a row

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -105,6 +105,7 @@ impl Cache {
     }
 
     /// On-disk path of the cache DB.
+    #[allow(dead_code)]
     pub fn db_path(&self) -> &Path {
         &self.db_path
     }

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -1,0 +1,178 @@
+// ABOUTME: High-level cache API: open, clear, info. Fingerprint-aware
+// get_or_parse lands in a follow-on commit alongside fingerprint.rs.
+
+//! High-level cache API surface.
+//!
+//! This commit lands the lifecycle primitives: open/disabled, clear,
+//! clear_path, info, default_db_path. The fingerprint-aware
+//! `get_or_parse` is added in the next commit together with
+//! [`super::fingerprint`].
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use rusqlite::{Connection, OptionalExtension, params};
+use thiserror::Error;
+
+use super::db;
+
+/// Versioned blob encoding for `files.calls_blob`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub enum BlobFormat {
+    /// `bincode::serialize` of `Vec<ProviderCall>` with default options.
+    Bincode = 1,
+}
+
+impl BlobFormat {
+    pub(crate) fn from_i64(v: i64) -> Option<Self> {
+        match v {
+            1 => Some(Self::Bincode),
+            _ => None,
+        }
+    }
+}
+
+/// Cache error surface. `Io`/`Sql` propagate underlying errors so callers can
+/// decide whether to log-and-fall-back-to-full-parse or surface to the user.
+#[derive(Debug, Error)]
+pub enum CacheError {
+    #[error("cache I/O: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("cache sqlite: {0}")]
+    Sql(#[from] rusqlite::Error),
+    #[error("cache encode: {0}")]
+    Encode(#[from] bincode::Error),
+    #[error("cache schema: {0}")]
+    Schema(String),
+}
+
+/// Snapshot of cache contents for `ainb usage cache info`.
+#[derive(Debug, Clone)]
+pub struct CacheInfo {
+    pub db_path: PathBuf,
+    pub size_bytes: u64,
+    pub file_count: i64,
+    pub oldest_updated_at: Option<i64>,
+}
+
+/// Persistent usage cache.
+///
+/// Internally a `Mutex<Connection>`. Reads are sub-millisecond (single-row
+/// PK lookup) so we don't bother with a separate read-only pool.
+pub struct Cache {
+    pub(crate) inner: CacheInner,
+    pub(crate) db_path: PathBuf,
+}
+
+pub(crate) enum CacheInner {
+    Open(Mutex<Connection>),
+    /// Cache disabled — every `get_or_parse` performs a full parse and the
+    /// result is *not* persisted. Used by `--no-cache` on the CLI.
+    Disabled,
+}
+
+impl Cache {
+    /// Open (or create) the cache DB at `db_path`. Returns an error on schema
+    /// or I/O failure — callers in the parse path should log and fall back to
+    /// a `disabled()` cache so analytics still work.
+    pub fn open(db_path: PathBuf) -> Result<Self, CacheError> {
+        let conn = db::open(&db_path)?;
+        Ok(Self {
+            inner: CacheInner::Open(Mutex::new(conn)),
+            db_path,
+        })
+    }
+
+    /// Construct a no-op cache. `get_or_parse` always full-parses and never
+    /// writes. `db_path` is informational only.
+    pub fn disabled() -> Self {
+        Self {
+            inner: CacheInner::Disabled,
+            db_path: PathBuf::new(),
+        }
+    }
+
+    /// Whether cache writes are enabled.
+    pub fn is_enabled(&self) -> bool {
+        matches!(self.inner, CacheInner::Open(_))
+    }
+
+    /// On-disk path of the cache DB.
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    /// Drop all cached rows. Schema row is preserved.
+    pub fn clear(&self) -> Result<(), CacheError> {
+        let CacheInner::Open(conn) = &self.inner else {
+            return Ok(());
+        };
+        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        lock.execute("DELETE FROM files", [])?;
+        Ok(())
+    }
+
+    /// Drop a single cache row by path.
+    pub fn clear_path(&self, path: &Path) -> Result<(), CacheError> {
+        let CacheInner::Open(conn) = &self.inner else {
+            return Ok(());
+        };
+        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        let path_str = path.to_string_lossy().into_owned();
+        lock.execute("DELETE FROM files WHERE path = ?1", params![path_str])?;
+        Ok(())
+    }
+
+    /// Return summary stats for the cache (`ainb usage cache info`).
+    pub fn info(&self) -> Result<CacheInfo, CacheError> {
+        let CacheInner::Open(conn) = &self.inner else {
+            return Ok(CacheInfo {
+                db_path: self.db_path.clone(),
+                size_bytes: 0,
+                file_count: 0,
+                oldest_updated_at: None,
+            });
+        };
+        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        let file_count: i64 =
+            lock.query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))?;
+        let oldest_updated_at: Option<i64> = lock
+            .query_row("SELECT MIN(updated_at) FROM files", [], |row| row.get(0))
+            .optional()?
+            .flatten();
+        let size_bytes = std::fs::metadata(&self.db_path).map(|m| m.len()).unwrap_or(0);
+        Ok(CacheInfo {
+            db_path: self.db_path.clone(),
+            size_bytes,
+            file_count,
+            oldest_updated_at,
+        })
+    }
+}
+
+/// Resolve the default cache DB path (`~/.agents-in-a-box/cache/usage.db`)
+/// honoring the `AINB_USAGE_CACHE_DB` env override (used by tests).
+pub fn default_db_path() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("AINB_USAGE_CACHE_DB") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("cache").join("usage.db"))
+}
+
+/// Internal helper for tests / diagnostics: stamp `updated_at` into a row
+/// after manual fixturing. Not part of the public API.
+#[allow(dead_code)]
+pub(crate) fn stamp_updated_at_now(conn: &Connection, path: &Path) -> Result<(), CacheError> {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let path_str = path.to_string_lossy().into_owned();
+    conn.execute(
+        "UPDATE files SET updated_at = ?1 WHERE path = ?2",
+        params![now, path_str],
+    )?;
+    Ok(())
+}

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -143,7 +143,10 @@ impl Cache {
         };
 
         let prior = {
-            let lock = conn.lock().expect("usage_cache mutex poisoned");
+            let lock = conn.lock().unwrap_or_else(|e| {
+            tracing::warn!("usage_cache mutex poisoned; recovering");
+            e.into_inner()
+        });
             load_row(&lock, path)?
         };
 
@@ -151,7 +154,10 @@ impl Cache {
             Ok(f) => f,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 if prior.is_some() {
-                    let lock = conn.lock().expect("usage_cache mutex poisoned");
+                    let lock = conn.lock().unwrap_or_else(|e| {
+            tracing::warn!("usage_cache mutex poisoned; recovering");
+            e.into_inner()
+        });
                     let _ = lock
                         .execute("DELETE FROM files WHERE path = ?1", params![path.to_string_lossy().into_owned()]);
                 }
@@ -221,7 +227,10 @@ impl Cache {
             return Ok(());
         };
         let blob = bincode::serialize(&row.calls)?;
-        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        let lock = conn.lock().unwrap_or_else(|e| {
+            tracing::warn!("usage_cache mutex poisoned; recovering");
+            e.into_inner()
+        });
         upsert_row(&lock, path, row, &blob)?;
         Ok(())
     }
@@ -231,7 +240,10 @@ impl Cache {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());
         };
-        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        let lock = conn.lock().unwrap_or_else(|e| {
+            tracing::warn!("usage_cache mutex poisoned; recovering");
+            e.into_inner()
+        });
         lock.execute("DELETE FROM files", [])?;
         Ok(())
     }
@@ -242,7 +254,10 @@ impl Cache {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());
         };
-        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        let lock = conn.lock().unwrap_or_else(|e| {
+            tracing::warn!("usage_cache mutex poisoned; recovering");
+            e.into_inner()
+        });
         let path_str = path.to_string_lossy().into_owned();
         lock.execute("DELETE FROM files WHERE path = ?1", params![path_str])?;
         Ok(())
@@ -258,7 +273,10 @@ impl Cache {
                 oldest_updated_at: None,
             });
         };
-        let lock = conn.lock().expect("usage_cache mutex poisoned");
+        let lock = conn.lock().unwrap_or_else(|e| {
+            tracing::warn!("usage_cache mutex poisoned; recovering");
+            e.into_inner()
+        });
         let file_count: i64 =
             lock.query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))?;
         let oldest_updated_at: Option<i64> = lock

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -1,8 +1,288 @@
 // ABOUTME: Unit tests for the usage_cache module — fingerprinting, schema
-// migration, and the store get_or_parse contract. Integration tests that
-// exercise the parser callbacks end-to-end live in
-// tests/usage_cache_integration.rs.
+// migration, and basic store get_or_parse semantics. End-to-end parser
+// integration lives in tests/usage_cache_integration.rs.
 
 #![cfg(test)]
 
-// (Tests added in the dedicated test commit.)
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use rusqlite::Connection;
+
+use crate::models::usage::ProviderCall;
+use crate::usage_cache::db::SCHEMA_VERSION;
+use crate::usage_cache::fingerprint::{
+    classify, verify_append_safe, FileFingerprint, FingerprintAction, SUFFIX_HASH_BYTES,
+};
+use crate::usage_cache::store::{Cache, ParseHint, ParseResult};
+
+fn write_file(dir: &TempDir, name: &str, contents: &[u8]) -> PathBuf {
+    let path = dir.path().join(name);
+    let mut f = fs::File::create(&path).unwrap();
+    f.write_all(contents).unwrap();
+    path
+}
+
+fn synth_call(seed: &str) -> ProviderCall {
+    use chrono::TimeZone;
+    ProviderCall {
+        provider: "claude".into(),
+        model: "test-model".into(),
+        session_id: format!("session-{seed}"),
+        project: "p".into(),
+        project_path: "/tmp/p".into(),
+        timestamp: chrono::Local.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap(),
+        input_tokens: 1,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        output_tokens: 1,
+        reasoning_tokens: 0,
+        cost_usd: None,
+        tools: Vec::new(),
+        bash_commands: Vec::new(),
+        user_message: String::new(),
+    }
+}
+
+#[test]
+fn schema_open_creates_files_table_and_records_version() {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("usage.db");
+    let cache = Cache::open(db.clone()).unwrap();
+    drop(cache);
+
+    let conn = Connection::open(&db).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+    let v: i64 = conn
+        .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(v, SCHEMA_VERSION);
+}
+
+#[test]
+fn schema_bump_drops_and_rebuilds() {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("usage.db");
+
+    // Hand-craft an "old" DB at version 0 with an unrelated table to prove
+    // the rebuild wipes things.
+    {
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+             INSERT INTO schema_version VALUES (0);
+             CREATE TABLE files (path TEXT PRIMARY KEY, junk TEXT);
+             INSERT INTO files VALUES ('legacy', 'should be wiped');",
+        )
+        .unwrap();
+    }
+
+    let _cache = Cache::open(db.clone()).unwrap();
+    let conn = Connection::open(&db).unwrap();
+    let v: i64 = conn
+        .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(v, SCHEMA_VERSION);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0, "legacy row must not survive a schema bump");
+}
+
+#[test]
+fn fingerprint_unchanged_when_size_and_suffix_match() {
+    let prior = FileFingerprint {
+        size_bytes: 100,
+        mtime_nanos: 1_000,
+        suffix_blake3: [0xAB; 32],
+    };
+    let current = FileFingerprint {
+        size_bytes: 100,
+        mtime_nanos: 2_000, // mtime changed but size + suffix identical
+        suffix_blake3: [0xAB; 32],
+    };
+    assert_eq!(classify(&prior, &current, 100), FingerprintAction::Unchanged);
+}
+
+#[test]
+fn fingerprint_truncate_forces_full_reparse() {
+    let prior = FileFingerprint {
+        size_bytes: 100,
+        mtime_nanos: 1_000,
+        suffix_blake3: [0xAB; 32],
+    };
+    let current = FileFingerprint {
+        size_bytes: 50,
+        mtime_nanos: 2_000,
+        suffix_blake3: [0xCD; 32],
+    };
+    assert_eq!(classify(&prior, &current, 100), FingerprintAction::FullReparse);
+}
+
+#[test]
+fn fingerprint_growth_signals_append() {
+    let prior = FileFingerprint {
+        size_bytes: 100,
+        mtime_nanos: 1_000,
+        suffix_blake3: [0xAB; 32],
+    };
+    let current = FileFingerprint {
+        size_bytes: 200,
+        mtime_nanos: 2_000,
+        suffix_blake3: [0xEF; 32],
+    };
+    assert_eq!(
+        classify(&prior, &current, 100),
+        FingerprintAction::Append { from_offset: 100 }
+    );
+}
+
+#[test]
+fn verify_append_safe_detects_in_place_rewrite() {
+    let dir = TempDir::new().unwrap();
+    // Original tail bytes:
+    let original = b"hello-world".repeat(10); // ~110 bytes
+    let path = write_file(&dir, "f.jsonl", &original);
+    let prior_size = original.len() as u64;
+    let prior_window = SUFFIX_HASH_BYTES.min(prior_size) as usize;
+    let prior_suffix = blake3::hash(&original[(original.len() - prior_window)..]);
+
+    // Rewrite the file in-place with different content same length, then
+    // append more bytes.
+    let mut rewritten = b"GOODBYE-WORLD".repeat(10);
+    rewritten.truncate(original.len());
+    rewritten.extend_from_slice(b"new-tail-bytes");
+    fs::write(&path, &rewritten).unwrap();
+
+    let mut handle = fs::File::open(&path).unwrap();
+    let safe = verify_append_safe(&mut handle, prior_size, prior_suffix.as_bytes()).unwrap();
+    assert!(!safe, "in-place rewrite must be detected");
+}
+
+#[test]
+fn cache_disabled_skips_all_writes() {
+    let dir = TempDir::new().unwrap();
+    let path = write_file(&dir, "f.jsonl", b"line\n");
+    let cache = Cache::disabled();
+
+    let calls_emitted = Arc::new(AtomicUsize::new(0));
+    let counter = calls_emitted.clone();
+    let result = cache.get_or_parse(&path, |_p, hint| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        assert!(matches!(hint, ParseHint::Full));
+        ParseResult {
+            calls: vec![synth_call("a")],
+            end_offset: 5,
+        }
+    });
+    assert_eq!(result.len(), 1);
+    assert_eq!(calls_emitted.load(Ordering::SeqCst), 1);
+
+    // Run again — disabled cache means we still fall through to parse.
+    let _ = cache.get_or_parse(&path, |_p, _hint| ParseResult {
+        calls: vec![synth_call("b")],
+        end_offset: 5,
+    });
+    assert!(!cache.is_enabled());
+}
+
+#[test]
+fn cache_first_scan_then_unchanged_serves_from_cache() {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("usage.db");
+    let path = write_file(&dir, "f.jsonl", b"line1\nline2\n");
+    let cache = Cache::open(db).unwrap();
+
+    let parses = Arc::new(AtomicUsize::new(0));
+
+    // First scan → parse called.
+    let counter = parses.clone();
+    let r1 = cache.get_or_parse(&path, |_p, hint| {
+        assert!(matches!(hint, ParseHint::Full));
+        counter.fetch_add(1, Ordering::SeqCst);
+        ParseResult {
+            calls: vec![synth_call("first")],
+            end_offset: 12,
+        }
+    });
+    assert_eq!(r1.len(), 1);
+    assert_eq!(parses.load(Ordering::SeqCst), 1);
+
+    // Second scan → cache hit; closure must not run.
+    let counter = parses.clone();
+    let r2 = cache.get_or_parse(&path, |_p, _hint| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        ParseResult {
+            calls: Vec::new(),
+            end_offset: 0,
+        }
+    });
+    assert_eq!(r2.len(), 1);
+    assert_eq!(
+        parses.load(Ordering::SeqCst),
+        1,
+        "unchanged file must not re-invoke parser"
+    );
+}
+
+#[test]
+fn concurrent_get_or_parse_does_not_deadlock() {
+    use std::thread;
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("usage.db");
+    let path = write_file(&dir, "f.jsonl", b"line1\nline2\n");
+    let cache = Arc::new(Cache::open(db).unwrap());
+
+    let handles: Vec<_> = (0..4)
+        .map(|i| {
+            let cache = cache.clone();
+            let path = path.clone();
+            thread::spawn(move || {
+                let r = cache.get_or_parse(&path, |_p, _h| ParseResult {
+                    calls: vec![synth_call(&format!("t{i}"))],
+                    end_offset: 12,
+                });
+                assert_eq!(r.len(), 1);
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    let info = cache.info().unwrap();
+    assert_eq!(info.file_count, 1, "single PK row regardless of contention");
+}
+
+#[test]
+fn cache_clear_drops_rows_but_preserves_schema() {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("usage.db");
+    let path = write_file(&dir, "f.jsonl", b"line\n");
+    let cache = Cache::open(db.clone()).unwrap();
+
+    cache.get_or_parse(&path, |_p, _h| ParseResult {
+        calls: vec![synth_call("x")],
+        end_offset: 5,
+    });
+
+    let before = cache.info().unwrap();
+    assert_eq!(before.file_count, 1);
+
+    cache.clear().unwrap();
+    let after = cache.info().unwrap();
+    assert_eq!(after.file_count, 0);
+
+    // Schema row still present.
+    let conn = Connection::open(&db).unwrap();
+    let v: i64 = conn
+        .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(v, SCHEMA_VERSION);
+}

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -286,3 +286,68 @@ fn cache_clear_drops_rows_but_preserves_schema() {
         .unwrap();
     assert_eq!(v, SCHEMA_VERSION);
 }
+
+#[test]
+fn fingerprint_full_reparse_when_size_equal_but_suffix_differs() {
+    // Same size + different suffix means the trailing bytes were rewritten
+    // in place; classify must NOT return Append (and rely on
+    // verify_append_safe to clean up). It must return FullReparse directly.
+    let prior = FileFingerprint {
+        size_bytes: 100,
+        mtime_nanos: 1_000,
+        suffix_blake3: [0xAA; 32],
+    };
+    let current = FileFingerprint {
+        size_bytes: 100,
+        mtime_nanos: 2_000,
+        suffix_blake3: [0xBB; 32],
+    };
+    assert_eq!(classify(&prior, &current, 100), FingerprintAction::FullReparse);
+}
+
+/// Layout-stability tripwire for the bincode-encoded `Vec<ProviderCall>`
+/// blob. If any field is added, removed, or reordered in `ProviderCall`
+/// (or any nested type), the encoded length will change and this test will
+/// fail. When it does, you MUST bump
+/// `usage_cache::db::BLOB_FORMAT_BINCODE_V1` AND update the expected length
+/// here — that's the protocol that prevents silent cache corruption from
+/// mis-decoding old blobs into a new struct shape.
+#[test]
+fn provider_call_bincode_layout_is_stable() {
+    let fixture = synth_call("layout-tripwire");
+    let encoded = bincode::serialize(&fixture).unwrap();
+
+    // Round-trip first as the meaningful behavioural check.
+    let decoded: ProviderCall = bincode::deserialize(&encoded).unwrap();
+    assert_eq!(decoded.session_id, fixture.session_id);
+    assert_eq!(decoded.input_tokens, fixture.input_tokens);
+    assert_eq!(decoded.output_tokens, fixture.output_tokens);
+
+    // Tripwire: if the byte length drifts, the struct layout changed.
+    // See the doc comment on `ProviderCall` in `models/usage.rs`.
+    const EXPECTED_LEN: usize = const_expected_len();
+    assert_eq!(
+        encoded.len(),
+        EXPECTED_LEN,
+        "ProviderCall bincode layout changed — bump BLOB_FORMAT_BINCODE_V1 \
+         and update EXPECTED_LEN. See ProviderCall doc comment."
+    );
+}
+
+/// Compute the expected serialized length once. Bincode uses a varint-free
+/// fixed encoding by default, so for a fixture with deterministic fields
+/// the size is deterministic. Computed at compile time conceptually, but
+/// inlined here so a layout drift surfaces as an `assert_eq!` mismatch.
+const fn const_expected_len() -> usize {
+    // String layout (bincode default options): u64 len + bytes.
+    // Vec<T>:                                  u64 len + items.
+    // Option<T> (None):                        1 byte tag.
+    // Option<T> (Some):                        1 byte tag + payload.
+    // chrono::DateTime<Local> serializes as a tagged enum + i64 secs +
+    // u32 nanos pair (via serde impl in chrono); seed value covers it.
+    //
+    // Rather than re-deriving the formula on every change, we hard-code
+    // the value observed for `synth_call("layout-tripwire")`. If chrono
+    // or bincode bump their encoding, update this constant intentionally.
+    184
+}

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -1,0 +1,8 @@
+// ABOUTME: Unit tests for the usage_cache module — fingerprinting, schema
+// migration, and the store get_or_parse contract. Integration tests that
+// exercise the parser callbacks end-to-end live in
+// tests/usage_cache_integration.rs.
+
+#![cfg(test)]
+
+// (Tests added in the dedicated test commit.)

--- a/ainb-tui/tests/usage_cache_integration.rs
+++ b/ainb-tui/tests/usage_cache_integration.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ainb::models::usage::{
-    parse_usage_for_with_roots_and_cache, UsageProviderFilter, UsageQuery, UsageSourceRoots,
+    UsageProviderFilter, UsageQuery, UsageSourceRoots, parse_usage_for_with_roots_and_cache,
 };
 use ainb::usage_cache::Cache;
 use tempfile::TempDir;
@@ -52,11 +52,7 @@ fn append_assistant_turn(
             }
         }
     });
-    let mut f = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .unwrap();
+    let mut f = fs::OpenOptions::new().create(true).append(true).open(path).unwrap();
     writeln!(f, "{user}").unwrap();
     writeln!(f, "{assistant}").unwrap();
 }
@@ -124,14 +120,15 @@ fn append_only_adds_new_rows_and_matches_full_reparse() {
     append_assistant_turn(&session, "sess-2", "2026-05-01T12:30:00Z", 200, 75);
 
     let after_append = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
-    assert_eq!(after_append.calls.len(), 2, "appended turn should be visible");
+    assert_eq!(
+        after_append.calls.len(),
+        2,
+        "appended turn should be visible"
+    );
 
     // Compare with a fresh disabled-cache full re-parse.
-    let fresh = parse_usage_for_with_roots_and_cache(
-        query_all(),
-        &roots,
-        Arc::new(Cache::disabled()),
-    );
+    let fresh =
+        parse_usage_for_with_roots_and_cache(query_all(), &roots, Arc::new(Cache::disabled()));
     assert_eq!(after_append.calls.len(), fresh.calls.len());
     assert_eq!(
         after_append.grand_total.total(),

--- a/ainb-tui/tests/usage_cache_integration.rs
+++ b/ainb-tui/tests/usage_cache_integration.rs
@@ -1,0 +1,187 @@
+// ABOUTME: End-to-end integration tests for the persistent usage cache —
+// exercises the real claude/codex parsers via parse_usage_for_with_roots_and_cache
+// against synthetic on-disk JSONL fixtures, asserting append-only semantics
+// and full-reparse fallbacks behave the way the cache contract says.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use ainb::models::usage::{
+    parse_usage_for_with_roots_and_cache, UsageProviderFilter, UsageQuery, UsageSourceRoots,
+};
+use ainb::usage_cache::Cache;
+use tempfile::TempDir;
+
+/// Build the minimal claude project layout the parser expects:
+///   <projects_dir>/<sanitized-project>/<sessionId>.jsonl
+fn build_claude_root(dir: &Path) -> std::path::PathBuf {
+    let projects = dir.join("projects");
+    let project = projects.join("-Users-test-myrepo");
+    fs::create_dir_all(&project).unwrap();
+    projects
+}
+
+/// Append a single assistant turn to a JSONL file, emitting the matching
+/// preceding "user" line so user_message attribution is exercised.
+fn append_assistant_turn(
+    path: &Path,
+    session_id: &str,
+    timestamp: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+) {
+    let user = serde_json::json!({
+        "type": "user",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "message": { "content": "hello world" }
+    });
+    let assistant = serde_json::json!({
+        "type": "assistant",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "cwd": "/Users/test/myrepo",
+        "message": {
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+        }
+    });
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap();
+    writeln!(f, "{user}").unwrap();
+    writeln!(f, "{assistant}").unwrap();
+}
+
+fn cache_at(dir: &Path) -> Arc<Cache> {
+    Arc::new(Cache::open(dir.join("usage.db")).unwrap())
+}
+
+fn query_all() -> UsageQuery {
+    UsageQuery {
+        period: ainb::models::usage::UsagePeriod::All,
+        provider_filter: UsageProviderFilter::Claude,
+        include_projects: Vec::new(),
+        exclude_projects: Vec::new(),
+    }
+}
+
+#[test]
+fn first_scan_then_unchanged_returns_same_data() {
+    let work = TempDir::new().unwrap();
+    let projects = build_claude_root(work.path());
+    let session = projects.join("-Users-test-myrepo").join("sess-1.jsonl");
+    append_assistant_turn(&session, "sess-1", "2026-05-01T12:00:00Z", 100, 50);
+
+    let roots = UsageSourceRoots {
+        claude_projects_dir: Some(projects.clone()),
+        codex_dir: None,
+    };
+
+    let cache_dir = TempDir::new().unwrap();
+    let cache = cache_at(cache_dir.path());
+
+    let first = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    assert_eq!(first.calls.len(), 1, "one assistant turn parsed");
+
+    // Second scan with the file untouched — same data.
+    let second = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    assert_eq!(second.calls.len(), 1);
+    assert_eq!(
+        first.grand_total.total(),
+        second.grand_total.total(),
+        "totals must be identical across cache hits"
+    );
+    let info = cache.info().unwrap();
+    assert_eq!(info.file_count, 1);
+}
+
+#[test]
+fn append_only_adds_new_rows_and_matches_full_reparse() {
+    let work = TempDir::new().unwrap();
+    let projects = build_claude_root(work.path());
+    let session = projects.join("-Users-test-myrepo").join("sess-2.jsonl");
+    append_assistant_turn(&session, "sess-2", "2026-05-01T12:00:00Z", 100, 50);
+
+    let roots = UsageSourceRoots {
+        claude_projects_dir: Some(projects.clone()),
+        codex_dir: None,
+    };
+    let cache_dir = TempDir::new().unwrap();
+    let cache = cache_at(cache_dir.path());
+
+    let _first = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+
+    // Append a second assistant turn.
+    append_assistant_turn(&session, "sess-2", "2026-05-01T12:30:00Z", 200, 75);
+
+    let after_append = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    assert_eq!(after_append.calls.len(), 2, "appended turn should be visible");
+
+    // Compare with a fresh disabled-cache full re-parse.
+    let fresh = parse_usage_for_with_roots_and_cache(
+        query_all(),
+        &roots,
+        Arc::new(Cache::disabled()),
+    );
+    assert_eq!(after_append.calls.len(), fresh.calls.len());
+    assert_eq!(
+        after_append.grand_total.total(),
+        fresh.grand_total.total(),
+        "append-only path must agree with full re-parse on totals"
+    );
+}
+
+#[test]
+fn truncate_triggers_full_reparse() {
+    let work = TempDir::new().unwrap();
+    let projects = build_claude_root(work.path());
+    let session = projects.join("-Users-test-myrepo").join("sess-3.jsonl");
+    append_assistant_turn(&session, "sess-3", "2026-05-01T12:00:00Z", 100, 50);
+    append_assistant_turn(&session, "sess-3", "2026-05-01T13:00:00Z", 100, 50);
+
+    let roots = UsageSourceRoots {
+        claude_projects_dir: Some(projects.clone()),
+        codex_dir: None,
+    };
+    let cache_dir = TempDir::new().unwrap();
+    let cache = cache_at(cache_dir.path());
+    let first = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    assert_eq!(first.calls.len(), 2);
+
+    // Truncate file completely and write one new turn.
+    fs::write(&session, b"").unwrap();
+    append_assistant_turn(&session, "sess-3", "2026-05-02T09:00:00Z", 1, 1);
+
+    let second = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    assert_eq!(
+        second.calls.len(),
+        1,
+        "truncate + rewrite must drop stale calls and parse only the new turn"
+    );
+}
+
+#[test]
+fn no_cache_path_writes_no_rows() {
+    let work = TempDir::new().unwrap();
+    let projects = build_claude_root(work.path());
+    let session = projects.join("-Users-test-myrepo").join("sess-4.jsonl");
+    append_assistant_turn(&session, "sess-4", "2026-05-01T12:00:00Z", 100, 50);
+
+    let roots = UsageSourceRoots {
+        claude_projects_dir: Some(projects.clone()),
+        codex_dir: None,
+    };
+    let disabled = Arc::new(Cache::disabled());
+    let _ = parse_usage_for_with_roots_and_cache(query_all(), &roots, disabled.clone());
+    // Disabled cache exposes no info; ensure it stays disabled.
+    assert!(!disabled.is_enabled());
+}


### PR DESCRIPTION
## Summary

Adds a persistent SQLite cache to the usage analytics scan path so unchanged Claude/Codex JSONL session files aren't re-parsed on every TUI start or `r`-refresh. Append-only files only re-parse the new bytes.

This is a perf-only refactor — same `UsageData` shape, same panels, same filters, no UX changes. Force-refresh paths (`--no-cache`, `Shift+R`, `ainb usage cache (clear|info)`) bypass it on demand.

### Codeburn comparison
The reference impl (`getagentseal/codeburn`) uses JSON files only and **fully re-parses every Claude JSONL on every invocation** (only an mtime pre-filter for date range). It does have `(mtime, size)` fingerprint caches but only for Codex `.pb` files and the Cursor monolithic SQLite — never for Claude. This PR fills that gap and goes beyond with append-only seek-from-offset incremental parse, blake3 suffix hashing, and SQLite WAL.

## What's in the PR

- `src/usage_cache/` module: `db.rs`, `fingerprint.rs`, `store.rs` + 12 unit tests + 4 integration tests
- SQLite at `~/.agents-in-a-box/cache/usage.db` (override via `AINB_USAGE_CACHE_DB`). WAL mode. Schema version table; bump = drop+rebuild
- `files` table: `path` PK + `size_bytes`, `mtime_nanos`, `last_offset`, `suffix_blake3` (4 KiB tail), bincode'd `Vec<ProviderCall>` blob, `blob_format` version, `updated_at`
- Per-file fingerprint classifier emits `Unchanged` / `Append { from_offset }` / `FullReparse`. `verify_append_safe` re-hashes the prior 4 KiB tail before trusting Append, downgrading to FullReparse on mismatch
- Force-refresh: `--no-cache` CLI flag, `Shift+R` keybinding, `ainb usage cache (clear|info)` subcommand. On `clear()` failure, falls back to `disabled_cache()` so bypass is honoured
- Cache-must-not-break-analytics contract: every cache error logs and falls through to full parse; `Mutex<Connection>` recovers from poison via `into_inner()`
- Bincode layout-stability tripwire test fails CI if `ProviderCall` field set/order drifts without an explicit `BLOB_FORMAT_BINCODE_V1` bump

## Atomic commit list

1. `feat(ainb-tui): add rusqlite + blake3 + bincode deps`
2. `feat(ainb-tui): scaffold usage_cache module with sqlite schema`
3. `feat(ainb-tui): per-file fingerprint with blake3 suffix hash`
4. `feat(ainb-tui): wire usage_cache into claude/codex parsers`
5. `feat(ainb-tui): cache-bypass force-refresh via Shift+R and --no-cache`
6. `feat(ainb-tui): ainb usage cache (clear|info) subcommand`
7. `test(ainb-tui): integration tests for usage cache`
8. `style(ainb-tui): clippy + rustfmt cleanup in usage_cache`
9. `fix(ainb-tui): classify same-size+different-suffix as FullReparse`  ← review fix
10. `fix(ainb-tui): recover from poisoned usage_cache mutex`  ← review fix
11. `fix(ainb-tui): honour force-refresh when cache clear fails`  ← review fix
12. `docs(ainb-tui): warn about bincode layout stability for ProviderCall`  ← review fix
13. `feat(ainb-tui): show [R] force refresh in usage help bar`  ← review fix
14. `test(ainb-tui): cover review findings — classify same-size, bincode tripwire`  ← review fix

## Deviations / non-obvious decisions

- **Codex parser routes through cache but always full-parses on change.** The codex parser uses cumulative-token-delta math that requires parser state we don't persist; the cache row still updates so unchanged-fingerprint short-circuit works on the next scan. Cache-write only, no append-incremental. Documented inline.
- **`current_user_message` is not restored across the append boundary** for Claude — new assistant rows that appear before the next user line in the appended tail get an empty `user_message`. Could persist parser state in a follow-up by adding a `parser_state_blob` column. Out of scope here.
- **`Vec<ProviderCall>` is encoded with bincode v1.** Positional encoding means struct layout changes silently invalidate cached blobs. Mitigated by (a) `BlobFormat` version column, (b) doc comment on `ProviderCall`, (c) layout tripwire test.

## Test plan

- [x] 12/12 `usage_cache` unit tests pass
- [x] 4/4 `usage_cache_integration` tests pass (first scan → unchanged, append-only delta matches full-parse, truncate fallback, no-cache writes nothing)
- [x] 20/20 existing `models::usage::tests` pass
- [x] Burndown UI tests pass (the 1 pre-existing `[f]refresh` failure on the home/session bottom-bar is unrelated to this PR — verified on `main`)
- [x] `cargo clippy --lib --tests` — 0 errors, baseline pedantic warnings unchanged
- [x] Code-reviewer pass with 1 HIGH + 4 MEDIUM findings, all addressed in commits 9–14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage analytics now cache for faster subsequent scans
  * Added Shift+R keyboard shortcut to force refresh analytics with cache bypass
  * New CLI commands for cache management: `ainb usage cache info` and `ainb usage cache clear`
  * Added `--no-cache` flag to usage report command for bypassing cache

<!-- end of auto-generated comment: release notes by coderabbit.ai -->