### PR TITLE
feat(statusline): --cache-only flag for side-channel cache writes

### DIFF
--- a/ainb-tui/src/cli/mod.rs
+++ b/ainb-tui/src/cli/mod.rs
@@ -184,7 +184,17 @@ pub enum ClaudeCodeCmd {
     /// Statusline hook: read JSON on stdin, cache rate-limit windows for
     /// the TUI, and emit a powerline status string on stdout. Wire into
     /// `~/.claude/settings.json` as `statusLine.command`.
-    Statusline,
+    Statusline {
+        /// Side-channel mode: write the cache only and emit nothing on
+        /// stdout. Use this when chaining ainb behind your own statusline
+        /// renderer (Claude Code only allows one `statusLine.command`,
+        /// so a custom script can pipe the same JSON to ainb in the
+        /// background to keep the TUI Live Window's Tier1 cache fresh).
+        /// Errors (malformed JSON, unwritable cache) still surface on
+        /// stderr with a non-zero exit so silent breakage is impossible.
+        #[arg(long)]
+        cache_only: bool,
+    },
 }
 
 /// Arguments for the run command
@@ -318,7 +328,21 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::Claudecode {
-                cmd: ClaudeCodeCmd::Statusline
+                cmd: ClaudeCodeCmd::Statusline { cache_only: false }
+            })
+        ));
+    }
+
+    /// `--cache-only` is a side-channel mode for users running their own
+    /// statusline renderer who still want ainb's Tier1 cache fresh.
+    #[test]
+    fn statusline_cache_only_flag_parses() {
+        let cli = Cli::try_parse_from(["ainb", "claudecode", "statusline", "--cache-only"])
+            .expect("--cache-only must parse");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Claudecode {
+                cmd: ClaudeCodeCmd::Statusline { cache_only: true }
             })
         ));
     }

--- a/ainb-tui/src/cli/statusline.rs
+++ b/ainb-tui/src/cli/statusline.rs
@@ -214,27 +214,79 @@ fn pct_color(pct: u8, amber_at: u8, red_at: u8) -> (u8, u8, u8) {
 }
 
 /// Subcommand entry point. Reads stdin to EOF, persists the cache, and
-/// prints a status string to stdout. Catches all errors and degrades to
-/// an empty line — the statusline runs every prompt render.
-pub fn execute() -> Result<()> {
+/// (in default render mode) prints a powerline status string on stdout.
+///
+/// Two modes:
+///
+/// * `cache_only = false` (default): write cache + emit powerline string.
+///   All errors are swallowed and degrade to an empty line — the
+///   statusline runs every prompt render and must never break the user's
+///   shell.
+/// * `cache_only = true`: side-channel mode for users running their own
+///   statusline. Write cache + emit nothing on stdout. Surfaces malformed
+///   JSON / cache-write failures on stderr with a non-zero exit so a
+///   broken pipeline is visible instead of silently rotting the cache.
+pub fn execute(cache_only: bool) -> Result<()> {
     let mut buf = Vec::new();
     let _ = std::io::stdin().read_to_end(&mut buf);
 
-    match parse_payload(&buf) {
-        Some(cache) => {
-            if let Some(path) = cache_path() {
-                let _ = write_cache(&path, &cache);
-            }
+    match run_with(&buf, cache_path().as_deref(), cache_only) {
+        Ok(Some(line)) => {
             // Newline so it integrates cleanly with shell prompt drawing.
-            println!("{}", render_powerline(&cache));
+            println!("{line}");
+            Ok(())
         }
-        None => {
-            // Empty stdin or malformed JSON — emit nothing rather than
-            // pollute the user's prompt.
+        Ok(None) => Ok(()),
+        Err(e) if cache_only => {
+            // Surface the failure so the calling script (and the user)
+            // can see why the cache isn't refreshing. stderr only —
+            // stdout stays silent in cache-only mode by contract.
+            // Exit directly so `anyhow::Error`'s default "Error: ..."
+            // chain doesn't double-print on top of our message.
+            eprintln!("ainb statusline --cache-only: {e}");
+            std::process::exit(1);
+        }
+        Err(_) => {
+            // Default render mode: degrade to an empty line so we never
+            // break the user's shell prompt.
             println!();
+            Ok(())
         }
     }
-    Ok(())
+}
+
+/// Pure core. Parses `buf`, writes the cache (if `cache_path` is
+/// `Some`), and returns what should be written to stdout.
+///
+/// Returned values:
+/// * `Ok(Some(line))` — print `line` then newline (default render mode).
+/// * `Ok(None)`       — print nothing (cache-only mode happy path).
+/// * `Err(e)`         — caller decides whether to surface (cache-only)
+///   or swallow (default render mode).
+///
+/// Splitting parse + write + render away from stdin/stdout lets us
+/// exercise both modes against an in-memory buffer and a temp cache
+/// path in tests.
+pub fn run_with(
+    buf: &[u8],
+    cache_path: Option<&std::path::Path>,
+    cache_only: bool,
+) -> Result<Option<String>> {
+    let cache = parse_payload(buf)
+        .ok_or_else(|| anyhow::anyhow!("malformed or empty statusline JSON payload on stdin"))?;
+
+    // Always attempt the cache write (the whole point of both modes).
+    // In cache-only mode we surface errors; in render mode the wrapper
+    // swallows them so the prompt keeps working.
+    if let Some(path) = cache_path {
+        write_cache(path, &cache)?;
+    }
+
+    if cache_only {
+        Ok(None)
+    } else {
+        Ok(Some(render_powerline(&cache)))
+    }
 }
 
 #[cfg(test)]
@@ -395,6 +447,75 @@ mod tests {
         };
         // Just don't panic; result may be empty string.
         let _ = render_powerline(&cache);
+    }
+
+    /// `--cache-only`: cache is written, stdout payload is `None`
+    /// (i.e. the wrapper prints nothing).
+    #[test]
+    fn cache_only_mode_writes_cache_and_emits_nothing_on_stdout() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("live.json");
+        let raw = br#"{
+            "model": {"display_name": "Opus 4.7"},
+            "rate_limits": {"five_hour": {"used_percentage": 42}}
+        }"#;
+
+        let out = run_with(raw, Some(&path), true).expect("cache-only must succeed");
+        assert!(out.is_none(), "cache-only must emit nothing on stdout");
+
+        let cache = read_cache(&path).expect("cache file must exist and be parseable");
+        assert_eq!(cache.model.as_deref(), Some("Opus 4.7"));
+        assert_eq!(cache.five_hour.unwrap().pct, 42);
+    }
+
+    /// `--cache-only` is the only mode that surfaces errors. A malformed
+    /// payload must return `Err` so the wrapper can exit non-zero and
+    /// log to stderr — silent rot would defeat the whole purpose of the
+    /// flag (users can't tell their pipeline broke).
+    #[test]
+    fn cache_only_mode_returns_error_on_malformed_json() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("live.json");
+
+        let err = run_with(b"not json at all", Some(&path), true)
+            .expect_err("malformed JSON must error in cache-only mode");
+        let msg = format!("{err}");
+        assert!(msg.contains("malformed"), "error must explain cause: got {msg}");
+        assert!(!path.exists(), "no cache file should be written on parse failure");
+    }
+
+    /// Both modes share a single parse + write path, so the bytes on
+    /// disk must be identical except for the `updated_at` timestamp
+    /// (which is intrinsically time-dependent — we normalize it before
+    /// comparing).
+    #[test]
+    fn cache_only_mode_writes_same_schema_as_full_mode() {
+        let dir = tempdir().unwrap();
+        let render_path = dir.path().join("render.json");
+        let cache_only_path = dir.path().join("cache_only.json");
+        let raw = br#"{
+            "model": {"display_name": "Sonnet 4.5"},
+            "context_window": {"used_percentage": 40},
+            "rate_limits": {
+                "five_hour": {"used_percentage": 12, "resets_at": "2026-05-07T05:00:00Z"},
+                "seven_day": {"used_percentage": 3,  "resets_at": "2026-05-13T00:00:00Z"}
+            },
+            "cost": {"total_cost_usd": 4.21}
+        }"#;
+
+        let line = run_with(raw, Some(&render_path), false).expect("render mode must succeed");
+        assert!(line.is_some(), "render mode must produce a powerline string");
+
+        let none = run_with(raw, Some(&cache_only_path), true).expect("cache-only must succeed");
+        assert!(none.is_none(), "cache-only must produce no stdout");
+
+        let mut a = read_cache(&render_path).expect("render cache exists");
+        let mut b = read_cache(&cache_only_path).expect("cache-only cache exists");
+        // Normalize the only field that differs between two real-time
+        // writes: the wall-clock timestamp.
+        a.updated_at.clear();
+        b.updated_at.clear();
+        assert_eq!(a, b, "both modes must persist byte-identical schema");
     }
 
     #[test]

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -772,15 +772,21 @@ pub fn build_live_status_spans(state: &mut AppState) -> Vec<Span<'static>> {
     let status = state.statusline_status_cached();
     let decision = state.app_config.ui_preferences.statusline_decision;
 
+    // Trust the cache: if Tier1 data is flowing — whether it came from
+    // our own command in settings.json (Configured) or from a user's
+    // custom statusline that side-channels via `ainb claudecode statusline
+    // --cache-only` (Other) — show the live widget. The CTA is for the
+    // genuinely-unwired case only.
+    let live = current();
+    if live.source == Source::Tier1Cache {
+        return build_live_widget_spans(&live);
+    }
+
     match status {
         Some(StatuslineStatus::Configured) => {
-            let live = current();
-            if live.source != Source::Tier1Cache {
-                // Wired but no fresh data yet — render nothing rather
-                // than misleading "0%" placeholders.
-                return Vec::new();
-            }
-            build_live_widget_spans(&live)
+            // Wired our command but no fresh data yet — render nothing
+            // rather than misleading "0%" placeholders.
+            Vec::new()
         }
         Some(StatuslineStatus::NotConfigured | StatuslineStatus::Other(_))
             if decision != StatuslineDecision::Declined =>

--- a/ainb-tui/src/main.rs
+++ b/ainb-tui/src/main.rs
@@ -122,9 +122,12 @@ async fn main() -> Result<()> {
         // existing `~/.claude/settings.json` entries keep working
         // unchanged.
         Some(cli::Commands::Claudecode {
-            cmd: cli::ClaudeCodeCmd::Statusline,
-        })
-        | Some(cli::Commands::Statusline) => cli::statusline::execute(),
+            cmd: cli::ClaudeCodeCmd::Statusline { cache_only },
+        }) => cli::statusline::execute(cache_only),
+        // Legacy top-level alias has no flag — preserves the original
+        // wire-format for `~/.claude/settings.json` entries written
+        // before --cache-only existed.
+        Some(cli::Commands::Statusline) => cli::statusline::execute(false),
         Some(cli::Commands::Completion { shell }) => {
             use clap::CommandFactory;
             let mut cmd = cli::Cli::command();


### PR DESCRIPTION
## Summary

Lets users keep their own custom `~/.claude/statusline.sh` AND have ainb-tui's Live Window flow Tier1 data, by piping the same Claude Code stdin JSON into `ainb` in the background just for the cache-write side effect.

Closes the dilemma surfaced after PR #86: Claude Code only allows one `statusLine.command`, so you'd previously have to choose between your richer custom statusline and ainb's Tier1 cache. Now you can have both.

## Behavior

| Mode | Cache write | stdout | Errors |
|---|---|---|---|
| Default (existing) | ✓ | powerline string | swallowed (prompt never breaks) |
| `--cache-only` (new) | ✓ | nothing | stderr + exit 1 (silent rot would defeat the purpose) |

Both modes share a single parse + write path; a regression test asserts byte-identical cache schema between them.

## Usage

```bash
#!/usr/bin/env bash
input=$(cat)

# Side-channel: keep ainb-tui's Live Window Tier1 cache fresh.
echo "$input" | ainb claudecode statusline --cache-only >/dev/null 2>&1 &

# Your existing rendering pipeline below — unchanged.
echo "$input" | <your renderer>
```

## Test plan

- [x] `cargo build --release` clean (warnings unchanged from main)
- [x] `cargo test --release --lib statusline -- --skip docker::` → 46/46 pass
- [x] Smoke: default mode emits ANSI powerline, cache-only emits 0 bytes, both write the same `~/Library/Caches/ainb/live.json`
- [x] Smoke: malformed JSON in `--cache-only` exits 1 with stderr message; in default mode degrades to empty line (existing behavior preserved)
- [x] Legacy `ainb statusline` (hidden top-level alias) still parses with `cache_only = false` hardcoded

## Files

- `ainb-tui/src/cli/mod.rs` — `cache_only: bool` flag on the subcommand + parse test
- `ainb-tui/src/cli/statusline.rs` — split `execute()` into thin wrapper + pure `run_with()` core; 3 new tests
- `ainb-tui/src/main.rs` — dispatcher passes the flag through; legacy alias hardcodes `false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --cache-only option to the statusline command to update cache silently (no stdout).

* **Improvements**
  * Cache-only mode now surfaces errors to stderr and exits non‑zero on failure for clearer diagnostics.
  * Preserved legacy statusline alias behavior.

* **UI**
  * Top status bar’s live OAuth widget now shows only when cached tier-1 data is the current source; CTA gating refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->