### PR TITLE
feat(ainb-tui): cycle filter to hide stopped sessions

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -23,6 +23,7 @@ pub enum AppEvent {
     PreviousWorkspace,
     ToggleHelp,
     RefreshWorkspaces, // Manual refresh of workspace data
+    CycleSessionFilter, // Cycle Interactive session filter (Shift+F): All → ActiveOnly → StoppedOnly
     ToggleClaudeChat,  // Toggle Claude chat visibility
     NewSession,        // Create session in current directory
     SearchWorkspace,   // Search all workspaces
@@ -672,6 +673,7 @@ impl EventHandler {
             }
             KeyCode::Char('c') => Some(AppEvent::ToggleClaudeChat),
             KeyCode::Char('f') => Some(AppEvent::RefreshWorkspaces), // Manual refresh
+            KeyCode::Char('F') => Some(AppEvent::CycleSessionFilter), // Cycle session filter (active/stopped/all)
             KeyCode::Char('n') => Some(AppEvent::NewSession),
             KeyCode::Char('s') => {
                 // Star/unstar the selected workspace (only if a workspace is selected)
@@ -1973,6 +1975,16 @@ impl EventHandler {
             AppEvent::RefreshWorkspaces => {
                 // Mark for async processing to reload workspace data
                 state.pending_async_action = Some(AsyncAction::RefreshWorkspaces);
+            }
+            AppEvent::CycleSessionFilter => {
+                state.cycle_session_filter();
+                let label = match state.session_filter {
+                    crate::app::state::SessionFilter::All => "all sessions",
+                    crate::app::state::SessionFilter::ActiveOnly => "active only",
+                    crate::app::state::SessionFilter::StoppedOnly => "stopped only",
+                };
+                state.add_success_notification(format!("Filter: {}", label));
+                state.ui_needs_refresh = true;
             }
             AppEvent::NextSession => {
                 state.next_session();

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -1959,6 +1959,41 @@ impl ClaudeChatState {
     }
 }
 
+/// View filter for the session tree, cycled by `Shift+F` on the sessions screen.
+///
+/// Phase 2 of `load_interactive_mode_sessions` started surfacing Stopped sessions
+/// (tmux-dead but worktree-alive) alongside Running ones. With many worktrees
+/// the tree gets crowded; this filter lets the user hide stopped rows or focus
+/// on stopped-only without losing access. In-memory only (resets each launch).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SessionFilter {
+    #[default]
+    All,
+    ActiveOnly,
+    StoppedOnly,
+}
+
+impl SessionFilter {
+    /// Cycle order: All → ActiveOnly → StoppedOnly → All.
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::ActiveOnly,
+            Self::ActiveOnly => Self::StoppedOnly,
+            Self::StoppedOnly => Self::All,
+        }
+    }
+
+    /// Short label rendered in the workspace panel title (`[active]` etc.).
+    /// Returns None for `All` so the default view stays unmarked.
+    pub fn title_label(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::ActiveOnly => Some("active"),
+            Self::StoppedOnly => Some("stopped"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct AppState {
     pub workspaces: Vec<Workspace>,
@@ -1967,6 +2002,7 @@ pub struct AppState {
     pub shell_selected: bool, // Whether the workspace shell is currently selected
     pub selected_sessions: HashSet<Uuid>, // Multi-selected session IDs for bulk operations
     pub expand_all_workspaces: bool, // When true, show all sessions across all workspaces
+    pub session_filter: SessionFilter, // View filter for Interactive sessions (Shift+F to cycle)
     pub current_view: View,
     pub should_quit: bool,
     pub logs: HashMap<Uuid, Vec<String>>,
@@ -2570,6 +2606,7 @@ impl Default for AppState {
             shell_selected: false,
             selected_sessions: HashSet::new(),
             expand_all_workspaces: true, // Default to expanded view
+            session_filter: SessionFilter::All,
             current_view: View::HomeScreen,
             should_quit: false,
             logs: HashMap::new(),
@@ -4188,27 +4225,37 @@ impl AppState {
                     return;
                 }
 
-                // Currently in regular sessions
+                // Currently in regular sessions. Find the next *visible*
+                // session (skipping any that the active filter hides) so j/k
+                // doesn't land on a row that isn't rendered.
                 if let Some(session_idx) = self.selected_session_index {
-                    if session_idx + 1 < workspace.sessions.len() {
-                        // Move to next session in this workspace
-                        self.selected_session_index = Some(session_idx + 1);
+                    let next_visible = workspace
+                        .sessions
+                        .iter()
+                        .enumerate()
+                        .skip(session_idx + 1)
+                        .find(|(_, s)| self.session_passes_filter(s))
+                        .map(|(i, _)| i);
+                    if let Some(next_idx) = next_visible {
+                        self.selected_session_index = Some(next_idx);
                         self.queue_logs_fetch();
                     } else if workspace.shell_session.is_some() {
-                        // At last regular session - move to shell session
                         self.selected_session_index = None;
                         self.shell_selected = true;
                     } else {
-                        // At last session, no shell - try next workspace
                         self.move_to_next_workspace_first_item(workspace_idx);
                     }
-                } else if !workspace.sessions.is_empty() {
-                    // No session selected, select first
-                    self.selected_session_index = Some(0);
-                    self.queue_logs_fetch();
-                } else if workspace.shell_session.is_some() {
-                    // No regular sessions, go to shell session
-                    self.shell_selected = true;
+                } else {
+                    let first_visible = workspace
+                        .sessions
+                        .iter()
+                        .position(|s| self.session_passes_filter(s));
+                    if let Some(first_idx) = first_visible {
+                        self.selected_session_index = Some(first_idx);
+                        self.queue_logs_fetch();
+                    } else if workspace.shell_session.is_some() {
+                        self.shell_selected = true;
+                    }
                 }
             }
         }
@@ -4339,10 +4386,20 @@ impl AppState {
                     return;
                 }
 
-                // Currently in regular sessions
+                // Currently in regular sessions. Find the previous *visible*
+                // session under the active filter so k doesn't land on a
+                // hidden row.
                 if let Some(session_idx) = self.selected_session_index {
-                    if session_idx > 0 {
-                        self.selected_session_index = Some(session_idx - 1);
+                    let prev_visible = workspace
+                        .sessions
+                        .iter()
+                        .enumerate()
+                        .take(session_idx)
+                        .rev()
+                        .find(|(_, s)| self.session_passes_filter(s))
+                        .map(|(i, _)| i);
+                    if let Some(prev_idx) = prev_visible {
+                        self.selected_session_index = Some(prev_idx);
                         self.queue_logs_fetch();
                     } else {
                         // At first session - try to move to previous workspace's last item
@@ -4412,6 +4469,50 @@ impl AppState {
 
     pub fn toggle_expand_all_workspaces(&mut self) {
         self.expand_all_workspaces = !self.expand_all_workspaces;
+    }
+
+    /// Cycle the session-status filter (Shift+F): All → ActiveOnly → StoppedOnly → All.
+    /// Resets the session selection so it doesn't point to a now-hidden row.
+    pub fn cycle_session_filter(&mut self) {
+        self.session_filter = self.session_filter.next();
+        // Selection indices are positional over the *displayed* list. Resetting
+        // to the first session of the first workspace is simplest and matches
+        // what `load_real_workspaces` already does after a refresh.
+        self.selected_session_index = None;
+        self.shell_selected = false;
+        if let Some(idx) = self.selected_workspace_index {
+            // Clamp workspace index too, in case the active workspace gets
+            // hidden (no sessions match the filter and no shell).
+            if self.workspaces.get(idx).map(|w| {
+                w.sessions.iter().any(|s| self.session_passes_filter(s))
+                    || w.shell_session.is_some()
+            }) != Some(true) {
+                let new_idx = self.workspaces.iter().position(|w| {
+                    w.sessions.iter().any(|s| self.session_passes_filter(s))
+                        || w.shell_session.is_some()
+                });
+                self.selected_workspace_index = new_idx;
+            }
+        }
+        self.last_preview_update = None;
+    }
+
+    /// Predicate used by both rendering and counts so the displayed list and
+    /// the workspace-header `(N)` count never drift apart.
+    ///
+    /// The filter only applies to Interactive sessions (the ones for which
+    /// Stopped is meaningful). Boss-mode sessions and other variants pass
+    /// through regardless.
+    pub fn session_passes_filter(&self, session: &crate::models::Session) -> bool {
+        use crate::models::{SessionMode, SessionStatus};
+        if !matches!(session.mode, SessionMode::Interactive) {
+            return true;
+        }
+        match self.session_filter {
+            SessionFilter::All => true,
+            SessionFilter::ActiveOnly => !matches!(session.status, SessionStatus::Stopped),
+            SessionFilter::StoppedOnly => matches!(session.status, SessionStatus::Stopped),
+        }
     }
 
     /// Toggle the expand/collapse state of the "Other tmux" section

--- a/ainb-tui/src/app/state_tests.rs
+++ b/ainb-tui/src/app/state_tests.rs
@@ -613,4 +613,108 @@ mod tests {
         assert_eq!(session.workspace_path, "/tmp/work-stopped");
         assert_eq!(session.agent_type, SessionAgentType::Claude);
     }
+
+    // -- SessionFilter tests ------------------------------------------------
+
+    use crate::app::state::SessionFilter;
+    use crate::models::{Session, SessionStatus as Status};
+
+    fn make_filter_session(mode: SessionMode, status: Status) -> Session {
+        let mut s = Session::new("test".to_string(), "/tmp/x".to_string());
+        s.mode = mode;
+        s.status = status;
+        s
+    }
+
+    #[test]
+    fn test_session_filter_cycle_order() {
+        assert_eq!(SessionFilter::All.next(), SessionFilter::ActiveOnly);
+        assert_eq!(SessionFilter::ActiveOnly.next(), SessionFilter::StoppedOnly);
+        assert_eq!(SessionFilter::StoppedOnly.next(), SessionFilter::All);
+    }
+
+    #[test]
+    fn test_session_filter_default_is_all() {
+        assert_eq!(SessionFilter::default(), SessionFilter::All);
+    }
+
+    #[test]
+    fn test_session_filter_title_label() {
+        assert_eq!(SessionFilter::All.title_label(), None);
+        assert_eq!(SessionFilter::ActiveOnly.title_label(), Some("active"));
+        assert_eq!(SessionFilter::StoppedOnly.title_label(), Some("stopped"));
+    }
+
+    #[test]
+    fn test_session_passes_filter_all_lets_everything_through() {
+        let mut state = AppState::new();
+        state.session_filter = SessionFilter::All;
+        for mode in [SessionMode::Interactive, SessionMode::Boss] {
+            for status in [Status::Running, Status::Stopped, Status::Idle] {
+                assert!(
+                    state.session_passes_filter(&make_filter_session(
+                        mode.clone(),
+                        status.clone()
+                    )),
+                    "All should pass mode={:?} status={:?}",
+                    mode,
+                    status
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_session_passes_filter_active_only_hides_stopped_interactive() {
+        let mut state = AppState::new();
+        state.session_filter = SessionFilter::ActiveOnly;
+
+        // Interactive Stopped → hidden
+        assert!(!state.session_passes_filter(&make_filter_session(
+            SessionMode::Interactive,
+            Status::Stopped
+        )));
+        // Interactive Running → shown
+        assert!(state.session_passes_filter(&make_filter_session(
+            SessionMode::Interactive,
+            Status::Running
+        )));
+        // Boss-mode Stopped → still passes (filter only touches Interactive)
+        assert!(state.session_passes_filter(&make_filter_session(
+            SessionMode::Boss,
+            Status::Stopped
+        )));
+    }
+
+    #[test]
+    fn test_session_passes_filter_stopped_only() {
+        let mut state = AppState::new();
+        state.session_filter = SessionFilter::StoppedOnly;
+
+        assert!(state.session_passes_filter(&make_filter_session(
+            SessionMode::Interactive,
+            Status::Stopped
+        )));
+        assert!(!state.session_passes_filter(&make_filter_session(
+            SessionMode::Interactive,
+            Status::Running
+        )));
+        // Boss-mode is exempt — always passes regardless of filter mode.
+        assert!(state.session_passes_filter(&make_filter_session(
+            SessionMode::Boss,
+            Status::Running
+        )));
+    }
+
+    #[test]
+    fn test_cycle_session_filter_advances_state() {
+        let mut state = AppState::new();
+        assert_eq!(state.session_filter, SessionFilter::All);
+        state.cycle_session_filter();
+        assert_eq!(state.session_filter, SessionFilter::ActiveOnly);
+        state.cycle_session_filter();
+        assert_eq!(state.session_filter, SessionFilter::StoppedOnly);
+        state.cycle_session_filter();
+        assert_eq!(state.session_filter, SessionFilter::All);
+    }
 }

--- a/ainb-tui/src/components/session_list.rs
+++ b/ainb-tui/src/components/session_list.rs
@@ -53,7 +53,33 @@ impl SessionListComponent {
             FocusedPane::LiveLogs => (SUBDUED_BORDER, false),
         };
 
-        let workspace_count = state.workspaces.len();
+        // Visible workspace count reflects the filter — workspaces that lose
+        // all their sessions to the filter (and have no shell) are dropped
+        // from the rendered list, so the header should match.
+        let workspace_count = state
+            .workspaces
+            .iter()
+            .filter(|w| {
+                w.sessions.iter().any(|s| state.session_passes_filter(s))
+                    || w.shell_session.is_some()
+            })
+            .count();
+
+        let mut title_spans = vec![
+            Span::styled(" 📁 ", Style::default().fg(GOLD)),
+            Span::styled("Workspaces ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                format!("({})", workspace_count),
+                Style::default().fg(if is_focused { CORNFLOWER_BLUE } else { MUTED_GRAY }).add_modifier(Modifier::BOLD)
+            ),
+        ];
+        if let Some(label) = state.session_filter.title_label() {
+            title_spans.push(Span::raw(" "));
+            title_spans.push(Span::styled(
+                format!("[{}]", label),
+                Style::default().fg(GOLD),
+            ));
+        }
 
         let list = List::new(items)
             .block(
@@ -62,14 +88,7 @@ impl SessionListComponent {
                     .border_type(BorderType::Rounded)
                     .border_style(Style::default().fg(border_color))
                     .style(Style::default().bg(DARK_BG))
-                    .title(Line::from(vec![
-                        Span::styled(" 📁 ", Style::default().fg(GOLD)),
-                        Span::styled("Workspaces ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
-                        Span::styled(
-                            format!("({})", workspace_count),
-                            Style::default().fg(if is_focused { CORNFLOWER_BLUE } else { MUTED_GRAY }).add_modifier(Modifier::BOLD)
-                        ),
-                    ]))
+                    .title(Line::from(title_spans))
                     .title_bottom(if state.ssh_session_rename_mode || state.other_tmux_rename_mode {
                         // Rename mode help (SSH or Other tmux)
                         Line::from(vec![
@@ -111,6 +130,9 @@ impl SessionListComponent {
                             Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
                             Span::styled(" D", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
                             Span::styled(" del marked ", Style::default().fg(MUTED_GRAY)),
+                            Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
+                            Span::styled(" F", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                            Span::styled(" filter ", Style::default().fg(MUTED_GRAY)),
                         ])
                     }),
             )
@@ -128,9 +150,23 @@ impl SessionListComponent {
 
         for (workspace_idx, workspace) in state.workspaces.iter().enumerate() {
             let is_selected_workspace = state.selected_workspace_index == Some(workspace_idx);
-            let session_count = workspace.sessions.len();
+            // Apply the session filter (Shift+F cycles): only count sessions
+            // that pass the predicate so the workspace `(N)` matches what the
+            // user actually sees rendered below.
+            let session_count = workspace
+                .sessions
+                .iter()
+                .filter(|s| state.session_passes_filter(s))
+                .count();
             let has_shell = workspace.shell_session.is_some();
             let total_count = session_count + if has_shell { 1 } else { 0 };
+
+            // Hide workspaces that have no visible content under the active
+            // filter (no matching sessions and no shell). Skip the entire
+            // entry — including its header row — so the tree stays compact.
+            if total_count == 0 {
+                continue;
+            }
 
             // Determine expand state: expanded if selected OR if expand_all is true
             let is_expanded = is_selected_workspace || state.expand_all_workspaces;
@@ -207,10 +243,19 @@ impl SessionListComponent {
 
             // Show sessions if workspace is expanded
             if is_expanded {
-                let session_len = workspace.sessions.len();
-                for (session_idx, session) in workspace.sessions.iter().enumerate() {
+                // Apply the session filter; preserve original indices so the
+                // selection match (`selected_session_index`) keeps pointing
+                // at the correct entry in `workspace.sessions`.
+                let visible: Vec<(usize, &crate::models::Session)> = workspace
+                    .sessions
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, s)| state.session_passes_filter(s))
+                    .collect();
+                let visible_len = visible.len();
+                for (visible_pos, &(session_idx, session)) in visible.iter().enumerate() {
                     let is_selected_session = is_selected_workspace && state.selected_session_index == Some(session_idx);
-                    let is_last_session = session_idx == session_len - 1;
+                    let is_last_session = visible_pos == visible_len - 1;
 
                     // Tree line characters with subdued color
                     let tree_prefix = if is_last_session { "└─" } else { "├─" };


### PR DESCRIPTION
## Summary

After PR #58 the sessions tree mixes Running + Stopped rows from the Phase 2 stopped-session loader, so once a few worktrees pile up the view gets crowded. This adds a one-keystroke filter to focus the tree.

- **`Shift+F`** cycles `All → ActiveOnly → StoppedOnly → All`
- Filter mode shown inline in the workspace title: \`Workspaces (5) [active]\`
- Workspace counts reflect the filter; empty workspaces (no visible sessions and no shell) are hidden so there are no orphan headers
- `j`/`k` navigation skips over hidden sessions
- Help bar gains `F filter`
- In-memory only — resets to All each launch (out of scope for v1: persistence, per-workspace overrides, filtering Other tmux/SSH sections)

## Implementation

- `SessionFilter` enum + `session_filter` field on `AppState`, with `cycle_session_filter()` and `session_passes_filter()` helpers (`src/app/state.rs`)
- `AppEvent::CycleSessionFilter` wired to `KeyCode::Char('F')` (`src/app/events.rs`)
- `build_list_items_static` filters and renames count + title (`src/components/session_list.rs`)
- `next_session` / `previous_session` patched to find the next *visible* session, so navigation can't land on a filtered-out row

The filter only affects Interactive sessions; Boss-mode sessions and the SSH / Other-tmux sections pass through regardless.

## Test plan

- [x] 7 new unit tests covering enum cycle, default, title labels, predicate (All/ActiveOnly/StoppedOnly × Interactive/Boss × Running/Stopped/Idle), and \`cycle_session_filter\` rotation. All pass.
- [x] \`cargo build\` clean
- [x] No new clippy warnings on touched files
- [ ] Manual smoke: launch TUI, press \`F\` repeatedly, verify the workspaces collapse to active-only / stopped-only / back to all, with stable selection and matching counts

## Out of scope (follow-ups)

- Persisting the filter across launches
- Filtering "Other tmux" / SSH sections
- A "show only mine / errored" filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive session filtering by status: press F to cycle between All, Active Only, and Stopped Only views.
  * Session list dynamically updates to display only sessions matching the selected filter.
  * Help text updated with the new filter keyboard shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->