### PR TITLE
feat: live window via Claude Code statusline integration

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -22,11 +22,11 @@ pub enum AppEvent {
     NextWorkspace,
     PreviousWorkspace,
     ToggleHelp,
-    RefreshWorkspaces, // Manual refresh of workspace data
+    RefreshWorkspaces,  // Manual refresh of workspace data
     CycleSessionFilter, // Cycle Interactive session filter (Shift+F): All → ActiveOnly → StoppedOnly
-    ToggleClaudeChat,  // Toggle Claude chat visibility
-    NewSession,        // Create session in current directory
-    SearchWorkspace,   // Search all workspaces
+    ToggleClaudeChat,   // Toggle Claude chat visibility
+    NewSession,         // Create session in current directory
+    SearchWorkspace,    // Search all workspaces
     AttachSession,
     DetachSession,
     KillContainer,
@@ -362,23 +362,26 @@ pub enum AppEvent {
     UsageInputSubmit,         // Submit usage input
     UsageInputCancel,         // Cancel usage input
     // Cross-filter (Grafana-style dashboard pivot) on Burndown view
-    UsageFocusNextPanel, // Tab while on Burndown
-    UsageFocusPrevPanel, // Shift+Tab while on Burndown
-    UsageFocusRowUp,     // Up/k while a panel is focused
-    UsageFocusRowDown,   // Down/j while a panel is focused
-    UsageCommitFilter,   // Enter on focused row -> add include chip
+    UsageFocusNextPanel,      // Tab while on Burndown
+    UsageFocusPrevPanel,      // Shift+Tab while on Burndown
+    UsageFocusRowUp,          // Up/k while a panel is focused
+    UsageFocusRowDown,        // Down/j while a panel is focused
+    UsageCommitFilter,        // Enter on focused row -> add include chip
     UsageCommitExcludeFilter, // Shift+X on focused row -> add exclude chip
-    UsagePopFilterChip,  // Esc when chips exist
-    UsageClearAllChips,  // C — drop every chip in one shot
+    UsagePopFilterChip,       // Esc when chips exist
+    UsageClearAllChips,       // C — drop every chip in one shot
+    /// W on the Burndown view when the Budget panel is focused and live
+    /// data is unavailable: triggers the statusline install confirmation.
+    UsageWireStatusline,
     // Zoom mode (PR-C)
-    UsageToggleZoom,         // z — toggle fullscreen panel zoom on Burndown
-    UsageZoomStartSearch,    // / inside zoom — begin fuzzy search
-    UsageZoomCommitSearch,   // Enter inside zoom search
-    UsageZoomCancelSearch,   // Esc inside zoom search
-    UsageZoomSearchChar(char),  // typed char in zoom search input
-    UsageZoomSearchBackspace,   // Backspace in zoom search input
-    UsageZoomToggleDetail,   // d inside zoom — toggle detail drawer
-    UsageZoomEsc,            // Esc inside zoom — detail-close > zoom-exit
+    UsageToggleZoom,           // z — toggle fullscreen panel zoom on Burndown
+    UsageZoomStartSearch,      // / inside zoom — begin fuzzy search
+    UsageZoomCommitSearch,     // Enter inside zoom search
+    UsageZoomCancelSearch,     // Esc inside zoom search
+    UsageZoomSearchChar(char), // typed char in zoom search input
+    UsageZoomSearchBackspace,  // Backspace in zoom search input
+    UsageZoomToggleDetail,     // d inside zoom — toggle detail drawer
+    UsageZoomEsc,              // Esc inside zoom — detail-close > zoom-exit
     // Skills browser events
     SkillsBack,             // Return to home screen (Esc)
     SkillsNextProvider,     // Next provider (Right arrow)
@@ -1729,6 +1732,10 @@ impl EventHandler {
                 // Capital X (Shift+x) only — lowercase x is reserved for
                 // future scope and must NOT trigger the exclude commit.
                 KeyCode::Char('X') => return Some(AppEvent::UsageCommitExcludeFilter),
+                // W wires up the Claude Code statusline. Only meaningful
+                // on the Budget panel when live data is unavailable; the
+                // handler enforces both checks before doing anything.
+                KeyCode::Char('W') => return Some(AppEvent::UsageWireStatusline),
                 KeyCode::Esc if state.usage_state.filters.any() => {
                     return Some(AppEvent::UsagePopFilterChip);
                 }
@@ -4358,12 +4365,70 @@ impl EventHandler {
             }
             AppEvent::UsagePopFilterChip => {
                 if let Some(chip) = state.usage_state.pop_filter_chip() {
-                    let kind = if chip.is_exclude() { "exclude" } else { "include" };
+                    let kind = if chip.is_exclude() {
+                        "exclude"
+                    } else {
+                        "include"
+                    };
                     state.add_success_notification(format!(
                         "Removed {kind} {}={}",
                         chip.label(),
                         chip.value()
                     ));
+                }
+            }
+            AppEvent::UsageWireStatusline => {
+                // Only act when (a) Budget panel is focused and (b) live
+                // data is unavailable. Either condition unmet → no-op so
+                // a stray `W` keystroke doesn't surprise the user.
+                let on_budget = matches!(
+                    state.usage_state.focused_panel,
+                    Some(crate::components::usage::UsagePanel::Budget)
+                );
+                let no_live = matches!(
+                    crate::models::live_window::current().source,
+                    crate::models::live_window::Source::None
+                );
+                if !on_budget || !no_live {
+                    return;
+                }
+                match crate::cli::statusline_install::install_statusline() {
+                    Ok(crate::cli::statusline_install::InstallOutcome::Installed) => {
+                        state.app_config.ui_preferences.statusline_decision =
+                            crate::config::StatuslineDecision::Installed;
+                        let _ = state.app_config.save();
+                        state.add_success_notification(
+                            "Wired Claude Code statusline. Live data appears next prompt render."
+                                .to_string(),
+                        );
+                    }
+                    Ok(crate::cli::statusline_install::InstallOutcome::AlreadyInstalled) => {
+                        state.app_config.ui_preferences.statusline_decision =
+                            crate::config::StatuslineDecision::Installed;
+                        let _ = state.app_config.save();
+                        state.add_success_notification(
+                            "Statusline already wired — waiting for first prompt render."
+                                .to_string(),
+                        );
+                    }
+                    Ok(crate::cli::statusline_install::InstallOutcome::ExistingDifferent {
+                        current_command,
+                    }) => {
+                        state.add_warning_notification(format!(
+                            "Existing statusline detected: {current_command}. Run `ainb init` for keep/replace/chain."
+                        ));
+                    }
+                    Ok(crate::cli::statusline_install::InstallOutcome::Chained) => {
+                        state.app_config.ui_preferences.statusline_decision =
+                            crate::config::StatuslineDecision::Chained;
+                        let _ = state.app_config.save();
+                        state.add_success_notification("Chained ainb statusline.".to_string());
+                    }
+                    Err(e) => {
+                        state.add_error_notification(format!(
+                            "Failed to install statusline: {e}"
+                        ));
+                    }
                 }
             }
             AppEvent::UsageClearAllChips => {

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -4415,14 +4415,8 @@ impl EventHandler {
                         current_command,
                     }) => {
                         state.add_warning_notification(format!(
-                            "Existing statusline detected: {current_command}. Run `ainb init` for keep/replace/chain."
+                            "Existing statusline detected: {current_command}. Run `ainb init` for keep/replace."
                         ));
-                    }
-                    Ok(crate::cli::statusline_install::InstallOutcome::Chained) => {
-                        state.app_config.ui_preferences.statusline_decision =
-                            crate::config::StatuslineDecision::Chained;
-                        let _ = state.app_config.save();
-                        state.add_success_notification("Chained ainb statusline.".to_string());
                     }
                     Err(e) => {
                         state.add_error_notification(format!(

--- a/ainb-tui/src/cli/init.rs
+++ b/ainb-tui/src/cli/init.rs
@@ -444,8 +444,6 @@ pub enum StatuslineStepOutcome {
     Skipped,
     /// User accepted; we ran the install.
     Installed,
-    /// User accepted "chain" against an existing command.
-    Chained,
     /// User declined; we record `Declined` so we don't re-prompt.
     Declined,
     /// User chose "keep" their existing different statusline.
@@ -460,7 +458,7 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
 ) -> Result<StatuslineStepOutcome> {
     use crate::cli::statusline_install::{
         InstallOutcome, StatuslineStatus, detect_statusline_status, install_statusline,
-        install_statusline_chained_at, install_statusline_replace_at, settings_path,
+        install_statusline_replace_at, settings_path,
     };
     use crate::config::StatuslineDecision;
 
@@ -484,15 +482,10 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
             writeln!(out, "Existing Claude Code statusline detected: {cmd}").ok();
             writeln!(
                 out,
-                "  [k]eep your current command  [r]eplace with ainb statusline"
+                "  [k]eep your current command  [r]eplace with ainb statusline  [s]kip for now"
             )
             .ok();
-            writeln!(
-                out,
-                "  [c]hain ('{cmd} | ainb statusline')   [s]kip for now"
-            )
-            .ok();
-            write!(out, "Choice [k/r/c/s]: ").ok();
+            write!(out, "Choice [k/r/s]: ").ok();
             out.flush().ok();
             let choice = read_choice(input)?;
             let path = settings_path()?;
@@ -503,17 +496,6 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
                     let _ = app_config.save();
                     writeln!(out, "  ✓ Replaced existing statusline.").ok();
                     Ok(StatuslineStepOutcome::Installed)
-                }
-                "c" => {
-                    install_statusline_chained_at(&path)?;
-                    app_config.ui_preferences.statusline_decision = StatuslineDecision::Chained;
-                    let _ = app_config.save();
-                    writeln!(
-                        out,
-                        "  ✓ Chained ainb statusline onto your existing command."
-                    )
-                    .ok();
-                    Ok(StatuslineStepOutcome::Chained)
                 }
                 "k" => {
                     // Treat "keep" as Declined for top-bar suppression
@@ -565,13 +547,6 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
                             let _ = app_config.save();
                             writeln!(out, "  ✓ Wired Claude Code statusline.").ok();
                             Ok(StatuslineStepOutcome::Installed)
-                        }
-                        InstallOutcome::Chained => {
-                            app_config.ui_preferences.statusline_decision =
-                                StatuslineDecision::Chained;
-                            let _ = app_config.save();
-                            writeln!(out, "  ✓ Chained ainb statusline.").ok();
-                            Ok(StatuslineStepOutcome::Chained)
                         }
                         InstallOutcome::ExistingDifferent { current_command } => {
                             // Race: someone wrote a different statusLine

--- a/ainb-tui/src/cli/init.rs
+++ b/ainb-tui/src/cli/init.rs
@@ -281,6 +281,13 @@ fn cmd_setup(format: OutputFormat) -> Result<()> {
     onboarding.mark_completed();
     onboarding.save().context("Failed to save onboarding config")?;
 
+    // Statusline wiring step. Only prompts in interactive Text mode AND
+    // only when the user hasn't already made a decision — `Unset` is the
+    // only state that re-prompts on a follow-up `ainb init` run.
+    if matches!(format, OutputFormat::Text) {
+        let _ = run_statusline_step(&mut std::io::stdin().lock(), &mut std::io::stdout().lock());
+    }
+
     match format {
         OutputFormat::Json => {
             let output = serde_json::json!({
@@ -426,6 +433,209 @@ fn cmd_reset(force: bool, format: OutputFormat) -> Result<()> {
     }
 
     Ok(())
+}
+
+// --- Statusline prompt -------------------------------------------------------
+
+/// Outcome of the statusline wizard step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatuslineStepOutcome {
+    /// Step skipped entirely (already wired, or user previously decided).
+    Skipped,
+    /// User accepted; we ran the install.
+    Installed,
+    /// User accepted "chain" against an existing command.
+    Chained,
+    /// User declined; we record `Declined` so we don't re-prompt.
+    Declined,
+    /// User chose "keep" their existing different statusline.
+    Kept,
+}
+
+/// Drive the statusline wizard step against a `BufRead` + `Write` pair.
+/// Pure on its IO so tests can drive it with in-memory buffers.
+pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
+    input: &mut R,
+    out: &mut W,
+) -> Result<StatuslineStepOutcome> {
+    use crate::cli::statusline_install::{
+        InstallOutcome, StatuslineStatus, detect_statusline_status, install_statusline,
+        install_statusline_chained_at, install_statusline_replace_at, settings_path,
+    };
+    use crate::config::StatuslineDecision;
+
+    let mut app_config = AppConfig::load().unwrap_or_default();
+    if app_config.ui_preferences.statusline_decision != StatuslineDecision::Unset {
+        // User already made a choice — don't re-prompt.
+        return Ok(StatuslineStepOutcome::Skipped);
+    }
+
+    let status = detect_statusline_status().unwrap_or(StatuslineStatus::NotConfigured);
+
+    match status {
+        StatuslineStatus::Configured => {
+            writeln!(out, "  ✓ Claude Code statusline already wired.").ok();
+            app_config.ui_preferences.statusline_decision = StatuslineDecision::Installed;
+            let _ = app_config.save();
+            Ok(StatuslineStepOutcome::Skipped)
+        }
+        StatuslineStatus::Other(cmd) => {
+            writeln!(out).ok();
+            writeln!(out, "Existing Claude Code statusline detected: {cmd}").ok();
+            writeln!(
+                out,
+                "  [k]eep your current command  [r]eplace with ainb statusline"
+            )
+            .ok();
+            writeln!(
+                out,
+                "  [c]hain ('{cmd} | ainb statusline')   [s]kip for now"
+            )
+            .ok();
+            write!(out, "Choice [k/r/c/s]: ").ok();
+            out.flush().ok();
+            let choice = read_choice(input)?;
+            let path = settings_path()?;
+            match choice.as_str() {
+                "r" => {
+                    install_statusline_replace_at(&path)?;
+                    app_config.ui_preferences.statusline_decision = StatuslineDecision::Installed;
+                    let _ = app_config.save();
+                    writeln!(out, "  ✓ Replaced existing statusline.").ok();
+                    Ok(StatuslineStepOutcome::Installed)
+                }
+                "c" => {
+                    install_statusline_chained_at(&path)?;
+                    app_config.ui_preferences.statusline_decision = StatuslineDecision::Chained;
+                    let _ = app_config.save();
+                    writeln!(
+                        out,
+                        "  ✓ Chained ainb statusline onto your existing command."
+                    )
+                    .ok();
+                    Ok(StatuslineStepOutcome::Chained)
+                }
+                "k" => {
+                    // Treat "keep" as Declined for top-bar suppression
+                    // but leave settings.json untouched.
+                    app_config.ui_preferences.statusline_decision = StatuslineDecision::Declined;
+                    let _ = app_config.save();
+                    writeln!(out, "  Keeping your existing statusline. (You can wire ainb later via the Budget panel.)").ok();
+                    Ok(StatuslineStepOutcome::Kept)
+                }
+                _ => {
+                    writeln!(out, "  Skipped — leave decision unset.").ok();
+                    Ok(StatuslineStepOutcome::Skipped)
+                }
+            }
+        }
+        StatuslineStatus::NotConfigured => {
+            print_install_offer(out);
+            write!(out, "Install? [Y/n/s] (s = show example): ").ok();
+            out.flush().ok();
+            let mut choice = read_choice(input)?;
+            // Loop the "show me" path a single time; defensible UX.
+            if choice == "s" {
+                writeln!(out).ok();
+                writeln!(out, "Example powerline output:").ok();
+                writeln!(
+                    out,
+                    "  {}",
+                    crate::cli::statusline::render_powerline(&example_cache())
+                )
+                .ok();
+                writeln!(out).ok();
+                write!(out, "Install? [Y/n]: ").ok();
+                out.flush().ok();
+                choice = read_choice(input)?;
+            }
+            match choice.as_str() {
+                "n" => {
+                    app_config.ui_preferences.statusline_decision = StatuslineDecision::Declined;
+                    let _ = app_config.save();
+                    writeln!(out, "  Skipped statusline wiring.").ok();
+                    Ok(StatuslineStepOutcome::Declined)
+                }
+                _ => {
+                    // Default to install on empty input or "y".
+                    match install_statusline()? {
+                        InstallOutcome::Installed | InstallOutcome::AlreadyInstalled => {
+                            app_config.ui_preferences.statusline_decision =
+                                StatuslineDecision::Installed;
+                            let _ = app_config.save();
+                            writeln!(out, "  ✓ Wired Claude Code statusline.").ok();
+                            Ok(StatuslineStepOutcome::Installed)
+                        }
+                        InstallOutcome::Chained => {
+                            app_config.ui_preferences.statusline_decision =
+                                StatuslineDecision::Chained;
+                            let _ = app_config.save();
+                            writeln!(out, "  ✓ Chained ainb statusline.").ok();
+                            Ok(StatuslineStepOutcome::Chained)
+                        }
+                        InstallOutcome::ExistingDifferent { current_command } => {
+                            // Race: someone wrote a different statusLine
+                            // between our detect and install. Don't
+                            // overwrite without consent.
+                            writeln!(
+                                out,
+                                "  Detected a foreign statusline ({current_command}); skipping."
+                            )
+                            .ok();
+                            Ok(StatuslineStepOutcome::Skipped)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn print_install_offer<W: std::io::Write>(out: &mut W) {
+    writeln!(out).ok();
+    writeln!(out, "Claude Code statusline").ok();
+    writeln!(out, "  ainb can install a statusline that shows live:").ok();
+    writeln!(out, "    - Current model + context %").ok();
+    writeln!(out, "    - 5-hour rate window % + 7-day window %").ok();
+    writeln!(out, "    - Today's spend (USD)").ok();
+    writeln!(out, "    - Reset countdown").ok();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "  Same data as Claude Code's /usage, rendered live in your terminal prompt."
+    )
+    .ok();
+    writeln!(
+        out,
+        "  ainb-tui's Budget panel + session window read from the same cache."
+    )
+    .ok();
+    writeln!(out).ok();
+}
+
+fn example_cache() -> crate::cli::statusline::LiveCache {
+    use crate::cli::statusline::{CACHE_SCHEMA_VERSION, LiveCache, RateWindow};
+    LiveCache {
+        version: CACHE_SCHEMA_VERSION,
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        five_hour: Some(RateWindow {
+            pct: 12,
+            resets_at: None,
+        }),
+        seven_day: Some(RateWindow {
+            pct: 3,
+            resets_at: None,
+        }),
+        today_cost_usd: Some(4.21),
+        context_pct: Some(32),
+        model: Some("Opus 4.7".to_string()),
+    }
+}
+
+fn read_choice<R: std::io::BufRead>(input: &mut R) -> Result<String> {
+    let mut line = String::new();
+    input.read_line(&mut line)?;
+    Ok(line.trim().to_lowercase())
 }
 
 // --- Tests ------------------------------------------------------------------
@@ -612,5 +822,99 @@ mod tests {
         assert_eq!(json["status"], "ok");
         assert_eq!(json["path"], "/fake/bin/tmux");
         assert_eq!(json["required"], true);
+    }
+
+    // --- statusline wizard step ---
+
+    /// Helper: run `run_statusline_step` with a HOME pointing at a tmpdir
+    /// so settings.json mutations don't touch the real ~/.claude.
+    fn run_step_with_home(input: &str) -> (StatuslineStepOutcome, String, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        // Single-process tests: HOME is process-global so this races
+        // with parallel tests. Tests in this module that mutate HOME
+        // are gated behind a shared mutex below.
+        let _guard = HOME_MUTEX.lock().unwrap();
+        std::env::set_var("HOME", dir.path());
+        // Also redirect XDG_CACHE_HOME if it would otherwise leak.
+        let prev_xdg = std::env::var("XDG_CACHE_HOME").ok();
+        std::env::set_var("XDG_CACHE_HOME", dir.path().join("cache"));
+        // Keep tmpdir alive for duration of test
+        let path = dir.path().to_path_buf();
+        std::mem::forget(dir);
+        let mut input_buf = std::io::Cursor::new(input.as_bytes().to_vec());
+        let mut out = Vec::new();
+        let outcome = run_statusline_step(&mut input_buf, &mut out).unwrap();
+        // Restore env to avoid leaking into other tests.
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
+            None => std::env::remove_var("XDG_CACHE_HOME"),
+        }
+        (outcome, String::from_utf8(out).unwrap(), path)
+    }
+
+    static HOME_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn print_install_offer_mentions_all_promised_fields() {
+        let mut buf = Vec::new();
+        print_install_offer(&mut buf);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("model"));
+        assert!(s.contains("context"));
+        assert!(s.contains("5-hour"));
+        assert!(s.contains("7-day"));
+        assert!(s.contains("spend"));
+        assert!(s.contains("Reset"));
+    }
+
+    #[test]
+    fn read_choice_lowercases_and_trims() {
+        let mut input = std::io::Cursor::new(b"  Y \n".to_vec());
+        let v = read_choice(&mut input).unwrap();
+        assert_eq!(v, "y");
+    }
+
+    #[test]
+    fn statusline_step_decline_path_persists_decision() {
+        let (outcome, output, home) = run_step_with_home("n\n");
+        assert_eq!(outcome, StatuslineStepOutcome::Declined);
+        assert!(output.contains("Skipped"));
+
+        // settings.json should NOT have been written
+        let settings = home.join(".claude").join("settings.json");
+        assert!(
+            !settings.exists(),
+            "decline path must not write settings.json"
+        );
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn statusline_step_install_path_writes_settings() {
+        let (outcome, output, home) = run_step_with_home("y\n");
+        assert_eq!(outcome, StatuslineStepOutcome::Installed);
+        assert!(output.contains("Wired"));
+        let settings = home.join(".claude").join("settings.json");
+        assert!(settings.exists());
+        let contents = std::fs::read_to_string(&settings).unwrap();
+        assert!(contents.contains("ainb statusline"));
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn statusline_step_show_example_then_install() {
+        // First "s" shows example, second "y" installs.
+        let (outcome, output, home) = run_step_with_home("s\ny\n");
+        assert_eq!(outcome, StatuslineStepOutcome::Installed);
+        assert!(output.contains("Example powerline"));
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -17,6 +17,7 @@ pub mod presets;
 pub mod recover;
 pub mod run;
 pub mod status;
+pub mod statusline;
 pub mod usage;
 pub mod util;
 
@@ -146,6 +147,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: usage::UsageCommands,
     },
+
+    /// Claude Code statusline hook: read JSON on stdin, cache rate-limit
+    /// windows for the TUI, and emit a powerline status string on stdout.
+    /// Wire into `~/.claude/settings.json` as the `statusLine.command`.
+    Statusline,
 
     /// Generate shell completions (bash, zsh, fish, powershell, elvish)
     Completion {

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub mod recover;
 pub mod run;
 pub mod status;
 pub mod statusline;
+pub mod statusline_install;
 pub mod usage;
 pub mod util;
 

--- a/ainb-tui/src/cli/statusline.rs
+++ b/ainb-tui/src/cli/statusline.rs
@@ -2,8 +2,10 @@
 //
 // Reads JSON on stdin (the statusline payload Claude Code feeds to its
 // statusLine.command), persists the rate-limit window data to a cache file
-// at `~/.cache/ainb/live.json`, and emits a single-line powerline-styled
-// status string on stdout for the user's prompt.
+// in the OS-specific cache dir (via `dirs::cache_dir()`, e.g.
+// `~/.cache/ainb/live.json` on Linux, `~/Library/Caches/ainb/live.json`
+// on macOS), and emits a single-line powerline-styled status string on
+// stdout for the user's prompt.
 //
 // Design constraints (the statusline runs on every prompt render):
 //   - Must NEVER panic. All fallible operations swallow errors and emit
@@ -20,7 +22,8 @@ use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-/// Schema version for `~/.cache/ainb/live.json`.
+/// Schema version for the live cache file (resolved via
+/// [`cache_path`] — OS-specific cache dir).
 pub const CACHE_SCHEMA_VERSION: u32 = 1;
 
 /// One side of a rate-limit window (used twice: 5h + 7d).
@@ -33,7 +36,9 @@ pub struct RateWindow {
     pub resets_at: Option<String>,
 }
 
-/// On-disk cache schema for `~/.cache/ainb/live.json`.
+/// On-disk cache schema for the live cache file (resolved via
+/// [`cache_path`] — OS-specific cache dir, e.g. `~/.cache/ainb/live.json`
+/// on Linux, `~/Library/Caches/ainb/live.json` on macOS).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LiveCache {
     pub version: u32,
@@ -51,8 +56,10 @@ pub struct LiveCache {
     pub model: Option<String>,
 }
 
-/// Resolve `~/.cache/ainb/live.json`. Returns `None` if no cache dir is
-/// available (mostly a guard for sandbox environments without a HOME).
+/// Resolve the OS-specific cache file path (via `dirs::cache_dir()`,
+/// e.g. `~/.cache/ainb/live.json` on Linux, `~/Library/Caches/ainb/live.json`
+/// on macOS). Returns `None` if no cache dir is available (mostly a
+/// guard for sandbox environments without a HOME).
 pub fn cache_path() -> Option<PathBuf> {
     let dir = dirs::cache_dir().or_else(|| dirs::home_dir().map(|h| h.join(".cache")))?;
     Some(dir.join("ainb").join("live.json"))

--- a/ainb-tui/src/cli/statusline.rs
+++ b/ainb-tui/src/cli/statusline.rs
@@ -1,0 +1,403 @@
+// ABOUTME: `ainb statusline` subcommand for the Claude Code statusline hook.
+//
+// Reads JSON on stdin (the statusline payload Claude Code feeds to its
+// statusLine.command), persists the rate-limit window data to a cache file
+// at `~/.cache/ainb/live.json`, and emits a single-line powerline-styled
+// status string on stdout for the user's prompt.
+//
+// Design constraints (the statusline runs on every prompt render):
+//   - Must NEVER panic. All fallible operations swallow errors and emit
+//     either a minimal status line or an empty line.
+//   - Must be cheap. No network, no heavy parsing.
+//   - Cache writes are atomic (write-tmp + rename) so a killed process
+//     can never leave a half-written file.
+//
+// The cache schema is intentionally narrow and uses `serde_json::Value`
+// on input so we don't break when Claude Code adds new fields.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+/// Schema version for `~/.cache/ainb/live.json`.
+pub const CACHE_SCHEMA_VERSION: u32 = 1;
+
+/// One side of a rate-limit window (used twice: 5h + 7d).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RateWindow {
+    /// Used percentage, 0..=100.
+    pub pct: u8,
+    /// ISO8601 reset timestamp as reported by Claude Code (passed through).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at: Option<String>,
+}
+
+/// On-disk cache schema for `~/.cache/ainb/live.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LiveCache {
+    pub version: u32,
+    /// ISO8601 timestamp of when this cache entry was written.
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub five_hour: Option<RateWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day: Option<RateWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub today_cost_usd: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_pct: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Resolve `~/.cache/ainb/live.json`. Returns `None` if no cache dir is
+/// available (mostly a guard for sandbox environments without a HOME).
+pub fn cache_path() -> Option<PathBuf> {
+    let dir = dirs::cache_dir().or_else(|| dirs::home_dir().map(|h| h.join(".cache")))?;
+    Some(dir.join("ainb").join("live.json"))
+}
+
+/// Parse a Claude Code statusline payload from raw stdin bytes into a
+/// `LiveCache`. Returns `None` if the payload is empty or not valid JSON
+/// (the statusline must degrade gracefully — see module docs).
+pub fn parse_payload(raw: &[u8]) -> Option<LiveCache> {
+    let text = std::str::from_utf8(raw).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+    Some(payload_to_cache(&value))
+}
+
+fn payload_to_cache(value: &serde_json::Value) -> LiveCache {
+    let five_hour = value.pointer("/rate_limits/five_hour").and_then(rate_window_from_value);
+    let seven_day = value.pointer("/rate_limits/seven_day").and_then(rate_window_from_value);
+    let today_cost_usd = value.pointer("/cost/total_cost_usd").and_then(serde_json::Value::as_f64);
+    let context_pct = value
+        .pointer("/context_window/used_percentage")
+        .and_then(serde_json::Value::as_f64)
+        .map(round_pct);
+    let model = value
+        .pointer("/model/display_name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+
+    LiveCache {
+        version: CACHE_SCHEMA_VERSION,
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        five_hour,
+        seven_day,
+        today_cost_usd,
+        context_pct,
+        model,
+    }
+}
+
+fn rate_window_from_value(value: &serde_json::Value) -> Option<RateWindow> {
+    let pct = value
+        .get("used_percentage")
+        .and_then(serde_json::Value::as_f64)
+        .map(round_pct)?;
+    let resets_at = value.get("resets_at").and_then(serde_json::Value::as_str).map(str::to_string);
+    Some(RateWindow { pct, resets_at })
+}
+
+fn round_pct(p: f64) -> u8 {
+    p.clamp(0.0, 100.0).round() as u8
+}
+
+/// Atomically write a `LiveCache` to `path` (via `<path>.tmp` + rename).
+/// Creates the parent directory if needed. Best-effort: returns `Err` on
+/// IO failure but the caller is expected to swallow.
+pub fn write_cache(path: &std::path::Path, cache: &LiveCache) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        match std::fs::create_dir_all(parent) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    let json = serde_json::to_vec_pretty(cache)?;
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(&json)?;
+        f.sync_all().ok();
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Read a `LiveCache` from disk if present and parseable. Returns `None`
+/// for missing files, IO errors, malformed JSON, or version mismatches.
+pub fn read_cache(path: &std::path::Path) -> Option<LiveCache> {
+    let bytes = std::fs::read(path).ok()?;
+    let cache: LiveCache = serde_json::from_slice(&bytes).ok()?;
+    if cache.version != CACHE_SCHEMA_VERSION {
+        return None;
+    }
+    Some(cache)
+}
+
+/// Render the powerline-styled status string. Hand-rolled ANSI escapes
+/// keep this dependency-free. The format is intentionally plain (no
+/// nerd-font glyphs) so it works in any terminal.
+pub fn render_powerline(cache: &LiveCache) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    if let Some(model) = &cache.model {
+        parts.push(ansi_fg(SOFT_WHITE, model));
+    }
+
+    if let Some(ctx) = cache.context_pct {
+        parts.push(format!(
+            "{} {}%",
+            ansi_fg(MUTED, "ctx"),
+            ansi_fg(pct_color(ctx, 60, 85), &ctx.to_string())
+        ));
+    }
+
+    if let Some(rw) = &cache.five_hour {
+        parts.push(format!(
+            "{} {}%",
+            ansi_fg(MUTED, "5h"),
+            ansi_fg(pct_color(rw.pct, 60, 85), &rw.pct.to_string())
+        ));
+    }
+
+    if let Some(rw) = &cache.seven_day {
+        parts.push(format!(
+            "{} {}%",
+            ansi_fg(MUTED, "wk"),
+            ansi_fg(pct_color(rw.pct, 70, 90), &rw.pct.to_string())
+        ));
+    }
+
+    if let Some(cost) = cache.today_cost_usd {
+        parts.push(ansi_fg(GOLD, &format!("${cost:.2}")));
+    }
+
+    parts.join(&format!(" {} ", ansi_fg(MUTED, "·")))
+}
+
+// Hand-rolled ANSI 24-bit escape sequences. Avoid pulling in a colored
+// crate just for the few escapes the powerline needs.
+const RESET: &str = "\x1b[0m";
+const SOFT_WHITE: (u8, u8, u8) = (220, 220, 230);
+const MUTED: (u8, u8, u8) = (120, 120, 140);
+const GOLD: (u8, u8, u8) = (255, 215, 0);
+const GREEN: (u8, u8, u8) = (100, 200, 100);
+const AMBER: (u8, u8, u8) = (255, 165, 0);
+const RED: (u8, u8, u8) = (230, 100, 100);
+
+fn ansi_fg(rgb: (u8, u8, u8), text: &str) -> String {
+    format!("\x1b[38;2;{};{};{}m{}{}", rgb.0, rgb.1, rgb.2, text, RESET)
+}
+
+fn pct_color(pct: u8, amber_at: u8, red_at: u8) -> (u8, u8, u8) {
+    if pct >= red_at {
+        RED
+    } else if pct >= amber_at {
+        AMBER
+    } else {
+        GREEN
+    }
+}
+
+/// Subcommand entry point. Reads stdin to EOF, persists the cache, and
+/// prints a status string to stdout. Catches all errors and degrades to
+/// an empty line — the statusline runs every prompt render.
+pub fn execute() -> Result<()> {
+    let mut buf = Vec::new();
+    let _ = std::io::stdin().read_to_end(&mut buf);
+
+    match parse_payload(&buf) {
+        Some(cache) => {
+            if let Some(path) = cache_path() {
+                let _ = write_cache(&path, &cache);
+            }
+            // Newline so it integrates cleanly with shell prompt drawing.
+            println!("{}", render_powerline(&cache));
+        }
+        None => {
+            // Empty stdin or malformed JSON — emit nothing rather than
+            // pollute the user's prompt.
+            println!();
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_payload_returns_none_for_empty_stdin() {
+        assert!(parse_payload(b"").is_none());
+        assert!(parse_payload(b"   \n\t  ").is_none());
+    }
+
+    #[test]
+    fn parse_payload_returns_none_for_malformed_json() {
+        assert!(parse_payload(b"not json").is_none());
+        assert!(parse_payload(b"{unterminated").is_none());
+    }
+
+    #[test]
+    fn parse_payload_full_schema_populates_all_fields() {
+        let raw = br#"{
+            "model": {"display_name": "Opus 4.7"},
+            "context_window": {"used_percentage": 32.4},
+            "rate_limits": {
+                "five_hour": {"used_percentage": 12.1, "resets_at": "2026-05-07T00:00:00Z"},
+                "seven_day": {"used_percentage": 3.0, "resets_at": "2026-05-13T00:00:00Z"}
+            },
+            "cost": {"total_cost_usd": 4.21}
+        }"#;
+        let cache = parse_payload(raw).expect("should parse");
+        assert_eq!(cache.version, CACHE_SCHEMA_VERSION);
+        assert_eq!(cache.model.as_deref(), Some("Opus 4.7"));
+        assert_eq!(cache.context_pct, Some(32));
+        assert_eq!(cache.five_hour.as_ref().unwrap().pct, 12);
+        assert_eq!(
+            cache.five_hour.as_ref().unwrap().resets_at.as_deref(),
+            Some("2026-05-07T00:00:00Z")
+        );
+        assert_eq!(cache.seven_day.as_ref().unwrap().pct, 3);
+        assert_eq!(cache.today_cost_usd, Some(4.21));
+    }
+
+    #[test]
+    fn parse_payload_partial_only_fills_present_fields() {
+        let raw = br#"{
+            "rate_limits": {
+                "five_hour": {"used_percentage": 50}
+            }
+        }"#;
+        let cache = parse_payload(raw).expect("should parse");
+        assert!(cache.model.is_none());
+        assert!(cache.context_pct.is_none());
+        assert!(cache.today_cost_usd.is_none());
+        assert!(cache.seven_day.is_none());
+        let fh = cache.five_hour.unwrap();
+        assert_eq!(fh.pct, 50);
+        assert!(fh.resets_at.is_none());
+    }
+
+    #[test]
+    fn round_pct_clamps_and_rounds() {
+        assert_eq!(round_pct(0.0), 0);
+        assert_eq!(round_pct(0.4), 0);
+        assert_eq!(round_pct(0.6), 1);
+        assert_eq!(round_pct(99.5), 100);
+        assert_eq!(round_pct(150.0), 100);
+        assert_eq!(round_pct(-5.0), 0);
+    }
+
+    #[test]
+    fn write_cache_is_atomic_and_roundtrips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("live.json");
+        let cache = LiveCache {
+            version: CACHE_SCHEMA_VERSION,
+            updated_at: "2026-05-07T00:00:00Z".to_string(),
+            five_hour: Some(RateWindow {
+                pct: 42,
+                resets_at: Some("2026-05-07T05:00:00Z".to_string()),
+            }),
+            seven_day: None,
+            today_cost_usd: Some(1.23),
+            context_pct: Some(20),
+            model: Some("Sonnet 4.5".to_string()),
+        };
+        write_cache(&path, &cache).unwrap();
+
+        // No leftover .tmp file
+        let tmp = path.with_extension("json.tmp");
+        assert!(!tmp.exists(), "tmp should be renamed away");
+
+        let read = read_cache(&path).expect("should read back");
+        assert_eq!(read, cache);
+    }
+
+    #[test]
+    fn read_cache_rejects_wrong_schema_version() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("live.json");
+        let mut bad = LiveCache {
+            version: 999,
+            updated_at: "2026-05-07T00:00:00Z".to_string(),
+            five_hour: None,
+            seven_day: None,
+            today_cost_usd: None,
+            context_pct: None,
+            model: None,
+        };
+        bad.version = 999;
+        std::fs::write(&path, serde_json::to_vec(&bad).unwrap()).unwrap();
+        assert!(read_cache(&path).is_none());
+    }
+
+    #[test]
+    fn read_cache_returns_none_for_missing_file() {
+        let dir = tempdir().unwrap();
+        assert!(read_cache(&dir.path().join("nope.json")).is_none());
+    }
+
+    #[test]
+    fn render_powerline_emits_each_present_field() {
+        let cache = LiveCache {
+            version: CACHE_SCHEMA_VERSION,
+            updated_at: "2026-05-07T00:00:00Z".to_string(),
+            five_hour: Some(RateWindow {
+                pct: 90,
+                resets_at: None,
+            }),
+            seven_day: Some(RateWindow {
+                pct: 50,
+                resets_at: None,
+            }),
+            today_cost_usd: Some(2.5),
+            context_pct: Some(45),
+            model: Some("Opus".to_string()),
+        };
+        let line = render_powerline(&cache);
+        assert!(line.contains("Opus"));
+        assert!(line.contains("ctx"));
+        assert!(line.contains("45"));
+        assert!(line.contains("5h"));
+        assert!(line.contains("90"));
+        assert!(line.contains("wk"));
+        assert!(line.contains("$2.50"));
+    }
+
+    #[test]
+    fn render_powerline_minimal_for_empty_cache() {
+        let cache = LiveCache {
+            version: CACHE_SCHEMA_VERSION,
+            updated_at: "2026-05-07T00:00:00Z".to_string(),
+            five_hour: None,
+            seven_day: None,
+            today_cost_usd: None,
+            context_pct: None,
+            model: None,
+        };
+        // Just don't panic; result may be empty string.
+        let _ = render_powerline(&cache);
+    }
+
+    #[test]
+    fn pct_color_thresholds_5h() {
+        // 5h thresholds are amber=60, red=85
+        assert_eq!(pct_color(0, 60, 85), GREEN);
+        assert_eq!(pct_color(59, 60, 85), GREEN);
+        assert_eq!(pct_color(60, 60, 85), AMBER);
+        assert_eq!(pct_color(84, 60, 85), AMBER);
+        assert_eq!(pct_color(85, 60, 85), RED);
+        assert_eq!(pct_color(100, 60, 85), RED);
+    }
+}

--- a/ainb-tui/src/cli/statusline_install.rs
+++ b/ainb-tui/src/cli/statusline_install.rs
@@ -136,7 +136,6 @@ pub fn install_statusline_at(path: &Path) -> Result<InstallOutcome> {
             current_command: current,
         }),
         StatuslineStatus::NotConfigured => {
-            backup(path)?;
             // Preserve every other key — only set `statusLine`.
             if let Some(obj) = value.as_object_mut() {
                 obj.insert("statusLine".to_string(), block);
@@ -145,7 +144,7 @@ pub fn install_statusline_at(path: &Path) -> Result<InstallOutcome> {
                 // is malformed config from the user's POV).
                 value = serde_json::json!({ "statusLine": block });
             }
-            atomic_write_json(path, &value)?;
+            write_with_backup(path, &bytes, &value)?;
             Ok(InstallOutcome::Installed)
         }
     }
@@ -153,7 +152,8 @@ pub fn install_statusline_at(path: &Path) -> Result<InstallOutcome> {
 
 /// Replace whatever is in `statusLine.command` with our command. Caller
 /// must have made the keep/replace decision; this is the "replace"
-/// branch. Backs up first.
+/// branch. Backup is written *after* the new file lands successfully so
+/// a failed write cannot leave a stray `.bak` with no rewrite.
 pub fn install_statusline_replace_at(path: &Path) -> Result<InstallOutcome> {
     if !path.exists() {
         return install_statusline_at(path);
@@ -162,13 +162,12 @@ pub fn install_statusline_replace_at(path: &Path) -> Result<InstallOutcome> {
         std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
     let mut value: serde_json::Value = serde_json::from_slice(&bytes)
         .with_context(|| format!("failed to parse {}", path.display()))?;
-    backup(path)?;
     if let Some(obj) = value.as_object_mut() {
         obj.insert("statusLine".to_string(), our_block());
     } else {
         value = serde_json::json!({ "statusLine": our_block() });
     }
-    atomic_write_json(path, &value)?;
+    write_with_backup(path, &bytes, &value)?;
     Ok(InstallOutcome::Installed)
 }
 
@@ -186,14 +185,43 @@ fn our_block() -> serde_json::Value {
 /// time.
 const MAX_BACKUPS: usize = 3;
 
-fn backup(path: &Path) -> Result<()> {
+/// Write `new_value` to `path` atomically, then write `prev_bytes` (the
+/// in-memory snapshot of the previous on-disk contents) to a sibling
+/// `<path>.bak.<unix-ts>` and prune older backups.
+///
+/// Backup-after-write ordering matters: if the new write fails (disk
+/// full, permissions, rename race), no `.bak` is left behind. If the
+/// new write succeeds but the backup write fails we swallow the error
+/// and log — the new file is the important artefact, and a missing
+/// backup is recoverable through normal version control.
+fn write_with_backup(
+    path: &Path,
+    prev_bytes: &[u8],
+    new_value: &serde_json::Value,
+) -> Result<()> {
+    atomic_write_json(path, new_value)?;
+    if let Err(e) = write_backup_from_bytes(path, prev_bytes) {
+        tracing::warn!(
+            "wrote {} but failed to record backup: {}",
+            path.display(),
+            e
+        );
+    }
+    Ok(())
+}
+
+/// Write `prev_bytes` to a `<path>.bak.<unix-ts>` file and prune older
+/// backups. Used by `write_with_backup` after a successful new-file
+/// write — the bytes are the *previous* on-disk contents captured
+/// before the write.
+fn write_backup_from_bytes(path: &Path, prev_bytes: &[u8]) -> Result<()> {
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let bak = path.with_extension(format!("json.bak.{ts}"));
-    std::fs::copy(path, &bak)
-        .with_context(|| format!("failed to back up {} -> {}", path.display(), bak.display()))?;
+    std::fs::write(&bak, prev_bytes)
+        .with_context(|| format!("failed to write backup {}", bak.display()))?;
     prune_old_backups(path, MAX_BACKUPS);
     Ok(())
 }

--- a/ainb-tui/src/cli/statusline_install.rs
+++ b/ainb-tui/src/cli/statusline_install.rs
@@ -4,7 +4,7 @@
 // Idempotency story:
 //   - If our block is already present we no-op (`AlreadyInstalled`).
 //   - If a different statusLine command is present we report it and let
-//     the caller decide keep/replace/chain — we never silently overwrite.
+//     the caller decide keep/replace — we never silently overwrite.
 //   - All writes are preceded by a backup at `settings.json.bak.<unix-ts>`
 //     so the user can always restore the prior config.
 
@@ -22,17 +22,14 @@ pub enum InstallOutcome {
     /// Our block was already present; nothing changed.
     AlreadyInstalled,
     /// A different statusLine command was present; we did NOT overwrite.
-    /// The caller decides keep / replace / chain based on the value.
+    /// The caller decides keep / replace based on the value.
     ExistingDifferent { current_command: String },
-    /// We chained our command onto the existing one (`existing | ainb ...`).
-    /// Returned only by `install_statusline_chained`.
-    Chained,
 }
 
 /// Status of the user's statusline configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StatuslineStatus {
-    /// Either `ainb statusline` is wired, or our chained variant is.
+    /// `ainb statusline` is wired as the sole statusLine command.
     Configured,
     /// No statusLine block at all.
     NotConfigured,
@@ -77,11 +74,7 @@ fn classify_status(value: &serde_json::Value) -> StatuslineStatus {
 }
 
 fn command_is_ours(cmd: &str) -> bool {
-    let trimmed = cmd.trim();
-    trimmed == AINB_STATUSLINE_CMD
-        // Chained variant: `existing | ainb statusline`
-        || trimmed.ends_with(&format!("| {AINB_STATUSLINE_CMD}"))
-        || trimmed.ends_with(&format!("|{AINB_STATUSLINE_CMD}"))
+    cmd.trim() == AINB_STATUSLINE_CMD
 }
 
 /// Has the cache file been written within `max_age_secs`?
@@ -159,7 +152,7 @@ pub fn install_statusline_at(path: &Path) -> Result<InstallOutcome> {
 }
 
 /// Replace whatever is in `statusLine.command` with our command. Caller
-/// must have made the keep/replace/chain decision; this is the "replace"
+/// must have made the keep/replace decision; this is the "replace"
 /// branch. Backs up first.
 pub fn install_statusline_replace_at(path: &Path) -> Result<InstallOutcome> {
     if !path.exists() {
@@ -177,48 +170,6 @@ pub fn install_statusline_replace_at(path: &Path) -> Result<InstallOutcome> {
     }
     atomic_write_json(path, &value)?;
     Ok(InstallOutcome::Installed)
-}
-
-/// Chain mode: rewrite `statusLine.command` to `<existing> | ainb statusline`.
-/// No-ops with `AlreadyInstalled` if we're already chained or already the
-/// sole command.
-pub fn install_statusline_chained_at(path: &Path) -> Result<InstallOutcome> {
-    if !path.exists() {
-        return install_statusline_at(path);
-    }
-    let bytes =
-        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
-        .with_context(|| format!("failed to parse {}", path.display()))?;
-
-    let current = value
-        .pointer("/statusLine/command")
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
-
-    let Some(current) = current else {
-        // Nothing to chain onto — fall back to plain install.
-        return install_statusline_at(path);
-    };
-
-    if command_is_ours(&current) {
-        return Ok(InstallOutcome::AlreadyInstalled);
-    }
-
-    backup(path)?;
-    let chained = format!("{current} | {AINB_STATUSLINE_CMD}");
-    if let Some(obj) = value.as_object_mut() {
-        obj.insert(
-            "statusLine".to_string(),
-            serde_json::json!({
-                "type": "command",
-                "command": chained,
-                "padding": 0,
-            }),
-        );
-    }
-    atomic_write_json(path, &value)?;
-    Ok(InstallOutcome::Chained)
 }
 
 fn our_block() -> serde_json::Value {
@@ -291,7 +242,9 @@ mod tests {
     }
 
     #[test]
-    fn detect_status_returns_configured_for_chained_variant() {
+    fn detect_status_returns_other_for_chained_command() {
+        // After dropping chain mode, a piped command is treated as a
+        // foreign command — caller must explicitly replace.
         let dir = tempdir().unwrap();
         let path = dir.path().join("settings.json");
         std::fs::write(
@@ -301,7 +254,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             detect_statusline_status_at(&path).unwrap(),
-            StatuslineStatus::Configured
+            StatuslineStatus::Other("~/bin/my-line.sh | ainb statusline".to_string())
         );
     }
 
@@ -415,26 +368,6 @@ mod tests {
         .unwrap();
         let outcome = install_statusline_replace_at(&path).unwrap();
         assert_eq!(outcome, InstallOutcome::Installed);
-        assert_eq!(
-            detect_statusline_status_at(&path).unwrap(),
-            StatuslineStatus::Configured
-        );
-    }
-
-    #[test]
-    fn chain_appends_pipe_to_existing() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("settings.json");
-        std::fs::write(
-            &path,
-            br#"{"statusLine":{"type":"command","command":"~/bin/foo"}}"#,
-        )
-        .unwrap();
-        let outcome = install_statusline_chained_at(&path).unwrap();
-        assert_eq!(outcome, InstallOutcome::Chained);
-        let bytes = std::fs::read(&path).unwrap();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(v["statusLine"]["command"], "~/bin/foo | ainb statusline");
         assert_eq!(
             detect_statusline_status_at(&path).unwrap(),
             StatuslineStatus::Configured

--- a/ainb-tui/src/cli/statusline_install.rs
+++ b/ainb-tui/src/cli/statusline_install.rs
@@ -1,0 +1,457 @@
+// ABOUTME: Helpers for wiring `ainb statusline` into Claude Code's
+// `~/.claude/settings.json`.
+//
+// Idempotency story:
+//   - If our block is already present we no-op (`AlreadyInstalled`).
+//   - If a different statusLine command is present we report it and let
+//     the caller decide keep/replace/chain — we never silently overwrite.
+//   - All writes are preceded by a backup at `settings.json.bak.<unix-ts>`
+//     so the user can always restore the prior config.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Command we install into Claude Code's `statusLine.command`.
+pub const AINB_STATUSLINE_CMD: &str = "ainb statusline";
+
+/// Outcome of an `install_statusline()` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallOutcome {
+    /// We wrote our block where there was none before.
+    Installed,
+    /// Our block was already present; nothing changed.
+    AlreadyInstalled,
+    /// A different statusLine command was present; we did NOT overwrite.
+    /// The caller decides keep / replace / chain based on the value.
+    ExistingDifferent { current_command: String },
+    /// We chained our command onto the existing one (`existing | ainb ...`).
+    /// Returned only by `install_statusline_chained`.
+    Chained,
+}
+
+/// Status of the user's statusline configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatuslineStatus {
+    /// Either `ainb statusline` is wired, or our chained variant is.
+    Configured,
+    /// No statusLine block at all.
+    NotConfigured,
+    /// Some other command is wired.
+    Other(String),
+}
+
+/// Resolve `~/.claude/settings.json`.
+pub fn settings_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("HOME not set; cannot resolve ~/.claude")?;
+    Ok(home.join(".claude").join("settings.json"))
+}
+
+/// Detect the current statusline configuration. Errors only on IO problems
+/// reading an existing settings.json — a missing file maps to `NotConfigured`.
+pub fn detect_statusline_status() -> Result<StatuslineStatus> {
+    let path = settings_path()?;
+    detect_statusline_status_at(&path)
+}
+
+/// Test seam: detect status from an explicit settings path.
+pub fn detect_statusline_status_at(path: &Path) -> Result<StatuslineStatus> {
+    if !path.exists() {
+        return Ok(StatuslineStatus::NotConfigured);
+    }
+    let bytes =
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(classify_status(&value))
+}
+
+fn classify_status(value: &serde_json::Value) -> StatuslineStatus {
+    let Some(cmd) = value.pointer("/statusLine/command").and_then(|v| v.as_str()) else {
+        return StatuslineStatus::NotConfigured;
+    };
+    if command_is_ours(cmd) {
+        StatuslineStatus::Configured
+    } else {
+        StatuslineStatus::Other(cmd.to_string())
+    }
+}
+
+fn command_is_ours(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    trimmed == AINB_STATUSLINE_CMD
+        // Chained variant: `existing | ainb statusline`
+        || trimmed.ends_with(&format!("| {AINB_STATUSLINE_CMD}"))
+        || trimmed.ends_with(&format!("|{AINB_STATUSLINE_CMD}"))
+}
+
+/// Has the cache file been written within `max_age_secs`?
+pub fn is_cache_fresh(max_age_secs: u64) -> bool {
+    let Some(path) = super::statusline::cache_path() else {
+        return false;
+    };
+    is_cache_fresh_at(&path, max_age_secs)
+}
+
+/// Test seam.
+pub fn is_cache_fresh_at(path: &Path, max_age_secs: u64) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    let Ok(elapsed) = modified.elapsed() else {
+        // System clock went backwards; treat as fresh — better than
+        // confusingly stale-flagging a file we just wrote.
+        return true;
+    };
+    elapsed.as_secs() <= max_age_secs
+}
+
+/// Install `ainb statusline` into `~/.claude/settings.json`.
+///
+/// See `InstallOutcome` for the four return states. Backs up any existing
+/// file to `settings.json.bak.<unix-ts>` before writing.
+pub fn install_statusline() -> Result<InstallOutcome> {
+    let path = settings_path()?;
+    install_statusline_at(&path)
+}
+
+/// Test seam: install at an explicit path.
+pub fn install_statusline_at(path: &Path) -> Result<InstallOutcome> {
+    let block = our_block();
+
+    // Case 1: file does not exist — create with just our block.
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let initial = serde_json::json!({ "statusLine": block });
+        atomic_write_json(path, &initial)?;
+        return Ok(InstallOutcome::Installed);
+    }
+
+    // Case 2: file exists — load, classify, decide.
+    let bytes =
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    match classify_status(&value) {
+        StatuslineStatus::Configured => Ok(InstallOutcome::AlreadyInstalled),
+        StatuslineStatus::Other(current) => Ok(InstallOutcome::ExistingDifferent {
+            current_command: current,
+        }),
+        StatuslineStatus::NotConfigured => {
+            backup(path)?;
+            // Preserve every other key — only set `statusLine`.
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert("statusLine".to_string(), block);
+            } else {
+                // Top-level wasn't an object — replace entire file (this
+                // is malformed config from the user's POV).
+                value = serde_json::json!({ "statusLine": block });
+            }
+            atomic_write_json(path, &value)?;
+            Ok(InstallOutcome::Installed)
+        }
+    }
+}
+
+/// Replace whatever is in `statusLine.command` with our command. Caller
+/// must have made the keep/replace/chain decision; this is the "replace"
+/// branch. Backs up first.
+pub fn install_statusline_replace_at(path: &Path) -> Result<InstallOutcome> {
+    if !path.exists() {
+        return install_statusline_at(path);
+    }
+    let bytes =
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    backup(path)?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("statusLine".to_string(), our_block());
+    } else {
+        value = serde_json::json!({ "statusLine": our_block() });
+    }
+    atomic_write_json(path, &value)?;
+    Ok(InstallOutcome::Installed)
+}
+
+/// Chain mode: rewrite `statusLine.command` to `<existing> | ainb statusline`.
+/// No-ops with `AlreadyInstalled` if we're already chained or already the
+/// sole command.
+pub fn install_statusline_chained_at(path: &Path) -> Result<InstallOutcome> {
+    if !path.exists() {
+        return install_statusline_at(path);
+    }
+    let bytes =
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    let current = value
+        .pointer("/statusLine/command")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let Some(current) = current else {
+        // Nothing to chain onto — fall back to plain install.
+        return install_statusline_at(path);
+    };
+
+    if command_is_ours(&current) {
+        return Ok(InstallOutcome::AlreadyInstalled);
+    }
+
+    backup(path)?;
+    let chained = format!("{current} | {AINB_STATUSLINE_CMD}");
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "statusLine".to_string(),
+            serde_json::json!({
+                "type": "command",
+                "command": chained,
+                "padding": 0,
+            }),
+        );
+    }
+    atomic_write_json(path, &value)?;
+    Ok(InstallOutcome::Chained)
+}
+
+fn our_block() -> serde_json::Value {
+    serde_json::json!({
+        "type": "command",
+        "command": AINB_STATUSLINE_CMD,
+        "padding": 0,
+    })
+}
+
+fn backup(path: &Path) -> Result<()> {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let bak = path.with_extension(format!("json.bak.{ts}"));
+    std::fs::copy(path, &bak)
+        .with_context(|| format!("failed to back up {} -> {}", path.display(), bak.display()))?;
+    Ok(())
+}
+
+fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &bytes).with_context(|| format!("failed to write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detect_status_returns_not_configured_for_missing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::NotConfigured
+        );
+    }
+
+    #[test]
+    fn detect_status_returns_not_configured_when_no_status_line_block() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, br#"{"theme":"dark"}"#).unwrap();
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::NotConfigured
+        );
+    }
+
+    #[test]
+    fn detect_status_returns_configured_for_our_command() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"ainb statusline"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Configured
+        );
+    }
+
+    #[test]
+    fn detect_status_returns_configured_for_chained_variant() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"~/bin/my-line.sh | ainb statusline"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Configured
+        );
+    }
+
+    #[test]
+    fn detect_status_returns_other_for_foreign_command() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"~/bin/my-line.sh"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Other("~/bin/my-line.sh".to_string())
+        );
+    }
+
+    #[test]
+    fn install_creates_file_when_absent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("settings.json");
+        let outcome = install_statusline_at(&path).unwrap();
+        assert_eq!(outcome, InstallOutcome::Installed);
+        assert!(path.exists());
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Configured
+        );
+    }
+
+    #[test]
+    fn install_merges_into_existing_file_preserving_keys() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"theme":"dark","mcpServers":{"foo":{"command":"foo"}}}"#,
+        )
+        .unwrap();
+
+        let outcome = install_statusline_at(&path).unwrap();
+        assert_eq!(outcome, InstallOutcome::Installed);
+
+        // Reload and verify other keys preserved
+        let bytes = std::fs::read(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["theme"], "dark");
+        assert!(v["mcpServers"].is_object());
+        assert_eq!(v["statusLine"]["command"], "ainb statusline");
+
+        // Backup created
+        let bak_count = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("settings.json.bak."))
+            .count();
+        assert_eq!(bak_count, 1, "exactly one backup should be created");
+    }
+
+    #[test]
+    fn install_is_idempotent_when_already_ours() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"ainb statusline","padding":0}}"#,
+        )
+        .unwrap();
+        let outcome = install_statusline_at(&path).unwrap();
+        assert_eq!(outcome, InstallOutcome::AlreadyInstalled);
+
+        // No backups created on no-op
+        let bak_count = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("settings.json.bak."))
+            .count();
+        assert_eq!(bak_count, 0);
+    }
+
+    #[test]
+    fn install_reports_existing_different_without_overwriting() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"~/bin/foo"}}"#,
+        )
+        .unwrap();
+        let outcome = install_statusline_at(&path).unwrap();
+        assert_eq!(
+            outcome,
+            InstallOutcome::ExistingDifferent {
+                current_command: "~/bin/foo".to_string()
+            }
+        );
+        // File untouched
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(std::str::from_utf8(&bytes).unwrap().contains("~/bin/foo"));
+    }
+
+    #[test]
+    fn replace_overwrites_existing_command() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"~/bin/foo"}}"#,
+        )
+        .unwrap();
+        let outcome = install_statusline_replace_at(&path).unwrap();
+        assert_eq!(outcome, InstallOutcome::Installed);
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Configured
+        );
+    }
+
+    #[test]
+    fn chain_appends_pipe_to_existing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"~/bin/foo"}}"#,
+        )
+        .unwrap();
+        let outcome = install_statusline_chained_at(&path).unwrap();
+        assert_eq!(outcome, InstallOutcome::Chained);
+        let bytes = std::fs::read(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["statusLine"]["command"], "~/bin/foo | ainb statusline");
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Configured
+        );
+    }
+
+    #[test]
+    fn is_cache_fresh_returns_false_for_missing_file() {
+        let dir = tempdir().unwrap();
+        assert!(!is_cache_fresh_at(&dir.path().join("nope"), 60));
+    }
+
+    #[test]
+    fn is_cache_fresh_returns_true_for_just_written_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("live.json");
+        std::fs::write(&path, b"{}").unwrap();
+        assert!(is_cache_fresh_at(&path, 60));
+    }
+}

--- a/ainb-tui/src/cli/statusline_install.rs
+++ b/ainb-tui/src/cli/statusline_install.rs
@@ -180,6 +180,12 @@ fn our_block() -> serde_json::Value {
     })
 }
 
+/// Maximum number of `settings.json.bak.*` files to retain alongside the
+/// settings file. Older backups are pruned (best-effort) on each new
+/// backup write so the directory does not accumulate stale copies over
+/// time.
+const MAX_BACKUPS: usize = 3;
+
 fn backup(path: &Path) -> Result<()> {
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -188,7 +194,43 @@ fn backup(path: &Path) -> Result<()> {
     let bak = path.with_extension(format!("json.bak.{ts}"));
     std::fs::copy(path, &bak)
         .with_context(|| format!("failed to back up {} -> {}", path.display(), bak.display()))?;
+    prune_old_backups(path, MAX_BACKUPS);
     Ok(())
+}
+
+/// Best-effort: keep only the `keep` newest `settings.json.bak.*` files
+/// in `path`'s parent directory. Errors are swallowed — a stale backup
+/// is clutter, not a correctness problem.
+fn prune_old_backups(path: &Path, keep: usize) {
+    let Some(parent) = path.parent() else { return };
+    let Some(stem) = path.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    // Match `<stem>.bak.<digits>` (we own this filename shape).
+    let prefix = format!("{stem}.bak.");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    let mut backups: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            let name = e.file_name();
+            let name_str = name.to_str()?;
+            if !name_str.starts_with(&prefix) {
+                return None;
+            }
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some((mtime, e.path()))
+        })
+        .collect();
+    if backups.len() <= keep {
+        return;
+    }
+    // Newest first.
+    backups.sort_by(|a, b| b.0.cmp(&a.0));
+    for (_, stale) in backups.into_iter().skip(keep) {
+        let _ = std::fs::remove_file(stale);
+    }
 }
 
 fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
@@ -372,6 +414,65 @@ mod tests {
             detect_statusline_status_at(&path).unwrap(),
             StatuslineStatus::Configured
         );
+    }
+
+    #[test]
+    fn prune_keeps_only_three_newest_backups() {
+        let dir = tempdir().unwrap();
+        let settings = dir.path().join("settings.json");
+        std::fs::write(&settings, b"{}").unwrap();
+
+        // Create five backup files with strictly-increasing mtimes so
+        // the test does not depend on filesystem listing order.
+        let now = std::time::SystemTime::now();
+        let mut paths = Vec::new();
+        for i in 0..5 {
+            let bak = dir.path().join(format!("settings.json.bak.{i}"));
+            std::fs::write(&bak, b"{}").unwrap();
+            // Older backups get older mtimes (i=0 oldest, i=4 newest).
+            let mtime = now - std::time::Duration::from_secs(60 * (5 - i as u64));
+            let f = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&bak)
+                .unwrap();
+            f.set_modified(mtime).unwrap();
+            paths.push(bak);
+        }
+
+        prune_old_backups(&settings, 3);
+
+        // The two oldest (i=0, i=1) should be gone; the three newest
+        // (i=2, i=3, i=4) should remain.
+        assert!(!paths[0].exists(), "oldest backup should be pruned");
+        assert!(!paths[1].exists(), "second-oldest backup should be pruned");
+        assert!(paths[2].exists(), "third-newest backup should remain");
+        assert!(paths[3].exists(), "second-newest backup should remain");
+        assert!(paths[4].exists(), "newest backup should remain");
+
+        // Sanity: only three backups left in the directory.
+        let remaining = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("settings.json.bak."))
+            .count();
+        assert_eq!(remaining, 3);
+    }
+
+    #[test]
+    fn prune_is_noop_when_under_threshold() {
+        let dir = tempdir().unwrap();
+        let settings = dir.path().join("settings.json");
+        std::fs::write(&settings, b"{}").unwrap();
+        for i in 0..2 {
+            std::fs::write(dir.path().join(format!("settings.json.bak.{i}")), b"{}").unwrap();
+        }
+        prune_old_backups(&settings, 3);
+        let remaining = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("settings.json.bak."))
+            .count();
+        assert_eq!(remaining, 2);
     }
 
     #[test]

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -4,7 +4,7 @@ use ratatui::{
     prelude::*,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, BorderType, Clear, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
 // Premium color palette (TUI Style Guide)
@@ -19,11 +19,11 @@ const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 
 use super::{
-    AgentSelectionComponent, AttachedTerminalComponent, AuthProviderPopupComponent, AuthSetupComponent, ClaudeChatComponent,
-    ConfigPopupComponent, ConfigScreenComponent, ConfirmationDialogComponent, HelpComponent, HomeScreenComponent,
-    HomeScreenV2Component, LogHistoryViewerComponent,
-    LiveLogsStreamComponent, LogsViewerComponent, NewSessionComponent, OnboardingComponent, SessionListComponent,
-    SetupMenuComponent, TmuxPreviewPane,
+    AgentSelectionComponent, AttachedTerminalComponent, AuthProviderPopupComponent,
+    AuthSetupComponent, ClaudeChatComponent, ConfigPopupComponent, ConfigScreenComponent,
+    ConfirmationDialogComponent, HelpComponent, HomeScreenComponent, HomeScreenV2Component,
+    LiveLogsStreamComponent, LogHistoryViewerComponent, LogsViewerComponent, NewSessionComponent,
+    OnboardingComponent, SessionListComponent, SetupMenuComponent, TmuxPreviewPane,
 };
 use crate::app::{AppState, state::View};
 
@@ -90,7 +90,13 @@ impl LayoutComponent {
         if state.current_view == View::SetupMenu {
             tracing::debug!("Rendering SetupMenu view");
             // First render the home screen as background
-            self.home_screen_v2.render_with_loading(frame, frame.size(), &mut state.home_screen_v2_state, &state.workspaces, state.is_loading_workspaces);
+            self.home_screen_v2.render_with_loading(
+                frame,
+                frame.size(),
+                &mut state.home_screen_v2_state,
+                &state.workspaces,
+                state.is_loading_workspaces,
+            );
             // Then render setup menu as overlay
             self.setup_menu.render(frame, frame.size(), &state.setup_menu_state);
             return;
@@ -120,7 +126,13 @@ impl LayoutComponent {
         // AINB 2.0: Home screen (full screen) - Now using V2 with sidebar and mascot
         if state.current_view == View::HomeScreen {
             tracing::debug!("Rendering HomeScreen V2 view");
-            self.home_screen_v2.render_with_loading(frame, frame.size(), &mut state.home_screen_v2_state, &state.workspaces, state.is_loading_workspaces);
+            self.home_screen_v2.render_with_loading(
+                frame,
+                frame.size(),
+                &mut state.home_screen_v2_state,
+                &state.workspaces,
+                state.is_loading_workspaces,
+            );
             // Render help overlay on top if visible
             if state.help_visible {
                 tracing::debug!("Rendering help overlay on HomeScreen");
@@ -169,7 +181,8 @@ impl LayoutComponent {
         // AINB 2.0: Log history viewer (full screen)
         if state.current_view == View::LogHistory {
             tracing::debug!("Rendering LogHistory view");
-            self.log_history_viewer.render(frame, frame.size(), &mut state.log_history_state);
+            self.log_history_viewer
+                .render(frame, frame.size(), &mut state.log_history_state);
             // Render help overlay on top if visible
             if state.help_visible {
                 tracing::debug!("Rendering help overlay on LogHistory");
@@ -181,7 +194,11 @@ impl LayoutComponent {
         // Changelog viewer (full screen)
         if state.current_view == View::Changelog {
             tracing::debug!("Rendering Changelog view");
-            crate::components::ChangelogComponent::render(frame, frame.size(), &state.changelog_state);
+            crate::components::ChangelogComponent::render(
+                frame,
+                frame.size(),
+                &state.changelog_state,
+            );
             // Render help overlay on top if visible
             if state.help_visible {
                 tracing::debug!("Rendering help overlay on Changelog");
@@ -216,7 +233,11 @@ impl LayoutComponent {
         // Session recovery view (full screen)
         if state.current_view == View::SessionRecovery {
             tracing::debug!("Rendering SessionRecovery view");
-            crate::components::SessionRecovery::render(frame, frame.size(), &mut state.session_recovery_state);
+            crate::components::SessionRecovery::render(
+                frame,
+                frame.size(),
+                &mut state.session_recovery_state,
+            );
             // Render help overlay on top if visible
             if state.help_visible {
                 tracing::debug!("Rendering help overlay on SessionRecovery");
@@ -321,51 +342,87 @@ impl LayoutComponent {
             Span::styled("ew ", Style::default().fg(MUTED_GRAY)),
             Span::styled("E", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled("xpand ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("Tab", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Tab",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" focus", Style::default().fg(MUTED_GRAY)),
             Span::styled(" │ ", Style::default().fg(SUBDUED_BORDER)),
             // Session actions group
-            Span::styled("a", Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "a",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
             Span::styled("ttach ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("e", Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "e",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" restart ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("d", Style::default().fg(Color::Rgb(230, 100, 100)).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "d",
+                Style::default().fg(Color::Rgb(230, 100, 100)).add_modifier(Modifier::BOLD),
+            ),
             Span::styled("elete ", Style::default().fg(MUTED_GRAY)),
             Span::styled("$", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled(" shell ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("o", Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "o",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" editor", Style::default().fg(MUTED_GRAY)),
         ];
 
         // Line 2: Git, Tools, System
         let line2_spans = vec![
             // Git group
-            Span::styled("g", Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "g",
+                Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled("it ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("p", Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "p",
+                Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" commit", Style::default().fg(MUTED_GRAY)),
             Span::styled(" │ ", Style::default().fg(SUBDUED_BORDER)),
             // Tools group
-            Span::styled("c", Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "c",
+                Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled("laude ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("f", Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "f",
+                Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" refresh ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("x", Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "x",
+                Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" cleanup", Style::default().fg(MUTED_GRAY)),
             Span::styled(" │ ", Style::default().fg(SUBDUED_BORDER)),
             // System group
-            Span::styled("r", Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "r",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" re-auth ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("H", Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "H",
+                Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" help ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("q", Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "q",
+                Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" home", Style::default().fg(MUTED_GRAY)),
         ];
 
-        let menu_lines = vec![
-            Line::from(line1_spans),
-            Line::from(line2_spans),
-        ];
+        let menu_lines = vec![Line::from(line1_spans), Line::from(line2_spans)];
 
         let menu = Paragraph::new(menu_lines)
             .block(
@@ -388,7 +445,10 @@ impl LayoutComponent {
             if let Some(workspace) = state.workspaces.get(workspace_idx) {
                 if let Some(repo_name) = workspace.path.file_name().and_then(|n| n.to_str()) {
                     status_spans.push(Span::styled("📁 ", Style::default().fg(GOLD)));
-                    status_spans.push(Span::styled(repo_name.to_string(), Style::default().fg(SOFT_WHITE)));
+                    status_spans.push(Span::styled(
+                        repo_name.to_string(),
+                        Style::default().fg(SOFT_WHITE),
+                    ));
                 }
             }
         }
@@ -401,26 +461,51 @@ impl LayoutComponent {
                         if let Some(session) = workspace.sessions.get(session_idx) {
                             // Separator
                             if !status_spans.is_empty() {
-                                status_spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
+                                status_spans.push(Span::styled(
+                                    "  │  ",
+                                    Style::default().fg(SUBDUED_BORDER),
+                                ));
                             }
 
                             // Branch info
-                            status_spans.push(Span::styled("🌿 ", Style::default().fg(SELECTION_GREEN)));
-                            status_spans.push(Span::styled(session.branch_name.clone(), Style::default().fg(SOFT_WHITE)));
+                            status_spans
+                                .push(Span::styled("🌿 ", Style::default().fg(SELECTION_GREEN)));
+                            status_spans.push(Span::styled(
+                                session.branch_name.clone(),
+                                Style::default().fg(SOFT_WHITE),
+                            ));
 
                             // Container info
                             if let Some(container_id) = &session.container_id {
                                 let short_id = &container_id[..8.min(container_id.len())];
                                 let (status_icon, status_color) = match session.status {
-                                    crate::models::SessionStatus::Running => ("🟢", SELECTION_GREEN),
-                                    crate::models::SessionStatus::Stopped => ("🔴", Color::Rgb(230, 100, 100)),
+                                    crate::models::SessionStatus::Running => {
+                                        ("🟢", SELECTION_GREEN)
+                                    }
+                                    crate::models::SessionStatus::Stopped => {
+                                        ("🔴", Color::Rgb(230, 100, 100))
+                                    }
                                     crate::models::SessionStatus::Idle => ("🟡", WARNING_ORANGE),
-                                    crate::models::SessionStatus::Error(_) => ("❌", Color::Rgb(230, 100, 100)),
+                                    crate::models::SessionStatus::Error(_) => {
+                                        ("❌", Color::Rgb(230, 100, 100))
+                                    }
                                 };
-                                status_spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
-                                status_spans.push(Span::styled(format!("{} ", status_icon), Style::default().fg(status_color)));
-                                status_spans.push(Span::styled(format!("{} ", session.name), Style::default().fg(SOFT_WHITE)));
-                                status_spans.push(Span::styled(format!("({})", short_id), Style::default().fg(MUTED_GRAY)));
+                                status_spans.push(Span::styled(
+                                    "  │  ",
+                                    Style::default().fg(SUBDUED_BORDER),
+                                ));
+                                status_spans.push(Span::styled(
+                                    format!("{} ", status_icon),
+                                    Style::default().fg(status_color),
+                                ));
+                                status_spans.push(Span::styled(
+                                    format!("{} ", session.name),
+                                    Style::default().fg(SOFT_WHITE),
+                                ));
+                                status_spans.push(Span::styled(
+                                    format!("({})", short_id),
+                                    Style::default().fg(MUTED_GRAY),
+                                ));
                             }
                         }
                     }
@@ -440,8 +525,32 @@ impl LayoutComponent {
             status_spans.push(Span::styled("OFF", Style::default().fg(MUTED_GRAY)));
         }
 
+        // Live OAuth window: append a compact widget when wired AND fresh,
+        // a red CTA when not wired (and the user hasn't declined).
+        // The status bar gracefully degrades on narrow terminals — we
+        // measure the existing content first and drop the live widget if
+        // it wouldn't fit.
+        let live_spans = build_live_status_spans(state);
+        let existing_w: usize = status_spans
+            .iter()
+            .map(|s| s.content.chars().count())
+            .sum();
+        // 4 chars for the " │  " separator we'd add
+        let live_w: usize =
+            live_spans.iter().map(|s| s.content.chars().count()).sum::<usize>().saturating_add(5);
+        let area_inner_w = area.width.saturating_sub(2) as usize; // borders
+        if !live_spans.is_empty() && existing_w + live_w <= area_inner_w {
+            if !status_spans.is_empty() {
+                status_spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
+            }
+            status_spans.extend(live_spans);
+        }
+
         let status_line = if status_spans.is_empty() {
-            Line::from(Span::styled("Agents-in-a-Box - No active session", Style::default().fg(MUTED_GRAY)))
+            Line::from(Span::styled(
+                "Agents-in-a-Box - No active session",
+                Style::default().fg(MUTED_GRAY),
+            ))
         } else {
             Line::from(status_spans)
         };
@@ -455,7 +564,10 @@ impl LayoutComponent {
                     .style(Style::default().bg(DARK_BG))
                     .title(Line::from(vec![
                         Span::styled(" 📊 ", Style::default().fg(GOLD)),
-                        Span::styled("Status", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                        Span::styled(
+                            "Status",
+                            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                        ),
                     ])),
             )
             .alignment(Alignment::Left);
@@ -510,8 +622,14 @@ impl LayoutComponent {
             };
 
             let notification_line = Line::from(vec![
-                Span::styled(icon, Style::default().fg(text_color).add_modifier(Modifier::BOLD)),
-                Span::styled(notification.message.as_str(), Style::default().fg(text_color)),
+                Span::styled(
+                    icon,
+                    Style::default().fg(text_color).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    notification.message.as_str(),
+                    Style::default().fg(text_color),
+                ),
             ]);
 
             let notification_widget = Paragraph::new(notification_line)
@@ -543,7 +661,10 @@ impl LayoutComponent {
             .style(Style::default().bg(PANEL_BG))
             .title(Line::from(vec![
                 Span::styled(" 📋 ", Style::default().fg(GOLD)),
-                Span::styled("Git Commit ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    "Git Commit ",
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ),
             ]));
         frame.render_widget(outer_block, dialog_area);
 
@@ -569,9 +690,8 @@ impl LayoutComponent {
         let commit_message = state.quick_commit_message.as_ref().unwrap_or(&empty_string);
 
         // Create spans with cursor visualization
-        let (before_cursor, after_cursor) = commit_message.split_at(
-            state.quick_commit_cursor.min(commit_message.len())
-        );
+        let (before_cursor, after_cursor) =
+            commit_message.split_at(state.quick_commit_cursor.min(commit_message.len()));
 
         let input_line = Line::from(vec![
             Span::styled(before_cursor, Style::default().fg(SOFT_WHITE)),
@@ -579,26 +699,34 @@ impl LayoutComponent {
             Span::styled(after_cursor, Style::default().fg(SOFT_WHITE)),
         ]);
 
-        let input_paragraph = Paragraph::new(input_line)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(SELECTION_GREEN))
-                    .style(Style::default().bg(DARK_BG))
-                    .title(Line::from(vec![
-                        Span::styled(" ✏️ ", Style::default().fg(GOLD)),
-                        Span::styled("Commit Message ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
-                    ])),
-            );
+        let input_paragraph = Paragraph::new(input_line).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(SELECTION_GREEN))
+                .style(Style::default().bg(DARK_BG))
+                .title(Line::from(vec![
+                    Span::styled(" ✏️ ", Style::default().fg(GOLD)),
+                    Span::styled(
+                        "Commit Message ",
+                        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                    ),
+                ])),
+        );
         frame.render_widget(input_paragraph, inner_layout[0]);
 
         // Render help bar (gold keys + muted descriptions)
         let help_bar = Paragraph::new(Line::from(vec![
-            Span::styled(" Enter", Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Enter",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" Commit & Push ", Style::default().fg(MUTED_GRAY)),
             Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
-            Span::styled(" Esc", Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Esc",
+                Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" Cancel ", Style::default().fg(MUTED_GRAY)),
         ]))
         .alignment(Alignment::Center)
@@ -610,6 +738,225 @@ impl LayoutComponent {
 impl Default for LayoutComponent {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Build the compact "live OAuth window" spans appended to the top status
+/// bar. Returns an empty vec when nothing should render (statusline
+/// unwired AND user declined, or status detection failed).
+pub fn build_live_status_spans(state: &AppState) -> Vec<Span<'static>> {
+    use crate::cli::statusline_install::{StatuslineStatus, detect_statusline_status};
+    use crate::config::StatuslineDecision;
+    use crate::models::live_window::{Source, current};
+
+    let status = detect_statusline_status().ok();
+    let decision = state.app_config.ui_preferences.statusline_decision;
+
+    match status {
+        Some(StatuslineStatus::Configured) => {
+            let live = current();
+            if live.source != Source::Tier1Cache {
+                // Wired but no fresh data yet — render nothing rather
+                // than misleading "0%" placeholders.
+                return Vec::new();
+            }
+            build_live_widget_spans(&live)
+        }
+        Some(StatuslineStatus::NotConfigured | StatuslineStatus::Other(_))
+            if decision != StatuslineDecision::Declined =>
+        {
+            build_cta_spans()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn build_live_widget_spans(live: &crate::models::live_window::LiveWindow) -> Vec<Span<'static>> {
+    let mut out: Vec<Span<'static>> = Vec::new();
+
+    if let Some(pct) = live.five_hour_pct {
+        out.push(Span::styled("5h ", Style::default().fg(MUTED_GRAY)));
+        out.push(Span::styled(mini_bar(pct), Style::default().fg(bar_color_5h(pct))));
+        out.push(Span::styled(
+            format!(" {pct}%"),
+            Style::default().fg(bar_color_5h(pct)).add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(pct) = live.seven_day_pct {
+        if !out.is_empty() {
+            out.push(Span::styled(" · ", Style::default().fg(SUBDUED_BORDER)));
+        }
+        out.push(Span::styled("wk ", Style::default().fg(MUTED_GRAY)));
+        out.push(Span::styled(mini_bar(pct), Style::default().fg(bar_color_7d(pct))));
+        out.push(Span::styled(
+            format!(" {pct}%"),
+            Style::default().fg(bar_color_7d(pct)).add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(cost) = live.today_cost_usd {
+        if !out.is_empty() {
+            out.push(Span::styled(" · ", Style::default().fg(SUBDUED_BORDER)));
+        }
+        out.push(Span::styled(
+            format!("${cost:.2} today"),
+            Style::default().fg(GOLD),
+        ));
+    }
+    if let Some(d) = live.resets_in {
+        if !out.is_empty() {
+            out.push(Span::styled(" · ", Style::default().fg(SUBDUED_BORDER)));
+        }
+        out.push(Span::styled("⏱ ", Style::default().fg(SOFT_WHITE)));
+        out.push(Span::styled(format_hms(d), Style::default().fg(SOFT_WHITE)));
+    }
+    out
+}
+
+fn build_cta_spans() -> Vec<Span<'static>> {
+    let red = Color::Rgb(230, 100, 100);
+    vec![
+        Span::styled("⚠ ", Style::default().fg(red).add_modifier(Modifier::BOLD)),
+        Span::styled("Live CC usage off", Style::default().fg(red)),
+        Span::styled(" · go to Stats to enable", Style::default().fg(MUTED_GRAY)),
+    ]
+}
+
+/// Three-cell mini-bar: ▰ for filled, ▱ for empty. Matches the brief.
+fn mini_bar(pct: u8) -> String {
+    let cells = ((pct as f64 / 100.0) * 3.0).round() as usize;
+    let filled = cells.min(3);
+    let empty = 3 - filled;
+    let mut s = String::with_capacity(3);
+    for _ in 0..filled {
+        s.push('▰');
+    }
+    for _ in 0..empty {
+        s.push('▱');
+    }
+    s
+}
+
+fn bar_color_5h(pct: u8) -> Color {
+    if pct >= 85 {
+        Color::Rgb(230, 100, 100)
+    } else if pct >= 60 {
+        WARNING_ORANGE
+    } else {
+        SELECTION_GREEN
+    }
+}
+
+fn bar_color_7d(pct: u8) -> Color {
+    if pct >= 90 {
+        Color::Rgb(230, 100, 100)
+    } else if pct >= 70 {
+        WARNING_ORANGE
+    } else {
+        SELECTION_GREEN
+    }
+}
+
+fn format_hms(d: std::time::Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    if h > 0 {
+        format!("{h}h {m:02}m")
+    } else {
+        format!("{m}m")
+    }
+}
+
+#[cfg(test)]
+mod live_widget_tests {
+    use super::*;
+    use crate::models::live_window::{LiveWindow, Source};
+    use std::time::Duration;
+
+    fn flatten(spans: &[Span<'static>]) -> String {
+        spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn cta_spans_contain_warning_and_stats_hint() {
+        let spans = build_cta_spans();
+        let text = flatten(&spans);
+        assert!(text.contains("Live CC usage off"));
+        assert!(text.contains("Stats"));
+    }
+
+    #[test]
+    fn live_widget_renders_5h_7d_cost_and_reset() {
+        let live = LiveWindow {
+            five_hour_pct: Some(40),
+            seven_day_pct: Some(8),
+            today_cost_usd: Some(1.5),
+            resets_in: Some(Duration::from_secs(2 * 3600)),
+            context_pct: None,
+            model: None,
+            source: Source::Tier1Cache,
+        };
+        let spans = build_live_widget_spans(&live);
+        let text = flatten(&spans);
+        assert!(text.contains("5h"));
+        assert!(text.contains("40%"));
+        assert!(text.contains("wk"));
+        assert!(text.contains("8%"));
+        assert!(text.contains("$1.50"));
+        assert!(text.contains("2h 00m"));
+    }
+
+    #[test]
+    fn live_widget_omits_missing_fields() {
+        let live = LiveWindow {
+            five_hour_pct: Some(20),
+            seven_day_pct: None,
+            today_cost_usd: None,
+            resets_in: None,
+            context_pct: None,
+            model: None,
+            source: Source::Tier1Cache,
+        };
+        let spans = build_live_widget_spans(&live);
+        let text = flatten(&spans);
+        assert!(text.contains("5h"));
+        assert!(!text.contains("wk"));
+        assert!(!text.contains("$"));
+        assert!(!text.contains("⏱"));
+    }
+
+    #[test]
+    fn mini_bar_clamps_and_buckets() {
+        assert_eq!(mini_bar(0), "▱▱▱");
+        assert_eq!(mini_bar(33), "▰▱▱");
+        assert_eq!(mini_bar(50), "▰▰▱");
+        assert_eq!(mini_bar(99), "▰▰▰");
+        assert_eq!(mini_bar(100), "▰▰▰");
+    }
+
+    #[test]
+    fn bar_color_5h_thresholds() {
+        assert_eq!(bar_color_5h(0), SELECTION_GREEN);
+        assert_eq!(bar_color_5h(59), SELECTION_GREEN);
+        assert_eq!(bar_color_5h(60), WARNING_ORANGE);
+        assert_eq!(bar_color_5h(84), WARNING_ORANGE);
+        assert_eq!(bar_color_5h(85), Color::Rgb(230, 100, 100));
+    }
+
+    #[test]
+    fn bar_color_7d_thresholds() {
+        assert_eq!(bar_color_7d(0), SELECTION_GREEN);
+        assert_eq!(bar_color_7d(69), SELECTION_GREEN);
+        assert_eq!(bar_color_7d(70), WARNING_ORANGE);
+        assert_eq!(bar_color_7d(89), WARNING_ORANGE);
+        assert_eq!(bar_color_7d(90), Color::Rgb(230, 100, 100));
+    }
+
+    #[test]
+    fn format_hms_smoke() {
+        assert_eq!(format_hms(Duration::ZERO), "0m");
+        assert_eq!(format_hms(Duration::from_secs(45 * 60)), "45m");
+        assert_eq!(format_hms(Duration::from_secs(3600)), "1h 00m");
     }
 }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3240,7 +3240,12 @@ fn render_budget_panel(
             .add_modifier(Modifier::BOLD),
     ));
 
-    let lines: Vec<Line> = vec![
+    // Live OAuth-window header. Renders above the existing monthly-cap
+    // content. Drives the W keybind's CTA when no source is available.
+    let live = crate::models::live_window::current();
+    let mut lines: Vec<Line> = budget_live_header_lines(&live, inner_w);
+
+    lines.extend(vec![
         Line::from(vec![
             Span::styled(" Monthly cap ", Style::default().fg(MUTED_GRAY)),
             Span::styled(
@@ -3274,8 +3279,113 @@ fn render_budget_panel(
             ),
             Span::styled(" days sampled", Style::default().fg(MUTED_GRAY)),
         ]),
-    ];
+    ]);
     render_panel_lines_with_focus(frame, area, "Budget · Alerts", lines, focus);
+}
+
+/// Build the live-window header injected at the top of the Budget panel.
+/// Tier1 → two gradient bars + cost + reset countdown; Tier2 → 5h bar +
+/// upgrade hint; None → CTA pointing at the W keybind.
+fn budget_live_header_lines(
+    live: &crate::models::live_window::LiveWindow,
+    inner_w: usize,
+) -> Vec<Line<'static>> {
+    use crate::models::live_window::Source;
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let bar_w = inner_w.saturating_sub(12).max(8);
+
+    match live.source {
+        Source::Tier1Cache => {
+            if let Some(pct) = live.five_hour_pct {
+                out.push(live_bar_line("5h burn ", pct, bar_w));
+            }
+            if let Some(pct) = live.seven_day_pct {
+                out.push(live_bar_line("7d wnd  ", pct, bar_w));
+            }
+            let mut footer: Vec<Span<'static>> = Vec::new();
+            if let Some(cost) = live.today_cost_usd {
+                footer.push(Span::styled(" Today ", Style::default().fg(MUTED_GRAY)));
+                footer.push(Span::styled(
+                    format!("${cost:.2}"),
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ));
+            }
+            if let Some(d) = live.resets_in {
+                if !footer.is_empty() {
+                    footer.push(Span::styled(" · ", Style::default().fg(MUTED_GRAY)));
+                }
+                footer.push(Span::styled(" Resets in ", Style::default().fg(MUTED_GRAY)));
+                footer.push(Span::styled(
+                    format_hms(d),
+                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                ));
+            }
+            if !footer.is_empty() {
+                out.push(Line::from(footer));
+            }
+        }
+        Source::Tier2Local => {
+            if let Some(pct) = live.five_hour_pct {
+                out.push(live_bar_line("5h burn ", pct, bar_w));
+            }
+            out.push(Line::from(Span::styled(
+                " Wire statusline (W) for 7d window + cost",
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+        Source::None => {
+            out.push(Line::from(Span::styled(
+                " ⓘ Live OAuth window data not available.",
+                Style::default().fg(MUTED_GRAY),
+            )));
+            out.push(Line::from(vec![
+                Span::styled("    Press ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("[W]", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    " to wire up Claude Code statusline.",
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ]));
+            out.push(Line::from(Span::styled(
+                "    (Provides 5h burn, 7d window, cost, reset times)",
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+    }
+    out
+}
+
+fn live_bar_line(label: &'static str, pct: u8, bar_w: usize) -> Line<'static> {
+    let mut spans = vec![Span::styled(
+        format!(" {label}"),
+        Style::default().fg(MUTED_GRAY),
+    )];
+    spans.extend(ratio_gradient_spans(pct as f64, 100.0, bar_w));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        format!("{pct:>3}%"),
+        Style::default()
+            .fg(if pct >= 85 {
+                BAR_HIGH
+            } else if pct >= 60 {
+                TERMINAL_ACCENT
+            } else {
+                TERMINAL_GOOD
+            })
+            .add_modifier(Modifier::BOLD),
+    ));
+    Line::from(spans)
+}
+
+fn format_hms(d: std::time::Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    if h > 0 {
+        format!("{h}h {m:02}m")
+    } else {
+        format!("{m}m")
+    }
 }
 
 fn render_optimize(frame: &mut Frame, area: Rect, data: &UsageData) {
@@ -4685,5 +4795,81 @@ mod cli_parity_tests {
         _: SessionUsage,
         _: TokenBucket,
     ) {
+    }
+}
+
+#[cfg(test)]
+mod budget_live_header_tests {
+    use super::*;
+    use crate::models::live_window::{LiveWindow, Source};
+    use std::time::Duration;
+
+    fn flat(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref().to_string()))
+            .collect::<Vec<_>>()
+            .join(" | ")
+    }
+
+    #[test]
+    fn cta_lines_rendered_when_source_is_none() {
+        let live = LiveWindow::empty();
+        let lines = budget_live_header_lines(&live, 60);
+        let text = flat(&lines);
+        assert!(text.contains("[W]"), "CTA must mention W key: {text}");
+        assert!(text.contains("statusline"), "CTA copy missing: {text}");
+    }
+
+    #[test]
+    fn tier1_renders_two_bars_plus_cost_and_reset() {
+        let live = LiveWindow {
+            five_hour_pct: Some(40),
+            seven_day_pct: Some(8),
+            today_cost_usd: Some(3.21),
+            resets_in: Some(Duration::from_secs(2 * 3600 + 30 * 60)),
+            context_pct: None,
+            model: None,
+            source: Source::Tier1Cache,
+        };
+        let lines = budget_live_header_lines(&live, 60);
+        let text = flat(&lines);
+        assert!(text.contains("5h burn"));
+        assert!(text.contains("7d wnd"));
+        assert!(text.contains("$3.21"));
+        assert!(text.contains("2h 30m"));
+    }
+
+    #[test]
+    fn tier2_renders_5h_bar_and_upgrade_hint_only() {
+        let live = LiveWindow {
+            five_hour_pct: Some(20),
+            seven_day_pct: None,
+            today_cost_usd: None,
+            resets_in: None,
+            context_pct: None,
+            model: None,
+            source: Source::Tier2Local,
+        };
+        let lines = budget_live_header_lines(&live, 60);
+        let text = flat(&lines);
+        assert!(text.contains("5h burn"));
+        assert!(!text.contains("7d wnd"));
+        assert!(text.contains("Wire statusline"));
+    }
+
+    #[test]
+    fn format_hms_zero_yields_zero_minutes() {
+        assert_eq!(format_hms(Duration::ZERO), "0m");
+    }
+
+    #[test]
+    fn format_hms_under_one_hour_omits_h_field() {
+        assert_eq!(format_hms(Duration::from_secs(45 * 60)), "45m");
+    }
+
+    #[test]
+    fn format_hms_pads_minutes_when_hours_present() {
+        assert_eq!(format_hms(Duration::from_secs(3 * 3600 + 5 * 60)), "3h 05m");
     }
 }

--- a/ainb-tui/src/config/mod.rs
+++ b/ainb-tui/src/config/mod.rs
@@ -390,6 +390,29 @@ pub struct UiPreferences {
     /// If None, falls back to: code -> $EDITOR -> error
     #[serde(default)]
     pub preferred_editor: Option<String>,
+
+    /// User's response to the "wire up Claude Code statusline" prompt.
+    /// `Unset` means we'll prompt again (init wizard) and surface the
+    /// CTA in the Budget panel. `Declined` suppresses the top-bar CTA
+    /// (the Budget-panel CTA remains visible for power users).
+    #[serde(default)]
+    pub statusline_decision: StatuslineDecision,
+}
+
+/// The user's recorded decision on the Claude Code statusline wiring.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StatuslineDecision {
+    /// User has never been asked, or has dismissed the prompt without
+    /// accepting or declining.
+    #[default]
+    Unset,
+    /// User explicitly opted out — suppress top-bar CTA.
+    Declined,
+    /// User accepted; we have written our block.
+    Installed,
+    /// User accepted "chain" — we appended ourselves to an existing cmd.
+    Chained,
 }
 
 impl Default for UiPreferences {
@@ -399,6 +422,7 @@ impl Default for UiPreferences {
             show_container_status: true,
             show_git_status: true,
             preferred_editor: None,
+            statusline_decision: StatuslineDecision::default(),
         }
     }
 }
@@ -984,6 +1008,7 @@ mod old_config_tests {
                 show_container_status: false,
                 show_git_status: false,
                 preferred_editor: None,
+                statusline_decision: StatuslineDecision::default(),
             },
             docker: DockerConfig {
                 host: None,
@@ -1023,6 +1048,7 @@ mod old_config_tests {
                 show_container_status: false,
                 show_git_status: false,
                 preferred_editor: None,
+                statusline_decision: StatuslineDecision::default(),
             },
             docker: DockerConfig {
                 host: None,

--- a/ainb-tui/src/config/mod.rs
+++ b/ainb-tui/src/config/mod.rs
@@ -411,8 +411,6 @@ pub enum StatuslineDecision {
     Declined,
     /// User accepted; we have written our block.
     Installed,
-    /// User accepted "chain" — we appended ourselves to an existing cmd.
-    Chained,
 }
 
 impl Default for UiPreferences {

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -117,6 +117,7 @@ async fn main() -> Result<()> {
             cli::presets::execute(command, args.format).await
         }
         Some(cli::Commands::Usage { command }) => cli::usage::execute(command, args.format).await,
+        Some(cli::Commands::Statusline) => cli::statusline::execute(),
         Some(cli::Commands::Completion { shell }) => {
             use clap::CommandFactory;
             let mut cmd = cli::Cli::command();

--- a/ainb-tui/src/models/live_window.rs
+++ b/ainb-tui/src/models/live_window.rs
@@ -265,21 +265,19 @@ fn time_until_block_end(block: &ActiveBlock, now: DateTime<Utc>) -> Duration {
 }
 
 /// Pull recent Claude calls (last 5h) without re-parsing the entire
-/// history. Mirrors `parse_usage_for` but with a tight time filter.
-fn collect_recent_claude_calls() -> Vec<ProviderCall> {
-    use crate::models::UsagePeriod;
-    use crate::models::usage::{UsageProviderFilter, UsageQuery, parse_usage_for};
+/// history. Goes through `collect_recent_claude_calls_within` which
+/// mtime-filters the JSONL files and keeps only entries inside the
+/// active 5-hour window — avoids the full-history walk that
+/// `parse_usage_for` does on every render.
+///
+/// `MTIME_GRACE_HOURS` widens the mtime filter to forgive small clock
+/// drift between the JSONL writer (Claude Code) and the filesystem.
+const MTIME_GRACE_HOURS: i64 = 1;
 
-    let query = UsageQuery {
-        period: UsagePeriod::Today,
-        provider_filter: UsageProviderFilter::Claude,
-        include_projects: Vec::new(),
-        exclude_projects: Vec::new(),
-        filters: Default::default(),
-    };
-    let data = parse_usage_for(query);
+fn collect_recent_claude_calls() -> Vec<ProviderCall> {
     let cutoff = Utc::now() - chrono::Duration::hours(5);
-    data.calls.into_iter().filter(|c| c.timestamp >= cutoff).collect()
+    let grace = chrono::Duration::hours(MTIME_GRACE_HOURS);
+    crate::models::usage::collect_recent_claude_calls_within(cutoff, grace)
 }
 
 #[cfg(test)]

--- a/ainb-tui/src/models/live_window.rs
+++ b/ainb-tui/src/models/live_window.rs
@@ -1,8 +1,11 @@
 // ABOUTME: Live OAuth-window reader with three-tier fallback.
 //
-// Tier 1 (Cache):    `~/.cache/ainb/live.json` written by the
-//                    `ainb statusline` hook. Authoritative — Claude Code
-//                    only exposes rate_limits to statusline subprocesses.
+// Tier 1 (Cache):    OS-specific cache dir (via `dirs::cache_dir()`,
+//                    e.g. `~/.cache/ainb/live.json` on Linux,
+//                    `~/Library/Caches/ainb/live.json` on macOS) written
+//                    by the `ainb statusline` hook. Authoritative —
+//                    Claude Code only exposes rate_limits to statusline
+//                    subprocesses.
 // Tier 2 (Local):    Native 5-hour-block aggregation over the local
 //                    Claude JSONL transcripts (mirrors `ccusage blocks
 //                    --active --json` logic). Provides 5h burn but not

--- a/ainb-tui/src/models/live_window.rs
+++ b/ainb-tui/src/models/live_window.rs
@@ -1,0 +1,454 @@
+// ABOUTME: Live OAuth-window reader with three-tier fallback.
+//
+// Tier 1 (Cache):    `~/.cache/ainb/live.json` written by the
+//                    `ainb statusline` hook. Authoritative — Claude Code
+//                    only exposes rate_limits to statusline subprocesses.
+// Tier 2 (Local):    Native 5-hour-block aggregation over the local
+//                    Claude JSONL transcripts (mirrors `ccusage blocks
+//                    --active --json` logic). Provides 5h burn but not
+//                    the 7d window — that data simply isn't local.
+// Tier 3 (None):     Empty `LiveWindow`; render path falls back to a
+//                    "wire the statusline" CTA.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Datelike, Timelike, Utc};
+
+use crate::cli::statusline::{LiveCache, cache_path, read_cache};
+use crate::models::usage::ProviderCall;
+
+/// Maximum age of the Tier 1 cache before we consider it stale and fall
+/// back to Tier 2.
+pub const CACHE_MAX_AGE_SECS: u64 = 120;
+
+/// Default token cap for the Pro 5-hour window when Tier 2 has to
+/// estimate burn percentage. Override via `AINB_TOKEN_LIMIT`.
+pub const DEFAULT_TOKEN_LIMIT: u64 = 220_000;
+
+/// Where the data came from. Drives the render path's fidelity choices
+/// (Tier1 → bars + cost + reset; Tier2 → 5h bar only; None → CTA).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    Tier1Cache,
+    Tier2Local,
+    None,
+}
+
+/// Snapshot of the user's live OAuth-window state at one point in time.
+#[derive(Debug, Clone, Default)]
+pub struct LiveWindow {
+    pub five_hour_pct: Option<u8>,
+    pub seven_day_pct: Option<u8>,
+    pub today_cost_usd: Option<f64>,
+    /// Time until the active window resets, when known.
+    pub resets_in: Option<Duration>,
+    pub context_pct: Option<u8>,
+    pub model: Option<String>,
+    pub source: Source,
+}
+
+impl LiveWindow {
+    pub fn empty() -> Self {
+        Self {
+            source: Source::None,
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for Source {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Read the current live window using the three-tier cascade.
+///
+/// In production the call site is the TUI render path on the Burndown
+/// view — keep it cheap. Tier 1 is a single small JSON file. Tier 2 only
+/// runs when Tier 1 is missing/stale and only walks the *most recent*
+/// JSONL files (filtered by mtime).
+pub fn current() -> LiveWindow {
+    if let Some(window) = current_tier1() {
+        return window;
+    }
+    if let Some(window) = current_tier2() {
+        return window;
+    }
+    LiveWindow::empty()
+}
+
+/// Tier 1: read the statusline cache if fresh.
+fn current_tier1() -> Option<LiveWindow> {
+    let path = cache_path()?;
+    let cache = read_cache(&path)?;
+    if !cache_is_fresh(&cache) {
+        return None;
+    }
+    Some(window_from_cache(cache))
+}
+
+fn cache_is_fresh(cache: &LiveCache) -> bool {
+    let Ok(updated) = chrono::DateTime::parse_from_rfc3339(&cache.updated_at) else {
+        return false;
+    };
+    let age = Utc::now().signed_duration_since(updated.with_timezone(&Utc)).num_seconds();
+    age >= 0 && (age as u64) <= CACHE_MAX_AGE_SECS
+}
+
+fn window_from_cache(cache: LiveCache) -> LiveWindow {
+    // Pick the soonest reset (5h is almost always the visible one, but
+    // honour 7d if 5h is missing).
+    let resets_in = cache
+        .five_hour
+        .as_ref()
+        .and_then(|w| w.resets_at.as_deref())
+        .and_then(duration_until_iso8601)
+        .or_else(|| {
+            cache
+                .seven_day
+                .as_ref()
+                .and_then(|w| w.resets_at.as_deref())
+                .and_then(duration_until_iso8601)
+        });
+
+    LiveWindow {
+        five_hour_pct: cache.five_hour.as_ref().map(|w| w.pct),
+        seven_day_pct: cache.seven_day.as_ref().map(|w| w.pct),
+        today_cost_usd: cache.today_cost_usd,
+        resets_in,
+        context_pct: cache.context_pct,
+        model: cache.model,
+        source: Source::Tier1Cache,
+    }
+}
+
+/// Convert an ISO8601 `resets_at` into a `Duration` from now. Returns
+/// `None` if the timestamp is unparseable or already in the past.
+pub fn duration_until_iso8601(s: &str) -> Option<Duration> {
+    let parsed = DateTime::parse_from_rfc3339(s).ok()?;
+    let secs = parsed.with_timezone(&Utc).signed_duration_since(Utc::now()).num_seconds();
+    if secs <= 0 {
+        None
+    } else {
+        Some(Duration::from_secs(secs as u64))
+    }
+}
+
+/// Tier 2: native 5-hour-block aggregation over the local Claude JSONL
+/// transcripts. Returns `None` when the user has no local JSONL data.
+fn current_tier2() -> Option<LiveWindow> {
+    let calls = collect_recent_claude_calls();
+    if calls.is_empty() {
+        return None;
+    }
+    let block = current_active_block(&calls, Utc::now())?;
+    let limit = token_limit_from_env();
+    let used = block.total_tokens;
+    let pct = ((used as f64 / limit as f64) * 100.0).clamp(0.0, 100.0).round() as u8;
+
+    Some(LiveWindow {
+        five_hour_pct: Some(pct),
+        seven_day_pct: None,
+        today_cost_usd: block.total_cost_usd,
+        resets_in: Some(time_until_block_end(&block, Utc::now())),
+        context_pct: None,
+        model: None,
+        source: Source::Tier2Local,
+    })
+}
+
+fn token_limit_from_env() -> u64 {
+    std::env::var("AINB_TOKEN_LIMIT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_TOKEN_LIMIT)
+}
+
+/// 5-hour block descriptor (ccusage parity).
+#[derive(Debug, Clone)]
+pub struct ActiveBlock {
+    pub start: DateTime<Utc>,
+    pub last_entry: DateTime<Utc>,
+    pub total_tokens: u64,
+    pub total_cost_usd: Option<f64>,
+}
+
+/// Resolve the currently-active 5-hour block from a list of provider
+/// calls. ccusage rules:
+///   - Block start is the floor-to-UTC-hour of the first entry.
+///   - The block ends when either:
+///       (a) `now - last_entry >= 5h`, OR
+///       (b) `entry.timestamp - block_start > 5h` (next call rolls over)
+///
+/// We walk calls in timestamp order, advancing block boundaries as
+/// needed, and return the *currently-active* block (the one containing
+/// `now`). Returns `None` when no block is currently active.
+pub fn current_active_block(calls: &[ProviderCall], now: DateTime<Utc>) -> Option<ActiveBlock> {
+    let mut sorted: Vec<&ProviderCall> = calls.iter().collect();
+    sorted.sort_by_key(|c| c.timestamp);
+
+    let mut block: Option<ActiveBlock> = None;
+    for call in sorted {
+        match block.as_mut() {
+            None => {
+                block = Some(ActiveBlock {
+                    start: floor_to_hour(call.timestamp),
+                    last_entry: call.timestamp,
+                    total_tokens: token_total(call),
+                    total_cost_usd: call.cost_usd,
+                });
+            }
+            Some(b) => {
+                let rolls_over = call.timestamp.signed_duration_since(b.start).num_hours() > 5;
+                let stale = call.timestamp.signed_duration_since(b.last_entry).num_hours() >= 5;
+                if rolls_over || stale {
+                    *b = ActiveBlock {
+                        start: floor_to_hour(call.timestamp),
+                        last_entry: call.timestamp,
+                        total_tokens: token_total(call),
+                        total_cost_usd: call.cost_usd,
+                    };
+                } else {
+                    b.last_entry = call.timestamp;
+                    b.total_tokens = b.total_tokens.saturating_add(token_total(call));
+                    b.total_cost_usd = match (b.total_cost_usd, call.cost_usd) {
+                        (Some(a), Some(c)) => Some(a + c),
+                        (Some(a), None) => Some(a),
+                        (None, c) => c,
+                    };
+                }
+            }
+        }
+    }
+
+    let block = block?;
+    // Block is active iff `now` falls within (start, start + 5h] AND
+    // we've seen activity in the last 5h.
+    let block_end = block.start + chrono::Duration::hours(5);
+    let now_in_block = now > block.start && now <= block_end;
+    let recent_activity = now.signed_duration_since(block.last_entry).num_hours() < 5;
+    if now_in_block && recent_activity {
+        Some(block)
+    } else {
+        None
+    }
+}
+
+fn token_total(c: &ProviderCall) -> u64 {
+    c.input_tokens
+        .saturating_add(c.output_tokens)
+        .saturating_add(c.reasoning_tokens)
+        .saturating_add(c.cache_creation_tokens)
+        .saturating_add(c.cache_read_tokens)
+}
+
+fn floor_to_hour(t: DateTime<Utc>) -> DateTime<Utc> {
+    t.with_minute(0)
+        .and_then(|t| t.with_second(0))
+        .and_then(|t| t.with_nanosecond(0))
+        .unwrap_or(t)
+}
+
+fn time_until_block_end(block: &ActiveBlock, now: DateTime<Utc>) -> Duration {
+    let end = block.start + chrono::Duration::hours(5);
+    let secs = end.signed_duration_since(now).num_seconds();
+    if secs <= 0 {
+        Duration::ZERO
+    } else {
+        Duration::from_secs(secs as u64)
+    }
+}
+
+/// Pull recent Claude calls (last 5h) without re-parsing the entire
+/// history. Mirrors `parse_usage_for` but with a tight time filter.
+fn collect_recent_claude_calls() -> Vec<ProviderCall> {
+    use crate::models::UsagePeriod;
+    use crate::models::usage::{UsageProviderFilter, UsageQuery, parse_usage_for};
+
+    let query = UsageQuery {
+        period: UsagePeriod::Today,
+        provider_filter: UsageProviderFilter::Claude,
+        include_projects: Vec::new(),
+        exclude_projects: Vec::new(),
+        filters: Default::default(),
+    };
+    let data = parse_usage_for(query);
+    let cutoff = Utc::now() - chrono::Duration::hours(5);
+    data.calls.into_iter().filter(|c| c.timestamp >= cutoff).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t(year: i32, mo: u32, d: u32, h: u32, m: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, mo, d, h, m, 0).unwrap()
+    }
+
+    fn call_at(ts: DateTime<Utc>, tokens: u64) -> ProviderCall {
+        ProviderCall {
+            id: ts.timestamp() as u64,
+            provider: "claude".to_string(),
+            model: "test".to_string(),
+            session_id: "s".to_string(),
+            project: "p".to_string(),
+            project_path: "/p".to_string(),
+            timestamp: ts,
+            input_tokens: tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 0,
+            reasoning_tokens: 0,
+            cost_usd: Some(0.01),
+            tools: Vec::new(),
+            bash_commands: Vec::new(),
+            user_message: String::new(),
+            branch: None,
+        }
+    }
+
+    #[test]
+    fn empty_calls_returns_no_active_block() {
+        let now = t(2026, 5, 7, 10, 0);
+        assert!(current_active_block(&[], now).is_none());
+    }
+
+    #[test]
+    fn single_recent_call_yields_active_block() {
+        let now = t(2026, 5, 7, 10, 30);
+        let calls = vec![call_at(t(2026, 5, 7, 10, 0), 1000)];
+        let block = current_active_block(&calls, now).expect("block should be active");
+        assert_eq!(block.total_tokens, 1000);
+        assert_eq!(block.start, t(2026, 5, 7, 10, 0));
+    }
+
+    #[test]
+    fn old_call_yields_no_active_block() {
+        // Last entry was 6h ago; should be inactive.
+        let now = t(2026, 5, 7, 16, 0);
+        let calls = vec![call_at(t(2026, 5, 7, 10, 0), 1000)];
+        assert!(current_active_block(&calls, now).is_none());
+    }
+
+    #[test]
+    fn block_rolls_over_after_5h_window() {
+        // Call at 10:00 starts block; call at 16:00 (>5h later) starts new block.
+        let now = t(2026, 5, 7, 16, 30);
+        let calls = vec![
+            call_at(t(2026, 5, 7, 10, 0), 1000),
+            call_at(t(2026, 5, 7, 16, 0), 500),
+        ];
+        let block = current_active_block(&calls, now).expect("active block");
+        assert_eq!(block.total_tokens, 500, "only second call counts");
+        assert_eq!(block.start, t(2026, 5, 7, 16, 0));
+    }
+
+    #[test]
+    fn calls_within_5h_aggregate() {
+        let now = t(2026, 5, 7, 12, 0);
+        let calls = vec![
+            call_at(t(2026, 5, 7, 10, 0), 500),
+            call_at(t(2026, 5, 7, 10, 30), 700),
+            call_at(t(2026, 5, 7, 11, 30), 800),
+        ];
+        let block = current_active_block(&calls, now).expect("active block");
+        assert_eq!(block.total_tokens, 2000);
+    }
+
+    #[test]
+    fn duration_until_iso8601_handles_future_and_past() {
+        let future = (Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let d = duration_until_iso8601(&future).expect("future");
+        assert!(d.as_secs() > 0);
+
+        let past = (Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        assert!(duration_until_iso8601(&past).is_none());
+
+        assert!(duration_until_iso8601("not a date").is_none());
+    }
+
+    #[test]
+    fn cache_is_fresh_within_window() {
+        let cache = LiveCache {
+            version: crate::cli::statusline::CACHE_SCHEMA_VERSION,
+            updated_at: Utc::now().to_rfc3339(),
+            five_hour: None,
+            seven_day: None,
+            today_cost_usd: None,
+            context_pct: None,
+            model: None,
+        };
+        assert!(cache_is_fresh(&cache));
+    }
+
+    #[test]
+    fn cache_is_stale_after_window() {
+        let old =
+            (Utc::now() - chrono::Duration::seconds(CACHE_MAX_AGE_SECS as i64 + 30)).to_rfc3339();
+        let cache = LiveCache {
+            version: crate::cli::statusline::CACHE_SCHEMA_VERSION,
+            updated_at: old,
+            five_hour: None,
+            seven_day: None,
+            today_cost_usd: None,
+            context_pct: None,
+            model: None,
+        };
+        assert!(!cache_is_fresh(&cache));
+    }
+
+    // Env-var tests share process state — fold both checks into one
+    // serial test to avoid races with other tests on the same var.
+    #[test]
+    fn token_limit_env_var_round_trip() {
+        // Default (no var set)
+        std::env::remove_var("AINB_TOKEN_LIMIT");
+        assert_eq!(token_limit_from_env(), DEFAULT_TOKEN_LIMIT);
+
+        // Valid value
+        std::env::set_var("AINB_TOKEN_LIMIT", "42");
+        assert_eq!(token_limit_from_env(), 42);
+
+        // Invalid value falls back
+        std::env::set_var("AINB_TOKEN_LIMIT", "not a number");
+        assert_eq!(token_limit_from_env(), DEFAULT_TOKEN_LIMIT);
+
+        // Zero value is treated as unset
+        std::env::set_var("AINB_TOKEN_LIMIT", "0");
+        assert_eq!(token_limit_from_env(), DEFAULT_TOKEN_LIMIT);
+
+        std::env::remove_var("AINB_TOKEN_LIMIT");
+    }
+
+    #[test]
+    fn window_from_cache_populates_all_optional_fields() {
+        use crate::cli::statusline::RateWindow;
+        let future = (Utc::now() + chrono::Duration::hours(2)).to_rfc3339();
+        let cache = LiveCache {
+            version: crate::cli::statusline::CACHE_SCHEMA_VERSION,
+            updated_at: Utc::now().to_rfc3339(),
+            five_hour: Some(RateWindow {
+                pct: 30,
+                resets_at: Some(future),
+            }),
+            seven_day: Some(RateWindow {
+                pct: 5,
+                resets_at: None,
+            }),
+            today_cost_usd: Some(2.5),
+            context_pct: Some(40),
+            model: Some("Opus".to_string()),
+        };
+        let w = window_from_cache(cache);
+        assert_eq!(w.source, Source::Tier1Cache);
+        assert_eq!(w.five_hour_pct, Some(30));
+        assert_eq!(w.seven_day_pct, Some(5));
+        assert_eq!(w.today_cost_usd, Some(2.5));
+        assert_eq!(w.context_pct, Some(40));
+        assert_eq!(w.model.as_deref(), Some("Opus"));
+        assert!(w.resets_in.unwrap().as_secs() > 0);
+    }
+}

--- a/ainb-tui/src/models/mod.rs
+++ b/ainb-tui/src/models/mod.rs
@@ -1,5 +1,6 @@
 // ABOUTME: Core data models for Claude-in-a-Box sessions, workspaces, and state management
 
+pub mod live_window;
 pub mod other_tmux;
 pub mod repo_lookup;
 pub mod session;

--- a/ainb-tui/src/models/usage.rs
+++ b/ainb-tui/src/models/usage.rs
@@ -899,6 +899,121 @@ fn collect_claude_jsonl_files(project_dir: &Path) -> Vec<PathBuf> {
     files
 }
 
+/// Collect Claude assistant calls whose timestamp is `>= cutoff`,
+/// skipping files whose mtime falls before `cutoff - grace`. This is the
+/// hot-path the live-window 5h aggregator relies on — it intentionally
+/// does *not* go through the usage cache because we only need a tight
+/// time slice, not the full history.
+///
+/// `grace` widens the mtime filter to forgive clock skew between
+/// timestamp comparisons (real-world JSONL files have been seen with
+/// mtime trailing the last entry's timestamp by a few seconds).
+///
+/// Returns an empty vec if the projects dir is missing.
+pub(crate) fn collect_recent_claude_calls_within(
+    cutoff: DateTime<Utc>,
+    grace: Duration,
+) -> Vec<ProviderCall> {
+    let roots = UsageSourceRoots::default();
+    let Some(projects_dir) = roots.claude_projects_dir.as_deref() else {
+        return Vec::new();
+    };
+    collect_recent_claude_calls_within_at(projects_dir, cutoff, grace)
+}
+
+/// Test seam for `collect_recent_claude_calls_within` — accepts an
+/// explicit `projects_dir` so tests can drive the walker against a
+/// tempdir without mutating environment variables.
+pub(crate) fn collect_recent_claude_calls_within_at(
+    projects_dir: &Path,
+    cutoff: DateTime<Utc>,
+    grace: Duration,
+) -> Vec<ProviderCall> {
+    if !projects_dir.is_dir() {
+        return Vec::new();
+    }
+    let username = whoami_username();
+    let mtime_floor = std::time::SystemTime::UNIX_EPOCH
+        + std::time::Duration::from_secs((cutoff - grace).timestamp().max(0) as u64);
+
+    let mut calls = Vec::new();
+    let Ok(project_dirs) = std::fs::read_dir(projects_dir) else {
+        return calls;
+    };
+    for entry in project_dirs.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let raw_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+        let project = clean_project_name(raw_name, &username);
+        let project_path = unsanitize_project_path(raw_name);
+
+        for jsonl_path in collect_claude_jsonl_files(&path) {
+            // mtime gate — skip files that haven't been touched in the
+            // window. Cheap and avoids opening cold archives.
+            if let Ok(meta) = std::fs::metadata(&jsonl_path) {
+                if let Ok(mtime) = meta.modified() {
+                    if mtime < mtime_floor {
+                        continue;
+                    }
+                }
+            }
+            parse_claude_jsonl_within(
+                &jsonl_path,
+                &project,
+                &project_path,
+                cutoff,
+                &mut calls,
+            );
+        }
+    }
+    calls
+}
+
+/// Stream a single Claude JSONL file and append calls whose timestamp
+/// is `>= cutoff` to `out`. JSONL files are append-only with
+/// monotonically increasing timestamps, so once we have collected at
+/// least one call inside the window and then encounter a call before
+/// the window we know the rest of the file is older too — but the
+/// converse is not guaranteed (header lines, "user"-typed lines, etc.
+/// have no usage data and emit `None`). To stay correct we just walk
+/// to EOF and filter; the mtime gate already keeps the per-file work
+/// bounded.
+fn parse_claude_jsonl_within(
+    path: &Path,
+    project: &str,
+    project_path: &str,
+    cutoff: DateTime<Utc>,
+    out: &mut Vec<ProviderCall>,
+) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+    let reader = BufReader::new(file);
+    let mut current_user_message = String::new();
+    let mut offset: u64 = 0;
+    for line in reader.lines() {
+        let Ok(line) = line else { return };
+        let line_offset = offset;
+        // Reconstruct byte advance: line bytes + the trailing newline
+        // we stripped (BufRead::lines drops the terminator).
+        offset += line.len() as u64 + 1;
+        if let Some(call) = parse_claude_line(
+            &line,
+            path,
+            project,
+            project_path,
+            &mut current_user_message,
+            line_offset,
+        ) {
+            if call.timestamp >= cutoff {
+                out.push(call);
+            }
+        }
+    }
+}
+
 /// Full parse of a Claude JSONL session file. Returns the complete
 /// `Vec<ProviderCall>` and the byte offset where parsing stopped (typically
 /// the file size at open time — note this is best-effort: if the file is
@@ -3778,5 +3893,94 @@ mod tests {
         let proj = &data.projects[0];
         assert_eq!(proj.name, "plain-folder");
         assert!(proj.repo.is_none());
+    }
+
+    #[test]
+    fn collect_recent_within_keeps_only_entries_inside_cutoff() {
+        // Two assistant lines: one inside the 5h window, one well
+        // outside it. The walker must return only the inside-window
+        // call.
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join("projects");
+        let project_dir = claude_projects.join("-Users-stevie-fixture");
+        let now = Utc::now();
+        let inside = (now - Duration::hours(2)).to_rfc3339();
+        let outside = (now - Duration::hours(8)).to_rfc3339();
+        let payload = format!(
+            "{}\n{}\n",
+            format!(
+                r#"{{"type":"assistant","timestamp":"{outside}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":100,"output_tokens":50}}}}}}"#,
+            ),
+            format!(
+                r#"{{"type":"assistant","timestamp":"{inside}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":200,"output_tokens":75}}}}}}"#,
+            ),
+        );
+        write_file(&project_dir.join("session.jsonl"), &payload);
+
+        let cutoff = now - Duration::hours(5);
+        let calls = collect_recent_claude_calls_within_at(
+            &claude_projects,
+            cutoff,
+            Duration::hours(1),
+        );
+
+        assert_eq!(calls.len(), 1, "only the in-window call should survive");
+        let call = &calls[0];
+        assert_eq!(call.input_tokens, 200);
+        assert!(
+            call.timestamp >= cutoff,
+            "kept call must be within cutoff"
+        );
+    }
+
+    #[test]
+    fn collect_recent_within_skips_files_below_mtime_floor() {
+        // File with one in-window assistant entry, but its mtime is
+        // older than the (cutoff - grace) floor. Expectation: skipped.
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join("projects");
+        let project_dir = claude_projects.join("-Users-stevie-stale");
+        let now = Utc::now();
+        // Even though the line itself is in-window, an old mtime
+        // proves the file hasn't been written to recently — Claude
+        // would have updated mtime if it were still appending. The
+        // walker treats stale-mtime files as cold archives.
+        let in_window = (now - Duration::minutes(30)).to_rfc3339();
+        let payload = format!(
+            r#"{{"type":"assistant","timestamp":"{in_window}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":99,"output_tokens":1}}}}}}"#
+        );
+        let session = project_dir.join("session.jsonl");
+        write_file(&session, &payload);
+        // Backdate mtime to 24h ago — well past the (5h + 1h) gate.
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&session)
+            .unwrap();
+        let twenty_four_hours_ago = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(60 * 60 * 24);
+        f.set_modified(twenty_four_hours_ago).unwrap();
+
+        let cutoff = now - Duration::hours(5);
+        let calls = collect_recent_claude_calls_within_at(
+            &claude_projects,
+            cutoff,
+            Duration::hours(1),
+        );
+        assert!(
+            calls.is_empty(),
+            "files older than (cutoff - grace) should be skipped",
+        );
+    }
+
+    #[test]
+    fn collect_recent_within_returns_empty_when_dir_missing() {
+        let temp = tempdir().unwrap();
+        let projects = temp.path().join("does-not-exist");
+        let calls = collect_recent_claude_calls_within_at(
+            &projects,
+            Utc::now() - Duration::hours(5),
+            Duration::hours(1),
+        );
+        assert!(calls.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Brings live OAuth-derived rate-limit windows (5h burn % + 7d window % + reset times) into ainb-tui by becoming a Claude Code statusline ourselves. Exposes the data in three places: powerline statusline output, session window top bar, and Burndown Budget panel.

**6 atomic commits**:
1. `bfe0666` `ainb statusline` subcommand reads stdin JSON, writes `~/.cache/ainb/live.json`, emits powerline status
2. `6169871` `install_statusline()` helper with idempotent `~/.claude/settings.json` merge + backup
3. `7974f67` `live_window.rs` three-tier reader: cache → native 5h-block aggregator → none
4. `6da72de` Budget panel live bars + `W` keybind triggers install
5. `2c5220d` Top-bar live widget + red CTA when not wired
6. `e4844c5` `ainb init` wizard step offers statusline install

**Architecture**:

```
shared install_statusline()  ◀────┐
        ▲          ▲              │
        │          │              │
   ainb init   Budget CTA   Top-bar widget
   (proactive) (reactive)  (always-visible state)
```

State machine `StatuslineDecision { Unset | Declined | Installed | Chained }` persists user choice. Top bar respects Declined; Budget panel CTA always visible to power users.

**Why this approach** vs OAuth + capacity estimator: ccusage-style local 5h-block aggregation handles non-OAuth users (Tier 2). For OAuth subscribers, becoming the statusline is the only way to access `rate_limits` data — Claude Code only pipes it to statusline hooks via stdin. Zero new auth code, zero new API surface.

## Test plan
- [x] 624 tests pass (52 new); 9 pre-existing Docker failures match main baseline
- [x] Each commit builds + tests independently
- [x] No new clippy warnings
- [ ] Visual smoke: install via init, run claude with prompt, verify top bar populates within 5s
- [ ] Visual smoke: decline at init, verify red CTA in top bar; press [W] in Budget panel to trigger install

## Follow-ups (out of scope, noted by agent)
- Top-bar CTA's "[N]" Stats key placeholder dropped (multi-key in this codebase) — could add single-digit Stats binding
- Tier 2 active-block reader does full local JSONL re-parse — could add tight last-5h-only path
- Budget CTA can push cap-bar off-screen on very narrow burndown layouts — height-constrain header
- Init wizard's "k/r/c/s" prompt re-loop on invalid input not implemented (typo == skip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live rate-limit monitoring (5h/7d burn) shown in the Budget panel with optional mini-bars and reset countdowns
  * Claude Code statusline integration plus a CLI statusline command for wiring
  * Interactive statusline setup wizard during initialization with persistent user decision
  * Press W from the Burndown view to wire the statusline; contextual CTA appears when not wired
  * Real-time token cost and model/context info displayed when available
<!-- end of auto-generated comment: release notes by coderabbit.ai -->