### PR TITLE
fix(ainb-tui): drop j/k nav from sessions help bar

### DIFF
--- a/ainb-tui/src/components/session_list.rs
+++ b/ainb-tui/src/components/session_list.rs
@@ -111,11 +111,10 @@ impl SessionListComponent {
                             Span::styled(" rename ", Style::default().fg(MUTED_GRAY)),
                         ])
                     } else {
-                        // Default help
+                        // Default help — `j/k` nav segment dropped: arrow keys
+                        // also navigate, and the panel was overflowing once
+                        // `F filter` was added.
                         Line::from(vec![
-                            Span::styled(" j/k", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
-                            Span::styled(" nav ", Style::default().fg(MUTED_GRAY)),
-                            Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
                             Span::styled(" Enter", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
                             Span::styled(" select ", Style::default().fg(MUTED_GRAY)),
                             Span::styled("│", Style::default().fg(SUBDUED_BORDER)),


### PR DESCRIPTION
PR #60 added `F filter` to the sessions panel help bar, but it was getting clipped to `F fil` at narrow widths. Arrow keys also navigate the list, so the explicit `j/k nav` segment is redundant — drop it to free space.

## Test plan
- [x] cargo build clean
- [ ] Manual: launch TUI at narrow width, confirm `F filter` renders fully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the help footer text in the session list to reflect current navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->