### PR TITLE
fix(marketplace): drop redundant skills array (resolves install-time warning)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,13 +21,6 @@
         "memory",
         "recall",
         "retrieval"
-      ],
-      "skills": [
-        "./toolkit/packages/plugins/reflect/skills/reflect",
-        "./toolkit/packages/plugins/reflect/skills/recall",
-        "./toolkit/packages/plugins/reflect/skills/consolidate",
-        "./toolkit/packages/plugins/reflect/skills/ingest",
-        "./toolkit/packages/plugins/reflect/skills/reflect-status"
       ]
     }
   ]


### PR DESCRIPTION
Sanity test of `claude plugin install reflect@agents-in-a-box` warned:

```
Error: Plugin reflect has conflicting manifests: both plugin.json
and marketplace entry specify components. Set strict: true in
marketplace entry or remove component specs from one location.
```

Drop the `skills:` array from marketplace.json. The plugin's own
`.claude-plugin/plugin.json` + `skills/` tree is sufficient for
discovery; marketplace.json stays as pure metadata.

Verified: install + list works clean after this change.