### PR TITLE
fix(usage): unbreak provider chip switch + drop bogus today price

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -4286,16 +4286,18 @@ impl EventHandler {
             }
             AppEvent::UsageNextProvider => {
                 state.usage_state.next_provider();
-                // Data is cached across provider switches; only trigger a load
-                // if we returned to Claude and nothing has been parsed yet.
+                // Force re-parse: each provider scopes the call set
+                // (Claude-only / Codex-only / All) so the cached
+                // UsageData is for the wrong provider after a switch.
+                // Per-file SQLite cache keeps the reparse cheap.
                 if state.usage_state.provider.has_data() {
-                    state.start_background_usage_load(false);
+                    state.start_background_usage_load(true);
                 }
             }
             AppEvent::UsagePrevProvider => {
                 state.usage_state.prev_provider();
                 if state.usage_state.provider.has_data() {
-                    state.start_background_usage_load(false);
+                    state.start_background_usage_load(true);
                 }
             }
             AppEvent::UsageNextTab => {

--- a/ainb-tui/src/cli/statusline.rs
+++ b/ainb-tui/src/cli/statusline.rs
@@ -480,8 +480,14 @@ mod tests {
         let err = run_with(b"not json at all", Some(&path), true)
             .expect_err("malformed JSON must error in cache-only mode");
         let msg = format!("{err}");
-        assert!(msg.contains("malformed"), "error must explain cause: got {msg}");
-        assert!(!path.exists(), "no cache file should be written on parse failure");
+        assert!(
+            msg.contains("malformed"),
+            "error must explain cause: got {msg}"
+        );
+        assert!(
+            !path.exists(),
+            "no cache file should be written on parse failure"
+        );
     }
 
     /// Both modes share a single parse + write path, so the bytes on
@@ -504,7 +510,10 @@ mod tests {
         }"#;
 
         let line = run_with(raw, Some(&render_path), false).expect("render mode must succeed");
-        assert!(line.is_some(), "render mode must produce a powerline string");
+        assert!(
+            line.is_some(),
+            "render mode must produce a powerline string"
+        );
 
         let none = run_with(raw, Some(&cache_only_path), true).expect("cache-only must succeed");
         assert!(none.is_none(), "cache-only must produce no stdout");

--- a/ainb-tui/src/components/layout.rs
+++ b/ainb-tui/src/components/layout.rs
@@ -825,15 +825,11 @@ fn build_live_widget_spans(live: &crate::models::live_window::LiveWindow) -> Vec
             Style::default().fg(bar_color_7d(pct)).add_modifier(Modifier::BOLD),
         ));
     }
-    if let Some(cost) = live.today_cost_usd {
-        if !out.is_empty() {
-            out.push(Span::styled(" · ", Style::default().fg(SUBDUED_BORDER)));
-        }
-        out.push(Span::styled(
-            format!("${cost:.2} today"),
-            Style::default().fg(GOLD),
-        ));
-    }
+    // today_cost_usd intentionally not rendered: Claude Code's
+    // /cost/total_cost_usd is the lifetime cost of a *single* session
+    // (whichever invoked the statusline most recently), not today's
+    // total. Misleading at a glance — keep the field on the cache
+    // schema but don't surface it.
     if let Some(d) = live.resets_in {
         if !out.is_empty() {
             out.push(Span::styled(" · ", Style::default().fg(SUBDUED_BORDER)));
@@ -921,7 +917,7 @@ mod live_widget_tests {
     }
 
     #[test]
-    fn live_widget_renders_5h_7d_cost_and_reset() {
+    fn live_widget_renders_5h_7d_and_reset() {
         let live = LiveWindow {
             five_hour_pct: Some(40),
             seven_day_pct: Some(8),
@@ -937,7 +933,10 @@ mod live_widget_tests {
         assert!(text.contains("40%"));
         assert!(text.contains("wk"));
         assert!(text.contains("8%"));
-        assert!(text.contains("$1.50"));
+        // today_cost_usd is in the cache but intentionally not rendered —
+        // it's a single session's lifetime cost, not today's total.
+        assert!(!text.contains("$"));
+        assert!(!text.contains("today"));
         assert!(text.contains("2h 00m"));
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1099,30 +1099,58 @@ fn render_no_data(frame: &mut Frame, area: Rect, state: &UsageViewState) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let lines = vec![
-        Line::from(""),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("  ", Style::default()),
-            Span::styled(
-                state.provider.label(),
-                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " usage tracking is not yet available.",
-                Style::default().fg(MUTED_GRAY),
-            ),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "  Usage data parsing is currently supported for Claude Code and Codex.",
-            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
-        )),
-        Line::from(Span::styled(
-            "  Other providers will be added as they expose session-level usage data.",
-            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
-        )),
-    ];
+    let lines = if state.provider.has_data() {
+        // Provider IS wired (Claude/Codex), the call set is just empty
+        // for the active period + filters. This is a normal "no
+        // activity in the selected window" state, not an "unsupported
+        // provider" state — wording must reflect that or users on a
+        // fresh install would think Claude usage tracking is broken.
+        vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("  ", Style::default()),
+                Span::styled(
+                    "No usage data",
+                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!(" for {} in this window.", state.provider.short_label()),
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Try widening the period (Tab) or clearing filters (X).",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )),
+        ]
+    } else {
+        vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("  ", Style::default()),
+                Span::styled(
+                    state.provider.label(),
+                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " usage tracking is not yet available.",
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Usage data parsing is currently supported for Claude Code and Codex.",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )),
+            Line::from(Span::styled(
+                "  Other providers will be added as they expose session-level usage data.",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )),
+        ]
+    };
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, inner);
@@ -3409,18 +3437,12 @@ fn budget_live_header_lines(
             if let Some(pct) = live.seven_day_pct {
                 out.push(live_bar_line("7d wnd  ", pct, bar_w));
             }
+            // today_cost_usd intentionally not rendered: it's the
+            // lifetime cost of one Claude Code session (whichever
+            // invoked the statusline command last), not a daily total
+            // — same reasoning as the Live Window widget in layout.rs.
             let mut footer: Vec<Span<'static>> = Vec::new();
-            if let Some(cost) = live.today_cost_usd {
-                footer.push(Span::styled(" Today ", Style::default().fg(MUTED_GRAY)));
-                footer.push(Span::styled(
-                    format!("${cost:.2}"),
-                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-                ));
-            }
             if let Some(d) = live.resets_in {
-                if !footer.is_empty() {
-                    footer.push(Span::styled(" · ", Style::default().fg(MUTED_GRAY)));
-                }
                 footer.push(Span::styled(" Resets in ", Style::default().fg(MUTED_GRAY)));
                 footer.push(Span::styled(
                     format_hms(d),
@@ -3436,7 +3458,7 @@ fn budget_live_header_lines(
                 out.push(live_bar_line("5h burn ", pct, bar_w));
             }
             out.push(Line::from(Span::styled(
-                " Wire Claude Code statusline (W) for 7d window + cost",
+                " Wire Claude Code statusline (W) for 7d window data",
                 Style::default().fg(MUTED_GRAY),
             )));
         }
@@ -4932,7 +4954,7 @@ mod budget_live_header_tests {
     }
 
     #[test]
-    fn tier1_renders_two_bars_plus_cost_and_reset() {
+    fn tier1_renders_two_bars_and_reset() {
         let live = LiveWindow {
             five_hour_pct: Some(40),
             seven_day_pct: Some(8),
@@ -4946,7 +4968,9 @@ mod budget_live_header_tests {
         let text = flat(&lines);
         assert!(text.contains("5h burn"));
         assert!(text.contains("7d wnd"));
-        assert!(text.contains("$3.21"));
+        // today_cost_usd is in the cache but intentionally not rendered —
+        // it's a single session's lifetime cost, not today's total.
+        assert!(!text.contains("$"));
         assert!(text.contains("2h 30m"));
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -1033,24 +1033,19 @@ fn render_provider_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         let is_active = *provider == state.provider;
         let style = match (is_active, provider.has_data()) {
             // Active + wired: gold bold underline (the canonical selection).
-            (true, true) => Style::default()
-                .fg(GOLD)
-                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            (true, true) => {
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            }
             // Active + not wired: keep underline so the user sees they
             // landed on it, but stay muted to flag it's a placeholder.
-            (true, false) => Style::default()
-                .fg(MUTED_GRAY)
-                .add_modifier(Modifier::UNDERLINED),
+            (true, false) => Style::default().fg(MUTED_GRAY).add_modifier(Modifier::UNDERLINED),
             (false, true) => Style::default().fg(SOFT_WHITE),
             (false, false) => Style::default().fg(MUTED_GRAY),
         };
 
         spans.push(Span::styled(provider.label(), style));
         if !provider.has_data() {
-            spans.push(Span::styled(
-                " (soon)",
-                Style::default().fg(MUTED_GRAY),
-            ));
+            spans.push(Span::styled(" (soon)", Style::default().fg(MUTED_GRAY)));
         }
     }
 

--- a/ainb-tui/src/components/usage.rs
+++ b/ainb-tui/src/components/usage.rs
@@ -859,11 +859,18 @@ pub fn render(frame: &mut Frame, area: Rect, state: &UsageViewState, ctx: Enable
     render_provider_bar(frame, layout[2], state);
     render_tab_bar(frame, layout[3], state);
 
-    if state.loading || state.data.is_none() {
+    if !state.provider.has_data() {
+        // Provider has no parser wired (Gemini, Copilot). Skip the
+        // loading spinner + cached-from-other-provider data and go
+        // straight to the "not yet wired" empty state. Without this
+        // gate the screen would silently render the previously-loaded
+        // Claude/Codex data while showing the Gemini chip as active.
+        render_no_data(frame, layout[4], state);
+    } else if state.loading || state.data.is_none() {
         render_loading(frame, layout[4]);
     } else {
         let data = state.data.as_ref().unwrap();
-        if data.calls.is_empty() && !state.provider.has_data() {
+        if data.calls.is_empty() {
             render_no_data(frame, layout[4], state);
         } else {
             match state.active_tab {
@@ -1024,15 +1031,27 @@ fn render_provider_bar(frame: &mut Frame, area: Rect, state: &UsageViewState) {
         }
 
         let is_active = *provider == state.provider;
-        let style = if is_active {
-            Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-        } else if provider.has_data() {
-            Style::default().fg(SOFT_WHITE)
-        } else {
-            Style::default().fg(MUTED_GRAY)
+        let style = match (is_active, provider.has_data()) {
+            // Active + wired: gold bold underline (the canonical selection).
+            (true, true) => Style::default()
+                .fg(GOLD)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            // Active + not wired: keep underline so the user sees they
+            // landed on it, but stay muted to flag it's a placeholder.
+            (true, false) => Style::default()
+                .fg(MUTED_GRAY)
+                .add_modifier(Modifier::UNDERLINED),
+            (false, true) => Style::default().fg(SOFT_WHITE),
+            (false, false) => Style::default().fg(MUTED_GRAY),
         };
 
         spans.push(Span::styled(provider.label(), style));
+        if !provider.has_data() {
+            spans.push(Span::styled(
+                " (soon)",
+                Style::default().fg(MUTED_GRAY),
+            ));
+        }
     }
 
     spans.push(Span::styled("    ", Style::default()));


### PR DESCRIPTION
## Summary

Three small fixes for the Stats / Live Window after observing two
field bugs:

1. **Live Window price was wrong.** `today_cost_usd` reads
   `/cost/total_cost_usd` from Claude Code's statusline JSON — that's
   the lifetime cost of *one* session (whichever invoked the
   statusline most recently), not today's total. Drop the render.
   Cache schema unchanged.

2. **Burndown provider chip didn't switch data.**
   `next_provider`/`prev_provider` called
   `start_background_usage_load(false)`, which early-returns when
   data is already cached. Net effect: switching Claude → Codex
   updated the filter on state but never reparsed. Pass
   `force=true`. Per-file SQLite cache keeps reparse cheap.

3. **Gemini and Copilot chips were vapor.** No parser, no
   `UsageSourceRoots` fields, no `UsageProviderFilter` variants —
   yet the chips were navigable and would silently re-render the
   previously-loaded Claude/Codex data. Render path now
   short-circuits to `render_no_data` for unwired providers, chip
   styling drops gold treatment, and a muted "(soon)" suffix flags
   the placeholder state.

Per Stevie's call: Gemini stays visible+greyed; Copilot wiring
tracked under `agents-in-a-box-2kp`.

## Test plan
- [x] `cargo test --lib live_widget` — 7 pass
- [x] `cargo test --lib usage::` — 105 pass
- [x] `cargo build` clean
- [ ] Manual: start TUI, press `i`, cycle ◀/▶ across Claude → Codex →
  Gemini → Copilot. Claude/Codex should reload data; Gemini/Copilot
  should drop straight to "not yet available".
- [ ] Live Window: verify no `$X.XX today` in the top bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage data now forces a fresh re-parse when switching providers with existing cached data, preventing stale provider-scoped results.

* **Style / UX**
  * Removed redundant "today" cost from live status and budget headers.
  * Provider status visuals clarified, with a "(soon)" suffix for providers not yet providing wired data.
  * Improved active/inactive provider distinctions and no-data messaging.

* **Tests**
  * Unit tests updated to reflect the adjusted rendering and empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->