### PR TITLE
feat(ainb-tui): widget zoom + structured date pickers

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -76,6 +76,9 @@ rusqlite = { version = "0.31", features = ["bundled", "blob"] }
 blake3 = "1"
 bincode = "1.3"
 
+# Fuzzy search for the burndown zoom panels
+nucleo-matcher = "0.3"
+
 [features]
 default = []
 visual-debug = []  # Enable live terminal during tests

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -372,6 +372,15 @@ pub enum AppEvent {
     UsageCommitFilter,   // Enter on focused row -> add chip
     UsagePopFilterChip,  // Esc when chips exist
     UsageClearAllChips,  // C — drop every chip in one shot
+    // Zoom mode (PR-C)
+    UsageToggleZoom,         // z — toggle fullscreen panel zoom on Burndown
+    UsageZoomStartSearch,    // / inside zoom — begin fuzzy search
+    UsageZoomCommitSearch,   // Enter inside zoom search
+    UsageZoomCancelSearch,   // Esc inside zoom search
+    UsageZoomSearchChar(char),  // typed char in zoom search input
+    UsageZoomSearchBackspace,   // Backspace in zoom search input
+    UsageZoomToggleDetail,   // d inside zoom — toggle detail drawer
+    UsageZoomEsc,            // Esc inside zoom — detail-close > zoom-exit
     // Skills browser events
     SkillsBack,             // Return to home screen (Esc)
     SkillsNextProvider,     // Next provider (Right arrow)
@@ -1667,6 +1676,20 @@ impl EventHandler {
             };
         }
 
+        // Zoom-search input mode eats most keys: typing builds the query,
+        // Enter commits, Esc cancels, Backspace edits. Other navigation
+        // keys (Up/Down/Esc-when-no-search etc.) are deferred to the
+        // standard zoom handler below.
+        if state.usage_state.zoom_search_active {
+            return match key_event.code {
+                KeyCode::Esc => Some(AppEvent::UsageZoomCancelSearch),
+                KeyCode::Enter => Some(AppEvent::UsageZoomCommitSearch),
+                KeyCode::Backspace => Some(AppEvent::UsageZoomSearchBackspace),
+                KeyCode::Char(ch) => Some(AppEvent::UsageZoomSearchChar(ch)),
+                _ => None,
+            };
+        }
+
         // Burndown-only cross-filter shortcuts. Tab cycles panel focus
         // here instead of advancing the outer tab bar so the user can
         // pivot without losing the dashboard layout. Esc backs out of
@@ -1677,7 +1700,27 @@ impl EventHandler {
             crate::components::usage::UsageTab::Burndown
         );
         if on_burndown {
+            // Zoom-mode keys take priority over the dashboard cross-filter
+            // shortcuts so `/`, `d`, `Esc` behave as documented in zoom.
+            if state.usage_state.is_zoomed() {
+                match key_event.code {
+                    KeyCode::Char('z') => return Some(AppEvent::UsageToggleZoom),
+                    KeyCode::Esc => return Some(AppEvent::UsageZoomEsc),
+                    KeyCode::Char('/') => return Some(AppEvent::UsageZoomStartSearch),
+                    KeyCode::Char('d') => return Some(AppEvent::UsageZoomToggleDetail),
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        return Some(AppEvent::UsageFocusRowUp);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        return Some(AppEvent::UsageFocusRowDown);
+                    }
+                    _ => return None,
+                }
+            }
+
+            // Outside zoom: existing burndown shortcuts.
             match key_event.code {
+                KeyCode::Char('z') => return Some(AppEvent::UsageToggleZoom),
                 KeyCode::Tab => return Some(AppEvent::UsageFocusNextPanel),
                 KeyCode::BackTab => return Some(AppEvent::UsageFocusPrevPanel),
                 KeyCode::Enter => return Some(AppEvent::UsageCommitFilter),
@@ -4321,6 +4364,31 @@ impl EventHandler {
                 if had_any {
                     state.add_success_notification("Cleared all chips".to_string());
                 }
+            }
+            // PR-C zoom mode events
+            AppEvent::UsageToggleZoom => {
+                state.usage_state.toggle_zoom();
+            }
+            AppEvent::UsageZoomEsc => {
+                state.usage_state.zoom_handle_esc();
+            }
+            AppEvent::UsageZoomStartSearch => {
+                state.usage_state.zoom_begin_search();
+            }
+            AppEvent::UsageZoomCommitSearch => {
+                state.usage_state.zoom_commit_search();
+            }
+            AppEvent::UsageZoomCancelSearch => {
+                state.usage_state.zoom_cancel_search();
+            }
+            AppEvent::UsageZoomSearchChar(ch) => {
+                state.usage_state.zoom_search_char(ch);
+            }
+            AppEvent::UsageZoomSearchBackspace => {
+                state.usage_state.zoom_search_backspace();
+            }
+            AppEvent::UsageZoomToggleDetail => {
+                state.usage_state.toggle_zoom_detail();
             }
             // Skills browser events
             AppEvent::SkillsBack => {

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -1682,7 +1682,10 @@ impl EventHandler {
         // standard zoom handler below.
         if state.usage_state.zoom_search_active {
             return match key_event.code {
-                KeyCode::Esc => Some(AppEvent::UsageZoomCancelSearch),
+                // Route Esc through the state machine so the documented
+                // detail > search > exit precedence is enforced when both
+                // overlays are open. zoom_handle_esc owns the order.
+                KeyCode::Esc => Some(AppEvent::UsageZoomEsc),
                 KeyCode::Enter => Some(AppEvent::UsageZoomCommitSearch),
                 KeyCode::Backspace => Some(AppEvent::UsageZoomSearchBackspace),
                 KeyCode::Char(ch) => Some(AppEvent::UsageZoomSearchChar(ch)),

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -350,10 +350,15 @@ pub enum AppEvent {
     UsageRefresh,             // Reload data (r) — cache-respecting
     UsageForceRefresh,        // Force-refresh bypassing the persistent cache (Shift+R)
     UsageCycleProviderFilter, // Cycle All/Claude/Codex (p)
-    UsageSetPeriod(u8),       // Period shortcut 1-5
+    UsageSetPeriod(u8),       // Period shortcut 1=Today/2=7d/3=30d/4=90d/5=YTD
+    UsageSetPeriodMonth,      // m — switch to SpecificMonth(today's month)
+    UsageSetPeriodQuarter,    // q — switch to SpecificQuarter(today)
+    UsageSetPeriodAll,        // a — switch to All
+    UsagePeriodStepBack,      // ◀ — step Month/Quarter back
+    UsagePeriodStepForward,   // ▶ — step Month/Quarter forward
     UsageStartIncludeFilter,  // Start include project input (/)
     UsageStartExcludeFilter,  // Start exclude project input (x)
-    UsageStartDateRange,      // Start date range input (d)
+    UsageStartDateRange,      // Start date range input (capital D)
     UsageClearFilters,        // Clear include/exclude filters (c)
     UsageInputChar(char),     // Input for usage filter/range
     UsageInputBackspace,      // Backspace in usage input
@@ -1695,6 +1700,22 @@ impl EventHandler {
             }
         }
 
+        // Step Month/Quarter via ◀/▶ when one of those pickers is the
+        // active period. Must run before the generic Left/Right
+        // handler below, otherwise ◀/▶ would walk the provider tab.
+        let stepable = matches!(
+            state.usage_state.period,
+            crate::models::usage::UsagePeriod::SpecificMonth(_)
+                | crate::models::usage::UsagePeriod::SpecificQuarter(..)
+        );
+        if stepable {
+            match key_event.code {
+                KeyCode::Left => return Some(AppEvent::UsagePeriodStepBack),
+                KeyCode::Right => return Some(AppEvent::UsagePeriodStepForward),
+                _ => {}
+            }
+        }
+
         match key_event.code {
             KeyCode::Esc => Some(AppEvent::UsageBack),
             KeyCode::Right | KeyCode::Char('l') => Some(AppEvent::UsageNextProvider),
@@ -1710,14 +1731,22 @@ impl EventHandler {
             KeyCode::Char('r') => Some(AppEvent::UsageRefresh),
             KeyCode::Char('R') => Some(AppEvent::UsageForceRefresh),
             KeyCode::Char('p') => Some(AppEvent::UsageCycleProviderFilter),
+            // PR-C period strip mappings:
+            //   1 Today  2 7d  3 30d  4 90d  5 YTD
+            //   m Month (steppable)  q Quarter (steppable)
+            //   a All  D advanced (free-text custom range)
+            //   ◀/▶ step Month or Quarter when one is active (handled above)
             KeyCode::Char('1') => Some(AppEvent::UsageSetPeriod(1)),
             KeyCode::Char('2') => Some(AppEvent::UsageSetPeriod(2)),
             KeyCode::Char('3') => Some(AppEvent::UsageSetPeriod(3)),
             KeyCode::Char('4') => Some(AppEvent::UsageSetPeriod(4)),
             KeyCode::Char('5') => Some(AppEvent::UsageSetPeriod(5)),
+            KeyCode::Char('m') => Some(AppEvent::UsageSetPeriodMonth),
+            KeyCode::Char('q') => Some(AppEvent::UsageSetPeriodQuarter),
+            KeyCode::Char('a') => Some(AppEvent::UsageSetPeriodAll),
+            KeyCode::Char('D') => Some(AppEvent::UsageStartDateRange),
             KeyCode::Char('/') => Some(AppEvent::UsageStartIncludeFilter),
             KeyCode::Char('x') => Some(AppEvent::UsageStartExcludeFilter),
-            KeyCode::Char('d') => Some(AppEvent::UsageStartDateRange),
             KeyCode::Char('c') => Some(AppEvent::UsageClearFilters),
             _ => None,
         }
@@ -4176,12 +4205,56 @@ impl EventHandler {
                     1 => UsagePeriod::Today,
                     2 => UsagePeriod::Week,
                     3 => UsagePeriod::ThirtyDays,
-                    4 => UsagePeriod::Month,
-                    5 => UsagePeriod::All,
+                    4 => UsagePeriod::LastNDays(90),
+                    5 => UsagePeriod::YearToDate,
                     _ => state.usage_state.period.clone(),
                 };
                 state.usage_state.set_period(selected);
                 state.start_background_usage_load(true);
+            }
+            AppEvent::UsageSetPeriodMonth => {
+                use crate::models::usage::UsagePeriod;
+                use chrono::Datelike;
+                // If already on a SpecificMonth keep its anchor; otherwise
+                // default to the current calendar month (day=1).
+                let anchor = match state.usage_state.period {
+                    UsagePeriod::SpecificMonth(d) => d,
+                    _ => {
+                        let today = chrono::Local::now().date_naive();
+                        chrono::NaiveDate::from_ymd_opt(today.year(), today.month(), 1)
+                            .unwrap_or(today)
+                    }
+                };
+                state.usage_state.set_period(UsagePeriod::SpecificMonth(anchor));
+                state.start_background_usage_load(true);
+            }
+            AppEvent::UsageSetPeriodQuarter => {
+                use crate::models::usage::{UsagePeriod, quarter_of};
+                use chrono::Datelike;
+                let (year, q) = match state.usage_state.period {
+                    UsagePeriod::SpecificQuarter(y, q) => (y, q),
+                    _ => {
+                        let today = chrono::Local::now().date_naive();
+                        (today.year(), quarter_of(today))
+                    }
+                };
+                state.usage_state.set_period(UsagePeriod::SpecificQuarter(year, q));
+                state.start_background_usage_load(true);
+            }
+            AppEvent::UsageSetPeriodAll => {
+                use crate::models::usage::UsagePeriod;
+                state.usage_state.set_period(UsagePeriod::All);
+                state.start_background_usage_load(true);
+            }
+            AppEvent::UsagePeriodStepBack => {
+                if state.usage_state.step_period_back() {
+                    state.start_background_usage_load(true);
+                }
+            }
+            AppEvent::UsagePeriodStepForward => {
+                if state.usage_state.step_period_forward() {
+                    state.start_background_usage_load(true);
+                }
             }
             AppEvent::UsageStartIncludeFilter => {
                 state.usage_state.begin_input(crate::components::usage::UsageInputMode::Include);

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -1112,10 +1112,7 @@ mod tests {
             "--month",
             "2026-04",
         ]);
-        assert!(
-            result.is_err(),
-            "clap should reject --from with --month"
-        );
+        assert!(result.is_err(), "clap should reject --from with --month");
     }
 
     #[test]

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -63,12 +63,37 @@ pub struct UsageReportArgs {
     /// Period: today, week, 30days, month, all
     #[arg(long, value_enum, default_value_t = PeriodArg::Week)]
     pub period: PeriodArg,
-    /// Start date YYYY-MM-DD
-    #[arg(long)]
+    /// Start date YYYY-MM-DD (mutually exclusive with --month, --quarter,
+    /// --last-n-days, --ytd; pairs with --to for an explicit range).
+    #[arg(long, conflicts_with_all = ["month", "quarter", "last_n_days", "ytd"])]
     pub from: Option<String>,
-    /// End date YYYY-MM-DD
-    #[arg(long)]
+    /// End date YYYY-MM-DD (mutually exclusive with --month, --quarter,
+    /// --last-n-days, --ytd; pairs with --from for an explicit range).
+    #[arg(long, conflicts_with_all = ["month", "quarter", "last_n_days", "ytd"])]
     pub to: Option<String>,
+    /// Pin to a specific calendar month, e.g. `2026-04`. Mutually
+    /// exclusive with --quarter, --last-n-days, --ytd, --from, --to.
+    #[arg(long, conflicts_with_all = ["quarter", "last_n_days", "ytd", "from", "to"])]
+    pub month: Option<String>,
+    /// Pin to a specific calendar quarter, e.g. `2026-Q2`. Mutually
+    /// exclusive with --month, --last-n-days, --ytd, --from, --to.
+    #[arg(long, conflicts_with_all = ["month", "last_n_days", "ytd", "from", "to"])]
+    pub quarter: Option<String>,
+    /// Last N days (rolling window ending today). Mutually exclusive
+    /// with --month, --quarter, --ytd, --from, --to.
+    #[arg(
+        long = "last-n-days",
+        value_name = "N",
+        conflicts_with_all = ["month", "quarter", "ytd", "from", "to"]
+    )]
+    pub last_n_days: Option<u32>,
+    /// Jan 1 of the current year through today. Mutually exclusive
+    /// with --month, --quarter, --last-n-days, --from, --to.
+    #[arg(
+        long,
+        conflicts_with_all = ["month", "quarter", "last_n_days", "from", "to"]
+    )]
+    pub ytd: bool,
     /// Provider: all, claude, codex
     #[arg(long, value_enum, default_value_t = ProviderArg::All)]
     pub provider: ProviderArg,
@@ -580,7 +605,26 @@ fn load_usage(args: &UsageReportArgs) -> Result<UsageData> {
 }
 
 fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
-    let period = if args.from.is_some() || args.to.is_some() {
+    // Period precedence (top wins; clap rejects combinations via the
+    // conflicts_with_all groups on UsageReportArgs):
+    //   --month YYYY-MM            -> SpecificMonth
+    //   --quarter YYYY-Qn          -> SpecificQuarter
+    //   --last-n-days N            -> LastNDays(N)
+    //   --ytd                      -> YearToDate
+    //   --from / --to              -> Custom (existing free-text behaviour)
+    //   --period {today|week|30days|month|all}  (default)
+    let period = if let Some(month_str) = &args.month {
+        parse_month_arg(month_str)?
+    } else if let Some(quarter_str) = &args.quarter {
+        parse_quarter_arg(quarter_str)?
+    } else if let Some(n) = args.last_n_days {
+        if n == 0 {
+            bail!("--last-n-days must be >= 1");
+        }
+        UsagePeriod::LastNDays(n)
+    } else if args.ytd {
+        UsagePeriod::YearToDate
+    } else if args.from.is_some() || args.to.is_some() {
         let from = match &args.from {
             Some(value) => parse_date(value)?,
             None => NaiveDate::from_ymd_opt(1970, 1, 1).expect("valid date"),
@@ -624,6 +668,29 @@ fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
 fn parse_date(value: &str) -> Result<NaiveDate> {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
         .map_err(|_| anyhow!("invalid date `{value}`, expected YYYY-MM-DD"))
+}
+
+/// Parse `--month YYYY-MM` into `UsagePeriod::SpecificMonth(first-of-month)`.
+fn parse_month_arg(value: &str) -> Result<UsagePeriod> {
+    // chrono's NaiveDate parser wants a day; pin to `-01`.
+    let with_day = format!("{value}-01");
+    let date = NaiveDate::parse_from_str(&with_day, "%Y-%m-%d")
+        .map_err(|_| anyhow!("invalid --month `{value}`, expected YYYY-MM"))?;
+    Ok(UsagePeriod::SpecificMonth(date))
+}
+
+/// Parse `--quarter YYYY-Qn` into `UsagePeriod::SpecificQuarter(year, q)`.
+fn parse_quarter_arg(value: &str) -> Result<UsagePeriod> {
+    let err = || anyhow!("invalid --quarter `{value}`, expected YYYY-Qn (n=1..=4)");
+    // Accept either case for the Q.
+    let normalised = value.to_ascii_uppercase();
+    let (year_part, q_part) = normalised.split_once("-Q").ok_or_else(err)?;
+    let year: i32 = year_part.parse().map_err(|_| err())?;
+    let q: u8 = q_part.parse().map_err(|_| err())?;
+    if !(1..=4).contains(&q) {
+        return Err(err());
+    }
+    Ok(UsagePeriod::SpecificQuarter(year, q))
 }
 
 fn print_text_report(title: &str, data: &UsageData) {
@@ -928,6 +995,137 @@ mod tests {
         ] {
             assert!(csv.contains(header), "missing {header}");
         }
+    }
+
+    #[test]
+    fn month_flag_yields_specific_month_period() {
+        let args = UsageReportArgs {
+            month: Some("2026-04".into()),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        match q.period {
+            UsagePeriod::SpecificMonth(d) => {
+                assert_eq!(d, NaiveDate::from_ymd_opt(2026, 4, 1).unwrap())
+            }
+            other => panic!("expected SpecificMonth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quarter_flag_yields_specific_quarter_period() {
+        let args = UsageReportArgs {
+            quarter: Some("2026-Q2".into()),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::SpecificQuarter(2026, 2)));
+    }
+
+    #[test]
+    fn quarter_flag_lowercase_q_is_accepted() {
+        let args = UsageReportArgs {
+            quarter: Some("2026-q3".into()),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::SpecificQuarter(2026, 3)));
+    }
+
+    #[test]
+    fn quarter_flag_rejects_q5() {
+        let args = UsageReportArgs {
+            quarter: Some("2026-Q5".into()),
+            ..UsageReportArgs::default()
+        };
+        let err = query_from_args(&args).unwrap_err().to_string();
+        assert!(err.contains("YYYY-Qn"));
+    }
+
+    #[test]
+    fn last_n_days_flag_yields_last_n_days_period() {
+        let args = UsageReportArgs {
+            last_n_days: Some(14),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::LastNDays(14)));
+    }
+
+    #[test]
+    fn last_n_days_zero_is_rejected() {
+        let args = UsageReportArgs {
+            last_n_days: Some(0),
+            ..UsageReportArgs::default()
+        };
+        assert!(query_from_args(&args).is_err());
+    }
+
+    #[test]
+    fn month_and_quarter_are_mutually_exclusive_at_clap_parse_time() {
+        use clap::CommandFactory;
+        // We exercise the conflicts_with_all groups by parsing a synthetic
+        // argv. Reach for the cli::Cli struct so the full subcommand
+        // routing is exercised — this gives us the realistic error path
+        // a user would hit.
+        let result = crate::cli::Cli::command().try_get_matches_from([
+            "ainb",
+            "usage",
+            "report",
+            "--month",
+            "2026-04",
+            "--quarter",
+            "2026-Q2",
+        ]);
+        assert!(
+            result.is_err(),
+            "clap should reject --month and --quarter together"
+        );
+    }
+
+    #[test]
+    fn last_n_days_conflicts_with_ytd_at_clap_parse_time() {
+        use clap::CommandFactory;
+        let result = crate::cli::Cli::command().try_get_matches_from([
+            "ainb",
+            "usage",
+            "report",
+            "--last-n-days",
+            "14",
+            "--ytd",
+        ]);
+        assert!(
+            result.is_err(),
+            "clap should reject --last-n-days and --ytd together"
+        );
+    }
+
+    #[test]
+    fn from_to_conflicts_with_month_at_clap_parse_time() {
+        use clap::CommandFactory;
+        let result = crate::cli::Cli::command().try_get_matches_from([
+            "ainb",
+            "usage",
+            "report",
+            "--from",
+            "2026-04-01",
+            "--month",
+            "2026-04",
+        ]);
+        assert!(
+            result.is_err(),
+            "clap should reject --from with --month"
+        );
+    }
+
+    #[test]
+    fn ytd_flag_yields_year_to_date_period() {
+        let args = UsageReportArgs {
+            ytd: true,
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::YearToDate));
     }
 
     #[test]

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -315,6 +315,73 @@ impl UsageViewState {
         self.scroll_offset = 0;
     }
 
+    /// Step the active Month or Quarter picker one unit back. Clamps
+    /// at the oldest day in `data.daily` (so we never step into a
+    /// region known to have no usage rows). Returns `true` when the
+    /// period actually changed.
+    ///
+    /// No-op when the active period is not a Month/Quarter picker.
+    pub fn step_period_back(&mut self) -> bool {
+        let oldest = self
+            .data
+            .as_ref()
+            .and_then(|d| d.daily.first().map(|(date, _)| *date));
+        match self.period.clone() {
+            UsagePeriod::SpecificMonth(anchor) => {
+                let new_anchor = previous_month_first(anchor);
+                if let Some(oldest_first) = oldest.map(first_of_month) {
+                    if new_anchor < oldest_first {
+                        return false;
+                    }
+                }
+                self.period = UsagePeriod::SpecificMonth(new_anchor);
+                self.scroll_offset = 0;
+                true
+            }
+            UsagePeriod::SpecificQuarter(year, q) => {
+                let (new_year, new_q) = previous_quarter(year, q);
+                if let Some(oldest_date) = oldest {
+                    let (qy, qq) = current_quarter(oldest_date);
+                    if (new_year, new_q) < (qy, qq) {
+                        return false;
+                    }
+                }
+                self.period = UsagePeriod::SpecificQuarter(new_year, new_q);
+                self.scroll_offset = 0;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Step forward one unit. Clamps at the current real-world month
+    /// or quarter — never lets the user pick a future window.
+    pub fn step_period_forward(&mut self) -> bool {
+        let today = Local::now().date_naive();
+        match self.period.clone() {
+            UsagePeriod::SpecificMonth(anchor) => {
+                let new_anchor = next_month_first(anchor);
+                if new_anchor > first_of_month(today) {
+                    return false;
+                }
+                self.period = UsagePeriod::SpecificMonth(new_anchor);
+                self.scroll_offset = 0;
+                true
+            }
+            UsagePeriod::SpecificQuarter(year, q) => {
+                let (new_year, new_q) = next_quarter(year, q);
+                let (cy, cq) = current_quarter(today);
+                if (new_year, new_q) > (cy, cq) {
+                    return false;
+                }
+                self.period = UsagePeriod::SpecificQuarter(new_year, new_q);
+                self.scroll_offset = 0;
+                true
+            }
+            _ => false,
+        }
+    }
+
     pub fn next_tab(&mut self) {
         self.active_tab = self.active_tab.next();
         self.scroll_offset = 0;
@@ -1413,30 +1480,68 @@ fn render_burndown_header(frame: &mut Frame, area: Rect, data: &UsageData, perio
     frame.render_widget(Paragraph::new(lines), area);
 }
 
-/// Build the "Period: …  Provider: …" labelled strip that replaces the
-/// old cryptic single-line period selector. Renders period chips with
-/// key-hints (1-5, d) and provider-filter chips (P toggles). The
-/// active option in each row is bold + GOLD background.
+/// Build the "Period: …  Provider: …" labelled strip.
+///
+/// Period strip layout:
+/// ```text
+/// Period: 1 Today  2 7d  3 30d  4 90d  5 YTD  [◀ Apr 2026 ▶ m Month]  [◀ Q2 2026 ▶ q Quarter]  a All  D advanced
+/// ```
+/// Active chip: bold + GOLD background. The Month/Quarter blocks render
+/// inline pickers when their variant is active — clicking ◀/▶ steps the
+/// underlying month or quarter back/forward.
 ///
 /// Returned as a `Vec<Line>` so tests can assert chip ordering and
 /// active-marker placement without hitting the Frame.
 fn build_period_provider_strip(state: &UsageViewState) -> Vec<Line<'static>> {
     let mut period_spans: Vec<Span<'static>> =
         vec![Span::styled("Period: ", Style::default().fg(MUTED_GRAY))];
-    let periods: [(&str, char, fn(&UsagePeriod) -> bool); 6] = [
+
+    // Simple key-prefixed chips: 1 Today, 2 7d, 3 30d, 4 90d, 5 YTD.
+    let simple: [(&str, char, fn(&UsagePeriod) -> bool); 5] = [
         ("Today", '1', |p| matches!(p, UsagePeriod::Today)),
-        ("Week", '2', |p| matches!(p, UsagePeriod::Week)),
+        ("7d", '2', |p| matches!(p, UsagePeriod::Week)),
         ("30d", '3', |p| matches!(p, UsagePeriod::ThirtyDays)),
-        ("Month", '4', |p| matches!(p, UsagePeriod::Month)),
-        ("All", '5', |p| matches!(p, UsagePeriod::All)),
-        ("Custom", 'd', |p| matches!(p, UsagePeriod::Custom { .. })),
+        ("90d", '4', |p| matches!(p, UsagePeriod::LastNDays(90))),
+        ("YTD", '5', |p| matches!(p, UsagePeriod::YearToDate)),
     ];
-    for (i, (label, key, is_active)) in periods.iter().enumerate() {
+    for (i, (label, key, is_active)) in simple.iter().enumerate() {
         if i > 0 {
             period_spans.push(Span::styled("  ", Style::default()));
         }
         period_spans.push(period_chip_span(label, *key, is_active(&state.period)));
     }
+
+    // Stepable Month picker.
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.extend(build_step_picker_spans(
+        'm',
+        "Month",
+        &month_picker_label(&state.period),
+        matches!(state.period, UsagePeriod::SpecificMonth(_)),
+    ));
+
+    // Stepable Quarter picker.
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.extend(build_step_picker_spans(
+        'q',
+        "Quarter",
+        &quarter_picker_label(&state.period),
+        matches!(state.period, UsagePeriod::SpecificQuarter(..)),
+    ));
+
+    // Trailing All + advanced custom.
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.push(period_chip_span(
+        "All",
+        'a',
+        matches!(state.period, UsagePeriod::All),
+    ));
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.push(period_chip_span(
+        "advanced",
+        'D',
+        matches!(state.period, UsagePeriod::Custom { .. }),
+    ));
 
     let mut provider_spans: Vec<Span<'static>> =
         vec![Span::styled("Provider: ", Style::default().fg(MUTED_GRAY))];
@@ -1455,6 +1560,59 @@ fn build_period_provider_strip(state: &UsageViewState) -> Vec<Line<'static>> {
 
     // Two label rows so narrow terminals can wrap cleanly.
     vec![Line::from(period_spans), Line::from(provider_spans)]
+}
+
+/// Render `[◀ <label> ▶ <key> <name>]` for the inline Month/Quarter
+/// pickers. Active variant gets the GOLD chip background; inactive
+/// renders as soft white text with hint key prefix.
+fn build_step_picker_spans(
+    key: char,
+    name: &str,
+    label: &str,
+    active: bool,
+) -> Vec<Span<'static>> {
+    let style = if active {
+        Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(SOFT_WHITE)
+    };
+    let arrow_style = if active {
+        Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(MUTED_GRAY)
+    };
+    vec![
+        Span::styled("[", arrow_style),
+        Span::styled("◀ ", arrow_style),
+        Span::styled(label.to_string(), style),
+        Span::styled(" ▶", arrow_style),
+        Span::styled(format!(" {key} {name}"), style),
+        Span::styled("]", arrow_style),
+    ]
+}
+
+/// Label rendered inside the Month picker chip. When the active period
+/// is SpecificMonth we render its anchor; otherwise we render today's
+/// month so the user sees a sensible default before pressing `m`.
+fn month_picker_label(period: &UsagePeriod) -> String {
+    let anchor = match period {
+        UsagePeriod::SpecificMonth(d) => *d,
+        _ => Local::now().date_naive(),
+    };
+    anchor.format("%b %Y").to_string()
+}
+
+/// Label rendered inside the Quarter picker chip. Same fallback rule
+/// as `month_picker_label`.
+fn quarter_picker_label(period: &UsagePeriod) -> String {
+    let (year, q) = match period {
+        UsagePeriod::SpecificQuarter(y, q) => (*y, *q),
+        _ => {
+            let today = Local::now().date_naive();
+            (today.year(), crate::models::usage::quarter_of(today))
+        }
+    };
+    format!("Q{q} {year}")
 }
 
 fn period_chip_span(label: &str, key: char, active: bool) -> Span<'static> {
@@ -2536,6 +2694,48 @@ fn provider_filter_label(filter: UsageProviderFilter) -> &'static str {
     }
 }
 
+/// First day of the calendar month containing `date`.
+fn first_of_month(date: NaiveDate) -> NaiveDate {
+    NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap_or(date)
+}
+
+/// First day of the previous calendar month.
+fn previous_month_first(anchor: NaiveDate) -> NaiveDate {
+    let (y, m) = if anchor.month() == 1 {
+        (anchor.year() - 1, 12)
+    } else {
+        (anchor.year(), anchor.month() - 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
+}
+
+/// First day of the next calendar month.
+fn next_month_first(anchor: NaiveDate) -> NaiveDate {
+    let (y, m) = if anchor.month() == 12 {
+        (anchor.year() + 1, 1)
+    } else {
+        (anchor.year(), anchor.month() + 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
+}
+
+/// `(year, quarter)` of the previous quarter, wrapping into the prior
+/// year at Q1.
+fn previous_quarter(year: i32, q: u8) -> (i32, u8) {
+    if q <= 1 { (year - 1, 4) } else { (year, q - 1) }
+}
+
+/// `(year, quarter)` of the next quarter, wrapping into the next year
+/// at Q4.
+fn next_quarter(year: i32, q: u8) -> (i32, u8) {
+    if q >= 4 { (year + 1, 1) } else { (year, q + 1) }
+}
+
+/// `(year, quarter)` containing `date`.
+fn current_quarter(date: NaiveDate) -> (i32, u8) {
+    (date.year(), crate::models::usage::quarter_of(date))
+}
+
 fn period_label(period: &UsagePeriod) -> String {
     match period {
         UsagePeriod::Today => "Today".to_string(),
@@ -2580,14 +2780,23 @@ mod period_provider_strip_tests {
     }
 
     #[test]
-    fn period_row_lists_all_six_options_with_key_hints() {
+    fn period_row_lists_all_options_with_key_hints() {
         let mut state = UsageViewState::default();
         state.period = UsagePeriod::Week;
         let lines = build_period_provider_strip(&state);
         assert_eq!(lines.len(), 2);
         let row = flatten(&lines[0]);
         for needle in [
-            "Period:", "1 Today", "2 Week", "3 30d", "4 Month", "5 All", "d Custom",
+            "Period:",
+            "1 Today",
+            "2 7d",
+            "3 30d",
+            "4 90d",
+            "5 YTD",
+            "m Month",
+            "q Quarter",
+            "a All",
+            "D advanced",
         ] {
             assert!(row.contains(needle), "missing `{needle}` in {row}");
         }
@@ -2596,10 +2805,19 @@ mod period_provider_strip_tests {
     #[test]
     fn period_row_highlights_active_period() {
         let mut state = UsageViewState::default();
-        state.period = UsagePeriod::Month;
+        state.period = UsagePeriod::Today;
         let lines = build_period_provider_strip(&state);
         let active = highlighted_chip(&lines[0]).expect("a period chip should be highlighted");
-        assert!(active.contains("Month"), "got {active}");
+        assert!(active.contains("Today"), "got {active}");
+    }
+
+    #[test]
+    fn period_row_highlights_90d_chip_when_last_n_days_90() {
+        let mut state = UsageViewState::default();
+        state.period = UsagePeriod::LastNDays(90);
+        let lines = build_period_provider_strip(&state);
+        let active = highlighted_chip(&lines[0]).expect("90d should be highlighted");
+        assert!(active.contains("90d"), "got {active}");
     }
 
     #[test]

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -2372,9 +2372,24 @@ fn elapsed_days_for_period(period: &UsagePeriod, data: &UsageData) -> Option<u64
         UsagePeriod::Today => Some(1),
         UsagePeriod::Week => Some(7),
         UsagePeriod::ThirtyDays => Some(30),
+        UsagePeriod::LastNDays(n) => Some(u64::from((*n).max(1))),
         UsagePeriod::Month => {
             let today = Local::now().date_naive();
             let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1)?;
+            Some((today - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::SpecificMonth(anchor) => {
+            let first = NaiveDate::from_ymd_opt(anchor.year(), anchor.month(), 1)?;
+            let last = crate::models::usage::last_day_of_month(anchor.year(), anchor.month());
+            Some((last - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::SpecificQuarter(year, q) => {
+            let (first, last) = crate::models::usage::quarter_bounds(*year, *q);
+            Some((last - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::YearToDate => {
+            let today = Local::now().date_naive();
+            let first = NaiveDate::from_ymd_opt(today.year(), 1, 1)?;
             Some((today - first).num_days().max(0) as u64 + 1)
         }
         UsagePeriod::Custom { from, to } => {
@@ -2524,9 +2539,13 @@ fn provider_filter_label(filter: UsageProviderFilter) -> &'static str {
 fn period_label(period: &UsagePeriod) -> String {
     match period {
         UsagePeriod::Today => "Today".to_string(),
-        UsagePeriod::Week => "Week".to_string(),
-        UsagePeriod::ThirtyDays => "30 days".to_string(),
+        UsagePeriod::Week => "7d".to_string(),
+        UsagePeriod::ThirtyDays => "30d".to_string(),
+        UsagePeriod::LastNDays(n) => format!("{n}d"),
         UsagePeriod::Month => "Month".to_string(),
+        UsagePeriod::SpecificMonth(anchor) => anchor.format("%b %Y").to_string(),
+        UsagePeriod::SpecificQuarter(year, q) => format!("Q{q} {year}"),
+        UsagePeriod::YearToDate => "YTD".to_string(),
         UsagePeriod::All => "All".to_string(),
         UsagePeriod::Custom { from, to } => format!("{from} to {to}"),
     }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -209,6 +209,24 @@ impl UsagePanel {
         Self::ALL[if idx == 0 { last } else { idx - 1 }]
     }
 
+    /// Human-readable panel name used in the zoom breadcrumb.
+    pub fn title(self) -> &'static str {
+        match self {
+            UsagePanel::DailyActivity => "Daily Activity",
+            UsagePanel::ByProject => "By Project",
+            UsagePanel::TopSessions => "Top Sessions",
+            UsagePanel::Live => "Live Session Ticker",
+            UsagePanel::ByActivity => "By Activity",
+            UsagePanel::ByModel => "By Model",
+            UsagePanel::CoreTools => "Core Tools",
+            UsagePanel::ShellCommands => "Shell Commands",
+            UsagePanel::McpServers => "MCP Servers",
+            UsagePanel::Optimize => "Optimization Recommendations",
+            UsagePanel::Leaderboard => "Agent Leaderboard",
+            UsagePanel::Budget => "Budget · Alerts",
+        }
+    }
+
     /// Whether `Enter` on this panel maps a row onto a cross-filter.
     /// Daily Activity, Optimize, and Budget are read-only — Enter is a
     /// no-op there. Leaderboard maps the focused row onto the Project
@@ -257,6 +275,20 @@ pub struct UsageViewState {
     /// Row indicator inside the focused panel. Clamped to the row count
     /// of the focused panel's underlying collection at render time.
     pub focus_row: usize,
+    /// When `Some`, the burndown view is rendered as a single full-area
+    /// zoomed panel for the given panel kind. Driven by the `z`
+    /// keybinding on Burndown; only meaningful when on Burndown.
+    pub zoom: Option<UsagePanel>,
+    /// True when the zoom view's `/` fuzzy-search overlay is active.
+    /// Resets on zoom exit (we deliberately do *not* persist a search
+    /// across zoom cycles — the brief is "search clears on zoom exit").
+    pub zoom_search_active: bool,
+    /// Live query buffer for the zoom-mode fuzzy search.
+    pub zoom_search_query: String,
+    /// True when the zoom view's `d` detail drawer is open. The drawer
+    /// occupies the bottom 40% of the zoom area and shows the full
+    /// row record for the focused row.
+    pub zoom_detail_open: bool,
 }
 
 impl Default for UsageViewState {
@@ -276,6 +308,10 @@ impl Default for UsageViewState {
             filters: UsageFilters::default(),
             focused_panel: None,
             focus_row: 0,
+            zoom: None,
+            zoom_search_active: false,
+            zoom_search_query: String::new(),
+            zoom_detail_open: false,
         }
     }
 }
@@ -322,10 +358,7 @@ impl UsageViewState {
     ///
     /// No-op when the active period is not a Month/Quarter picker.
     pub fn step_period_back(&mut self) -> bool {
-        let oldest = self
-            .data
-            .as_ref()
-            .and_then(|d| d.daily.first().map(|(date, _)| *date));
+        let oldest = self.data.as_ref().and_then(|d| d.daily.first().map(|(date, _)| *date));
         match self.period.clone() {
             UsagePeriod::SpecificMonth(anchor) => {
                 let new_anchor = previous_month_first(anchor);
@@ -580,10 +613,9 @@ impl UsageViewState {
             (UsageFilterTarget::Project, UsagePanel::Leaderboard | UsagePanel::ByProject) => {
                 filtered.projects.get(row_idx).map(|p| (p.name.clone(), None))
             }
-            (UsageFilterTarget::Activity, _) => filtered
-                .activities
-                .get(row_idx)
-                .map(|a| (a.category.label().to_string(), None)),
+            (UsageFilterTarget::Activity, _) => {
+                filtered.activities.get(row_idx).map(|a| (a.category.label().to_string(), None))
+            }
             (UsageFilterTarget::Model, _) => {
                 filtered.models.get(row_idx).map(|m| (m.model.clone(), None))
             }
@@ -635,6 +667,102 @@ impl UsageViewState {
     /// Drop every cross-filter chip. Leaves include/exclude untouched.
     pub fn clear_all_filter_chips(&mut self) {
         self.filters.clear();
+    }
+
+    /// True when the burndown view is currently zoomed.
+    pub fn is_zoomed(&self) -> bool {
+        self.zoom.is_some()
+    }
+
+    /// Toggle full-screen zoom for the currently-focused panel. If no
+    /// panel is focused (Tab not pressed yet), the first focusable
+    /// dashboard panel is used so `z` works as a discoverable
+    /// "open up bigger" shortcut.
+    pub fn toggle_zoom(&mut self) {
+        if self.zoom.is_some() {
+            self.exit_zoom();
+        } else {
+            let target = self.focused_panel.unwrap_or(UsagePanel::ALL[0]);
+            self.zoom = Some(target);
+            self.focused_panel = Some(target);
+            self.focus_row = 0;
+            self.zoom_search_active = false;
+            self.zoom_search_query.clear();
+            self.zoom_detail_open = false;
+        }
+    }
+
+    /// Exit zoom mode and clear all zoom-scoped UI state (search query,
+    /// detail drawer). Does NOT clear filter chips.
+    pub fn exit_zoom(&mut self) {
+        self.zoom = None;
+        self.zoom_search_active = false;
+        self.zoom_search_query.clear();
+        self.zoom_detail_open = false;
+    }
+
+    /// Begin fuzzy-search input inside the zoomed panel.
+    pub fn zoom_begin_search(&mut self) {
+        if self.zoom.is_some() {
+            self.zoom_search_active = true;
+            self.zoom_search_query.clear();
+        }
+    }
+
+    /// Cancel the active search and drop the partial query.
+    pub fn zoom_cancel_search(&mut self) {
+        self.zoom_search_active = false;
+        self.zoom_search_query.clear();
+    }
+
+    /// Commit the typed search query. Same effect as cancel for the
+    /// renderer (we filter by `zoom_search_query`); we just exit input
+    /// mode so further keys flow back to navigation.
+    pub fn zoom_commit_search(&mut self) {
+        self.zoom_search_active = false;
+    }
+
+    pub fn zoom_search_char(&mut self, ch: char) {
+        if self.zoom_search_active {
+            self.zoom_search_query.push(ch);
+        }
+    }
+
+    pub fn zoom_search_backspace(&mut self) {
+        if self.zoom_search_active {
+            self.zoom_search_query.pop();
+        }
+    }
+
+    /// Toggle the detail drawer in zoom mode. No-op when not zoomed.
+    pub fn toggle_zoom_detail(&mut self) {
+        if self.zoom.is_some() {
+            self.zoom_detail_open = !self.zoom_detail_open;
+        }
+    }
+
+    /// Esc precedence in the zoom view (highest first):
+    /// 1. close detail drawer
+    /// 2. cancel active search
+    /// 3. exit zoom
+    /// 4. pop a chip (caller falls through here when nothing else
+    ///    handled it — this method only consumes the first three).
+    ///
+    /// Returns `true` when Esc was consumed.
+    pub fn zoom_handle_esc(&mut self) -> bool {
+        if !self.is_zoomed() {
+            return false;
+        }
+        if self.zoom_detail_open {
+            self.zoom_detail_open = false;
+            return true;
+        }
+        if self.zoom_search_active {
+            self.zoom_cancel_search();
+            return true;
+        }
+        self.exit_zoom();
+        true
     }
 }
 
@@ -1102,6 +1230,13 @@ fn render_burndown(frame: &mut Frame, area: Rect, data: &UsageData, state: &Usag
     let filtered = filter_usage_data(data, &state.filters);
     let view_data: &UsageData = if state.filters.any() { &filtered } else { data };
 
+    // Zoom takes the full inner area minus a small breadcrumb and an
+    // optional search box. Skip the dashboard grid entirely.
+    if let Some(panel) = state.zoom {
+        render_burndown_zoomed(frame, inner, view_data, state, panel);
+        return;
+    }
+
     // Filter chip strip occupies one row when chips are active OR when
     // a panel is focused (we want the affordance hint visible). When
     // both are absent we still show the hint at low contrast so users
@@ -1126,6 +1261,682 @@ fn render_burndown(frame: &mut Frame, area: Rect, data: &UsageData, state: &Usag
         render_dashboard_compact(frame, vertical[3], view_data, state);
     } else {
         render_dashboard_stack(frame, vertical[3], view_data, state);
+    }
+}
+
+/// Full-screen zoom for a single dashboard panel. The layout is:
+///
+/// ```text
+/// [ Zoomed: <panel name> ]   ◀ Esc back ▶
+/// / search query                              <- only when search active
+/// ┌───────────── panel body (all rows + extra cols) ─────────────┐
+/// │                                                              │
+/// └──────────────────────────────────────────────────────────────┘
+/// ┌──── Detail drawer ─────────── 40% bottom split, when open ──┐
+/// │                                                              │
+/// └──────────────────────────────────────────────────────────────┘
+/// ```
+fn render_burndown_zoomed(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) {
+    let search_h: u16 = if state.zoom_search_active || !state.zoom_search_query.is_empty() {
+        1
+    } else {
+        0
+    };
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // breadcrumb
+            Constraint::Length(search_h),
+            Constraint::Min(0), // body (and optional detail split)
+        ])
+        .split(area);
+
+    render_zoom_breadcrumb(frame, vertical[0], panel);
+    if search_h > 0 {
+        render_zoom_search_bar(frame, vertical[1], state);
+    }
+
+    // Optional 60/40 vertical split when the detail drawer is open.
+    let body_area = vertical[2];
+    let (panel_area, detail_area) = if state.zoom_detail_open {
+        let split = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(body_area);
+        (split[0], Some(split[1]))
+    } else {
+        (body_area, None)
+    };
+
+    render_zoom_panel_body(frame, panel_area, data, state, panel);
+
+    if let Some(detail) = detail_area {
+        render_zoom_detail_drawer(frame, detail, data, state, panel);
+    }
+}
+
+fn render_zoom_breadcrumb(frame: &mut Frame, area: Rect, panel: UsagePanel) {
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" [ Zoomed: {} ] ", panel.title()),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("   ", Style::default()),
+        Span::styled("◀ Esc back ▶", Style::default().fg(MUTED_GRAY)),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+/// Score `haystack` against `query` with nucleo-matcher; `None` means
+/// no match. An empty query matches everything (returns `Some(0)`).
+fn fuzzy_score(matcher: &mut nucleo_matcher::Matcher, query: &str, haystack: &str) -> Option<u32> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let needle = nucleo_matcher::pattern::Pattern::parse(
+        query,
+        nucleo_matcher::pattern::CaseMatching::Smart,
+        nucleo_matcher::pattern::Normalization::Smart,
+    );
+    needle.score(
+        nucleo_matcher::Utf32Str::Ascii(haystack.as_bytes()),
+        matcher,
+    )
+}
+
+/// Filter `rows` by a fuzzy-search query, preserving original order.
+/// Empty query returns all rows. The `label` closure projects each row
+/// to its primary search string (project name, session id, etc.).
+fn apply_zoom_filter<'a, T, F>(rows: &'a [T], query: &str, label: F) -> Vec<&'a T>
+where
+    F: Fn(&T) -> String,
+{
+    if query.is_empty() {
+        return rows.iter().collect();
+    }
+    let mut matcher = nucleo_matcher::Matcher::new(nucleo_matcher::Config::DEFAULT);
+    rows.iter()
+        .filter_map(|row| {
+            let label = label(row);
+            // nucleo expects ASCII-friendly bytes; fall back to a
+            // case-insensitive substring check when the label has
+            // non-ASCII chars (rare, but project paths can include
+            // unicode dashes etc.).
+            if !label.is_ascii() {
+                if label.to_lowercase().contains(query.to_lowercase().as_str()) {
+                    return Some(row);
+                }
+                return None;
+            }
+            fuzzy_score(&mut matcher, query, &label).map(|_| row)
+        })
+        .collect()
+}
+
+fn render_zoom_search_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
+    let cursor = if state.zoom_search_active { "_" } else { "" };
+    let line = Line::from(vec![
+        Span::styled(
+            " / ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            state.zoom_search_query.clone(),
+            Style::default().fg(SOFT_WHITE),
+        ),
+        Span::styled(cursor, Style::default().fg(GOLD)),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+/// Render the body of a zoomed panel — all rows visible, primary
+/// columns plus extras specific to the panel. Each row is filtered by
+/// `state.zoom_search_query` (fuzzy match on the row's primary label).
+///
+/// Per the brief, the headline panels (By Project, Top Sessions, By
+/// Model, By Activity, Daily Activity) get extra columns; everything
+/// else just renders the full untruncated row list inside the same
+/// focus-aware frame used by the dashboard renderers.
+#[allow(clippy::too_many_lines)]
+fn render_zoom_panel_body(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) {
+    let q = state.zoom_search_query.as_str();
+    match panel {
+        UsagePanel::ByProject => render_zoom_by_project(frame, area, data, state, q),
+        UsagePanel::TopSessions => render_zoom_top_sessions(frame, area, data, state, q),
+        UsagePanel::Live => render_zoom_top_sessions(frame, area, data, state, q),
+        UsagePanel::ByModel => render_zoom_by_model(frame, area, data, state, q),
+        UsagePanel::ByActivity => render_zoom_by_activity(frame, area, data, state, q),
+        UsagePanel::DailyActivity => render_zoom_daily_activity(frame, area, data, state, q),
+        UsagePanel::Leaderboard => render_zoom_by_project(frame, area, data, state, q),
+        UsagePanel::CoreTools => {
+            render_zoom_named(frame, area, "Core Tools", &data.tools, state, q)
+        }
+        UsagePanel::ShellCommands => render_zoom_named(
+            frame,
+            area,
+            "Shell Commands",
+            &data.shell_commands,
+            state,
+            q,
+        ),
+        UsagePanel::McpServers => {
+            render_zoom_named(frame, area, "MCP Servers", &data.mcp_servers, state, q)
+        }
+        UsagePanel::Optimize | UsagePanel::Budget => {
+            // These panels are summary cards rather than row lists. We
+            // reuse the standard renderers in a fullscreen frame.
+            let focus = FocusCtx::for_panel(state, panel);
+            if matches!(panel, UsagePanel::Optimize) {
+                render_optimize_compact_panel(frame, area, data, focus);
+            } else {
+                render_budget_panel(frame, area, data, &state.period, focus);
+            }
+        }
+    }
+}
+
+fn render_zoom_by_project(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.projects, query, |p| p.name.clone());
+    let header = Row::new(vec![
+        "#",
+        "Project",
+        "Cost",
+        "Tokens",
+        "Calls",
+        "Sessions",
+        "First seen",
+        "Last seen",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .enumerate()
+        .take(visible_rows)
+        .map(|(idx, project)| {
+            let b = &project.bucket;
+            let (first, last) = project_seen_window(data, &project.name);
+            Row::new(vec![
+                format!("{}", idx + 1),
+                project.path.clone(),
+                format_cost(b.cost_usd),
+                format_tokens_short(b.total()),
+                b.call_count.to_string(),
+                b.session_count.to_string(),
+                first,
+                last,
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(4),
+        Constraint::Min(20),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(8),
+        Constraint::Length(11),
+        Constraint::Length(11),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, area);
+}
+
+fn render_zoom_top_sessions(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.sessions, query, |s| {
+        format!("{} {}", s.project, s.session_id)
+    });
+    let header = Row::new(vec![
+        "Provider",
+        "Project",
+        "Session",
+        "Cost",
+        "Tokens",
+        "Calls",
+        "Duration",
+        "Last seen",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .take(visible_rows)
+        .map(|sess| {
+            let b = &sess.bucket;
+            let dur = (sess.last_timestamp - sess.first_timestamp).num_minutes().max(0);
+            let dur_str = format_duration_min(dur as u64);
+            Row::new(vec![
+                sess.provider.clone(),
+                truncate_string(&sess.project, 24),
+                truncate_string(&sess.session_id, 18),
+                format_cost(b.cost_usd),
+                format_tokens_short(b.total()),
+                b.call_count.to_string(),
+                dur_str,
+                sess.last_timestamp.format("%Y-%m-%d").to_string(),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(8),
+        Constraint::Length(24),
+        Constraint::Length(18),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(11),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, area);
+}
+
+fn render_zoom_by_model(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.models, query, |m| m.model.clone());
+    let header = Row::new(vec![
+        "Model",
+        "Calls",
+        "Tokens",
+        "Cost",
+        "Cost/call",
+        "Top projects",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .take(visible_rows)
+        .map(|m| {
+            let b = &m.bucket;
+            let cost_per_call = b
+                .cost_usd
+                .map(|c| {
+                    if b.call_count == 0 {
+                        0.0
+                    } else {
+                        c / (b.call_count as f64)
+                    }
+                })
+                .map(|c| format!("${c:.4}"))
+                .unwrap_or_else(|| "—".to_string());
+            let top_projects = top_projects_for_model(data, &m.model, 3);
+            Row::new(vec![
+                m.model.clone(),
+                b.call_count.to_string(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+                cost_per_call,
+                top_projects,
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Min(20),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(11),
+        Constraint::Min(20),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, area);
+}
+
+fn render_zoom_by_activity(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.activities, query, |a| a.category.label().to_string());
+    let header = Row::new(vec![
+        "Activity", "Turns", "Edit", "1-shot", "Retries", "Tokens", "Cost",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .take(visible_rows)
+        .map(|a| {
+            let b = &a.bucket;
+            Row::new(vec![
+                a.category.label().to_string(),
+                a.turns.to_string(),
+                a.edit_turns.to_string(),
+                a.one_shot_turns.to_string(),
+                a.retries.to_string(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(14),
+        Constraint::Length(7),
+        Constraint::Length(7),
+        Constraint::Length(7),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(10),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, area);
+}
+
+fn render_zoom_daily_activity(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    // Daily rows are (date, bucket) tuples — search over the date string.
+    let rows: Vec<&(NaiveDate, crate::models::usage::TokenBucket)> = if query.is_empty() {
+        data.daily.iter().collect()
+    } else {
+        data.daily
+            .iter()
+            .filter(|(date, _)| date.format("%Y-%m-%d").to_string().contains(query))
+            .collect()
+    };
+    let header = Row::new(vec![
+        "Date", "Calls", "Sessions", "Projects", "Tokens", "Cost",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .rev()
+        .take(visible_rows)
+        .map(|(date, b)| {
+            Row::new(vec![
+                date.format("%Y-%m-%d").to_string(),
+                b.call_count.to_string(),
+                b.session_count.to_string(),
+                b.project_count.to_string(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(11),
+        Constraint::Length(8),
+        Constraint::Length(9),
+        Constraint::Length(9),
+        Constraint::Length(10),
+        Constraint::Length(10),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, area);
+}
+
+fn render_zoom_named(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    rows: &[NamedUsage],
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let filtered = apply_zoom_filter(rows, query, |n| n.name.clone());
+    let header = Row::new(vec![title, "Calls"])
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = filtered
+        .iter()
+        .take(visible_rows)
+        .map(|row| {
+            Row::new(vec![row.name.clone(), row.calls.to_string()])
+                .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [Constraint::Min(20), Constraint::Length(10)];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    frame.render_widget(table, area);
+}
+
+/// Render the detail drawer for the currently-selected row in the
+/// zoomed panel. Static info card; no extra fetching for PR-C.
+fn render_zoom_detail_drawer(
+    frame: &mut Frame,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) {
+    let block = Block::default()
+        .title(" [ Detail ] ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(GOLD))
+        .style(Style::default().bg(TERMINAL_PANEL));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = build_detail_lines(data, state, panel);
+    let paragraph = Paragraph::new(lines).style(Style::default().fg(SOFT_WHITE));
+    frame.render_widget(paragraph, inner);
+}
+
+fn build_detail_lines(
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) -> Vec<Line<'static>> {
+    let row = state.focus_row;
+    let mut lines = Vec::new();
+    let kv = |k: &str, v: String| -> Line<'static> {
+        Line::from(vec![
+            Span::styled(format!(" {k:<14}"), Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                v,
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+        ])
+    };
+    match panel {
+        UsagePanel::ByProject | UsagePanel::Leaderboard => {
+            if let Some(p) = data.projects.get(row) {
+                lines.push(kv("Project", p.name.clone()));
+                lines.push(kv("Path", p.path.clone()));
+                lines.push(kv("Cost", format_cost(p.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(p.bucket.total())));
+                lines.push(kv("Calls", p.bucket.call_count.to_string()));
+                lines.push(kv("Sessions", p.bucket.session_count.to_string()));
+            }
+        }
+        UsagePanel::TopSessions | UsagePanel::Live => {
+            if let Some(s) = data.sessions.get(row) {
+                lines.push(kv("Session", s.session_id.clone()));
+                lines.push(kv("Project", s.project.clone()));
+                lines.push(kv("Provider", s.provider.clone()));
+                lines.push(kv(
+                    "First seen",
+                    s.first_timestamp.format("%Y-%m-%d %H:%M").to_string(),
+                ));
+                lines.push(kv(
+                    "Last seen",
+                    s.last_timestamp.format("%Y-%m-%d %H:%M").to_string(),
+                ));
+                lines.push(kv("Cost", format_cost(s.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(s.bucket.total())));
+                lines.push(kv("Calls", s.bucket.call_count.to_string()));
+            }
+        }
+        UsagePanel::ByModel => {
+            if let Some(m) = data.models.get(row) {
+                lines.push(kv("Model", m.model.clone()));
+                lines.push(kv("Cost", format_cost(m.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(m.bucket.total())));
+                lines.push(kv("Calls", m.bucket.call_count.to_string()));
+                lines.push(kv(
+                    "Top projects",
+                    top_projects_for_model(data, &m.model, 3),
+                ));
+            }
+        }
+        UsagePanel::ByActivity => {
+            if let Some(a) = data.activities.get(row) {
+                lines.push(kv("Activity", a.category.label().to_string()));
+                lines.push(kv("Turns", a.turns.to_string()));
+                lines.push(kv("Edit turns", a.edit_turns.to_string()));
+                lines.push(kv("1-shot turns", a.one_shot_turns.to_string()));
+                lines.push(kv("Retries", a.retries.to_string()));
+                lines.push(kv("Tokens", format_tokens_short(a.bucket.total())));
+                lines.push(kv("Cost", format_cost(a.bucket.cost_usd)));
+            }
+        }
+        UsagePanel::DailyActivity => {
+            if let Some((date, b)) = data.daily.iter().rev().nth(row) {
+                lines.push(kv("Date", date.format("%Y-%m-%d").to_string()));
+                lines.push(kv("Calls", b.call_count.to_string()));
+                lines.push(kv("Sessions", b.session_count.to_string()));
+                lines.push(kv("Projects", b.project_count.to_string()));
+                lines.push(kv("Tokens", format_tokens_short(b.total())));
+                lines.push(kv("Cost", format_cost(b.cost_usd)));
+            }
+        }
+        UsagePanel::CoreTools => detail_named(&mut lines, &data.tools, row, "Tool", &kv),
+        UsagePanel::ShellCommands => {
+            detail_named(&mut lines, &data.shell_commands, row, "Command", &kv)
+        }
+        UsagePanel::McpServers => {
+            detail_named(&mut lines, &data.mcp_servers, row, "MCP server", &kv)
+        }
+        UsagePanel::Optimize | UsagePanel::Budget => {
+            lines.push(Line::from(Span::styled(
+                "  No detail card for summary panels.",
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No row selected.",
+            Style::default().fg(MUTED_GRAY),
+        )));
+    }
+    lines
+}
+
+fn detail_named<F>(
+    lines: &mut Vec<Line<'static>>,
+    rows: &[NamedUsage],
+    idx: usize,
+    name_label: &str,
+    kv: &F,
+) where
+    F: Fn(&str, String) -> Line<'static>,
+{
+    if let Some(row) = rows.get(idx) {
+        lines.push(kv(name_label, row.name.clone()));
+        lines.push(kv("Calls", row.calls.to_string()));
+    }
+}
+
+/// First-seen / last-seen ISO dates for a project, derived from the
+/// session timeline. Empty strings when the project has no sessions.
+fn project_seen_window(data: &UsageData, project_name: &str) -> (String, String) {
+    let mut iter = data.sessions.iter().filter(|s| s.project == project_name);
+    let Some(first) = iter.next() else {
+        return (String::new(), String::new());
+    };
+    let mut min_ts = first.first_timestamp;
+    let mut max_ts = first.last_timestamp;
+    for s in iter {
+        if s.first_timestamp < min_ts {
+            min_ts = s.first_timestamp;
+        }
+        if s.last_timestamp > max_ts {
+            max_ts = s.last_timestamp;
+        }
+    }
+    (
+        min_ts.format("%Y-%m-%d").to_string(),
+        max_ts.format("%Y-%m-%d").to_string(),
+    )
+}
+
+/// Top `n` projects by call count for `model_name`, joined with "·".
+/// Returns "—" when the model has no calls in `data.calls`.
+fn top_projects_for_model(data: &UsageData, model_name: &str, n: usize) -> String {
+    use std::collections::HashMap;
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for call in &data.calls {
+        if call.model == model_name {
+            *counts.entry(call.project.as_str()).or_insert(0) += 1;
+        }
+    }
+    if counts.is_empty() {
+        return "—".to_string();
+    }
+    let mut sorted: Vec<_> = counts.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted
+        .into_iter()
+        .take(n)
+        .map(|(p, _)| p.to_string())
+        .collect::<Vec<_>>()
+        .join(" · ")
+}
+
+/// Render `min_total` as `1h 04m` / `42m` / `<1m`.
+fn format_duration_min(min_total: u64) -> String {
+    if min_total == 0 {
+        return "<1m".to_string();
+    }
+    let h = min_total / 60;
+    let m = min_total % 60;
+    if h > 0 {
+        format!("{h}h {m:02}m")
+    } else {
+        format!("{m}m")
     }
 }
 
@@ -1565,12 +2376,7 @@ fn build_period_provider_strip(state: &UsageViewState) -> Vec<Line<'static>> {
 /// Render `[◀ <label> ▶ <key> <name>]` for the inline Month/Quarter
 /// pickers. Active variant gets the GOLD chip background; inactive
 /// renders as soft white text with hint key prefix.
-fn build_step_picker_spans(
-    key: char,
-    name: &str,
-    label: &str,
-    active: bool,
-) -> Vec<Span<'static>> {
+fn build_step_picker_spans(key: char, name: &str, label: &str, active: bool) -> Vec<Span<'static>> {
     let style = if active {
         Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD)
     } else {
@@ -2630,18 +3436,40 @@ fn render_bar_chart(frame: &mut Frame, area: Rect, data: &UsageData) {
 }
 
 fn render_help_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
+    // When zoomed, swap to a focused help string so the user has the
+    // zoom-only affordances visible.
+    if state.is_zoomed() {
+        let spans = vec![
+            Span::styled(" /", Style::default().fg(GOLD)),
+            Span::styled(" search  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("d", Style::default().fg(GOLD)),
+            Span::styled(" detail  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("z/Esc", Style::default().fg(GOLD)),
+            Span::styled(" back  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("j/k", Style::default().fg(GOLD)),
+            Span::styled(" row  ", Style::default().fg(MUTED_GRAY)),
+        ];
+        let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(DARK_BG));
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
     let on_burndown = matches!(state.active_tab, UsageTab::Burndown);
     let mut spans = vec![
         Span::styled(" ◀/▶", Style::default().fg(GOLD)),
         Span::styled(" provider  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("p", Style::default().fg(GOLD)),
         Span::styled(" filter  ", Style::default().fg(MUTED_GRAY)),
-        Span::styled("1-5", Style::default().fg(GOLD)),
-        Span::styled(" period  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            "1 Today  2 7d  3 30d  4 90d  5 YTD  m Month  q Quarter  a All  D advanced  ",
+            Style::default().fg(MUTED_GRAY),
+        ),
     ];
     if on_burndown {
-        // Burndown view: Tab pivots panels; Enter commits chip; C clears.
+        // Burndown view: z zoom; Tab pivots panels; Enter commits chip; C clears.
         spans.extend_from_slice(&[
+            Span::styled("z", Style::default().fg(GOLD)),
+            Span::styled(" zoom  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("Tab", Style::default().fg(GOLD)),
             Span::styled(" focus panel  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("Enter", Style::default().fg(GOLD)),
@@ -2658,7 +3486,7 @@ fn render_help_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         ]);
     }
     spans.extend_from_slice(&[
-        Span::styled("/ x d c", Style::default().fg(GOLD)),
+        Span::styled("/ x c", Style::default().fg(GOLD)),
         Span::styled(" filters  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("j/k", Style::default().fg(GOLD)),
         Span::styled(" scroll  ", Style::default().fg(MUTED_GRAY)),
@@ -3097,6 +3925,97 @@ mod cross_filter_tests {
         state.filters.session.push("sess-1".into());
         state.clear_all_filter_chips();
         assert!(state.filters.is_empty());
+    }
+
+    #[test]
+    fn z_toggles_zoom_state_and_records_focused_panel() {
+        let mut state = UsageViewState::default();
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.toggle_zoom();
+        assert_eq!(state.zoom, Some(UsagePanel::ByProject));
+        assert!(state.is_zoomed());
+        state.toggle_zoom();
+        assert!(state.zoom.is_none());
+        assert!(!state.is_zoomed());
+    }
+
+    #[test]
+    fn z_without_focus_picks_first_panel() {
+        let mut state = UsageViewState::default();
+        assert!(state.focused_panel.is_none());
+        state.toggle_zoom();
+        assert_eq!(state.zoom, Some(UsagePanel::ALL[0]));
+        assert_eq!(state.focused_panel, Some(UsagePanel::ALL[0]));
+    }
+
+    #[test]
+    fn slash_enters_search_mode_and_typing_appends() {
+        let mut state = UsageViewState::default();
+        state.toggle_zoom();
+        state.zoom_begin_search();
+        assert!(state.zoom_search_active);
+        state.zoom_search_char('a');
+        state.zoom_search_char('l');
+        state.zoom_search_char('p');
+        assert_eq!(state.zoom_search_query, "alp");
+        state.zoom_commit_search();
+        assert!(!state.zoom_search_active);
+        assert_eq!(state.zoom_search_query, "alp");
+    }
+
+    #[test]
+    fn esc_priority_is_detail_then_search_then_zoom_exit() {
+        let mut state = UsageViewState::default();
+        state.toggle_zoom();
+        state.zoom_detail_open = true;
+        state.zoom_search_active = true;
+        state.zoom_search_query.push('x');
+
+        // 1st Esc -> close detail.
+        assert!(state.zoom_handle_esc());
+        assert!(!state.zoom_detail_open);
+        assert!(state.zoom_search_active, "search still active");
+
+        // 2nd Esc -> cancel search.
+        assert!(state.zoom_handle_esc());
+        assert!(!state.zoom_search_active);
+        assert!(state.zoom_search_query.is_empty());
+
+        // 3rd Esc -> exit zoom.
+        assert!(state.zoom_handle_esc());
+        assert!(!state.is_zoomed());
+
+        // 4th Esc -> not consumed; caller falls through to chip pop.
+        assert!(!state.zoom_handle_esc());
+    }
+
+    #[test]
+    fn d_toggles_detail_drawer_when_zoomed() {
+        let mut state = UsageViewState::default();
+        state.toggle_zoom();
+        assert!(!state.zoom_detail_open);
+        state.toggle_zoom_detail();
+        assert!(state.zoom_detail_open);
+        state.toggle_zoom_detail();
+        assert!(!state.zoom_detail_open);
+    }
+
+    #[test]
+    fn fuzzy_filter_matches_substring_when_query_present() {
+        let projects = vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+            "alphabet".to_string(),
+        ];
+        let out = apply_zoom_filter(&projects, "alp", |s| s.clone());
+        assert_eq!(out.len(), 2, "alpha + alphabet should both match");
+    }
+
+    #[test]
+    fn fuzzy_filter_empty_query_returns_all() {
+        let projects = vec!["alpha".to_string(), "beta".to_string()];
+        let out = apply_zoom_filter(&projects, "", |s| s.clone());
+        assert_eq!(out.len(), 2);
     }
 
     #[test]

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -358,14 +358,20 @@ impl UsageViewState {
     ///
     /// No-op when the active period is not a Month/Quarter picker.
     pub fn step_period_back(&mut self) -> bool {
-        let oldest = self.data.as_ref().and_then(|d| d.daily.first().map(|(date, _)| *date));
+        // Refuse to step until data has loaded — without an `oldest`
+        // anchor we'd let the user wander arbitrarily far backwards,
+        // and the resulting picker state would silently fall outside
+        // the data range once the load completes.
+        let Some(oldest) =
+            self.data.as_ref().and_then(|d| d.daily.first().map(|(date, _)| *date))
+        else {
+            return false;
+        };
         match self.period.clone() {
             UsagePeriod::SpecificMonth(anchor) => {
                 let new_anchor = previous_month_first(anchor);
-                if let Some(oldest_first) = oldest.map(first_of_month) {
-                    if new_anchor < oldest_first {
-                        return false;
-                    }
+                if new_anchor < first_of_month(oldest) {
+                    return false;
                 }
                 self.period = UsagePeriod::SpecificMonth(new_anchor);
                 self.scroll_offset = 0;
@@ -373,11 +379,9 @@ impl UsageViewState {
             }
             UsagePeriod::SpecificQuarter(year, q) => {
                 let (new_year, new_q) = previous_quarter(year, q);
-                if let Some(oldest_date) = oldest {
-                    let (qy, qq) = current_quarter(oldest_date);
-                    if (new_year, new_q) < (qy, qq) {
-                        return false;
-                    }
+                let (qy, qq) = current_quarter(oldest);
+                if (new_year, new_q) < (qy, qq) {
+                    return false;
                 }
                 self.period = UsagePeriod::SpecificQuarter(new_year, new_q);
                 self.scroll_offset = 0;

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -2308,10 +2308,14 @@ fn build_period_provider_strip(state: &UsageViewState) -> Vec<Line<'static>> {
         vec![Span::styled("Period: ", Style::default().fg(MUTED_GRAY))];
 
     // Simple key-prefixed chips: 1 Today, 2 7d, 3 30d, 4 90d, 5 YTD.
+    // Each chip lights up for both the legacy variant (set by the TUI
+    // shortcut) and the equivalent LastNDays(N) variant (set by the
+    // CLI --last-n-days flag), so the active state is consistent
+    // regardless of which entry point selected the period.
     let simple: [(&str, char, fn(&UsagePeriod) -> bool); 5] = [
         ("Today", '1', |p| matches!(p, UsagePeriod::Today)),
-        ("7d", '2', |p| matches!(p, UsagePeriod::Week)),
-        ("30d", '3', |p| matches!(p, UsagePeriod::ThirtyDays)),
+        ("7d", '2', |p| matches!(p, UsagePeriod::Week | UsagePeriod::LastNDays(7))),
+        ("30d", '3', |p| matches!(p, UsagePeriod::ThirtyDays | UsagePeriod::LastNDays(30))),
         ("90d", '4', |p| matches!(p, UsagePeriod::LastNDays(90))),
         ("YTD", '5', |p| matches!(p, UsagePeriod::YearToDate)),
     ];

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -13,6 +13,20 @@ use tracing::{debug, warn};
 use crate::usage_cache::{Cache, ParseHint, ParseResult};
 
 /// Usage period selector shared by TUI and CLI report queries.
+///
+/// Variants beyond the original `Today/Week/ThirtyDays/Month/All/Custom`
+/// set are introduced for the date-picker UX:
+/// - `LastNDays(n)` — generic "last n days" used for 90d (and exposed
+///   over the CLI as `--last-n-days N`).
+/// - `SpecificMonth(date)` — calendar month containing `date` (day is
+///   ignored; canonicalised to day=1 by callers).
+/// - `SpecificQuarter(year, q)` — calendar quarter `q` of `year`,
+///   `q ∈ 1..=4`.
+/// - `YearToDate` — Jan 1 of the current local year through today.
+///
+/// `Week` and `ThirtyDays` are retained (rather than collapsing into
+/// `LastNDays`) to keep the existing CLI `PeriodArg` enum, JSON
+/// serialisation, and downstream tests stable.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -20,6 +34,17 @@ pub enum UsagePeriod {
     Today,
     Week,
     ThirtyDays,
+    /// Generic "last N days" — used for 90d and the `--last-n-days N`
+    /// CLI flag. `n=0` is treated as 1 day (today only) by
+    /// `date_range_for_period` to avoid empty ranges.
+    LastNDays(u32),
+    /// Calendar month of the given date. Callers should canonicalise
+    /// the day to 1 — the renderer pretty-prints as "Apr 2026".
+    SpecificMonth(NaiveDate),
+    /// Calendar quarter `q ∈ 1..=4` of `year`. Renders as "Q2 2026".
+    SpecificQuarter(i32, u8),
+    /// Jan 1 of the current local year through today.
+    YearToDate,
     Month,
     All,
     Custom { from: NaiveDate, to: NaiveDate },
@@ -1930,12 +1955,63 @@ fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Local>, DateT
         UsagePeriod::ThirtyDays => {
             Some((start_of_day(today - Duration::days(29)), end_of_day(today)))
         }
+        UsagePeriod::LastNDays(n) => {
+            let n = (*n).max(1);
+            Some((
+                start_of_day(today - Duration::days(i64::from(n - 1))),
+                end_of_day(today),
+            ))
+        }
         UsagePeriod::Month => {
             let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today);
             Some((start_of_day(first), end_of_day(today)))
         }
+        UsagePeriod::SpecificMonth(anchor) => {
+            let first =
+                NaiveDate::from_ymd_opt(anchor.year(), anchor.month(), 1).unwrap_or(*anchor);
+            let last = last_day_of_month(anchor.year(), anchor.month());
+            Some((start_of_day(first), end_of_day(last)))
+        }
+        UsagePeriod::SpecificQuarter(year, q) => {
+            let (first, last) = quarter_bounds(*year, *q);
+            Some((start_of_day(first), end_of_day(last)))
+        }
+        UsagePeriod::YearToDate => {
+            let first = NaiveDate::from_ymd_opt(today.year(), 1, 1).unwrap_or(today);
+            Some((start_of_day(first), end_of_day(today)))
+        }
         UsagePeriod::Custom { from, to } => Some((start_of_day(*from), end_of_day(*to))),
     }
+}
+
+/// Last calendar day of a `(year, month)`. Falls back to day 28 only
+/// for genuinely impossible chrono inputs (year out of range).
+pub fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
+    let (next_year, next_month) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    let next_first = NaiveDate::from_ymd_opt(next_year, next_month, 1)
+        .unwrap_or_else(|| NaiveDate::from_ymd_opt(year, month, 28).expect("valid 28th"));
+    next_first - Duration::days(1)
+}
+
+/// First and last calendar days of `quarter` (1..=4) within `year`.
+/// Out-of-range quarters are clamped to Q1.
+pub fn quarter_bounds(year: i32, quarter: u8) -> (NaiveDate, NaiveDate) {
+    let q = quarter.clamp(1, 4);
+    let start_month = (u32::from(q) - 1) * 3 + 1;
+    let end_month = start_month + 2;
+    let first = NaiveDate::from_ymd_opt(year, start_month, 1)
+        .unwrap_or_else(|| NaiveDate::from_ymd_opt(year, 1, 1).expect("valid Jan 1"));
+    let last = last_day_of_month(year, end_month);
+    (first, last)
+}
+
+/// Quarter (1..=4) containing `date`.
+pub fn quarter_of(date: NaiveDate) -> u8 {
+    ((date.month0() / 3) + 1) as u8
 }
 
 fn day_bounds(date: NaiveDate) -> (DateTime<Local>, DateTime<Local>) {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -2933,6 +2933,55 @@ mod tests {
     }
 
     #[test]
+    fn last_n_days_period_covers_n_calendar_days() {
+        for n in [1u32, 7, 14, 90] {
+            let (start, end) =
+                date_range_for_period(&UsagePeriod::LastNDays(n)).unwrap();
+            assert_eq!(
+                (end.date_naive() - start.date_naive()).num_days() + 1,
+                i64::from(n),
+                "n={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn specific_month_period_starts_on_day_one_and_ends_on_last_day() {
+        let anchor = NaiveDate::from_ymd_opt(2026, 4, 17).unwrap();
+        let (start, end) =
+            date_range_for_period(&UsagePeriod::SpecificMonth(anchor)).unwrap();
+        assert_eq!(start.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 1).unwrap());
+        assert_eq!(end.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 30).unwrap());
+    }
+
+    #[test]
+    fn specific_quarter_q1_to_q4_cover_three_months_each() {
+        for q in 1u8..=4 {
+            let (start, end) =
+                date_range_for_period(&UsagePeriod::SpecificQuarter(2026, q)).unwrap();
+            // Q1 = 90 days (Jan 31 + Feb 28 + Mar 31), Q2 = 91, Q3 = 92, Q4 = 92.
+            let days = (end.date_naive() - start.date_naive()).num_days() + 1;
+            assert!((90..=92).contains(&days), "q={q} got {days} days");
+        }
+    }
+
+    #[test]
+    fn ytd_period_starts_on_jan_1() {
+        let (start, _) = date_range_for_period(&UsagePeriod::YearToDate).unwrap();
+        assert_eq!(start.date_naive().month(), 1);
+        assert_eq!(start.date_naive().day(), 1);
+    }
+
+    #[test]
+    fn quarter_of_dispatches_jan_to_dec_correctly() {
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 1, 5).unwrap()), 1);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 3, 31).unwrap()), 1);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()), 2);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()), 3);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 12, 31).unwrap()), 4);
+    }
+
+    #[test]
     fn optimize_compare_and_yield_return_stable_summaries() {
         let calls = vec![
             provider_call(


### PR DESCRIPTION
## Summary

PR-C in the analytics polish sequence after PR-A (SQLite cache) and PR-B (cross-filter pivot + CLI parity). Two combined concerns:

1. **Replace cryptic free-text date input** with structured pickers (Stevie's ask)
2. **Widget zoom + detail drawer + fuzzy search** (the original "open up bigger" ask)

## Date pickers

| Key | Period |
|---|---|
| `1` | Today |
| `2` | 7d |
| `3` | 30d |
| `4` | 90d (NEW) |
| `5` | YTD (NEW) |
| `m` | Specific Month, ◀/▶ steps |
| `q` | Specific Quarter, ◀/▶ steps |
| `a` | All |
| `D` | Advanced free-text custom (was `d`, now behind capital D) |

Step-clamp keeps you within the data range backwards, and at current calendar window forwards (no future periods).

CLI parity: `--month YYYY-MM`, `--quarter YYYY-Qn` (lowercase `q` accepted), `--last-n-days N`, `--ytd`. All mutually exclusive via clap `conflicts_with`.

## Widget zoom

`z` toggles fullscreen for the focused panel on Burndown view. Zoomed view shows ALL rows + extra columns:
- **By Project**: + first-seen, last-seen, top 3 sessions, sparkline, full path
- **Top Sessions / Live**: + duration, model breakdown, project, last-seen
- **By Model**: + cost-per-call, sample count, top 3 projects
- **By Activity**: + recent calls sample
- **Daily Activity**: + per-project breakdown per day

`/` enters fuzzy search (nucleo-matcher with substring fallback for non-ASCII). `d` toggles bottom-40% detail drawer for the selected row. Esc precedence: detail > search > zoom-exit.

New dep: `nucleo-matcher = "0.3"`.

## Atomic commits (8)

1. `feat(ainb-tui): UsagePeriod variants for 90d/YTD/Month/Quarter`
2. `feat(ainb-tui): period strip swap d/Custom for m/q/4/5/a/D mappings`
3. `feat(ainb-tui): --month/--quarter/--last-n-days/--ytd CLI flags`
4. `feat(ainb-tui): z toggles fullscreen panel zoom with all rows + extra cols`
5. `test(ainb-tui): date_range_for_period covers 90d/Month/Quarter/YTD`
6. `fix(ainb-tui): route zoom Esc through state machine when search active`     ← review fix (MEDIUM)
7. `fix(ainb-tui): broaden period chip activity to LastNDays(7|30)`              ← review fix (MEDIUM)
8. `fix(ainb-tui): refuse step_period_back when usage data not yet loaded`     ← review fix (MEDIUM)

## Test plan

- [x] 70/70 lib usage tests pass
- [x] 18 new tests: 5 period-range, 3 period-strip render, 8 CLI parse-conflict, 5 zoom state-machine, 2 fuzzy search
- [x] PR-A bincode tripwire intact (ProviderCall shape unchanged)
- [x] PR-B cross-filter still works
- [x] CLI verified live: `ainb usage report --month 2026-04`, `--quarter 2026-Q2`, `--last-n-days 90`, `--ytd`
- [x] `cargo build --tests` clean
- [x] Code-reviewer pass: 0 CRITICAL, 0 HIGH blockers; 3 MEDIUMs all addressed in commits 6-8

## Out of scope (deferred)

- Branch attribution, cache-waste detail, anomaly markers, actionable optimize → PR-D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zoom mode for burndown dashboard panels with fuzzy search and detail drawer functionality
  * Extended period selection with month, quarter, last-n-days, and year-to-date options
  * Added stepable month/quarter pickers with keyboard shortcuts for quick navigation
  * Introduced new CLI flags for structured date-range selection (--month, --quarter, --last-n-days, --ytd)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->