### PR TITLE
refactor(cli): namespace statusline under claudecode subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ brew install stevengonsalvez/agents-in-a-box/ainb
 - **git** — worktree operations
 - **Claude Code CLI** — the `claude` command
 
+### Live window source matrix
+
+| Provider | 5h burn | 7d window | Cost | Reset times | Source |
+|---|---|---|---|---|---|
+| Claude Code (Pro/Max OAuth + statusline wired) | ✓ | ✓ | ✓ | ✓ | OAuth-grade via Claude Code |
+| Claude Code (API key) | ✓ | — | ✓ | — | local JSONL fallback |
+| Claude Code (statusline not wired) | ✓ | — | ✓ | — | local JSONL fallback |
+| Codex | ✓ | — | ✓ | — | local JSONL fallback |
+| Other agents | — | — | — | — | not supported |
+
+**Why the asymmetry**: only Anthropic publishes rate-limit windows over OAuth, and only the Claude Code CLI exposes them to statusline hooks. Wiring `ainb claudecode statusline` brings the OAuth-grade signal into ainb-tui's Burndown panel and session-window top bar.
+
 ---
 
 ## Toolkit

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -4411,6 +4411,18 @@ impl EventHandler {
                                 .to_string(),
                         );
                     }
+                    Ok(crate::cli::statusline_install::InstallOutcome::Migrated) => {
+                        // Legacy `ainb statusline` was rewritten in
+                        // place to `ainb claudecode statusline`. The
+                        // user already opted in; surface as a success.
+                        state.app_config.ui_preferences.statusline_decision =
+                            crate::config::StatuslineDecision::Installed;
+                        let _ = state.app_config.save();
+                        state.add_success_notification(
+                            "Migrated existing ainb statusline → ainb claudecode statusline."
+                                .to_string(),
+                        );
+                    }
                     Ok(crate::cli::statusline_install::InstallOutcome::ExistingDifferent {
                         current_command,
                     }) => {

--- a/ainb-tui/src/cli/init.rs
+++ b/ainb-tui/src/cli/init.rs
@@ -458,7 +458,7 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
 ) -> Result<StatuslineStepOutcome> {
     use crate::cli::statusline_install::{
         InstallOutcome, StatuslineStatus, detect_statusline_status, install_statusline,
-        install_statusline_replace_at, settings_path,
+        install_statusline_at, install_statusline_replace_at, settings_path,
     };
     use crate::config::StatuslineDecision;
 
@@ -472,7 +472,25 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
 
     match status {
         StatuslineStatus::Configured => {
-            writeln!(out, "  ✓ Claude Code statusline already wired.").ok();
+            // Already wired. If on the legacy `ainb statusline` form,
+            // silently migrate to the new namespaced command — the user
+            // already opted in; the rename is an internal concern. Both
+            // legacy and new forms classify as Configured, so we have to
+            // call into install to do the in-place rewrite and read its
+            // outcome to differentiate.
+            let path = settings_path()?;
+            match install_statusline_at(&path)? {
+                InstallOutcome::Migrated => {
+                    writeln!(
+                        out,
+                        "  ✓ Migrated existing ainb statusline → ainb claudecode statusline."
+                    )
+                    .ok();
+                }
+                _ => {
+                    writeln!(out, "  ✓ Claude Code statusline already wired.").ok();
+                }
+            }
             app_config.ui_preferences.statusline_decision = StatuslineDecision::Installed;
             let _ = app_config.save();
             Ok(StatuslineStepOutcome::Skipped)
@@ -482,7 +500,7 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
             writeln!(out, "Existing Claude Code statusline detected: {cmd}").ok();
             writeln!(
                 out,
-                "  [k]eep your current command  [r]eplace with ainb statusline  [s]kip for now"
+                "  [k]eep your current command  [r]eplace with ainb claudecode statusline  [s]kip for now"
             )
             .ok();
             write!(out, "Choice [k/r/s]: ").ok();
@@ -546,6 +564,22 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
                                 StatuslineDecision::Installed;
                             let _ = app_config.save();
                             writeln!(out, "  ✓ Wired Claude Code statusline.").ok();
+                            Ok(StatuslineStepOutcome::Installed)
+                        }
+                        InstallOutcome::Migrated => {
+                            // Race: between detect (which classified as
+                            // NotConfigured) and install, the legacy
+                            // form appeared and was migrated in place.
+                            // Surface it the same as a fresh install so
+                            // the user knows the statusline is wired.
+                            app_config.ui_preferences.statusline_decision =
+                                StatuslineDecision::Installed;
+                            let _ = app_config.save();
+                            writeln!(
+                                out,
+                                "  ✓ Migrated existing ainb statusline → ainb claudecode statusline."
+                            )
+                            .ok();
                             Ok(StatuslineStepOutcome::Installed)
                         }
                         InstallOutcome::ExistingDifferent { current_command } => {
@@ -879,7 +913,10 @@ mod tests {
         let settings = home.join(".claude").join("settings.json");
         assert!(settings.exists());
         let contents = std::fs::read_to_string(&settings).unwrap();
-        assert!(contents.contains("ainb statusline"));
+        assert!(
+            contents.contains("ainb claudecode statusline"),
+            "expected new namespaced command, got: {contents}"
+        );
 
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -149,9 +149,21 @@ pub enum Commands {
         command: usage::UsageCommands,
     },
 
-    /// Claude Code statusline hook: read JSON on stdin, cache rate-limit
-    /// windows for the TUI, and emit a powerline status string on stdout.
-    /// Wire into `~/.claude/settings.json` as the `statusLine.command`.
+    /// Claude Code-specific commands (statusline, etc.)
+    ///
+    /// Provider-namespaced commands that only apply to the Claude Code CLI
+    /// — e.g. wiring its statusline hook so OAuth-grade rate-limit windows
+    /// flow into ainb-tui's Burndown panel.
+    Claudecode {
+        #[command(subcommand)]
+        cmd: ClaudeCodeCmd,
+    },
+
+    /// (Legacy alias) Claude Code statusline hook. Prefer
+    /// `ainb claudecode statusline`. Kept so existing
+    /// `~/.claude/settings.json` entries keep working unchanged; new
+    /// installs write the new path and migrate on next `ainb init`.
+    #[command(hide = true)]
     Statusline,
 
     /// Generate shell completions (bash, zsh, fish, powershell, elvish)
@@ -159,6 +171,20 @@ pub enum Commands {
         /// Shell to generate completions for
         shell: clap_complete::Shell,
     },
+}
+
+/// Claude Code provider-specific subcommands.
+///
+/// New surface area for anything tied to the Claude Code CLI specifically
+/// (statusline hook today; doctor / config introspection in the future).
+/// Kept in a dedicated namespace so that other providers (e.g. Codex) can
+/// grow their own equivalents without lying at the top level.
+#[derive(clap::Subcommand)]
+pub enum ClaudeCodeCmd {
+    /// Statusline hook: read JSON on stdin, cache rate-limit windows for
+    /// the TUI, and emit a powerline status string on stdout. Wire into
+    /// `~/.claude/settings.json` as `statusLine.command`.
+    Statusline,
 }
 
 /// Arguments for the run command
@@ -268,4 +294,39 @@ pub struct KillArgs {
     /// Force kill without confirmation
     #[arg(long, short)]
     pub force: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Both `ainb statusline` (legacy) and `ainb claudecode statusline`
+    /// (new canonical) must parse successfully so existing
+    /// `~/.claude/settings.json` entries keep working unchanged while new
+    /// installs migrate to the namespaced form.
+    #[test]
+    fn statusline_legacy_alias_still_parses() {
+        let cli = Cli::try_parse_from(["ainb", "statusline"]).expect("legacy alias must parse");
+        assert!(matches!(cli.command, Some(Commands::Statusline)));
+    }
+
+    #[test]
+    fn statusline_new_namespaced_path_parses() {
+        let cli = Cli::try_parse_from(["ainb", "claudecode", "statusline"])
+            .expect("namespaced path must parse");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Claudecode {
+                cmd: ClaudeCodeCmd::Statusline
+            })
+        ));
+    }
+
+    /// The namespace is provider-specific; bare `ainb claudecode` without
+    /// a subcommand must fail rather than silently doing nothing.
+    #[test]
+    fn claudecode_without_subcommand_is_rejected() {
+        assert!(Cli::try_parse_from(["ainb", "claudecode"]).is_err());
+    }
 }

--- a/ainb-tui/src/cli/statusline_install.rs
+++ b/ainb-tui/src/cli/statusline_install.rs
@@ -18,11 +18,7 @@ pub const AINB_STATUSLINE_CMD: &str = "ainb statusline";
 
 /// Canonical command we install into Claude Code's `statusLine.command`.
 /// Provider-namespaced so that other providers (Codex et al.) can grow
-/// their own equivalents without lying at the top level. Wired into the
-/// install/migrate path in the next commit; declared here so the clap
-/// surface and the install helper land in atomic, independently-testable
-/// steps.
-#[allow(dead_code)]
+/// their own equivalents without lying at the top level.
 pub const AINB_CLAUDECODE_STATUSLINE_CMD: &str = "ainb claudecode statusline";
 
 /// Outcome of an `install_statusline()` call.
@@ -35,6 +31,11 @@ pub enum InstallOutcome {
     /// A different statusLine command was present; we did NOT overwrite.
     /// The caller decides keep / replace based on the value.
     ExistingDifferent { current_command: String },
+    /// The legacy `ainb statusline` command was present and we rewrote it
+    /// in place to the new `ainb claudecode statusline` form. Treated as
+    /// a successful upgrade — the user already opted in to ainb owning
+    /// the statusline; namespace is an internal concern.
+    Migrated,
 }
 
 /// Status of the user's statusline configuration.
@@ -84,7 +85,19 @@ fn classify_status(value: &serde_json::Value) -> StatuslineStatus {
     }
 }
 
+/// True if `cmd` is *either* the legacy `ainb statusline` or the new
+/// canonical `ainb claudecode statusline` form. Used to decide whether
+/// the on-disk config is "owned by ainb" — separately, the legacy form
+/// is detected via [`is_legacy_command`] to drive the in-place migration.
 fn command_is_ours(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    trimmed == AINB_STATUSLINE_CMD || trimmed == AINB_CLAUDECODE_STATUSLINE_CMD
+}
+
+/// True if `cmd` is the legacy top-level `ainb statusline` form. Drives
+/// the migration branch in `install_statusline_at` so existing settings
+/// land on the new namespaced command on the next install/init.
+fn is_legacy_command(cmd: &str) -> bool {
     cmd.trim() == AINB_STATUSLINE_CMD
 }
 
@@ -142,7 +155,25 @@ pub fn install_statusline_at(path: &Path) -> Result<InstallOutcome> {
         .with_context(|| format!("failed to parse {}", path.display()))?;
 
     match classify_status(&value) {
-        StatuslineStatus::Configured => Ok(InstallOutcome::AlreadyInstalled),
+        StatuslineStatus::Configured => {
+            // Both legacy and new forms classify as `Configured`. If the
+            // user is on the legacy form, rewrite in place to the new
+            // namespaced command — they already opted in to ainb owning
+            // the statusline; the old name is just a stale label.
+            let current = value
+                .pointer("/statusLine/command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if is_legacy_command(current) {
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert("statusLine".to_string(), block);
+                }
+                write_with_backup(path, &bytes, &value)?;
+                Ok(InstallOutcome::Migrated)
+            } else {
+                Ok(InstallOutcome::AlreadyInstalled)
+            }
+        }
         StatuslineStatus::Other(current) => Ok(InstallOutcome::ExistingDifferent {
             current_command: current,
         }),
@@ -185,7 +216,7 @@ pub fn install_statusline_replace_at(path: &Path) -> Result<InstallOutcome> {
 fn our_block() -> serde_json::Value {
     serde_json::json!({
         "type": "command",
-        "command": AINB_STATUSLINE_CMD,
+        "command": AINB_CLAUDECODE_STATUSLINE_CMD,
         "padding": 0,
     })
 }
@@ -308,12 +339,27 @@ mod tests {
     }
 
     #[test]
-    fn detect_status_returns_configured_for_our_command() {
+    fn detect_status_returns_configured_for_legacy_command() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("settings.json");
         std::fs::write(
             &path,
             br#"{"statusLine":{"type":"command","command":"ainb statusline"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_statusline_status_at(&path).unwrap(),
+            StatuslineStatus::Configured
+        );
+    }
+
+    #[test]
+    fn detect_status_returns_configured_for_new_namespaced_command() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"statusLine":{"type":"command","command":"ainb claudecode statusline"}}"#,
         )
         .unwrap();
         assert_eq!(
@@ -385,7 +431,7 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["theme"], "dark");
         assert!(v["mcpServers"].is_object());
-        assert_eq!(v["statusLine"]["command"], "ainb statusline");
+        assert_eq!(v["statusLine"]["command"], AINB_CLAUDECODE_STATUSLINE_CMD);
 
         // Backup created
         let bak_count = std::fs::read_dir(dir.path())
@@ -397,12 +443,12 @@ mod tests {
     }
 
     #[test]
-    fn install_is_idempotent_when_already_ours() {
+    fn install_is_idempotent_when_already_on_new_command() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("settings.json");
         std::fs::write(
             &path,
-            br#"{"statusLine":{"type":"command","command":"ainb statusline","padding":0}}"#,
+            br#"{"statusLine":{"type":"command","command":"ainb claudecode statusline","padding":0}}"#,
         )
         .unwrap();
         let outcome = install_statusline_at(&path).unwrap();
@@ -415,6 +461,54 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().starts_with("settings.json.bak."))
             .count();
         assert_eq!(bak_count, 0);
+    }
+
+    #[test]
+    fn install_migrates_legacy_command_to_namespaced_form() {
+        // Existing settings.json carrying the pre-namespacing command
+        // must be rewritten in place on the next install/init pass.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            br#"{"theme":"dark","statusLine":{"type":"command","command":"ainb statusline","padding":0}}"#,
+        )
+        .unwrap();
+
+        let outcome = install_statusline_at(&path).unwrap();
+        assert_eq!(outcome, InstallOutcome::Migrated);
+
+        // Other keys preserved, command rewritten.
+        let v: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["theme"], "dark");
+        assert_eq!(v["statusLine"]["command"], AINB_CLAUDECODE_STATUSLINE_CMD);
+
+        // Migration is a real write — it must produce a backup so the
+        // user can revert if the rewrite was unwanted.
+        let bak_count = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("settings.json.bak."))
+            .count();
+        assert_eq!(bak_count, 1, "migration must record a backup");
+    }
+
+    #[test]
+    fn is_legacy_command_only_matches_old_top_level_form() {
+        assert!(is_legacy_command("ainb statusline"));
+        assert!(is_legacy_command("  ainb statusline\n"));
+        assert!(!is_legacy_command(AINB_CLAUDECODE_STATUSLINE_CMD));
+        assert!(!is_legacy_command("ainb usage"));
+        assert!(!is_legacy_command(""));
+    }
+
+    #[test]
+    fn command_is_ours_accepts_both_legacy_and_new() {
+        assert!(command_is_ours("ainb statusline"));
+        assert!(command_is_ours(AINB_CLAUDECODE_STATUSLINE_CMD));
+        assert!(!command_is_ours("~/bin/foo"));
+        assert!(!command_is_ours("~/bin/foo | ainb statusline"));
     }
 
     #[test]

--- a/ainb-tui/src/cli/statusline_install.rs
+++ b/ainb-tui/src/cli/statusline_install.rs
@@ -11,8 +11,19 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
-/// Command we install into Claude Code's `statusLine.command`.
+/// Legacy command we used to install into Claude Code's
+/// `statusLine.command`. Retained for migration detection — fresh installs
+/// write [`AINB_CLAUDECODE_STATUSLINE_CMD`] instead.
 pub const AINB_STATUSLINE_CMD: &str = "ainb statusline";
+
+/// Canonical command we install into Claude Code's `statusLine.command`.
+/// Provider-namespaced so that other providers (Codex et al.) can grow
+/// their own equivalents without lying at the top level. Wired into the
+/// install/migrate path in the next commit; declared here so the clap
+/// surface and the install helper land in atomic, independently-testable
+/// steps.
+#[allow(dead_code)]
+pub const AINB_CLAUDECODE_STATUSLINE_CMD: &str = "ainb claudecode statusline";
 
 /// Outcome of an `install_statusline()` call.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -816,7 +816,7 @@ fn build_cta_spans() -> Vec<Span<'static>> {
     let red = Color::Rgb(230, 100, 100);
     vec![
         Span::styled("⚠ ", Style::default().fg(red).add_modifier(Modifier::BOLD)),
-        Span::styled("Live CC usage off", Style::default().fg(red)),
+        Span::styled("Live Claude Code usage off", Style::default().fg(red)),
         Span::styled(" · go to Stats to enable", Style::default().fg(MUTED_GRAY)),
     ]
 }
@@ -881,7 +881,7 @@ mod live_widget_tests {
     fn cta_spans_contain_warning_and_stats_hint() {
         let spans = build_cta_spans();
         let text = flatten(&spans);
-        assert!(text.contains("Live CC usage off"));
+        assert!(text.contains("Live Claude Code usage off"));
         assert!(text.contains("Stats"));
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -3329,7 +3329,7 @@ fn budget_live_header_lines(
                 out.push(live_bar_line("5h burn ", pct, bar_w));
             }
             out.push(Line::from(Span::styled(
-                " Wire statusline (W) for 7d window + cost",
+                " Wire Claude Code statusline (W) for 7d window + cost",
                 Style::default().fg(MUTED_GRAY),
             )));
         }
@@ -4855,7 +4855,7 @@ mod budget_live_header_tests {
         let text = flat(&lines);
         assert!(text.contains("5h burn"));
         assert!(!text.contains("7d wnd"));
-        assert!(text.contains("Wire statusline"));
+        assert!(text.contains("Wire Claude Code statusline"));
     }
 
     #[test]

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -117,7 +117,14 @@ async fn main() -> Result<()> {
             cli::presets::execute(command, args.format).await
         }
         Some(cli::Commands::Usage { command }) => cli::usage::execute(command, args.format).await,
-        Some(cli::Commands::Statusline) => cli::statusline::execute(),
+        // New canonical namespace: `ainb claudecode statusline`. Legacy
+        // top-level `Statusline` dispatches to the same handler so
+        // existing `~/.claude/settings.json` entries keep working
+        // unchanged.
+        Some(cli::Commands::Claudecode {
+            cmd: cli::ClaudeCodeCmd::Statusline,
+        })
+        | Some(cli::Commands::Statusline) => cli::statusline::execute(),
         Some(cli::Commands::Completion { shell }) => {
             use clap::CommandFactory;
             let mut cmd = cli::Cli::command();


### PR DESCRIPTION
## Summary

Provider-namespaces the `statusline` subcommand under a new `claudecode` group so future provider-specific work has a clean home. The Claude Code statusline hook, OAuth rate-limit JSON shape, and `~/.claude/settings.json` integration are inherently Anthropic+Claude-Code-specific — the flat top-level namespace was misleading.

```
ainb claudecode statusline       # new canonical
ainb statusline                  # legacy alias, hidden in --help, still works
```

3 atomic commits:

- `70ba779` — clap restructure with `ClaudeCode { cmd: ClaudeCodeCmd::Statusline }`, legacy variant kept hidden but functional
- `cfed661` — `InstallOutcome::Migrated` variant; `install_statusline_at` rewrites legacy → namespaced on next install/init, with backup
- `b4abb09` — copy clarity (top-bar 'Live Claude Code usage off', Tier 2 hint), README adds per-provider source matrix

## Why

Codex / other agents have no `statusLine.command` analog. Namespacing makes the boundary obvious and gives `ainb codex <future-thing>` a clean slot.

## Migration

Existing users with `ainb statusline` in settings.json keep working through the alias. Re-running `ainb init` (or any install path) auto-migrates the command to `ainb claudecode statusline` with a backup.

## Test plan
- [x] 635 tests pass (+7 net new), 9 pre-existing Docker baseline failures unchanged
- [x] Each commit independently builds + tests
- [x] Verified end-to-end: both `ainb statusline` and `ainb claudecode statusline` produce identical powerline output
- [x] `ainb claudecode` (no sub) is rejected as expected
- [ ] Visual smoke: re-run `ainb init` against a config with legacy statusline, confirm migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced namespaced command structure for Claude Code functionality with automatic backward compatibility.
  * Automatic migration of existing configurations from legacy command format to new structure.

* **Documentation**
  * Added provider data availability matrix documenting feature support across services.

* **Improvements**
  * Enhanced UI messaging for improved clarity around Claude Code features and statusline integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->