### PR TITLE
feat(ainb-tui): UTC timestamps + analyze_turns precompute (cache blob V3)

### DIFF
--- a/ainb-tui/CHANGELOG.md
+++ b/ainb-tui/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- **BREAKING (ainb-tui usage cache)**: bumped the cache blob format to
+  V3 (`BLOB_FORMAT_BINCODE_CURRENT = 3`). Caches built under V1
+  (pre-branch) or V2 (Local-timestamp) are recognised as stale and
+  skipped on first run after upgrade — the affected files are
+  re-parsed from the underlying JSONL transparently. No user action
+  required, but the first analytics scan after the bump will be
+  slower than usual while the cache rebuilds. The bump folds two
+  layout changes:
+  - `ProviderCall.timestamp` migrated from `DateTime<Local>` to
+    `DateTime<Utc>` so cached blobs are timezone-independent
+    (cache vs full-reparse no longer drifts after a timezone move
+    or DST transition). Display is still local — render sites
+    convert via `.with_timezone(&Local)` at the boundary.
+  - `ProviderCall.id: u64` added (stable hash of `path:offset`) so
+    `analyze_turns` results can be precomputed once on the
+    unfiltered call set; chip-pivot re-aggregates in
+    `filter_usage_data` now skip the per-session timeline rewalk.
 - **BREAKING (ainb-tui CLI)**: `--include` no longer treats `--project` as
   an alias. Users must migrate `--project foo` filters that relied on
   substring matching to `--include foo` (substring match) or keep

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -843,8 +843,12 @@ fn sessions_csv(sessions: &[SessionUsage]) -> String {
             csv_cell(&session.provider),
             csv_cell(&session.project),
             csv_cell(&session.session_id),
-            session.first_timestamp.to_rfc3339(),
-            session.last_timestamp.to_rfc3339(),
+            // Emit RFC3339 in the user's local offset. The instant is
+            // the same as the Utc-stored value; rendering with the
+            // local offset matches what the TUI shows so a CSV row
+            // round-trips visibly to the user's clock.
+            session.first_timestamp.with_timezone(&chrono::Local).to_rfc3339(),
+            session.last_timestamp.with_timezone(&chrono::Local).to_rfc3339(),
             session.bucket.call_count,
             session.bucket.total(),
             session.bucket.cost_usd.unwrap_or(0.0)

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1594,7 +1594,10 @@ fn render_zoom_top_sessions(
                 format_tokens_short(b.total()),
                 b.call_count.to_string(),
                 dur_str,
-                sess.last_timestamp.format("%Y-%m-%d").to_string(),
+                sess.last_timestamp
+                    .with_timezone(&chrono::Local)
+                    .format("%Y-%m-%d")
+                    .to_string(),
             ])
             .style(Style::default().fg(SOFT_WHITE))
         })
@@ -1849,11 +1852,17 @@ fn build_detail_lines(
                 lines.push(kv("Provider", s.provider.clone()));
                 lines.push(kv(
                     "First seen",
-                    s.first_timestamp.format("%Y-%m-%d %H:%M").to_string(),
+                    s.first_timestamp
+                        .with_timezone(&chrono::Local)
+                        .format("%Y-%m-%d %H:%M")
+                        .to_string(),
                 ));
                 lines.push(kv(
                     "Last seen",
-                    s.last_timestamp.format("%Y-%m-%d %H:%M").to_string(),
+                    s.last_timestamp
+                        .with_timezone(&chrono::Local)
+                        .format("%Y-%m-%d %H:%M")
+                        .to_string(),
                 ));
                 lines.push(kv("Cost", format_cost(s.bucket.cost_usd)));
                 lines.push(kv("Tokens", format_tokens_short(s.bucket.total())));
@@ -1949,8 +1958,8 @@ fn project_seen_window(data: &UsageData, project_name: &str) -> (String, String)
         }
     }
     (
-        min_ts.format("%Y-%m-%d").to_string(),
-        max_ts.format("%Y-%m-%d").to_string(),
+        min_ts.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string(),
+        max_ts.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string(),
     )
 }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3726,7 +3726,7 @@ mod cross_filter_tests {
     use crate::models::usage::{
         ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, SessionUsage, TokenBucket,
     };
-    use chrono::Local;
+    use chrono::Utc;
 
     fn bucket(call_count: usize) -> TokenBucket {
         TokenBucket {
@@ -3746,7 +3746,7 @@ mod cross_filter_tests {
     /// activities and two sessions — enough surface for the
     /// commit_focused_row dispatch table.
     fn fixture() -> UsageData {
-        let now = Local::now();
+        let now = Utc::now();
         UsageData {
             daily: vec![],
             weekly: vec![],
@@ -3868,7 +3868,7 @@ mod cross_filter_tests {
         // session row's project on commit_focused_row. The first
         // commit must attach the alpha project chip; a subsequent
         // pop+commit on a beta-owned row must attach beta.
-        let now = Local::now();
+        let now = Utc::now();
         let session_alpha = SessionUsage {
             provider: "claude".into(),
             project: "alpha".into(),

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -4127,7 +4127,7 @@ mod cli_parity_tests {
         ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, ProviderCall, SessionUsage,
         TokenBucket, UsageData, UsageFilters, filter_usage_data,
     };
-    use chrono::Local;
+    use chrono::Utc;
 
     fn call(project: &str, model: &str, session: &str) -> ProviderCall {
         crate::test_support::ProviderCallBuilder::new()
@@ -4135,7 +4135,7 @@ mod cli_parity_tests {
             .with_session(session)
             .with_project(project)
             .with_project_path(format!("/work/{project}"))
-            .with_timestamp(Local::now())
+            .with_timestamp(Utc::now())
             .with_input_tokens(100)
             .with_output_tokens(50)
             .with_cost(1.0)

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -682,12 +682,10 @@ pub fn parse_usage_for_with_roots_and_cache(
         .into_iter()
         .filter(|call| {
             range.as_ref().map_or(true, |(start, end)| {
-                // Period bounds are still DateTime<Local>; bridge by
-                // converting the Utc-stored call timestamp at the
-                // comparison. Subsequent commit will flip period
-                // bounds to Utc and remove this conversion.
-                let local = call.timestamp.with_timezone(&Local);
-                local >= *start && local <= *end
+                // Period bounds and call timestamps both live in Utc
+                // (period bounds are anchored at local-midnight and
+                // converted via `start_of_day` / `end_of_day`).
+                call.timestamp >= *start && call.timestamp <= *end
             })
         })
         .filter(|call| project_matches(call, &query.include_projects, &query.exclude_projects))
@@ -2143,7 +2141,14 @@ fn project_matches(call: &ProviderCall, include: &[String], exclude: &[String]) 
     true
 }
 
-fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Local>, DateTime<Local>)> {
+/// Returns the inclusive `(start, end)` instants for `period`, expressed
+/// in UTC for direct comparison against `ProviderCall.timestamp`.
+///
+/// The "day" anchor is the user's local calendar day (so "today" still
+/// means the user's wall-clock today across DST and timezone moves) —
+/// `start_of_day` / `end_of_day` build a local-midnight / local-23:59
+/// datetime first, then convert to UTC for the comparison surface.
+fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
     let now = Local::now();
     let today = now.date_naive();
 
@@ -2269,20 +2274,28 @@ pub fn current_quarter(date: NaiveDate) -> (i32, u8) {
     (date.year(), quarter_of(date))
 }
 
-fn day_bounds(date: NaiveDate) -> (DateTime<Local>, DateTime<Local>) {
+fn day_bounds(date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
     (start_of_day(date), end_of_day(date))
 }
 
-fn start_of_day(date: NaiveDate) -> DateTime<Local> {
+/// Local-midnight on `date`, converted to UTC. The local interpretation
+/// is intentional: `date` originates from the user's calendar (`today`
+/// in the period helpers), so the bound has to anchor at local midnight
+/// to match how the user experiences "the day". Conversion to UTC
+/// happens last so the bound is directly comparable to the
+/// Utc-stored `ProviderCall.timestamp`.
+fn start_of_day(date: NaiveDate) -> DateTime<Utc> {
     Local
         .from_local_datetime(&date.and_hms_opt(0, 0, 0).expect("valid start of day"))
         .single()
         .unwrap_or_else(|| {
             Local.from_utc_datetime(&date.and_hms_opt(0, 0, 0).expect("valid start of day"))
         })
+        .with_timezone(&Utc)
 }
 
-fn end_of_day(date: NaiveDate) -> DateTime<Local> {
+/// Local-23:59:59.999 on `date`, converted to UTC. See `start_of_day`.
+fn end_of_day(date: NaiveDate) -> DateTime<Utc> {
     Local
         .from_local_datetime(&date.and_hms_milli_opt(23, 59, 59, 999).expect("valid end of day"))
         .single()
@@ -2291,6 +2304,7 @@ fn end_of_day(date: NaiveDate) -> DateTime<Local> {
                 &date.and_hms_milli_opt(23, 59, 59, 999).expect("valid end of day"),
             )
         })
+        .with_timezone(&Utc)
 }
 
 fn parse_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
@@ -3317,14 +3331,16 @@ mod tests {
         let week = date_range_for_period(&UsagePeriod::Week).unwrap();
         let thirty = date_range_for_period(&UsagePeriod::ThirtyDays).unwrap();
 
-        assert_eq!(
-            (week.1.date_naive() - week.0.date_naive()).num_days() + 1,
-            7
-        );
-        assert_eq!(
-            (thirty.1.date_naive() - thirty.0.date_naive()).num_days() + 1,
-            30
-        );
+        // Bounds are Utc-stored but anchored at the user's local
+        // midnight; convert back to Local before reading the calendar
+        // day so the assertion is independent of the host offset.
+        let week_start = week.0.with_timezone(&Local).date_naive();
+        let week_end = week.1.with_timezone(&Local).date_naive();
+        let thirty_start = thirty.0.with_timezone(&Local).date_naive();
+        let thirty_end = thirty.1.with_timezone(&Local).date_naive();
+
+        assert_eq!((week_end - week_start).num_days() + 1, 7);
+        assert_eq!((thirty_end - thirty_start).num_days() + 1, 30);
     }
 
     #[test]
@@ -3332,8 +3348,10 @@ mod tests {
         for n in [1u32, 7, 14, 90] {
             let (start, end) =
                 date_range_for_period(&UsagePeriod::LastNDays(n)).unwrap();
+            let start_d = start.with_timezone(&Local).date_naive();
+            let end_d = end.with_timezone(&Local).date_naive();
             assert_eq!(
-                (end.date_naive() - start.date_naive()).num_days() + 1,
+                (end_d - start_d).num_days() + 1,
                 i64::from(n),
                 "n={n}"
             );
@@ -3345,8 +3363,14 @@ mod tests {
         let anchor = NaiveDate::from_ymd_opt(2026, 4, 17).unwrap();
         let (start, end) =
             date_range_for_period(&UsagePeriod::SpecificMonth(anchor)).unwrap();
-        assert_eq!(start.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 1).unwrap());
-        assert_eq!(end.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 30).unwrap());
+        assert_eq!(
+            start.with_timezone(&Local).date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()
+        );
+        assert_eq!(
+            end.with_timezone(&Local).date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 30).unwrap()
+        );
     }
 
     #[test]
@@ -3354,8 +3378,10 @@ mod tests {
         for q in 1u8..=4 {
             let (start, end) =
                 date_range_for_period(&UsagePeriod::SpecificQuarter(2026, q)).unwrap();
+            let start_d = start.with_timezone(&Local).date_naive();
+            let end_d = end.with_timezone(&Local).date_naive();
             // Q1 = 90 days (Jan 31 + Feb 28 + Mar 31), Q2 = 91, Q3 = 92, Q4 = 92.
-            let days = (end.date_naive() - start.date_naive()).num_days() + 1;
+            let days = (end_d - start_d).num_days() + 1;
             assert!((90..=92).contains(&days), "q={q} got {days} days");
         }
     }
@@ -3363,8 +3389,9 @@ mod tests {
     #[test]
     fn ytd_period_starts_on_jan_1() {
         let (start, _) = date_range_for_period(&UsagePeriod::YearToDate).unwrap();
-        assert_eq!(start.date_naive().month(), 1);
-        assert_eq!(start.date_naive().day(), 1);
+        let start_d = start.with_timezone(&Local).date_naive();
+        assert_eq!(start_d.month(), 1);
+        assert_eq!(start_d.day(), 1);
     }
 
     #[test]

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1328,9 +1328,11 @@ fn aggregate_calls(calls: Vec<ProviderCall>) -> UsageData {
 /// session timeline — this is what `filter_usage_data` uses so chip
 /// pivots don't pay a fresh O(N) timeline scan on each re-aggregate.
 ///
-/// When the precompute is missing or doesn't contain an id (test
-/// fixtures default id to 0), the function falls back to computing
-/// `analyze_turns` over `calls` exactly as the unparameterised path.
+/// Fallback semantics: only `None` triggers a local `analyze_turns`
+/// recompute. `Some(map)` is trusted as authoritative — calls whose id
+/// is missing from the map silently get a default `TurnAnalysis` (zero
+/// retries, zero edits). Callers passing `Some` must ensure every
+/// `call.id` in the unfiltered superset appears in the precompute.
 fn aggregate_calls_with_analysis(
     mut calls: Vec<ProviderCall>,
     precomputed_analysis: Option<&HashMap<u64, TurnAnalysis>>,

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -395,8 +395,8 @@ pub struct SessionUsage {
     pub provider: String,
     pub project: String,
     pub session_id: String,
-    pub first_timestamp: DateTime<Local>,
-    pub last_timestamp: DateTime<Local>,
+    pub first_timestamp: DateTime<Utc>,
+    pub last_timestamp: DateTime<Utc>,
     pub bucket: TokenBucket,
 }
 
@@ -1306,22 +1306,19 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         project.1.insert(session_key.clone());
         project.2.merge(&bucket);
 
-        // SessionUsageAccumulator still carries DateTime<Local> until
-        // the SessionUsage migration commit; convert at insertion.
-        let call_ts_local = call.timestamp.with_timezone(&Local);
         let session = session_map.entry(session_key).or_insert_with(|| SessionUsageAccumulator {
             provider: call.provider.clone(),
             project: call.project.clone(),
             session_id: call.session_id.clone(),
-            first_timestamp: call_ts_local,
-            last_timestamp: call_ts_local,
+            first_timestamp: call.timestamp,
+            last_timestamp: call.timestamp,
             bucket: TokenBucket::default(),
         });
-        if call_ts_local < session.first_timestamp {
-            session.first_timestamp = call_ts_local;
+        if call.timestamp < session.first_timestamp {
+            session.first_timestamp = call.timestamp;
         }
-        if call_ts_local > session.last_timestamp {
-            session.last_timestamp = call_ts_local;
+        if call.timestamp > session.last_timestamp {
+            session.last_timestamp = call.timestamp;
         }
         session.bucket.merge(&bucket);
 
@@ -2082,8 +2079,8 @@ struct SessionUsageAccumulator {
     provider: String,
     project: String,
     session_id: String,
-    first_timestamp: DateTime<Local>,
-    last_timestamp: DateTime<Local>,
+    first_timestamp: DateTime<Utc>,
+    last_timestamp: DateTime<Utc>,
     bucket: TokenBucket,
 }
 

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Token usage data model and local session parsers for usage analytics.
 // Parses Claude and Codex JSONL histories into reusable aggregates for TUI and CLI views.
 
-use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone};
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -326,15 +326,11 @@ pub struct ProviderCall {
     pub session_id: String,
     pub project: String,
     pub project_path: String,
-    // TODO(refactor): migrate this to DateTime<Utc>. The Local variant
-    // bakes a timezone offset into the cached blob, so a user moving
-    // across timezones (or DST transition) sees inconsistent
-    // serialised representations between cache hit and full reparse.
-    // Migration bumps BLOB_FORMAT_BINCODE_CURRENT to 3 and forces
-    // every constructor + render site to convert at the boundary.
-    // Deferred — V2 was bumped to 2 recently for branch attribution
-    // and another bump is best paired with the analyze_turns id work.
-    pub timestamp: DateTime<Local>,
+    /// Stored in UTC so cached blobs are timezone-independent. Render
+    /// sites convert to local at the display boundary via
+    /// `.with_timezone(&Local)` (see `components/usage.rs`,
+    /// `cli/usage.rs`).
+    pub timestamp: DateTime<Utc>,
     pub input_tokens: u64,
     pub cache_creation_tokens: u64,
     pub cache_read_tokens: u64,
@@ -686,7 +682,12 @@ pub fn parse_usage_for_with_roots_and_cache(
         .into_iter()
         .filter(|call| {
             range.as_ref().map_or(true, |(start, end)| {
-                call.timestamp >= *start && call.timestamp <= *end
+                // Period bounds are still DateTime<Local>; bridge by
+                // converting the Utc-stored call timestamp at the
+                // comparison. Subsequent commit will flip period
+                // bounds to Utc and remove this conversion.
+                let local = call.timestamp.with_timezone(&Local);
+                local >= *start && local <= *end
             })
         })
         .filter(|call| project_matches(call, &query.include_projects, &query.exclude_projects))
@@ -1282,7 +1283,11 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
 
     for (idx, call) in calls.iter().enumerate() {
         let bucket = call.bucket();
-        let day = call.timestamp.date_naive();
+        // Daily bucketing is a user-facing calendar concept: render and
+        // the period bounds both treat "a day" as a local-tz day, so the
+        // grouping key has to be local. The cached call timestamp is
+        // Utc — convert at the boundary.
+        let day = call.timestamp.with_timezone(&Local).date_naive();
         let session_key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
 
         let daily = daily_map.entry(day).or_default();
@@ -1301,19 +1306,22 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
         project.1.insert(session_key.clone());
         project.2.merge(&bucket);
 
+        // SessionUsageAccumulator still carries DateTime<Local> until
+        // the SessionUsage migration commit; convert at insertion.
+        let call_ts_local = call.timestamp.with_timezone(&Local);
         let session = session_map.entry(session_key).or_insert_with(|| SessionUsageAccumulator {
             provider: call.provider.clone(),
             project: call.project.clone(),
             session_id: call.session_id.clone(),
-            first_timestamp: call.timestamp,
-            last_timestamp: call.timestamp,
+            first_timestamp: call_ts_local,
+            last_timestamp: call_ts_local,
             bucket: TokenBucket::default(),
         });
-        if call.timestamp < session.first_timestamp {
-            session.first_timestamp = call.timestamp;
+        if call_ts_local < session.first_timestamp {
+            session.first_timestamp = call_ts_local;
         }
-        if call.timestamp > session.last_timestamp {
-            session.last_timestamp = call.timestamp;
+        if call_ts_local > session.last_timestamp {
+            session.last_timestamp = call_ts_local;
         }
         session.bucket.merge(&bucket);
 
@@ -1754,7 +1762,9 @@ fn plan_cost_for_range(
         .calls
         .iter()
         .filter(|call| {
-            let date = call.timestamp.date_naive();
+            // start/end are NaiveDate in the user's local calendar;
+            // bucket the Utc timestamp into the same calendar.
+            let date = call.timestamp.with_timezone(&Local).date_naive();
             date >= start && date <= end && plan_provider_includes(provider, &call.provider)
         })
         .filter_map(|call| call.cost_usd)
@@ -2286,8 +2296,8 @@ fn end_of_day(date: NaiveDate) -> DateTime<Local> {
         })
 }
 
-fn parse_timestamp(timestamp: &str) -> Option<DateTime<Local>> {
-    DateTime::parse_from_rfc3339(timestamp).map(|dt| dt.with_timezone(&Local)).ok()
+fn parse_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(timestamp).map(|dt| dt.with_timezone(&Utc)).ok()
 }
 
 fn extract_claude_user_text(content: Option<&Value>) -> String {
@@ -3260,7 +3270,7 @@ mod tests {
                 session_id: "s1".to_string(),
                 project: "alpha".to_string(),
                 project_path: "/work/alpha".to_string(),
-                timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+                timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
                 cost_usd: Some(70.0),
                 ..provider_call(
                     "claude",
@@ -3278,7 +3288,7 @@ mod tests {
                 session_id: "s2".to_string(),
                 project: "alpha".to_string(),
                 project_path: "/work/alpha".to_string(),
-                timestamp: Local.with_ymd_and_hms(2026, 4, 29, 11, 0, 0).unwrap(),
+                timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 11, 0, 0).unwrap(),
                 cost_usd: Some(30.0),
                 ..provider_call(
                     "codex",

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -321,6 +321,20 @@ impl TokenBucket {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderCall {
+    /// Stable per-call identifier: `blake3(format!("{path}:{offset}"))`
+    /// truncated to a `u64` (first 8 little-endian bytes of the digest).
+    /// `path` is the source JSONL file, `offset` is the byte position of
+    /// the assistant line that produced this call. The combination is
+    /// unique per call across a parse run and stable across cache hits
+    /// (the parser feeds the same `(path, offset)` tuple every time the
+    /// same line is rewalked), which makes `analyze_turns` results safe
+    /// to memoise on the unfiltered call set and look up by id during
+    /// chip-pivot re-aggregation in `filter_usage_data`.
+    ///
+    /// `blake3` is reused here rather than introducing a new hashing
+    /// dependency just for an id; the cryptographic strength is overkill
+    /// but the API is already in scope (see `usage_cache::fingerprint`).
+    pub id: u64,
     pub provider: String,
     pub model: String,
     pub session_id: String,
@@ -808,10 +822,23 @@ fn parse_claude_source_full(path: &Path, project: &str, project_path: &str) -> P
 
     let mut calls = Vec::new();
     let mut current_user_message = String::new();
-    for line in content.lines() {
-        if let Some(call) =
-            parse_claude_line(line, path, project, project_path, &mut current_user_message)
-        {
+    // Walk lines manually rather than using `content.lines()` so each
+    // call carries the byte offset of its source line in the file, which
+    // feeds the stable `ProviderCall.id`. `split_inclusive` keeps the
+    // newline byte counted in the offset advance.
+    let mut offset: u64 = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line_offset = offset;
+        offset += chunk.len() as u64;
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
+        if let Some(call) = parse_claude_line(
+            line,
+            path,
+            project,
+            project_path,
+            &mut current_user_message,
+            line_offset,
+        ) {
             calls.push(call);
         }
     }
@@ -857,27 +884,44 @@ fn parse_claude_source_append(
             end_offset: from_offset,
         };
     }
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut calls = existing.to_vec();
     let mut current_user_message = current_user_message;
-    for line in reader.lines() {
-        // On any I/O or UTF-8 error from BufReader::lines we cannot
-        // safely advance the cached end_offset — the next run would
-        // skip past the unread tail and silently lose data. Roll the
-        // cursor back to from_offset so the next scan retries the
-        // append. Mirror the Full path's all-or-nothing semantics.
-        let Ok(line) = line else {
-            return ParseResult {
-                calls: existing.to_vec(),
-                end_offset: from_offset,
-            };
+    // Track the running byte offset so each call's stable id matches
+    // the full-parse path. `read_line` advances exactly the bytes it
+    // consumed (including the trailing newline), so `running_offset`
+    // is the offset of the *next* line at any iteration tip — the
+    // current line's offset is captured before the read.
+    let mut running_offset = from_offset;
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        let line_offset = running_offset;
+        let read = match reader.read_line(&mut buf) {
+            Ok(0) => break, // EOF
+            Ok(n) => n,
+            Err(_) => {
+                // On any I/O or UTF-8 error we cannot safely advance
+                // the cached end_offset — the next run would skip past
+                // the unread tail and silently lose data. Roll the
+                // cursor back to from_offset so the next scan retries
+                // the append. Mirror the Full path's all-or-nothing
+                // semantics.
+                return ParseResult {
+                    calls: existing.to_vec(),
+                    end_offset: from_offset,
+                };
+            }
         };
+        running_offset += read as u64;
+        let line = buf.strip_suffix('\n').unwrap_or(&buf);
         if let Some(call) = parse_claude_line(
-            &line,
+            line,
             path,
             project,
             project_path,
             &mut current_user_message,
+            line_offset,
         ) {
             calls.push(call);
         }
@@ -932,12 +976,17 @@ fn recover_user_message_before(
 /// Parse a single Claude JSONL line. Returns `Some(call)` for assistant
 /// lines that carry usage data; mutates `current_user_message` when a
 /// user line is encountered. None for unrecognized / unparseable lines.
+///
+/// `line_offset` is the byte position of `line` in `path` and feeds the
+/// stable `ProviderCall.id` derivation. The full and append parsers
+/// track the running offset and pass it in.
 fn parse_claude_line(
     line: &str,
     path: &Path,
     project: &str,
     project_path: &str,
     current_user_message: &mut String,
+    line_offset: u64,
 ) -> Option<ProviderCall> {
     let parsed: ClaudeLine = serde_json::from_str(line).ok()?;
     match parsed.msg_type.as_deref() {
@@ -969,6 +1018,7 @@ fn parse_claude_line(
             );
 
             Some(ProviderCall {
+                id: provider_call_id(path, line_offset),
                 provider: "claude".to_string(),
                 model,
                 session_id: parsed.session_id.unwrap_or_else(|| {
@@ -1087,7 +1137,14 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
     let mut pending_tools: Vec<String> = Vec::new();
     let mut pending_user_message = String::new();
 
-    for line in content.lines() {
+    // Mirror the Claude parser's offset-tracking so each codex call
+    // carries a stable `(path, offset)` id. `split_inclusive` ensures
+    // the trailing newline is counted in the per-line advance.
+    let mut offset: u64 = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line_offset = offset;
+        offset += chunk.len() as u64;
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
         let entry: CodexEntry = match serde_json::from_str(line) {
             Ok(entry) => entry,
             Err(_) => continue,
@@ -1230,6 +1287,7 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
         );
 
         calls.push(ProviderCall {
+            id: provider_call_id(path, line_offset),
             provider: "codex".to_string(),
             model,
             session_id: session_id.clone(),
@@ -2309,6 +2367,18 @@ fn end_of_day(date: NaiveDate) -> DateTime<Utc> {
 
 fn parse_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(timestamp).map(|dt| dt.with_timezone(&Utc)).ok()
+}
+
+/// Compute the stable per-call id from `(path, offset)`. See the
+/// doc-comment on `ProviderCall.id` for the rationale (reusing blake3 to
+/// avoid pulling in a separate hashing crate).
+fn provider_call_id(path: &Path, offset: u64) -> u64 {
+    let key = format!("{}:{}", path.to_string_lossy(), offset);
+    let digest = blake3::hash(key.as_bytes());
+    let bytes = digest.as_bytes();
+    u64::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
 }
 
 fn extract_claude_user_text(content: Option<&Value>) -> String {

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1318,13 +1318,41 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
 // Deferred — the largest single change in this cleanup pass and best
 // landed alongside the analyze_turns precompute (whose stable-id
 // requirement triggers a coordinated bincode bump). See PR-E thread.
-fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
+fn aggregate_calls(calls: Vec<ProviderCall>) -> UsageData {
+    aggregate_calls_with_analysis(calls, None)
+}
+
+/// Variant of `aggregate_calls` that accepts an optional precomputed
+/// `analyze_turns` result keyed by `ProviderCall.id`. When `Some`, the
+/// per-call analysis is looked up by id rather than re-walking the
+/// session timeline — this is what `filter_usage_data` uses so chip
+/// pivots don't pay a fresh O(N) timeline scan on each re-aggregate.
+///
+/// When the precompute is missing or doesn't contain an id (test
+/// fixtures default id to 0), the function falls back to computing
+/// `analyze_turns` over `calls` exactly as the unparameterised path.
+fn aggregate_calls_with_analysis(
+    mut calls: Vec<ProviderCall>,
+    precomputed_analysis: Option<&HashMap<u64, TurnAnalysis>>,
+) -> UsageData {
     if calls.is_empty() {
         return UsageData::default();
     }
 
     calls.sort_by_key(|call| call.timestamp);
-    let turn_analysis = analyze_turns(&calls);
+    // Local fallback only if the caller didn't precompute. Using the
+    // precomputed map preserves correctness across filtering: a call's
+    // retry count is measured against its *own* session's timeline in
+    // the unfiltered set, not against whatever subset survived the
+    // filter.
+    let local_analysis: HashMap<u64, TurnAnalysis>;
+    let turn_analysis: &HashMap<u64, TurnAnalysis> = match precomputed_analysis {
+        Some(m) => m,
+        None => {
+            local_analysis = analyze_turns(&calls);
+            &local_analysis
+        }
+    };
 
     let mut daily_map: HashMap<NaiveDate, (HashSet<String>, HashSet<String>, TokenBucket)> =
         HashMap::new();
@@ -1337,7 +1365,7 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
     let mut mcp_map: HashMap<String, usize> = HashMap::new();
     let mut shell_map: HashMap<String, usize> = HashMap::new();
 
-    for (idx, call) in calls.iter().enumerate() {
+    for call in &calls {
         let bucket = call.bucket();
         // Daily bucketing is a user-facing calendar concept: render and
         // the period bounds both treat "a day" as a local-tz day, so the
@@ -1384,7 +1412,7 @@ fn aggregate_calls(mut calls: Vec<ProviderCall>) -> UsageData {
             add_bucket(&mut branch_map, branch.to_string(), &bucket);
         }
 
-        let analysis = turn_analysis.get(&idx).copied().unwrap_or_else(|| TurnAnalysis {
+        let analysis = turn_analysis.get(&call.id).copied().unwrap_or_else(|| TurnAnalysis {
             category: classify_activity(call),
             retries: 0,
             has_edits: has_edit_tool(&call.tools),
@@ -1537,13 +1565,20 @@ pub fn filter_usage_data(data: &UsageData, filters: &UsageFilters) -> UsageData 
     if filters.is_empty() {
         return data.clone();
     }
+    // Precompute analyze_turns once on the *unfiltered* call set so
+    // each call's retry/has_edits classification reflects its actual
+    // session timeline, not the post-filter subset (a retry that
+    // happened before a filtered-out edit still counts). The
+    // aggregate path looks up by ProviderCall.id, which is stable
+    // across the filter-and-sort pipeline.
+    let turn_analysis = analyze_turns(&data.calls);
     let filtered_calls: Vec<ProviderCall> = data
         .calls
         .iter()
         .filter(|call| filters.matches(call, classify_activity(call)))
         .cloned()
         .collect();
-    aggregate_calls(filtered_calls)
+    aggregate_calls_with_analysis(filtered_calls, Some(&turn_analysis))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1562,13 +1597,18 @@ struct ActivityAccumulator {
     one_shot_turns: usize,
 }
 
-// TODO(perf): precompute analyze_turns once on the unfiltered call set
-// and thread it into aggregate_calls so filter_usage_data chip pivots
-// don't re-run the per-session timeline walk. Requires a stable
-// per-call key; ProviderCall has no id field today and adding one bumps
-// the bincode blob format. Deferred — the win is bounded by session
-// length and the TUI hot path is sub-frame already.
-fn analyze_turns(calls: &[ProviderCall]) -> HashMap<usize, TurnAnalysis> {
+/// Walk the per-session timeline and produce a per-call
+/// `TurnAnalysis` keyed by `ProviderCall.id`. Idempotent on the same
+/// inputs — produced once on the unfiltered call set in
+/// `filter_usage_data` and reused across chip-pivot re-aggregates so
+/// each chip switch costs an O(1) lookup per call instead of an O(N)
+/// timeline rewalk over the filtered subset.
+///
+/// Keying on `id` (rather than the previous positional `idx`) means the
+/// map survives sorting and filtering: the precompute can be done on
+/// the unfiltered set and consumed by `aggregate_calls_with_analysis`
+/// after `filter_usage_data` has dropped non-matching calls.
+fn analyze_turns(calls: &[ProviderCall]) -> HashMap<u64, TurnAnalysis> {
     let mut sessions: HashMap<String, Vec<usize>> = HashMap::new();
     for (idx, call) in calls.iter().enumerate() {
         let key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
@@ -1596,7 +1636,7 @@ fn analyze_turns(calls: &[ProviderCall]) -> HashMap<usize, TurnAnalysis> {
             }
 
             analysis.insert(
-                idx,
+                call.id,
                 TurnAnalysis {
                     category: classify_activity(call),
                     retries,
@@ -2726,10 +2766,22 @@ mod tests {
         }
     }
 
+    /// Per-test-process counter for ProviderCall.id. Tests that key
+    /// off id (analyze_turns, the precompute lookup) need each call to
+    /// have a distinct id; using an atomic counter keeps the helper
+    /// stateless from the caller's perspective.
+    static TEST_CALL_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+    fn next_test_call_id() -> u64 {
+        TEST_CALL_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Test-only convenience that wraps the shared `ProviderCallBuilder`
     /// with the parameter shape this module's parser tests expect.
     /// Picks gpt-5 for codex and claude-sonnet-4-5 otherwise; sets
     /// output_tokens to a fixed 10 (the tests rely on that constant).
+    /// Each call gets a fresh `id` from `next_test_call_id` so
+    /// analyze_turns can key the result map without collisions.
     fn provider_call(
         provider: &str,
         session_id: &str,
@@ -2741,6 +2793,7 @@ mod tests {
     ) -> ProviderCall {
         let model = if provider == "codex" { "gpt-5" } else { "claude-sonnet-4-5" };
         crate::test_support::ProviderCallBuilder::new()
+            .with_id(next_test_call_id())
             .with_provider(provider)
             .with_model(model)
             .with_session(session_id)
@@ -3241,9 +3294,12 @@ mod tests {
         ];
 
         let analysis = analyze_turns(&calls);
-        assert_eq!(analysis.get(&0).unwrap().retries, 0);
-        assert!(analysis.get(&0).unwrap().has_edits);
-        assert_eq!(analysis.get(&2).unwrap().retries, 1);
+        // Lookups now key on ProviderCall.id (was positional idx); the
+        // helper assigns a fresh id per call from an atomic counter so
+        // we read the actual id off each call rather than guessing.
+        assert_eq!(analysis.get(&calls[0].id).unwrap().retries, 0);
+        assert!(analysis.get(&calls[0].id).unwrap().has_edits);
+        assert_eq!(analysis.get(&calls[2].id).unwrap().retries, 1);
 
         let data = aggregate_calls(calls);
         let edit_turns: usize = data.activities.iter().map(|activity| activity.edit_turns).sum();

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -1315,9 +1315,9 @@ fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
 // activities, tools, mcp, shell). Extract a per-dimension Accumulator
 // trait so each one is unit-testable in isolation; orchestrator
 // becomes `for call in calls { for acc in &mut accumulators { acc.ingest(call) } }`.
-// Deferred — the largest single change in this cleanup pass and best
-// landed alongside the analyze_turns precompute (whose stable-id
-// requirement triggers a coordinated bincode bump). See PR-E thread.
+// Deferred — large refactor with no functional delta. The
+// analyze_turns precompute that previously gated this work has landed,
+// so a future pass is unblocked.
 fn aggregate_calls(calls: Vec<ProviderCall>) -> UsageData {
     aggregate_calls_with_analysis(calls, None)
 }

--- a/ainb-tui/src/test_support.rs
+++ b/ainb-tui/src/test_support.rs
@@ -33,6 +33,10 @@ impl ProviderCallBuilder {
     pub fn new() -> Self {
         Self {
             call: ProviderCall {
+                // Deterministic placeholder id for fixtures. Tests that
+                // exercise the analyze_turns precompute (which keys on
+                // id) override via `with_id` to differentiate calls.
+                id: 0,
                 provider: "claude".to_string(),
                 model: "claude-sonnet-4-5".to_string(),
                 session_id: "s1".to_string(),
@@ -53,6 +57,10 @@ impl ProviderCallBuilder {
         }
     }
 
+    pub fn with_id(mut self, v: u64) -> Self {
+        self.call.id = v;
+        self
+    }
     pub fn with_provider(mut self, v: impl Into<String>) -> Self {
         self.call.provider = v.into();
         self

--- a/ainb-tui/src/test_support.rs
+++ b/ainb-tui/src/test_support.rs
@@ -9,7 +9,17 @@
 //! are available to in-tree unit tests automatically and to integration
 //! tests in `tests/` via `--features test-support`.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use chrono::{DateTime, TimeZone, Utc};
+
+/// Monotonic id source for `ProviderCallBuilder::new()`'s default. Starts at
+/// 1 so `0` stays available for explicit "unset" semantics elsewhere. Each
+/// fresh builder gets a unique id, so multi-call test fixtures don't
+/// silently collide on `analyze_turns`'s id-keyed map (which would mask
+/// retry/has_edits assertions). Tests that need a deterministic id still
+/// override via `with_id`.
+static BUILDER_DEFAULT_ID: AtomicU64 = AtomicU64::new(1);
 
 use crate::models::{
     ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
@@ -33,10 +43,11 @@ impl ProviderCallBuilder {
     pub fn new() -> Self {
         Self {
             call: ProviderCall {
-                // Deterministic placeholder id for fixtures. Tests that
-                // exercise the analyze_turns precompute (which keys on
-                // id) override via `with_id` to differentiate calls.
-                id: 0,
+                // Unique-per-builder id from a process-wide counter so
+                // multi-call fixtures don't collide on analyze_turns'
+                // id-keyed map. Tests that need a stable id override via
+                // `with_id`.
+                id: BUILDER_DEFAULT_ID.fetch_add(1, Ordering::Relaxed),
                 provider: "claude".to_string(),
                 model: "claude-sonnet-4-5".to_string(),
                 session_id: "s1".to_string(),

--- a/ainb-tui/src/test_support.rs
+++ b/ainb-tui/src/test_support.rs
@@ -9,7 +9,7 @@
 //! are available to in-tree unit tests automatically and to integration
 //! tests in `tests/` via `--features test-support`.
 
-use chrono::{DateTime, Local, TimeZone};
+use chrono::{DateTime, Local, TimeZone, Utc};
 
 use crate::models::{
     ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
@@ -73,7 +73,7 @@ impl ProviderCallBuilder {
         self.call.project_path = v.into();
         self
     }
-    pub fn with_timestamp(mut self, v: DateTime<Local>) -> Self {
+    pub fn with_timestamp(mut self, v: DateTime<Utc>) -> Self {
         self.call.timestamp = v;
         self
     }
@@ -124,13 +124,13 @@ pub fn provider_call_default() -> ProviderCall {
 }
 
 /// Deterministic default timestamp shared across fixtures. Pinning this
-/// to a specific value (rather than `Local::now()`) keeps tests
-/// reproducible.
-fn default_timestamp() -> DateTime<Local> {
-    Local
-        .with_ymd_and_hms(2026, 4, 29, 10, 0, 0)
+/// to a specific value (rather than `Utc::now()`) keeps tests
+/// reproducible. Stored Utc to match `ProviderCall.timestamp`; render
+/// sites convert to local at the boundary.
+fn default_timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 4, 29, 10, 0, 0)
         .single()
-        .unwrap_or_else(Local::now)
+        .unwrap_or_else(Utc::now)
 }
 
 /// Build a small `UsageData` fixture covering one project, one model,
@@ -150,6 +150,10 @@ pub fn sample_usage_data() -> UsageData {
         ..TokenBucket::default()
     };
     let now = default_timestamp();
+    // SessionUsage carries DateTime<Local> until the SessionUsage Utc
+    // migration commit; bridge here so the fixture compiles in the
+    // intermediate state.
+    let now_local = now.with_timezone(&Local);
     UsageData {
         calls: vec![
             ProviderCallBuilder::new()
@@ -181,8 +185,8 @@ pub fn sample_usage_data() -> UsageData {
             provider: "claude".to_string(),
             project: "agents-in-a-box".to_string(),
             session_id: "s1".to_string(),
-            first_timestamp: now,
-            last_timestamp: now,
+            first_timestamp: now_local,
+            last_timestamp: now_local,
             bucket: bucket.clone(),
         }],
         models: vec![ModelUsage {

--- a/ainb-tui/src/test_support.rs
+++ b/ainb-tui/src/test_support.rs
@@ -9,7 +9,7 @@
 //! are available to in-tree unit tests automatically and to integration
 //! tests in `tests/` via `--features test-support`.
 
-use chrono::{DateTime, Local, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 
 use crate::models::{
     ActivityCategory, ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, ProviderCall,
@@ -150,10 +150,6 @@ pub fn sample_usage_data() -> UsageData {
         ..TokenBucket::default()
     };
     let now = default_timestamp();
-    // SessionUsage carries DateTime<Local> until the SessionUsage Utc
-    // migration commit; bridge here so the fixture compiles in the
-    // intermediate state.
-    let now_local = now.with_timezone(&Local);
     UsageData {
         calls: vec![
             ProviderCallBuilder::new()
@@ -185,8 +181,8 @@ pub fn sample_usage_data() -> UsageData {
             provider: "claude".to_string(),
             project: "agents-in-a-box".to_string(),
             session_id: "s1".to_string(),
-            first_timestamp: now_local,
-            last_timestamp: now_local,
+            first_timestamp: now,
+            last_timestamp: now,
             bucket: bucket.clone(),
         }],
         models: vec![ModelUsage {

--- a/ainb-tui/src/usage_cache/db.rs
+++ b/ainb-tui/src/usage_cache/db.rs
@@ -24,7 +24,11 @@ pub const SCHEMA_VERSION: i64 = 1;
 /// History:
 ///   1 — original 14-field `ProviderCall`.
 ///   2 — added `branch: Option<String>` (PR-D, branch attribution).
-pub const BLOB_FORMAT_BINCODE_CURRENT: i64 = 2;
+///   3 — `timestamp` migrated from `DateTime<Local>` to `DateTime<Utc>` so
+///       caches survive timezone moves / DST transitions, and a stable
+///       `id: u64` field added (hash of `path:offset`) so `analyze_turns`
+///       results can be precomputed once on the unfiltered call set.
+pub const BLOB_FORMAT_BINCODE_CURRENT: i64 = 3;
 
 /// Open (or create) the usage-cache sqlite DB at `path`, applying schema and
 /// performance pragmas. Caller owns the resulting connection — wrap in a

--- a/ainb-tui/src/usage_cache/store.rs
+++ b/ainb-tui/src/usage_cache/store.rs
@@ -28,10 +28,13 @@ use super::fingerprint::{FileFingerprint, FingerprintAction, classify, verify_ap
 #[repr(i64)]
 pub enum BlobFormat {
     /// `bincode::serialize` of `Vec<ProviderCall>` with default options at
-    /// the V2 layout: V2 added `ProviderCall.branch: Option<String>` (PR-D).
-    /// V1 was the pre-branch layout — rows tagged 1 are stale on upgrade
-    /// and intentionally skipped (re-parsed on next scan).
-    BincodeV2 = 2,
+    /// the V3 layout: V3 migrated `ProviderCall.timestamp` from
+    /// `DateTime<Local>` to `DateTime<Utc>` and added a stable
+    /// `id: u64` field (hash of `path:offset`).
+    /// V1 (pre-branch) and V2 (`branch: Option<String>` at Local
+    /// timestamp) are stale on upgrade and intentionally skipped
+    /// (re-parsed on next scan).
+    BincodeV3 = 3,
 }
 
 /// Result of decoding a `files.blob_format` column. Behaviour for `Stale`
@@ -55,10 +58,12 @@ impl BlobFormat {
     /// distinction is useful for diagnostics.
     pub(crate) const fn lookup(v: i64) -> BlobFormatLookup {
         match v {
-            2 => BlobFormatLookup::Current(Self::BincodeV2),
-            // 1 was the pre-branch layout (PR-D bumped to 2). Recognised
-            // but intentionally not deserialized — fields don't align.
-            1 => BlobFormatLookup::Stale(v),
+            3 => BlobFormatLookup::Current(Self::BincodeV3),
+            // 1 was the pre-branch layout (PR-D bumped to 2). 2 was the
+            // Local-timestamp layout (PR-F bumped to 3). Both are
+            // recognised but intentionally not deserialized — fields
+            // don't align with the current struct shape.
+            1 | 2 => BlobFormatLookup::Stale(v),
             _ => BlobFormatLookup::Unknown(v),
         }
     }
@@ -414,9 +419,10 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<CacheRow>, CacheErr
 
     let format = match BlobFormat::lookup(fmt) {
         BlobFormatLookup::Current(fmt) => fmt,
-        // Stale = recognised prior format (PR-D bumped 1->2). Unknown =
-        // never written by us. Both skip+reparse; the debug log lets us
-        // tell the two apart when diagnosing unexpected reparses.
+        // Stale = recognised prior format (PR-D bumped 1->2; PR-F bumped
+        // 2->3). Unknown = never written by us. Both skip+reparse; the
+        // debug log lets us tell the two apart when diagnosing
+        // unexpected reparses.
         BlobFormatLookup::Stale(v) => {
             tracing::debug!(
                 "usage_cache stale blob_format={v} for {:?}; reparsing",
@@ -433,7 +439,7 @@ fn load_row(conn: &Connection, path: &Path) -> Result<Option<CacheRow>, CacheErr
         }
     };
     let calls: Vec<crate::models::usage::ProviderCall> = match format {
-        BlobFormat::BincodeV2 => bincode::deserialize(&blob)?,
+        BlobFormat::BincodeV3 => bincode::deserialize(&blob)?,
     };
     let fingerprint = FileFingerprint::from_columns(
         u64::try_from(size_i).unwrap_or(0),

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -333,13 +333,21 @@ const fn expected_layout_len() -> usize {
     // Vec<T>:                                  u64 len + items.
     // Option<T> (None):                        1 byte tag.
     // Option<T> (Some):                        1 byte tag + payload.
-    // chrono::DateTime<Local> serializes as a tagged enum + i64 secs +
-    // u32 nanos pair (via serde impl in chrono); seed value covers it.
+    // chrono::DateTime<Utc> serializes as i64 secs + u32 nanos pair
+    // (via serde impl in chrono); seed value covers it. Local previously
+    // serialized as a tagged enum (+5 bytes for the offset variant tag
+    // and payload) — the V3 migration to Utc shaved those bytes off.
     //
     // Rather than re-deriving the formula on every change, we hard-code
-    // the value observed for `synth_call("layout-tripwire")`. If chrono
-    // or bincode bump their encoding, update this constant intentionally.
+    // the value observed for `synth_call("layout-tripwire")` (verified
+    // by running with the old constant once and reading the actual size
+    // from the failure message — see feedback_dont_guess_test_constants).
+    // If chrono or bincode bump their encoding, update this constant
+    // intentionally.
     //
-    // History: 184 (V1) -> 185 (V2: +Option<String> branch field, None tag).
-    185
+    // History:
+    //   184 (V1) — original 14-field layout with Local timestamp.
+    //   185 (V2) — +Option<String> branch field (None tag).
+    //   180 (V3) — timestamp Utc instead of Local (-5 bytes).
+    180
 }

--- a/ainb-tui/src/usage_cache/tests.rs
+++ b/ainb-tui/src/usage_cache/tests.rs
@@ -348,6 +348,7 @@ const fn expected_layout_len() -> usize {
     // History:
     //   184 (V1) — original 14-field layout with Local timestamp.
     //   185 (V2) — +Option<String> branch field (None tag).
-    //   180 (V3) — timestamp Utc instead of Local (-5 bytes).
-    180
+    //   180     — timestamp Utc instead of Local (-5 bytes).
+    //   188 (V3) — +id: u64 from (path, offset) (+8 bytes).
+    188
 }

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -28,7 +28,7 @@ fn sample_usage_data() -> UsageData {
         ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, ProviderCall, SessionUsage,
         TokenBucket,
     };
-    use chrono::{Local, TimeZone, Utc};
+    use chrono::{TimeZone, Utc};
     let bucket = TokenBucket {
         input_tokens: 100,
         output_tokens: 50,
@@ -75,8 +75,8 @@ fn sample_usage_data() -> UsageData {
             provider: "claude".to_string(),
             project: "agents-in-a-box".to_string(),
             session_id: "s1".to_string(),
-            first_timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
-            last_timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 10, 0).unwrap(),
+            first_timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+            last_timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 10, 10, 0).unwrap(),
             bucket: bucket.clone(),
         }],
         models: vec![ModelUsage {

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -28,7 +28,7 @@ fn sample_usage_data() -> UsageData {
         ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, ProviderCall, SessionUsage,
         TokenBucket,
     };
-    use chrono::{Local, TimeZone};
+    use chrono::{Local, TimeZone, Utc};
     let bucket = TokenBucket {
         input_tokens: 100,
         output_tokens: 50,
@@ -45,7 +45,7 @@ fn sample_usage_data() -> UsageData {
             session_id: "s1".to_string(),
             project: "agents-in-a-box".to_string(),
             project_path: "/tmp/agents-in-a-box".to_string(),
-            timestamp: Local.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+            timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
             input_tokens: 100,
             cache_creation_tokens: 0,
             cache_read_tokens: 0,

--- a/ainb-tui/tests/test_ui_display.rs
+++ b/ainb-tui/tests/test_ui_display.rs
@@ -40,6 +40,7 @@ fn sample_usage_data() -> UsageData {
     };
     UsageData {
         calls: vec![ProviderCall {
+            id: 0,
             provider: "claude".to_string(),
             model: "claude-sonnet-4-5".to_string(),
             session_id: "s1".to_string(),


### PR DESCRIPTION
## Summary

Folds two deferred PR-E TODOs into one PR riding the same blob format bump V2→V3.

- **Utc timestamps** — `ProviderCall.timestamp` migrated from `DateTime<Local>` to `DateTime<Utc>`. Cached blobs are now timezone-independent; cache-vs-full-reparse no longer drifts after a timezone move or DST transition. `SessionUsage.first/last_timestamp` and `date_range_for_period` / `day_bounds` follow suit. Display sites convert via `.with_timezone(&Local)` at the boundary, so the daily-usage UX still renders in the user's wall-clock tz.
- **`ProviderCall.id`** — stable u64 id derived from `blake3(format!("{path}:{offset}"))[0..8]`, populated at parse time from the byte offset of the assistant line. Lets `analyze_turns` results be precomputed once on the unfiltered call set; `filter_usage_data` chip pivots now look up by id instead of re-walking the per-session timeline on every re-aggregate.

### BREAKING — usage cache blob V3

`BLOB_FORMAT_BINCODE_CURRENT` bumps from 2 to 3. Caches built under V1/V2 are recognised as Stale and skip+reparse on first run. No user action; the first analytics scan after upgrade will be slower while the cache rebuilds. Schema version stays at 1 — the table layout is unchanged.

CHANGELOG entry under `[Unreleased] / Changed`.

## Atomic commit sequence

1. `chore(ainb-tui): bump usage cache blob format to V3`
2. `refactor(ainb-tui): store ProviderCall.timestamp as DateTime<Utc>`
3. `refactor(ainb-tui): convert SessionUsage timestamps to DateTime<Utc>`
4. `refactor(ainb-tui): convert period date ranges to Utc internals`
5. `refactor(ainb-tui): render usage timestamps in local time at the boundary`
6. `test(ainb-tui): update bincode layout tripwire for V3 (Utc timestamp)` — 185→180
7. `feat(ainb-tui): add stable ProviderCall.id from (path, offset)`
8. `test(ainb-tui): re-verify bincode tripwire after id field addition` — 180→188
9. `perf(ainb-tui): precompute analyze_turns once on the unfiltered set`
10. `chore(ainb-tui): refresh accumulator-trait TODO rationale`
11. `docs(ainb-tui): CHANGELOG entry for V3 cache blob format`

Tripwire constants verified by running with the prior value once and reading the actual size from the panic message — see `feedback_dont_guess_test_constants`. Each step builds clean.

## Test plan

- [x] `cargo build` clean after every commit
- [x] `cargo test --lib` — 545 passing, 9 docker failures (pre-existing, no Docker daemon — out of scope)
- [x] `cargo test --test usage_cache_integration` — 6/6 passing
- [x] Bincode tripwire updated twice across the PR (Utc move = -5 bytes; id field = +8 bytes) and confirmed against the actual fixture size both times
- [x] `test_bottom_menu_bar_shows_refresh_key` failure on `tests/test_ui_display.rs` is pre-existing on origin/main and unrelated to this PR (verified by checkout-and-rerun)

## Notes

- No `Closes #N` — there's no GH issue tracking these TODOs; the PR-E review thread referenced them inline.
- The accumulator-trait TODO that previously gated on the analyze_turns precompute now records that gate as released — the refactor itself remains deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Cache format upgraded to V3 (triggers one-time transparent reparse of existing data)
  * CLI: `--include` and `--project` are now distinct filters (no longer interchangeable)

* **New Features**
  * Branch attribution panel data
  * Session recovery support on cache hits
  * Precomputed model project counts index

* **Bug Fixes**
  * Improved cache maintenance and shrinking behavior
  * Fixed Unicode fuzzy-search handling
  * Corrected session duration rendering (distinguishes 0m vs <1m)
  * Enhanced append parsing error rollback
  * Fixed month-end date calculations

* **Changes**
  * Timestamps now consistently display in your local timezone across CSV exports and UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->