### PR TITLE
feat(ainb-tui): branch attribution foundation (PR-D part 1)

### DIFF
--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -128,6 +128,11 @@ pub struct UsageReportArgs {
     /// Drill into a single session id. Repeatable.
     #[arg(long)]
     pub session: Vec<String>,
+    /// Drill into a single git branch (exact match against `gitBranch` on
+    /// Claude turns). Repeatable. Codex turns have no recorded branch and
+    /// are excluded by any non-empty `--branch` filter.
+    #[arg(long)]
+    pub branch: Vec<String>,
 }
 
 #[derive(Args, Clone, Default)]
@@ -661,6 +666,7 @@ fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
             model: args.model.clone(),
             activity: args.activity.clone(),
             session: args.session.clone(),
+            branch: args.branch.clone(),
         },
     })
 }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3809,6 +3809,7 @@ mod cross_filter_tests {
             tools: vec![],
             mcp_servers: vec![],
             shell_commands: vec![],
+            branches: vec![],
         }
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -4065,6 +4065,7 @@ mod cli_parity_tests {
             tools: vec!["Edit".into()],
             bash_commands: vec![],
             user_message: "tidy".into(),
+            branch: None,
         }
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -4153,6 +4153,32 @@ mod cli_parity_tests {
     }
 
     #[test]
+    fn branch_filter_keeps_only_matching_branch_and_drops_branchless_calls() {
+        let mut on_main = call("alpha", "opus", "s1");
+        on_main.branch = Some("main".into());
+        let mut on_feat = call("alpha", "opus", "s2");
+        on_feat.branch = Some("feat/x".into());
+        let no_branch = call("alpha", "opus", "s3"); // branch: None
+
+        let data = data_with_calls(vec![on_main, on_feat, no_branch]);
+
+        let mut filters = UsageFilters::default();
+        filters.branch.push("feat/x".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 1, "only feat/x survives");
+        assert_eq!(filtered.calls[0].session_id, "s2");
+
+        // Branchless calls must NOT match a non-empty branch filter — even
+        // a generic "main" filter excludes calls that have no recorded
+        // branch (codex turns, Claude turns outside a git repo).
+        let mut main_only = UsageFilters::default();
+        main_only.branch.push("main".into());
+        let only_main = filter_usage_data(&data, &main_only);
+        assert_eq!(only_main.calls.len(), 1);
+        assert!(only_main.calls.iter().all(|c| c.branch.as_deref() == Some("main")));
+    }
+
+    #[test]
     fn session_filter_keeps_only_matching_session_id() {
         let data = data_with_calls(vec![
             call("alpha", "opus", "s1"),

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -302,6 +302,10 @@ pub struct ProviderCall {
     pub tools: Vec<String>,
     pub bash_commands: Vec<String>,
     pub user_message: String,
+    /// Git branch the turn was made from, parsed from `gitBranch` on
+    /// Claude assistant turns. Codex transcripts don't carry branch state,
+    /// so codex calls always have `None` here.
+    pub branch: Option<String>,
 }
 
 impl ProviderCall {
@@ -466,6 +470,8 @@ struct ClaudeLine {
     #[serde(rename = "sessionId")]
     session_id: Option<String>,
     cwd: Option<String>,
+    #[serde(rename = "gitBranch")]
+    git_branch: Option<String>,
     message: Option<ClaudeMessage>,
 }
 
@@ -850,6 +856,7 @@ fn parse_claude_line(
                 tools,
                 bash_commands,
                 user_message: current_user_message.clone(),
+                branch: parsed.git_branch.filter(|b| !b.is_empty()),
             })
         }
         _ => None,
@@ -1108,6 +1115,7 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
             tools: std::mem::take(&mut pending_tools),
             bash_commands: Vec::new(),
             user_message: std::mem::take(&mut pending_user_message),
+            branch: None,
         });
     }
 
@@ -2345,6 +2353,7 @@ mod tests {
             tools: tools.iter().map(|tool| tool.to_string()).collect(),
             bash_commands: bash_commands.iter().map(|command| command.to_string()).collect(),
             user_message: message.to_string(),
+            branch: None,
         }
     }
 
@@ -2381,6 +2390,40 @@ mod tests {
         assert_eq!(data.grand_total.session_count, 1);
         assert!(data.tools.iter().any(|tool| tool.name == "Read" && tool.calls == 1));
         assert!(data.shell_commands.iter().any(|cmd| cmd.name == "cargo test" && cmd.calls == 1));
+    }
+
+    #[test]
+    fn claude_assistant_turn_carries_git_branch_through_parser() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("-Users-stevie-myrepo");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","gitBranch":"feat/x","message":{"role":"user","content":"go"}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:05Z","sessionId":"s1","gitBranch":"feat/x","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":5}}}
+{"type":"assistant","timestamp":"2026-04-10T09:01:00Z","sessionId":"s1","gitBranch":"","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"again"}],"usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"assistant","timestamp":"2026-04-10T09:02:00Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"none"}],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.calls.len(), 3);
+        assert_eq!(data.calls[0].branch.as_deref(), Some("feat/x"));
+        assert_eq!(
+            data.calls[1].branch, None,
+            "empty gitBranch should normalize to None so empty doesn't leak as a real branch label",
+        );
+        assert_eq!(data.calls[2].branch, None, "missing gitBranch becomes None");
     }
 
     #[test]

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -131,18 +131,24 @@ pub struct UsageQuery {
 
 /// Exact-match drill-down filters set by the dashboard cross-filter
 /// (Grafana-style click-to-pivot) and the `--project / --model /
-/// --activity / --session` CLI flags.
+/// --activity / --session / --branch` CLI flags.
 ///
 /// All filter sets are AND-combined with each other and with the existing
 /// `include_projects` / `exclude_projects` globs. Each filter list is
 /// internally OR-combined: `--project a --project b` matches calls in
 /// either project.
+///
+/// Branch filtering matches `call.branch` exactly. Calls with no recorded
+/// branch (`branch == None`, eg. codex turns or Claude turns made outside a
+/// git repo) are excluded by any non-empty branch filter — there's no way
+/// to ask for "untracked branch" via this struct on purpose.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct UsageFilters {
     pub project: Vec<String>,
     pub model: Vec<String>,
     pub activity: Vec<String>,
     pub session: Vec<String>,
+    pub branch: Vec<String>,
 }
 
 impl UsageFilters {
@@ -151,6 +157,7 @@ impl UsageFilters {
             && self.model.is_empty()
             && self.activity.is_empty()
             && self.session.is_empty()
+            && self.branch.is_empty()
     }
 
     /// True if any cross-filter is set. Mirror of `!is_empty()` for sites
@@ -159,10 +166,13 @@ impl UsageFilters {
         !self.is_empty()
     }
 
-    /// Pop the most-recently-added filter chip. Removal order: session →
-    /// activity → model → project (matches the chip-strip render order so
-    /// `Esc` removes the visually rightmost chip first).
+    /// Pop the most-recently-added filter chip. Removal order: branch →
+    /// session → activity → model → project (matches the chip-strip render
+    /// order so `Esc` removes the visually rightmost chip first).
     pub fn pop_last(&mut self) -> Option<UsageFilterChip> {
+        if let Some(value) = self.branch.pop() {
+            return Some(UsageFilterChip::Branch(value));
+        }
         if let Some(value) = self.session.pop() {
             return Some(UsageFilterChip::Session(value));
         }
@@ -183,6 +193,7 @@ impl UsageFilters {
         self.model.clear();
         self.activity.clear();
         self.session.clear();
+        self.branch.clear();
     }
 
     fn matches(&self, call: &ProviderCall, category: ActivityCategory) -> bool {
@@ -201,6 +212,14 @@ impl UsageFilters {
                 return false;
             }
         }
+        if !self.branch.is_empty() {
+            let Some(branch) = call.branch.as_deref() else {
+                return false;
+            };
+            if !self.branch.iter().any(|b| b == branch) {
+                return false;
+            }
+        }
         true
     }
 }
@@ -212,6 +231,7 @@ pub enum UsageFilterChip {
     Model(String),
     Activity(String),
     Session(String),
+    Branch(String),
 }
 
 impl UsageFilterChip {
@@ -221,12 +241,17 @@ impl UsageFilterChip {
             Self::Model(_) => "model",
             Self::Activity(_) => "activity",
             Self::Session(_) => "session",
+            Self::Branch(_) => "branch",
         }
     }
 
     pub fn value(&self) -> &str {
         match self {
-            Self::Project(v) | Self::Model(v) | Self::Activity(v) | Self::Session(v) => v,
+            Self::Project(v)
+            | Self::Model(v)
+            | Self::Activity(v)
+            | Self::Session(v)
+            | Self::Branch(v) => v,
         }
     }
 }

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -386,6 +386,16 @@ pub struct ModelUsage {
     pub bucket: TokenBucket,
 }
 
+/// Per-branch summary. Built only from calls whose `branch` is `Some`;
+/// branchless calls (codex, non-git Claude turns) are dropped from this
+/// view so the panel never grows a misleading "(no branch)" bucket.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+pub struct BranchUsage {
+    pub branch: String,
+    pub bucket: TokenBucket,
+}
+
 /// Activity summary with classified turns and retry counts.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
@@ -421,6 +431,9 @@ pub struct UsageData {
     pub tools: Vec<NamedUsage>,
     pub mcp_servers: Vec<NamedUsage>,
     pub shell_commands: Vec<NamedUsage>,
+    /// Branch attribution rows, sorted by largest bucket. Only Claude
+    /// assistant turns with a non-empty `gitBranch` populate this.
+    pub branches: Vec<BranchUsage>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -458,6 +471,7 @@ impl Default for UsageData {
             tools: Vec::new(),
             mcp_servers: Vec::new(),
             shell_commands: Vec::new(),
+            branches: Vec::new(),
         }
     }
 }
@@ -1160,6 +1174,7 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
     let mut project_map: HashMap<String, (String, HashSet<String>, TokenBucket)> = HashMap::new();
     let mut session_map: HashMap<String, SessionUsageAccumulator> = HashMap::new();
     let mut model_map: HashMap<String, TokenBucket> = HashMap::new();
+    let mut branch_map: HashMap<String, TokenBucket> = HashMap::new();
     let mut activity_map: HashMap<ActivityCategory, ActivityAccumulator> = HashMap::new();
     let mut tool_map: HashMap<String, usize> = HashMap::new();
     let mut mcp_map: HashMap<String, usize> = HashMap::new();
@@ -1203,6 +1218,10 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         session.bucket.merge(&bucket);
 
         model_map.entry(call.model.clone()).or_default().merge(&bucket);
+
+        if let Some(branch) = call.branch.as_deref().filter(|b| !b.is_empty()) {
+            branch_map.entry(branch.to_string()).or_default().merge(&bucket);
+        }
 
         let analysis = turn_analysis.get(&idx).copied().unwrap_or_else(|| TurnAnalysis {
             category: classify_activity(call),
@@ -1265,6 +1284,12 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         .collect();
     models.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
 
+    let mut branches: Vec<_> = branch_map
+        .into_iter()
+        .map(|(branch, bucket)| BranchUsage { branch, bucket })
+        .collect();
+    branches.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+
     let tools = sorted_named_usage(tool_map);
     let mcp_servers = sorted_named_usage(mcp_map);
     let shell_commands = sorted_named_usage(shell_map);
@@ -1301,6 +1326,7 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         tools,
         mcp_servers,
         shell_commands,
+        branches,
     }
 }
 
@@ -2415,6 +2441,46 @@ mod tests {
         assert_eq!(data.grand_total.session_count, 1);
         assert!(data.tools.iter().any(|tool| tool.name == "Read" && tool.calls == 1));
         assert!(data.shell_commands.iter().any(|cmd| cmd.name == "cargo test" && cmd.calls == 1));
+    }
+
+    #[test]
+    fn branches_aggregate_only_from_calls_with_recorded_branch() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("-Users-stevie-myrepo");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","gitBranch":"main","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"a"}],"usage":{"input_tokens":100,"output_tokens":10}}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:01Z","sessionId":"s1","gitBranch":"main","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"b"}],"usage":{"input_tokens":50,"output_tokens":5}}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:02Z","sessionId":"s1","gitBranch":"feat/x","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"c"}],"usage":{"input_tokens":1000,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:03Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"d"}],"usage":{"input_tokens":99999,"output_tokens":99999}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        // 4 turns parsed but only 3 have a recorded branch — the 4th is
+        // missing gitBranch and must be excluded from `branches`. Note its
+        // huge token count: if we accidentally bucketed branchless calls
+        // under "(none)" it would dominate the sort and the assertion
+        // below would fail noisily.
+        assert_eq!(data.calls.len(), 4);
+        assert_eq!(data.branches.len(), 2, "only main and feat/x are recorded");
+
+        // Sorted largest first by total bucket value.
+        assert_eq!(data.branches[0].branch, "feat/x");
+        assert_eq!(data.branches[0].bucket.input_tokens, 1000);
+        assert_eq!(data.branches[1].branch, "main");
+        assert_eq!(data.branches[1].bucket.input_tokens, 150);
     }
 
     #[test]

--- a/ainb-tui/src/usage_cache/db.rs
+++ b/ainb-tui/src/usage_cache/db.rs
@@ -13,9 +13,13 @@ use super::store::CacheError;
 /// Bumping this drops & rebuilds the DB on next open.
 pub const SCHEMA_VERSION: i64 = 1;
 
-/// `files.blob_format` value for bincode v1 (`bincode::serialize` of
-/// `Vec<ProviderCall>` with default options).
-pub const BLOB_FORMAT_BINCODE_V1: i64 = 1;
+/// `files.blob_format` value for the current bincode-encoded
+/// `Vec<ProviderCall>` blob shape (default options).
+///
+/// History:
+///   1 — original 14-field `ProviderCall`.
+///   2 — added `branch: Option<String>` (PR-D, branch attribution).
+pub const BLOB_FORMAT_BINCODE_V1: i64 = 2;
 
 /// Open (or create) the usage-cache sqlite DB at `path`, applying schema and
 /// performance pragmas. Caller owns the resulting connection — wrap in a

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -21,18 +21,25 @@ use crate::models::usage::ProviderCall;
 use super::db;
 use super::fingerprint::{FileFingerprint, FingerprintAction, classify, verify_append_safe};
 
-/// Versioned blob encoding for `files.calls_blob`.
+/// Versioned blob encoding for `files.calls_blob`. Discriminant must match
+/// `db::BLOB_FORMAT_BINCODE_V1` — bump both together when `ProviderCall`
+/// layout changes, and update the deserializer match below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i64)]
 pub enum BlobFormat {
-    /// `bincode::serialize` of `Vec<ProviderCall>` with default options.
-    Bincode = 1,
+    /// Current `bincode::serialize` of `Vec<ProviderCall>` with default
+    /// options. Version 2 replaced version 1 when `ProviderCall.branch`
+    /// (Option<String>) was added in PR-D.
+    Bincode = 2,
 }
 
 impl BlobFormat {
     pub(crate) const fn from_i64(v: i64) -> Option<Self> {
         match v {
-            1 => Some(Self::Bincode),
+            // 1 was the pre-branch layout. Rows tagged 1 are stale on
+            // upgrade and intentionally skipped — the next scan re-parses
+            // and rewrites them at version 2.
+            2 => Some(Self::Bincode),
             _ => None,
         }
     }

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -45,6 +45,7 @@ fn synth_call(seed: &str) -> ProviderCall {
         tools: Vec::new(),
         bash_commands: Vec::new(),
         user_message: String::new(),
+        branch: None,
     }
 }
 
@@ -349,5 +350,7 @@ const fn const_expected_len() -> usize {
     // Rather than re-deriving the formula on every change, we hard-code
     // the value observed for `synth_call("layout-tripwire")`. If chrono
     // or bincode bump their encoding, update this constant intentionally.
-    184
+    //
+    // History: 184 (V1) -> 185 (V2: +Option<String> branch field, None tag).
+    185
 }

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -37,6 +37,7 @@ fn sample_usage_data() -> UsageData {
             tools: vec!["Edit".to_string()],
             bash_commands: vec!["cargo test".to_string()],
             user_message: "implement burndown".to_string(),
+            branch: None,
         }],
         daily: vec![(
             chrono::NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),


### PR DESCRIPTION
## Summary

This is **PR-D part 1** — the data foundation for branch-aware analytics. It threads `gitBranch` from Claude JSONL turns all the way through the parser, cache, filter, CLI, and aggregation layers. The remaining PR-D scope (TUI by-branch panel, cache-waste waterfall, anomaly markers, optimization-tab rewrite) lands in PR-E so this PR stays reviewable and Stevie can live-test branch filtering immediately.

### What's shipped

- **`ProviderCall.branch: Option<String>`** — populated from `gitBranch` on Claude assistant turns. Codex turns and non-git Claude turns stay `None` (no fake \"unknown\" bucket).
- **Bincode tripwire bumped** — `BLOB_FORMAT_BINCODE_V1: 1 → 2`, `BlobFormat::Bincode` discriminant aligned, layout tripwire updated `184 → 185` bytes.
- **`UsageFilters.branch: Vec<String>`** + `UsageFilterChip::Branch(String)` — exact-match cross-filter, integrated with `pop_last`/`clear`/`matches`. Calls without a recorded branch are excluded by any non-empty branch filter on purpose.
- **`--branch` CLI flag** on `ainb usage report` — repeatable, mirrors PR-B's `--project / --model / --activity / --session` parity.
- **`UsageData.branches: Vec<BranchUsage>`** — sorted-by-bucket aggregator on the model side, ready for the by-branch panel.

### Tests added

- `claude_assistant_turn_carries_git_branch_through_parser` — empty/missing `gitBranch` normalize to `None`, populated values flow through.
- `branches_aggregate_only_from_calls_with_recorded_branch` — sentinel value (99999 tokens on a branchless call) would dominate the sort if branchless calls leaked through; assertion proves they don't.
- `branch_filter_keeps_only_matching_branch_and_drops_branchless_calls` — verifies AND-combine with project/model and the no-recorded-branch exclusion contract.
- All 90 lib usage tests + 4 integration tests + bincode tripwire green.

### Commits (atomic, per concern)

1. `a37bc5e feat(ainb-tui): attach git branch to ProviderCall via Claude JSONL`
2. `0fff621 feat(ainb-tui): branch chip on UsageFilters + --branch CLI flag`
3. `202a30a fix(ainb-tui): align BlobFormat discriminant with bumped V1 constant`
4. `fe07458 feat(ainb-tui): aggregate per-branch usage rows on UsageData`

### Deferred to PR-E

- TUI **By-Branch panel** + zoom (renders `UsageData.branches`)
- **Cache-hit waterfall** per session (input vs cache_read vs cache_write breakdown ranked by waste)
- **Anomaly markers** (>2σ daily totals get red triangles in burndown)
- **Optimization tab rewrite** (replace generic score with actionable rows)

### Pre-existing test note

`tests::test_bottom_menu_bar_shows_refresh_key` fails on this branch and on `origin/main` identically — unrelated to this PR.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib usage::` 90/90 pass
- [x] `cargo test --test usage_cache_integration` 4/4 pass
- [x] `cargo test --lib provider_call_bincode_layout_is_stable` confirms 185-byte tripwire
- [ ] Live: `ainb usage report --branch main --provider claude` shows only main-branch turns
- [ ] Live: `ainb usage report --format json | jq '.branches[0]'` shows top branch row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--branch` CLI flag to filter usage reports by Git branch name (repeatable for multiple branches)
  * Usage analytics now capture and display Git branch information for calls
  * Added branch-based filtering in the UI with chip-based controls for easy selection and removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->