### PR TITLE
docs(readme): make Homebrew the primary install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,54 +172,52 @@ ainb completion zsh > ~/.zsh/completions/_ainb
 
 ### Installation
 
-<details>
-<summary><b>Homebrew (macOS / Linux)</b></summary>
+**Recommended — Homebrew (macOS / Linux):**
 
 ```bash
 brew tap stevengonsalvez/agents-in-a-box
 brew install ainb
 ```
-</details>
+
+The tap lives at [`stevengonsalvez/homebrew-agents-in-a-box`](https://github.com/stevengonsalvez/homebrew-agents-in-a-box) and is auto-updated by the release workflow on every tagged release — `brew upgrade ainb` always pulls the latest.
 
 <details>
-<summary><b>One-liner install</b></summary>
+<summary><b>Other install methods</b></summary>
 
+**One-liner curl install** (any Unix):
 ```bash
 curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
 ```
-</details>
 
-<details>
-<summary><b>Homebrew (macOS / Linux)</b></summary>
-
-```bash
-brew tap stevengonsalvez/agents-in-a-box
-brew install ainb
-```
-</details>
-
-<details>
-<summary><b>Cargo (any platform)</b></summary>
-
+**Cargo** (any platform with a Rust toolchain):
 ```bash
 cargo install --git https://github.com/stevengonsalvez/agents-in-a-box --branch main ainb
 ```
-</details>
 
-<details>
-<summary><b>Windows (WSL)</b></summary>
-
+**Windows via WSL2** — native Windows is not supported (`ainb` uses Unix-only APIs: PTY, POSIX file modes). Use WSL2:
 ```powershell
-# 1. Install WSL2
-wsl --install
-
-# 2. Inside Ubuntu/Debian
+wsl --install                                                                         # 1. Install WSL2
+# Inside Ubuntu/Debian:
 curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
 sudo apt update && sudo apt install -y tmux
 ainb
 ```
+</details>
 
-> Native Windows is not supported — `ainb` uses Unix-only APIs (PTY, POSIX file modes). WSL2 + the Linux binary is the supported path.
+<details>
+<summary><b>Troubleshooting Homebrew</b></summary>
+
+**`Error: Your Command Line Tools are too outdated`** — this is a Homebrew check on the standalone `CommandLineTools` package, separate from a full Xcode install. If you have a recent Xcode but an old standalone CLT, brew picks the older one. Reinstall the CLT:
+```bash
+sudo rm -rf /Library/Developer/CommandLineTools
+sudo xcode-select --install
+```
+
+**`Formulae found in multiple taps`** — if you previously tapped a similarly-named bucket, untap it:
+```bash
+brew untap stevengonsalvez/ainb   # only if you tapped this earlier
+brew install stevengonsalvez/agents-in-a-box/ainb
+```
 </details>
 
 ### Keyboard Shortcuts


### PR DESCRIPTION
## Summary
- Strip the duplicate \`Homebrew (macOS / Linux)\` panel left over from the windows-cleanup merges
- Promote Homebrew out of the collapsed details list into a top-level **Recommended** block, with a one-line link to the auto-updated tap repo (\`stevengonsalvez/homebrew-agents-in-a-box\`)
- Collapse the remaining methods (curl, Cargo, WSL2) into a single "Other install methods" panel
- Add a "Troubleshooting Homebrew" panel covering two real-world snags:
  - **Outdated standalone Command Line Tools** — \`brew\` checks the \`CommandLineTools\` package (e.g. CLT 16.2 from 2024) separately from a full Xcode.app (e.g. 26.4.1). Fix is one line: \`sudo rm -rf /Library/Developer/CommandLineTools && sudo xcode-select --install\`
  - **Tap-name collisions** — if a similarly-named bucket is already tapped, the install errors with "Formulae found in multiple taps". Fully-qualified name + untap of the legacy one resolves it

Pure docs change, single file (README.md), 1 commit.

## Test plan
- [ ] PR /review
- [ ] Merge with \`--merge\`
- [ ] Eyeball the rendered README on main