### PR TITLE
feat(usage): aggregate stats by upstream repo, fall back to folder

### DIFF
--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3812,11 +3812,13 @@ mod cross_filter_tests {
                     name: "alpha".into(),
                     path: "/work/alpha".into(),
                     bucket: bucket(3),
+                    repo: None,
                 },
                 ProjectUsage {
                     name: "beta".into(),
                     path: "/work/beta".into(),
                     bucket: bucket(2),
+                    repo: None,
                 },
             ],
             grand_total: bucket(5),

--- a/ainb-tui/src/models/mod.rs
+++ b/ainb-tui/src/models/mod.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Core data models for Claude-in-a-Box sessions, workspaces, and state management
 
 pub mod other_tmux;
+pub mod repo_lookup;
 pub mod session;
 pub mod skills;
 pub mod usage;

--- a/ainb-tui/src/models/repo_lookup.rs
+++ b/ainb-tui/src/models/repo_lookup.rs
@@ -1,0 +1,441 @@
+// ABOUTME: Resolve a working directory to its upstream repo identifier
+// (e.g. "owner/repo") by reading .git/config without shelling out.
+//
+// Used by usage aggregation to collapse worktrees of the same repo into
+// a single ProjectUsage row keyed by the upstream remote.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Resolve a working directory to its upstream repo identifier
+/// (e.g. `"owner/repo"`).
+///
+/// Returns `None` for non-git paths or repos without an `origin`
+/// remote. Failures are silent — callers fall back to the local folder
+/// name. Results are memoised in `cache` keyed by the input `cwd`
+/// string.
+///
+/// Implementation notes:
+/// - Walks up from `cwd` looking for `.git` (file or directory).
+/// - When `.git` is a file (worktree pointer of the form
+///   `gitdir: <path>`), follows the pointer to the main repo's git
+///   directory. Worktree gitdirs typically nest under
+///   `<main>/.git/worktrees/<name>/`; we strip down to the repo's
+///   top-level git dir before reading `config` so all worktrees of a
+///   repo collapse to the same remote.
+/// - Parses `.git/config` as INI: looks for the `[remote "origin"]`
+///   section and reads its `url = ...` entry.
+/// - Extracts `owner/repo` from common URL shapes (HTTPS, SSH,
+///   `ssh://`, `git://`, scp-style `user@host:path`). The full
+///   path-after-host is preserved so nested GitLab groups
+///   (`group/sub/repo`) are kept intact. Trailing `.git` is stripped.
+pub fn resolve_repo(cwd: &str, cache: &mut HashMap<String, Option<String>>) -> Option<String> {
+    if let Some(hit) = cache.get(cwd) {
+        return hit.clone();
+    }
+    let resolved = resolve_repo_uncached(Path::new(cwd));
+    cache.insert(cwd.to_string(), resolved.clone());
+    resolved
+}
+
+fn resolve_repo_uncached(start: &Path) -> Option<String> {
+    let git_dir = find_git_dir(start)?;
+    let config_path = git_dir.join("config");
+    let config_text = fs::read_to_string(&config_path).ok()?;
+    let url = parse_origin_url(&config_text)?;
+    extract_owner_repo(&url)
+}
+
+/// Walk up from `start` to find a `.git` entry. If `.git` is a file
+/// (worktree pointer), resolve it to the main repo's top-level git
+/// directory. Returns the directory containing the `config` file we
+/// should read.
+fn find_git_dir(start: &Path) -> Option<PathBuf> {
+    let mut cur = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        // Best-effort canonicalize; if cwd is missing, fall back to
+        // the path as given so we can still walk parents.
+        fs::canonicalize(start).unwrap_or_else(|_| start.to_path_buf())
+    };
+
+    loop {
+        let candidate = cur.join(".git");
+        if let Ok(meta) = fs::metadata(&candidate) {
+            if meta.is_dir() {
+                return Some(candidate);
+            }
+            if meta.is_file() {
+                if let Some(gitdir) = read_gitdir_pointer(&candidate) {
+                    return Some(normalize_worktree_gitdir(&gitdir));
+                }
+                return None;
+            }
+        }
+        if !cur.pop() {
+            return None;
+        }
+    }
+}
+
+/// Parse a `.git` pointer file (`gitdir: <path>`).
+fn read_gitdir_pointer(path: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(path).ok()?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("gitdir:") {
+            let target = rest.trim();
+            if target.is_empty() {
+                return None;
+            }
+            let target_path = PathBuf::from(target);
+            // Pointer paths can be relative to the directory holding
+            // the `.git` file.
+            if target_path.is_absolute() {
+                return Some(target_path);
+            }
+            let parent = path.parent()?;
+            return Some(parent.join(target_path));
+        }
+    }
+    None
+}
+
+/// Worktree gitdirs typically look like
+/// `<main>/.git/worktrees/<name>`. The shared `config` lives at
+/// `<main>/.git/config`. Walk up until we find a directory that
+/// contains a `config` file (the canonical git dir layout).
+fn normalize_worktree_gitdir(gitdir: &Path) -> PathBuf {
+    let mut cur = gitdir.to_path_buf();
+    // The top-level git dir is always called `.git` and contains
+    // `config`. Step up while we're inside `worktrees/...`.
+    loop {
+        if cur.join("config").is_file() && cur.file_name().and_then(|s| s.to_str()) == Some(".git")
+        {
+            return cur;
+        }
+        if !cur.pop() {
+            return gitdir.to_path_buf();
+        }
+    }
+}
+
+/// Parse a tiny subset of INI: locate `[remote "origin"]` and return
+/// its `url = ...` value. We don't pull a full INI crate because git
+/// config has its own quirks (subsections, includes) and we only need
+/// one field.
+fn parse_origin_url(config: &str) -> Option<String> {
+    let mut in_origin = false;
+    for raw_line in config.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            // Section header. Match `[remote "origin"]` with flexible
+            // whitespace; reject anything else.
+            in_origin = is_remote_origin_header(line);
+            continue;
+        }
+        if !in_origin {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            if key.trim().eq_ignore_ascii_case("url") {
+                let v = value.trim().trim_matches('"');
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_remote_origin_header(line: &str) -> bool {
+    // Strip the [ ] and normalize whitespace.
+    let inner = &line[1..line.len() - 1].trim();
+    // Expected shape: `remote "origin"` (subsection name in quotes).
+    let Some(rest) = inner.strip_prefix("remote") else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    rest == "\"origin\""
+}
+
+/// Extract `owner/repo` (or full path-after-host) from a git URL.
+/// Returns `None` for unrecognised shapes.
+fn extract_owner_repo(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Order matters: check explicit schemes first, then fall back to
+    // scp-style `user@host:path`.
+    let path = if let Some(rest) = strip_scheme(trimmed) {
+        // After scheme, rest is `[user@]host[:port]/path`. Skip the
+        // host segment.
+        let after_host = rest.split_once('/')?.1;
+        after_host.to_string()
+    } else if let Some(after_colon) = scp_style_path(trimmed) {
+        after_colon.to_string()
+    } else {
+        return None;
+    };
+
+    let path = path.trim_start_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let path = path.trim_end_matches('/');
+
+    // Require at least `owner/repo` (one slash). A bare `repo` with no
+    // namespace can't be attributed to an upstream id.
+    if !path.contains('/') {
+        return None;
+    }
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+/// Recognise `scheme://` prefixes and return the remainder. Returns
+/// `None` for inputs without an explicit scheme.
+fn strip_scheme(url: &str) -> Option<&str> {
+    for scheme in ["https://", "http://", "ssh://", "git://", "git+ssh://"] {
+        if let Some(rest) = url.strip_prefix(scheme) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// Match scp-style `[user@]host:path` (e.g. `git@github.com:owner/repo.git`).
+/// Returns the path portion or `None` if the input doesn't look like
+/// scp form.
+fn scp_style_path(url: &str) -> Option<&str> {
+    // scp-style has no `//` and the first `:` separates host from path.
+    if url.contains("://") {
+        return None;
+    }
+    let (host, path) = url.split_once(':')?;
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    // Reject Windows-style drive letters like `C:\foo`.
+    if host.len() == 1 && host.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parses_ssh_scp_style_url() {
+        assert_eq!(
+            extract_owner_repo("git@github.com:owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_url_with_dot_git() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_url_without_dot_git() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/owner/repo"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_gitlab_nested_group() {
+        assert_eq!(
+            extract_owner_repo("https://gitlab.com/group/sub/repo"),
+            Some("group/sub/repo".to_string())
+        );
+        assert_eq!(
+            extract_owner_repo("git@gitlab.com:group/sub/repo.git"),
+            Some("group/sub/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_scheme_url() {
+        assert_eq!(
+            extract_owner_repo("ssh://git@github.com/owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_owner_repo("ssh://git@host.example.com:2222/team/proj.git"),
+            Some("team/proj".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_bare_repo_name() {
+        // Need at least owner/repo — a bare name has no upstream id.
+        assert_eq!(extract_owner_repo("git@github.com:repo.git"), None);
+    }
+
+    #[test]
+    fn rejects_unknown_scheme() {
+        assert_eq!(extract_owner_repo(""), None);
+        // Local file path is not a remote URL we can attribute.
+        assert_eq!(extract_owner_repo("/tmp/some/path"), None);
+    }
+
+    #[test]
+    fn parses_origin_section_only() {
+        let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "upstream"]
+    url = https://github.com/other/upstream.git
+[remote "origin"]
+    url = git@github.com:owner/repo.git
+[branch "main"]
+    remote = origin
+"#;
+        assert_eq!(
+            parse_origin_url(cfg),
+            Some("git@github.com:owner/repo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_origin_returns_none_when_no_origin() {
+        let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "upstream"]
+    url = https://github.com/other/upstream.git
+"#;
+        assert_eq!(parse_origin_url(cfg), None);
+    }
+
+    #[test]
+    fn resolve_returns_none_for_non_git_path() {
+        let dir = tempdir().unwrap();
+        let mut cache = HashMap::new();
+        let cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), None);
+        // Cache hit (negative) — second call should not re-resolve.
+        assert!(cache.contains_key(&cwd));
+        assert_eq!(resolve_repo(&cwd, &mut cache), None);
+    }
+
+    #[test]
+    fn resolve_returns_none_when_no_origin_remote() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[core]\n\trepositoryformatversion = 0\n",
+        )
+        .unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), None);
+    }
+
+    #[test]
+    fn resolve_finds_origin_in_repo_root() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:acme/widget.git\n",
+        )
+        .unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), Some("acme/widget".to_string()));
+    }
+
+    #[test]
+    fn resolve_walks_up_from_subdirectory() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = https://github.com/acme/widget\n",
+        )
+        .unwrap();
+        let nested = dir.path().join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = nested.to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), Some("acme/widget".to_string()));
+    }
+
+    #[test]
+    fn resolve_follows_worktree_pointer_to_main_repo() {
+        // Layout:
+        //   <root>/main/.git/        (real git dir)
+        //   <root>/main/.git/config  (with origin)
+        //   <root>/main/.git/worktrees/wt1/   (worktree gitdir)
+        //   <root>/wt1/.git          (file: "gitdir: <root>/main/.git/worktrees/wt1")
+        let dir = tempdir().unwrap();
+        let main = dir.path().join("main");
+        let main_git = main.join(".git");
+        let wt_gitdir = main_git.join("worktrees").join("wt1");
+        fs::create_dir_all(&wt_gitdir).unwrap();
+        fs::write(
+            main_git.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:acme/widget.git\n",
+        )
+        .unwrap();
+
+        let wt = dir.path().join("wt1");
+        fs::create_dir_all(&wt).unwrap();
+        fs::write(
+            wt.join(".git"),
+            format!("gitdir: {}\n", wt_gitdir.display()),
+        )
+        .unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = wt.to_string_lossy().into_owned();
+        assert_eq!(
+            resolve_repo(&cwd, &mut cache),
+            Some("acme/widget".to_string())
+        );
+    }
+
+    #[test]
+    fn cache_hit_short_circuits_resolution() {
+        let mut cache = HashMap::new();
+        cache.insert("/no/such/path".to_string(), Some("cached/value".to_string()));
+        // No filesystem access — value comes straight from cache.
+        assert_eq!(
+            resolve_repo("/no/such/path", &mut cache),
+            Some("cached/value".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_scp_style_with_drive_letter() {
+        // Ensure Windows paths don't get mistaken for scp URLs.
+        assert_eq!(extract_owner_repo("C:\\users\\dev\\repo"), None);
+    }
+
+}

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, warn};
 
+use crate::models::repo_lookup;
 use crate::usage_cache::{Cache, ParseHint, ParseResult};
 
 /// Usage period selector shared by TUI and CLI report queries.
@@ -484,12 +485,27 @@ pub struct DailyUsage {
 }
 
 /// Per-project summary.
+///
+/// `name` is the display label and aggregation key. When the project's
+/// `cwd` belongs to a git repo with a resolvable `origin` remote,
+/// `name` is the upstream identifier (e.g. `"owner/repo"`) and `repo`
+/// holds the same value as an explicit "this came from a remote"
+/// marker. Otherwise `name` falls back to the local folder/sanitised
+/// project name and `repo` is `None`.
+///
+/// Two worktrees of the same upstream repo collapse into a single
+/// `ProjectUsage` row because they share the same `name`. Chip filters
+/// match on `name`, so the filter UI follows the same rule.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectUsage {
     pub name: String,
     pub path: String,
     pub bucket: TokenBucket,
+    /// `Some(owner/repo)` when the project's working directory was
+    /// successfully resolved to an upstream remote at aggregation
+    /// time. `None` for non-git paths or repos without an `origin`.
+    pub repo: Option<String>,
 }
 
 /// Per-session summary.
@@ -1448,7 +1464,19 @@ fn aggregate_calls_with_analysis(
 
     let mut daily_map: HashMap<NaiveDate, (HashSet<String>, HashSet<String>, TokenBucket)> =
         HashMap::new();
-    let mut project_map: HashMap<String, (String, HashSet<String>, TokenBucket)> = HashMap::new();
+    // Project aggregation key is the *display* name: the upstream repo
+    // id (e.g. "owner/repo") when resolvable, otherwise the local
+    // folder/sanitised project name. This is what collapses two
+    // worktrees of the same repo into one ProjectUsage row.
+    //
+    // Value tuple: (project_path, session_keys, bucket, repo_marker).
+    // `repo_marker` is `Some(owner/repo)` when the key came from the
+    // remote and `None` when it fell back to the folder name.
+    let mut project_map: HashMap<String, (String, HashSet<String>, TokenBucket, Option<String>)> =
+        HashMap::new();
+    // Per-cwd repo lookup cache: shared across the loop so each
+    // distinct working directory is parsed at most once.
+    let mut repo_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut session_map: HashMap<String, SessionUsageAccumulator> = HashMap::new();
     let mut model_map: HashMap<String, TokenBucket> = HashMap::new();
     let mut branch_map: HashMap<String, TokenBucket> = HashMap::new();
@@ -1466,21 +1494,33 @@ fn aggregate_calls_with_analysis(
         let day = call.timestamp.with_timezone(&Local).date_naive();
         let session_key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
 
+        // Resolve the call's working directory to an upstream repo id
+        // so worktrees collapse. Falls back to the folder/sanitised
+        // project name when the cwd isn't a git repo or has no origin.
+        let resolved_repo = repo_lookup::resolve_repo(&call.project_path, &mut repo_cache);
+        let project_key = resolved_repo.clone().unwrap_or_else(|| call.project.clone());
+
         let daily = daily_map.entry(day).or_default();
-        daily.0.insert(call.project.clone());
+        daily.0.insert(project_key.clone());
         daily.1.insert(session_key.clone());
         daily.2.merge(&bucket);
 
-        let project = project_map.entry(call.project.clone()).or_insert_with(|| {
+        let project = project_map.entry(project_key.clone()).or_insert_with(|| {
             (
                 call.project_path.clone(),
                 HashSet::new(),
                 TokenBucket::default(),
+                resolved_repo.clone(),
             )
         });
         project.0 = call.project_path.clone();
         project.1.insert(session_key.clone());
         project.2.merge(&bucket);
+        // Once a row is keyed by the upstream repo, keep it that way
+        // even if a later call from the same key fails resolution.
+        if project.3.is_none() && resolved_repo.is_some() {
+            project.3 = resolved_repo.clone();
+        }
 
         let session = session_map.entry(session_key).or_insert_with(|| SessionUsageAccumulator {
             provider: call.provider.clone(),
@@ -1548,9 +1588,14 @@ fn aggregate_calls_with_analysis(
 
     let mut projects: Vec<_> = project_map
         .into_iter()
-        .map(|(name, (path, sessions, mut bucket))| {
+        .map(|(name, (path, sessions, mut bucket, repo))| {
             bucket.session_count = sessions.len();
-            ProjectUsage { name, path, bucket }
+            ProjectUsage {
+                name,
+                path,
+                bucket,
+                repo,
+            }
         })
         .collect();
     sort_by_bucket_desc(&mut projects, |p| &p.bucket);
@@ -3654,5 +3699,87 @@ mod tests {
         let yield_result = analyze_yield(&data);
         assert_eq!(yield_result.productive_sessions, 1);
         assert_eq!(yield_result.abandoned_sessions, 1);
+    }
+
+    /// Two worktrees of the same upstream repo must collapse into a
+    /// single ProjectUsage row keyed by `owner/repo`. We materialise a
+    /// pair of throwaway repos on disk that share an `origin` so the
+    /// resolver attributes both worktrees to the same upstream id.
+    #[test]
+    fn aggregation_collapses_worktrees_with_shared_origin() {
+        let temp = tempdir().unwrap();
+        let wt_a = temp.path().join("wt-a");
+        let wt_b = temp.path().join("wt-b");
+
+        for wt in [&wt_a, &wt_b] {
+            let git_dir = wt.join(".git");
+            std::fs::create_dir_all(&git_dir).unwrap();
+            std::fs::write(
+                git_dir.join("config"),
+                "[remote \"origin\"]\n\turl = git@github.com:acme/widget.git\n",
+            )
+            .unwrap();
+        }
+
+        // Distinct sanitised project names — same upstream repo.
+        let mut call1 = provider_call(
+            "claude",
+            "s1",
+            "2026-04-10T09:00:00Z",
+            "edit",
+            &[],
+            &[],
+            100,
+        );
+        call1.project = "wt-a-folder".to_string();
+        call1.project_path = wt_a.to_string_lossy().into_owned();
+
+        let mut call2 = provider_call(
+            "claude",
+            "s2",
+            "2026-04-10T10:00:00Z",
+            "edit",
+            &[],
+            &[],
+            150,
+        );
+        call2.project = "wt-b-folder".to_string();
+        call2.project_path = wt_b.to_string_lossy().into_owned();
+
+        let data = aggregate_calls(vec![call1, call2]);
+        assert_eq!(data.projects.len(), 1, "worktrees should collapse");
+        let proj = &data.projects[0];
+        assert_eq!(proj.name, "acme/widget");
+        assert_eq!(proj.repo.as_deref(), Some("acme/widget"));
+        assert_eq!(proj.bucket.input_tokens, 250);
+    }
+
+    /// When a call's working directory has no resolvable upstream the
+    /// row falls back to the sanitised project name and `repo` stays
+    /// `None`.
+    #[test]
+    fn aggregation_falls_back_to_folder_when_no_origin() {
+        let temp = tempdir().unwrap();
+        let wt = temp.path().join("plain");
+        std::fs::create_dir_all(&wt).unwrap();
+        // No .git at all.
+
+        let mut call = provider_call(
+            "claude",
+            "s1",
+            "2026-04-10T09:00:00Z",
+            "edit",
+            &[],
+            &[],
+            100,
+        );
+        call.project = "plain-folder".to_string();
+        call.project_path = wt.to_string_lossy().into_owned();
+
+        let data = aggregate_calls(vec![call]);
+        assert_eq!(data.projects.len(), 1);
+        let proj = &data.projects[0];
+        assert_eq!(proj.name, "plain-folder");
+        assert!(proj.repo.is_none());
     }
 }

--- a/ainb-tui/src/test_support.rs
+++ b/ainb-tui/src/test_support.rs
@@ -194,6 +194,7 @@ pub fn sample_usage_data() -> UsageData {
             name: "agents-in-a-box".to_string(),
             path: "/tmp/agents-in-a-box".to_string(),
             bucket: bucket.clone(),
+            repo: None,
         }],
         grand_total: bucket.clone(),
         sessions: vec![SessionUsage {


### PR DESCRIPTION
## Summary

- Replace dynamic worktree folder names in Burndown stats with the upstream repo id (`owner/repo`). Two worktrees of the same repo now collapse into a single `ProjectUsage` row.
- New `models/repo_lookup` helper walks up from a cwd to `.git`, follows worktree pointers to the main repo, parses `.git/config` as INI, and extracts `owner/repo` from the `origin` URL. Pure Rust, no shell-out, no new dependencies.
- `ProjectUsage` gains `repo: Option<String>` — `Some(owner/repo)` when resolved from origin, `None` when falling back to the local folder/sanitised name.
- Aggregation in `aggregate_calls` keys projects by the resolved repo (or folder fallback). The display name and filter chip key are the same value, so chip filters keep working without renderer changes.
- Renderers and CLI output paths use `ProjectUsage.name` already, which after this PR is the friendly value — no renderer logic changes needed.

## URL parsing

- `git@github.com:owner/repo.git` -> `owner/repo`
- `https://github.com/owner/repo[.git]` -> `owner/repo`
- `https://gitlab.com/group/sub/repo` -> `group/sub/repo` (nested path preserved)
- `ssh://git@host[:port]/owner/repo.git` -> `owner/repo`
- Bare `repo` (no namespace) -> `None` (can't attribute upstream)
- Windows `C:\...` paths rejected (not mistaken for scp-style)

## Edge cases handled

- `.git` is a worktree pointer file -> follow `gitdir: <path>`, walk up to the canonical `.git` containing `config` so all worktrees share the same lookup.
- No `.git` ancestor -> `None`.
- `.git/config` exists without `[remote "origin"]` -> `None`.
- Cache hits short-circuit before any filesystem access.

## Cache compatibility

Cache blob format unchanged. Repo resolution runs at aggregation time on freshly aggregated `ProviderCall`s, never persisted, so existing on-disk caches keep working.

## Test plan

- [x] `cargo check --bin ainb` clean
- [x] `cargo test --bin ainb` -> 568 passed, 9 failed (pre-existing docker tests requiring a daemon, unchanged from `origin/main` baseline)
- [x] 16 new tests in `repo_lookup` module covering URL shapes, worktree pointer traversal, missing-origin, no-`.git`, cache hits
- [x] 2 new aggregation tests verifying worktree collapse and folder fallback
- [x] Local sanity check on this very worktree resolves `stevengonsalvez/agents-in-a-box`