### PR TITLE
feat(statusline): one-key install + top-of-Stats enable card

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -42,14 +42,12 @@ toml = "0.8"
 
 # Claude API integration
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
-async-stream = "0.3"
 tokio-stream = "0.1"
 
 # Utils
 shell-escape = "0.1"  # Safe shell escaping for paths
 anyhow = "1.0"
 thiserror = "1.0"
-directories = "5.0"
 dirs = "5.0"
 uuid = { version = "1.5", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -6,7 +6,9 @@ use crate::app::{
     AppState,
     state::{AsyncAction, AuthMethod, ConfigPane, View},
 };
+use crate::cli::statusline_install::{InstallOutcome, StatuslineStatus, install_statusline};
 use crate::credentials;
+use crate::models::live_window::Source as LiveSource;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tracing::info;
 
@@ -50,10 +52,22 @@ pub enum AppEvent {
     ScrollLogsToBottom,
     ToggleAutoScroll, // Toggle auto-scroll mode in live logs
     // Mouse events
-    MouseClick { x: u16, y: u16 },
-    MouseDragStart { x: u16, y: u16 },
-    MouseDragEnd { x: u16, y: u16 },
-    MouseDragging { x: u16, y: u16 },
+    MouseClick {
+        x: u16,
+        y: u16,
+    },
+    MouseDragStart {
+        x: u16,
+        y: u16,
+    },
+    MouseDragEnd {
+        x: u16,
+        y: u16,
+    },
+    MouseDragging {
+        x: u16,
+        y: u16,
+    },
     // New session creation events
     NewSessionCancel,
     NewSessionNextRepo,
@@ -506,13 +520,10 @@ impl EventHandler {
     /// already flowing from the Tier1 cache *and* the user's
     /// `~/.claude/settings.json` doesn't already carry our block.
     fn should_wire_statusline_inner(
-        live_source: crate::models::live_window::Source,
-        statusline_status: Option<&crate::cli::statusline_install::StatuslineStatus>,
+        live_source: LiveSource,
+        statusline_status: Option<&StatuslineStatus>,
     ) -> bool {
-        use crate::cli::statusline_install::StatuslineStatus;
-        use crate::models::live_window::Source;
-
-        if live_source == Source::Tier1Cache {
+        if live_source == LiveSource::Tier1Cache {
             return false;
         }
         matches!(
@@ -525,12 +536,14 @@ impl EventHandler {
     /// Drives the global `W` shortcut. When this is `false` the keystroke
     /// is ignored at the global layer and falls through to the active
     /// view's normal handling.
-    fn should_wire_statusline() -> bool {
-        use crate::cli::statusline_install::detect_statusline_status;
-        use crate::models::live_window::current;
-
-        let status = detect_statusline_status().ok();
-        Self::should_wire_statusline_inner(current().source, status.as_ref())
+    ///
+    /// The settings.json read goes through [`AppState::statusline_status_cached`]
+    /// so that holding `W` (or rapid keystrokes elsewhere) doesn't hammer
+    /// the filesystem.
+    fn should_wire_statusline(state: &mut AppState) -> bool {
+        let live_source = crate::models::live_window::current().source;
+        let status = state.statusline_status_cached();
+        Self::should_wire_statusline_inner(live_source, status.as_ref())
     }
 
     pub fn handle_key_event(key_event: KeyEvent, state: &mut AppState) -> Option<AppEvent> {
@@ -612,14 +625,34 @@ impl EventHandler {
             return Some(AppEvent::ToggleHelp);
         }
 
-        // Global `W`: wire Claude Code statusline. Active from any non-text
-        // view when the statusline is unwired or stale (live data isn't
-        // coming from the Tier1 cache). The CTA in the top status bar
-        // points users here, so the shortcut must work everywhere — not
-        // just from the Burndown panel where it originally lived.
+        // Global `W`: wire Claude Code statusline. Active from any
+        // non-text-input context when the statusline is unwired or
+        // stale (live data isn't coming from the Tier1 cache). The CTA
+        // in the top status bar points users here, so the shortcut
+        // must work everywhere — not just from the Burndown panel
+        // where it originally lived.
         //
-        // Suppressed in views that take free-form character input so an
-        // accidental Shift+W during typing doesn't trigger an install.
+        // The suppress list below covers two kinds of context:
+        //   (a) views that fundamentally accept free-form character
+        //       input (NewSession's prompt/branch/repo entry,
+        //       SearchWorkspace, ClaudeChat, AuthSetup, the Config
+        //       editor, the AttachedTerminal pass-through, the auth
+        //       provider popup),
+        //   (b) per-view text-entry overlays toggled inside otherwise
+        //       navigable screens (GitView's commit message, the
+        //       Analytics input/zoom-search modes, the Skills search
+        //       overlay).
+        //
+        // Modal text inputs that already early-return at the top of
+        // `handle_key_event` (confirmation dialog, OtherTmux/SshSession
+        // rename, onboarding/setup menus, quick-commit) don't reach
+        // this block, so they don't need entries here.
+        let analytics_text_active = state.current_view == View::Analytics
+            && (state.usage_state.input_mode.is_some() || state.usage_state.zoom_search_active);
+        let skills_text_active =
+            state.current_view == View::Skills && state.skills_state.search_active;
+        let git_view_text_active = state.current_view == View::GitView
+            && state.git_view_state.as_ref().map(|gv| gv.is_in_commit_mode()).unwrap_or(false);
         let suppress_global_w = matches!(
             state.current_view,
             View::NewSession
@@ -628,10 +661,13 @@ impl EventHandler {
                 | View::AuthSetup
                 | View::Config
                 | View::AttachedTerminal
-        ) || state.auth_provider_popup_state.show_popup;
+        ) || state.auth_provider_popup_state.show_popup
+            || analytics_text_active
+            || skills_text_active
+            || git_view_text_active;
         if !suppress_global_w
             && matches!(key_event.code, KeyCode::Char('W'))
-            && Self::should_wire_statusline()
+            && Self::should_wire_statusline(state)
         {
             return Some(AppEvent::UsageWireStatusline);
         }
@@ -4439,18 +4475,20 @@ impl EventHandler {
                 // already carry our block. This event is reachable from the
                 // global `W` shortcut as well as the legacy Burndown route,
                 // so the guard lives here rather than at the keymap.
-                use crate::cli::statusline_install::{StatuslineStatus, detect_statusline_status};
-                let live_source = crate::models::live_window::current().source;
-                if live_source == crate::models::live_window::Source::Tier1Cache {
+                if crate::models::live_window::current().source == LiveSource::Tier1Cache {
                     return;
                 }
-                match detect_statusline_status() {
-                    Ok(StatuslineStatus::Configured) => return,
-                    Ok(_) => {}
-                    Err(_) => return,
+                match state.statusline_status_cached() {
+                    Some(StatuslineStatus::Configured) => return,
+                    Some(_) => {}
+                    None => return,
                 }
-                match crate::cli::statusline_install::install_statusline() {
-                    Ok(crate::cli::statusline_install::InstallOutcome::Installed) => {
+                let outcome = install_statusline();
+                // Any successful install path mutates settings.json, so
+                // drop the cached detection result before the next read.
+                state.invalidate_statusline_status_cache();
+                match outcome {
+                    Ok(InstallOutcome::Installed) => {
                         state.app_config.ui_preferences.statusline_decision =
                             crate::config::StatuslineDecision::Installed;
                         let _ = state.app_config.save();
@@ -4459,7 +4497,7 @@ impl EventHandler {
                                 .to_string(),
                         );
                     }
-                    Ok(crate::cli::statusline_install::InstallOutcome::AlreadyInstalled) => {
+                    Ok(InstallOutcome::AlreadyInstalled) => {
                         state.app_config.ui_preferences.statusline_decision =
                             crate::config::StatuslineDecision::Installed;
                         let _ = state.app_config.save();
@@ -4468,7 +4506,7 @@ impl EventHandler {
                                 .to_string(),
                         );
                     }
-                    Ok(crate::cli::statusline_install::InstallOutcome::Migrated) => {
+                    Ok(InstallOutcome::Migrated) => {
                         // Legacy `ainb statusline` was rewritten in
                         // place to `ainb claudecode statusline`. The
                         // user already opted in; surface as a success.
@@ -4480,17 +4518,13 @@ impl EventHandler {
                                 .to_string(),
                         );
                     }
-                    Ok(crate::cli::statusline_install::InstallOutcome::ExistingDifferent {
-                        current_command,
-                    }) => {
+                    Ok(InstallOutcome::ExistingDifferent { current_command }) => {
                         state.add_warning_notification(format!(
                             "Existing statusline detected: {current_command}. Run `ainb init` for keep/replace."
                         ));
                     }
                     Err(e) => {
-                        state.add_error_notification(format!(
-                            "Failed to install statusline: {e}"
-                        ));
+                        state.add_error_notification(format!("Failed to install statusline: {e}"));
                     }
                 }
             }

--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -501,6 +501,38 @@ impl EventHandler {
         }
     }
 
+    /// Pure decision logic shared between the production global-`W`
+    /// shortcut and tests. Wiring is productive when live data isn't
+    /// already flowing from the Tier1 cache *and* the user's
+    /// `~/.claude/settings.json` doesn't already carry our block.
+    fn should_wire_statusline_inner(
+        live_source: crate::models::live_window::Source,
+        statusline_status: Option<&crate::cli::statusline_install::StatuslineStatus>,
+    ) -> bool {
+        use crate::cli::statusline_install::StatuslineStatus;
+        use crate::models::live_window::Source;
+
+        if live_source == Source::Tier1Cache {
+            return false;
+        }
+        matches!(
+            statusline_status,
+            Some(StatuslineStatus::NotConfigured) | Some(StatuslineStatus::Other(_))
+        )
+    }
+
+    /// True when wiring the Claude Code statusline would be productive.
+    /// Drives the global `W` shortcut. When this is `false` the keystroke
+    /// is ignored at the global layer and falls through to the active
+    /// view's normal handling.
+    fn should_wire_statusline() -> bool {
+        use crate::cli::statusline_install::detect_statusline_status;
+        use crate::models::live_window::current;
+
+        let status = detect_statusline_status().ok();
+        Self::should_wire_statusline_inner(current().source, status.as_ref())
+    }
+
     pub fn handle_key_event(key_event: KeyEvent, state: &mut AppState) -> Option<AppEvent> {
         use crate::app::state::View;
 
@@ -578,6 +610,30 @@ impl EventHandler {
         // Supports both '?' and Shift+H
         if matches!(key_event.code, KeyCode::Char('?' | 'H')) {
             return Some(AppEvent::ToggleHelp);
+        }
+
+        // Global `W`: wire Claude Code statusline. Active from any non-text
+        // view when the statusline is unwired or stale (live data isn't
+        // coming from the Tier1 cache). The CTA in the top status bar
+        // points users here, so the shortcut must work everywhere — not
+        // just from the Burndown panel where it originally lived.
+        //
+        // Suppressed in views that take free-form character input so an
+        // accidental Shift+W during typing doesn't trigger an install.
+        let suppress_global_w = matches!(
+            state.current_view,
+            View::NewSession
+                | View::SearchWorkspace
+                | View::ClaudeChat
+                | View::AuthSetup
+                | View::Config
+                | View::AttachedTerminal
+        ) || state.auth_provider_popup_state.show_popup;
+        if !suppress_global_w
+            && matches!(key_event.code, KeyCode::Char('W'))
+            && Self::should_wire_statusline()
+        {
+            return Some(AppEvent::UsageWireStatusline);
         }
 
         // AINB 2.0: Handle home screen view
@@ -1732,10 +1788,10 @@ impl EventHandler {
                 // Capital X (Shift+x) only — lowercase x is reserved for
                 // future scope and must NOT trigger the exclude commit.
                 KeyCode::Char('X') => return Some(AppEvent::UsageCommitExcludeFilter),
-                // W wires up the Claude Code statusline. Only meaningful
-                // on the Budget panel when live data is unavailable; the
-                // handler enforces both checks before doing anything.
-                KeyCode::Char('W') => return Some(AppEvent::UsageWireStatusline),
+                // `W` (wire Claude Code statusline) is now a global
+                // shortcut handled at the top of `handle_key_event`. The
+                // local arm has been removed so there is exactly one
+                // dispatch path; the global handler covers Burndown too.
                 KeyCode::Esc if state.usage_state.filters.any() => {
                     return Some(AppEvent::UsagePopFilterChip);
                 }
@@ -4378,19 +4434,20 @@ impl EventHandler {
                 }
             }
             AppEvent::UsageWireStatusline => {
-                // Only act when (a) Budget panel is focused and (b) live
-                // data is unavailable. Either condition unmet → no-op so
-                // a stray `W` keystroke doesn't surprise the user.
-                let on_budget = matches!(
-                    state.usage_state.focused_panel,
-                    Some(crate::components::usage::UsagePanel::Budget)
-                );
-                let no_live = matches!(
-                    crate::models::live_window::current().source,
-                    crate::models::live_window::Source::None
-                );
-                if !on_budget || !no_live {
+                // Fire when the statusline isn't already serving fresh data
+                // from the Tier1 cache *and* the user's settings.json doesn't
+                // already carry our block. This event is reachable from the
+                // global `W` shortcut as well as the legacy Burndown route,
+                // so the guard lives here rather than at the keymap.
+                use crate::cli::statusline_install::{StatuslineStatus, detect_statusline_status};
+                let live_source = crate::models::live_window::current().source;
+                if live_source == crate::models::live_window::Source::Tier1Cache {
                     return;
+                }
+                match detect_statusline_status() {
+                    Ok(StatuslineStatus::Configured) => return,
+                    Ok(_) => {}
+                    Err(_) => return,
                 }
                 match crate::cli::statusline_install::install_statusline() {
                     Ok(crate::cli::statusline_install::InstallOutcome::Installed) => {
@@ -4923,5 +4980,72 @@ impl EventHandler {
                 // These are processed by handle_mouse_event
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod global_w_tests {
+    use super::*;
+    use crate::cli::statusline_install::StatuslineStatus;
+    use crate::models::live_window::Source;
+
+    #[test]
+    fn fires_when_source_is_none_and_statusline_unconfigured() {
+        assert!(EventHandler::should_wire_statusline_inner(
+            Source::None,
+            Some(&StatuslineStatus::NotConfigured),
+        ));
+    }
+
+    #[test]
+    fn fires_when_tier2_local_and_statusline_unconfigured() {
+        // Tier2Local means ainb is reading JSONL fallback — not the
+        // Tier1 cache the statusline would write to. Wiring is still
+        // productive.
+        assert!(EventHandler::should_wire_statusline_inner(
+            Source::Tier2Local,
+            Some(&StatuslineStatus::NotConfigured),
+        ));
+    }
+
+    #[test]
+    fn fires_when_other_command_present() {
+        assert!(EventHandler::should_wire_statusline_inner(
+            Source::None,
+            Some(&StatuslineStatus::Other("ccusage statusline".into())),
+        ));
+    }
+
+    #[test]
+    fn no_op_when_tier1_cache_active() {
+        // Already wired and fresh — `W` should fall through and not
+        // re-trigger the install.
+        assert!(!EventHandler::should_wire_statusline_inner(
+            Source::Tier1Cache,
+            Some(&StatuslineStatus::Configured),
+        ));
+        assert!(!EventHandler::should_wire_statusline_inner(
+            Source::Tier1Cache,
+            Some(&StatuslineStatus::NotConfigured),
+        ));
+    }
+
+    #[test]
+    fn no_op_when_already_configured_even_without_fresh_cache() {
+        // Settings.json has our block but the cache hasn't been written
+        // yet (statusline hasn't run). Re-installing wouldn't help.
+        assert!(!EventHandler::should_wire_statusline_inner(
+            Source::None,
+            Some(&StatuslineStatus::Configured),
+        ));
+    }
+
+    #[test]
+    fn no_op_when_status_detection_failed() {
+        // IO failure reading settings.json — refuse to install blindly.
+        assert!(!EventHandler::should_wire_statusline_inner(
+            Source::None,
+            None,
+        ));
     }
 }

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -424,7 +424,7 @@ pub struct ConfirmationDialog {
     pub title: String,
     pub message: String,
     pub confirm_action: ConfirmAction,
-    pub selected_option: bool, // true = Yes, false = No (binary mode)
+    pub selected_option: bool,   // true = Yes, false = No (binary mode)
     pub warning: Option<String>, // Optional warning (e.g., uncommitted files in worktree)
     // Tri-option mode: when `options` is `Some`, the dialog renders one button per
     // entry and Left/Right cycles `selected_index`. The final-option index is
@@ -443,10 +443,10 @@ pub struct DialogOption {
 #[derive(Debug, Clone)]
 pub enum ConfirmAction {
     DeleteSession(Uuid),
-    StopSession(Uuid),         // Soft-stop interactive session (tmux only; preserves worktree)
-    KillOtherTmux(String),     // Kill a non-agents-in-a-box tmux session by name
+    StopSession(Uuid), // Soft-stop interactive session (tmux only; preserves worktree)
+    KillOtherTmux(String), // Kill a non-agents-in-a-box tmux session by name
     KillWorkspaceShell(usize), // Kill workspace shell by workspace index
-    Cancel,                    // No-op terminator for tri-option dialogs
+    Cancel,            // No-op terminator for tri-option dialogs
 }
 
 // ============================================================================
@@ -2114,6 +2114,19 @@ pub struct AppState {
     // Session recovery state (for orphaned agent sessions)
     pub session_recovery_state: crate::components::SessionRecoveryState,
 
+    /// Cached result of `detect_statusline_status()` paired with the time
+    /// it was read. Refreshed lazily through
+    /// [`AppState::statusline_status_cached`] on a 15s TTL so the Stats
+    /// screen and the global `W` shortcut don't re-read
+    /// `~/.claude/settings.json` on every render or keystroke.
+    ///
+    /// Invalidated explicitly after the install event fires so the CTA
+    /// flips state on the very next frame instead of waiting out the TTL.
+    pub statusline_status_cache: Option<(
+        Option<crate::cli::statusline_install::StatuslineStatus>,
+        Instant,
+    )>,
+
     // Usage analytics state
     pub usage_state: crate::components::usage::UsageViewState,
     /// Channel receiver for background usage-data parsing.
@@ -2559,23 +2572,23 @@ pub enum AsyncAction {
     CloneRemoteRepo,         // NEW: Clone remote repo to cache
     FetchRemoteBranches,     // NEW: Get branch list from remote
     CreateNewSession,
-    DeleteSession(Uuid),         // New - delete session with container cleanup
-    StopSession(Uuid),           // Soft-stop interactive session (kill tmux only)
+    DeleteSession(Uuid),           // New - delete session with container cleanup
+    StopSession(Uuid),             // Soft-stop interactive session (kill tmux only)
     ResumeSession(Uuid, String), // Recreate tmux for a Stopped interactive session; String is the trigger key for audit
     BulkDeleteSessions(Vec<Uuid>), // Bulk delete multiple sessions
-    RefreshWorkspaces,             // Manual refresh of workspace data
-    FetchContainerLogs(Uuid),      // Fetch container logs for a session
-    AttachToContainer(Uuid),       // Attach to a container session
-    AttachToTmuxSession(Uuid),     // Attach to a tmux session
-    KillContainer(Uuid),           // Kill container for a session
-    AuthSetupOAuth,                // Run OAuth authentication setup
-    AuthSetupApiKey,               // Save API key authentication
-    ReauthenticateCredentials,     // Re-authenticate Claude credentials
-    RestartSession(Uuid),          // Restart a stopped session with new container
-    CleanupOrphaned,               // Clean up orphaned containers without worktrees
-    AttachToOtherTmux(String),     // Attach to a non-agents-in-a-box tmux session by name
-    KillOtherTmux(String),         // Kill a non-agents-in-a-box tmux session by name
-    ConfirmOtherTmuxRename,        // Confirm and execute rename for "Other tmux" session
+    RefreshWorkspaces,           // Manual refresh of workspace data
+    FetchContainerLogs(Uuid),    // Fetch container logs for a session
+    AttachToContainer(Uuid),     // Attach to a container session
+    AttachToTmuxSession(Uuid),   // Attach to a tmux session
+    KillContainer(Uuid),         // Kill container for a session
+    AuthSetupOAuth,              // Run OAuth authentication setup
+    AuthSetupApiKey,             // Save API key authentication
+    ReauthenticateCredentials,   // Re-authenticate Claude credentials
+    RestartSession(Uuid),        // Restart a stopped session with new container
+    CleanupOrphaned,             // Clean up orphaned containers without worktrees
+    AttachToOtherTmux(String),   // Attach to a non-agents-in-a-box tmux session by name
+    KillOtherTmux(String),       // Kill a non-agents-in-a-box tmux session by name
+    ConfirmOtherTmuxRename,      // Confirm and execute rename for "Other tmux" session
     // Shell session actions (one shell per workspace)
     OpenWorkspaceShell {
         workspace_index: usize,                 // Index of workspace to open shell for
@@ -2684,6 +2697,8 @@ impl Default for AppState {
             // Session recovery state (lazy-load when entering view)
             session_recovery_state: crate::components::SessionRecoveryState::default(),
 
+            statusline_status_cache: None,
+
             // Usage analytics state
             usage_state: crate::components::usage::UsageViewState::default(),
             usage_load_receiver: None,
@@ -2724,9 +2739,68 @@ fn merge_oldest_call_day(
     }
 }
 
+/// TTL for the cached `detect_statusline_status()` result. The Stats
+/// screen re-renders at ~30-60Hz and the global `W` shortcut runs on
+/// every keystroke; without a cache each frame pays a settings.json
+/// read. 15s is short enough that a manual edit of `~/.claude/settings.json`
+/// is reflected almost immediately, long enough to coalesce normal
+/// scrolling activity.
+pub(crate) const STATUSLINE_STATUS_CACHE_TTL_SECS: u64 = 15;
+
 impl AppState {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Read the statusline status with a TTL-bounded cache.
+    ///
+    /// The first call (or any call after the cache has expired) re-reads
+    /// `~/.claude/settings.json`; subsequent calls within
+    /// [`STATUSLINE_STATUS_CACHE_TTL_SECS`] return the memoised value.
+    /// Returns `None` only when status detection itself failed (IO/JSON
+    /// error) — in that case both the global `W` shortcut and the
+    /// top-of-Stats card no-op rather than guessing.
+    pub fn statusline_status_cached(
+        &mut self,
+    ) -> Option<crate::cli::statusline_install::StatuslineStatus> {
+        Self::statusline_status_cached_inner(
+            &mut self.statusline_status_cache,
+            std::time::Duration::from_secs(STATUSLINE_STATUS_CACHE_TTL_SECS),
+            Instant::now(),
+            crate::cli::statusline_install::detect_statusline_status,
+        )
+    }
+
+    /// Test seam for [`statusline_status_cached`]. Lets unit tests inject
+    /// a clock and a fake detector to verify TTL coalescing without
+    /// touching the filesystem.
+    pub(crate) fn statusline_status_cached_inner<F>(
+        cache: &mut Option<(
+            Option<crate::cli::statusline_install::StatuslineStatus>,
+            Instant,
+        )>,
+        ttl: std::time::Duration,
+        now: Instant,
+        detect: F,
+    ) -> Option<crate::cli::statusline_install::StatuslineStatus>
+    where
+        F: FnOnce() -> anyhow::Result<crate::cli::statusline_install::StatuslineStatus>,
+    {
+        if let Some((value, written)) = cache {
+            if now.saturating_duration_since(*written) < ttl {
+                return value.clone();
+            }
+        }
+        let fresh = detect().ok();
+        *cache = Some((fresh.clone(), now));
+        fresh
+    }
+
+    /// Drop the cached statusline status so the next reader re-detects.
+    /// Called after the install event lands so the CTA flips on the very
+    /// next frame instead of waiting out the TTL.
+    pub fn invalidate_statusline_status_cache(&mut self) {
+        self.statusline_status_cache = None;
     }
 
     /// Get the log directory path for the log history viewer
@@ -3824,8 +3898,7 @@ impl AppState {
                         &metadata.worktree_path,
                         &source_repo,
                     );
-                let mut workspace =
-                    crate::models::Workspace::new(workspace_name, workspace_path);
+                let mut workspace = crate::models::Workspace::new(workspace_name, workspace_path);
                 workspace.sessions.push(stopped);
                 self.workspaces.push(workspace);
             }
@@ -3834,7 +3907,9 @@ impl AppState {
 
     /// Build a `Session` model in `Stopped` state from persisted metadata.
     /// Used to render sessions whose tmux is dead but whose worktree is alive.
-    pub(crate) fn stopped_session_from_metadata(metadata: &crate::interactive::SessionMetadata) -> crate::models::Session {
+    pub(crate) fn stopped_session_from_metadata(
+        metadata: &crate::interactive::SessionMetadata,
+    ) -> crate::models::Session {
         use crate::models::{Session, SessionMode, SessionStatus};
 
         let mut session = Session::new_with_options(
@@ -4309,10 +4384,8 @@ impl AppState {
                         self.move_to_next_workspace_first_item(workspace_idx);
                     }
                 } else {
-                    let first_visible = workspace
-                        .sessions
-                        .iter()
-                        .position(|s| self.session_passes_filter(s));
+                    let first_visible =
+                        workspace.sessions.iter().position(|s| self.session_passes_filter(s));
                     if let Some(first_idx) = first_visible {
                         self.selected_session_index = Some(first_idx);
                         self.queue_logs_fetch();
@@ -4549,7 +4622,8 @@ impl AppState {
             if self.workspaces.get(idx).map(|w| {
                 w.sessions.iter().any(|s| self.session_passes_filter(s))
                     || w.shell_session.is_some()
-            }) != Some(true) {
+            }) != Some(true)
+            {
                 let new_idx = self.workspaces.iter().position(|w| {
                     w.sessions.iter().any(|s| self.session_passes_filter(s))
                         || w.shell_session.is_some()
@@ -4795,7 +4869,10 @@ impl AppState {
     /// worktree, sessions.json entry, and `by-session/<uuid>` symlink intact.
     /// Delete maps to the existing destructive flow.
     pub fn show_delete_or_stop_confirmation(&mut self, session_id: Uuid) {
-        info!("Showing Stop/Delete/Cancel dialog for session: {}", session_id);
+        info!(
+            "Showing Stop/Delete/Cancel dialog for session: {}",
+            session_id
+        );
 
         let warning = self.check_session_uncommitted_warning(session_id);
 
@@ -4816,7 +4893,8 @@ impl AppState {
 
         self.confirmation_dialog = Some(ConfirmationDialog {
             title: "Stop or Delete Session".to_string(),
-            message: "Stop keeps the worktree and resumes later. Delete removes the worktree.".to_string(),
+            message: "Stop keeps the worktree and resumes later. Delete removes the worktree."
+                .to_string(),
             // confirm_action mirrors the default (Stop) so the legacy ConfirmationConfirm
             // handler still has something sensible if it ever runs without options.
             confirm_action: ConfirmAction::StopSession(session_id),
@@ -8221,10 +8299,7 @@ impl AppState {
             .tmux_sessions
             .get(&session_id)
             .map(|t| t.name().to_string())
-            .or_else(|| {
-                self.find_session(session_id)
-                    .and_then(|s| s.tmux_session_name.clone())
-            })
+            .or_else(|| self.find_session(session_id).and_then(|s| s.tmux_session_name.clone()))
             .or_else(|| {
                 let store = SessionStore::load();
                 store
@@ -8234,9 +8309,7 @@ impl AppState {
                     .map(|m| m.tmux_session_name.clone())
             });
 
-        let worktree_path = self
-            .find_session(session_id)
-            .map(|s| s.workspace_path.clone());
+        let worktree_path = self.find_session(session_id).map(|s| s.workspace_path.clone());
 
         let result: anyhow::Result<()> = if let Some(ref name) = tmux_name {
             // Hard constraint: kill only the exact named session. NEVER kill-server.
@@ -8311,15 +8384,14 @@ impl AppState {
         use crate::interactive::{InteractiveSessionManager, SessionStore};
         use crate::models::SessionStatus;
 
-        info!("Resuming interactive session: {} (trigger={})", session_id, trigger_key);
+        info!(
+            "Resuming interactive session: {} (trigger={})",
+            session_id, trigger_key
+        );
 
         // Resolve metadata up-front so we can audit even if subsequent steps fail.
         let store = SessionStore::load();
-        let metadata = store
-            .sessions()
-            .values()
-            .find(|m| m.session_id == session_id)
-            .cloned();
+        let metadata = store.sessions().values().find(|m| m.session_id == session_id).cloned();
 
         // Pull skip_permissions and model from the in-memory Session if available.
         let (skip_permissions, model) = self
@@ -8330,9 +8402,7 @@ impl AppState {
         // Capture audit context before any fallible step so we can record both
         // success and failure with the same fields.
         let tmux_name_for_audit = metadata.as_ref().map(|m| m.tmux_session_name.clone());
-        let worktree_for_audit = metadata
-            .as_ref()
-            .map(|m| m.worktree_path.display().to_string());
+        let worktree_for_audit = metadata.as_ref().map(|m| m.worktree_path.display().to_string());
 
         let mut transcript: Option<PathBuf> = None;
         let result: anyhow::Result<()> = async {

--- a/ainb-tui/src/app/state_tests.rs
+++ b/ainb-tui/src/app/state_tests.rs
@@ -4,7 +4,7 @@
 mod tests {
     use super::*;
     use crate::app::state::{AppState, NewSessionState, NewSessionStep, SessionAgentOption};
-    use crate::models::{SessionMode, SessionAgentType};
+    use crate::models::{SessionAgentType, SessionMode};
     use std::path::PathBuf;
 
     /// Test that pressing 'n' for new session should go through mode selection
@@ -423,9 +423,7 @@ mod tests {
     // Stop / Resume coverage
     // ========================================================================
 
-    use crate::app::state::{
-        ConfirmAction, ConfirmationDialog, DialogOption,
-    };
+    use crate::app::state::{ConfirmAction, ConfirmationDialog, DialogOption};
 
     /// Verify the tri-option dialog defaults to Stop and cycles forward through
     /// all three options before wrapping back to Stop.
@@ -436,10 +434,7 @@ mod tests {
 
         state.show_delete_or_stop_confirmation(session_id);
 
-        let dialog = state
-            .confirmation_dialog
-            .as_ref()
-            .expect("Dialog should be present");
+        let dialog = state.confirmation_dialog.as_ref().expect("Dialog should be present");
         let opts = dialog.options.as_ref().expect("Tri-option dialog");
         assert_eq!(opts.len(), 3, "Stop / Delete / Cancel");
         assert_eq!(opts[0].label, "Stop");
@@ -467,9 +462,18 @@ mod tests {
             selected_option: false,
             warning: None,
             options: Some(vec![
-                DialogOption { label: "A".into(), action: ConfirmAction::Cancel },
-                DialogOption { label: "B".into(), action: ConfirmAction::Cancel },
-                DialogOption { label: "C".into(), action: ConfirmAction::Cancel },
+                DialogOption {
+                    label: "A".into(),
+                    action: ConfirmAction::Cancel,
+                },
+                DialogOption {
+                    label: "B".into(),
+                    action: ConfirmAction::Cancel,
+                },
+                DialogOption {
+                    label: "C".into(),
+                    action: ConfirmAction::Cancel,
+                },
             ]),
             selected_index: 0,
         };
@@ -609,7 +613,10 @@ mod tests {
         let session = AppState::stopped_session_from_metadata(&metadata);
         assert_eq!(session.id, metadata.session_id);
         assert!(matches!(session.status, SessionStatus::Stopped));
-        assert_eq!(session.tmux_session_name.as_deref(), Some("tmux_some_branch"));
+        assert_eq!(
+            session.tmux_session_name.as_deref(),
+            Some("tmux_some_branch")
+        );
         assert_eq!(session.workspace_path, "/tmp/work-stopped");
         assert_eq!(session.agent_type, SessionAgentType::Claude);
     }
@@ -652,10 +659,7 @@ mod tests {
         for mode in [SessionMode::Interactive, SessionMode::Boss] {
             for status in [Status::Running, Status::Stopped, Status::Idle] {
                 assert!(
-                    state.session_passes_filter(&make_filter_session(
-                        mode.clone(),
-                        status.clone()
-                    )),
+                    state.session_passes_filter(&make_filter_session(mode.clone(), status.clone())),
                     "All should pass mode={:?} status={:?}",
                     mode,
                     status
@@ -680,10 +684,9 @@ mod tests {
             Status::Running
         )));
         // Boss-mode Stopped → still passes (filter only touches Interactive)
-        assert!(state.session_passes_filter(&make_filter_session(
-            SessionMode::Boss,
-            Status::Stopped
-        )));
+        assert!(
+            state.session_passes_filter(&make_filter_session(SessionMode::Boss, Status::Stopped))
+        );
     }
 
     #[test]
@@ -700,10 +703,9 @@ mod tests {
             Status::Running
         )));
         // Boss-mode is exempt — always passes regardless of filter mode.
-        assert!(state.session_passes_filter(&make_filter_session(
-            SessionMode::Boss,
-            Status::Running
-        )));
+        assert!(
+            state.session_passes_filter(&make_filter_session(SessionMode::Boss, Status::Running))
+        );
     }
 
     #[test]
@@ -725,7 +727,10 @@ mod tests {
         let may = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
 
         // First load establishes the anchor.
-        assert_eq!(crate::app::state::merge_oldest_call_day(None, Some(april)), Some(april));
+        assert_eq!(
+            crate::app::state::merge_oldest_call_day(None, Some(april)),
+            Some(april)
+        );
 
         // Reproduces the reported defect: a wide load establishes April,
         // a subsequent narrow (May-only) load must NOT raise the anchor.
@@ -749,5 +754,165 @@ mod tests {
 
         // Empty existing + empty candidate stays None.
         assert_eq!(crate::app::state::merge_oldest_call_day(None, None), None);
+    }
+
+    // -- statusline status TTL cache --------------------------------
+    //
+    // The cache backs both the global `W` shortcut (settings.json read on
+    // every keystroke before this PR) and the top-of-Stats enable card
+    // (settings.json read on every render frame). The tests below exercise
+    // the pure inner helper with an injected clock + detector counter so
+    // they're hermetic — no temp dirs or HOME mutation needed.
+
+    use std::cell::Cell;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn statusline_cache_returns_value_on_first_call_and_records_time() {
+        use crate::cli::statusline_install::StatuslineStatus;
+
+        let mut cache = None;
+        let calls = Cell::new(0u32);
+        let now = Instant::now();
+        let detect = || {
+            calls.set(calls.get() + 1);
+            Ok(StatuslineStatus::NotConfigured)
+        };
+
+        let result = AppState::statusline_status_cached_inner(
+            &mut cache,
+            Duration::from_secs(15),
+            now,
+            detect,
+        );
+
+        assert_eq!(result, Some(StatuslineStatus::NotConfigured));
+        assert_eq!(calls.get(), 1, "first call must hit the detector");
+        assert!(cache.is_some(), "cache must be populated after first call");
+    }
+
+    #[test]
+    fn statusline_cache_coalesces_within_ttl() {
+        use crate::cli::statusline_install::StatuslineStatus;
+
+        let mut cache = None;
+        let calls = Cell::new(0u32);
+        let t0 = Instant::now();
+        let detect_first = || {
+            calls.set(calls.get() + 1);
+            Ok(StatuslineStatus::Configured)
+        };
+        let _ = AppState::statusline_status_cached_inner(
+            &mut cache,
+            Duration::from_secs(15),
+            t0,
+            detect_first,
+        );
+        assert_eq!(calls.get(), 1);
+
+        // Second call 5 seconds later — still inside the 15s TTL window.
+        // Must serve from cache without invoking the detector.
+        let t1 = t0 + Duration::from_secs(5);
+        let detect_must_not_run = || -> anyhow::Result<StatuslineStatus> {
+            panic!("detector must not run while cache is fresh");
+        };
+        let result = AppState::statusline_status_cached_inner(
+            &mut cache,
+            Duration::from_secs(15),
+            t1,
+            detect_must_not_run,
+        );
+        assert_eq!(
+            result,
+            Some(StatuslineStatus::Configured),
+            "fresh cache hit must return the original value"
+        );
+        assert_eq!(calls.get(), 1, "second call inside TTL must not re-detect");
+    }
+
+    #[test]
+    fn statusline_cache_re_detects_after_ttl_expires() {
+        use crate::cli::statusline_install::StatuslineStatus;
+
+        let mut cache = None;
+        let calls = Cell::new(0u32);
+        let ttl = Duration::from_secs(15);
+        let t0 = Instant::now();
+        let detect = || {
+            calls.set(calls.get() + 1);
+            Ok(StatuslineStatus::NotConfigured)
+        };
+        let _ = AppState::statusline_status_cached_inner(&mut cache, ttl, t0, detect);
+        assert_eq!(calls.get(), 1);
+
+        // 30 seconds later: well past the 15s TTL — detector must run.
+        let t1 = t0 + Duration::from_secs(30);
+        let detect_again = || {
+            calls.set(calls.get() + 1);
+            Ok(StatuslineStatus::Configured)
+        };
+        let result = AppState::statusline_status_cached_inner(&mut cache, ttl, t1, detect_again);
+        assert_eq!(result, Some(StatuslineStatus::Configured));
+        assert_eq!(calls.get(), 2, "expired cache must re-detect");
+    }
+
+    #[test]
+    fn statusline_cache_stores_detector_failure_to_avoid_retry_storm() {
+        // A failing detector returns None and the cache records None +
+        // the timestamp. A subsequent call within TTL serves the None
+        // from cache without re-hitting the detector — otherwise an IO
+        // error on settings.json would translate into one filesystem
+        // probe per render frame.
+        let mut cache = None;
+        let calls = Cell::new(0u32);
+        let t0 = Instant::now();
+        let detect_err = || -> anyhow::Result<crate::cli::statusline_install::StatuslineStatus> {
+            calls.set(calls.get() + 1);
+            anyhow::bail!("simulated read failure")
+        };
+        let result = AppState::statusline_status_cached_inner(
+            &mut cache,
+            Duration::from_secs(15),
+            t0,
+            detect_err,
+        );
+        assert_eq!(result, None);
+        assert_eq!(calls.get(), 1);
+
+        // Within TTL, the cached None is returned without re-detecting.
+        let t1 = t0 + Duration::from_secs(2);
+        let detect_must_not_run =
+            || -> anyhow::Result<crate::cli::statusline_install::StatuslineStatus> {
+                panic!("detector must not run while cache is fresh, even when value is None");
+            };
+        let result = AppState::statusline_status_cached_inner(
+            &mut cache,
+            Duration::from_secs(15),
+            t1,
+            detect_must_not_run,
+        );
+        assert_eq!(result, None);
+        assert_eq!(
+            calls.get(),
+            1,
+            "cached None must not retrigger the detector"
+        );
+    }
+
+    #[test]
+    fn invalidate_statusline_status_cache_forces_refresh() {
+        use crate::cli::statusline_install::StatuslineStatus;
+
+        let mut state = AppState::new();
+        // Seed the cache directly with a stale value.
+        state.statusline_status_cache =
+            Some((Some(StatuslineStatus::NotConfigured), Instant::now()));
+        assert!(state.statusline_status_cache.is_some());
+
+        state.invalidate_statusline_status_cache();
+        assert!(
+            state.statusline_status_cache.is_none(),
+            "invalidation must drop the cached entry"
+        );
     }
 }

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -210,7 +210,23 @@ impl LayoutComponent {
         // Usage analytics view (full screen)
         if state.current_view == View::Analytics {
             tracing::debug!("Rendering Usage Analytics view");
-            crate::components::usage::render(frame, frame.size(), &state.usage_state);
+            // Compute the enable-card visibility inputs once per frame
+            // through the AppState cache so we don't re-read settings.json
+            // on every refresh tick.
+            let live_source = crate::models::live_window::current().source;
+            let statusline_status = state.statusline_status_cached();
+            let statusline_decision = state.app_config.ui_preferences.statusline_decision;
+            let enable_card_ctx = crate::components::usage::EnableCardCtx {
+                live_source,
+                statusline_status,
+                statusline_decision,
+            };
+            crate::components::usage::render(
+                frame,
+                frame.size(),
+                &state.usage_state,
+                enable_card_ctx,
+            );
             // Render help overlay on top if visible
             if state.help_visible {
                 tracing::debug!("Rendering help overlay on Analytics");
@@ -437,7 +453,7 @@ impl LayoutComponent {
         frame.render_widget(menu, area);
     }
 
-    fn render_status_bar(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+    fn render_status_bar(&self, frame: &mut Frame, area: Rect, state: &mut AppState) {
         let mut status_spans: Vec<Span> = vec![];
 
         // Current workspace/repo info
@@ -531,13 +547,13 @@ impl LayoutComponent {
         // measure the existing content first and drop the live widget if
         // it wouldn't fit.
         let live_spans = build_live_status_spans(state);
-        let existing_w: usize = status_spans
+        let existing_w: usize = status_spans.iter().map(|s| s.content.chars().count()).sum();
+        // 4 chars for the " │  " separator we'd add
+        let live_w: usize = live_spans
             .iter()
             .map(|s| s.content.chars().count())
-            .sum();
-        // 4 chars for the " │  " separator we'd add
-        let live_w: usize =
-            live_spans.iter().map(|s| s.content.chars().count()).sum::<usize>().saturating_add(5);
+            .sum::<usize>()
+            .saturating_add(5);
         let area_inner_w = area.width.saturating_sub(2) as usize; // borders
         if !live_spans.is_empty() && existing_w + live_w <= area_inner_w {
             if !status_spans.is_empty() {
@@ -744,12 +760,16 @@ impl Default for LayoutComponent {
 /// Build the compact "live OAuth window" spans appended to the top status
 /// bar. Returns an empty vec when nothing should render (statusline
 /// unwired AND user declined, or status detection failed).
-pub fn build_live_status_spans(state: &AppState) -> Vec<Span<'static>> {
-    use crate::cli::statusline_install::{StatuslineStatus, detect_statusline_status};
+///
+/// The settings.json read goes through [`AppState::statusline_status_cached`]
+/// so the top bar's 30-60Hz redraws don't translate into 30-60Hz
+/// filesystem reads.
+pub fn build_live_status_spans(state: &mut AppState) -> Vec<Span<'static>> {
+    use crate::cli::statusline_install::StatuslineStatus;
     use crate::config::StatuslineDecision;
     use crate::models::live_window::{Source, current};
 
-    let status = detect_statusline_status().ok();
+    let status = state.statusline_status_cached();
     let decision = state.app_config.ui_preferences.statusline_decision;
 
     match status {
@@ -776,7 +796,10 @@ fn build_live_widget_spans(live: &crate::models::live_window::LiveWindow) -> Vec
 
     if let Some(pct) = live.five_hour_pct {
         out.push(Span::styled("5h ", Style::default().fg(MUTED_GRAY)));
-        out.push(Span::styled(mini_bar(pct), Style::default().fg(bar_color_5h(pct))));
+        out.push(Span::styled(
+            mini_bar(pct),
+            Style::default().fg(bar_color_5h(pct)),
+        ));
         out.push(Span::styled(
             format!(" {pct}%"),
             Style::default().fg(bar_color_5h(pct)).add_modifier(Modifier::BOLD),
@@ -787,7 +810,10 @@ fn build_live_widget_spans(live: &crate::models::live_window::LiveWindow) -> Vec
             out.push(Span::styled(" · ", Style::default().fg(SUBDUED_BORDER)));
         }
         out.push(Span::styled("wk ", Style::default().fg(MUTED_GRAY)));
-        out.push(Span::styled(mini_bar(pct), Style::default().fg(bar_color_7d(pct))));
+        out.push(Span::styled(
+            mini_bar(pct),
+            Style::default().fg(bar_color_7d(pct)),
+        ));
         out.push(Span::styled(
             format!(" {pct}%"),
             Style::default().fg(bar_color_7d(pct)).add_modifier(Modifier::BOLD),

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -817,7 +817,7 @@ fn build_cta_spans() -> Vec<Span<'static>> {
     vec![
         Span::styled("⚠ ", Style::default().fg(red).add_modifier(Modifier::BOLD)),
         Span::styled("Live Claude Code usage off", Style::default().fg(red)),
-        Span::styled(" · go to Stats to enable", Style::default().fg(MUTED_GRAY)),
+        Span::styled(" · press W to enable", Style::default().fg(MUTED_GRAY)),
     ]
 }
 
@@ -878,11 +878,14 @@ mod live_widget_tests {
     }
 
     #[test]
-    fn cta_spans_contain_warning_and_stats_hint() {
+    fn cta_spans_contain_warning_and_w_shortcut_hint() {
         let spans = build_cta_spans();
         let text = flatten(&spans);
         assert!(text.contains("Live Claude Code usage off"));
-        assert!(text.contains("Stats"));
+        // The CTA points at the global `W` shortcut so the keystroke is
+        // discoverable without navigating into Stats first.
+        assert!(text.contains("press W"));
+        assert!(!text.contains("Stats"), "stale Stats hint must be gone");
     }
 
     #[test]

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -830,40 +830,122 @@ impl UsageViewState {
 
 /// Render the usage analytics screen
 pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
-    // Main layout: header + provider selector + tabs + content + help bar
+    // The enable card is hoisted above the panel grid when the Claude
+    // Code statusline isn't wired. Once Tier1 cache is flowing the card
+    // disappears and the rest of the screen takes the freed space.
+    let show_enable_card = should_show_enable_card();
+    let enable_card_h: u16 = if show_enable_card { 5 } else { 0 };
+
+    // Main layout: optional enable card + header + provider selector
+    // + tabs + content + help bar.
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // Summary bar
-            Constraint::Length(3), // Provider selector
-            Constraint::Length(3), // Tab bar
-            Constraint::Min(0),    // Table content
-            Constraint::Length(2), // Help bar
+            Constraint::Length(enable_card_h), // Enable card (0 when wired)
+            Constraint::Length(3),             // Summary bar
+            Constraint::Length(3),             // Provider selector
+            Constraint::Length(3),             // Tab bar
+            Constraint::Min(0),                // Table content
+            Constraint::Length(2),             // Help bar
         ])
         .split(area);
 
-    render_summary_bar(frame, layout[0], state);
-    render_provider_bar(frame, layout[1], state);
-    render_tab_bar(frame, layout[2], state);
+    if show_enable_card {
+        render_enable_card(frame, layout[0]);
+    }
+    render_summary_bar(frame, layout[1], state);
+    render_provider_bar(frame, layout[2], state);
+    render_tab_bar(frame, layout[3], state);
 
     if state.loading || state.data.is_none() {
-        render_loading(frame, layout[3]);
+        render_loading(frame, layout[4]);
     } else {
         let data = state.data.as_ref().unwrap();
         if data.calls.is_empty() && !state.provider.has_data() {
-            render_no_data(frame, layout[3], state);
+            render_no_data(frame, layout[4], state);
         } else {
             match state.active_tab {
-                UsageTab::Daily => render_daily(frame, layout[3], data, state.scroll_offset),
-                UsageTab::Weekly => render_weekly(frame, layout[3], data, state.scroll_offset),
-                UsageTab::Projects => render_projects(frame, layout[3], data, state.scroll_offset),
-                UsageTab::Burndown => render_burndown(frame, layout[3], data, state),
-                UsageTab::Optimize => render_optimize(frame, layout[3], data),
+                UsageTab::Daily => render_daily(frame, layout[4], data, state.scroll_offset),
+                UsageTab::Weekly => render_weekly(frame, layout[4], data, state.scroll_offset),
+                UsageTab::Projects => render_projects(frame, layout[4], data, state.scroll_offset),
+                UsageTab::Burndown => render_burndown(frame, layout[4], data, state),
+                UsageTab::Optimize => render_optimize(frame, layout[4], data),
             }
         }
     }
 
-    render_help_bar(frame, layout[4], state);
+    render_help_bar(frame, layout[5], state);
+}
+
+/// True when the Stats screen should hoist the "Press W to wire" enable
+/// card above the panel grid. We show it when the live window has *no*
+/// data at all (Source::None) and the user's settings.json doesn't
+/// already carry our block.
+///
+/// Tier2Local is intentionally treated as "card hidden" — at that point
+/// the user is already getting the 5h burn estimate, so the contextual
+/// hint inside the Burndown Budget panel (which mentions the missing 7d
+/// data) is a better fit than a top-of-screen alarm.
+fn should_show_enable_card() -> bool {
+    use crate::cli::statusline_install::detect_statusline_status;
+    use crate::models::live_window::current;
+
+    let status = detect_statusline_status().ok();
+    should_show_enable_card_inner(current().source, status.as_ref())
+}
+
+/// Pure decision logic for `should_show_enable_card`. Split out for
+/// unit testing without touching the live cache or filesystem.
+fn should_show_enable_card_inner(
+    live_source: crate::models::live_window::Source,
+    statusline_status: Option<&crate::cli::statusline_install::StatuslineStatus>,
+) -> bool {
+    use crate::cli::statusline_install::StatuslineStatus;
+    use crate::models::live_window::Source;
+
+    if live_source != Source::None {
+        return false;
+    }
+    matches!(
+        statusline_status,
+        Some(StatuslineStatus::NotConfigured) | Some(StatuslineStatus::Other(_))
+    )
+}
+
+fn render_enable_card(frame: &mut Frame, area: Rect) {
+    let lines = build_enable_card_lines();
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Rgb(230, 100, 100)))
+                .style(Style::default().bg(DARK_BG)),
+        )
+        .alignment(ratatui::layout::Alignment::Left);
+    frame.render_widget(paragraph, area);
+}
+
+/// Pure helper for the enable-card body. Pulled out so tests can assert
+/// the exact copy and styling without driving a Frame.
+fn build_enable_card_lines() -> Vec<Line<'static>> {
+    let red = Color::Rgb(230, 100, 100);
+    vec![
+        Line::from(vec![
+            Span::styled(" ⚠ ", Style::default().fg(red).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Live Claude Code usage off",
+                Style::default().fg(red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" — Press ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("[W]", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" to wire up", Style::default().fg(MUTED_GRAY)),
+        ]),
+        Line::from(Span::styled(
+            "    Provides 5h burn, 7d window, cost, reset times",
+            Style::default().fg(MUTED_GRAY),
+        )),
+    ]
 }
 
 fn render_summary_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
@@ -4871,5 +4953,129 @@ mod budget_live_header_tests {
     #[test]
     fn format_hms_pads_minutes_when_hours_present() {
         assert_eq!(format_hms(Duration::from_secs(3 * 3600 + 5 * 60)), "3h 05m");
+    }
+}
+
+#[cfg(test)]
+mod enable_card_tests {
+    use super::*;
+
+    fn flat(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    #[test]
+    fn card_copy_mentions_w_key_and_value_proposition() {
+        let lines = build_enable_card_lines();
+        let text = flat(&lines);
+        assert!(text.contains("Live Claude Code usage off"));
+        assert!(text.contains("[W]"));
+        assert!(text.contains("wire up"));
+        // Tagline lists what wiring unlocks so users know what they get.
+        assert!(text.contains("5h burn"));
+        assert!(text.contains("7d window"));
+        assert!(text.contains("cost"));
+        assert!(text.contains("reset"));
+    }
+
+    #[test]
+    fn card_uses_warning_red_and_gold_w_per_style_guide() {
+        let lines = build_enable_card_lines();
+        // Find the [W] span and confirm gold styling.
+        let mut found_gold_w = false;
+        let mut found_red_warning = false;
+        for line in &lines {
+            for span in &line.spans {
+                if span.content.contains("[W]") && span.style.fg == Some(GOLD) {
+                    found_gold_w = true;
+                }
+                if span.content.contains("⚠") && span.style.fg == Some(Color::Rgb(230, 100, 100)) {
+                    found_red_warning = true;
+                }
+            }
+        }
+        assert!(found_gold_w, "[W] should be styled GOLD per tui-style-guide");
+        assert!(found_red_warning, "warning glyph should use the CTA red");
+    }
+
+    #[test]
+    fn card_is_two_lines_for_compact_layout() {
+        // The enable-card row is `Constraint::Length(5)` (4 inner + 2
+        // border ~= 4 lines visible incl. padding). Body must stay at
+        // two text lines so it fits without scroll.
+        let lines = build_enable_card_lines();
+        assert_eq!(
+            lines.len(),
+            2,
+            "enable card body must remain two lines; layout reserves only 5 rows"
+        );
+    }
+
+    #[test]
+    fn card_visible_when_source_none_and_statusline_unconfigured() {
+        use crate::cli::statusline_install::StatuslineStatus;
+        use crate::models::live_window::Source;
+        assert!(should_show_enable_card_inner(
+            Source::None,
+            Some(&StatuslineStatus::NotConfigured),
+        ));
+    }
+
+    #[test]
+    fn card_visible_when_source_none_and_other_command_present() {
+        use crate::cli::statusline_install::StatuslineStatus;
+        use crate::models::live_window::Source;
+        assert!(should_show_enable_card_inner(
+            Source::None,
+            Some(&StatuslineStatus::Other("ccusage statusline".into())),
+        ));
+    }
+
+    #[test]
+    fn card_hidden_when_tier1_cache_active() {
+        use crate::cli::statusline_install::StatuslineStatus;
+        use crate::models::live_window::Source;
+        assert!(!should_show_enable_card_inner(
+            Source::Tier1Cache,
+            Some(&StatuslineStatus::Configured),
+        ));
+        // Even if settings.json was hand-edited away, Tier1Cache means
+        // data is flowing — don't shout.
+        assert!(!should_show_enable_card_inner(
+            Source::Tier1Cache,
+            Some(&StatuslineStatus::NotConfigured),
+        ));
+    }
+
+    #[test]
+    fn card_hidden_when_tier2_local_active() {
+        // Burndown panel's own contextual hint is the right surface
+        // for Tier2 — top-of-Stats card would be redundant.
+        use crate::cli::statusline_install::StatuslineStatus;
+        use crate::models::live_window::Source;
+        assert!(!should_show_enable_card_inner(
+            Source::Tier2Local,
+            Some(&StatuslineStatus::NotConfigured),
+        ));
+    }
+
+    #[test]
+    fn card_hidden_when_already_configured() {
+        use crate::cli::statusline_install::StatuslineStatus;
+        use crate::models::live_window::Source;
+        assert!(!should_show_enable_card_inner(
+            Source::None,
+            Some(&StatuslineStatus::Configured),
+        ));
+    }
+
+    #[test]
+    fn card_hidden_when_status_detection_failed() {
+        use crate::models::live_window::Source;
+        assert!(!should_show_enable_card_inner(Source::None, None));
     }
 }

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -829,12 +829,14 @@ impl UsageViewState {
 }
 
 /// Render the usage analytics screen
-pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
+pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState, ctx: EnableCardCtx) {
     // The enable card is hoisted above the panel grid when the Claude
     // Code statusline isn't wired. Once Tier1 cache is flowing the card
     // disappears and the rest of the screen takes the freed space.
-    let show_enable_card = should_show_enable_card();
-    let enable_card_h: u16 = if show_enable_card { 5 } else { 0 };
+    let show_enable_card = should_show_enable_card_inner(ctx);
+    // Body is two lines + rounded borders top/bottom = 4 rows total.
+    // No padding — the card is meant to be tight, not airy.
+    let enable_card_h: u16 = if show_enable_card { 4 } else { 0 };
 
     // Main layout: optional enable card + header + provider selector
     // + tabs + content + help bar.
@@ -877,37 +879,43 @@ pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState) {
     render_help_bar(frame, layout[5], state);
 }
 
-/// True when the Stats screen should hoist the "Press W to wire" enable
-/// card above the panel grid. We show it when the live window has *no*
-/// data at all (Source::None) and the user's settings.json doesn't
-/// already carry our block.
-///
-/// Tier2Local is intentionally treated as "card hidden" — at that point
-/// the user is already getting the 5h burn estimate, so the contextual
-/// hint inside the Burndown Budget panel (which mentions the missing 7d
-/// data) is a better fit than a top-of-screen alarm.
-fn should_show_enable_card() -> bool {
-    use crate::cli::statusline_install::detect_statusline_status;
-    use crate::models::live_window::current;
-
-    let status = detect_statusline_status().ok();
-    should_show_enable_card_inner(current().source, status.as_ref())
+/// Inputs the Stats screen needs to decide whether to hoist the enable
+/// card above the panel grid. The caller (`layout.rs`) computes these
+/// once per frame from the cached statusline detection so this code path
+/// never touches the filesystem.
+#[derive(Debug, Clone)]
+pub struct EnableCardCtx {
+    pub live_source: crate::models::live_window::Source,
+    pub statusline_status: Option<crate::cli::statusline_install::StatuslineStatus>,
+    pub statusline_decision: crate::config::StatuslineDecision,
 }
 
-/// Pure decision logic for `should_show_enable_card`. Split out for
-/// unit testing without touching the live cache or filesystem.
-fn should_show_enable_card_inner(
-    live_source: crate::models::live_window::Source,
-    statusline_status: Option<&crate::cli::statusline_install::StatuslineStatus>,
-) -> bool {
+/// Pure decision logic for whether the Stats screen should hoist the
+/// "Press W to wire" enable card above the panel grid.
+///
+/// Visibility rule:
+/// - Live window source must be `None` — Tier1Cache means data is
+///   already flowing; Tier2Local intentionally hides the card so the
+///   Burndown Budget panel's contextual hint stays the canonical
+///   surface for the "5h works, 7d doesn't" state.
+/// - Statusline must not already carry our block (NotConfigured or
+///   `Other` — i.e. there's something for `W` to do).
+/// - User must not have explicitly declined in the init wizard. The
+///   top-bar CTA already respects this; the Stats card mirrors it so
+///   the two surfaces never disagree.
+pub(crate) fn should_show_enable_card_inner(ctx: EnableCardCtx) -> bool {
     use crate::cli::statusline_install::StatuslineStatus;
+    use crate::config::StatuslineDecision;
     use crate::models::live_window::Source;
 
-    if live_source != Source::None {
+    if ctx.statusline_decision == StatuslineDecision::Declined {
+        return false;
+    }
+    if ctx.live_source != Source::None {
         return false;
     }
     matches!(
-        statusline_status,
+        ctx.statusline_status,
         Some(StatuslineStatus::NotConfigured) | Some(StatuslineStatus::Other(_))
     )
 }
@@ -938,7 +946,10 @@ fn build_enable_card_lines() -> Vec<Line<'static>> {
                 Style::default().fg(red).add_modifier(Modifier::BOLD),
             ),
             Span::styled(" — Press ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("[W]", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "[W]",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" to wire up", Style::default().fg(MUTED_GRAY)),
         ]),
         Line::from(Span::styled(
@@ -3422,7 +3433,10 @@ fn budget_live_header_lines(
             )));
             out.push(Line::from(vec![
                 Span::styled("    Press ", Style::default().fg(MUTED_GRAY)),
-                Span::styled("[W]", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    "[W]",
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(
                     " to wire up Claude Code statusline.",
                     Style::default().fg(MUTED_GRAY),
@@ -4993,89 +5007,125 @@ mod enable_card_tests {
                 if span.content.contains("[W]") && span.style.fg == Some(GOLD) {
                     found_gold_w = true;
                 }
-                if span.content.contains("⚠") && span.style.fg == Some(Color::Rgb(230, 100, 100)) {
+                if span.content.contains("⚠") && span.style.fg == Some(Color::Rgb(230, 100, 100))
+                {
                     found_red_warning = true;
                 }
             }
         }
-        assert!(found_gold_w, "[W] should be styled GOLD per tui-style-guide");
+        assert!(
+            found_gold_w,
+            "[W] should be styled GOLD per tui-style-guide"
+        );
         assert!(found_red_warning, "warning glyph should use the CTA red");
     }
 
     #[test]
     fn card_is_two_lines_for_compact_layout() {
-        // The enable-card row is `Constraint::Length(5)` (4 inner + 2
-        // border ~= 4 lines visible incl. padding). Body must stay at
-        // two text lines so it fits without scroll.
+        // The enable-card row is `Constraint::Length(4)` (2 borders +
+        // 2 body lines, no padding). Body must stay at two text lines
+        // so it fits without scroll.
         let lines = build_enable_card_lines();
         assert_eq!(
             lines.len(),
             2,
-            "enable card body must remain two lines; layout reserves only 5 rows"
+            "enable card body must remain two lines; layout reserves only 4 rows"
         );
+    }
+
+    use crate::cli::statusline_install::StatuslineStatus;
+    use crate::config::StatuslineDecision;
+    use crate::models::live_window::Source;
+
+    fn ctx(
+        live_source: Source,
+        statusline_status: Option<StatuslineStatus>,
+        statusline_decision: StatuslineDecision,
+    ) -> EnableCardCtx {
+        EnableCardCtx {
+            live_source,
+            statusline_status,
+            statusline_decision,
+        }
     }
 
     #[test]
     fn card_visible_when_source_none_and_statusline_unconfigured() {
-        use crate::cli::statusline_install::StatuslineStatus;
-        use crate::models::live_window::Source;
-        assert!(should_show_enable_card_inner(
+        assert!(should_show_enable_card_inner(ctx(
             Source::None,
-            Some(&StatuslineStatus::NotConfigured),
-        ));
+            Some(StatuslineStatus::NotConfigured),
+            StatuslineDecision::Unset,
+        )));
     }
 
     #[test]
     fn card_visible_when_source_none_and_other_command_present() {
-        use crate::cli::statusline_install::StatuslineStatus;
-        use crate::models::live_window::Source;
-        assert!(should_show_enable_card_inner(
+        assert!(should_show_enable_card_inner(ctx(
             Source::None,
-            Some(&StatuslineStatus::Other("ccusage statusline".into())),
-        ));
+            Some(StatuslineStatus::Other("ccusage statusline".into())),
+            StatuslineDecision::Unset,
+        )));
+    }
+
+    #[test]
+    fn card_hidden_when_user_declined_in_init_wizard() {
+        // Mirrors the top-bar CTA logic. If the user explicitly opted
+        // out, the Stats screen must respect the decision — anything
+        // else is two surfaces disagreeing about the same setting.
+        assert!(!should_show_enable_card_inner(ctx(
+            Source::None,
+            Some(StatuslineStatus::NotConfigured),
+            StatuslineDecision::Declined,
+        )));
+        assert!(!should_show_enable_card_inner(ctx(
+            Source::None,
+            Some(StatuslineStatus::Other("ccusage statusline".into())),
+            StatuslineDecision::Declined,
+        )));
     }
 
     #[test]
     fn card_hidden_when_tier1_cache_active() {
-        use crate::cli::statusline_install::StatuslineStatus;
-        use crate::models::live_window::Source;
-        assert!(!should_show_enable_card_inner(
+        assert!(!should_show_enable_card_inner(ctx(
             Source::Tier1Cache,
-            Some(&StatuslineStatus::Configured),
-        ));
+            Some(StatuslineStatus::Configured),
+            StatuslineDecision::Installed,
+        )));
         // Even if settings.json was hand-edited away, Tier1Cache means
         // data is flowing — don't shout.
-        assert!(!should_show_enable_card_inner(
+        assert!(!should_show_enable_card_inner(ctx(
             Source::Tier1Cache,
-            Some(&StatuslineStatus::NotConfigured),
-        ));
+            Some(StatuslineStatus::NotConfigured),
+            StatuslineDecision::Unset,
+        )));
     }
 
     #[test]
     fn card_hidden_when_tier2_local_active() {
         // Burndown panel's own contextual hint is the right surface
         // for Tier2 — top-of-Stats card would be redundant.
-        use crate::cli::statusline_install::StatuslineStatus;
-        use crate::models::live_window::Source;
-        assert!(!should_show_enable_card_inner(
+        assert!(!should_show_enable_card_inner(ctx(
             Source::Tier2Local,
-            Some(&StatuslineStatus::NotConfigured),
-        ));
+            Some(StatuslineStatus::NotConfigured),
+            StatuslineDecision::Unset,
+        )));
     }
 
     #[test]
     fn card_hidden_when_already_configured() {
-        use crate::cli::statusline_install::StatuslineStatus;
-        use crate::models::live_window::Source;
-        assert!(!should_show_enable_card_inner(
+        assert!(!should_show_enable_card_inner(ctx(
             Source::None,
-            Some(&StatuslineStatus::Configured),
-        ));
+            Some(StatuslineStatus::Configured),
+            StatuslineDecision::Installed,
+        )));
     }
 
     #[test]
     fn card_hidden_when_status_detection_failed() {
-        use crate::models::live_window::Source;
-        assert!(!should_show_enable_card_inner(Source::None, None));
+        assert!(!should_show_enable_card_inner(ctx(
+            Source::None,
+            None,
+            StatuslineDecision::Unset,
+        )));
     }
 }


### PR DESCRIPTION
## Summary

The top-bar CTA promised "go to Stats to enable" but the actual install affordance was buried three nav steps deep (Stats → Burndown → focus Budget panel). This PR closes that discoverability gap on three fronts:

- **Global `W` shortcut** — wires the Claude Code statusline from any non-text view when live data isn't already flowing from the Tier1 cache. Single dispatch path; the legacy Burndown-local W arm is removed.
- **Top-of-Stats enable card** — when source is `None` and settings.json doesn't carry our block, a compact 5-row card renders above the Stats panel grid spelling out the keystroke and what wiring unlocks. Disappears once Tier1 cache is flowing.
- **CTA copy** — top status bar now reads "press W to enable" instead of "go to Stats to enable". The promise lines up with the keystroke.

## Commits

1. `fa67b35` `feat(layout): global W shortcut to wire Claude Code statusline`
   Promote `UsageWireStatusline` from the Burndown match arm to a global handler at the top of `handle_key_event`. Suppressed in text-input views (NewSession, Config, ClaudeChat, AuthSetup, AttachedTerminal, SearchWorkspace, auth provider popup) so an accidental Shift+W during typing never triggers an install. Decision logic split out as `should_wire_statusline_inner` for unit testability across all six (Source × StatuslineStatus) combinations.

2. `fce2296` `feat(usage): hoist enable card to top of Stats screen`
   New 5-row card above the panel grid:
   ```
   ⚠ Live Claude Code usage off — Press [W] to wire up
      Provides 5h burn, 7d window, cost, reset times
   ```
   Tier2Local intentionally hides the card (the contextual Burndown Budget hint is the better surface there). Styling follows the tui-style-guide skill (BorderType::Rounded, gold `[W]`, warning-red `⚠`, MUTED_GRAY tagline). Visibility logic is split into `should_show_enable_card_inner` for unit tests.

3. `5936835` `docs(layout): point top-bar CTA at the W shortcut`
   - Before: `⚠ Live Claude Code usage off · go to Stats to enable`
   - After: `⚠ Live Claude Code usage off · press W to enable`

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release --lib -- --skip docker::` — 639 passed, 0 failed (Docker tests fail on origin/main too; pre-existing infrastructure issue, unrelated)
- [x] New tests:
  - 6 in `app::events::global_w_tests` (global W decision logic across all source/status combos)
  - 9 in `components::usage::enable_card_tests` (card visibility + copy + styling)
  - 1 updated assertion in `components::layout::live_widget_tests::cta_spans_contain_warning_and_w_shortcut_hint`
- [x] Smoke test: piped sample Claude Code stdin JSON to `./target/release/ainb claudecode statusline`; confirmed cache write at `~/Library/Caches/ainb/live.json` (119 bytes, formatted statusline output)
- [x] All 36 statusline-related lib tests still pass

## Don't / Notes

- No new dependencies, no `StatuslineDecision` enum changes, no persistence schema changes.
- The in-Burndown Budget panel hint is intentionally left intact — it serves a different audience (users already on the Budget panel who want the contextual reason for the missing data).
- No release/tag bump in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (W) to enable live usage analytics in the statusline
  * New warning card appears when live data is not yet configured

* **Improvements**
  * UI prompts updated to say “press W” instead of directing to settings
  * Smarter statusline detection with short-lived caching to reduce redundant checks

* **Tests**
  * Added unit tests covering the new wiring and detection behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->