### PR TITLE
cleanup(ainb-tui): /review + /simplify findings across PRs #59 #61 #62 #63 (PR-E)

### DIFF
--- a/ainb-tui/CHANGELOG.md
+++ b/ainb-tui/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING (ainb-tui CLI)**: `--include` no longer treats `--project` as
+  an alias. Users must migrate `--project foo` filters that relied on
+  substring matching to `--include foo` (substring match) or keep
+  `--project foo` for exact-match. The split makes intent explicit:
+  `--include` is the substring-match flag, `--project` is the exact
+  cross-filter chip equivalent of clicking a project in the burndown.
+
+### Added
+- **ainb-tui**: branch attribution panel data — `BranchUsage` rows on
+  `UsageData` aggregate per-`gitBranch` token totals (rendering wired
+  in a follow-on; data is already available via the cache).
+- **ainb-tui**: `recover_user_message_before` recovers `user_message`
+  attribution on cache-hit append paths so cached and full-reparse
+  rows agree turn-for-turn.
+- **ainb-tui**: `model_project_counts` precomputed index on `UsageData`
+  removes the O(N·M) per-render scan for "top projects per model".
+
+### Fixed
+- **ainb-tui**: cache `clear` now `VACUUM`s so the on-disk db shrinks.
+- **ainb-tui**: cache write rejects non-UTF8 paths instead of silent
+  lossy collisions.
+- **ainb-tui**: append parser rolls back `end_offset` on I/O errors,
+  preventing silent data loss on the next scan.
+- **ainb-tui**: fuzzy-search routes non-ASCII queries through
+  `Utf32String` so unicode queries match unicode haystacks.
+- **ainb-tui**: `last_day_of_month` returns `Option` for invalid input
+  instead of silently producing the 28th.
+- **ainb-tui**: session-duration column distinguishes `0m` from `<1m`.
 
 ## [0.5.5-beta1] - 2026-04-14
 ### Added

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -83,6 +83,10 @@ nucleo-matcher = "0.3"
 default = []
 visual-debug = []  # Enable live terminal during tests
 vt100-tests = []   # Enable vt100 screen verification
+# Exposes shared test fixtures (test_support module) so integration
+# tests in tests/ can use them. Always enabled under #[cfg(test)] for
+# unit tests; integration tests must opt in via this feature.
+test-support = []
 
 [dev-dependencies]
 mockall = "0.12"

--- a/ainb-tui/src/cli/git_cmd.rs
+++ b/ainb-tui/src/cli/git_cmd.rs
@@ -440,18 +440,10 @@ fn short_session_id(id: &str) -> String {
     id.chars().take(8).collect()
 }
 
-/// Truncate a string with an ellipsis for fixed-width table columns
+/// Truncate a string for fixed-width table columns. Delegates to the
+/// canonical `truncate_with_ellipsis` (uses `…`, single Unicode char).
 fn truncate(s: &str, max_len: usize) -> String {
-    if max_len <= 3 {
-        return ".".repeat(max_len);
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_len {
-        s.to_string()
-    } else {
-        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
-        format!("{truncated}...")
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }
 
 #[cfg(test)]
@@ -606,7 +598,7 @@ mod tests {
 
     #[test]
     fn test_truncate_long() {
-        assert_eq!(truncate("hello world foo", 10), "hello w...");
+        assert_eq!(truncate("hello world foo", 10), "hello wor…");
     }
 
     #[test]
@@ -616,7 +608,9 @@ mod tests {
 
     #[test]
     fn test_truncate_tiny_max_len() {
-        assert_eq!(truncate("hello", 2), "..");
+        // Canonical truncate_with_ellipsis returns N-1 chars + `…` for any
+        // truncation, so max_len=2 yields one source char plus the ellipsis.
+        assert_eq!(truncate("hello", 2), "h…");
     }
 
     // --- short_session_id ---

--- a/ainb-tui/src/cli/list.rs
+++ b/ainb-tui/src/cli/list.rs
@@ -161,18 +161,10 @@ fn output_text(sessions: &[SessionInfo]) {
     }
 }
 
-/// Truncate a string to fit in the given width (character-aware for UTF-8)
+/// Truncate a string to fit in the given width. Delegates to the canonical
+/// `truncate_with_ellipsis` (uses `…`, single Unicode char).
 fn truncate(s: &str, max_len: usize) -> String {
-    if max_len <= 3 {
-        return ".".repeat(max_len);
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_len {
-        s.to_string()
-    } else {
-        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
-        format!("{truncated}...")
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }
 
 #[cfg(test)]
@@ -241,7 +233,7 @@ mod tests {
 
     #[test]
     fn test_truncate_long_string() {
-        assert_eq!(truncate("hello world", 8), "hello...");
+        assert_eq!(truncate("hello world", 8), "hello w…");
     }
 
     #[test]

--- a/ainb-tui/src/cli/recover.rs
+++ b/ainb-tui/src/cli/recover.rs
@@ -589,18 +589,10 @@ fn find_orphan<'a>(needle: &str, orphans: &'a [OrphanedSession]) -> Result<&'a O
     ))
 }
 
-/// Truncate a string to fit in the given width
+/// Truncate a string to fit in the given width. Delegates to the canonical
+/// `truncate_with_ellipsis` (uses `…`, single Unicode char).
 fn truncate(s: &str, max_len: usize) -> String {
-    if max_len <= 3 {
-        return ".".repeat(max_len);
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_len {
-        s.to_string()
-    } else {
-        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
-        format!("{truncated}...")
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }
 
 #[cfg(test)]
@@ -853,7 +845,7 @@ mod tests {
 
     #[test]
     fn test_truncate_long() {
-        assert_eq!(truncate("hello world foo", 10), "hello w...");
+        assert_eq!(truncate("hello world foo", 10), "hello wor…");
     }
 
     #[test]

--- a/ainb-tui/src/components/git_view.rs
+++ b/ainb-tui/src/components/git_view.rs
@@ -1935,16 +1935,9 @@ impl GitViewComponent {
     }
 }
 
-/// Truncate a string to a maximum length, adding "..." if truncated
-/// Uses char-based counting to safely handle UTF-8 multi-byte characters
+/// Truncate a string to at most `max_len` displayed chars. Delegates to
+/// the canonical `truncate_with_ellipsis` (uses `…`, single Unicode char).
+/// Renamed-on-merge from a per-file copy that used `...` (3 ASCII chars).
 fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else if max_len <= 3 {
-        "...".to_string()
-    } else {
-        let mut truncated: String = s.chars().take(max_len - 3).collect();
-        truncated.push_str("...");
-        truncated
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }

--- a/ainb-tui/src/components/new_session.rs
+++ b/ainb-tui/src/components/new_session.rs
@@ -3100,14 +3100,8 @@ impl Default for NewSessionComponent {
     }
 }
 
-/// Truncate a string to max_len characters, adding "..." if truncated
+/// Truncate a string to at most `max_len` displayed chars. Delegates to
+/// the canonical `truncate_with_ellipsis` (uses `…`).
 fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else if max_len <= 3 {
-        "...".to_string()
-    } else {
-        let truncated: String = s.chars().take(max_len - 3).collect();
-        format!("{truncated}...")
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }

--- a/ainb-tui/src/components/skills.rs
+++ b/ainb-tui/src/components/skills.rs
@@ -971,16 +971,7 @@ fn one_line(s: &str) -> String {
 }
 
 fn truncate_string(s: &str, max_len: usize) -> String {
-    if max_len == 0 {
-        return String::new();
-    }
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else {
-        let mut out: String = s.chars().take(max_len.saturating_sub(1)).collect();
-        out.push('…');
-        out
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }
 
 fn display_path(p: &str) -> String {

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -557,7 +557,6 @@ impl UsageViewState {
         self.focus_row = 0;
     }
 
-    /// Cycle focus backward.
     pub fn focus_prev_panel(&mut self) {
         self.focused_panel = Some(match self.focused_panel {
             Some(panel) => panel.prev(),
@@ -740,7 +739,6 @@ impl UsageViewState {
         }
     }
 
-    /// Toggle the detail drawer in zoom mode. No-op when not zoomed.
     pub fn toggle_zoom_detail(&mut self) {
         if self.zoom.is_some() {
             self.zoom_detail_open = !self.zoom_detail_open;

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3216,8 +3216,11 @@ fn pretty_project_name(name: &str, max_w: usize) -> String {
         // branch portion, keeping the `repo:` prefix intact when we can.
         if let Some((repo, branch)) = pretty.split_once(':') {
             let repo_w = repo.chars().count();
-            // Need room for repo + ':' + at least 1 branch char.
-            if repo_w + 2 <= max_w {
+            // Need room for repo + ':' + at least 2 branch chars. With
+            // branch_w == 1 truncate_string returns just `…`, producing
+            // `repo:…` which conveys nothing — fall through to the
+            // generic shortener instead so we keep the repo name whole.
+            if repo_w + 3 <= max_w {
                 let branch_w = max_w - repo_w - 1;
                 let truncated_branch = truncate_string(branch, branch_w);
                 let combined = format!("{repo}:{truncated_branch}");

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3862,6 +3862,49 @@ mod cross_filter_tests {
     }
 
     #[test]
+    fn cross_project_session_id_collision_attaches_owning_project_chip() {
+        // Two sessions with the same id "s1" but different owning
+        // projects — exactly the case that prompted carrying the
+        // session row's project on commit_focused_row. The first
+        // commit must attach the alpha project chip; a subsequent
+        // pop+commit on a beta-owned row must attach beta.
+        let now = Local::now();
+        let session_alpha = SessionUsage {
+            provider: "claude".into(),
+            project: "alpha".into(),
+            session_id: "s1".into(),
+            first_timestamp: now,
+            last_timestamp: now,
+            bucket: bucket(3),
+        };
+        let session_beta = SessionUsage {
+            provider: "claude".into(),
+            project: "beta".into(),
+            session_id: "s1".into(),
+            first_timestamp: now,
+            last_timestamp: now,
+            bucket: bucket(2),
+        };
+        let mut data = fixture();
+        data.sessions = vec![session_alpha, session_beta];
+
+        let mut state = UsageViewState::default();
+        state.data = Some(data);
+        state.focused_panel = Some(UsagePanel::TopSessions);
+        state.focus_row = 0;
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.session, vec!["s1".to_string()]);
+        assert_eq!(state.filters.project, vec!["alpha".to_string()]);
+
+        // Pop both chips and target the beta row.
+        state.filters.clear();
+        state.focus_row = 1;
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.session, vec!["s1".to_string()]);
+        assert_eq!(state.filters.project, vec!["beta".to_string()]);
+    }
+
+    #[test]
     fn enter_on_by_model_row_sets_model_filter() {
         let mut state = UsageViewState::default();
         state.data = Some(fixture());

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1483,6 +1483,12 @@ fn render_zoom_panel_body(
     }
 }
 
+// TODO(refactor): the 5 render_zoom_* fns below all build a header,
+// truncate to area.height-2 visible rows, build per-row cells, and
+// hand a Table back to the frame. Extract a `render_zoom_table` helper
+// taking `ZoomTableSpec { headers, widths, rows }` once snapshot tests
+// exist to assert visual identity — without them a refactor risks
+// silent column-spacing/header-style drift.
 fn render_zoom_by_project(
     frame: &mut Frame,
     area: Rect,

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -705,11 +705,13 @@ impl UsageViewState {
         self.zoom_detail_open = false;
     }
 
-    /// Begin fuzzy-search input inside the zoomed panel.
+    /// Begin fuzzy-search input inside the zoomed panel. Preserves the
+    /// prior typed query so re-pressing `/` resumes editing where the
+    /// last search left off (vim / fzf convention). Esc (`zoom_cancel_search`)
+    /// is the path that drops the query entirely.
     pub fn zoom_begin_search(&mut self) {
         if self.zoom.is_some() {
             self.zoom_search_active = true;
-            self.zoom_search_query.clear();
         }
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1924,23 +1924,20 @@ fn project_seen_window(data: &UsageData, project_name: &str) -> (String, String)
 
 /// Top `n` projects by call count for `model_name`, joined with "·".
 /// Returns "—" when the model has no calls in `data.calls`.
+///
+/// Reads from the precomputed `data.model_project_counts` index built
+/// during `aggregate_calls`. Render path is O(n) (constant) instead of
+/// O(N) over `data.calls` per call.
 fn top_projects_for_model(data: &UsageData, model_name: &str, n: usize) -> String {
-    use std::collections::HashMap;
-    let mut counts: HashMap<&str, usize> = HashMap::new();
-    for call in &data.calls {
-        if call.model == model_name {
-            *counts.entry(call.project.as_str()).or_insert(0) += 1;
-        }
-    }
-    if counts.is_empty() {
+    let Some(rows) = data.model_project_counts.get(model_name) else {
+        return "—".to_string();
+    };
+    if rows.is_empty() {
         return "—".to_string();
     }
-    let mut sorted: Vec<_> = counts.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1));
-    sorted
-        .into_iter()
+    rows.iter()
         .take(n)
-        .map(|(p, _)| p.to_string())
+        .map(|(p, _)| p.clone())
         .collect::<Vec<_>>()
         .join(" · ")
 }
@@ -3785,6 +3782,7 @@ mod cross_filter_tests {
             mcp_servers: vec![],
             shell_commands: vec![],
             branches: vec![],
+            model_project_counts: std::collections::HashMap::new(),
         }
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -320,6 +320,14 @@ impl Default for UsageViewState {
     }
 }
 
+/// Direction parameter for `step_period`. Internal — wrappers
+/// `step_period_back` / `step_period_forward` are the public API.
+#[derive(Debug, Clone, Copy)]
+enum StepDirection {
+    Back,
+    Forward,
+}
+
 impl UsageViewState {
     pub fn next_provider(&mut self) {
         self.provider = self.provider.next();
@@ -371,38 +379,32 @@ impl UsageViewState {
         else {
             return false;
         };
-        match self.period.clone() {
-            UsagePeriod::SpecificMonth(anchor) => {
-                let new_anchor = previous_month_first(anchor);
-                if new_anchor < first_of_month(oldest) {
-                    return false;
-                }
-                self.period = UsagePeriod::SpecificMonth(new_anchor);
-                self.scroll_offset = 0;
-                true
-            }
-            UsagePeriod::SpecificQuarter(year, q) => {
-                let (new_year, new_q) = previous_quarter(year, q);
-                let (qy, qq) = current_quarter(oldest);
-                if (new_year, new_q) < (qy, qq) {
-                    return false;
-                }
-                self.period = UsagePeriod::SpecificQuarter(new_year, new_q);
-                self.scroll_offset = 0;
-                true
-            }
-            _ => false,
-        }
+        self.step_period(StepDirection::Back, oldest)
     }
 
     /// Step forward one unit. Clamps at the current real-world month
     /// or quarter — never lets the user pick a future window.
     pub fn step_period_forward(&mut self) -> bool {
         let today = Local::now().date_naive();
+        self.step_period(StepDirection::Forward, today)
+    }
+
+    /// Shared body for back/forward stepping. `clamp_anchor` is the
+    /// extreme of the allowed range — the oldest data day for `Back`,
+    /// today for `Forward`.
+    fn step_period(&mut self, direction: StepDirection, clamp_anchor: NaiveDate) -> bool {
         match self.period.clone() {
             UsagePeriod::SpecificMonth(anchor) => {
-                let new_anchor = next_month_first(anchor);
-                if new_anchor > first_of_month(today) {
+                let new_anchor = match direction {
+                    StepDirection::Back => previous_month_first(anchor),
+                    StepDirection::Forward => next_month_first(anchor),
+                };
+                let clamp = first_of_month(clamp_anchor);
+                let out_of_range = match direction {
+                    StepDirection::Back => new_anchor < clamp,
+                    StepDirection::Forward => new_anchor > clamp,
+                };
+                if out_of_range {
                     return false;
                 }
                 self.period = UsagePeriod::SpecificMonth(new_anchor);
@@ -410,9 +412,16 @@ impl UsageViewState {
                 true
             }
             UsagePeriod::SpecificQuarter(year, q) => {
-                let (new_year, new_q) = next_quarter(year, q);
-                let (cy, cq) = current_quarter(today);
-                if (new_year, new_q) > (cy, cq) {
+                let (new_year, new_q) = match direction {
+                    StepDirection::Back => previous_quarter(year, q),
+                    StepDirection::Forward => next_quarter(year, q),
+                };
+                let (cy, cq) = current_quarter(clamp_anchor);
+                let out_of_range = match direction {
+                    StepDirection::Back => (new_year, new_q) < (cy, cq),
+                    StepDirection::Forward => (new_year, new_q) > (cy, cq),
+                };
+                if out_of_range {
                     return false;
                 }
                 self.period = UsagePeriod::SpecificQuarter(new_year, new_q);

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1352,6 +1352,11 @@ fn render_zoom_breadcrumb(frame: &mut Frame, area: Rect, panel: UsagePanel) {
 
 /// Score `haystack` against `query` with nucleo-matcher; `None` means
 /// no match. An empty query matches everything (returns `Some(0)`).
+///
+/// When either side carries non-ASCII codepoints we route through
+/// `Utf32String` so multibyte chars match natively. The previous code
+/// fed `Utf32Str::Ascii(haystack.as_bytes())` even when the query had
+/// non-ASCII content, which silently lost matches.
 fn fuzzy_score(matcher: &mut nucleo_matcher::Matcher, query: &str, haystack: &str) -> Option<u32> {
     if query.is_empty() {
         return Some(0);
@@ -1361,10 +1366,15 @@ fn fuzzy_score(matcher: &mut nucleo_matcher::Matcher, query: &str, haystack: &st
         nucleo_matcher::pattern::CaseMatching::Smart,
         nucleo_matcher::pattern::Normalization::Smart,
     );
-    needle.score(
-        nucleo_matcher::Utf32Str::Ascii(haystack.as_bytes()),
-        matcher,
-    )
+    if query.is_ascii() && haystack.is_ascii() {
+        needle.score(
+            nucleo_matcher::Utf32Str::Ascii(haystack.as_bytes()),
+            matcher,
+        )
+    } else {
+        let utf32 = nucleo_matcher::Utf32String::from(haystack);
+        needle.score(utf32.slice(..), matcher)
+    }
 }
 
 /// Filter `rows` by a fuzzy-search query, preserving original order.
@@ -1381,16 +1391,8 @@ where
     rows.iter()
         .filter_map(|row| {
             let label = label(row);
-            // nucleo expects ASCII-friendly bytes; fall back to a
-            // case-insensitive substring check when the label has
-            // non-ASCII chars (rare, but project paths can include
-            // unicode dashes etc.).
-            if !label.is_ascii() {
-                if label.to_lowercase().contains(query.to_lowercase().as_str()) {
-                    return Some(row);
-                }
-                return None;
-            }
+            // fuzzy_score routes non-ASCII through Utf32String, so we
+            // no longer need a substring fallback for unicode labels.
             fuzzy_score(&mut matcher, query, &label).map(|_| row)
         })
         .collect()

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -2475,6 +2475,7 @@ pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
     push_chip_group(&mut spans, "model", &state.filters.model);
     push_chip_group(&mut spans, "activity", &state.filters.activity);
     push_chip_group(&mut spans, "session", &state.filters.session);
+    push_chip_group(&mut spans, "branch", &state.filters.branch);
     spans.push(Span::styled("  ·  ", Style::default().fg(MUTED_GRAY)));
     spans.push(Span::styled(
         "Esc",
@@ -3902,27 +3903,59 @@ mod cross_filter_tests {
         let mut state = UsageViewState::default();
         state.filters.project.push("alpha".into());
         state.filters.model.push("opus".into());
+        state.filters.branch.push("main".into());
 
-        // First pop -> model (the chip-strip pop order: session →
-        // activity → model → project).
+        // First pop -> branch (rightmost in the strip; pop order is
+        // branch → session → activity → model → project).
+        let removed = state.pop_filter_chip();
+        assert!(matches!(removed, Some(UsageFilterChip::Branch(v)) if v == "main"));
+        assert!(state.filters.branch.is_empty());
+
+        // The chip strip must show every surviving chip — including the
+        // branch chip while it was set. Render symmetry: the chip the
+        // user sees rightmost is the one Esc removes next.
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("project=alpha"), "got {flat}");
+        assert!(flat.contains("model=opus"), "got {flat}");
+        assert!(!flat.contains("branch="), "branch chip lingered: {flat}");
+
+        // Second pop -> model.
         let removed = state.pop_filter_chip();
         assert!(matches!(removed, Some(UsageFilterChip::Model(v)) if v == "opus"));
-        assert!(state.filters.model.is_empty());
-        assert_eq!(state.filters.project, vec!["alpha".to_string()]);
-
-        // Chip strip should still show the remaining chip + Esc/C hint.
         let line = build_filter_chip_line(&state);
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(flat.contains("project=alpha"), "got {flat}");
         assert!(flat.contains("Esc") && flat.contains("C"), "got {flat}");
 
-        // Second pop -> project. With no chips left we fall back to
+        // Third pop -> project. With no chips left we fall back to
         // the discoverability hint.
         assert!(state.pop_filter_chip().is_some());
         assert!(state.filters.is_empty());
         let line = build_filter_chip_line(&state);
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(flat.contains("(none)"), "got {flat}");
+    }
+
+    /// Tripwire: every `UsageFilterChip` variant must render in
+    /// `build_filter_chip_line`. If a new variant is added without a
+    /// `push_chip_group` call this test fails — the PR-D regression where
+    /// `branch` chips set via `--branch` were invisible but still consumed
+    /// `Esc` is exactly what this guards against.
+    #[test]
+    fn every_filter_chip_variant_renders_in_strip() {
+        let mut state = UsageViewState::default();
+        state.filters.project.push("p".into());
+        state.filters.model.push("m".into());
+        state.filters.activity.push("Coding".into());
+        state.filters.session.push("s".into());
+        state.filters.branch.push("b".into());
+
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        for needle in ["project=p", "model=m", "activity=Coding", "session=s", "branch=b"] {
+            assert!(flat.contains(needle), "chip strip missing {needle}: {flat}");
+        }
     }
 
     #[test]

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -15,6 +15,10 @@ use crate::models::{
     UsageFilters, UsagePeriod, UsageProviderFilter, UsageQuery, filter_usage_data,
     format_tokens_short, optimize_usage,
 };
+use crate::models::usage::{
+    current_quarter, first_of_month, next_month_first, next_quarter, previous_month_first,
+    previous_quarter,
+};
 
 // Color palette from TUI style guide
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
@@ -3530,48 +3534,6 @@ fn provider_filter_label(filter: UsageProviderFilter) -> &'static str {
         UsageProviderFilter::Claude => "Claude",
         UsageProviderFilter::Codex => "Codex",
     }
-}
-
-/// First day of the calendar month containing `date`.
-fn first_of_month(date: NaiveDate) -> NaiveDate {
-    NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap_or(date)
-}
-
-/// First day of the previous calendar month.
-fn previous_month_first(anchor: NaiveDate) -> NaiveDate {
-    let (y, m) = if anchor.month() == 1 {
-        (anchor.year() - 1, 12)
-    } else {
-        (anchor.year(), anchor.month() - 1)
-    };
-    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
-}
-
-/// First day of the next calendar month.
-fn next_month_first(anchor: NaiveDate) -> NaiveDate {
-    let (y, m) = if anchor.month() == 12 {
-        (anchor.year() + 1, 1)
-    } else {
-        (anchor.year(), anchor.month() + 1)
-    };
-    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
-}
-
-/// `(year, quarter)` of the previous quarter, wrapping into the prior
-/// year at Q1.
-fn previous_quarter(year: i32, q: u8) -> (i32, u8) {
-    if q <= 1 { (year - 1, 4) } else { (year, q - 1) }
-}
-
-/// `(year, quarter)` of the next quarter, wrapping into the next year
-/// at Q4.
-fn next_quarter(year: i32, q: u8) -> (i32, u8) {
-    if q >= 4 { (year + 1, 1) } else { (year, q + 1) }
-}
-
-/// `(year, quarter)` containing `date`.
-fn current_quarter(date: NaiveDate) -> (i32, u8) {
-    (date.year(), crate::models::usage::quarter_of(date))
 }
 
 fn period_label(period: &UsagePeriod) -> String {

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -255,7 +255,16 @@ pub enum UsageFilterTarget {
     Session,
 }
 
-/// View state for the usage analytics screen
+/// View state for the usage analytics screen.
+///
+// TODO(refactor): collapse the 4 zoom-related fields (zoom,
+// zoom_search_active, zoom_search_query, zoom_detail_open) into a
+// single `Option<ZoomState>` so the "in zoom" invariant lives in the
+// type system. Currently every zoom-related callsite has to remember
+// to check `self.zoom.is_some()` and the search/detail flags carry
+// stale values from prior zoom sessions. Deferred — touches every
+// zoom-related event handler and renderer; safer to land alongside
+// snapshot tests for the zoom view.
 #[derive(Debug, Clone)]
 pub struct UsageViewState {
     pub provider: UsageProvider,

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1380,6 +1380,10 @@ fn fuzzy_score(matcher: &mut nucleo_matcher::Matcher, query: &str, haystack: &st
 /// Filter `rows` by a fuzzy-search query, preserving original order.
 /// Empty query returns all rows. The `label` closure projects each row
 /// to its primary search string (project name, session id, etc.).
+///
+/// Pattern parsing happens once before the filter loop (was per-call
+/// inside the filter via fuzzy_score). Worth doing because zoom-mode
+/// re-renders typing-rate (~10/s) over potentially 1k+ row sets.
 fn apply_zoom_filter<'a, T, F>(rows: &'a [T], query: &str, label: F) -> Vec<&'a T>
 where
     F: Fn(&T) -> String,
@@ -1387,13 +1391,26 @@ where
     if query.is_empty() {
         return rows.iter().collect();
     }
+    let needle = nucleo_matcher::pattern::Pattern::parse(
+        query,
+        nucleo_matcher::pattern::CaseMatching::Smart,
+        nucleo_matcher::pattern::Normalization::Smart,
+    );
+    let query_ascii = query.is_ascii();
     let mut matcher = nucleo_matcher::Matcher::new(nucleo_matcher::Config::DEFAULT);
     rows.iter()
         .filter_map(|row| {
             let label = label(row);
-            // fuzzy_score routes non-ASCII through Utf32String, so we
-            // no longer need a substring fallback for unicode labels.
-            fuzzy_score(&mut matcher, query, &label).map(|_| row)
+            let score = if query_ascii && label.is_ascii() {
+                needle.score(
+                    nucleo_matcher::Utf32Str::Ascii(label.as_bytes()),
+                    &mut matcher,
+                )
+            } else {
+                let utf32 = nucleo_matcher::Utf32String::from(label.as_str());
+                needle.score(utf32.slice(..), &mut matcher)
+            };
+            score.map(|_| row)
         })
         .collect()
 }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3521,18 +3521,7 @@ fn render_help_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
 }
 
 fn truncate_string(s: &str, max_len: usize) -> String {
-    // max_len is char count, not bytes. The previous `s.len()` gate let
-    // multi-byte strings reach a byte-slice (`&s[..max_len-1]`) that
-    // could fall inside a codepoint and panic. Since pretty_project_name
-    // now feeds branch names into here, that path is reachable on any
-    // non-ASCII branch name. Switch to char-count + chars().take().
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else {
-        let take = max_len.saturating_sub(1);
-        let truncated: String = s.chars().take(take).collect();
-        format!("{truncated}…")
-    }
+    crate::widgets::truncate_with_ellipsis(s, max_len).into_owned()
 }
 
 fn provider_filter_label(filter: UsageProviderFilter) -> &'static str {

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3353,7 +3353,7 @@ fn elapsed_days_for_period(period: &UsagePeriod, data: &UsageData) -> Option<u64
         }
         UsagePeriod::SpecificMonth(anchor) => {
             let first = NaiveDate::from_ymd_opt(anchor.year(), anchor.month(), 1)?;
-            let last = crate::models::usage::last_day_of_month(anchor.year(), anchor.month());
+            let last = crate::models::usage::last_day_of_month(anchor.year(), anchor.month())?;
             Some((last - first).num_days().max(0) as u64 + 1)
         }
         UsagePeriod::SpecificQuarter(year, q) => {

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1537,7 +1537,7 @@ fn render_zoom_top_sessions(
         .take(visible_rows)
         .map(|sess| {
             let b = &sess.bucket;
-            let dur = (sess.last_timestamp - sess.first_timestamp).num_minutes().max(0);
+            let dur = (sess.last_timestamp - sess.first_timestamp).num_seconds().max(0);
             let dur_str = format_duration_min(dur as u64);
             Row::new(vec![
                 sess.provider.clone(),
@@ -1930,8 +1930,17 @@ fn top_projects_for_model(data: &UsageData, model_name: &str, n: usize) -> Strin
         .join(" · ")
 }
 
-/// Render `min_total` as `1h 04m` / `42m` / `<1m`.
-fn format_duration_min(min_total: u64) -> String {
+/// Render a duration (in seconds) as `1h 04m` / `42m` / `<1m` / `0m`.
+///
+/// Distinguishes a true zero duration (`first == last` timestamp, e.g. a
+/// session with one logged turn) from a positive sub-minute duration
+/// (rounded down to 0 minutes). Both used to render as `<1m`, which
+/// hid the zero case.
+fn format_duration_min(secs_total: u64) -> String {
+    if secs_total == 0 {
+        return "0m".to_string();
+    }
+    let min_total = secs_total / 60;
     if min_total == 0 {
         return "<1m".to_string();
     }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -4055,24 +4055,18 @@ mod cli_parity_tests {
     use chrono::Local;
 
     fn call(project: &str, model: &str, session: &str) -> ProviderCall {
-        ProviderCall {
-            provider: "claude".into(),
-            model: model.into(),
-            session_id: session.into(),
-            project: project.into(),
-            project_path: format!("/work/{project}"),
-            timestamp: Local::now(),
-            input_tokens: 100,
-            cache_creation_tokens: 0,
-            cache_read_tokens: 0,
-            output_tokens: 50,
-            reasoning_tokens: 0,
-            cost_usd: Some(1.0),
-            tools: vec!["Edit".into()],
-            bash_commands: vec![],
-            user_message: "tidy".into(),
-            branch: None,
-        }
+        crate::test_support::ProviderCallBuilder::new()
+            .with_model(model)
+            .with_session(session)
+            .with_project(project)
+            .with_project_path(format!("/work/{project}"))
+            .with_timestamp(Local::now())
+            .with_input_tokens(100)
+            .with_output_tokens(50)
+            .with_cost(1.0)
+            .with_tools(&["Edit"])
+            .with_user_message("tidy")
+            .build()
     }
 
     fn data_with_calls(calls: Vec<ProviderCall>) -> UsageData {

--- a/ainb-tui/src/lib.rs
+++ b/ainb-tui/src/lib.rs
@@ -18,3 +18,6 @@ pub mod models;
 pub mod tmux;
 pub mod usage_cache;
 pub mod widgets;
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -46,6 +46,9 @@ mod tmux;
 mod usage_cache;
 mod widgets;
 
+#[cfg(any(test, feature = "test-support"))]
+mod test_support;
+
 use app::{App, EventHandler};
 use components::LayoutComponent;
 

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -298,13 +298,13 @@ impl TokenBucket {
 /// **WARNING — bincode layout stability.** Bincode v1 with default options
 /// encodes positionally with no field tags. Any change to the field set or
 /// order of this struct (or any nested type it owns) silently invalidates
-/// every cached blob written under the current `BLOB_FORMAT_BINCODE_V1`.
+/// every cached blob written under the current `BLOB_FORMAT_BINCODE_CURRENT`.
 /// Wrong-shape decodes can either panic (caught — falls through to a full
 /// re-parse) or, much worse, succeed with mis-aligned bytes and return
 /// wrong analytics from the cache.
 ///
 /// **If you change this struct or any nested type, you MUST:**
-/// 1. Bump `usage_cache::db::BLOB_FORMAT_BINCODE_V1` to a new value, and
+/// 1. Bump `usage_cache::db::BLOB_FORMAT_BINCODE_CURRENT` to a new value, and
 /// 2. Update the layout-stability tripwire test in `usage_cache::tests`.
 ///
 /// The tripwire test asserts a fixed serialized byte length for a known

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -235,6 +235,15 @@ pub enum UsageFilterChip {
 }
 
 impl UsageFilterChip {
+    /// Stable string key for this chip, used by the chip-strip widget,
+    /// CLI flag mapping, and filter telemetry. The match below is the
+    /// single source of truth — keep it in sync with new variants.
+    //
+    // NOTE: an earlier cleanup considered switching to strum_macros'
+    // AsRefStr. Skipped: adding the strum crate purely for five mappings
+    // costs more than the match itself, and a const-slice indexed by
+    // discriminant order is harder to read than the match and not type-
+    // checked when a variant is added. The match is already canonical.
     pub fn label(&self) -> &'static str {
         match self {
             Self::Project(_) => "project",

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -831,6 +831,12 @@ fn parse_claude_source_append(
         }
     };
     let total_len = file.metadata().map(|m| m.len()).unwrap_or(from_offset);
+    // Recover the user message that was last in scope at `from_offset`
+    // by reading the prefix [0, from_offset) and walking it for "type":
+    // "user" lines. Without this, every appended assistant turn would
+    // carry an empty user_message and lose attribution. Bounded by
+    // from_offset; only paid on cache-hit append paths.
+    let current_user_message = recover_user_message_before(&mut file, from_offset);
     if file.seek(SeekFrom::Start(from_offset)).is_err() {
         return ParseResult {
             calls: existing.to_vec(),
@@ -839,7 +845,7 @@ fn parse_claude_source_append(
     }
     let reader = BufReader::new(file);
     let mut calls = existing.to_vec();
-    let mut current_user_message = String::new();
+    let mut current_user_message = current_user_message;
     for line in reader.lines() {
         // On any I/O or UTF-8 error from BufReader::lines we cannot
         // safely advance the cached end_offset — the next run would
@@ -866,6 +872,47 @@ fn parse_claude_source_append(
         calls,
         end_offset: total_len,
     }
+}
+
+/// Walk the prefix `[0, from_offset)` of `file` looking for the last
+/// `"type":"user"` line, returning its extracted message text. Used by
+/// the append parser so user_message attribution survives a cache hit
+/// (the user line that primed the message is in the prefix; without
+/// recovery, every appended assistant turn ends up with an empty
+/// `user_message`).
+///
+/// Errors are absorbed — if the prefix is unreadable we return an empty
+/// string and the next assistant turn's `user_message` is empty (same
+/// fallback as before this fix). Leaves the file cursor at an
+/// undefined offset; the caller must re-seek to `from_offset`.
+fn recover_user_message_before(
+    file: &mut std::fs::File,
+    from_offset: u64,
+) -> String {
+    if from_offset == 0 {
+        return String::new();
+    }
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return String::new();
+    }
+    let limited = (file as &mut std::fs::File).take(from_offset);
+    let reader = BufReader::new(limited);
+    let mut last = String::new();
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            // Partial scan still useful — keep whatever we'd
+            // discovered up to the error.
+            break;
+        };
+        if let Ok(parsed) = serde_json::from_str::<ClaudeLine>(&line) {
+            if parsed.msg_type.as_deref() == Some("user") {
+                if let Some(message) = parsed.message {
+                    last = extract_claude_user_text(message.content.as_ref());
+                }
+            }
+        }
+    }
+    last
 }
 
 /// Parse a single Claude JSONL line. Returns `Some(call)` for assistant

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -213,7 +213,7 @@ impl UsageFilters {
             }
         }
         if !self.branch.is_empty() {
-            let Some(branch) = call.branch.as_deref() else {
+            let Some(branch) = call.recorded_branch() else {
                 return false;
             };
             if !self.branch.iter().any(|b| b == branch) {
@@ -346,6 +346,15 @@ impl ProviderCall {
             call_count: 1,
             cost_usd: self.cost_usd,
         }
+    }
+
+    /// Branch attribution that's safe to display: returns the recorded
+    /// branch only when it's `Some(non-empty)`. Empty strings creep in
+    /// from downstream branch detection that returns `""` for a non-git
+    /// project; the canonical accessor stops them from being aggregated
+    /// as a real branch named "" anywhere in the pipeline.
+    pub fn recorded_branch(&self) -> Option<&str> {
+        self.branch.as_deref().filter(|b| !b.is_empty())
     }
 }
 
@@ -1221,7 +1230,7 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
 
         model_map.entry(call.model.clone()).or_default().merge(&bucket);
 
-        if let Some(branch) = call.branch.as_deref().filter(|b| !b.is_empty()) {
+        if let Some(branch) = call.recorded_branch() {
             branch_map.entry(branch.to_string()).or_default().merge(&bucket);
         }
 

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -910,7 +910,7 @@ fn recover_user_message_before(
     if file.seek(SeekFrom::Start(0)).is_err() {
         return String::new();
     }
-    let limited = (file as &mut std::fs::File).take(from_offset);
+    let limited = file.by_ref().take(from_offset);
     let reader = BufReader::new(limited);
     let mut last = String::new();
     for line in reader.lines() {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -454,6 +454,12 @@ pub struct UsageData {
     /// Branch attribution rows, sorted by largest bucket. Only Claude
     /// assistant turns with a non-empty `gitBranch` populate this.
     pub branches: Vec<BranchUsage>,
+    /// Precomputed `model -> [(project, call_count), ...]` sorted by
+    /// count descending. Built once during `aggregate_calls` so the
+    /// render path's "top N projects for model X" lookup is O(1) plus
+    /// the constant-N truncation, instead of a full O(N·M) scan of
+    /// `data.calls` per render frame.
+    pub model_project_counts: HashMap<String, Vec<(String, usize)>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -492,6 +498,7 @@ impl Default for UsageData {
             mcp_servers: Vec::new(),
             shell_commands: Vec::new(),
             branches: Vec::new(),
+            model_project_counts: HashMap::new(),
         }
     }
 }
@@ -1393,6 +1400,8 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         grand_total.total()
     );
 
+    let model_project_counts = build_model_project_counts(&calls);
+
     UsageData {
         daily,
         weekly: {
@@ -1409,7 +1418,32 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         mcp_servers,
         shell_commands,
         branches,
+        model_project_counts,
     }
+}
+
+/// Build the `model -> [(project, count), ...]` index used by the
+/// burndown render path's "top N projects for model X" lookup. Sorted
+/// desc by count so the render call is `take(n)` with no extra work.
+fn build_model_project_counts(
+    calls: &[ProviderCall],
+) -> HashMap<String, Vec<(String, usize)>> {
+    let mut by_model: HashMap<String, HashMap<String, usize>> = HashMap::new();
+    for call in calls {
+        *by_model
+            .entry(call.model.clone())
+            .or_default()
+            .entry(call.project.clone())
+            .or_insert(0) += 1;
+    }
+    by_model
+        .into_iter()
+        .map(|(model, projs)| {
+            let mut v: Vec<(String, usize)> = projs.into_iter().collect();
+            v.sort_by(|a, b| b.1.cmp(&a.1));
+            (model, v)
+        })
+        .collect()
 }
 
 /// Filter an already-parsed `UsageData` by exact-match cross-filters.

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -824,11 +824,11 @@ fn parse_claude_source_full(path: &Path, project: &str, project_path: &str) -> P
 /// concatenated with the new calls, so the cache can persist a complete
 /// blob for the file.
 ///
-/// Trade-off: `current_user_message` state from before `from_offset` is
-/// not restored. New assistant rows that appear *before* the next user
-/// line in the appended tail will get an empty `user_message`. This is
-/// rare in practice and cheap to fix in a follow-up by persisting parser
-/// state alongside the row.
+/// `current_user_message` state from before `from_offset` is restored
+/// by `recover_user_message_before`, which walks the prefix
+/// `[0, from_offset)` for the last `"type":"user"` line. Without that,
+/// every appended assistant turn would lose user_message attribution
+/// across cache hits.
 fn parse_claude_source_append(
     path: &Path,
     project: &str,

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -2028,7 +2028,7 @@ fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Local>, DateT
         UsagePeriod::SpecificMonth(anchor) => {
             let first =
                 NaiveDate::from_ymd_opt(anchor.year(), anchor.month(), 1).unwrap_or(*anchor);
-            let last = last_day_of_month(anchor.year(), anchor.month());
+            let last = last_day_of_month(anchor.year(), anchor.month()).unwrap_or(*anchor);
             Some((start_of_day(first), end_of_day(last)))
         }
         UsagePeriod::SpecificQuarter(year, q) => {
@@ -2043,17 +2043,25 @@ fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Local>, DateT
     }
 }
 
-/// Last calendar day of a `(year, month)`. Falls back to day 28 only
-/// for genuinely impossible chrono inputs (year out of range).
-pub fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
+/// Last calendar day of a `(year, month)`. Returns `None` if the inputs
+/// are out of chrono's representable range (year < -262_144 or > 262_143,
+/// month not in 1..=12). Previously this silently returned the 28th,
+/// which produced wrong-on-purpose results for callers that didn't
+/// notice — `Option` makes the failure explicit.
+pub fn last_day_of_month(year: i32, month: u32) -> Option<NaiveDate> {
+    // Reject obviously-invalid months up front so month=0 doesn't silently
+    // roll into the previous December (which the next-month-minus-one
+    // trick below would otherwise compute).
+    if !(1..=12).contains(&month) {
+        return None;
+    }
     let (next_year, next_month) = if month == 12 {
         (year + 1, 1)
     } else {
         (year, month + 1)
     };
-    let next_first = NaiveDate::from_ymd_opt(next_year, next_month, 1)
-        .unwrap_or_else(|| NaiveDate::from_ymd_opt(year, month, 28).expect("valid 28th"));
-    next_first - Duration::days(1)
+    let next_first = NaiveDate::from_ymd_opt(next_year, next_month, 1)?;
+    Some(next_first - Duration::days(1))
 }
 
 /// First and last calendar days of `quarter` (1..=4) within `year`.
@@ -2064,7 +2072,10 @@ pub fn quarter_bounds(year: i32, quarter: u8) -> (NaiveDate, NaiveDate) {
     let end_month = start_month + 2;
     let first = NaiveDate::from_ymd_opt(year, start_month, 1)
         .unwrap_or_else(|| NaiveDate::from_ymd_opt(year, 1, 1).expect("valid Jan 1"));
-    let last = last_day_of_month(year, end_month);
+    // Quarter end-month is always 3, 6, 9, or 12 — last_day_of_month can
+    // only fail for an out-of-range `year`. In that case fall back to
+    // `first` so the bounds collapse to a single day rather than panic.
+    let last = last_day_of_month(year, end_month).unwrap_or(first);
     (first, last)
 }
 
@@ -2360,6 +2371,43 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn last_day_of_month_handles_leap_years() {
+        // Leap year: Feb has 29 days.
+        assert_eq!(
+            last_day_of_month(2024, 2),
+            Some(NaiveDate::from_ymd_opt(2024, 2, 29).unwrap())
+        );
+        // Non-leap year: Feb has 28 days.
+        assert_eq!(
+            last_day_of_month(2023, 2),
+            Some(NaiveDate::from_ymd_opt(2023, 2, 28).unwrap())
+        );
+        // Century non-leap (divisible by 100 but not 400).
+        assert_eq!(
+            last_day_of_month(1900, 2),
+            Some(NaiveDate::from_ymd_opt(1900, 2, 28).unwrap())
+        );
+        // Quad-century leap (divisible by 400).
+        assert_eq!(
+            last_day_of_month(2000, 2),
+            Some(NaiveDate::from_ymd_opt(2000, 2, 29).unwrap())
+        );
+        // 31-day month.
+        assert_eq!(
+            last_day_of_month(2024, 1),
+            Some(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap())
+        );
+        // December rollover into next year.
+        assert_eq!(
+            last_day_of_month(2024, 12),
+            Some(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap())
+        );
+        // Out-of-range month returns None instead of silently wrong data.
+        assert_eq!(last_day_of_month(2024, 13), None);
+        assert_eq!(last_day_of_month(2024, 0), None);
+    }
 
     fn write_file(path: &Path, content: &str) {
         if let Some(parent) = path.parent() {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1274,23 +1274,23 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
             ProjectUsage { name, path, bucket }
         })
         .collect();
-    projects.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+    sort_by_bucket_desc(&mut projects, |p| &p.bucket);
 
     let mut sessions: Vec<_> =
         session_map.into_values().map(SessionUsageAccumulator::into_usage).collect();
-    sessions.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+    sort_by_bucket_desc(&mut sessions, |s| &s.bucket);
 
     let mut models: Vec<_> = model_map
         .into_iter()
         .map(|(model, bucket)| ModelUsage { model, bucket })
         .collect();
-    models.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+    sort_by_bucket_desc(&mut models, |m| &m.bucket);
 
     let mut branches: Vec<_> = branch_map
         .into_iter()
         .map(|(branch, bucket)| BranchUsage { branch, bucket })
         .collect();
-    branches.sort_by(|a, b| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)));
+    sort_by_bucket_desc(&mut branches, |b| &b.bucket);
 
     let tools = sorted_named_usage(tool_map);
     let mcp_servers = sorted_named_usage(mcp_map);
@@ -2267,6 +2267,20 @@ fn merge_cost(left: Option<f64>, right: Option<f64>) -> Option<f64> {
 
 fn bucket_sort_value(bucket: &TokenBucket) -> f64 {
     bucket.cost_usd.unwrap_or(bucket.total() as f64)
+}
+
+/// Sort `rows` in-place by bucket weight (descending), where each row's
+/// bucket is extracted via `key`. Centralises the cost-then-tokens
+/// ranking used across every usage panel (projects, sessions, models,
+/// branches, ...). The closure return type is `&TokenBucket` so callers
+/// can point at a field without cloning.
+fn sort_by_bucket_desc<T, F>(rows: &mut Vec<T>, key: F)
+where
+    F: Fn(&T) -> &TokenBucket,
+{
+    rows.sort_by(|a, b| {
+        bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a)))
+    });
 }
 
 fn estimate_cost_usd(

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -2522,6 +2522,10 @@ mod tests {
         }
     }
 
+    /// Test-only convenience that wraps the shared `ProviderCallBuilder`
+    /// with the parameter shape this module's parser tests expect.
+    /// Picks gpt-5 for codex and claude-sonnet-4-5 otherwise; sets
+    /// output_tokens to a fixed 10 (the tests rely on that constant).
     fn provider_call(
         provider: &str,
         session_id: &str,
@@ -2531,28 +2535,18 @@ mod tests {
         bash_commands: &[&str],
         input_tokens: u64,
     ) -> ProviderCall {
-        ProviderCall {
-            provider: provider.to_string(),
-            model: if provider == "codex" {
-                "gpt-5".to_string()
-            } else {
-                "claude-sonnet-4-5".to_string()
-            },
-            session_id: session_id.to_string(),
-            project: "alpha".to_string(),
-            project_path: "/work/alpha".to_string(),
-            timestamp: parse_timestamp(timestamp).unwrap(),
-            input_tokens,
-            cache_creation_tokens: 0,
-            cache_read_tokens: 0,
-            output_tokens: 10,
-            reasoning_tokens: 0,
-            cost_usd: None,
-            tools: tools.iter().map(|tool| tool.to_string()).collect(),
-            bash_commands: bash_commands.iter().map(|command| command.to_string()).collect(),
-            user_message: message.to_string(),
-            branch: None,
-        }
+        let model = if provider == "codex" { "gpt-5" } else { "claude-sonnet-4-5" };
+        crate::test_support::ProviderCallBuilder::new()
+            .with_provider(provider)
+            .with_model(model)
+            .with_session(session_id)
+            .with_timestamp(parse_timestamp(timestamp).unwrap())
+            .with_input_tokens(input_tokens)
+            .with_output_tokens(10)
+            .with_tools(tools)
+            .with_bash(bash_commands)
+            .with_user_message(message)
+            .build()
     }
 
     #[test]

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -389,6 +389,8 @@ pub struct ModelUsage {
 /// Per-branch summary. Built only from calls whose `branch` is `Some`;
 /// branchless calls (codex, non-git Claude turns) are dropped from this
 /// view so the panel never grows a misleading "(no branch)" bucket.
+// TODO(PR-E): wire BranchUsage into render_branch_panel — currently
+// aggregated but not rendered (see UsageData.branches).
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 pub struct BranchUsage {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -841,7 +841,17 @@ fn parse_claude_source_append(
     let mut calls = existing.to_vec();
     let mut current_user_message = String::new();
     for line in reader.lines() {
-        let Ok(line) = line else { break };
+        // On any I/O or UTF-8 error from BufReader::lines we cannot
+        // safely advance the cached end_offset — the next run would
+        // skip past the unread tail and silently lose data. Roll the
+        // cursor back to from_offset so the next scan retries the
+        // append. Mirror the Full path's all-or-nothing semantics.
+        let Ok(line) = line else {
+            return ParseResult {
+                calls: existing.to_vec(),
+                end_offset: from_offset,
+            };
+        };
         if let Some(call) = parse_claude_line(
             &line,
             path,

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1238,6 +1238,14 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
     calls
 }
 
+// TODO(refactor): the function below ingests `calls` into ten parallel
+// accumulators (daily, weekly, projects, sessions, models, branches,
+// activities, tools, mcp, shell). Extract a per-dimension Accumulator
+// trait so each one is unit-testable in isolation; orchestrator
+// becomes `for call in calls { for acc in &mut accumulators { acc.ingest(call) } }`.
+// Deferred — the largest single change in this cleanup pass and best
+// landed alongside the analyze_turns precompute (whose stable-id
+// requirement triggers a coordinated bincode bump). See PR-E thread.
 fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
     if calls.is_empty() {
         return UsageData::default();

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -196,7 +196,7 @@ impl UsageFilters {
         self.branch.clear();
     }
 
-    fn matches(&self, call: &ProviderCall, category: ActivityCategory) -> bool {
+    pub(crate) fn matches(&self, call: &ProviderCall, category: ActivityCategory) -> bool {
         if !self.project.is_empty() && !self.project.iter().any(|p| p == &call.project) {
             return false;
         }
@@ -678,6 +678,7 @@ pub fn parse_usage_for_with_roots_and_cache(
         ));
     }
 
+    let filters_active = !query.filters.is_empty();
     let filtered: Vec<ProviderCall> = calls
         .into_iter()
         .filter(|call| {
@@ -686,14 +687,18 @@ pub fn parse_usage_for_with_roots_and_cache(
             })
         })
         .filter(|call| project_matches(call, &query.include_projects, &query.exclude_projects))
+        // Apply cross-filter chips up-front when present. Saves a full
+        // aggregate+re-aggregate round trip on the CLI path: previously
+        // we built the full UsageData and then filter_usage_data
+        // re-aggregated the filtered subset. The TUI hot path keeps
+        // calling filter_usage_data over cached UsageData and is
+        // unaffected.
+        .filter(|call| {
+            !filters_active || query.filters.matches(call, classify_activity(call))
+        })
         .collect();
 
-    let aggregated = aggregate_calls(filtered);
-    if query.filters.is_empty() {
-        aggregated
-    } else {
-        filter_usage_data(&aggregated, &query.filters)
-    }
+    aggregate_calls(filtered)
 }
 
 fn parse_claude_sources(projects_dir: Option<&Path>, cache: &Cache) -> Vec<ProviderCall> {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -2065,7 +2065,8 @@ pub fn last_day_of_month(year: i32, month: u32) -> Option<NaiveDate> {
 }
 
 /// First and last calendar days of `quarter` (1..=4) within `year`.
-/// Out-of-range quarters are clamped to Q1.
+/// Out-of-range quarters are clamped to the nearest valid quarter
+/// (`quarter < 1 -> Q1`, `quarter > 4 -> Q4`) via `clamp(1, 4)`.
 pub fn quarter_bounds(year: i32, quarter: u8) -> (NaiveDate, NaiveDate) {
     let q = quarter.clamp(1, 4);
     let start_month = (u32::from(q) - 1) * 3 + 1;

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1228,10 +1228,10 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         }
         session.bucket.merge(&bucket);
 
-        model_map.entry(call.model.clone()).or_default().merge(&bucket);
+        add_bucket(&mut model_map, call.model.clone(), &bucket);
 
         if let Some(branch) = call.recorded_branch() {
-            branch_map.entry(branch.to_string()).or_default().merge(&bucket);
+            add_bucket(&mut branch_map, branch.to_string(), &bucket);
         }
 
         let analysis = turn_analysis.get(&idx).copied().unwrap_or_else(|| TurnAnalysis {
@@ -1254,13 +1254,13 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
             if let Some(server) =
                 tool.strip_prefix("mcp__").and_then(|rest| rest.split("__").next())
             {
-                *mcp_map.entry(server.to_string()).or_default() += 1;
+                bump(&mut mcp_map, server.to_string());
             } else {
-                *tool_map.entry(tool.clone()).or_default() += 1;
+                bump(&mut tool_map, tool.clone());
             }
         }
         for command in &call.bash_commands {
-            *shell_map.entry(command.clone()).or_default() += 1;
+            bump(&mut shell_map, command.clone());
         }
     }
 
@@ -2334,6 +2334,26 @@ where
     rows.sort_by(|a, b| {
         bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a)))
     });
+}
+
+/// Merge `bucket` into the entry at `key` in a `String -> TokenBucket`
+/// map, defaulting to an empty bucket when the key is absent. Centralises
+/// the model_map / branch_map merge pattern used inside `aggregate_calls`.
+fn add_bucket<K>(map: &mut HashMap<K, TokenBucket>, key: K, bucket: &TokenBucket)
+where
+    K: std::hash::Hash + Eq,
+{
+    map.entry(key).or_default().merge(bucket);
+}
+
+/// Increment the count at `key` in a `String -> usize` map, defaulting to
+/// zero when the key is absent. Centralises the tool/mcp/shell counter
+/// pattern used inside `aggregate_calls`.
+fn bump<K>(map: &mut HashMap<K, usize>, key: K)
+where
+    K: std::hash::Hash + Eq,
+{
+    *map.entry(key).or_default() += 1;
 }
 
 fn estimate_cost_usd(

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -326,6 +326,14 @@ pub struct ProviderCall {
     pub session_id: String,
     pub project: String,
     pub project_path: String,
+    // TODO(refactor): migrate this to DateTime<Utc>. The Local variant
+    // bakes a timezone offset into the cached blob, so a user moving
+    // across timezones (or DST transition) sees inconsistent
+    // serialised representations between cache hit and full reparse.
+    // Migration bumps BLOB_FORMAT_BINCODE_CURRENT to 3 and forces
+    // every constructor + render site to convert at the boundary.
+    // Deferred — V2 was bumped to 2 recently for branch attribution
+    // and another bump is best paired with the analyze_turns id work.
     pub timestamp: DateTime<Local>,
     pub input_tokens: u64,
     pub cache_creation_tokens: u64,
@@ -696,6 +704,13 @@ pub fn parse_usage_for_with_roots_and_cache(
     aggregate_calls(filtered)
 }
 
+// TODO(perf): parallelise per-file cache.get_or_parse with rayon
+// (par_iter() over collect_claude_jsonl_files results). SQLite writes
+// still serialise on the connection mutex but JSONL parsing +
+// fingerprinting can run concurrent. Cache itself is already
+// Send+Sync via Mutex<Connection>. Deferred — adding rayon as a
+// dependency is the largest unrelated lift in this batch and is
+// best landed in its own change with benchmarks attached.
 fn parse_claude_sources(projects_dir: Option<&Path>, cache: &Cache) -> Vec<ProviderCall> {
     let Some(projects_dir) = projects_dir else {
         return Vec::new();

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -2096,6 +2096,50 @@ pub fn quarter_of(date: NaiveDate) -> u8 {
     ((date.month0() / 3) + 1) as u8
 }
 
+/// First day of the calendar month containing `date`. Falls back to
+/// `date` itself if chrono rejects the (year, month, 1) tuple, which is
+/// only possible at the extreme edges of the representable range.
+pub fn first_of_month(date: NaiveDate) -> NaiveDate {
+    NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap_or(date)
+}
+
+/// First day of the previous calendar month, wrapping the year at Jan.
+pub fn previous_month_first(anchor: NaiveDate) -> NaiveDate {
+    let (y, m) = if anchor.month() == 1 {
+        (anchor.year() - 1, 12)
+    } else {
+        (anchor.year(), anchor.month() - 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
+}
+
+/// First day of the next calendar month, wrapping the year at Dec.
+pub fn next_month_first(anchor: NaiveDate) -> NaiveDate {
+    let (y, m) = if anchor.month() == 12 {
+        (anchor.year() + 1, 1)
+    } else {
+        (anchor.year(), anchor.month() + 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
+}
+
+/// `(year, quarter)` of the previous quarter, wrapping into the prior
+/// year at Q1.
+pub fn previous_quarter(year: i32, q: u8) -> (i32, u8) {
+    if q <= 1 { (year - 1, 4) } else { (year, q - 1) }
+}
+
+/// `(year, quarter)` of the next quarter, wrapping into the next year
+/// at Q4.
+pub fn next_quarter(year: i32, q: u8) -> (i32, u8) {
+    if q >= 4 { (year + 1, 1) } else { (year, q + 1) }
+}
+
+/// `(year, quarter)` containing `date`.
+pub fn current_quarter(date: NaiveDate) -> (i32, u8) {
+    (date.year(), quarter_of(date))
+}
+
 fn day_bounds(date: NaiveDate) -> (DateTime<Local>, DateTime<Local>) {
     (start_of_day(date), end_of_day(date))
 }

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -602,18 +602,6 @@ struct CodexTokenUsage {
     total_tokens: Option<u64>,
 }
 
-/// Parse all known local session files using the legacy Claude-only query.
-/// This is designed to run in a background thread.
-pub fn parse_usage() -> UsageData {
-    parse_usage_for(UsageQuery {
-        provider_filter: UsageProviderFilter::Claude,
-        period: UsagePeriod::All,
-        include_projects: Vec::new(),
-        exclude_projects: Vec::new(),
-        filters: UsageFilters::default(),
-    })
-}
-
 /// Parse local session files for a query using default user data roots.
 pub fn parse_usage_for(query: UsageQuery) -> UsageData {
     parse_usage_for_with_roots(query, &UsageSourceRoots::default())

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1490,6 +1490,12 @@ struct ActivityAccumulator {
     one_shot_turns: usize,
 }
 
+// TODO(perf): precompute analyze_turns once on the unfiltered call set
+// and thread it into aggregate_calls so filter_usage_data chip pivots
+// don't re-run the per-session timeline walk. Requires a stable
+// per-call key; ProviderCall has no id field today and adding one bumps
+// the bincode blob format. Deferred — the win is bounded by session
+// length and the TUI hot path is sub-frame already.
 fn analyze_turns(calls: &[ProviderCall]) -> HashMap<usize, TurnAnalysis> {
     let mut sessions: HashMap<String, Vec<usize>> = HashMap::new();
     for (idx, call) in calls.iter().enumerate() {

--- a/ainb-tui/src/test_support.rs
+++ b/ainb-tui/src/test_support.rs
@@ -1,0 +1,231 @@
+// ABOUTME: Shared test fixtures for ProviderCall, UsageData, and the
+// Claude JSONL turn-line shape. Centralised so a layout change to
+// ProviderCall touches one builder rather than four near-identical
+// inline literals across unit + integration tests.
+
+//! Shared test fixtures for the usage analytics pipeline.
+//!
+//! Gated by `cfg(any(test, feature = "test-support"))` so the helpers
+//! are available to in-tree unit tests automatically and to integration
+//! tests in `tests/` via `--features test-support`.
+
+use chrono::{DateTime, Local, TimeZone};
+
+use crate::models::{
+    ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
+    SessionUsage, TokenBucket, UsageData,
+};
+
+/// Fluent builder for `ProviderCall`. Each `with_*` method overrides the
+/// corresponding default so a test only mentions the fields it actually
+/// cares about. When `ProviderCall` grows a new field, add a default in
+/// `new()` and (optionally) a builder method here — every existing test
+/// keeps compiling without an edit.
+#[derive(Debug, Clone)]
+pub struct ProviderCallBuilder {
+    call: ProviderCall,
+}
+
+impl ProviderCallBuilder {
+    /// Construct a builder pre-filled with conservative defaults:
+    /// claude-sonnet-4-5 model, session "s1", project "alpha", a fixed
+    /// timestamp (2026-04-29T10:00:00 local), and zero tokens.
+    pub fn new() -> Self {
+        Self {
+            call: ProviderCall {
+                provider: "claude".to_string(),
+                model: "claude-sonnet-4-5".to_string(),
+                session_id: "s1".to_string(),
+                project: "alpha".to_string(),
+                project_path: "/work/alpha".to_string(),
+                timestamp: default_timestamp(),
+                input_tokens: 0,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                output_tokens: 0,
+                reasoning_tokens: 0,
+                cost_usd: None,
+                tools: Vec::new(),
+                bash_commands: Vec::new(),
+                user_message: String::new(),
+                branch: None,
+            },
+        }
+    }
+
+    pub fn with_provider(mut self, v: impl Into<String>) -> Self {
+        self.call.provider = v.into();
+        self
+    }
+    pub fn with_model(mut self, v: impl Into<String>) -> Self {
+        self.call.model = v.into();
+        self
+    }
+    pub fn with_session(mut self, v: impl Into<String>) -> Self {
+        self.call.session_id = v.into();
+        self
+    }
+    pub fn with_project(mut self, v: impl Into<String>) -> Self {
+        self.call.project = v.into();
+        self
+    }
+    pub fn with_project_path(mut self, v: impl Into<String>) -> Self {
+        self.call.project_path = v.into();
+        self
+    }
+    pub fn with_timestamp(mut self, v: DateTime<Local>) -> Self {
+        self.call.timestamp = v;
+        self
+    }
+    pub fn with_input_tokens(mut self, v: u64) -> Self {
+        self.call.input_tokens = v;
+        self
+    }
+    pub fn with_output_tokens(mut self, v: u64) -> Self {
+        self.call.output_tokens = v;
+        self
+    }
+    pub fn with_cost(mut self, v: f64) -> Self {
+        self.call.cost_usd = Some(v);
+        self
+    }
+    pub fn with_tools(mut self, tools: &[&str]) -> Self {
+        self.call.tools = tools.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+    pub fn with_bash(mut self, cmds: &[&str]) -> Self {
+        self.call.bash_commands = cmds.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+    pub fn with_user_message(mut self, v: impl Into<String>) -> Self {
+        self.call.user_message = v.into();
+        self
+    }
+    pub fn with_branch(mut self, v: impl Into<String>) -> Self {
+        self.call.branch = Some(v.into());
+        self
+    }
+
+    pub fn build(self) -> ProviderCall {
+        self.call
+    }
+}
+
+impl Default for ProviderCallBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convenience: a fully-defaulted `ProviderCall`. Equivalent to
+/// `ProviderCallBuilder::new().build()`.
+pub fn provider_call_default() -> ProviderCall {
+    ProviderCallBuilder::new().build()
+}
+
+/// Deterministic default timestamp shared across fixtures. Pinning this
+/// to a specific value (rather than `Local::now()`) keeps tests
+/// reproducible.
+fn default_timestamp() -> DateTime<Local> {
+    Local
+        .with_ymd_and_hms(2026, 4, 29, 10, 0, 0)
+        .single()
+        .unwrap_or_else(Local::now)
+}
+
+/// Build a small `UsageData` fixture covering one project, one model,
+/// one activity, one session, plus tools/shell — enough surface for the
+/// burndown render path and `commit_focused_row` dispatch tests.
+///
+/// Collapses three near-identical fixtures that previously lived
+/// inline in `tests/test_ui_display.rs` and `components/usage::fixture()`.
+pub fn sample_usage_data() -> UsageData {
+    let bucket = TokenBucket {
+        input_tokens: 100,
+        output_tokens: 50,
+        call_count: 2,
+        session_count: 1,
+        project_count: 1,
+        cost_usd: Some(0.42),
+        ..TokenBucket::default()
+    };
+    let now = default_timestamp();
+    UsageData {
+        calls: vec![
+            ProviderCallBuilder::new()
+                .with_project("agents-in-a-box")
+                .with_project_path("/tmp/agents-in-a-box")
+                .with_input_tokens(100)
+                .with_output_tokens(50)
+                .with_cost(0.42)
+                .with_tools(&["Edit"])
+                .with_bash(&["cargo test"])
+                .with_user_message("implement burndown")
+                .build(),
+        ],
+        daily: vec![(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+            bucket.clone(),
+        )],
+        weekly: vec![(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 27).unwrap(),
+            bucket.clone(),
+        )],
+        projects: vec![ProjectUsage {
+            name: "agents-in-a-box".to_string(),
+            path: "/tmp/agents-in-a-box".to_string(),
+            bucket: bucket.clone(),
+        }],
+        grand_total: bucket.clone(),
+        sessions: vec![SessionUsage {
+            provider: "claude".to_string(),
+            project: "agents-in-a-box".to_string(),
+            session_id: "s1".to_string(),
+            first_timestamp: now,
+            last_timestamp: now,
+            bucket: bucket.clone(),
+        }],
+        models: vec![ModelUsage {
+            model: "claude-sonnet-4-5".to_string(),
+            bucket: bucket.clone(),
+        }],
+        activities: vec![ActivityUsage {
+            category: ActivityCategory::Feature,
+            bucket: bucket.clone(),
+            turns: 2,
+            retries: 0,
+            edit_turns: 1,
+            one_shot_turns: 1,
+        }],
+        tools: vec![NamedUsage {
+            name: "Edit".to_string(),
+            calls: 1,
+        }],
+        shell_commands: vec![NamedUsage {
+            name: "cargo test".to_string(),
+            calls: 1,
+        }],
+        ..UsageData::default()
+    }
+}
+
+/// Build a single Claude JSONL "assistant" turn line. Used by branch
+/// attribution and parser tests that need realistic on-disk shape but
+/// only care about a handful of fields.
+///
+/// `branch` is emitted as `gitBranch` when `Some`; omitted when `None`
+/// so the parser exercises the "branchless turn" path.
+pub fn claude_jsonl_turn(
+    branch: Option<&str>,
+    model: &str,
+    in_tok: u64,
+    out_tok: u64,
+) -> String {
+    let branch_field = match branch {
+        Some(b) => format!(r#","gitBranch":"{b}""#),
+        None => String::new(),
+    };
+    format!(
+        r#"{{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1"{branch_field},"message":{{"role":"assistant","model":"{model}","content":[{{"type":"text","text":"x"}}],"usage":{{"input_tokens":{in_tok},"output_tokens":{out_tok}}}}}}}"#
+    )
+}

--- a/ainb-tui/src/usage_cache/db.rs
+++ b/ainb-tui/src/usage_cache/db.rs
@@ -16,10 +16,15 @@ pub const SCHEMA_VERSION: i64 = 1;
 /// `files.blob_format` value for the current bincode-encoded
 /// `Vec<ProviderCall>` blob shape (default options).
 ///
+/// Renamed from `BLOB_FORMAT_BINCODE_V1` because the discriminant value drifts
+/// (currently 2, was 1) every time `ProviderCall` layout changes. The constant
+/// names the *current* on-disk format, not a fixed schema generation — the
+/// numeric value is the version, the constant name is its role.
+///
 /// History:
 ///   1 — original 14-field `ProviderCall`.
 ///   2 — added `branch: Option<String>` (PR-D, branch attribution).
-pub const BLOB_FORMAT_BINCODE_V1: i64 = 2;
+pub const BLOB_FORMAT_BINCODE_CURRENT: i64 = 2;
 
 /// Open (or create) the usage-cache sqlite DB at `path`, applying schema and
 /// performance pragmas. Caller owns the resulting connection — wrap in a

--- a/ainb-tui/src/usage_cache/fingerprint.rs
+++ b/ainb-tui/src/usage_cache/fingerprint.rs
@@ -10,9 +10,13 @@ use std::path::Path;
 
 use super::store::CacheError;
 
-/// How many trailing bytes feed into the suffix hash. 4 KiB is enough to
-/// catch nearly all in-place rewrites without paying for a full re-hash.
-pub const SUFFIX_HASH_BYTES: u64 = 4096;
+/// How many trailing bytes feed into the suffix hash. 64 KiB chosen
+/// over 4 KiB because Claude assistant-line bodies routinely exceed
+/// 4 KiB (long tool results, large diffs); an in-place tail edit could
+/// leave the last 4 KiB byte-identical and the cache would serve a
+/// stale entry. blake3 runs at ~1 GB/s on modern hardware so the
+/// extra 60 KiB is sub-millisecond per file.
+pub const SUFFIX_HASH_BYTES: u64 = 65_536;
 
 /// Per-file change-detection record stored in the cache.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -27,10 +27,11 @@ use super::fingerprint::{FileFingerprint, FingerprintAction, classify, verify_ap
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i64)]
 pub enum BlobFormat {
-    /// Current `bincode::serialize` of `Vec<ProviderCall>` with default
-    /// options. Version 2 replaced version 1 when `ProviderCall.branch`
-    /// (Option<String>) was added in PR-D.
-    Bincode = 2,
+    /// `bincode::serialize` of `Vec<ProviderCall>` with default options at
+    /// the V2 layout: V2 added `ProviderCall.branch: Option<String>` (PR-D).
+    /// V1 was the pre-branch layout — rows tagged 1 are stale on upgrade
+    /// and intentionally skipped (re-parsed on next scan).
+    BincodeV2 = 2,
 }
 
 impl BlobFormat {
@@ -39,7 +40,7 @@ impl BlobFormat {
             // 1 was the pre-branch layout. Rows tagged 1 are stale on
             // upgrade and intentionally skipped — the next scan re-parses
             // and rewrites them at version 2.
-            2 => Some(Self::Bincode),
+            2 => Some(Self::BincodeV2),
             _ => None,
         }
     }
@@ -375,7 +376,7 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<LoadedRow>, CacheEr
         return Ok(None);
     };
     let calls: Vec<crate::models::usage::ProviderCall> = match format {
-        BlobFormat::Bincode => bincode::deserialize(&blob)?,
+        BlobFormat::BincodeV2 => bincode::deserialize(&blob)?,
     };
     let fingerprint = FileFingerprint::from_columns(
         u64::try_from(size_i).unwrap_or(0),

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -415,9 +415,20 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<CacheRow>, CacheErr
     let format = match BlobFormat::lookup(fmt) {
         BlobFormatLookup::Current(fmt) => fmt,
         // Stale = recognised prior format (PR-D bumped 1->2). Unknown =
-        // never written by us. Both skip+reparse; callers may log if they
-        // want to distinguish (currently neither path emits telemetry).
-        BlobFormatLookup::Stale(_) | BlobFormatLookup::Unknown(_) => {
+        // never written by us. Both skip+reparse; the debug log lets us
+        // tell the two apart when diagnosing unexpected reparses.
+        BlobFormatLookup::Stale(v) => {
+            tracing::debug!(
+                "usage_cache stale blob_format={v} for {:?}; reparsing",
+                path
+            );
+            return Ok(None);
+        }
+        BlobFormatLookup::Unknown(v) => {
+            tracing::debug!(
+                "usage_cache unknown blob_format={v} for {:?}; reparsing",
+                path
+            );
             return Ok(None);
         }
     };

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -124,6 +124,17 @@ fn lock_conn(conn: &Mutex<Connection>) -> std::sync::MutexGuard<'_, Connection> 
     })
 }
 
+/// Convert `path` to a UTF-8 string for use as the cache primary key.
+/// Returns `CacheError::Schema` for non-UTF8 paths instead of using
+/// `to_string_lossy`, because lossy conversion can collide two distinct
+/// paths into one cache key (different `?` byte sequences both render
+/// as `?` in the lossy string).
+fn path_key(path: &Path) -> Result<String, CacheError> {
+    path.to_str().map(str::to_string).ok_or_else(|| {
+        CacheError::Schema(format!("non-UTF8 path: {path:?}"))
+    })
+}
+
 impl Cache {
     /// Open (or create) the cache DB at `db_path`. Returns an error on schema
     /// or I/O failure — callers in the parse path should log and fall back to
@@ -432,7 +443,7 @@ fn upsert_row(
     row: &CacheRow,
     blob: &[u8],
 ) -> Result<(), CacheError> {
-    let path_str = path.to_string_lossy().into_owned();
+    let path_str = path_key(path)?;
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -112,6 +112,18 @@ pub(crate) enum CacheInner {
     Disabled,
 }
 
+/// Acquire the connection mutex, recovering from poisoning by reusing the
+/// inner guard. The cache is a derived store and individual writes are
+/// independent, so a poisoned mutex from one panicked write is safe to
+/// continue using — the worst case is the corrupt row is overwritten on
+/// the next scan. Centralised so we log the recovery once and consistently.
+fn lock_conn(conn: &Mutex<Connection>) -> std::sync::MutexGuard<'_, Connection> {
+    conn.lock().unwrap_or_else(|e| {
+        tracing::warn!("usage_cache mutex poisoned; recovering");
+        e.into_inner()
+    })
+}
+
 impl Cache {
     /// Open (or create) the cache DB at `db_path`. Returns an error on schema
     /// or I/O failure — callers in the parse path should log and fall back to
@@ -178,10 +190,7 @@ impl Cache {
         };
 
         let prior = {
-            let lock = conn.lock().unwrap_or_else(|e| {
-            tracing::warn!("usage_cache mutex poisoned; recovering");
-            e.into_inner()
-        });
+            let lock = lock_conn(conn);
             load_row(&lock, path)?
         };
 
@@ -189,10 +198,7 @@ impl Cache {
             Ok(f) => f,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 if prior.is_some() {
-                    let lock = conn.lock().unwrap_or_else(|e| {
-            tracing::warn!("usage_cache mutex poisoned; recovering");
-            e.into_inner()
-        });
+                    let lock = lock_conn(conn);
                     let _ = lock
                         .execute("DELETE FROM files WHERE path = ?1", params![path.to_string_lossy().into_owned()]);
                 }
@@ -262,10 +268,7 @@ impl Cache {
             return Ok(());
         };
         let blob = bincode::serialize(&row.calls)?;
-        let lock = conn.lock().unwrap_or_else(|e| {
-            tracing::warn!("usage_cache mutex poisoned; recovering");
-            e.into_inner()
-        });
+        let lock = lock_conn(conn);
         upsert_row(&lock, path, row, &blob)?;
         Ok(())
     }
@@ -275,10 +278,7 @@ impl Cache {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());
         };
-        let lock = conn.lock().unwrap_or_else(|e| {
-            tracing::warn!("usage_cache mutex poisoned; recovering");
-            e.into_inner()
-        });
+        let lock = lock_conn(conn);
         lock.execute("DELETE FROM files", [])?;
         Ok(())
     }
@@ -289,10 +289,7 @@ impl Cache {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());
         };
-        let lock = conn.lock().unwrap_or_else(|e| {
-            tracing::warn!("usage_cache mutex poisoned; recovering");
-            e.into_inner()
-        });
+        let lock = lock_conn(conn);
         let path_str = path.to_string_lossy().into_owned();
         lock.execute("DELETE FROM files WHERE path = ?1", params![path_str])?;
         Ok(())
@@ -308,10 +305,7 @@ impl Cache {
                 oldest_updated_at: None,
             });
         };
-        let lock = conn.lock().unwrap_or_else(|e| {
-            tracing::warn!("usage_cache mutex poisoned; recovering");
-            e.into_inner()
-        });
+        let lock = lock_conn(conn);
         let file_count: i64 =
             lock.query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))?;
         let oldest_updated_at: Option<i64> = lock

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -274,12 +274,24 @@ impl Cache {
     }
 
     /// Drop all cached rows. Schema row is preserved.
+    ///
+    /// Runs `VACUUM` after the bulk delete so freed pages are returned
+    /// to the filesystem. SQLite's freelist would otherwise keep the
+    /// db at its high-water mark, defeating the user's expectation that
+    /// `cache clear` reclaims disk.
     pub fn clear(&self) -> Result<(), CacheError> {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());
         };
         let lock = lock_conn(conn);
         lock.execute("DELETE FROM files", [])?;
+        // VACUUM cannot run inside an explicit transaction, but rusqlite
+        // doesn't auto-wrap a single execute() so this is fine. Failure
+        // is non-fatal — clearing the rows already gave the user the
+        // semantic they asked for; a stale freelist is a tidiness issue.
+        if let Err(err) = lock.execute("VACUUM", []) {
+            tracing::warn!("usage_cache VACUUM after clear failed: {err}");
+        }
         Ok(())
     }
 

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -34,14 +34,41 @@ pub enum BlobFormat {
     BincodeV2 = 2,
 }
 
+/// Result of decoding a `files.blob_format` column. Behaviour for `Stale`
+/// and `Unknown` is identical (skip the row, re-parse), but the variants
+/// stay distinct so callers can emit different telemetry: stale rows are
+/// expected after a schema bump, unknown rows indicate corruption or a
+/// downgrade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BlobFormatLookup {
+    /// Row matches the current on-disk format; safe to deserialize.
+    Current(BlobFormat),
+    /// Row is a recognised prior format; skip and re-parse.
+    Stale(i64),
+    /// Row carries a value we've never written; skip and re-parse.
+    Unknown(i64),
+}
+
 impl BlobFormat {
-    pub(crate) const fn from_i64(v: i64) -> Option<Self> {
+    /// Classify a `files.blob_format` value. Distinguishes "old known
+    /// format" from "never seen" — both result in skip+reparse but the
+    /// distinction is useful for diagnostics.
+    pub(crate) const fn lookup(v: i64) -> BlobFormatLookup {
         match v {
-            // 1 was the pre-branch layout. Rows tagged 1 are stale on
-            // upgrade and intentionally skipped — the next scan re-parses
-            // and rewrites them at version 2.
-            2 => Some(Self::BincodeV2),
-            _ => None,
+            2 => BlobFormatLookup::Current(Self::BincodeV2),
+            // 1 was the pre-branch layout (PR-D bumped to 2). Recognised
+            // but intentionally not deserialized — fields don't align.
+            1 => BlobFormatLookup::Stale(v),
+            _ => BlobFormatLookup::Unknown(v),
+        }
+    }
+
+    /// Convenience: returns `Some(Current)` only, matching the prior
+    /// `from_i64` shape for callers that don't care about the distinction.
+    pub(crate) const fn from_i64(v: i64) -> Option<Self> {
+        match Self::lookup(v) {
+            BlobFormatLookup::Current(fmt) => Some(fmt),
+            BlobFormatLookup::Stale(_) | BlobFormatLookup::Unknown(_) => None,
         }
     }
 }
@@ -372,8 +399,14 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<LoadedRow>, CacheEr
         return Ok(None);
     };
 
-    let Some(format) = BlobFormat::from_i64(fmt) else {
-        return Ok(None);
+    let format = match BlobFormat::lookup(fmt) {
+        BlobFormatLookup::Current(fmt) => fmt,
+        // Stale = recognised prior format (PR-D bumped 1->2). Unknown =
+        // never written by us. Both skip+reparse; callers may log if they
+        // want to distinguish (currently neither path emits telemetry).
+        BlobFormatLookup::Stale(_) | BlobFormatLookup::Unknown(_) => {
+            return Ok(None);
+        }
     };
     let calls: Vec<crate::models::usage::ProviderCall> = match format {
         BlobFormat::BincodeV2 => bincode::deserialize(&blob)?,

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -252,7 +252,7 @@ impl Cache {
             }
         };
 
-        let row = StoredRow {
+        let row = CacheRow {
             fingerprint: current,
             last_offset: result.end_offset,
             calls: result.calls,
@@ -263,7 +263,7 @@ impl Cache {
         Ok(row.calls)
     }
 
-    fn write_row(&self, path: &Path, row: &StoredRow) -> Result<(), CacheError> {
+    fn write_row(&self, path: &Path, row: &CacheRow) -> Result<(), CacheError> {
         let CacheInner::Open(conn) = &self.inner else {
             return Ok(());
         };
@@ -355,21 +355,17 @@ pub struct ParseResult {
     pub end_offset: u64,
 }
 
+/// One row of the `files` table, deserialized. Used both for inserts
+/// (write_row) and lookups (load_row) — the schema is symmetric so a
+/// single struct serves both directions.
 #[derive(Debug)]
-struct StoredRow {
+struct CacheRow {
     fingerprint: FileFingerprint,
     last_offset: u64,
     calls: Vec<crate::models::usage::ProviderCall>,
 }
 
-#[derive(Debug)]
-struct LoadedRow {
-    fingerprint: FileFingerprint,
-    last_offset: u64,
-    calls: Vec<crate::models::usage::ProviderCall>,
-}
-
-fn load_row(conn: &Connection, path: &Path) -> Result<Option<LoadedRow>, CacheError> {
+fn load_row(conn: &Connection, path: &Path) -> Result<Option<CacheRow>, CacheError> {
     let path_str = path.to_string_lossy().into_owned();
     let row = conn
         .query_row(
@@ -411,7 +407,7 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<LoadedRow>, CacheEr
         &suffix,
     )?;
 
-    Ok(Some(LoadedRow {
+    Ok(Some(CacheRow {
         fingerprint,
         last_offset: u64::try_from(offset).unwrap_or(0),
         calls,
@@ -421,7 +417,7 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<LoadedRow>, CacheEr
 fn upsert_row(
     conn: &Connection,
     path: &Path,
-    row: &StoredRow,
+    row: &CacheRow,
     blob: &[u8],
 ) -> Result<(), CacheError> {
     let path_str = path.to_string_lossy().into_owned();

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -22,7 +22,7 @@ use super::db;
 use super::fingerprint::{FileFingerprint, FingerprintAction, classify, verify_append_safe};
 
 /// Versioned blob encoding for `files.calls_blob`. Discriminant must match
-/// `db::BLOB_FORMAT_BINCODE_V1` — bump both together when `ProviderCall`
+/// `db::BLOB_FORMAT_BINCODE_CURRENT` — bump both together when `ProviderCall`
 /// layout changes, and update the deserializer match below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i64)]
@@ -423,7 +423,7 @@ fn upsert_row(
             row.fingerprint.suffix_blake3.to_vec(),
             i64::try_from(row.calls.len()).unwrap_or(i64::MAX),
             blob,
-            db::BLOB_FORMAT_BINCODE_V1,
+            db::BLOB_FORMAT_BINCODE_CURRENT,
             now,
         ],
     )?;

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -326,7 +326,7 @@ fn provider_call_bincode_layout_is_stable() {
 
     // Tripwire: if the byte length drifts, the struct layout changed.
     // See the doc comment on `ProviderCall` in `models/usage.rs`.
-    const EXPECTED_LEN: usize = const_expected_len();
+    const EXPECTED_LEN: usize = expected_layout_len();
     assert_eq!(
         encoded.len(),
         EXPECTED_LEN,
@@ -339,7 +339,7 @@ fn provider_call_bincode_layout_is_stable() {
 /// fixed encoding by default, so for a fixture with deterministic fields
 /// the size is deterministic. Computed at compile time conceptually, but
 /// inlined here so a layout drift surfaces as an `assert_eq!` mismatch.
-const fn const_expected_len() -> usize {
+const fn expected_layout_len() -> usize {
     // String layout (bincode default options): u64 len + bytes.
     // Vec<T>:                                  u64 len + items.
     // Option<T> (None):                        1 byte tag.

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -28,25 +28,14 @@ fn write_file(dir: &TempDir, name: &str, contents: &[u8]) -> PathBuf {
 }
 
 fn synth_call(seed: &str) -> ProviderCall {
-    use chrono::TimeZone;
-    ProviderCall {
-        provider: "claude".into(),
-        model: "test-model".into(),
-        session_id: format!("session-{seed}"),
-        project: "p".into(),
-        project_path: "/tmp/p".into(),
-        timestamp: chrono::Local.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap(),
-        input_tokens: 1,
-        cache_creation_tokens: 0,
-        cache_read_tokens: 0,
-        output_tokens: 1,
-        reasoning_tokens: 0,
-        cost_usd: None,
-        tools: Vec::new(),
-        bash_commands: Vec::new(),
-        user_message: String::new(),
-        branch: None,
-    }
+    crate::test_support::ProviderCallBuilder::new()
+        .with_model("test-model")
+        .with_session(format!("session-{seed}"))
+        .with_project("p")
+        .with_project_path("/tmp/p")
+        .with_input_tokens(1)
+        .with_output_tokens(1)
+        .build()
 }
 
 #[test]

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -310,7 +310,7 @@ fn fingerprint_full_reparse_when_size_equal_but_suffix_differs() {
 /// blob. If any field is added, removed, or reordered in `ProviderCall`
 /// (or any nested type), the encoded length will change and this test will
 /// fail. When it does, you MUST bump
-/// `usage_cache::db::BLOB_FORMAT_BINCODE_V1` AND update the expected length
+/// `usage_cache::db::BLOB_FORMAT_BINCODE_CURRENT` AND update the expected length
 /// here — that's the protocol that prevents silent cache corruption from
 /// mis-decoding old blobs into a new struct shape.
 #[test]
@@ -330,7 +330,7 @@ fn provider_call_bincode_layout_is_stable() {
     assert_eq!(
         encoded.len(),
         EXPECTED_LEN,
-        "ProviderCall bincode layout changed — bump BLOB_FORMAT_BINCODE_V1 \
+        "ProviderCall bincode layout changed — bump BLOB_FORMAT_BINCODE_CURRENT \
          and update EXPECTED_LEN. See ProviderCall doc comment."
     );
 }

--- a/ainb-tui/src/widgets/mod.rs
+++ b/ainb-tui/src/widgets/mod.rs
@@ -54,6 +54,30 @@ pub use tool_result_store::ToolResultStore;
 pub use unified_message::{UnifiedMessage, MessageType, ContentBlock};
 pub use reminder_filter::ReminderFilter;
 
+/// Truncate a string to at most `max_chars` displayed characters,
+/// appending the ellipsis glyph `…` when truncation occurs. Returns
+/// the input borrowed when no truncation is needed.
+///
+/// Char-safe: counts and slices on Unicode scalars, so multi-byte
+/// strings (branch names, project paths) cannot land mid-codepoint.
+/// `max_chars == 0` returns an empty string. `max_chars == 1` returns
+/// just `…`.
+///
+/// Use this in place of the per-file `truncate_string` / `truncate`
+/// copies that previously lived in components/cli modules.
+pub fn truncate_with_ellipsis(s: &str, max_chars: usize) -> std::borrow::Cow<'_, str> {
+    if max_chars == 0 {
+        return std::borrow::Cow::Borrowed("");
+    }
+    if s.chars().count() <= max_chars {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let take = max_chars.saturating_sub(1);
+    let mut out: String = s.chars().take(take).collect();
+    out.push('…');
+    std::borrow::Cow::Owned(out)
+}
+
 /// Output from widget rendering
 #[derive(Debug, Clone)]
 pub enum WidgetOutput {

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -3,14 +3,32 @@
 use ainb::app::{App, state::View};
 use ainb::components::LayoutComponent;
 use ainb::components::usage::{UsageProvider, UsageTab};
-use ainb::models::{
-    ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
-    TokenBucket, UsageData, UsagePeriod,
-};
-use chrono::{Local, TimeZone};
+use ainb::models::{NamedUsage, UsageData, UsagePeriod};
 use ratatui::{Terminal, backend::TestBackend};
 
+#[cfg(feature = "test-support")]
 fn sample_usage_data() -> UsageData {
+    // Augment the shared fixture with the mcp_servers entry this test
+    // file's UI assertions look for. The shared fixture stays minimal so
+    // unit tests don't depend on mcp surface.
+    let mut data = ainb::test_support::sample_usage_data();
+    data.mcp_servers = vec![NamedUsage {
+        name: "github".to_string(),
+        calls: 1,
+    }];
+    data
+}
+
+// Fallback for cargo test invocations without --features test-support.
+// Mirrors the prior inline fixture exactly so existing test runs are
+// unaffected when the feature is off.
+#[cfg(not(feature = "test-support"))]
+fn sample_usage_data() -> UsageData {
+    use ainb::models::{
+        ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, ProviderCall, SessionUsage,
+        TokenBucket,
+    };
+    use chrono::{Local, TimeZone};
     let bucket = TokenBucket {
         input_tokens: 100,
         output_tokens: 50,
@@ -53,7 +71,7 @@ fn sample_usage_data() -> UsageData {
             bucket: bucket.clone(),
         }],
         grand_total: bucket.clone(),
-        sessions: vec![ainb::models::SessionUsage {
+        sessions: vec![SessionUsage {
             provider: "claude".to_string(),
             project: "agents-in-a-box".to_string(),
             session_id: "s1".to_string(),

--- a/ainb-tui/tests/usage_cache_integration.rs
+++ b/ainb-tui/tests/usage_cache_integration.rs
@@ -167,6 +167,75 @@ fn truncate_triggers_full_reparse() {
     );
 }
 
+/// Append a user line + assistant turn with a chosen `user_text`. Used
+/// to assert user_message attribution survives an append-from-cache path.
+fn append_pair_with_user(
+    path: &Path,
+    session_id: &str,
+    timestamp: &str,
+    user_text: &str,
+) {
+    let user = serde_json::json!({
+        "type": "user",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "message": { "content": user_text }
+    });
+    let assistant = serde_json::json!({
+        "type": "assistant",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "cwd": "/Users/test/myrepo",
+        "message": {
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": { "input_tokens": 1, "output_tokens": 1 }
+        }
+    });
+    let mut f = fs::OpenOptions::new().create(true).append(true).open(path).unwrap();
+    writeln!(f, "{user}").unwrap();
+    writeln!(f, "{assistant}").unwrap();
+}
+
+#[test]
+fn append_path_recovers_user_message_from_prefix() {
+    let work = TempDir::new().unwrap();
+    let projects = build_claude_root(work.path());
+    let session = projects.join("-Users-test-myrepo").join("sess-um.jsonl");
+    append_pair_with_user(&session, "sess-um", "2026-05-01T12:00:00Z", "first turn");
+
+    let roots = UsageSourceRoots {
+        claude_projects_dir: Some(projects.clone()),
+        codex_dir: None,
+    };
+    let cache_dir = TempDir::new().unwrap();
+    let cache = cache_at(cache_dir.path());
+
+    let _ = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+
+    // Append a second user+assistant pair. The second assistant turn
+    // sees the second user line in its own append window so its
+    // user_message should be "second turn". The first user line is
+    // *before* from_offset; recovery makes sure that turn (already
+    // cached) keeps its original user_message.
+    append_pair_with_user(&session, "sess-um", "2026-05-01T12:30:00Z", "second turn");
+
+    let cached =
+        parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    let fresh =
+        parse_usage_for_with_roots_and_cache(query_all(), &roots, Arc::new(Cache::disabled()));
+
+    assert_eq!(cached.calls.len(), 2);
+    assert_eq!(fresh.calls.len(), 2);
+    // Per-row user_message must agree between cached-append and full
+    // reparse — that's the contract the recovery path restores.
+    let cached_msgs: Vec<&str> =
+        cached.calls.iter().map(|c| c.user_message.as_str()).collect();
+    let fresh_msgs: Vec<&str> =
+        fresh.calls.iter().map(|c| c.user_message.as_str()).collect();
+    assert_eq!(cached_msgs, fresh_msgs);
+}
+
 #[test]
 fn no_cache_path_writes_no_rows() {
     let work = TempDir::new().unwrap();

--- a/ainb-tui/tests/usage_cache_integration.rs
+++ b/ainb-tui/tests/usage_cache_integration.rs
@@ -236,6 +236,67 @@ fn append_path_recovers_user_message_from_prefix() {
     assert_eq!(cached_msgs, fresh_msgs);
 }
 
+/// Append a single assistant turn with NO preceding user line. Used to
+/// exercise the prefix-only branch of `recover_user_message_before` —
+/// the new turn's `user_message` can only come from the prefix walk.
+fn append_assistant_only(path: &Path, session_id: &str, timestamp: &str) {
+    let assistant = serde_json::json!({
+        "type": "assistant",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "cwd": "/Users/test/myrepo",
+        "message": {
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": { "input_tokens": 1, "output_tokens": 1 }
+        }
+    });
+    let mut f = fs::OpenOptions::new().create(true).append(true).open(path).unwrap();
+    writeln!(f, "{assistant}").unwrap();
+}
+
+#[test]
+fn append_only_assistant_recovers_user_message_from_prefix_walk() {
+    // The append window contains *only* an assistant turn — no fresh
+    // user line. The only way the new row can carry "first turn" as its
+    // user_message is via the prefix walk in `recover_user_message_before`.
+    let work = TempDir::new().unwrap();
+    let projects = build_claude_root(work.path());
+    let session = projects.join("-Users-test-myrepo").join("sess-um-prefix.jsonl");
+    append_pair_with_user(&session, "sess-um-prefix", "2026-05-01T12:00:00Z", "first turn");
+
+    let roots = UsageSourceRoots {
+        claude_projects_dir: Some(projects.clone()),
+        codex_dir: None,
+    };
+    let cache_dir = TempDir::new().unwrap();
+    let cache = cache_at(cache_dir.path());
+
+    let _ = parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+
+    // Append assistant-only — no preceding user line in the window.
+    append_assistant_only(&session, "sess-um-prefix", "2026-05-01T12:30:00Z");
+
+    let cached =
+        parse_usage_for_with_roots_and_cache(query_all(), &roots, cache.clone());
+    let fresh =
+        parse_usage_for_with_roots_and_cache(query_all(), &roots, Arc::new(Cache::disabled()));
+
+    assert_eq!(cached.calls.len(), 2);
+    assert_eq!(fresh.calls.len(), 2);
+
+    let cached_msgs: Vec<&str> =
+        cached.calls.iter().map(|c| c.user_message.as_str()).collect();
+    let fresh_msgs: Vec<&str> =
+        fresh.calls.iter().map(|c| c.user_message.as_str()).collect();
+    // Both rows must carry "first turn" — the second from prefix recovery.
+    assert_eq!(cached_msgs, fresh_msgs);
+    assert_eq!(
+        cached_msgs[1], "first turn",
+        "appended assistant turn must inherit user_message from prefix walk"
+    );
+}
+
 #[test]
 fn no_cache_path_writes_no_rows() {
     let work = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Multi-wave cleanup landing the ~40 findings from a 7-agent /review + /simplify pass against the recent burndown stack (PRs #59 cache, #61 cross-filter, #62 zoom+dates, #63 branch attribution). 39 atomic commits, every concern in its own commit. Wave-by-wave breakdown below.

## Wave 1 — Branch chip rendering (pre-existing, on the branch when work began)
- `32d1419` fix(ainb-tui): render branch chip in cross-filter strip

## Wave 2 — Polish
- `cf58dfb` rename `BLOB_FORMAT_BINCODE_V1` -> `BLOB_FORMAT_BINCODE_CURRENT` (constant names a role, not a fixed schema generation)
- `2c650be` rename `BlobFormat::Bincode` -> `BincodeV2` (variant names track the discriminant)
- `77cf554` `BlobFormatLookup` distinguishes Stale vs Unknown blob_format values for telemetry
- `e380e51` extract `lock_conn()` poisoned-mutex helper (5 sites)
- `2eff207` collapse `StoredRow` + `LoadedRow` -> `CacheRow` (byte-identical)
- `65129cb` rename `const_expected_len` -> `expected_layout_len` (function isn't const-evaluated)
- `53a098e` `last_day_of_month` returns `Option<NaiveDate>` for OOR input + leap-year tests
- `26cdf4f` correct `quarter_bounds` clamp behaviour comment
- `d81b64f` distinguish `0m` from `<1m` in session-duration column
- `cf2c2fb` preserve zoom search query when re-entering search mode (vim/fzf convention)
- `3126dac` gate `pretty_project_name` branch width at >= 2 chars (avoids `repo:…` rendering)
- `a8de0c5` drop two redundant doc comments + add `BranchUsage` TODO

## Wave 3 — Reuse helpers
- `d997e7f` extract `sort_by_bucket_desc<T, F>` (4 sites)
- `db77f88` `ProviderCall::recorded_branch` accessor (2 sites)
- `3921a5f` centralise `truncate_with_ellipsis` in widgets (7 per-file copies, unified on `…`)
- `f7eefd7` co-locate period helpers in `models::usage`
- `63b92f6` extract `add_bucket` / `bump` map micro-helpers
- `ffde805` document why `UsageFilterChip::label` stays a manual match (strum overkill for 5 mappings)
- `5fe3d68` unify `step_period_back` / `_forward` via `StepDirection`

## Wave 4 — Test fixtures
- `a8d202d` new `src/test_support.rs` with `ProviderCallBuilder`, `sample_usage_data`, `claude_jsonl_turn`. Cargo `test-support` feature for integration tests.
- `e2c5954` migrate 4 fixture sites (`synth_call`, `provider_call`, `call`, integration `sample_usage_data`)

## Wave 5 — Correctness
- `0b71441` roll back `end_offset` on append parse I/O error (was silently advancing past unread data)
- `16eb754` route non-ASCII queries through `Utf32String` in `fuzzy_score`
- `5c13f67` recover `user_message` attribution on cache-hit append paths via prefix backscan + integration test asserting cached vs full-reparse parity

## Wave 6 — Perf
- `3ed80eb` widen `SUFFIX_HASH_BYTES` 4 KiB -> 64 KiB (Claude bodies routinely exceed 4 KiB; tail-rewrites slipped through)
- `749967b` apply cross-filter chips before aggregate on CLI path (skip a full re-aggregate)
- `46860fe` precompute `model_project_counts` index in `aggregate_calls` (was O(N*M) per render)
- `db3c329` hoist `Pattern::parse` out of `apply_zoom_filter` inner loop
- `b419075` TODO for `analyze_turns` precompute (needs stable per-call key + bincode bump)

## Wave 7 — Structural
- `724df79` drop dead `parse_usage()` shim; keep the 3-fn parse cascade with rationale
- `10e627d` TODO for `render_zoom_*` table extraction (needs snapshot tests first)
- `98dea32` TODOs for `UsageViewState` zoom-state collapse and `aggregate_calls` Accumulator trait

## Wave 8 — Big-ticket
- `16902fc` `VACUUM` after `Cache::clear` (frees disk pages)
- `3eeeb62` reject non-UTF8 paths at cache write time (was silently lossy-merging)
- `5581d04` CHANGELOG entries including the BREAKING `--include` vs `--project` split note (PR-B)
- `95a4294` cross-project session-id collision test (s1 in alpha vs beta)
- `dfc932d` TODOs for `DateTime<Utc>` migration and rayon parallelism
- `aab9a26` expose `test_support` to bin compile under `cfg(test)`

## Deferred items (TODOs land in code)

Five items had clear scope but heavy unblocking work and are documented inline rather than rushed:

1. **`analyze_turns` precompute** — needs stable per-call id; bincode bump (b419075).
2. **`render_zoom_table` extraction** — needs snapshot tests to verify visual identity (10e627d).
3. **`UsageViewState` zoom collapse** — touches every zoom event handler and renderer (98dea32).
4. **`aggregate_calls` Accumulator trait** — largest single change, pairs with item 1 (98dea32).
5. **`DateTime<Utc>` migration** — bumps `BLOB_FORMAT_BINCODE_CURRENT` to 3, pair with item 1 (dfc932d).
6. **rayon parallel parse** — adds top-level dep, wants benchmarks (dfc932d).

## Test plan

- [x] `cargo build` clean (warnings only — pre-existing on main)
- [x] `cargo test --lib usage` 93 passed
- [x] `cargo test --test usage_cache_integration` 5 passed (added 1 new — user_message recovery)
- [x] `cargo test --bin ainb` 545 passed; 9 failing are all `docker::agents_dev_tests` connection refused (no Docker daemon — pre-existing on main, environment-only)
- [x] Bincode layout tripwire still passes (`provider_call_bincode_layout_is_stable`)
- [x] Pre-existing test_ui_display failure (`test_bottom_menu_bar_shows_refresh_key`) unchanged
- [x] Manual review: all 39 commits are single-concern, conventional, no AI/Claude attribution

## Migration notes for users

The CHANGELOG carries the `--include` vs `--project` BREAKING note from PR-B (5581d04). No new breaking changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Branch information now displayed in session filters
  * Improved session duration display to better distinguish short durations

* **Bug Fixes**
  * Fixed date calculations for month-end operations
  * Enhanced cache reliability with stricter path validation
  * Improved user message recovery during cache updates
  * Better fuzzy search handling for non-ASCII characters

* **Performance**
  * Optimized model-to-project rendering performance

* **Breaking Changes**
  * CLI: `--include` no longer treats `--project` as an alias; migrate filters to `--include`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->