### PR TITLE
fix(ainb-tui): burndown TUI cleanups (month nav, p label, picker filters)

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -356,11 +356,8 @@ pub enum AppEvent {
     UsageSetPeriodAll,        // a — switch to All
     UsagePeriodStepBack,      // ◀ — step Month/Quarter back
     UsagePeriodStepForward,   // ▶ — step Month/Quarter forward
-    UsageStartIncludeFilter,  // Start include project input (/)
-    UsageStartExcludeFilter,  // Start exclude project input (x)
     UsageStartDateRange,      // Start date range input (capital D)
-    UsageClearFilters,        // Clear include/exclude filters (c)
-    UsageInputChar(char),     // Input for usage filter/range
+    UsageInputChar(char),     // Input for usage date range
     UsageInputBackspace,      // Backspace in usage input
     UsageInputSubmit,         // Submit usage input
     UsageInputCancel,         // Cancel usage input
@@ -1795,9 +1792,11 @@ impl EventHandler {
             KeyCode::Char('q') => Some(AppEvent::UsageSetPeriodQuarter),
             KeyCode::Char('a') => Some(AppEvent::UsageSetPeriodAll),
             KeyCode::Char('D') => Some(AppEvent::UsageStartDateRange),
-            KeyCode::Char('/') => Some(AppEvent::UsageStartIncludeFilter),
-            KeyCode::Char('x') => Some(AppEvent::UsageStartExcludeFilter),
-            KeyCode::Char('c') => Some(AppEvent::UsageClearFilters),
+            // `/`, `x`, `c` are intentionally unmapped on the burndown
+            // view — include/exclude/clear are now picker-driven via
+            // the chip strip (Enter / Shift+X / Shift+C). Free-text
+            // prompts violated the project's "no free text in TUI"
+            // principle and were removed.
             _ => None,
         }
     }
@@ -4306,20 +4305,10 @@ impl EventHandler {
                     state.start_background_usage_load(true);
                 }
             }
-            AppEvent::UsageStartIncludeFilter => {
-                state.usage_state.begin_input(crate::components::usage::UsageInputMode::Include);
-            }
-            AppEvent::UsageStartExcludeFilter => {
-                state.usage_state.begin_input(crate::components::usage::UsageInputMode::Exclude);
-            }
             AppEvent::UsageStartDateRange => {
                 state
                     .usage_state
                     .begin_input(crate::components::usage::UsageInputMode::DateRange);
-            }
-            AppEvent::UsageClearFilters => {
-                state.usage_state.clear_filters();
-                state.start_background_usage_load(true);
             }
             AppEvent::UsageInputChar(ch) => {
                 state.usage_state.input_char(ch);

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -4358,8 +4358,9 @@ impl EventHandler {
             }
             AppEvent::UsagePopFilterChip => {
                 if let Some(chip) = state.usage_state.pop_filter_chip() {
+                    let kind = if chip.is_exclude() { "exclude" } else { "include" };
                     state.add_success_notification(format!(
-                        "Removed filter {}={}",
+                        "Removed {kind} {}={}",
                         chip.label(),
                         chip.value()
                     ));

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -4237,6 +4237,12 @@ impl EventHandler {
             }
             AppEvent::UsageForceRefresh => {
                 tracing::info!("Force-refreshing usage data (bypass cache)");
+                // Force-refresh re-reads JSONL from disk; the data extent
+                // could legitimately have shrunk (files deleted, cache
+                // cleared on rotated logs). Reset oldest_call_day so the
+                // monotonic-min on reload picks up the true new extent
+                // rather than a stale earlier value.
+                state.usage_state.oldest_call_day = None;
                 let msg = if state.start_background_usage_load_with_options(true, true) {
                     "Force-refreshing usage data (cache cleared)…"
                 } else {

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -369,7 +369,8 @@ pub enum AppEvent {
     UsageFocusPrevPanel, // Shift+Tab while on Burndown
     UsageFocusRowUp,     // Up/k while a panel is focused
     UsageFocusRowDown,   // Down/j while a panel is focused
-    UsageCommitFilter,   // Enter on focused row -> add chip
+    UsageCommitFilter,   // Enter on focused row -> add include chip
+    UsageCommitExcludeFilter, // Shift+X on focused row -> add exclude chip
     UsagePopFilterChip,  // Esc when chips exist
     UsageClearAllChips,  // C — drop every chip in one shot
     // Zoom mode (PR-C)
@@ -1728,6 +1729,9 @@ impl EventHandler {
                 KeyCode::BackTab => return Some(AppEvent::UsageFocusPrevPanel),
                 KeyCode::Enter => return Some(AppEvent::UsageCommitFilter),
                 KeyCode::Char('C') => return Some(AppEvent::UsageClearAllChips),
+                // Capital X (Shift+x) only — lowercase x is reserved for
+                // future scope and must NOT trigger the exclude commit.
+                KeyCode::Char('X') => return Some(AppEvent::UsageCommitExcludeFilter),
                 KeyCode::Esc if state.usage_state.filters.any() => {
                     return Some(AppEvent::UsagePopFilterChip);
                 }
@@ -4350,6 +4354,11 @@ impl EventHandler {
                     // The next render will run filter_usage_data over
                     // the already-parsed call set.
                     state.add_success_notification("Filter added".to_string());
+                }
+            }
+            AppEvent::UsageCommitExcludeFilter => {
+                if state.usage_state.commit_focused_row_exclude() {
+                    state.add_success_notification("Exclude filter added".to_string());
                 }
             }
             AppEvent::UsagePopFilterChip => {

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -2707,6 +2707,23 @@ impl Default for AppState {
     }
 }
 
+/// Monotonic-min merge for `oldest_call_day`. Keeps the session-wide
+/// anchor honest across narrow→wide period switches: a wide load
+/// establishes the true extent and a subsequent narrow load only
+/// narrows the data view, never the anchor. `None` candidates leave
+/// the existing anchor untouched; `None` existing accepts whatever
+/// the candidate gives.
+fn merge_oldest_call_day(
+    existing: Option<chrono::NaiveDate>,
+    candidate: Option<chrono::NaiveDate>,
+) -> Option<chrono::NaiveDate> {
+    match (existing, candidate) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, b) => b,
+    }
+}
+
 impl AppState {
     pub fn new() -> Self {
         Self::default()
@@ -3573,11 +3590,7 @@ impl AppState {
                         .map(|c| c.timestamp.with_timezone(&Local).date_naive())
                         .min();
                     self.usage_state.oldest_call_day =
-                        match (self.usage_state.oldest_call_day, new_oldest) {
-                            (Some(a), Some(b)) => Some(a.min(b)),
-                            (Some(a), None) => Some(a),
-                            (None, b) => b,
-                        };
+                        merge_oldest_call_day(self.usage_state.oldest_call_day, new_oldest);
                     self.usage_state.data = Some(data);
                     self.usage_state.loading = false;
                     self.usage_load_receiver = None;

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3560,6 +3560,24 @@ impl AppState {
         if let Some(ref mut receiver) = self.usage_load_receiver {
             match receiver.try_recv() {
                 Ok(data) => {
+                    // Refresh `oldest_call_day` monotonically (only ever
+                    // narrows downward). The call set delivered here is
+                    // already period-filtered, so a narrow period would
+                    // raise the local minimum above an earlier value
+                    // seen on a wider load — we want the absolute oldest
+                    // observed across the session, so we take the min.
+                    use chrono::Local;
+                    let new_oldest = data
+                        .calls
+                        .iter()
+                        .map(|c| c.timestamp.with_timezone(&Local).date_naive())
+                        .min();
+                    self.usage_state.oldest_call_day =
+                        match (self.usage_state.oldest_call_day, new_oldest) {
+                            (Some(a), Some(b)) => Some(a.min(b)),
+                            (Some(a), None) => Some(a),
+                            (None, b) => b,
+                        };
                     self.usage_state.data = Some(data);
                     self.usage_state.loading = false;
                     self.usage_load_receiver = None;

--- a/ainb-tui/src/app/state_tests.rs
+++ b/ainb-tui/src/app/state_tests.rs
@@ -717,4 +717,37 @@ mod tests {
         state.cycle_session_filter();
         assert_eq!(state.session_filter, SessionFilter::All);
     }
+
+    #[test]
+    fn merge_oldest_call_day_keeps_earliest_across_loads() {
+        use chrono::NaiveDate;
+        let april = NaiveDate::from_ymd_opt(2026, 4, 1).unwrap();
+        let may = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+
+        // First load establishes the anchor.
+        assert_eq!(crate::app::state::merge_oldest_call_day(None, Some(april)), Some(april));
+
+        // Reproduces the reported defect: a wide load establishes April,
+        // a subsequent narrow (May-only) load must NOT raise the anchor.
+        assert_eq!(
+            crate::app::state::merge_oldest_call_day(Some(april), Some(may)),
+            Some(april),
+            "narrow load must not raise the anchor above its earlier extent"
+        );
+
+        // Order-independent: narrow first, then wide, narrows the anchor.
+        assert_eq!(
+            crate::app::state::merge_oldest_call_day(Some(may), Some(april)),
+            Some(april)
+        );
+
+        // Empty load (no calls in the period) leaves anchor untouched.
+        assert_eq!(
+            crate::app::state::merge_oldest_call_day(Some(april), None),
+            Some(april)
+        );
+
+        // Empty existing + empty candidate stays None.
+        assert_eq!(crate::app::state::merge_oldest_call_day(None, None), None);
+    }
 }

--- a/ainb-tui/src/cli/usage.rs
+++ b/ainb-tui/src/cli/usage.rs
@@ -667,6 +667,9 @@ fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
             activity: args.activity.clone(),
             session: args.session.clone(),
             branch: args.branch.clone(),
+            // No CLI surface for exclude filters yet — populated only
+            // via the TUI X-on-row picker.
+            ..UsageFilters::default()
         },
     })
 }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3590,18 +3590,20 @@ fn render_help_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         ),
     ];
     if on_burndown {
-        // Burndown view: z zoom; Tab pivots panels; Enter commits chip; C clears.
+        // Burndown view: z zoom; Tab pivots panels; Enter/X commit chips; C clears.
         spans.extend_from_slice(&[
             Span::styled("z", Style::default().fg(GOLD)),
             Span::styled(" zoom  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("Tab", Style::default().fg(GOLD)),
-            Span::styled(" focus panel  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" focus  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("Enter", Style::default().fg(GOLD)),
-            Span::styled(" pin filter  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" add  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("X", Style::default().fg(GOLD)),
+            Span::styled(" exclude  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("Esc", Style::default().fg(GOLD)),
-            Span::styled(" pop chip  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" pop  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("C", Style::default().fg(GOLD)),
-            Span::styled(" clear all  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" clear  ", Style::default().fg(MUTED_GRAY)),
         ]);
     } else {
         spans.extend_from_slice(&[
@@ -3610,8 +3612,6 @@ fn render_help_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         ]);
     }
     spans.extend_from_slice(&[
-        Span::styled("/ x c", Style::default().fg(GOLD)),
-        Span::styled(" filters  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("j/k", Style::default().fg(GOLD)),
         Span::styled(" scroll  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("r/R", Style::default().fg(GOLD)),

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3539,10 +3539,8 @@ fn render_help_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
 
     let on_burndown = matches!(state.active_tab, UsageTab::Burndown);
     let mut spans = vec![
-        Span::styled(" ◀/▶", Style::default().fg(GOLD)),
+        Span::styled(" ◀/▶ p", Style::default().fg(GOLD)),
         Span::styled(" provider  ", Style::default().fg(MUTED_GRAY)),
-        Span::styled("p", Style::default().fg(GOLD)),
-        Span::styled(" filter  ", Style::default().fg(MUTED_GRAY)),
         Span::styled(
             "1 Today  2 7d  3 30d  4 90d  5 YTD  m Month  q Quarter  a All  D advanced  ",
             Style::default().fg(MUTED_GRAY),

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -156,10 +156,14 @@ impl UsageTab {
     }
 }
 
+/// Live free-text input mode on the usage screen. Only `DateRange`
+/// remains — include/exclude project prompts were replaced by the
+/// picker-style chip strip (Enter / Shift+X) per the "no free text in
+/// TUI" principle. The variant is retained as a single-arm enum for
+/// forward compatibility (eg. CLI-driven advanced filters that may
+/// reintroduce a typed input later).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UsageInputMode {
-    Include,
-    Exclude,
     DateRange,
 }
 
@@ -540,16 +544,6 @@ impl UsageViewState {
     pub fn submit_input(&mut self) -> Result<(), String> {
         let value = self.input_buffer.trim().to_string();
         match self.input_mode {
-            Some(UsageInputMode::Include) => {
-                if !value.is_empty() {
-                    self.include_projects.push(value);
-                }
-            }
-            Some(UsageInputMode::Exclude) => {
-                if !value.is_empty() {
-                    self.exclude_projects.push(value);
-                }
-            }
             Some(UsageInputMode::DateRange) => {
                 let parts: Vec<_> = value
                     .split(|ch| ch == '.' || ch == ',' || ch == ' ')
@@ -571,11 +565,6 @@ impl UsageViewState {
         }
         self.cancel_input();
         Ok(())
-    }
-
-    pub fn clear_filters(&mut self) {
-        self.include_projects.clear();
-        self.exclude_projects.clear();
     }
 
     /// Cycle the focus pointer to the next panel. If unfocused, focus
@@ -2572,7 +2561,7 @@ pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
         vec![Span::styled("Filters: ", Style::default().fg(MUTED_GRAY))];
     if !state.filters.any() {
         spans.push(Span::styled(
-            "(none) — Tab focus a panel, ↑↓ pick a row, Enter to add",
+            "(none)",
             Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
         ));
         return Line::from(spans);
@@ -3663,8 +3652,6 @@ fn period_label(period: &UsagePeriod) -> String {
 
 fn input_label(mode: UsageInputMode) -> &'static str {
     match mode {
-        UsageInputMode::Include => "include",
-        UsageInputMode::Exclude => "exclude",
         UsageInputMode::DateRange => "date range",
     }
 }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -621,6 +621,38 @@ impl UsageViewState {
         self.data.as_ref().map(|data| filter_usage_data(data, &self.filters))
     }
 
+    /// Resolve the focused panel row to a `(target, value, owner_project)`
+    /// triple. Shared by include and exclude commit paths so both
+    /// dispatch tables stay in lock-step.
+    fn resolve_focused_row(&self) -> Option<(UsageFilterTarget, String, Option<String>)> {
+        let panel = self.focused_panel?;
+        let target = panel.enter_target()?;
+        let filtered = self.filtered_data()?;
+        let row_idx = self.focus_row;
+        // For Session rows we also need the owning project so we can
+        // auto-attach a project chip — session ids can collide across
+        // projects/providers because the aggregator key is
+        // `provider:project:session_id` but `filters.session` only holds
+        // the bare id. Other targets pass None as the second element.
+        match (target, panel) {
+            (UsageFilterTarget::Project, UsagePanel::Leaderboard | UsagePanel::ByProject) => {
+                filtered.projects.get(row_idx).map(|p| (target, p.name.clone(), None))
+            }
+            (UsageFilterTarget::Activity, _) => filtered
+                .activities
+                .get(row_idx)
+                .map(|a| (target, a.category.label().to_string(), None)),
+            (UsageFilterTarget::Model, _) => {
+                filtered.models.get(row_idx).map(|m| (target, m.model.clone(), None))
+            }
+            (UsageFilterTarget::Session, _) => filtered
+                .sessions
+                .get(row_idx)
+                .map(|s| (target, s.session_id.clone(), Some(s.project.clone()))),
+            _ => None,
+        }
+    }
+
     /// Append the focused row of the focused panel as a chip. Returns
     /// `true` if a chip was added (so callers can show feedback).
     /// Requires `data` to be loaded; uses the unfiltered `data` to
@@ -628,38 +660,7 @@ impl UsageViewState {
     /// looking at when focus is active (we render from filtered_data
     /// at draw time, which is the same source).
     pub fn commit_focused_row(&mut self) -> bool {
-        let Some(panel) = self.focused_panel else {
-            return false;
-        };
-        let Some(target) = panel.enter_target() else {
-            return false;
-        };
-        let Some(filtered) = self.filtered_data() else {
-            return false;
-        };
-        let row_idx = self.focus_row;
-        // For Session rows we also need the owning project so we can
-        // auto-attach a project chip — session ids can collide across
-        // projects/providers because the aggregator key is
-        // `provider:project:session_id` but `filters.session` only holds
-        // the bare id. Other targets pass None as the second element.
-        let value: Option<(String, Option<String>)> = match (target, panel) {
-            (UsageFilterTarget::Project, UsagePanel::Leaderboard | UsagePanel::ByProject) => {
-                filtered.projects.get(row_idx).map(|p| (p.name.clone(), None))
-            }
-            (UsageFilterTarget::Activity, _) => {
-                filtered.activities.get(row_idx).map(|a| (a.category.label().to_string(), None))
-            }
-            (UsageFilterTarget::Model, _) => {
-                filtered.models.get(row_idx).map(|m| (m.model.clone(), None))
-            }
-            (UsageFilterTarget::Session, _) => filtered
-                .sessions
-                .get(row_idx)
-                .map(|s| (s.session_id.clone(), Some(s.project.clone()))),
-            _ => None,
-        };
-        let Some((value, owner_project)) = value else {
+        let Some((target, value, owner_project)) = self.resolve_focused_row() else {
             return false;
         };
         match target {
@@ -686,6 +687,40 @@ impl UsageViewState {
                     if !self.filters.project.contains(&p) {
                         self.filters.project.push(p);
                     }
+                }
+            }
+        }
+        true
+    }
+
+    /// Append the focused row as an *exclude* chip. Mirror of
+    /// `commit_focused_row` that routes into the `exclude_*` filter
+    /// lists. Session rows do NOT auto-attach an owner-project exclude
+    /// — excluding the project because one of its sessions was excluded
+    /// would discard sibling sessions the user did not target.
+    pub fn commit_focused_row_exclude(&mut self) -> bool {
+        let Some((target, value, _owner_project)) = self.resolve_focused_row() else {
+            return false;
+        };
+        match target {
+            UsageFilterTarget::Project => {
+                if !self.filters.exclude_project.contains(&value) {
+                    self.filters.exclude_project.push(value);
+                }
+            }
+            UsageFilterTarget::Model => {
+                if !self.filters.exclude_model.contains(&value) {
+                    self.filters.exclude_model.push(value);
+                }
+            }
+            UsageFilterTarget::Activity => {
+                if !self.filters.exclude_activity.contains(&value) {
+                    self.filters.exclude_activity.push(value);
+                }
+            }
+            UsageFilterTarget::Session => {
+                if !self.filters.exclude_session.contains(&value) {
+                    self.filters.exclude_session.push(value);
                 }
             }
         }
@@ -2547,6 +2582,11 @@ pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
     push_chip_group(&mut spans, "activity", &state.filters.activity);
     push_chip_group(&mut spans, "session", &state.filters.session);
     push_chip_group(&mut spans, "branch", &state.filters.branch);
+    push_exclude_chip_group(&mut spans, "project", &state.filters.exclude_project);
+    push_exclude_chip_group(&mut spans, "model", &state.filters.exclude_model);
+    push_exclude_chip_group(&mut spans, "activity", &state.filters.exclude_activity);
+    push_exclude_chip_group(&mut spans, "session", &state.filters.exclude_session);
+    push_exclude_chip_group(&mut spans, "branch", &state.filters.exclude_branch);
     spans.push(Span::styled("  ·  ", Style::default().fg(MUTED_GRAY)));
     spans.push(Span::styled(
         "Esc",
@@ -2570,6 +2610,20 @@ fn push_chip_group(spans: &mut Vec<Span<'static>>, label: &str, values: &[String
         spans.push(Span::styled(
             chip_text,
             Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+    }
+}
+
+/// Exclude chips render with a leading `~` and a muted-orange fill so
+/// they are immediately distinguishable from include (gold) chips.
+/// They also pop first via Esc — see `UsageFilters::pop_last`.
+fn push_exclude_chip_group(spans: &mut Vec<Span<'static>>, label: &str, values: &[String]) {
+    for value in values {
+        let chip_text = format!(" ~{label}={value} ");
+        spans.push(Span::styled(
+            chip_text,
+            Style::default().fg(DARK_BG).bg(BAR_HIGH).add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
     }
@@ -4019,6 +4073,48 @@ mod cross_filter_tests {
         for needle in ["project=p", "model=m", "activity=Coding", "session=s", "branch=b"] {
             assert!(flat.contains(needle), "chip strip missing {needle}: {flat}");
         }
+    }
+
+    #[test]
+    fn x_on_by_project_row_adds_exclude_chip_and_filter_drops_project() {
+        use crate::models::usage::{filter_usage_data, UsageData, UsageFilters};
+        use crate::test_support::ProviderCallBuilder;
+        use std::collections::HashMap;
+
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.focus_row = 1; // beta
+        assert!(state.commit_focused_row_exclude());
+        assert_eq!(state.filters.exclude_project, vec!["beta".to_string()]);
+        assert!(state.filters.project.is_empty(), "include side must be untouched");
+
+        // End-to-end: filter_usage_data must drop calls matching the
+        // exclude project, leaving only the alpha call.
+        let calls = vec![
+            ProviderCallBuilder::new().with_project("alpha").build(),
+            ProviderCallBuilder::new().with_project("beta").build(),
+        ];
+        let data = UsageData {
+            daily: vec![],
+            weekly: vec![],
+            projects: vec![],
+            grand_total: TokenBucket::default(),
+            calls,
+            sessions: vec![],
+            models: vec![],
+            activities: vec![],
+            tools: vec![],
+            mcp_servers: vec![],
+            shell_commands: vec![],
+            branches: vec![],
+            model_project_counts: HashMap::new(),
+        };
+        let mut filters = UsageFilters::default();
+        filters.exclude_project.push("beta".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 1);
+        assert_eq!(filtered.calls[0].project, "alpha");
     }
 
     #[test]

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -302,6 +302,16 @@ pub struct UsageViewState {
     /// occupies the bottom 40% of the zoom area and shows the full
     /// row record for the focused row.
     pub zoom_detail_open: bool,
+    /// Absolute oldest call day observed across the unfiltered call
+    /// set, monotonically narrowing across loads. Used to clamp
+    /// `step_period_back` independent of the currently-active period
+    /// (which restricts `data.daily` to the visible window and would
+    /// otherwise prevent stepping into earlier months/quarters).
+    ///
+    /// Updated on every load via `min(existing, new_min_from_data_calls)`
+    /// so a narrow period (eg. `SpecificMonth(May)`) cannot raise the
+    /// anchor above an earlier value seen during a wider load.
+    pub oldest_call_day: Option<NaiveDate>,
 }
 
 impl Default for UsageViewState {
@@ -325,6 +335,7 @@ impl Default for UsageViewState {
             zoom_search_active: false,
             zoom_search_query: String::new(),
             zoom_detail_open: false,
+            oldest_call_day: None,
         }
     }
 }
@@ -373,19 +384,17 @@ impl UsageViewState {
     }
 
     /// Step the active Month or Quarter picker one unit back. Clamps
-    /// at the oldest day in `data.daily` (so we never step into a
-    /// region known to have no usage rows). Returns `true` when the
-    /// period actually changed.
+    /// at `oldest_call_day` — the absolute oldest day observed across
+    /// the unfiltered call set — so the user can step from a narrow
+    /// period (eg. `SpecificMonth(May)`) into an earlier month, even
+    /// though `data.daily` only holds the May rows in that state.
+    /// Returns `true` when the period actually changed.
     ///
-    /// No-op when the active period is not a Month/Quarter picker.
+    /// No-op when the active period is not a Month/Quarter picker, or
+    /// when no data has been loaded yet (no oldest anchor to clamp
+    /// against — would let the user wander arbitrarily far back).
     pub fn step_period_back(&mut self) -> bool {
-        // Refuse to step until data has loaded — without an `oldest`
-        // anchor we'd let the user wander arbitrarily far backwards,
-        // and the resulting picker state would silently fall outside
-        // the data range once the load completes.
-        let Some(oldest) =
-            self.data.as_ref().and_then(|d| d.daily.first().map(|(date, _)| *date))
-        else {
+        let Some(oldest) = self.oldest_call_day else {
             return false;
         };
         self.step_period(StepDirection::Back, oldest)
@@ -4012,6 +4021,54 @@ mod cross_filter_tests {
         for needle in ["project=p", "model=m", "activity=Coding", "session=s", "branch=b"] {
             assert!(flat.contains(needle), "chip strip missing {needle}: {flat}");
         }
+    }
+
+    #[test]
+    fn step_period_back_uses_oldest_call_day_not_data_daily() {
+        // The picker must clamp at the absolute oldest call day (which
+        // tracks the unfiltered call set across loads), not at
+        // `data.daily.first()` — when the active period is
+        // `SpecificMonth(May)`, `data.daily` only has May rows so the
+        // old clamp-at-data path would refuse to step into April even
+        // though April is in range.
+        use crate::models::usage::UsagePeriod;
+        let mut state = UsageViewState::default();
+        state.oldest_call_day = NaiveDate::from_ymd_opt(2026, 4, 1);
+        state.period = UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap());
+
+        assert!(state.step_period_back(), "April is in range; back must succeed");
+        assert_eq!(
+            state.period,
+            UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn step_period_back_clamps_when_oldest_is_inside_target_month() {
+        // April 1 < May 15, so stepping back from May lands on April 1,
+        // which is BEFORE the oldest known day — must refuse the step.
+        use crate::models::usage::UsagePeriod;
+        let mut state = UsageViewState::default();
+        state.oldest_call_day = NaiveDate::from_ymd_opt(2026, 5, 15);
+        state.period = UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap());
+
+        assert!(!state.step_period_back(), "April predates oldest May 15; back must fail");
+        assert_eq!(
+            state.period,
+            UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn step_period_back_returns_false_when_no_data_loaded() {
+        // Without an oldest anchor the user could wander arbitrarily
+        // far back; refuse to step until at least one load has populated
+        // `oldest_call_day`.
+        use crate::models::usage::UsagePeriod;
+        let mut state = UsageViewState::default();
+        state.oldest_call_day = None;
+        state.period = UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap());
+        assert!(!state.step_period_back());
     }
 
     #[test]

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -149,6 +149,14 @@ pub struct UsageFilters {
     pub activity: Vec<String>,
     pub session: Vec<String>,
     pub branch: Vec<String>,
+    /// Negative filters set via the X-on-row picker. A call is rejected
+    /// as soon as it matches any value in any of these lists. Mirrors
+    /// the include lists above so all five dimensions support exclude.
+    pub exclude_project: Vec<String>,
+    pub exclude_model: Vec<String>,
+    pub exclude_activity: Vec<String>,
+    pub exclude_session: Vec<String>,
+    pub exclude_branch: Vec<String>,
 }
 
 impl UsageFilters {
@@ -158,6 +166,11 @@ impl UsageFilters {
             && self.activity.is_empty()
             && self.session.is_empty()
             && self.branch.is_empty()
+            && self.exclude_project.is_empty()
+            && self.exclude_model.is_empty()
+            && self.exclude_activity.is_empty()
+            && self.exclude_session.is_empty()
+            && self.exclude_branch.is_empty()
     }
 
     /// True if any cross-filter is set. Mirror of `!is_empty()` for sites
@@ -166,10 +179,27 @@ impl UsageFilters {
         !self.is_empty()
     }
 
-    /// Pop the most-recently-added filter chip. Removal order: branch →
-    /// session → activity → model → project (matches the chip-strip render
-    /// order so `Esc` removes the visually rightmost chip first).
+    /// Pop the most-recently-added filter chip. Removal order matches
+    /// the chip-strip render order so `Esc` removes the visually
+    /// rightmost chip first: exclude chips are rendered after include
+    /// chips, so they pop first; within each group the order is
+    /// branch → session → activity → model → project.
     pub fn pop_last(&mut self) -> Option<UsageFilterChip> {
+        if let Some(value) = self.exclude_branch.pop() {
+            return Some(UsageFilterChip::ExcludeBranch(value));
+        }
+        if let Some(value) = self.exclude_session.pop() {
+            return Some(UsageFilterChip::ExcludeSession(value));
+        }
+        if let Some(value) = self.exclude_activity.pop() {
+            return Some(UsageFilterChip::ExcludeActivity(value));
+        }
+        if let Some(value) = self.exclude_model.pop() {
+            return Some(UsageFilterChip::ExcludeModel(value));
+        }
+        if let Some(value) = self.exclude_project.pop() {
+            return Some(UsageFilterChip::ExcludeProject(value));
+        }
         if let Some(value) = self.branch.pop() {
             return Some(UsageFilterChip::Branch(value));
         }
@@ -194,6 +224,11 @@ impl UsageFilters {
         self.activity.clear();
         self.session.clear();
         self.branch.clear();
+        self.exclude_project.clear();
+        self.exclude_model.clear();
+        self.exclude_activity.clear();
+        self.exclude_session.clear();
+        self.exclude_branch.clear();
     }
 
     pub(crate) fn matches(&self, call: &ProviderCall, category: ActivityCategory) -> bool {
@@ -220,6 +255,33 @@ impl UsageFilters {
                 return false;
             }
         }
+        // Exclude lists: a call is rejected if it matches any value.
+        // Branch exclusions only apply to calls with a recorded branch
+        // — calls without a branch are unaffected by branch excludes
+        // (mirror of the include-side semantics where `branch == None`
+        // means "no branch was recorded for this call").
+        if self.exclude_project.iter().any(|p| p == &call.project) {
+            return false;
+        }
+        if self.exclude_model.iter().any(|m| m == &call.model) {
+            return false;
+        }
+        if self.exclude_session.iter().any(|s| s == &call.session_id) {
+            return false;
+        }
+        if !self.exclude_activity.is_empty() {
+            let label = category.label();
+            if self.exclude_activity.iter().any(|a| a == label) {
+                return false;
+            }
+        }
+        if !self.exclude_branch.is_empty() {
+            if let Some(branch) = call.recorded_branch() {
+                if self.exclude_branch.iter().any(|b| b == branch) {
+                    return false;
+                }
+            }
+        }
         true
     }
 }
@@ -232,6 +294,15 @@ pub enum UsageFilterChip {
     Activity(String),
     Session(String),
     Branch(String),
+    /// Exclude variants set via the X-on-row picker. The chip strip
+    /// renders these with a leading `~` and `pop_last` returns them
+    /// before the include variants so Esc walks the visually
+    /// rightmost chip first.
+    ExcludeProject(String),
+    ExcludeModel(String),
+    ExcludeActivity(String),
+    ExcludeSession(String),
+    ExcludeBranch(String),
 }
 
 impl UsageFilterChip {
@@ -246,12 +317,26 @@ impl UsageFilterChip {
     // checked when a variant is added. The match is already canonical.
     pub fn label(&self) -> &'static str {
         match self {
-            Self::Project(_) => "project",
-            Self::Model(_) => "model",
-            Self::Activity(_) => "activity",
-            Self::Session(_) => "session",
-            Self::Branch(_) => "branch",
+            Self::Project(_) | Self::ExcludeProject(_) => "project",
+            Self::Model(_) | Self::ExcludeModel(_) => "model",
+            Self::Activity(_) | Self::ExcludeActivity(_) => "activity",
+            Self::Session(_) | Self::ExcludeSession(_) => "session",
+            Self::Branch(_) | Self::ExcludeBranch(_) => "branch",
         }
+    }
+
+    /// True for negative (exclude) variants. Used by the chip strip to
+    /// render with a `~` prefix and by callers that want a single test
+    /// for "is this an exclusion".
+    pub fn is_exclude(&self) -> bool {
+        matches!(
+            self,
+            Self::ExcludeProject(_)
+                | Self::ExcludeModel(_)
+                | Self::ExcludeActivity(_)
+                | Self::ExcludeSession(_)
+                | Self::ExcludeBranch(_)
+        )
     }
 
     pub fn value(&self) -> &str {
@@ -260,7 +345,12 @@ impl UsageFilterChip {
             | Self::Model(v)
             | Self::Activity(v)
             | Self::Session(v)
-            | Self::Branch(v) => v,
+            | Self::Branch(v)
+            | Self::ExcludeProject(v)
+            | Self::ExcludeModel(v)
+            | Self::ExcludeActivity(v)
+            | Self::ExcludeSession(v)
+            | Self::ExcludeBranch(v) => v,
         }
     }
 }

--- a/ainb-tui/tests/test_events.rs
+++ b/ainb-tui/tests/test_events.rs
@@ -268,7 +268,18 @@ async fn test_usage_period_and_provider_events() {
     // view — the picker (Enter / Shift+X / Shift+C) replaces them.
     let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('/')), &mut state);
     assert!(event.is_none(), "/ must not bind to any usage event");
-    // `c` and `x` collide with other key handlers in non-burndown
-    // contexts; the important assertion is that they no longer produce
-    // the removed UsageStartExcludeFilter / UsageClearFilters events.
+    // `c` and `x` may resolve to other unrelated events outside the
+    // burndown filter path. The chip-strip lives on capitals (X / C).
+    // Lowercase must NOT trigger the picker — that asymmetry is the
+    // contract a regression would break.
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('x')), &mut state);
+    assert!(
+        !matches!(event, Some(AppEvent::UsageCommitExcludeFilter)),
+        "lowercase x must not commit an exclude chip (capital X owns that)"
+    );
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('c')), &mut state);
+    assert!(
+        !matches!(event, Some(AppEvent::UsageClearAllChips)),
+        "lowercase c must not clear chips (capital C owns that)"
+    );
 }

--- a/ainb-tui/tests/test_events.rs
+++ b/ainb-tui/tests/test_events.rs
@@ -3,7 +3,6 @@
 use ainb::app::events::AppEvent;
 use ainb::app::state::View;
 use ainb::app::{AppState, EventHandler};
-use ainb::components::usage::UsageInputMode;
 use ainb::models::{UsagePeriod, UsageProviderFilter};
 use chrono::NaiveDate;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -227,7 +226,10 @@ fn test_process_help_toggle_event() {
 }
 
 #[tokio::test]
-async fn test_usage_period_provider_and_filters_events() {
+async fn test_usage_period_and_provider_events() {
+    // Free-text include/exclude/clear prompts have been removed in
+    // favour of the picker-style chip strip; this test now exercises
+    // the period and provider key bindings only.
     let mut state = AppState::default();
     state.current_view = View::Analytics;
 
@@ -244,42 +246,12 @@ async fn test_usage_period_provider_and_filters_events() {
     EventHandler::process_event(event.unwrap(), &mut state);
     assert!(matches!(state.usage_state.period, UsagePeriod::ThirtyDays));
 
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('/')), &mut state);
-    assert!(matches!(event, Some(AppEvent::UsageStartIncludeFilter)));
-    EventHandler::process_event(event.unwrap(), &mut state);
-    for ch in "agents".chars() {
-        let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char(ch)), &mut state);
-        EventHandler::process_event(event.unwrap(), &mut state);
-    }
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Enter), &mut state);
-    assert!(matches!(event, Some(AppEvent::UsageInputSubmit)));
-    EventHandler::process_event(event.unwrap(), &mut state);
-    assert_eq!(state.usage_state.include_projects, vec!["agents"]);
-
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('x')), &mut state);
-    assert!(matches!(event, Some(AppEvent::UsageStartExcludeFilter)));
-    EventHandler::process_event(event.unwrap(), &mut state);
-    assert!(matches!(
-        state.usage_state.input_mode,
-        Some(UsageInputMode::Exclude)
-    ));
-    for ch in "scratch".chars() {
-        let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char(ch)), &mut state);
-        EventHandler::process_event(event.unwrap(), &mut state);
-    }
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Backspace), &mut state);
-    assert!(matches!(event, Some(AppEvent::UsageInputBackspace)));
-    EventHandler::process_event(event.unwrap(), &mut state);
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('h')), &mut state);
-    EventHandler::process_event(event.unwrap(), &mut state);
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Enter), &mut state);
-    EventHandler::process_event(event.unwrap(), &mut state);
-    assert_eq!(state.usage_state.exclude_projects, vec!["scratch"]);
-
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('d')), &mut state);
+    // Capital D opens the date-range input (the only surviving free-text
+    // path on the usage screen).
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('D')), &mut state);
     assert!(matches!(event, Some(AppEvent::UsageStartDateRange)));
     EventHandler::process_event(event.unwrap(), &mut state);
-    for ch in "2026-04-01..2026-04-10".chars() {
+    for ch in "2026-04-01 2026-04-10".chars() {
         let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char(ch)), &mut state);
         EventHandler::process_event(event.unwrap(), &mut state);
     }
@@ -292,9 +264,11 @@ async fn test_usage_period_provider_and_filters_events() {
                 && to == NaiveDate::from_ymd_opt(2026, 4, 10).unwrap()
     ));
 
-    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('c')), &mut state);
-    assert!(matches!(event, Some(AppEvent::UsageClearFilters)));
-    EventHandler::process_event(event.unwrap(), &mut state);
-    assert!(state.usage_state.include_projects.is_empty());
-    assert!(state.usage_state.exclude_projects.is_empty());
+    // Lowercase `/`, `x`, `c` are intentionally unbound on the burndown
+    // view — the picker (Enter / Shift+X / Shift+C) replaces them.
+    let event = EventHandler::handle_key_event(create_key_event(KeyCode::Char('/')), &mut state);
+    assert!(event.is_none(), "/ must not bind to any usage event");
+    // `c` and `x` collide with other key handlers in non-burndown
+    // contexts; the important assertion is that they no longer produce
+    // the removed UsageStartExcludeFilter / UsageClearFilters events.
 }


### PR DESCRIPTION
## Summary

Five atomic burndown-dashboard cleanups addressing the issues users hit on the usage TUI:

1. `fix(ainb-tui): clamp step_period_back at unfiltered call-set extent` — `←/→` on the Month/Quarter picker now actually steps the period. The old clamp read `data.daily.first()`, which is the period-filtered slice (eg. `SpecificMonth(May)` only contains May rows), so any step into an earlier window was rejected. Track an absolute `oldest_call_day` on `UsageViewState`, monotonically narrowing across loads, and clamp against that anchor.
2. `style(ainb-tui): label burndown help bar p as provider, not filter` — `p` cycles the provider filter; the old `p filter` label invited confusion with the chip-strip filters. Collapse `◀/▶ provider  p filter` into `◀/▶ p provider`.
3. `feat(ainb-tui): commit focused row as exclude chip via X` — Shift+X is the picker mirror of Enter: pin the focused row as an exclude chip. `UsageFilters` gains parallel `exclude_*` lists for project, model, activity, session, branch (rejected if any value matches). Exclude chips render with a `~` prefix and BAR_HIGH fill; Esc walks them first.
4. `refactor(ainb-tui): drop free-text include/exclude/clear filter prompts` — chip strip replaces `/`, `x`, `c` prompts. Removes `UsageStartIncludeFilter` / `UsageStartExcludeFilter` / `UsageClearFilters` events, their handlers, and the corresponding `UsageInputMode::Include` / `Exclude` variants. Zoom-mode `/` search is unaffected.
5. `style(ainb-tui): update bottom help bar to chip-strip filter vocabulary` — burndown help bar reads `Tab focus / Enter add / X exclude / Esc pop / C clear`, and the trailing `/ x c filters` segment is gone.

## BREAKING TUI behaviour

Lowercase `c`, `/`, `x` no longer have any effect on the burndown view. Capital `C` still clears all chips, capital `X` is the new exclude binding, and Enter still adds an include chip.

## Test plan

- [x] `cargo build` (clean)
- [x] `cargo test --lib` — 549 passed (was 545; +4 new tests for `oldest_call_day` clamp behaviour and X-exclude flow). 9 pre-existing docker failures unchanged.
- [x] `cargo test --test usage_cache_integration` — 6/6 green
- [x] `cargo clippy --lib` — no new warnings introduced by this PR
- [ ] Manual TUI walkthrough: open burndown, switch to `m Month`, verify `←/→` step. Tab → focus a panel → Enter add chip / X exclude chip → see chip strip render with `~` for exclude. C clears all.