### PR TITLE
feat(plugin-burndown): Phase 7c — migrate burndown to subprocess plugin

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/ainb-core",
+    "crates/ainb-plugin-burndown",
     "crates/ainb-plugin-protocol",
     "crates/ainb-plugin-runtime",
     "crates/ainb-plugin-sdk-rust",
@@ -9,10 +10,9 @@ members = [
     "xtask",
 ]
 default-members = ["crates/ainb-core"]
-# Phase 7b: wasmi host + v1 plugins removed in this PR. The legacy
-# CTS canaries, burndown, session-reader, and v1 plugin-host/plugin-api
-# crates were deleted entirely. Re-shipped subprocess plugins land in
-# Phase 7c — until then this workspace ships zero plugins.
+# Phase 7c: burndown returns as a subprocess plugin (native binary,
+# stdio JSON-RPC over the SDK). session-reader is being re-shipped in
+# parallel under agents-in-a-box-4is.
 
 [workspace.package]
 version = "1.1.0"

--- a/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "ainb-plugin-burndown"
+version = "2.0.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Daily/weekly/project usage burndown analytics — subprocess plugin (ABI v2)"
+
+[lib]
+name = "ainb_plugin_burndown"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ainb-plugin-burndown"
+path = "src/main.rs"
+
+[dependencies]
+ainb-plugin-sdk-rust = { path = "../ainb-plugin-sdk-rust" }
+ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
+
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+rmp-serde = "1.3"
+bytes = { version = "1.6", features = ["serde"] }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+toml = { workspace = true }
+async-trait = "0.1"
+nucleo-matcher = "0.3"
+dirs = { workspace = true }
+
+# UI: ratatui without termion/crossterm backends — we paint into a
+# ratatui Buffer and convert to a WireBuffer cell stream for the host.
+ratatui = { version = "0.26", default-features = false }
+
+# Stdout capture for `cli_dispatch` (`tempfile` + `libc::dup2` reroutes
+# fd 1 into a tempfile while the legacy `println!`-based report runs).
+tempfile = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/ainb-tui/crates/ainb-plugin-burndown/plugin.toml
+++ b/ainb-tui/crates/ainb-plugin-burndown/plugin.toml
@@ -1,0 +1,40 @@
+# ainb plugin manifest — burndown (subprocess plugin, ABI v2).
+#
+# Loaded by ainb-plugin-runtime at host startup (discovery) and again
+# at plugin/init for validation. Schema lives in
+# `ainb-plugin-protocol::manifest::Manifest` — keep field names in
+# sync with that type.
+
+[plugin]
+name = "burndown"
+version = "2.0.0"
+abi_version = 2
+description = "Daily/weekly/project usage burndown panels"
+
+[capabilities]
+# Burndown no longer scans session files itself — the session-reader
+# plugin owns the data plane and publishes UsageDataEvent on
+# sessions.usage_data, which we consume via [subscribes].snapshots.
+read_sessions      = true
+# Persist any plugin-local config (model aliases, currency) under the
+# plugin data dir.
+write_plugin_data  = true
+# Required so the runtime exposes host/snapshot/get + host/snapshot/publish
+# + host/log on the reverse channel.
+event_bus          = true
+
+[provides]
+screens        = ["analytics"]
+commands       = ["/usage", "/burndown"]
+cli_namespaces = ["usage"]
+snapshots      = []
+
+[subscribes]
+# The runtime auto-pushes plugin/handle_event for every publish on
+# these topics. No imperative `host/snapshot/subscribe` call needed at
+# startup.
+snapshots = ["sessions.usage_data"]
+
+[lifecycle]
+spawn          = "lazy"
+idle_reap_secs = 600

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cache/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cache/mod.rs
@@ -1,0 +1,14 @@
+// ABOUTME: No-op cache stub. The plugin's persistent SQLite cache was
+// retired in Phase 3 (host pushes UsageData snapshots; plugin doesn't
+// own its own DB). The surface here keeps `parse_usage_for_*` compiling.
+
+//! Usage analytics cache — no-op stub.
+//!
+//! Public surface kept for API compatibility:
+//! * [`Cache`] — open / disabled / get_or_parse / clear / info (all no-op).
+//! * [`store::default_db_path`] — resolve the historical cache location
+//!   (only used for `cache info` reporting; nothing is written there).
+
+pub mod store;
+
+pub use store::{BlobFormat, Cache, CacheError, CacheInfo, ParseHint, ParseResult};

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cache/store.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cache/store.rs
@@ -1,0 +1,137 @@
+// ABOUTME: No-op usage-cache stub.
+//
+// The plugin's persistent SQLite cache was retired in Phase 3: at runtime
+// the host loads UsageData via its own host-side cache and pushes the
+// snapshot to the plugin via the `burndown.usage_data` event. The plugin
+// never opens its own DB. The surface here exists only to keep the
+// in-process parser (`parse_usage_for_*`) compiling — every call falls
+// through to a full re-parse with no persistence.
+
+//! No-op cache surface. All operations succeed; nothing is persisted.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::data::usage::ProviderCall;
+
+/// Cache error surface (kept for API compatibility — never returned by
+/// the no-op implementation).
+#[derive(Debug, Error)]
+pub enum CacheError {
+    #[error("cache I/O: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("cache schema: {0}")]
+    Schema(String),
+}
+
+/// Versioned blob encoding for cached call rows. Retained as a stable
+/// constant so callers that referenced `BlobFormat::BincodeV3` still
+/// compile; the value is no longer written anywhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub enum BlobFormat {
+    BincodeV3 = 3,
+}
+
+/// Snapshot of cache contents (`ainb usage cache info`). Always reports
+/// zero now that the cache is a no-op.
+#[derive(Debug, Clone)]
+pub struct CacheInfo {
+    pub db_path: PathBuf,
+    pub size_bytes: u64,
+    pub file_count: i64,
+    pub oldest_updated_at: Option<i64>,
+}
+
+/// No-op cache. Public surface stays compatible with the previous
+/// SQLite-backed implementation; every call full-parses and never
+/// persists.
+pub struct Cache {
+    db_path: PathBuf,
+}
+
+impl Cache {
+    /// Open a "cache" at `db_path`. The path is recorded for `info()`
+    /// reporting only — no DB is opened.
+    pub fn open(db_path: PathBuf) -> Result<Self, CacheError> {
+        Ok(Self { db_path })
+    }
+
+    /// Construct a disabled cache. Identical to `open()` in behaviour
+    /// post-stub; the distinct constructor exists for callers that want
+    /// to make their intent explicit.
+    pub fn disabled() -> Self {
+        Self {
+            db_path: PathBuf::new(),
+        }
+    }
+
+    /// Reports false — cache is never enabled.
+    pub const fn is_enabled(&self) -> bool {
+        false
+    }
+
+    /// On-disk path of the (notional) cache DB.
+    #[allow(dead_code)]
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    /// Always full-parse via `parse(path, ParseHint::Full)`.
+    pub fn get_or_parse<F>(&self, path: &Path, mut parse: F) -> Vec<ProviderCall>
+    where
+        F: FnMut(&Path, ParseHint<'_>) -> ParseResult,
+    {
+        parse(path, ParseHint::Full).calls
+    }
+
+    /// No-op: nothing to clear.
+    pub fn clear(&self) -> Result<(), CacheError> {
+        Ok(())
+    }
+
+    /// No-op: nothing to clear.
+    #[allow(dead_code)]
+    pub fn clear_path(&self, _path: &Path) -> Result<(), CacheError> {
+        Ok(())
+    }
+
+    /// Always reports an empty cache.
+    pub fn info(&self) -> Result<CacheInfo, CacheError> {
+        Ok(CacheInfo {
+            db_path: self.db_path.clone(),
+            size_bytes: 0,
+            file_count: 0,
+            oldest_updated_at: None,
+        })
+    }
+}
+
+/// Resolve the default cache DB path (`~/.agents-in-a-box/cache/usage.db`)
+/// honoring the `AINB_USAGE_CACHE_DB` env override. Retained for the
+/// `usage cache info` CLI path's reporting; nothing is written there.
+pub fn default_db_path() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("AINB_USAGE_CACHE_DB") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("cache").join("usage.db"))
+}
+
+/// Hint passed to user parsers. Always `Full` post-stub.
+#[derive(Debug, Clone)]
+pub enum ParseHint<'a> {
+    /// No cache row, or fingerprint forced a full re-parse.
+    Full,
+    /// Append-only parse (unused post-stub; retained for API compat).
+    Append {
+        from_offset: u64,
+        existing: &'a [crate::data::usage::ProviderCall],
+    },
+}
+
+/// Result the caller's parser must produce.
+pub struct ParseResult {
+    pub calls: Vec<crate::data::usage::ProviderCall>,
+    pub end_offset: u64,
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -1,0 +1,1400 @@
+// ABOUTME: Non-interactive usage analytics commands.
+// Provides CodeBurn-style reports, exports, plans, optimization, compare, and yield.
+
+use crate::output_format::OutputFormat;
+use crate::config::{AppConfig, CurrencyConfig, UsagePlan, UsagePlanId, UsagePlanProvider};
+use crate::data::usage::{
+    ActivityUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsageFilters, UsagePeriod,
+    UsageProviderFilter, UsageQuery, UsageSourceRoots, analyze_yield, billing_period,
+    compare_models, disabled_cache, optimize_usage, parse_usage_for,
+    parse_usage_for_with_roots_and_cache, shared_cache,
+};
+use anyhow::{Result, anyhow, bail};
+use chrono::{Local, NaiveDate};
+use clap::{Args, Subcommand, ValueEnum};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Subcommand)]
+pub enum UsageCommands {
+    /// Print a compact burndown report
+    Report(UsageReportArgs),
+    /// Print current usage status
+    Status(UsageReportArgs),
+    /// Print today's usage
+    Today(UsageReportArgs),
+    /// Print current month's usage
+    Month(UsageReportArgs),
+    /// Export usage data as CSV or JSON
+    Export(UsageExportArgs),
+    /// Manage usage plan
+    Plan {
+        #[command(subcommand)]
+        command: UsagePlanCommands,
+    },
+    /// Set or reset display currency
+    Currency(UsageCurrencyArgs),
+    /// Manage model aliases
+    ModelAlias(UsageModelAliasArgs),
+    /// Show read-only optimization findings
+    Optimize(UsageReportArgs),
+    /// Compare models
+    Compare(UsageReportArgs),
+    /// Estimate usage yield from session signals
+    Yield(UsageReportArgs),
+    /// Inspect or wipe the persistent usage cache
+    Cache {
+        #[command(subcommand)]
+        command: UsageCacheCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UsageCacheCommands {
+    /// Show cache DB path, on-disk size, file count, oldest entry timestamp
+    Info,
+    /// Drop all cached file rows (schema_version row preserved)
+    Clear,
+}
+
+#[derive(Args, Clone, Default)]
+pub struct UsageReportArgs {
+    /// Period: today, week, 30days, month, all
+    #[arg(long, value_enum, default_value_t = PeriodArg::Week)]
+    pub period: PeriodArg,
+    /// Start date YYYY-MM-DD (mutually exclusive with --month, --quarter,
+    /// --last-n-days, --ytd; pairs with --to for an explicit range).
+    #[arg(long, conflicts_with_all = ["month", "quarter", "last_n_days", "ytd"])]
+    pub from: Option<String>,
+    /// End date YYYY-MM-DD (mutually exclusive with --month, --quarter,
+    /// --last-n-days, --ytd; pairs with --from for an explicit range).
+    #[arg(long, conflicts_with_all = ["month", "quarter", "last_n_days", "ytd"])]
+    pub to: Option<String>,
+    /// Pin to a specific calendar month, e.g. `2026-04`. Mutually
+    /// exclusive with --quarter, --last-n-days, --ytd, --from, --to.
+    #[arg(long, conflicts_with_all = ["quarter", "last_n_days", "ytd", "from", "to"])]
+    pub month: Option<String>,
+    /// Pin to a specific calendar quarter, e.g. `2026-Q2`. Mutually
+    /// exclusive with --month, --last-n-days, --ytd, --from, --to.
+    #[arg(long, conflicts_with_all = ["month", "last_n_days", "ytd", "from", "to"])]
+    pub quarter: Option<String>,
+    /// Last N days (rolling window ending today). Mutually exclusive
+    /// with --month, --quarter, --ytd, --from, --to.
+    #[arg(
+        long = "last-n-days",
+        value_name = "N",
+        conflicts_with_all = ["month", "quarter", "ytd", "from", "to"]
+    )]
+    pub last_n_days: Option<u32>,
+    /// Jan 1 of the current year through today. Mutually exclusive
+    /// with --month, --quarter, --last-n-days, --from, --to.
+    #[arg(
+        long,
+        conflicts_with_all = ["month", "quarter", "last_n_days", "from", "to"]
+    )]
+    pub ytd: bool,
+    /// Provider: all, claude, codex
+    #[arg(long, value_enum, default_value_t = ProviderArg::All)]
+    pub provider: ProviderArg,
+    /// Include projects matching substring (repeatable; OR-combined).
+    /// Note: previously aliased as `--project`; the alias has been
+    /// removed because `--project` is now a distinct exact-match
+    /// cross-filter flag (see below). Use `--include <substring>` for
+    /// the substring/glob behaviour.
+    #[arg(long)]
+    pub include: Vec<String>,
+    /// Exclude projects matching substring (repeatable; OR-combined).
+    #[arg(long)]
+    pub exclude: Vec<String>,
+    /// Bypass the persistent usage cache and force a full re-parse.
+    #[arg(long)]
+    pub no_cache: bool,
+    // ---- Cross-filter knobs (mirrors of the TUI dashboard pivot) ----
+    // All four are repeatable; multiple values for the same filter
+    // are OR-combined, and different filters AND together. They layer
+    // on top of `--include` / `--exclude` and run through the same
+    // `filter_usage_data` helper as the TUI.
+    /// Drill into a single project (exact match). Repeatable.
+    #[arg(long)]
+    pub project: Vec<String>,
+    /// Drill into a single model (exact match). Repeatable.
+    #[arg(long)]
+    pub model: Vec<String>,
+    /// Drill into one activity category (Coding, Conversation, Git,
+    /// etc. — see ActivityCategory::label). Repeatable.
+    #[arg(long)]
+    pub activity: Vec<String>,
+    /// Drill into a single session id. Repeatable.
+    #[arg(long)]
+    pub session: Vec<String>,
+    /// Drill into a single git branch (exact match against `gitBranch` on
+    /// Claude turns). Repeatable. Codex turns have no recorded branch and
+    /// are excluded by any non-empty `--branch` filter.
+    #[arg(long)]
+    pub branch: Vec<String>,
+}
+
+#[derive(Args, Clone, Default)]
+pub struct UsageExportArgs {
+    #[command(flatten)]
+    pub report: UsageReportArgs,
+    /// Output file or directory
+    #[arg(long, short)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Subcommand)]
+pub enum UsagePlanCommands {
+    /// Show configured plan and current projection
+    Show(UsageReportArgs),
+    /// Set a known or custom plan
+    Set {
+        plan: PlanArg,
+        #[arg(long)]
+        monthly_usd: Option<f64>,
+        #[arg(long, value_enum, default_value_t = PlanProviderArg::All)]
+        provider: PlanProviderArg,
+        #[arg(long, default_value_t = 1)]
+        reset_day: u8,
+    },
+    /// Remove plan
+    Reset,
+    /// Attempt to detect plan from Claude CLI
+    Detect,
+}
+
+#[derive(Args)]
+pub struct UsageCurrencyArgs {
+    /// Currency code, for example USD, GBP, EUR
+    pub code: Option<String>,
+    /// Display symbol
+    #[arg(long)]
+    pub symbol: Option<String>,
+    /// Reset to USD
+    #[arg(long)]
+    pub reset: bool,
+}
+
+#[derive(Args)]
+pub struct UsageModelAliasArgs {
+    /// List aliases
+    #[arg(long)]
+    pub list: bool,
+    /// Remove alias by source model name
+    #[arg(long)]
+    pub remove: Option<String>,
+    /// Source model name
+    pub from: Option<String>,
+    /// Alias target model name
+    pub to: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum PeriodArg {
+    Today,
+    #[default]
+    Week,
+    #[clap(name = "30days")]
+    ThirtyDays,
+    Month,
+    All,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum ProviderArg {
+    #[default]
+    All,
+    Claude,
+    Codex,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum PlanArg {
+    ClaudePro,
+    ClaudeMax,
+    ClaudeMax5x,
+    CursorPro,
+    Custom,
+    None,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum PlanProviderArg {
+    #[default]
+    All,
+    Claude,
+    Codex,
+    Cursor,
+}
+
+/// Plugin-mode entry point. Uses a pre-loaded [`UsageData`] snapshot
+/// fetched from the host's snapshot bus (`sessions.usage_data`) rather
+/// than opening a local cache. The 9-subcommand surface matches the
+/// `usage` CLI namespace declared in the manifest's `[provides]`.
+pub fn execute_for_plugin(
+    data: &UsageData,
+    command: UsageCommands,
+    format: OutputFormat,
+) -> Result<()> {
+    match command {
+        UsageCommands::Report(args) => print_report_with_data(data, &args, format, "Usage Report"),
+        UsageCommands::Status(args) => print_status_with_data(data, &args, format),
+        UsageCommands::Today(mut args) => {
+            args.period = PeriodArg::Today;
+            print_report_with_data(data, &args, format, "Today")
+        }
+        UsageCommands::Month(mut args) => {
+            args.period = PeriodArg::Month;
+            print_report_with_data(data, &args, format, "Month")
+        }
+        UsageCommands::Export(args) => export_usage_with_data(data, &args, format),
+        UsageCommands::Optimize(args) => print_optimize_with_data(data, &args, format),
+        UsageCommands::Compare(args) => print_compare_with_data(data, &args, format),
+        UsageCommands::Yield(args) => print_yield_with_data(data, &args, format),
+        UsageCommands::ModelAlias(args) => model_alias_command_plugin(args),
+        // Plan / Currency / Cache stay in the host-side `cli/usage.rs`
+        // shim — they're config admin, not analytics.
+        UsageCommands::Plan { .. }
+        | UsageCommands::Currency(_)
+        | UsageCommands::Cache { .. } => anyhow::bail!(
+            "subcommand handled in host (config admin), not the burndown plugin"
+        ),
+    }
+}
+
+
+fn print_report_with_data(
+    data: &UsageData,
+    args: &UsageReportArgs,
+    format: OutputFormat,
+    title: &str,
+) -> Result<()> {
+    // Apply the same filter pipeline the host-side `print_report` uses,
+    // but operate on the supplied snapshot directly instead of opening
+    // the cache.
+    let filters = build_filters_from_args(args);
+    let view = if filters.is_empty() {
+        data.clone()
+    } else {
+        crate::data::usage::filter_usage_data(data, &filters)
+    };
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report_json(&view))?);
+        }
+        OutputFormat::Csv => {
+            print!("{}", combined_csv(&view));
+        }
+        OutputFormat::Text => {
+            print_text_report(title, &view);
+        }
+    }
+    Ok(())
+}
+
+fn print_status_with_data(
+    data: &UsageData,
+    _args: &UsageReportArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    let projection = AppConfig::load()
+        .unwrap_or_default()
+        .usage
+        .plan
+        .as_ref()
+        .map(|plan| {
+            crate::data::usage::project_plan_usage(data, plan, Local::now().date_naive())
+        });
+    match format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "overview": data.overview(),
+                "plan": projection,
+            }))?
+        ),
+        OutputFormat::Csv => print!("{}", combined_csv(data)),
+        OutputFormat::Text => {
+            print_text_report("Usage Status", data);
+        }
+    }
+    Ok(())
+}
+
+fn export_usage_with_data(
+    data: &UsageData,
+    args: &UsageExportArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    // Plugin-mode export = dump CSV/JSON to stdout. The host-side path
+    // wrote to disk via fs IO (--out arg); plugin-mode pipes the same
+    // payload to the captured stdout buffer instead so the host can
+    // forward it / write to disk itself if needed.
+    let _ = args;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report_json(data))?);
+        }
+        OutputFormat::Csv | OutputFormat::Text => {
+            print!("{}", combined_csv(data));
+        }
+    }
+    Ok(())
+}
+
+/// Translate the CLI's filter args into a [`UsageFilters`] struct so the
+/// plugin path can reuse [`filter_usage_data`] without touching the
+/// load-from-cache path.
+fn build_filters_from_args(args: &UsageReportArgs) -> UsageFilters {
+    UsageFilters {
+        project: args.project.clone(),
+        model: args.model.clone(),
+        branch: args.branch.clone(),
+        ..UsageFilters::default()
+    }
+}
+
+/// Plugin-mode `optimize` — same shape as the host-side [`print_optimize`]
+/// but skips the cache load (data is supplied).
+fn print_optimize_with_data(
+    data: &UsageData,
+    args: &UsageReportArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    let filters = build_filters_from_args(args);
+    let view = if filters.is_empty() {
+        data.clone()
+    } else {
+        crate::data::usage::filter_usage_data(data, &filters)
+    };
+    let result = optimize_usage(&view);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Optimize Findings");
+    println!("Health: {:?} ({}/100)", result.grade, result.score);
+    println!(
+        "Potential savings: {} tokens",
+        result.potential_tokens_saved
+    );
+    for finding in &result.findings {
+        println!(
+            "- {:?}: {} ({})",
+            finding.impact, finding.title, finding.details
+        );
+        for action in &finding.actions {
+            match &action.command {
+                Some(command) => println!("  Suggestion: {} -> {}", action.label, command),
+                None => println!("  Suggestion: {}", action.label),
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Plugin-mode `compare`.
+fn print_compare_with_data(
+    data: &UsageData,
+    args: &UsageReportArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    let filters = build_filters_from_args(args);
+    let view = if filters.is_empty() {
+        data.clone()
+    } else {
+        crate::data::usage::filter_usage_data(data, &filters)
+    };
+    let result = compare_models(&view);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Model Compare");
+    if let Some(winner) = &result.winner {
+        println!("Leader: {winner}");
+    }
+    if result.low_data {
+        println!("Low data: compare results need more sessions.");
+    }
+    for row in &result.models {
+        println!(
+            "- {}: {} calls, {} tokens/call, {} one-shot, {} retries",
+            row.model, row.calls, row.tokens_per_call, row.one_shot_turns, row.retries
+        );
+    }
+    Ok(())
+}
+
+/// Plugin-mode `yield`.
+fn print_yield_with_data(
+    data: &UsageData,
+    args: &UsageReportArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    let filters = build_filters_from_args(args);
+    let view = if filters.is_empty() {
+        data.clone()
+    } else {
+        crate::data::usage::filter_usage_data(data, &filters)
+    };
+    let result = analyze_yield(&view);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Usage Yield");
+    println!(
+        "Productive: {} sessions (${:.2})",
+        result.productive_sessions, result.productive_usd
+    );
+    println!(
+        "Reverted: {} sessions (${:.2})",
+        result.reverted_sessions, result.reverted_usd
+    );
+    println!(
+        "Abandoned: {} sessions (${:.2})",
+        result.abandoned_sessions, result.abandoned_usd
+    );
+    Ok(())
+}
+
+/// Plugin-mode `model-alias`. The host-side path persists aliases via
+/// `AppConfig::save()` — filesystem write through the plugin's config
+/// dir. Inside wasmi we have no arbitrary fs path access, so the
+/// plugin path is reflection-only for now: lists empty for `--list`,
+/// treats `--remove`/`from→to` as no-ops with an informational note.
+/// Real persistence (via `cache_get`/`cache_put`) lands in a follow-up;
+/// the test surface only asserts the subcommand routes through the
+/// plugin and produces non-empty output.
+fn model_alias_command_plugin(args: UsageModelAliasArgs) -> Result<()> {
+    if args.list {
+        println!("Model aliases (plugin scope): none configured.");
+        return Ok(());
+    }
+    if let Some(remove) = args.remove {
+        println!(
+            "Model alias '{remove}' would be removed (plugin-mode persistence \
+             pending — no-op)."
+        );
+        return Ok(());
+    }
+    match (args.from, args.to) {
+        (Some(from), Some(to)) => {
+            println!(
+                "Model alias {from} -> {to} would be saved (plugin-mode \
+                 persistence pending — no-op)."
+            );
+            Ok(())
+        }
+        _ => bail!("Use --list, --remove <model>, or <from> <to>"),
+    }
+}
+
+pub async fn execute(command: UsageCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        UsageCommands::Report(args) => print_report(&args, format, "Usage Report"),
+        UsageCommands::Status(args) => print_status(&args, format),
+        UsageCommands::Today(mut args) => {
+            args.period = PeriodArg::Today;
+            print_report(&args, format, "Today")
+        }
+        UsageCommands::Month(mut args) => {
+            args.period = PeriodArg::Month;
+            print_report(&args, format, "Month")
+        }
+        UsageCommands::Export(args) => export_usage(&args, format),
+        UsageCommands::Plan { command } => plan_command(command, format),
+        UsageCommands::Currency(args) => currency_command(args),
+        UsageCommands::ModelAlias(args) => model_alias_command(args),
+        UsageCommands::Optimize(args) => print_optimize(&args, format),
+        UsageCommands::Compare(args) => print_compare(&args, format),
+        UsageCommands::Yield(args) => print_yield(&args, format),
+        UsageCommands::Cache { command } => cache_command(command, format),
+    }
+}
+
+fn cache_command(command: UsageCacheCommands, format: OutputFormat) -> Result<()> {
+    match command {
+        UsageCacheCommands::Info => {
+            let cache = shared_cache();
+            let info = cache.info().map_err(|e| anyhow!("usage cache info failed: {e}"))?;
+            match format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "db_path": info.db_path,
+                            "size_bytes": info.size_bytes,
+                            "file_count": info.file_count,
+                            "oldest_updated_at": info.oldest_updated_at,
+                            "enabled": cache.is_enabled(),
+                        }))?
+                    );
+                }
+                _ => {
+                    println!("Usage cache");
+                    println!("  Path:           {}", info.db_path.display());
+                    println!("  Size on disk:   {} bytes", info.size_bytes);
+                    println!("  File count:     {}", info.file_count);
+                    println!(
+                        "  Oldest entry:   {}",
+                        info.oldest_updated_at
+                            .map(|t| t.to_string())
+                            .unwrap_or_else(|| "—".to_string())
+                    );
+                    println!(
+                        "  Enabled:        {}",
+                        if cache.is_enabled() { "yes" } else { "no" }
+                    );
+                }
+            }
+            Ok(())
+        }
+        UsageCacheCommands::Clear => {
+            let cache = shared_cache();
+            cache.clear().map_err(|e| anyhow!("usage cache clear failed: {e}"))?;
+            match format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({"cleared": true}))?
+                    );
+                }
+                _ => println!("Usage cache cleared."),
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_report(args: &UsageReportArgs, format: OutputFormat, title: &str) -> Result<()> {
+    let data = load_usage(args)?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report_json(&data))?);
+        }
+        OutputFormat::Csv => {
+            print!("{}", combined_csv(&data));
+        }
+        OutputFormat::Text => {
+            print_text_report(title, &data);
+        }
+    }
+    Ok(())
+}
+
+fn print_status(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let config = AppConfig::load().unwrap_or_default();
+    let projection = config.usage.plan.as_ref().map(|plan| {
+        crate::data::usage::project_plan_usage(&data, plan, Local::now().date_naive())
+    });
+    match format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "overview": data.overview(),
+                "plan": projection,
+            }))?
+        ),
+        OutputFormat::Csv => print!("{}", combined_csv(&data)),
+        OutputFormat::Text => {
+            print_text_report("Usage Status", &data);
+            if let Some(projection) = projection {
+                println!(
+                    "Plan: ${:.2} / ${:.2} ({:.0}%) {:?}",
+                    projection.spent_usd,
+                    projection.monthly_usd,
+                    projection.percent_used * 100.0,
+                    projection.status
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_optimize(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let result = optimize_usage(&data);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Optimize Findings");
+    println!("Health: {:?} ({}/100)", result.grade, result.score);
+    println!(
+        "Potential savings: {} tokens",
+        result.potential_tokens_saved
+    );
+    for finding in &result.findings {
+        println!(
+            "- {:?}: {} ({})",
+            finding.impact, finding.title, finding.details
+        );
+        for action in &finding.actions {
+            match &action.command {
+                Some(command) => println!("  Suggestion: {} -> {}", action.label, command),
+                None => println!("  Suggestion: {}", action.label),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_compare(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let result = compare_models(&data);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Model Compare");
+    if let Some(winner) = &result.winner {
+        println!("Leader: {winner}");
+    }
+    if result.low_data {
+        println!("Low data: compare results need more sessions.");
+    }
+    for row in &result.models {
+        println!(
+            "- {}: {} calls, {} tokens/call, {} one-shot, {} retries",
+            row.model, row.calls, row.tokens_per_call, row.one_shot_turns, row.retries
+        );
+    }
+    Ok(())
+}
+
+fn print_yield(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(args)?;
+    let result = analyze_yield(&data);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    println!("Usage Yield");
+    println!(
+        "Productive: {} sessions (${:.2})",
+        result.productive_sessions, result.productive_usd
+    );
+    println!(
+        "Reverted: {} sessions (${:.2})",
+        result.reverted_sessions, result.reverted_usd
+    );
+    println!(
+        "Abandoned: {} sessions (${:.2})",
+        result.abandoned_sessions, result.abandoned_usd
+    );
+    Ok(())
+}
+
+fn export_usage(args: &UsageExportArgs, format: OutputFormat) -> Result<()> {
+    let data = load_usage(&args.report)?;
+    match format {
+        OutputFormat::Json => {
+            let text = serde_json::to_string_pretty(&json!({
+                "schema": "ainb.usage.v1",
+                "generated_at": Local::now().to_rfc3339(),
+                "currency": "USD",
+                "report": report_json(&data),
+            }))?;
+            write_or_print(args.output.as_deref(), &text)
+        }
+        OutputFormat::Text => {
+            let text = serde_json::to_string_pretty(&report_json(&data))?;
+            write_or_print(args.output.as_deref(), &text)
+        }
+        OutputFormat::Csv => {
+            if let Some(path) = &args.output {
+                if path.extension().is_some() {
+                    fs::write(path, combined_csv(&data))?;
+                } else {
+                    fs::create_dir_all(path)?;
+                    fs::write(path.join("README.md"), "AINB usage export\n")?;
+                    fs::write(path.join("summary.csv"), summary_csv(&data))?;
+                    fs::write(path.join("daily.csv"), daily_csv(&data))?;
+                    fs::write(path.join("projects.csv"), projects_csv(&data.projects))?;
+                    fs::write(path.join("sessions.csv"), sessions_csv(&data.sessions))?;
+                    fs::write(
+                        path.join("activities.csv"),
+                        activities_csv(&data.activities),
+                    )?;
+                    fs::write(path.join("models.csv"), models_csv(&data))?;
+                    fs::write(path.join("tools.csv"), named_csv("tool", &data.tools))?;
+                    fs::write(
+                        path.join("shell_commands.csv"),
+                        named_csv("command", &data.shell_commands),
+                    )?;
+                    fs::write(
+                        path.join("mcp_servers.csv"),
+                        named_csv("server", &data.mcp_servers),
+                    )?;
+                }
+                Ok(())
+            } else {
+                print!("{}", combined_csv(&data));
+                Ok(())
+            }
+        }
+    }
+}
+
+fn plan_command(command: UsagePlanCommands, format: OutputFormat) -> Result<()> {
+    let mut config = AppConfig::load().unwrap_or_default();
+    match command {
+        UsagePlanCommands::Show(args) => {
+            let today = Local::now().date_naive();
+            let data = if let Some(plan) = config.usage.plan.as_ref() {
+                load_usage(&plan_show_args_for_plan(&args, plan, today))?
+            } else {
+                load_usage(&args)?
+            };
+            let projection = config
+                .usage
+                .plan
+                .as_ref()
+                .map(|plan| crate::data::usage::project_plan_usage(&data, plan, today));
+            if matches!(format, OutputFormat::Json) {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "plan": config.usage.plan,
+                        "projection": projection,
+                    }))?
+                );
+            } else if let Some(plan) = &config.usage.plan {
+                println!(
+                    "Plan: {:?} ${:.2}/month reset day {}",
+                    plan.id, plan.monthly_usd, plan.reset_day
+                );
+                if let Some(projection) = projection {
+                    println!(
+                        "Spend: ${:.2}, projected ${:.2}, {:?}",
+                        projection.spent_usd, projection.projected_usd, projection.status
+                    );
+                }
+            } else {
+                println!("No usage plan configured.");
+            }
+        }
+        UsagePlanCommands::Set {
+            plan,
+            monthly_usd,
+            provider,
+            reset_day,
+        } => {
+            let id = plan_id(plan);
+            let monthly_usd = monthly_usd
+                .or_else(|| id.monthly_usd())
+                .ok_or_else(|| anyhow!("custom plan requires --monthly-usd"))?;
+            config.usage.plan = Some(UsagePlan {
+                id,
+                monthly_usd,
+                provider: plan_provider(provider),
+                reset_day: reset_day.clamp(1, 28),
+                set_at: Local::now().to_rfc3339(),
+            });
+            config.save()?;
+            println!("Usage plan saved.");
+        }
+        UsagePlanCommands::Reset => {
+            config.usage.plan = None;
+            config.save()?;
+            println!("Usage plan reset.");
+        }
+        UsagePlanCommands::Detect => {
+            bail!("Plan detection unavailable. Use `ainb usage plan set <plan>`.");
+        }
+    }
+    Ok(())
+}
+
+fn currency_command(args: UsageCurrencyArgs) -> Result<()> {
+    let mut config = AppConfig::load().unwrap_or_default();
+    if args.reset {
+        config.usage.currency = CurrencyConfig::default();
+    } else {
+        let Some(code) = args.code else {
+            println!(
+                "{} {}",
+                config.usage.currency.symbol, config.usage.currency.code
+            );
+            return Ok(());
+        };
+        let code = code.to_uppercase();
+        if code.len() != 3 || !code.chars().all(|ch| ch.is_ascii_uppercase()) {
+            bail!("Currency code must be a 3-letter ISO-style code");
+        }
+        config.usage.currency.code = code.clone();
+        config.usage.currency.symbol = args.symbol.unwrap_or(code);
+    }
+    config.save()?;
+    println!("Currency saved.");
+    Ok(())
+}
+
+fn model_alias_command(args: UsageModelAliasArgs) -> Result<()> {
+    let mut config = AppConfig::load().unwrap_or_default();
+    if args.list {
+        for (from, to) in &config.usage.model_aliases {
+            println!("{from} -> {to}");
+        }
+        return Ok(());
+    }
+    if let Some(remove) = args.remove {
+        config.usage.model_aliases.remove(&remove);
+        config.save()?;
+        println!("Model alias removed.");
+        return Ok(());
+    }
+    match (args.from, args.to) {
+        (Some(from), Some(to)) => {
+            config.usage.model_aliases.insert(from, to);
+            config.save()?;
+            println!("Model alias saved.");
+            Ok(())
+        }
+        _ => bail!("Use --list, --remove <model>, or <from> <to>"),
+    }
+}
+
+fn load_usage(args: &UsageReportArgs) -> Result<UsageData> {
+    let query = query_from_args(args)?;
+    if args.no_cache {
+        Ok(parse_usage_for_with_roots_and_cache(
+            query,
+            &UsageSourceRoots::default(),
+            disabled_cache(),
+        ))
+    } else {
+        Ok(parse_usage_for(query))
+    }
+}
+
+fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
+    // Period precedence (top wins; clap rejects combinations via the
+    // conflicts_with_all groups on UsageReportArgs):
+    //   --month YYYY-MM            -> SpecificMonth
+    //   --quarter YYYY-Qn          -> SpecificQuarter
+    //   --last-n-days N            -> LastNDays(N)
+    //   --ytd                      -> YearToDate
+    //   --from / --to              -> Custom (existing free-text behaviour)
+    //   --period {today|week|30days|month|all}  (default)
+    let period = if let Some(month_str) = &args.month {
+        parse_month_arg(month_str)?
+    } else if let Some(quarter_str) = &args.quarter {
+        parse_quarter_arg(quarter_str)?
+    } else if let Some(n) = args.last_n_days {
+        if n == 0 {
+            bail!("--last-n-days must be >= 1");
+        }
+        UsagePeriod::LastNDays(n)
+    } else if args.ytd {
+        UsagePeriod::YearToDate
+    } else if args.from.is_some() || args.to.is_some() {
+        let from = match &args.from {
+            Some(value) => parse_date(value)?,
+            None => NaiveDate::from_ymd_opt(1970, 1, 1).expect("valid date"),
+        };
+        let to = match &args.to {
+            Some(value) => parse_date(value)?,
+            None => Local::now().date_naive(),
+        };
+        if from > to {
+            bail!("from date must be before or equal to to date");
+        }
+        UsagePeriod::Custom { from, to }
+    } else {
+        match args.period {
+            PeriodArg::Today => UsagePeriod::Today,
+            PeriodArg::Week => UsagePeriod::Week,
+            PeriodArg::ThirtyDays => UsagePeriod::ThirtyDays,
+            PeriodArg::Month => UsagePeriod::Month,
+            PeriodArg::All => UsagePeriod::All,
+        }
+    };
+
+    Ok(UsageQuery {
+        period,
+        provider_filter: match args.provider {
+            ProviderArg::All => UsageProviderFilter::All,
+            ProviderArg::Claude => UsageProviderFilter::Claude,
+            ProviderArg::Codex => UsageProviderFilter::Codex,
+        },
+        include_projects: args.include.clone(),
+        exclude_projects: args.exclude.clone(),
+        filters: UsageFilters {
+            project: args.project.clone(),
+            model: args.model.clone(),
+            activity: args.activity.clone(),
+            session: args.session.clone(),
+            branch: args.branch.clone(),
+            // No CLI surface for exclude filters yet — populated only
+            // via the TUI X-on-row picker.
+            ..UsageFilters::default()
+        },
+    })
+}
+
+fn parse_date(value: &str) -> Result<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| anyhow!("invalid date `{value}`, expected YYYY-MM-DD"))
+}
+
+/// Parse `--month YYYY-MM` into `UsagePeriod::SpecificMonth(first-of-month)`.
+fn parse_month_arg(value: &str) -> Result<UsagePeriod> {
+    // chrono's NaiveDate parser wants a day; pin to `-01`.
+    let with_day = format!("{value}-01");
+    let date = NaiveDate::parse_from_str(&with_day, "%Y-%m-%d")
+        .map_err(|_| anyhow!("invalid --month `{value}`, expected YYYY-MM"))?;
+    Ok(UsagePeriod::SpecificMonth(date))
+}
+
+/// Parse `--quarter YYYY-Qn` into `UsagePeriod::SpecificQuarter(year, q)`.
+fn parse_quarter_arg(value: &str) -> Result<UsagePeriod> {
+    let err = || anyhow!("invalid --quarter `{value}`, expected YYYY-Qn (n=1..=4)");
+    // Accept either case for the Q.
+    let normalised = value.to_ascii_uppercase();
+    let (year_part, q_part) = normalised.split_once("-Q").ok_or_else(err)?;
+    let year: i32 = year_part.parse().map_err(|_| err())?;
+    let q: u8 = q_part.parse().map_err(|_| err())?;
+    if !(1..=4).contains(&q) {
+        return Err(err());
+    }
+    Ok(UsagePeriod::SpecificQuarter(year, q))
+}
+
+fn print_text_report(title: &str, data: &UsageData) {
+    println!("{title}");
+    println!(
+        "Overview: {} calls, {} sessions, {} projects, {} tokens, {}",
+        data.grand_total.call_count,
+        data.grand_total.session_count,
+        data.grand_total.project_count,
+        data.grand_total.total(),
+        format_cost(data.grand_total.cost_usd)
+    );
+    println!();
+    print_top_projects(data);
+    print_top_activities(data);
+    print_top_models(data);
+}
+
+fn print_top_projects(data: &UsageData) {
+    println!("By Project");
+    for project in data.projects.iter().take(8) {
+        println!(
+            "- {}: {} calls, {} tokens, {}",
+            project.name,
+            project.bucket.call_count,
+            project.bucket.total(),
+            format_cost(project.bucket.cost_usd)
+        );
+    }
+}
+
+fn print_top_activities(data: &UsageData) {
+    println!("By Activity");
+    for activity in data.activities.iter().take(8) {
+        println!(
+            "- {}: {} turns, {} retries, {} tokens",
+            activity.category.label(),
+            activity.turns,
+            activity.retries,
+            activity.bucket.total()
+        );
+    }
+}
+
+fn print_top_models(data: &UsageData) {
+    println!("By Model");
+    for model in data.models.iter().take(8) {
+        println!(
+            "- {}: {} calls, {} tokens, {}",
+            model.model,
+            model.bucket.call_count,
+            model.bucket.total(),
+            format_cost(model.bucket.cost_usd)
+        );
+    }
+}
+
+pub(crate) fn report_json(data: &UsageData) -> serde_json::Value {
+    json!({
+        "overview": data.overview(),
+        "daily": data.daily,
+        "projects": data.projects,
+        "models": data.models,
+        "activities": data.activities,
+        "sessions": data.sessions,
+        "tools": data.tools,
+        "shell_commands": data.shell_commands,
+        "mcp_servers": data.mcp_servers,
+    })
+}
+
+fn write_or_print(path: Option<&Path>, text: &str) -> Result<()> {
+    if let Some(path) = path {
+        fs::write(path, text)?;
+    } else {
+        println!("{text}");
+    }
+    Ok(())
+}
+
+fn combined_csv(data: &UsageData) -> String {
+    [
+        summary_csv(data),
+        daily_csv(data),
+        projects_csv(&data.projects),
+        sessions_csv(&data.sessions),
+        activities_csv(&data.activities),
+        models_csv(data),
+        named_csv("tool", &data.tools),
+        named_csv("command", &data.shell_commands),
+        named_csv("server", &data.mcp_servers),
+    ]
+    .join("\n")
+}
+
+fn summary_csv(data: &UsageData) -> String {
+    format!(
+        "section,metric,value\nsummary,calls,{}\nsummary,sessions,{}\nsummary,projects,{}\nsummary,tokens,{}\nsummary,cost_usd,{}\n",
+        data.grand_total.call_count,
+        data.grand_total.session_count,
+        data.grand_total.project_count,
+        data.grand_total.total(),
+        data.grand_total.cost_usd.unwrap_or(0.0)
+    )
+}
+
+fn daily_csv(data: &UsageData) -> String {
+    let mut out = "date,calls,sessions,projects,tokens,cost_usd\n".to_string();
+    for (date, bucket) in &data.daily {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            date,
+            bucket.call_count,
+            bucket.session_count,
+            bucket.project_count,
+            bucket.total(),
+            bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn projects_csv(projects: &[ProjectUsage]) -> String {
+    let mut out = "project,path,calls,sessions,tokens,cost_usd\n".to_string();
+    for project in projects {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            csv_cell(&project.name),
+            csv_cell(&project.path),
+            project.bucket.call_count,
+            project.bucket.session_count,
+            project.bucket.total(),
+            project.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn sessions_csv(sessions: &[SessionUsage]) -> String {
+    let mut out = "provider,project,session_id,first,last,calls,tokens,cost_usd\n".to_string();
+    for session in sessions {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{}\n",
+            csv_cell(&session.provider),
+            csv_cell(&session.project),
+            csv_cell(&session.session_id),
+            // Emit RFC3339 in the user's local offset. The instant is
+            // the same as the Utc-stored value; rendering with the
+            // local offset matches what the TUI shows so a CSV row
+            // round-trips visibly to the user's clock.
+            session.first_timestamp.with_timezone(&chrono::Local).to_rfc3339(),
+            session.last_timestamp.with_timezone(&chrono::Local).to_rfc3339(),
+            session.bucket.call_count,
+            session.bucket.total(),
+            session.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn activities_csv(activities: &[ActivityUsage]) -> String {
+    let mut out = "activity,turns,retries,edit_turns,one_shot_turns,tokens,cost_usd\n".to_string();
+    for activity in activities {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{}\n",
+            activity.category.label(),
+            activity.turns,
+            activity.retries,
+            activity.edit_turns,
+            activity.one_shot_turns,
+            activity.bucket.total(),
+            activity.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn models_csv(data: &UsageData) -> String {
+    let mut out = "model,calls,tokens,cost_usd\n".to_string();
+    for model in &data.models {
+        out.push_str(&format!(
+            "{},{},{},{}\n",
+            csv_cell(&model.model),
+            model.bucket.call_count,
+            model.bucket.total(),
+            model.bucket.cost_usd.unwrap_or(0.0)
+        ));
+    }
+    out
+}
+
+fn named_csv(name_header: &str, rows: &[NamedUsage]) -> String {
+    let mut out = format!("{name_header},calls\n");
+    for row in rows {
+        out.push_str(&format!("{},{}\n", csv_cell(&row.name), row.calls));
+    }
+    out
+}
+
+fn csv_cell(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    let protected = if escaped
+        .chars()
+        .next()
+        .is_some_and(|ch| matches!(ch, '\t' | '\r' | '=' | '+' | '-' | '@'))
+    {
+        format!("'{escaped}")
+    } else {
+        escaped
+    };
+    format!("\"{protected}\"")
+}
+
+fn format_cost(cost: Option<f64>) -> String {
+    cost.map(|value| format!("${value:.2}"))
+        .unwrap_or_else(|| "cost unavailable".to_string())
+}
+
+fn plan_id(plan: PlanArg) -> UsagePlanId {
+    match plan {
+        PlanArg::ClaudePro => UsagePlanId::ClaudePro,
+        PlanArg::ClaudeMax => UsagePlanId::ClaudeMax,
+        PlanArg::ClaudeMax5x => UsagePlanId::ClaudeMax5x,
+        PlanArg::CursorPro => UsagePlanId::CursorPro,
+        PlanArg::Custom => UsagePlanId::Custom,
+        PlanArg::None => UsagePlanId::None,
+    }
+}
+
+fn plan_provider(provider: PlanProviderArg) -> UsagePlanProvider {
+    match provider {
+        PlanProviderArg::All => UsagePlanProvider::All,
+        PlanProviderArg::Claude => UsagePlanProvider::Claude,
+        PlanProviderArg::Codex => UsagePlanProvider::Codex,
+        PlanProviderArg::Cursor => UsagePlanProvider::Cursor,
+    }
+}
+
+fn provider_arg_for_plan(provider: UsagePlanProvider) -> ProviderArg {
+    match provider {
+        UsagePlanProvider::All | UsagePlanProvider::Cursor => ProviderArg::All,
+        UsagePlanProvider::Claude => ProviderArg::Claude,
+        UsagePlanProvider::Codex => ProviderArg::Codex,
+    }
+}
+
+fn plan_show_args_for_plan(
+    args: &UsageReportArgs,
+    plan: &UsagePlan,
+    today: NaiveDate,
+) -> UsageReportArgs {
+    let (from, to) = billing_period(today, plan.reset_day);
+    let mut scoped_args = args.clone();
+    scoped_args.period = PeriodArg::All;
+    scoped_args.from = Some(from.to_string());
+    scoped_args.to = Some(to.to_string());
+    scoped_args.provider = provider_arg_for_plan(plan.provider);
+    scoped_args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn csv_cell_escapes_formula_starts() {
+        assert_eq!(csv_cell("=cmd"), "\"'=cmd\"");
+        assert_eq!(csv_cell("@user"), "\"'@user\"");
+        assert_eq!(csv_cell("safe"), "\"safe\"");
+    }
+
+    #[test]
+    fn report_json_keeps_expected_top_level_sections() {
+        let data = UsageData::default();
+        let json = report_json(&data);
+
+        for key in [
+            "overview",
+            "daily",
+            "projects",
+            "models",
+            "activities",
+            "sessions",
+            "tools",
+            "shell_commands",
+            "mcp_servers",
+        ] {
+            assert!(json.get(key).is_some(), "missing {key}");
+        }
+    }
+
+    #[test]
+    fn combined_csv_includes_export_section_headers() {
+        let csv = combined_csv(&UsageData::default());
+
+        for header in [
+            "section,metric,value",
+            "date,calls,sessions,projects,tokens,cost_usd",
+            "project,path,calls,sessions,tokens,cost_usd",
+            "provider,project,session_id,first,last,calls,tokens,cost_usd",
+            "activity,turns,retries,edit_turns,one_shot_turns,tokens,cost_usd",
+            "model,calls,tokens,cost_usd",
+            "tool,calls",
+            "command,calls",
+            "server,calls",
+        ] {
+            assert!(csv.contains(header), "missing {header}");
+        }
+    }
+
+    #[test]
+    fn month_flag_yields_specific_month_period() {
+        let args = UsageReportArgs {
+            month: Some("2026-04".into()),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        match q.period {
+            UsagePeriod::SpecificMonth(d) => {
+                assert_eq!(d, NaiveDate::from_ymd_opt(2026, 4, 1).unwrap())
+            }
+            other => panic!("expected SpecificMonth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quarter_flag_yields_specific_quarter_period() {
+        let args = UsageReportArgs {
+            quarter: Some("2026-Q2".into()),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::SpecificQuarter(2026, 2)));
+    }
+
+    #[test]
+    fn quarter_flag_lowercase_q_is_accepted() {
+        let args = UsageReportArgs {
+            quarter: Some("2026-q3".into()),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::SpecificQuarter(2026, 3)));
+    }
+
+    #[test]
+    fn quarter_flag_rejects_q5() {
+        let args = UsageReportArgs {
+            quarter: Some("2026-Q5".into()),
+            ..UsageReportArgs::default()
+        };
+        let err = query_from_args(&args).unwrap_err().to_string();
+        assert!(err.contains("YYYY-Qn"));
+    }
+
+    #[test]
+    fn last_n_days_flag_yields_last_n_days_period() {
+        let args = UsageReportArgs {
+            last_n_days: Some(14),
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::LastNDays(14)));
+    }
+
+    #[test]
+    fn last_n_days_zero_is_rejected() {
+        let args = UsageReportArgs {
+            last_n_days: Some(0),
+            ..UsageReportArgs::default()
+        };
+        assert!(query_from_args(&args).is_err());
+    }
+
+    // Three clap-parse-time tests (month-vs-quarter, last-n-days-vs-ytd,
+    // from-vs-month) lived here in core, exercising the *root* `ainb`
+    // clap definition (`crate::cli::registry::CommandRegistry` +
+    // `crate::cli::root_clap_command`) which is host-side. From the
+    // plugin perspective those flags are still mutually exclusive (the
+    // `#[command(group = ...)]` attributes on UsageReportArgs enforce
+    // that locally), but the registry-level test belongs on the host
+    // side. Re-staged as host integration tests in
+    // `crates/ainb-core/tests/plugin_burndown_cli.rs` once the host
+    // CLI registry dispatches into the plugin (Phase 3 host wiring).
+
+    #[test]
+    fn ytd_flag_yields_year_to_date_period() {
+        let args = UsageReportArgs {
+            ytd: true,
+            ..UsageReportArgs::default()
+        };
+        let q = query_from_args(&args).unwrap();
+        assert!(matches!(q.period, UsagePeriod::YearToDate));
+    }
+
+    #[test]
+    fn invalid_date_returns_clear_error() {
+        let args = UsageReportArgs {
+            from: Some("2026/04/01".to_string()),
+            ..UsageReportArgs::default()
+        };
+        let err = query_from_args(&args).unwrap_err().to_string();
+        assert!(err.contains("expected YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn inverted_date_range_errors() {
+        let args = UsageReportArgs {
+            from: Some("2026-04-02".to_string()),
+            to: Some("2026-04-01".to_string()),
+            ..UsageReportArgs::default()
+        };
+        let err = query_from_args(&args).unwrap_err().to_string();
+        assert!(err.contains("from date"));
+    }
+
+    #[test]
+    fn plan_show_uses_billing_window_and_plan_provider() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let plan = UsagePlan {
+            id: UsagePlanId::ClaudePro,
+            monthly_usd: 20.0,
+            provider: UsagePlanProvider::Claude,
+            reset_day: 12,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        };
+
+        let scoped = plan_show_args_for_plan(&UsageReportArgs::default(), &plan, today);
+
+        assert_eq!(scoped.from.as_deref(), Some("2026-04-12"));
+        assert_eq!(scoped.to.as_deref(), Some("2026-05-11"));
+        assert!(matches!(scoped.provider, ProviderArg::Claude));
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
@@ -1,0 +1,184 @@
+//! Plugin-side mirror of the burndown-relevant slice of ainb-core's config.
+//!
+//! ainb-core lives on the host side and the plugin can't link against it,
+//! so we define a narrow set of POD types matching the on-disk
+//! `~/.agents-in-a-box/config.toml` schema for the fields the plugin
+//! cares about (plan projection + currency display).
+//!
+//! Wire shape is identical to `ainb-core::config::{UsagePlan, UsagePlanId,
+//! UsagePlanProvider, CurrencyConfig}` — the host serialises its config
+//! into msgpack on `_init`, the plugin deserialises into these mirrors.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UsagePlan {
+    pub id: UsagePlanId,
+    pub monthly_usd: f64,
+    pub provider: UsagePlanProvider,
+    pub reset_day: u8,
+    pub set_at: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum UsagePlanId {
+    ClaudePro,
+    ClaudeMax,
+    ClaudeMax5x,
+    CursorPro,
+    Custom,
+    None,
+}
+
+impl UsagePlanId {
+    pub fn monthly_usd(self) -> Option<f64> {
+        match self {
+            Self::ClaudePro => Some(20.0),
+            Self::ClaudeMax => Some(200.0),
+            Self::ClaudeMax5x => Some(100.0),
+            Self::CursorPro => Some(20.0),
+            Self::Custom | Self::None => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UsagePlanProvider {
+    All,
+    Claude,
+    Codex,
+    Cursor,
+}
+
+impl Default for UsagePlanProvider {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CurrencyConfig {
+    #[serde(default = "default_currency_code")]
+    pub code: String,
+    #[serde(default = "default_currency_symbol")]
+    pub symbol: String,
+    #[serde(default = "default_exchange_rate")]
+    pub usd_rate: f64,
+}
+
+impl Default for CurrencyConfig {
+    fn default() -> Self {
+        Self {
+            code: default_currency_code(),
+            symbol: default_currency_symbol(),
+            usd_rate: default_exchange_rate(),
+        }
+    }
+}
+
+fn default_currency_code() -> String {
+    "USD".to_string()
+}
+
+fn default_currency_symbol() -> String {
+    "$".to_string()
+}
+
+fn default_exchange_rate() -> f64 {
+    1.0
+}
+
+/// Subset of ainb-core's `UsageConfig` the plugin reads/writes.
+///
+/// The on-disk schema in `~/.agents-in-a-box/config.toml` lives under the
+/// `[usage]` table. The plugin only owns this slice — other top-level
+/// tables (docker, mcp, ui_preferences, etc.) are read-modify-write
+/// preserved through `toml::Value` round-tripping in [`AppConfig::save`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct UsageConfig {
+    #[serde(default)]
+    pub plan: Option<UsagePlan>,
+    #[serde(default)]
+    pub currency: CurrencyConfig,
+    #[serde(default)]
+    pub model_aliases: HashMap<String, String>,
+}
+
+/// Plugin-side AppConfig: only the `usage` table is hydrated; all other
+/// host-managed tables are kept as opaque `toml::Value`s in
+/// `_other_tables` so `save()` doesn't clobber them.
+#[derive(Debug, Clone, Default)]
+pub struct AppConfig {
+    pub usage: UsageConfig,
+    /// Original parsed TOML — used by `save()` to preserve sections the
+    /// plugin doesn't own (docker / ui_preferences / mcp_servers / …).
+    /// `None` when the file didn't exist on `load()`.
+    _original: Option<toml::Value>,
+}
+
+impl AppConfig {
+    /// Read `~/.agents-in-a-box/config.toml` (if present), parsing only
+    /// the `[usage]` table. Other tables are retained as raw
+    /// `toml::Value` so `save()` can write them back unchanged.
+    pub fn load() -> Result<Self> {
+        let path = config_path()?;
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let original: toml::Value = toml::from_str(&content)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+
+        let usage: UsageConfig = original
+            .get("usage")
+            .cloned()
+            .map(|v| v.try_into())
+            .transpose()
+            .context("failed to deserialize [usage] table")?
+            .unwrap_or_default();
+
+        Ok(Self { usage, _original: Some(original) })
+    }
+
+    /// Atomic write of `~/.agents-in-a-box/config.toml`. Replaces only
+    /// the `[usage]` table; leaves every other table the plugin doesn't
+    /// own intact.
+    pub fn save(&self) -> Result<()> {
+        let path = config_path()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Start from the parsed original (or an empty inline table) so
+        // we preserve [docker], [ui_preferences], etc.
+        let mut root = self
+            ._original
+            .clone()
+            .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
+        if let toml::Value::Table(ref mut table) = root {
+            let usage_value = toml::Value::try_from(&self.usage)
+                .context("failed to serialise [usage] table")?;
+            table.insert("usage".to_string(), usage_value);
+        }
+        let content = toml::to_string_pretty(&root)
+            .context("failed to serialise config to TOML")?;
+
+        // Best-effort atomic write: tmp + rename.
+        let tmp = path.with_extension("toml.tmp");
+        std::fs::write(&tmp, content)?;
+        std::fs::rename(&tmp, &path)?;
+        Ok(())
+    }
+}
+
+fn config_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not resolve home directory")?;
+    Ok(home.join(".agents-in-a-box").join("config.toml"))
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/mod.rs
@@ -1,0 +1,14 @@
+//! Burndown data layer — usage parsing + project resolution.
+//!
+//! Lifted verbatim from `ainb-core::models::{usage, repo_lookup}` with
+//! import paths rewired to the plugin-local module tree. The data
+//! semantics (UsageData, ProviderCall, UsagePeriod, etc.) are
+//! unchanged from the pre-Phase-3 core implementation.
+
+pub mod repo_lookup;
+pub mod usage;
+
+// Re-export the surface that `crate::models::*` provided in core, so
+// downstream Phase 3 moves (UI, CLI) can keep their `crate::data::X`
+// or `crate::data::usage::X` import paths working.
+pub use usage::*;

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/repo_lookup.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/repo_lookup.rs
@@ -1,0 +1,441 @@
+// ABOUTME: Resolve a working directory to its upstream repo identifier
+// (e.g. "owner/repo") by reading .git/config without shelling out.
+//
+// Used by usage aggregation to collapse worktrees of the same repo into
+// a single ProjectUsage row keyed by the upstream remote.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Resolve a working directory to its upstream repo identifier
+/// (e.g. `"owner/repo"`).
+///
+/// Returns `None` for non-git paths or repos without an `origin`
+/// remote. Failures are silent — callers fall back to the local folder
+/// name. Results are memoised in `cache` keyed by the input `cwd`
+/// string.
+///
+/// Implementation notes:
+/// - Walks up from `cwd` looking for `.git` (file or directory).
+/// - When `.git` is a file (worktree pointer of the form
+///   `gitdir: <path>`), follows the pointer to the main repo's git
+///   directory. Worktree gitdirs typically nest under
+///   `<main>/.git/worktrees/<name>/`; we strip down to the repo's
+///   top-level git dir before reading `config` so all worktrees of a
+///   repo collapse to the same remote.
+/// - Parses `.git/config` as INI: looks for the `[remote "origin"]`
+///   section and reads its `url = ...` entry.
+/// - Extracts `owner/repo` from common URL shapes (HTTPS, SSH,
+///   `ssh://`, `git://`, scp-style `user@host:path`). The full
+///   path-after-host is preserved so nested GitLab groups
+///   (`group/sub/repo`) are kept intact. Trailing `.git` is stripped.
+pub fn resolve_repo(cwd: &str, cache: &mut HashMap<String, Option<String>>) -> Option<String> {
+    if let Some(hit) = cache.get(cwd) {
+        return hit.clone();
+    }
+    let resolved = resolve_repo_uncached(Path::new(cwd));
+    cache.insert(cwd.to_string(), resolved.clone());
+    resolved
+}
+
+fn resolve_repo_uncached(start: &Path) -> Option<String> {
+    let git_dir = find_git_dir(start)?;
+    let config_path = git_dir.join("config");
+    let config_text = fs::read_to_string(&config_path).ok()?;
+    let url = parse_origin_url(&config_text)?;
+    extract_owner_repo(&url)
+}
+
+/// Walk up from `start` to find a `.git` entry. If `.git` is a file
+/// (worktree pointer), resolve it to the main repo's top-level git
+/// directory. Returns the directory containing the `config` file we
+/// should read.
+fn find_git_dir(start: &Path) -> Option<PathBuf> {
+    let mut cur = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        // Best-effort canonicalize; if cwd is missing, fall back to
+        // the path as given so we can still walk parents.
+        fs::canonicalize(start).unwrap_or_else(|_| start.to_path_buf())
+    };
+
+    loop {
+        let candidate = cur.join(".git");
+        if let Ok(meta) = fs::metadata(&candidate) {
+            if meta.is_dir() {
+                return Some(candidate);
+            }
+            if meta.is_file() {
+                if let Some(gitdir) = read_gitdir_pointer(&candidate) {
+                    return Some(normalize_worktree_gitdir(&gitdir));
+                }
+                return None;
+            }
+        }
+        if !cur.pop() {
+            return None;
+        }
+    }
+}
+
+/// Parse a `.git` pointer file (`gitdir: <path>`).
+fn read_gitdir_pointer(path: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(path).ok()?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("gitdir:") {
+            let target = rest.trim();
+            if target.is_empty() {
+                return None;
+            }
+            let target_path = PathBuf::from(target);
+            // Pointer paths can be relative to the directory holding
+            // the `.git` file.
+            if target_path.is_absolute() {
+                return Some(target_path);
+            }
+            let parent = path.parent()?;
+            return Some(parent.join(target_path));
+        }
+    }
+    None
+}
+
+/// Worktree gitdirs typically look like
+/// `<main>/.git/worktrees/<name>`. The shared `config` lives at
+/// `<main>/.git/config`. Walk up until we find a directory that
+/// contains a `config` file (the canonical git dir layout).
+fn normalize_worktree_gitdir(gitdir: &Path) -> PathBuf {
+    let mut cur = gitdir.to_path_buf();
+    // The top-level git dir is always called `.git` and contains
+    // `config`. Step up while we're inside `worktrees/...`.
+    loop {
+        if cur.join("config").is_file() && cur.file_name().and_then(|s| s.to_str()) == Some(".git")
+        {
+            return cur;
+        }
+        if !cur.pop() {
+            return gitdir.to_path_buf();
+        }
+    }
+}
+
+/// Parse a tiny subset of INI: locate `[remote "origin"]` and return
+/// its `url = ...` value. We don't pull a full INI crate because git
+/// config has its own quirks (subsections, includes) and we only need
+/// one field.
+fn parse_origin_url(config: &str) -> Option<String> {
+    let mut in_origin = false;
+    for raw_line in config.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            // Section header. Match `[remote "origin"]` with flexible
+            // whitespace; reject anything else.
+            in_origin = is_remote_origin_header(line);
+            continue;
+        }
+        if !in_origin {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            if key.trim().eq_ignore_ascii_case("url") {
+                let v = value.trim().trim_matches('"');
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_remote_origin_header(line: &str) -> bool {
+    // Strip the [ ] and normalize whitespace.
+    let inner = &line[1..line.len() - 1].trim();
+    // Expected shape: `remote "origin"` (subsection name in quotes).
+    let Some(rest) = inner.strip_prefix("remote") else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    rest == "\"origin\""
+}
+
+/// Extract `owner/repo` (or full path-after-host) from a git URL.
+/// Returns `None` for unrecognised shapes.
+fn extract_owner_repo(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Order matters: check explicit schemes first, then fall back to
+    // scp-style `user@host:path`.
+    let path = if let Some(rest) = strip_scheme(trimmed) {
+        // After scheme, rest is `[user@]host[:port]/path`. Skip the
+        // host segment.
+        let after_host = rest.split_once('/')?.1;
+        after_host.to_string()
+    } else if let Some(after_colon) = scp_style_path(trimmed) {
+        after_colon.to_string()
+    } else {
+        return None;
+    };
+
+    let path = path.trim_start_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let path = path.trim_end_matches('/');
+
+    // Require at least `owner/repo` (one slash). A bare `repo` with no
+    // namespace can't be attributed to an upstream id.
+    if !path.contains('/') {
+        return None;
+    }
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+/// Recognise `scheme://` prefixes and return the remainder. Returns
+/// `None` for inputs without an explicit scheme.
+fn strip_scheme(url: &str) -> Option<&str> {
+    for scheme in ["https://", "http://", "ssh://", "git://", "git+ssh://"] {
+        if let Some(rest) = url.strip_prefix(scheme) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// Match scp-style `[user@]host:path` (e.g. `git@github.com:owner/repo.git`).
+/// Returns the path portion or `None` if the input doesn't look like
+/// scp form.
+fn scp_style_path(url: &str) -> Option<&str> {
+    // scp-style has no `//` and the first `:` separates host from path.
+    if url.contains("://") {
+        return None;
+    }
+    let (host, path) = url.split_once(':')?;
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    // Reject Windows-style drive letters like `C:\foo`.
+    if host.len() == 1 && host.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parses_ssh_scp_style_url() {
+        assert_eq!(
+            extract_owner_repo("git@github.com:owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_url_with_dot_git() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_url_without_dot_git() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/owner/repo"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_gitlab_nested_group() {
+        assert_eq!(
+            extract_owner_repo("https://gitlab.com/group/sub/repo"),
+            Some("group/sub/repo".to_string())
+        );
+        assert_eq!(
+            extract_owner_repo("git@gitlab.com:group/sub/repo.git"),
+            Some("group/sub/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_scheme_url() {
+        assert_eq!(
+            extract_owner_repo("ssh://git@github.com/owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_owner_repo("ssh://git@host.example.com:2222/team/proj.git"),
+            Some("team/proj".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_bare_repo_name() {
+        // Need at least owner/repo — a bare name has no upstream id.
+        assert_eq!(extract_owner_repo("git@github.com:repo.git"), None);
+    }
+
+    #[test]
+    fn rejects_unknown_scheme() {
+        assert_eq!(extract_owner_repo(""), None);
+        // Local file path is not a remote URL we can attribute.
+        assert_eq!(extract_owner_repo("/tmp/some/path"), None);
+    }
+
+    #[test]
+    fn parses_origin_section_only() {
+        let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "upstream"]
+    url = https://github.com/other/upstream.git
+[remote "origin"]
+    url = git@github.com:owner/repo.git
+[branch "main"]
+    remote = origin
+"#;
+        assert_eq!(
+            parse_origin_url(cfg),
+            Some("git@github.com:owner/repo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_origin_returns_none_when_no_origin() {
+        let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "upstream"]
+    url = https://github.com/other/upstream.git
+"#;
+        assert_eq!(parse_origin_url(cfg), None);
+    }
+
+    #[test]
+    fn resolve_returns_none_for_non_git_path() {
+        let dir = tempdir().unwrap();
+        let mut cache = HashMap::new();
+        let cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), None);
+        // Cache hit (negative) — second call should not re-resolve.
+        assert!(cache.contains_key(&cwd));
+        assert_eq!(resolve_repo(&cwd, &mut cache), None);
+    }
+
+    #[test]
+    fn resolve_returns_none_when_no_origin_remote() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[core]\n\trepositoryformatversion = 0\n",
+        )
+        .unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), None);
+    }
+
+    #[test]
+    fn resolve_finds_origin_in_repo_root() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:acme/widget.git\n",
+        )
+        .unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), Some("acme/widget".to_string()));
+    }
+
+    #[test]
+    fn resolve_walks_up_from_subdirectory() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = https://github.com/acme/widget\n",
+        )
+        .unwrap();
+        let nested = dir.path().join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = nested.to_string_lossy().into_owned();
+        assert_eq!(resolve_repo(&cwd, &mut cache), Some("acme/widget".to_string()));
+    }
+
+    #[test]
+    fn resolve_follows_worktree_pointer_to_main_repo() {
+        // Layout:
+        //   <root>/main/.git/        (real git dir)
+        //   <root>/main/.git/config  (with origin)
+        //   <root>/main/.git/worktrees/wt1/   (worktree gitdir)
+        //   <root>/wt1/.git          (file: "gitdir: <root>/main/.git/worktrees/wt1")
+        let dir = tempdir().unwrap();
+        let main = dir.path().join("main");
+        let main_git = main.join(".git");
+        let wt_gitdir = main_git.join("worktrees").join("wt1");
+        fs::create_dir_all(&wt_gitdir).unwrap();
+        fs::write(
+            main_git.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:acme/widget.git\n",
+        )
+        .unwrap();
+
+        let wt = dir.path().join("wt1");
+        fs::create_dir_all(&wt).unwrap();
+        fs::write(
+            wt.join(".git"),
+            format!("gitdir: {}\n", wt_gitdir.display()),
+        )
+        .unwrap();
+
+        let mut cache = HashMap::new();
+        let cwd = wt.to_string_lossy().into_owned();
+        assert_eq!(
+            resolve_repo(&cwd, &mut cache),
+            Some("acme/widget".to_string())
+        );
+    }
+
+    #[test]
+    fn cache_hit_short_circuits_resolution() {
+        let mut cache = HashMap::new();
+        cache.insert("/no/such/path".to_string(), Some("cached/value".to_string()));
+        // No filesystem access — value comes straight from cache.
+        assert_eq!(
+            resolve_repo("/no/such/path", &mut cache),
+            Some("cached/value".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_scp_style_with_drive_letter() {
+        // Ensure Windows paths don't get mistaken for scp URLs.
+        assert_eq!(extract_owner_repo("C:\\users\\dev\\repo"), None);
+    }
+
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -1,0 +1,3992 @@
+// ABOUTME: Token usage data model and local session parsers for usage analytics.
+// Parses Claude and Codex JSONL histories into reusable aggregates for TUI and CLI views.
+
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+use crate::data::repo_lookup;
+use crate::cache::{Cache, ParseHint, ParseResult};
+
+/// Usage period selector shared by TUI and CLI report queries.
+///
+/// Variants beyond the original `Today/Week/ThirtyDays/Month/All/Custom`
+/// set are introduced for the date-picker UX:
+/// - `LastNDays(n)` — generic "last n days" used for 90d (and exposed
+///   over the CLI as `--last-n-days N`).
+/// - `SpecificMonth(date)` — calendar month containing `date` (day is
+///   ignored; canonicalised to day=1 by callers).
+/// - `SpecificQuarter(year, q)` — calendar quarter `q` of `year`,
+///   `q ∈ 1..=4`.
+/// - `YearToDate` — Jan 1 of the current local year through today.
+///
+/// `Week` and `ThirtyDays` are retained (rather than collapsing into
+/// `LastNDays`) to keep the existing CLI `PeriodArg` enum, JSON
+/// serialisation, and downstream tests stable.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsagePeriod {
+    Today,
+    Week,
+    ThirtyDays,
+    /// Generic "last N days" — used for 90d and the `--last-n-days N`
+    /// CLI flag. `n=0` is treated as 1 day (today only) by
+    /// `date_range_for_period` to avoid empty ranges.
+    LastNDays(u32),
+    /// Calendar month of the given date. Callers should canonicalise
+    /// the day to 1 — the renderer pretty-prints as "Apr 2026".
+    SpecificMonth(NaiveDate),
+    /// Calendar quarter `q ∈ 1..=4` of `year`. Renders as "Q2 2026".
+    SpecificQuarter(i32, u8),
+    /// Jan 1 of the current local year through today.
+    YearToDate,
+    Month,
+    All,
+    Custom { from: NaiveDate, to: NaiveDate },
+}
+
+impl Default for UsagePeriod {
+    fn default() -> Self {
+        Self::Week
+    }
+}
+
+/// Provider filter shared by TUI and CLI report queries.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageProviderFilter {
+    #[default]
+    All,
+    Claude,
+    Codex,
+}
+
+impl UsageProviderFilter {
+    fn includes(self, provider: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Claude => provider == "claude",
+            Self::Codex => provider == "codex",
+        }
+    }
+}
+
+/// Deterministic activity categories. Phase 2 fills these from turn classification.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityCategory {
+    Coding,
+    Debugging,
+    Feature,
+    Refactoring,
+    Testing,
+    Exploration,
+    Planning,
+    Delegation,
+    Git,
+    BuildDeploy,
+    Brainstorming,
+    Conversation,
+    General,
+}
+
+impl ActivityCategory {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Coding => "Coding",
+            Self::Debugging => "Debugging",
+            Self::Feature => "Feature",
+            Self::Refactoring => "Refactoring",
+            Self::Testing => "Testing",
+            Self::Exploration => "Exploration",
+            Self::Planning => "Planning",
+            Self::Delegation => "Delegation",
+            Self::Git => "Git",
+            Self::BuildDeploy => "Build/Deploy",
+            Self::Brainstorming => "Brainstorming",
+            Self::Conversation => "Conversation",
+            Self::General => "General",
+        }
+    }
+}
+
+/// Query used to parse and aggregate usage.
+#[derive(Debug, Clone, Default)]
+pub struct UsageQuery {
+    pub period: UsagePeriod,
+    pub provider_filter: UsageProviderFilter,
+    pub include_projects: Vec<String>,
+    pub exclude_projects: Vec<String>,
+    /// Cross-filters (exact-match drill-downs) layered on top of the
+    /// substring `include_projects` / `exclude_projects` globs.
+    pub filters: UsageFilters,
+}
+
+/// Exact-match drill-down filters set by the dashboard cross-filter
+/// (Grafana-style click-to-pivot) and the `--project / --model /
+/// --activity / --session / --branch` CLI flags.
+///
+/// All filter sets are AND-combined with each other and with the existing
+/// `include_projects` / `exclude_projects` globs. Each filter list is
+/// internally OR-combined: `--project a --project b` matches calls in
+/// either project.
+///
+/// Branch filtering matches `call.branch` exactly. Calls with no recorded
+/// branch (`branch == None`, eg. codex turns or Claude turns made outside a
+/// git repo) are excluded by any non-empty branch filter — there's no way
+/// to ask for "untracked branch" via this struct on purpose.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UsageFilters {
+    pub project: Vec<String>,
+    pub model: Vec<String>,
+    pub activity: Vec<String>,
+    pub session: Vec<String>,
+    pub branch: Vec<String>,
+    /// Negative filters set via the X-on-row picker. A call is rejected
+    /// as soon as it matches any value in any of these lists. Mirrors
+    /// the include lists above so all five dimensions support exclude.
+    pub exclude_project: Vec<String>,
+    pub exclude_model: Vec<String>,
+    pub exclude_activity: Vec<String>,
+    pub exclude_session: Vec<String>,
+    pub exclude_branch: Vec<String>,
+}
+
+impl UsageFilters {
+    pub fn is_empty(&self) -> bool {
+        self.project.is_empty()
+            && self.model.is_empty()
+            && self.activity.is_empty()
+            && self.session.is_empty()
+            && self.branch.is_empty()
+            && self.exclude_project.is_empty()
+            && self.exclude_model.is_empty()
+            && self.exclude_activity.is_empty()
+            && self.exclude_session.is_empty()
+            && self.exclude_branch.is_empty()
+    }
+
+    /// True if any cross-filter is set. Mirror of `!is_empty()` for sites
+    /// where the positive form reads better.
+    pub fn any(&self) -> bool {
+        !self.is_empty()
+    }
+
+    /// Pop the most-recently-added filter chip. Removal order matches
+    /// the chip-strip render order so `Esc` removes the visually
+    /// rightmost chip first: exclude chips are rendered after include
+    /// chips, so they pop first; within each group the order is
+    /// branch → session → activity → model → project.
+    pub fn pop_last(&mut self) -> Option<UsageFilterChip> {
+        if let Some(value) = self.exclude_branch.pop() {
+            return Some(UsageFilterChip::ExcludeBranch(value));
+        }
+        if let Some(value) = self.exclude_session.pop() {
+            return Some(UsageFilterChip::ExcludeSession(value));
+        }
+        if let Some(value) = self.exclude_activity.pop() {
+            return Some(UsageFilterChip::ExcludeActivity(value));
+        }
+        if let Some(value) = self.exclude_model.pop() {
+            return Some(UsageFilterChip::ExcludeModel(value));
+        }
+        if let Some(value) = self.exclude_project.pop() {
+            return Some(UsageFilterChip::ExcludeProject(value));
+        }
+        if let Some(value) = self.branch.pop() {
+            return Some(UsageFilterChip::Branch(value));
+        }
+        if let Some(value) = self.session.pop() {
+            return Some(UsageFilterChip::Session(value));
+        }
+        if let Some(value) = self.activity.pop() {
+            return Some(UsageFilterChip::Activity(value));
+        }
+        if let Some(value) = self.model.pop() {
+            return Some(UsageFilterChip::Model(value));
+        }
+        if let Some(value) = self.project.pop() {
+            return Some(UsageFilterChip::Project(value));
+        }
+        None
+    }
+
+    pub fn clear(&mut self) {
+        self.project.clear();
+        self.model.clear();
+        self.activity.clear();
+        self.session.clear();
+        self.branch.clear();
+        self.exclude_project.clear();
+        self.exclude_model.clear();
+        self.exclude_activity.clear();
+        self.exclude_session.clear();
+        self.exclude_branch.clear();
+    }
+
+    pub(crate) fn matches(&self, call: &ProviderCall, category: ActivityCategory) -> bool {
+        if !self.project.is_empty() && !self.project.iter().any(|p| p == &call.project) {
+            return false;
+        }
+        if !self.model.is_empty() && !self.model.iter().any(|m| m == &call.model) {
+            return false;
+        }
+        if !self.session.is_empty() && !self.session.iter().any(|s| s == &call.session_id) {
+            return false;
+        }
+        if !self.activity.is_empty() {
+            let label = category.label();
+            if !self.activity.iter().any(|a| a == label) {
+                return false;
+            }
+        }
+        if !self.branch.is_empty() {
+            let Some(branch) = call.recorded_branch() else {
+                return false;
+            };
+            if !self.branch.iter().any(|b| b == branch) {
+                return false;
+            }
+        }
+        // Exclude lists: a call is rejected if it matches any value.
+        // Branch exclusions only apply to calls with a recorded branch
+        // — calls without a branch are unaffected by branch excludes
+        // (mirror of the include-side semantics where `branch == None`
+        // means "no branch was recorded for this call").
+        if self.exclude_project.iter().any(|p| p == &call.project) {
+            return false;
+        }
+        if self.exclude_model.iter().any(|m| m == &call.model) {
+            return false;
+        }
+        if self.exclude_session.iter().any(|s| s == &call.session_id) {
+            return false;
+        }
+        if !self.exclude_activity.is_empty() {
+            let label = category.label();
+            if self.exclude_activity.iter().any(|a| a == label) {
+                return false;
+            }
+        }
+        if !self.exclude_branch.is_empty() {
+            if let Some(branch) = call.recorded_branch() {
+                if self.exclude_branch.iter().any(|b| b == branch) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// One filter chip — used by the chip-strip widget and `pop_last`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UsageFilterChip {
+    Project(String),
+    Model(String),
+    Activity(String),
+    Session(String),
+    Branch(String),
+    /// Exclude variants set via the X-on-row picker. The chip strip
+    /// renders these with a leading `~` and `pop_last` returns them
+    /// before the include variants so Esc walks the visually
+    /// rightmost chip first.
+    ExcludeProject(String),
+    ExcludeModel(String),
+    ExcludeActivity(String),
+    ExcludeSession(String),
+    ExcludeBranch(String),
+}
+
+impl UsageFilterChip {
+    /// Stable string key for this chip, used by the chip-strip widget,
+    /// CLI flag mapping, and filter telemetry. The match below is the
+    /// single source of truth — keep it in sync with new variants.
+    //
+    // NOTE: an earlier cleanup considered switching to strum_macros'
+    // AsRefStr. Skipped: adding the strum crate purely for five mappings
+    // costs more than the match itself, and a const-slice indexed by
+    // discriminant order is harder to read than the match and not type-
+    // checked when a variant is added. The match is already canonical.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Project(_) | Self::ExcludeProject(_) => "project",
+            Self::Model(_) | Self::ExcludeModel(_) => "model",
+            Self::Activity(_) | Self::ExcludeActivity(_) => "activity",
+            Self::Session(_) | Self::ExcludeSession(_) => "session",
+            Self::Branch(_) | Self::ExcludeBranch(_) => "branch",
+        }
+    }
+
+    /// True for negative (exclude) variants. Used by the chip strip to
+    /// render with a `~` prefix and by callers that want a single test
+    /// for "is this an exclusion".
+    pub fn is_exclude(&self) -> bool {
+        matches!(
+            self,
+            Self::ExcludeProject(_)
+                | Self::ExcludeModel(_)
+                | Self::ExcludeActivity(_)
+                | Self::ExcludeSession(_)
+                | Self::ExcludeBranch(_)
+        )
+    }
+
+    pub fn value(&self) -> &str {
+        match self {
+            Self::Project(v)
+            | Self::Model(v)
+            | Self::Activity(v)
+            | Self::Session(v)
+            | Self::Branch(v)
+            | Self::ExcludeProject(v)
+            | Self::ExcludeModel(v)
+            | Self::ExcludeActivity(v)
+            | Self::ExcludeSession(v)
+            | Self::ExcludeBranch(v) => v,
+        }
+    }
+}
+
+/// Token counts for a single usage bucket, provider call, or aggregate row.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TokenBucket {
+    pub input_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub output_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub session_count: usize,
+    pub project_count: usize,
+    pub call_count: usize,
+    pub cost_usd: Option<f64>,
+}
+
+impl TokenBucket {
+    pub fn total(&self) -> u64 {
+        self.input_tokens
+            + self.cache_creation_tokens
+            + self.cache_read_tokens
+            + self.output_tokens
+            + self.reasoning_tokens
+    }
+
+    fn merge(&mut self, other: &TokenBucket) {
+        self.input_tokens += other.input_tokens;
+        self.cache_creation_tokens += other.cache_creation_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.output_tokens += other.output_tokens;
+        self.reasoning_tokens += other.reasoning_tokens;
+        self.call_count += other.call_count;
+        self.cost_usd = merge_cost(self.cost_usd, other.cost_usd);
+    }
+}
+
+/// Per-provider API call parsed from a local session file.
+///
+/// `Deserialize` is required for bincode round-trip in the persistent
+/// usage cache (`usage_cache::store`).
+///
+/// **WARNING — bincode layout stability.** Bincode v1 with default options
+/// encodes positionally with no field tags. Any change to the field set or
+/// order of this struct (or any nested type it owns) silently invalidates
+/// every cached blob written under the current `BLOB_FORMAT_BINCODE_CURRENT`.
+/// Wrong-shape decodes can either panic (caught — falls through to a full
+/// re-parse) or, much worse, succeed with mis-aligned bytes and return
+/// wrong analytics from the cache.
+///
+/// **If you change this struct or any nested type, you MUST:**
+/// 1. Bump `usage_cache::db::BLOB_FORMAT_BINCODE_CURRENT` to a new value, and
+/// 2. Update the layout-stability tripwire test in `usage_cache::tests`.
+///
+/// The tripwire test asserts a fixed serialized byte length for a known
+/// fixture and will fail CI if the layout drifts without an explicit bump.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderCall {
+    /// Stable per-call identifier: `blake3(format!("{path}:{offset}"))`
+    /// truncated to a `u64` (first 8 little-endian bytes of the digest).
+    /// `path` is the source JSONL file, `offset` is the byte position of
+    /// the assistant line that produced this call. The combination is
+    /// unique per call across a parse run and stable across cache hits
+    /// (the parser feeds the same `(path, offset)` tuple every time the
+    /// same line is rewalked), which makes `analyze_turns` results safe
+    /// to memoise on the unfiltered call set and look up by id during
+    /// chip-pivot re-aggregation in `filter_usage_data`.
+    ///
+    /// `blake3` is reused here rather than introducing a new hashing
+    /// dependency just for an id; the cryptographic strength is overkill
+    /// but the API is already in scope (see `usage_cache::fingerprint`).
+    pub id: u64,
+    pub provider: String,
+    pub model: String,
+    pub session_id: String,
+    pub project: String,
+    pub project_path: String,
+    /// Stored in UTC so cached blobs are timezone-independent. Render
+    /// sites convert to local at the display boundary via
+    /// `.with_timezone(&Local)` (see `components/usage.rs`,
+    /// `cli/usage.rs`).
+    pub timestamp: DateTime<Utc>,
+    pub input_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub output_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub cost_usd: Option<f64>,
+    pub tools: Vec<String>,
+    pub bash_commands: Vec<String>,
+    pub user_message: String,
+    /// Git branch the turn was made from, parsed from `gitBranch` on
+    /// Claude assistant turns. Codex transcripts don't carry branch state,
+    /// so codex calls always have `None` here.
+    pub branch: Option<String>,
+}
+
+impl ProviderCall {
+    fn bucket(&self) -> TokenBucket {
+        TokenBucket {
+            input_tokens: self.input_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            output_tokens: self.output_tokens,
+            reasoning_tokens: self.reasoning_tokens,
+            session_count: 0,
+            project_count: 0,
+            call_count: 1,
+            cost_usd: self.cost_usd,
+        }
+    }
+
+    /// Branch attribution that's safe to display: returns the recorded
+    /// branch only when it's `Some(non-empty)`. Empty strings creep in
+    /// from downstream branch detection that returns `""` for a non-git
+    /// project; the canonical accessor stops them from being aggregated
+    /// as a real branch named "" anywhere in the pipeline.
+    pub fn recorded_branch(&self) -> Option<&str> {
+        self.branch.as_deref().filter(|b| !b.is_empty())
+    }
+}
+
+/// Daily dashboard row.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyUsage {
+    pub date: NaiveDate,
+    pub bucket: TokenBucket,
+}
+
+/// Per-project summary.
+///
+/// `name` is the display label and aggregation key. When the project's
+/// `cwd` belongs to a git repo with a resolvable `origin` remote,
+/// `name` is the upstream identifier (e.g. `"owner/repo"`) and `repo`
+/// holds the same value as an explicit "this came from a remote"
+/// marker. Otherwise `name` falls back to the local folder/sanitised
+/// project name and `repo` is `None`.
+///
+/// Two worktrees of the same upstream repo collapse into a single
+/// `ProjectUsage` row because they share the same `name`. Chip filters
+/// match on `name`, so the filter UI follows the same rule.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectUsage {
+    pub name: String,
+    pub path: String,
+    pub bucket: TokenBucket,
+    /// `Some(owner/repo)` when the project's working directory was
+    /// successfully resolved to an upstream remote at aggregation
+    /// time. `None` for non-git paths or repos without an `origin`.
+    pub repo: Option<String>,
+}
+
+/// Per-session summary.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionUsage {
+    pub provider: String,
+    pub project: String,
+    pub session_id: String,
+    pub first_timestamp: DateTime<Utc>,
+    pub last_timestamp: DateTime<Utc>,
+    pub bucket: TokenBucket,
+}
+
+/// Per-model summary.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelUsage {
+    pub model: String,
+    pub bucket: TokenBucket,
+}
+
+/// Per-branch summary. Built only from calls whose `branch` is `Some`;
+/// branchless calls (codex, non-git Claude turns) are dropped from this
+/// view so the panel never grows a misleading "(no branch)" bucket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchUsage {
+    pub branch: String,
+    pub bucket: TokenBucket,
+}
+
+/// Activity summary with classified turns and retry counts.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityUsage {
+    pub category: ActivityCategory,
+    pub bucket: TokenBucket,
+    pub turns: usize,
+    pub retries: usize,
+    pub edit_turns: usize,
+    pub one_shot_turns: usize,
+}
+
+/// Tool/MCP/shell breakdown row.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedUsage {
+    pub name: String,
+    pub calls: usize,
+}
+
+/// Complete parsed usage data.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageData {
+    pub daily: Vec<(NaiveDate, TokenBucket)>,
+    pub weekly: Vec<(NaiveDate, TokenBucket)>,
+    pub projects: Vec<ProjectUsage>,
+    pub grand_total: TokenBucket,
+    pub calls: Vec<ProviderCall>,
+    pub sessions: Vec<SessionUsage>,
+    pub models: Vec<ModelUsage>,
+    pub activities: Vec<ActivityUsage>,
+    pub tools: Vec<NamedUsage>,
+    pub mcp_servers: Vec<NamedUsage>,
+    pub shell_commands: Vec<NamedUsage>,
+    /// Branch attribution rows, sorted by largest bucket. Only Claude
+    /// assistant turns with a non-empty `gitBranch` populate this.
+    pub branches: Vec<BranchUsage>,
+    /// Precomputed `model -> [(project, call_count), ...]` sorted by
+    /// count descending. Built once during `aggregate_calls` so the
+    /// render path's "top N projects for model X" lookup is O(1) plus
+    /// the constant-N truncation, instead of a full O(N·M) scan of
+    /// `data.calls` per render frame.
+    pub model_project_counts: HashMap<String, Vec<(String, usize)>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageOverview {
+    pub calls: usize,
+    pub sessions: usize,
+    pub projects: usize,
+    pub tokens: u64,
+    pub cost_usd: Option<f64>,
+}
+
+impl UsageData {
+    pub fn overview(&self) -> UsageOverview {
+        UsageOverview {
+            calls: self.grand_total.call_count,
+            sessions: self.grand_total.session_count,
+            projects: self.grand_total.project_count,
+            tokens: self.grand_total.total(),
+            cost_usd: self.grand_total.cost_usd,
+        }
+    }
+}
+
+impl Default for UsageData {
+    fn default() -> Self {
+        Self {
+            daily: Vec::new(),
+            weekly: Vec::new(),
+            projects: Vec::new(),
+            grand_total: TokenBucket::default(),
+            calls: Vec::new(),
+            sessions: Vec::new(),
+            models: Vec::new(),
+            activities: Vec::new(),
+            tools: Vec::new(),
+            mcp_servers: Vec::new(),
+            shell_commands: Vec::new(),
+            branches: Vec::new(),
+            model_project_counts: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UsageSourceRoots {
+    pub claude_projects_dir: Option<PathBuf>,
+    pub codex_dir: Option<PathBuf>,
+}
+
+impl Default for UsageSourceRoots {
+    fn default() -> Self {
+        let home = dirs::home_dir();
+        let claude_projects_dir = std::env::var_os("CLAUDE_CONFIG_DIR")
+            .map(PathBuf::from)
+            .map(|path| path.join("projects"))
+            .or_else(|| home.as_ref().map(|path| path.join(".claude").join("projects")));
+
+        let codex_dir = std::env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|path| path.join(".codex")));
+
+        Self {
+            claude_projects_dir,
+            codex_dir,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ClaudeLine {
+    #[serde(rename = "type")]
+    msg_type: Option<String>,
+    timestamp: Option<String>,
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+    cwd: Option<String>,
+    #[serde(rename = "gitBranch")]
+    git_branch: Option<String>,
+    message: Option<ClaudeMessage>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeMessage {
+    content: Option<Value>,
+    model: Option<String>,
+    usage: Option<ClaudeUsage>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeUsage {
+    input_tokens: Option<u64>,
+    cache_creation_input_tokens: Option<u64>,
+    cache_read_input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct CodexEntry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    timestamp: Option<String>,
+    payload: Option<CodexPayload>,
+}
+
+#[derive(Deserialize)]
+struct CodexPayload {
+    #[serde(rename = "type")]
+    payload_type: Option<String>,
+    role: Option<String>,
+    cwd: Option<String>,
+    originator: Option<String>,
+    session_id: Option<String>,
+    model: Option<String>,
+    name: Option<String>,
+    content: Option<Vec<CodexContent>>,
+    info: Option<CodexInfo>,
+}
+
+#[derive(Deserialize)]
+struct CodexContent {
+    #[serde(rename = "type")]
+    content_type: Option<String>,
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CodexInfo {
+    model: Option<String>,
+    model_name: Option<String>,
+    last_token_usage: Option<CodexTokenUsage>,
+    total_token_usage: Option<CodexTokenUsage>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+struct CodexTokenUsage {
+    input_tokens: Option<u64>,
+    cached_input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    reasoning_output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+/// Parse local session files for a query using default user data roots.
+pub fn parse_usage_for(query: UsageQuery) -> UsageData {
+    parse_usage_for_with_roots(query, &UsageSourceRoots::default())
+}
+
+/// Process-wide singleton cache handle. Constructed lazily; on open
+/// failure (eg. read-only home dir) we fall back to a disabled cache so
+/// analytics remain functional.
+fn default_cache() -> Arc<Cache> {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<Arc<Cache>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let Some(path) = crate::cache::store::default_db_path() else {
+                debug!("usage_cache: no home dir; running with cache disabled");
+                return Arc::new(Cache::disabled());
+            };
+            match Cache::open(path.clone()) {
+                Ok(c) => Arc::new(c),
+                Err(err) => {
+                    warn!(
+                        "usage_cache: failed to open {:?} ({err}); cache disabled",
+                        path
+                    );
+                    Arc::new(Cache::disabled())
+                }
+            }
+        })
+        .clone()
+}
+
+/// Public helper for callers (CLI `--no-cache`, tests) to get a fresh
+/// disabled cache without going through the singleton.
+pub fn disabled_cache() -> Arc<Cache> {
+    Arc::new(Cache::disabled())
+}
+
+/// Public helper for callers that want the process-wide cache (eg. CLI
+/// `cache info` / `cache clear`).
+pub fn shared_cache() -> Arc<Cache> {
+    default_cache()
+}
+
+/// Parse local session files for a query using explicit roots.
+pub fn parse_usage_for_with_roots(query: UsageQuery, roots: &UsageSourceRoots) -> UsageData {
+    parse_usage_for_with_roots_and_cache(query, roots, default_cache())
+}
+
+/// Parse local session files for a query, using an explicit cache. Pass
+/// `Cache::disabled()` to bypass the cache entirely.
+pub fn parse_usage_for_with_roots_and_cache(
+    query: UsageQuery,
+    roots: &UsageSourceRoots,
+    cache: Arc<Cache>,
+) -> UsageData {
+    let range = date_range_for_period(&query.period);
+    let mut calls = Vec::new();
+
+    if query.provider_filter.includes("claude") {
+        calls.extend(parse_claude_sources(
+            roots.claude_projects_dir.as_deref(),
+            cache.as_ref(),
+        ));
+    }
+    if query.provider_filter.includes("codex") {
+        calls.extend(parse_codex_sources(
+            roots.codex_dir.as_deref(),
+            cache.as_ref(),
+        ));
+    }
+
+    let filters_active = !query.filters.is_empty();
+    let filtered: Vec<ProviderCall> = calls
+        .into_iter()
+        .filter(|call| {
+            range.as_ref().map_or(true, |(start, end)| {
+                // Period bounds and call timestamps both live in Utc
+                // (period bounds are anchored at local-midnight and
+                // converted via `start_of_day` / `end_of_day`).
+                call.timestamp >= *start && call.timestamp <= *end
+            })
+        })
+        .filter(|call| project_matches(call, &query.include_projects, &query.exclude_projects))
+        // Apply cross-filter chips up-front when present. Saves a full
+        // aggregate+re-aggregate round trip on the CLI path: previously
+        // we built the full UsageData and then filter_usage_data
+        // re-aggregated the filtered subset. The TUI hot path keeps
+        // calling filter_usage_data over cached UsageData and is
+        // unaffected.
+        .filter(|call| {
+            !filters_active || query.filters.matches(call, classify_activity(call))
+        })
+        .collect();
+
+    aggregate_calls(filtered)
+}
+
+// TODO(perf): parallelise per-file cache.get_or_parse with rayon
+// (par_iter() over collect_claude_jsonl_files results). SQLite writes
+// still serialise on the connection mutex but JSONL parsing +
+// fingerprinting can run concurrent. Cache itself is already
+// Send+Sync via Mutex<Connection>. Deferred — adding rayon as a
+// dependency is the largest unrelated lift in this batch and is
+// best landed in its own change with benchmarks attached.
+fn parse_claude_sources(projects_dir: Option<&Path>, cache: &Cache) -> Vec<ProviderCall> {
+    let Some(projects_dir) = projects_dir else {
+        return Vec::new();
+    };
+    if !projects_dir.is_dir() {
+        warn!("Claude projects directory not found: {:?}", projects_dir);
+        return Vec::new();
+    }
+
+    let username = whoami_username();
+    let mut calls = Vec::new();
+    let Ok(project_dirs) = std::fs::read_dir(projects_dir) else {
+        return calls;
+    };
+
+    for entry in project_dirs.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let raw_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+        let project = clean_project_name(raw_name, &username);
+        let project_path = unsanitize_project_path(raw_name);
+
+        for jsonl_path in collect_claude_jsonl_files(&path) {
+            let project = project.clone();
+            let project_path = project_path.clone();
+            let parsed = cache.get_or_parse(&jsonl_path, |path, hint| match hint {
+                ParseHint::Full => parse_claude_source_full(path, &project, &project_path),
+                ParseHint::Append {
+                    from_offset,
+                    existing,
+                } => {
+                    parse_claude_source_append(path, &project, &project_path, from_offset, existing)
+                }
+            });
+            calls.extend(parsed);
+        }
+    }
+
+    calls
+}
+
+fn collect_claude_jsonl_files(project_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(project_dir) else {
+        return files;
+    };
+
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "jsonl") {
+            files.push(path);
+            continue;
+        }
+
+        let subagents = path.join("subagents");
+        let Ok(sub_entries) = std::fs::read_dir(subagents) else {
+            continue;
+        };
+        for sub_entry in sub_entries.filter_map(Result::ok) {
+            let sub_path = sub_entry.path();
+            if sub_path.extension().is_some_and(|ext| ext == "jsonl") {
+                files.push(sub_path);
+            }
+        }
+    }
+
+    files
+}
+
+/// Collect Claude assistant calls whose timestamp is `>= cutoff`,
+/// skipping files whose mtime falls before `cutoff - grace`. This is the
+/// hot-path the live-window 5h aggregator relies on — it intentionally
+/// does *not* go through the usage cache because we only need a tight
+/// time slice, not the full history.
+///
+/// `grace` widens the mtime filter to forgive clock skew between
+/// timestamp comparisons (real-world JSONL files have been seen with
+/// mtime trailing the last entry's timestamp by a few seconds).
+///
+/// Returns an empty vec if the projects dir is missing.
+pub(crate) fn collect_recent_claude_calls_within(
+    cutoff: DateTime<Utc>,
+    grace: Duration,
+) -> Vec<ProviderCall> {
+    let roots = UsageSourceRoots::default();
+    let Some(projects_dir) = roots.claude_projects_dir.as_deref() else {
+        return Vec::new();
+    };
+    collect_recent_claude_calls_within_at(projects_dir, cutoff, grace)
+}
+
+/// Test seam for `collect_recent_claude_calls_within` — accepts an
+/// explicit `projects_dir` so tests can drive the walker against a
+/// tempdir without mutating environment variables.
+pub(crate) fn collect_recent_claude_calls_within_at(
+    projects_dir: &Path,
+    cutoff: DateTime<Utc>,
+    grace: Duration,
+) -> Vec<ProviderCall> {
+    if !projects_dir.is_dir() {
+        return Vec::new();
+    }
+    let username = whoami_username();
+    let mtime_floor = std::time::SystemTime::UNIX_EPOCH
+        + std::time::Duration::from_secs((cutoff - grace).timestamp().max(0) as u64);
+
+    let mut calls = Vec::new();
+    let Ok(project_dirs) = std::fs::read_dir(projects_dir) else {
+        return calls;
+    };
+    for entry in project_dirs.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let raw_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+        let project = clean_project_name(raw_name, &username);
+        let project_path = unsanitize_project_path(raw_name);
+
+        for jsonl_path in collect_claude_jsonl_files(&path) {
+            // mtime gate — skip files that haven't been touched in the
+            // window. Cheap and avoids opening cold archives.
+            if let Ok(meta) = std::fs::metadata(&jsonl_path) {
+                if let Ok(mtime) = meta.modified() {
+                    if mtime < mtime_floor {
+                        continue;
+                    }
+                }
+            }
+            parse_claude_jsonl_within(
+                &jsonl_path,
+                &project,
+                &project_path,
+                cutoff,
+                &mut calls,
+            );
+        }
+    }
+    calls
+}
+
+/// Stream a single Claude JSONL file and append calls whose timestamp
+/// is `>= cutoff` to `out`. JSONL files are append-only with
+/// monotonically increasing timestamps, so once we have collected at
+/// least one call inside the window and then encounter a call before
+/// the window we know the rest of the file is older too — but the
+/// converse is not guaranteed (header lines, "user"-typed lines, etc.
+/// have no usage data and emit `None`). To stay correct we just walk
+/// to EOF and filter; the mtime gate already keeps the per-file work
+/// bounded.
+fn parse_claude_jsonl_within(
+    path: &Path,
+    project: &str,
+    project_path: &str,
+    cutoff: DateTime<Utc>,
+    out: &mut Vec<ProviderCall>,
+) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+    let reader = BufReader::new(file);
+    let mut current_user_message = String::new();
+    let mut offset: u64 = 0;
+    for line in reader.lines() {
+        let Ok(line) = line else { return };
+        let line_offset = offset;
+        // Reconstruct byte advance: line bytes + the trailing newline
+        // we stripped (BufRead::lines drops the terminator).
+        offset += line.len() as u64 + 1;
+        if let Some(call) = parse_claude_line(
+            &line,
+            path,
+            project,
+            project_path,
+            &mut current_user_message,
+            line_offset,
+        ) {
+            if call.timestamp >= cutoff {
+                out.push(call);
+            }
+        }
+    }
+}
+
+/// Full parse of a Claude JSONL session file. Returns the complete
+/// `Vec<ProviderCall>` and the byte offset where parsing stopped (typically
+/// the file size at open time — note this is best-effort: if the file is
+/// being appended to concurrently we may stop short, which the cache will
+/// recover from on the next call via append-only).
+fn parse_claude_source_full(path: &Path, project: &str, project_path: &str) -> ParseResult {
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => {
+            return ParseResult {
+                calls: Vec::new(),
+                end_offset: 0,
+            };
+        }
+    };
+    let mut content = String::new();
+    if file.read_to_string(&mut content).is_err() {
+        return ParseResult {
+            calls: Vec::new(),
+            end_offset: 0,
+        };
+    }
+    let end_offset = content.len() as u64;
+
+    let mut calls = Vec::new();
+    let mut current_user_message = String::new();
+    // Walk lines manually rather than using `content.lines()` so each
+    // call carries the byte offset of its source line in the file, which
+    // feeds the stable `ProviderCall.id`. `split_inclusive` keeps the
+    // newline byte counted in the offset advance.
+    let mut offset: u64 = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line_offset = offset;
+        offset += chunk.len() as u64;
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
+        if let Some(call) = parse_claude_line(
+            line,
+            path,
+            project,
+            project_path,
+            &mut current_user_message,
+            line_offset,
+        ) {
+            calls.push(call);
+        }
+    }
+    ParseResult { calls, end_offset }
+}
+
+/// Append-only parse: re-open the file, seek to `from_offset`, and parse
+/// only the new bytes. The returned `Vec<ProviderCall>` is `existing`
+/// concatenated with the new calls, so the cache can persist a complete
+/// blob for the file.
+///
+/// `current_user_message` state from before `from_offset` is restored
+/// by `recover_user_message_before`, which walks the prefix
+/// `[0, from_offset)` for the last `"type":"user"` line. Without that,
+/// every appended assistant turn would lose user_message attribution
+/// across cache hits.
+fn parse_claude_source_append(
+    path: &Path,
+    project: &str,
+    project_path: &str,
+    from_offset: u64,
+    existing: &[ProviderCall],
+) -> ParseResult {
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => {
+            return ParseResult {
+                calls: existing.to_vec(),
+                end_offset: from_offset,
+            };
+        }
+    };
+    let total_len = file.metadata().map(|m| m.len()).unwrap_or(from_offset);
+    // Recover the user message that was last in scope at `from_offset`
+    // by reading the prefix [0, from_offset) and walking it for "type":
+    // "user" lines. Without this, every appended assistant turn would
+    // carry an empty user_message and lose attribution. Bounded by
+    // from_offset; only paid on cache-hit append paths.
+    let current_user_message = recover_user_message_before(&mut file, from_offset);
+    if file.seek(SeekFrom::Start(from_offset)).is_err() {
+        return ParseResult {
+            calls: existing.to_vec(),
+            end_offset: from_offset,
+        };
+    }
+    let mut reader = BufReader::new(file);
+    let mut calls = existing.to_vec();
+    let mut current_user_message = current_user_message;
+    // Track the running byte offset so each call's stable id matches
+    // the full-parse path. `read_line` advances exactly the bytes it
+    // consumed (including the trailing newline), so `running_offset`
+    // is the offset of the *next* line at any iteration tip — the
+    // current line's offset is captured before the read.
+    let mut running_offset = from_offset;
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        let line_offset = running_offset;
+        let read = match reader.read_line(&mut buf) {
+            Ok(0) => break, // EOF
+            Ok(n) => n,
+            Err(_) => {
+                // On any I/O or UTF-8 error we cannot safely advance
+                // the cached end_offset — the next run would skip past
+                // the unread tail and silently lose data. Roll the
+                // cursor back to from_offset so the next scan retries
+                // the append. Mirror the Full path's all-or-nothing
+                // semantics.
+                return ParseResult {
+                    calls: existing.to_vec(),
+                    end_offset: from_offset,
+                };
+            }
+        };
+        running_offset += read as u64;
+        let line = buf.strip_suffix('\n').unwrap_or(&buf);
+        if let Some(call) = parse_claude_line(
+            line,
+            path,
+            project,
+            project_path,
+            &mut current_user_message,
+            line_offset,
+        ) {
+            calls.push(call);
+        }
+    }
+    ParseResult {
+        calls,
+        end_offset: total_len,
+    }
+}
+
+/// Walk the prefix `[0, from_offset)` of `file` looking for the last
+/// `"type":"user"` line, returning its extracted message text. Used by
+/// the append parser so user_message attribution survives a cache hit
+/// (the user line that primed the message is in the prefix; without
+/// recovery, every appended assistant turn ends up with an empty
+/// `user_message`).
+///
+/// Errors are absorbed — if the prefix is unreadable we return an empty
+/// string and the next assistant turn's `user_message` is empty (same
+/// fallback as before this fix). Leaves the file cursor at an
+/// undefined offset; the caller must re-seek to `from_offset`.
+fn recover_user_message_before(
+    file: &mut std::fs::File,
+    from_offset: u64,
+) -> String {
+    if from_offset == 0 {
+        return String::new();
+    }
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return String::new();
+    }
+    let limited = file.by_ref().take(from_offset);
+    let reader = BufReader::new(limited);
+    let mut last = String::new();
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            // Partial scan still useful — keep whatever we'd
+            // discovered up to the error.
+            break;
+        };
+        if let Ok(parsed) = serde_json::from_str::<ClaudeLine>(&line) {
+            if parsed.msg_type.as_deref() == Some("user") {
+                if let Some(message) = parsed.message {
+                    last = extract_claude_user_text(message.content.as_ref());
+                }
+            }
+        }
+    }
+    last
+}
+
+/// Parse a single Claude JSONL line. Returns `Some(call)` for assistant
+/// lines that carry usage data; mutates `current_user_message` when a
+/// user line is encountered. None for unrecognized / unparseable lines.
+///
+/// `line_offset` is the byte position of `line` in `path` and feeds the
+/// stable `ProviderCall.id` derivation. The full and append parsers
+/// track the running offset and pass it in.
+fn parse_claude_line(
+    line: &str,
+    path: &Path,
+    project: &str,
+    project_path: &str,
+    current_user_message: &mut String,
+    line_offset: u64,
+) -> Option<ProviderCall> {
+    let parsed: ClaudeLine = serde_json::from_str(line).ok()?;
+    match parsed.msg_type.as_deref() {
+        Some("user") => {
+            if let Some(message) = parsed.message {
+                *current_user_message = extract_claude_user_text(message.content.as_ref());
+            }
+            None
+        }
+        Some("assistant") => {
+            let message = parsed.message?;
+            let usage = message.usage?;
+            let timestamp = parsed.timestamp.as_deref().and_then(parse_timestamp)?;
+
+            let model = message.model.unwrap_or_else(|| "claude-unknown".to_string());
+            let tools = extract_claude_tools(message.content.as_ref());
+            let bash_commands = extract_bash_commands_from_claude_content(message.content.as_ref());
+            let input_tokens = usage.input_tokens.unwrap_or(0);
+            let output_tokens = usage.output_tokens.unwrap_or(0);
+            let cache_creation_tokens = usage.cache_creation_input_tokens.unwrap_or(0);
+            let cache_read_tokens = usage.cache_read_input_tokens.unwrap_or(0);
+            let cost_usd = estimate_cost_usd(
+                &model,
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                0,
+            );
+
+            Some(ProviderCall {
+                id: provider_call_id(path, line_offset),
+                provider: "claude".to_string(),
+                model,
+                session_id: parsed.session_id.unwrap_or_else(|| {
+                    path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("unknown").to_string()
+                }),
+                project: project.to_string(),
+                project_path: parsed.cwd.unwrap_or_else(|| project_path.to_string()),
+                timestamp,
+                input_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                output_tokens,
+                reasoning_tokens: 0,
+                cost_usd,
+                tools,
+                bash_commands,
+                user_message: current_user_message.clone(),
+                branch: parsed.git_branch.filter(|b| !b.is_empty()),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_codex_sources(codex_dir: Option<&Path>, cache: &Cache) -> Vec<ProviderCall> {
+    let Some(codex_dir) = codex_dir else {
+        return Vec::new();
+    };
+    let sessions_dir = codex_dir.join("sessions");
+    if !sessions_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut calls = Vec::new();
+    for file in discover_codex_sources(&sessions_dir) {
+        // Codex sessions accumulate cumulative token totals across the file,
+        // so an append-only parse would need replayed state. For PR-A we
+        // ignore the append hint and always full-parse on change. The cache
+        // still serves the unchanged-fingerprint path.
+        let parsed = cache.get_or_parse(&file, |path, _hint| {
+            let calls = parse_codex_source(path);
+            let end_offset = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+            ParseResult { calls, end_offset }
+        });
+        calls.extend(parsed);
+    }
+    calls
+}
+
+fn discover_codex_sources(sessions_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(years) = std::fs::read_dir(sessions_dir) else {
+        return files;
+    };
+
+    for year in years.filter_map(Result::ok) {
+        let year_path = year.path();
+        if !year_path.is_dir() || !is_date_component(&year_path, 4) {
+            continue;
+        }
+        let Ok(months) = std::fs::read_dir(year_path) else {
+            continue;
+        };
+        for month in months.filter_map(Result::ok) {
+            let month_path = month.path();
+            if !month_path.is_dir() || !is_date_component(&month_path, 2) {
+                continue;
+            }
+            let Ok(days) = std::fs::read_dir(month_path) else {
+                continue;
+            };
+            for day in days.filter_map(Result::ok) {
+                let day_path = day.path();
+                if !day_path.is_dir() || !is_date_component(&day_path, 2) {
+                    continue;
+                }
+                let Ok(entries) = std::fs::read_dir(day_path) else {
+                    continue;
+                };
+                for entry in entries.filter_map(Result::ok) {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                        continue;
+                    };
+                    if name.starts_with("rollout-")
+                        && name.ends_with(".jsonl")
+                        && is_valid_codex_session(&path)
+                    {
+                        files.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    files
+}
+
+fn parse_codex_source(path: &Path) -> Vec<ProviderCall> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut calls = Vec::new();
+    let mut session_id =
+        path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("unknown").to_string();
+    let mut session_model: Option<String> = None;
+    let mut cwd = "unknown".to_string();
+    let mut project = "unknown".to_string();
+    let mut previous_cumulative_total = 0_u64;
+    let mut previous_input = 0_u64;
+    let mut previous_cached = 0_u64;
+    let mut previous_output = 0_u64;
+    let mut previous_reasoning = 0_u64;
+    let mut pending_tools: Vec<String> = Vec::new();
+    let mut pending_user_message = String::new();
+
+    // Mirror the Claude parser's offset-tracking so each codex call
+    // carries a stable `(path, offset)` id. `split_inclusive` ensures
+    // the trailing newline is counted in the per-line advance.
+    let mut offset: u64 = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line_offset = offset;
+        offset += chunk.len() as u64;
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
+        let entry: CodexEntry = match serde_json::from_str(line) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+
+        let payload = entry.payload.as_ref();
+
+        if entry.entry_type == "session_meta" {
+            if let Some(payload) = payload {
+                if let Some(id) = &payload.session_id {
+                    session_id = id.clone();
+                }
+                if let Some(model) = &payload.model {
+                    session_model = Some(model.clone());
+                }
+                if let Some(session_cwd) = &payload.cwd {
+                    cwd = session_cwd.clone();
+                    project = sanitize_codex_project(session_cwd);
+                }
+            }
+            continue;
+        }
+
+        if entry.entry_type == "turn_context" {
+            if let Some(model) = payload.and_then(|payload| payload.model.as_ref()) {
+                session_model = Some(model.clone());
+            }
+            continue;
+        }
+
+        if entry.entry_type == "response_item"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("function_call")
+        {
+            if let Some(raw_name) = payload.and_then(|p| p.name.as_deref()) {
+                pending_tools.push(normalize_codex_tool(raw_name).to_string());
+            }
+            continue;
+        }
+
+        if entry.entry_type == "event_msg"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("patch_apply_end")
+        {
+            pending_tools.push("Edit".to_string());
+            continue;
+        }
+
+        if entry.entry_type == "response_item"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("message")
+            && payload.and_then(|p| p.role.as_deref()) == Some("user")
+        {
+            let texts = payload
+                .and_then(|p| p.content.as_ref())
+                .map(|content| {
+                    content
+                        .iter()
+                        .filter(|item| item.content_type.as_deref() == Some("input_text"))
+                        .filter_map(|item| item.text.as_deref())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            if !texts.is_empty() {
+                pending_user_message = texts;
+            }
+            continue;
+        }
+
+        if entry.entry_type != "event_msg"
+            || payload.and_then(|p| p.payload_type.as_deref()) != Some("token_count")
+        {
+            continue;
+        }
+
+        let Some(info) = payload.and_then(|p| p.info.as_ref()) else {
+            continue;
+        };
+
+        let cumulative_total =
+            info.total_token_usage.and_then(|usage| usage.total_tokens).unwrap_or(0);
+        if cumulative_total > 0 && cumulative_total == previous_cumulative_total {
+            continue;
+        }
+        previous_cumulative_total = cumulative_total;
+
+        let (input_tokens, cached_tokens, output_tokens, reasoning_tokens) =
+            if let Some(last) = info.last_token_usage {
+                let input = last.input_tokens.unwrap_or(0);
+                let cached = last.cached_input_tokens.unwrap_or(0);
+                let output = last.output_tokens.unwrap_or(0);
+                let reasoning = last.reasoning_output_tokens.unwrap_or(0);
+
+                if let Some(total) = info.total_token_usage {
+                    previous_input = total.input_tokens.unwrap_or(previous_input + input);
+                    previous_cached = total.cached_input_tokens.unwrap_or(previous_cached + cached);
+                    previous_output = total.output_tokens.unwrap_or(previous_output + output);
+                    previous_reasoning =
+                        total.reasoning_output_tokens.unwrap_or(previous_reasoning + reasoning);
+                } else {
+                    previous_input += input;
+                    previous_cached += cached;
+                    previous_output += output;
+                    previous_reasoning += reasoning;
+                }
+
+                (input, cached, output, reasoning)
+            } else if let Some(total) = info.total_token_usage {
+                let input = total.input_tokens.unwrap_or(0).saturating_sub(previous_input);
+                let cached = total.cached_input_tokens.unwrap_or(0).saturating_sub(previous_cached);
+                let output = total.output_tokens.unwrap_or(0).saturating_sub(previous_output);
+                let reasoning =
+                    total.reasoning_output_tokens.unwrap_or(0).saturating_sub(previous_reasoning);
+
+                previous_input = total.input_tokens.unwrap_or(0);
+                previous_cached = total.cached_input_tokens.unwrap_or(0);
+                previous_output = total.output_tokens.unwrap_or(0);
+                previous_reasoning = total.reasoning_output_tokens.unwrap_or(0);
+
+                (input, cached, output, reasoning)
+            } else {
+                continue;
+            };
+
+        if input_tokens + cached_tokens + output_tokens + reasoning_tokens == 0 {
+            continue;
+        }
+
+        let Some(timestamp) = entry.timestamp.as_deref().and_then(parse_timestamp) else {
+            continue;
+        };
+
+        let uncached_input_tokens = input_tokens.saturating_sub(cached_tokens);
+        let model = resolve_codex_model(payload, session_model.as_deref());
+        let cost_usd = estimate_cost_usd(
+            &model,
+            uncached_input_tokens,
+            output_tokens + reasoning_tokens,
+            0,
+            cached_tokens,
+            0,
+        );
+
+        calls.push(ProviderCall {
+            id: provider_call_id(path, line_offset),
+            provider: "codex".to_string(),
+            model,
+            session_id: session_id.clone(),
+            project: project.clone(),
+            project_path: cwd.clone(),
+            timestamp,
+            input_tokens: uncached_input_tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens: cached_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cost_usd,
+            tools: std::mem::take(&mut pending_tools),
+            bash_commands: Vec::new(),
+            user_message: std::mem::take(&mut pending_user_message),
+            branch: None,
+        });
+    }
+
+    calls
+}
+
+// TODO(refactor): the function below ingests `calls` into ten parallel
+// accumulators (daily, weekly, projects, sessions, models, branches,
+// activities, tools, mcp, shell). Extract a per-dimension Accumulator
+// trait so each one is unit-testable in isolation; orchestrator
+// becomes `for call in calls { for acc in &mut accumulators { acc.ingest(call) } }`.
+// Deferred — large refactor with no functional delta. The
+// analyze_turns precompute that previously gated this work has landed,
+// so a future pass is unblocked.
+fn aggregate_calls(calls: Vec<ProviderCall>) -> UsageData {
+    aggregate_calls_with_analysis(calls, None)
+}
+
+/// Variant of `aggregate_calls` that accepts an optional precomputed
+/// `analyze_turns` result keyed by `ProviderCall.id`. When `Some`, the
+/// per-call analysis is looked up by id rather than re-walking the
+/// session timeline — this is what `filter_usage_data` uses so chip
+/// pivots don't pay a fresh O(N) timeline scan on each re-aggregate.
+///
+/// Fallback semantics: only `None` triggers a local `analyze_turns`
+/// recompute. `Some(map)` is trusted as authoritative — calls whose id
+/// is missing from the map silently get a default `TurnAnalysis` (zero
+/// retries, zero edits). Callers passing `Some` must ensure every
+/// `call.id` in the unfiltered superset appears in the precompute.
+fn aggregate_calls_with_analysis(
+    mut calls: Vec<ProviderCall>,
+    precomputed_analysis: Option<&HashMap<u64, TurnAnalysis>>,
+) -> UsageData {
+    if calls.is_empty() {
+        return UsageData::default();
+    }
+
+    calls.sort_by_key(|call| call.timestamp);
+    // Local fallback only if the caller didn't precompute. Using the
+    // precomputed map preserves correctness across filtering: a call's
+    // retry count is measured against its *own* session's timeline in
+    // the unfiltered set, not against whatever subset survived the
+    // filter.
+    let local_analysis: HashMap<u64, TurnAnalysis>;
+    let turn_analysis: &HashMap<u64, TurnAnalysis> = match precomputed_analysis {
+        Some(m) => m,
+        None => {
+            local_analysis = analyze_turns(&calls);
+            &local_analysis
+        }
+    };
+
+    let mut daily_map: HashMap<NaiveDate, (HashSet<String>, HashSet<String>, TokenBucket)> =
+        HashMap::new();
+    // Project aggregation key is the *display* name: the upstream repo
+    // id (e.g. "owner/repo") when resolvable, otherwise the local
+    // folder/sanitised project name. This is what collapses two
+    // worktrees of the same repo into one ProjectUsage row.
+    //
+    // Value tuple: (project_path, session_keys, bucket, repo_marker).
+    // `repo_marker` is `Some(owner/repo)` when the key came from the
+    // remote and `None` when it fell back to the folder name.
+    let mut project_map: HashMap<String, (String, HashSet<String>, TokenBucket, Option<String>)> =
+        HashMap::new();
+    // Per-cwd repo lookup cache: shared across the loop so each
+    // distinct working directory is parsed at most once.
+    let mut repo_cache: HashMap<String, Option<String>> = HashMap::new();
+    let mut session_map: HashMap<String, SessionUsageAccumulator> = HashMap::new();
+    let mut model_map: HashMap<String, TokenBucket> = HashMap::new();
+    let mut branch_map: HashMap<String, TokenBucket> = HashMap::new();
+    let mut activity_map: HashMap<ActivityCategory, ActivityAccumulator> = HashMap::new();
+    let mut tool_map: HashMap<String, usize> = HashMap::new();
+    let mut mcp_map: HashMap<String, usize> = HashMap::new();
+    let mut shell_map: HashMap<String, usize> = HashMap::new();
+
+    for call in &calls {
+        let bucket = call.bucket();
+        // Daily bucketing is a user-facing calendar concept: render and
+        // the period bounds both treat "a day" as a local-tz day, so the
+        // grouping key has to be local. The cached call timestamp is
+        // Utc — convert at the boundary.
+        let day = call.timestamp.with_timezone(&Local).date_naive();
+        let session_key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
+
+        // Resolve the call's working directory to an upstream repo id
+        // so worktrees collapse. Falls back to the folder/sanitised
+        // project name when the cwd isn't a git repo or has no origin.
+        let resolved_repo = repo_lookup::resolve_repo(&call.project_path, &mut repo_cache);
+        let project_key = resolved_repo.clone().unwrap_or_else(|| call.project.clone());
+
+        let daily = daily_map.entry(day).or_default();
+        daily.0.insert(project_key.clone());
+        daily.1.insert(session_key.clone());
+        daily.2.merge(&bucket);
+
+        let project = project_map.entry(project_key.clone()).or_insert_with(|| {
+            (
+                call.project_path.clone(),
+                HashSet::new(),
+                TokenBucket::default(),
+                resolved_repo.clone(),
+            )
+        });
+        project.0 = call.project_path.clone();
+        project.1.insert(session_key.clone());
+        project.2.merge(&bucket);
+        // Once a row is keyed by the upstream repo, keep it that way
+        // even if a later call from the same key fails resolution.
+        if project.3.is_none() && resolved_repo.is_some() {
+            project.3 = resolved_repo.clone();
+        }
+
+        let session = session_map.entry(session_key).or_insert_with(|| SessionUsageAccumulator {
+            provider: call.provider.clone(),
+            project: call.project.clone(),
+            session_id: call.session_id.clone(),
+            first_timestamp: call.timestamp,
+            last_timestamp: call.timestamp,
+            bucket: TokenBucket::default(),
+        });
+        if call.timestamp < session.first_timestamp {
+            session.first_timestamp = call.timestamp;
+        }
+        if call.timestamp > session.last_timestamp {
+            session.last_timestamp = call.timestamp;
+        }
+        session.bucket.merge(&bucket);
+
+        add_bucket(&mut model_map, call.model.clone(), &bucket);
+
+        if let Some(branch) = call.recorded_branch() {
+            add_bucket(&mut branch_map, branch.to_string(), &bucket);
+        }
+
+        let analysis = turn_analysis.get(&call.id).copied().unwrap_or_else(|| TurnAnalysis {
+            category: classify_activity(call),
+            retries: 0,
+            has_edits: has_edit_tool(&call.tools),
+        });
+        let activity = activity_map.entry(analysis.category).or_default();
+        activity.bucket.merge(&bucket);
+        activity.turns += 1;
+        activity.retries += analysis.retries;
+        if analysis.has_edits {
+            activity.edit_turns += 1;
+            if analysis.retries == 0 {
+                activity.one_shot_turns += 1;
+            }
+        }
+
+        for tool in &call.tools {
+            if let Some(server) =
+                tool.strip_prefix("mcp__").and_then(|rest| rest.split("__").next())
+            {
+                bump(&mut mcp_map, server.to_string());
+            } else {
+                bump(&mut tool_map, tool.clone());
+            }
+        }
+        for command in &call.bash_commands {
+            bump(&mut shell_map, command.clone());
+        }
+    }
+
+    let mut daily: Vec<_> = daily_map
+        .into_iter()
+        .map(|(date, (projects, sessions, mut bucket))| {
+            bucket.project_count = projects.len();
+            bucket.session_count = sessions.len();
+            (date, bucket)
+        })
+        .collect();
+    daily.sort_by_key(|(date, _)| *date);
+
+    let mut weekly = aggregate_weekly(&daily);
+
+    let mut projects: Vec<_> = project_map
+        .into_iter()
+        .map(|(name, (path, sessions, mut bucket, repo))| {
+            bucket.session_count = sessions.len();
+            ProjectUsage {
+                name,
+                path,
+                bucket,
+                repo,
+            }
+        })
+        .collect();
+    sort_by_bucket_desc(&mut projects, |p| &p.bucket);
+
+    let mut sessions: Vec<_> =
+        session_map.into_values().map(SessionUsageAccumulator::into_usage).collect();
+    sort_by_bucket_desc(&mut sessions, |s| &s.bucket);
+
+    let mut models: Vec<_> = model_map
+        .into_iter()
+        .map(|(model, bucket)| ModelUsage { model, bucket })
+        .collect();
+    sort_by_bucket_desc(&mut models, |m| &m.bucket);
+
+    let mut branches: Vec<_> = branch_map
+        .into_iter()
+        .map(|(branch, bucket)| BranchUsage { branch, bucket })
+        .collect();
+    sort_by_bucket_desc(&mut branches, |b| &b.bucket);
+
+    let tools = sorted_named_usage(tool_map);
+    let mcp_servers = sorted_named_usage(mcp_map);
+    let shell_commands = sorted_named_usage(shell_map);
+    let activities = sorted_activities(activity_map);
+
+    let mut grand_total = TokenBucket::default();
+    for (_, bucket) in &daily {
+        grand_total.merge(bucket);
+    }
+    grand_total.session_count = sessions.len();
+    grand_total.project_count = projects.len();
+
+    debug!(
+        "Parsed usage: {} days, {} weeks, {} projects, {} calls, {} total tokens",
+        daily.len(),
+        weekly.len(),
+        projects.len(),
+        calls.len(),
+        grand_total.total()
+    );
+
+    let model_project_counts = build_model_project_counts(&calls);
+
+    UsageData {
+        daily,
+        weekly: {
+            weekly.sort_by_key(|(date, _)| *date);
+            weekly
+        },
+        projects,
+        grand_total,
+        calls,
+        sessions,
+        models,
+        activities,
+        tools,
+        mcp_servers,
+        shell_commands,
+        branches,
+        model_project_counts,
+    }
+}
+
+/// Build the `model -> [(project, count), ...]` index used by the
+/// burndown render path's "top N projects for model X" lookup. Sorted
+/// desc by count so the render call is `take(n)` with no extra work.
+fn build_model_project_counts(
+    calls: &[ProviderCall],
+) -> HashMap<String, Vec<(String, usize)>> {
+    let mut by_model: HashMap<String, HashMap<String, usize>> = HashMap::new();
+    for call in calls {
+        *by_model
+            .entry(call.model.clone())
+            .or_default()
+            .entry(call.project.clone())
+            .or_insert(0) += 1;
+    }
+    by_model
+        .into_iter()
+        .map(|(model, projs)| {
+            let mut v: Vec<(String, usize)> = projs.into_iter().collect();
+            v.sort_by(|a, b| b.1.cmp(&a.1));
+            (model, v)
+        })
+        .collect()
+}
+
+/// Filter an already-parsed `UsageData` by exact-match cross-filters.
+///
+/// Returns a new `UsageData` with `calls`, `daily`, `weekly`, `projects`,
+/// `sessions`, `models`, `activities`, `tools`, `mcp_servers`,
+/// `shell_commands`, and `grand_total` re-aggregated from the filtered
+/// call set. If no filters are active the original data is returned
+/// unchanged via clone.
+///
+/// This is the in-memory pivot used by:
+/// - the TUI cross-filter (Grafana-style click-to-pivot on rows), and
+/// - the CLI `--project / --model / --activity / --session` flags after
+///   the period+provider+include/exclude pre-pass.
+///
+/// The activity filter compares against the per-call classified category
+/// label (see `ActivityCategory::label()`), case-sensitive.
+pub fn filter_usage_data(data: &UsageData, filters: &UsageFilters) -> UsageData {
+    if filters.is_empty() {
+        return data.clone();
+    }
+    // Precompute analyze_turns once on the *unfiltered* call set so
+    // each call's retry/has_edits classification reflects its actual
+    // session timeline, not the post-filter subset (a retry that
+    // happened before a filtered-out edit still counts). The
+    // aggregate path looks up by ProviderCall.id, which is stable
+    // across the filter-and-sort pipeline.
+    let turn_analysis = analyze_turns(&data.calls);
+    let filtered_calls: Vec<ProviderCall> = data
+        .calls
+        .iter()
+        .filter(|call| filters.matches(call, classify_activity(call)))
+        .cloned()
+        .collect();
+    aggregate_calls_with_analysis(filtered_calls, Some(&turn_analysis))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TurnAnalysis {
+    category: ActivityCategory,
+    retries: usize,
+    has_edits: bool,
+}
+
+#[derive(Debug, Default)]
+struct ActivityAccumulator {
+    bucket: TokenBucket,
+    turns: usize,
+    retries: usize,
+    edit_turns: usize,
+    one_shot_turns: usize,
+}
+
+/// Walk the per-session timeline and produce a per-call
+/// `TurnAnalysis` keyed by `ProviderCall.id`. Idempotent on the same
+/// inputs — produced once on the unfiltered call set in
+/// `filter_usage_data` and reused across chip-pivot re-aggregates so
+/// each chip switch costs an O(1) lookup per call instead of an O(N)
+/// timeline rewalk over the filtered subset.
+///
+/// Keying on `id` (rather than the previous positional `idx`) means the
+/// map survives sorting and filtering: the precompute can be done on
+/// the unfiltered set and consumed by `aggregate_calls_with_analysis`
+/// after `filter_usage_data` has dropped non-matching calls.
+fn analyze_turns(calls: &[ProviderCall]) -> HashMap<u64, TurnAnalysis> {
+    let mut sessions: HashMap<String, Vec<usize>> = HashMap::new();
+    for (idx, call) in calls.iter().enumerate() {
+        let key = format!("{}:{}:{}", call.provider, call.project, call.session_id);
+        sessions.entry(key).or_default().push(idx);
+    }
+
+    let mut analysis = HashMap::new();
+    for mut indices in sessions.into_values() {
+        indices.sort_by_key(|idx| calls[*idx].timestamp);
+
+        let mut edit_seen = false;
+        let mut bash_after_edit = false;
+        for idx in indices {
+            let call = &calls[idx];
+            let has_edits = has_edit_tool(&call.tools);
+            let has_bash = has_bash_tool(call);
+            let retries = usize::from(has_edits && bash_after_edit);
+
+            if has_edits {
+                edit_seen = true;
+                bash_after_edit = false;
+            }
+            if has_bash && edit_seen {
+                bash_after_edit = true;
+            }
+
+            analysis.insert(
+                call.id,
+                TurnAnalysis {
+                    category: classify_activity(call),
+                    retries,
+                    has_edits,
+                },
+            );
+        }
+    }
+
+    analysis
+}
+
+fn classify_activity(call: &ProviderCall) -> ActivityCategory {
+    let base = if has_tool(&call.tools, &["EnterPlanMode", "TodoWrite", "Plan"]) {
+        ActivityCategory::Planning
+    } else if has_tool(&call.tools, &["Agent", "Task"]) {
+        ActivityCategory::Delegation
+    } else if call.bash_commands.iter().any(|command| command_matches(command, &["git"])) {
+        ActivityCategory::Git
+    } else if call.bash_commands.iter().any(|command| {
+        command_matches(
+            command,
+            &["cargo", "npm", "pnpm", "yarn", "docker", "kubectl", "make"],
+        )
+    }) {
+        ActivityCategory::BuildDeploy
+    } else if has_edit_tool(&call.tools) {
+        ActivityCategory::Coding
+    } else if has_tool(
+        &call.tools,
+        &[
+            "Read",
+            "Glob",
+            "Grep",
+            "LS",
+            "Search",
+            "WebSearch",
+            "Fetch",
+            "ReadFile",
+        ],
+    ) || call.tools.iter().any(|tool| tool.starts_with("mcp__"))
+    {
+        ActivityCategory::Exploration
+    } else if call.user_message.trim().is_empty() && !has_any_tool(call) {
+        ActivityCategory::General
+    } else {
+        ActivityCategory::Conversation
+    };
+
+    refine_activity_with_message(base, &call.user_message)
+}
+
+fn refine_activity_with_message(base: ActivityCategory, message: &str) -> ActivityCategory {
+    let text = message.to_lowercase();
+    if contains_any(&text, &["debug", "bug", "error", "fail", "failing", "fix"]) {
+        ActivityCategory::Debugging
+    } else if contains_any(&text, &["test", "spec", "coverage", "assert"]) {
+        ActivityCategory::Testing
+    } else if contains_any(&text, &["refactor", "cleanup", "rename", "simplify"]) {
+        ActivityCategory::Refactoring
+    } else if contains_any(&text, &["feature", "implement", "add support", "build"]) {
+        ActivityCategory::Feature
+    } else if contains_any(&text, &["brainstorm", "ideas", "options"]) {
+        ActivityCategory::Brainstorming
+    } else if contains_any(&text, &["research", "investigate", "look into", "explore"]) {
+        ActivityCategory::Exploration
+    } else {
+        base
+    }
+}
+
+fn has_any_tool(call: &ProviderCall) -> bool {
+    !call.tools.is_empty() || !call.bash_commands.is_empty()
+}
+
+fn has_edit_tool(tools: &[String]) -> bool {
+    has_tool(
+        tools,
+        &[
+            "Edit",
+            "Write",
+            "MultiEdit",
+            "NotebookEdit",
+            "FileEditTool",
+            "FileWriteTool",
+        ],
+    )
+}
+
+fn has_bash_tool(call: &ProviderCall) -> bool {
+    has_tool(&call.tools, &["Bash", "Shell", "exec_command"]) || !call.bash_commands.is_empty()
+}
+
+fn has_tool(tools: &[String], names: &[&str]) -> bool {
+    tools.iter().any(|tool| names.iter().any(|name| tool == name))
+}
+
+fn command_matches(command: &str, names: &[&str]) -> bool {
+    let trimmed = command.trim_start();
+    names
+        .iter()
+        .any(|name| trimmed == *name || trimmed.starts_with(&format!("{name} ")))
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn sorted_activities(map: HashMap<ActivityCategory, ActivityAccumulator>) -> Vec<ActivityUsage> {
+    let mut rows: Vec<_> = map
+        .into_iter()
+        .map(|(category, activity)| ActivityUsage {
+            category,
+            bucket: activity.bucket,
+            turns: activity.turns,
+            retries: activity.retries,
+            edit_turns: activity.edit_turns,
+            one_shot_turns: activity.one_shot_turns,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        bucket_sort_value(&b.bucket)
+            .total_cmp(&bucket_sort_value(&a.bucket))
+            .then_with(|| activity_rank(a.category).cmp(&activity_rank(b.category)))
+    });
+    rows
+}
+
+fn activity_rank(category: ActivityCategory) -> usize {
+    match category {
+        ActivityCategory::Coding => 0,
+        ActivityCategory::Debugging => 1,
+        ActivityCategory::Feature => 2,
+        ActivityCategory::Refactoring => 3,
+        ActivityCategory::Testing => 4,
+        ActivityCategory::Exploration => 5,
+        ActivityCategory::Planning => 6,
+        ActivityCategory::Delegation => 7,
+        ActivityCategory::Git => 8,
+        ActivityCategory::BuildDeploy => 9,
+        ActivityCategory::Brainstorming => 10,
+        ActivityCategory::Conversation => 11,
+        ActivityCategory::General => 12,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStatus {
+    Under,
+    Near,
+    Over,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanProjection {
+    pub period_start: NaiveDate,
+    pub period_end: NaiveDate,
+    pub monthly_usd: f64,
+    pub spent_usd: f64,
+    pub percent_used: f64,
+    pub projected_usd: f64,
+    pub status: PlanStatus,
+    pub remaining_days: i64,
+}
+
+pub fn project_plan_usage(
+    data: &UsageData,
+    plan: &crate::config::UsagePlan,
+    today: NaiveDate,
+) -> PlanProjection {
+    let (period_start, period_end) = billing_period(today, plan.reset_day);
+    let spent_usd = plan_cost_for_range(data, plan.provider, period_start, period_end);
+    let percent_used = if plan.monthly_usd > 0.0 {
+        spent_usd / plan.monthly_usd
+    } else {
+        0.0
+    };
+    let mut last_week: Vec<f64> = (0..7)
+        .map(|offset| {
+            let date = today - Duration::days(offset);
+            plan_cost_for_range(data, plan.provider, date, date)
+        })
+        .collect();
+    last_week.sort_by(f64::total_cmp);
+    let median_daily = last_week[last_week.len() / 2];
+    let remaining_days = (period_end - today).num_days().max(0);
+    let projected_usd = spent_usd + median_daily * remaining_days as f64;
+    let status = if percent_used > 1.0 {
+        PlanStatus::Over
+    } else if percent_used >= 0.8 {
+        PlanStatus::Near
+    } else {
+        PlanStatus::Under
+    };
+
+    PlanProjection {
+        period_start,
+        period_end,
+        monthly_usd: plan.monthly_usd,
+        spent_usd,
+        percent_used,
+        projected_usd,
+        status,
+        remaining_days,
+    }
+}
+
+fn plan_cost_for_range(
+    data: &UsageData,
+    provider: crate::config::UsagePlanProvider,
+    start: NaiveDate,
+    end: NaiveDate,
+) -> f64 {
+    let call_cost = data
+        .calls
+        .iter()
+        .filter(|call| {
+            // start/end are NaiveDate in the user's local calendar;
+            // bucket the Utc timestamp into the same calendar.
+            let date = call.timestamp.with_timezone(&Local).date_naive();
+            date >= start && date <= end && plan_provider_includes(provider, &call.provider)
+        })
+        .filter_map(|call| call.cost_usd)
+        .sum::<f64>();
+
+    if call_cost > 0.0 || provider != crate::config::UsagePlanProvider::All {
+        return call_cost;
+    }
+
+    data.daily
+        .iter()
+        .filter(|(date, _)| *date >= start && *date <= end)
+        .filter_map(|(_, bucket)| bucket.cost_usd)
+        .sum::<f64>()
+}
+
+fn plan_provider_includes(provider: crate::config::UsagePlanProvider, call_provider: &str) -> bool {
+    match provider {
+        crate::config::UsagePlanProvider::All => true,
+        crate::config::UsagePlanProvider::Claude => call_provider == "claude",
+        crate::config::UsagePlanProvider::Codex => call_provider == "codex",
+        crate::config::UsagePlanProvider::Cursor => call_provider == "cursor",
+    }
+}
+
+pub fn billing_period(today: NaiveDate, reset_day: u8) -> (NaiveDate, NaiveDate) {
+    let reset_day = reset_day.clamp(1, 28) as u32;
+    let current_reset =
+        NaiveDate::from_ymd_opt(today.year(), today.month(), reset_day).unwrap_or(today);
+    let start = if today >= current_reset {
+        current_reset
+    } else {
+        add_months(current_reset, -1)
+    };
+    let end = add_months(start, 1) - Duration::days(1);
+    (start, end)
+}
+
+fn add_months(date: NaiveDate, months: i32) -> NaiveDate {
+    let month_index = date.year() * 12 + date.month() as i32 - 1 + months;
+    let year = month_index.div_euclid(12);
+    let month = month_index.rem_euclid(12) as u32 + 1;
+    NaiveDate::from_ymd_opt(year, month, date.day()).unwrap_or(date)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Impact {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HealthGrade {
+    A,
+    B,
+    C,
+    D,
+    F,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WasteAction {
+    pub label: String,
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WasteFinding {
+    pub id: String,
+    pub title: String,
+    pub impact: Impact,
+    pub tokens_saved: u64,
+    pub details: String,
+    pub actions: Vec<WasteAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptimizeResult {
+    pub score: u8,
+    pub grade: HealthGrade,
+    pub potential_tokens_saved: u64,
+    pub findings: Vec<WasteFinding>,
+}
+
+pub fn optimize_usage(data: &UsageData) -> OptimizeResult {
+    let mut findings = Vec::new();
+    let read_calls =
+        data.tools.iter().find(|tool| tool.name == "Read").map_or(0, |tool| tool.calls);
+    let edit_calls =
+        data.tools.iter().find(|tool| tool.name == "Edit").map_or(0, |tool| tool.calls);
+    let bash_calls =
+        data.tools.iter().find(|tool| tool.name == "Bash").map_or(0, |tool| tool.calls);
+
+    if read_calls > edit_calls.saturating_mul(8).max(8) {
+        findings.push(WasteFinding {
+            id: "low-read-edit-ratio".to_string(),
+            title: "Heavy reading before edits".to_string(),
+            impact: Impact::Medium,
+            tokens_saved: data.grand_total.input_tokens / 10,
+            details: format!("{read_calls} reads for {edit_calls} edits"),
+            actions: vec![WasteAction {
+                label: "Prefer targeted file reads and ripgrep before broad scans".to_string(),
+                command: None,
+            }],
+        });
+    }
+
+    let cache_tokens = data.grand_total.cache_creation_tokens + data.grand_total.cache_read_tokens;
+    if cache_tokens > data.grand_total.input_tokens.saturating_mul(2) {
+        findings.push(WasteFinding {
+            id: "cache-bloat".to_string(),
+            title: "Large cache footprint".to_string(),
+            impact: Impact::Low,
+            tokens_saved: cache_tokens / 20,
+            details: format!("{} cached tokens", format_tokens_short(cache_tokens)),
+            actions: vec![WasteAction {
+                label: "Keep prompts and context focused for long sessions".to_string(),
+                command: None,
+            }],
+        });
+    }
+
+    if bash_calls > data.grand_total.call_count.saturating_mul(3).max(10) {
+        findings.push(WasteFinding {
+            id: "bash-output-bloat".to_string(),
+            title: "Frequent shell output".to_string(),
+            impact: Impact::Medium,
+            tokens_saved: data.grand_total.output_tokens / 12,
+            details: format!("{bash_calls} shell calls"),
+            actions: vec![WasteAction {
+                label: "Pipe large command output through focused filters".to_string(),
+                command: Some("rg <pattern> <path>".to_string()),
+            }],
+        });
+    }
+
+    let agent_calls =
+        data.tools.iter().find(|tool| tool.name == "Agent").map_or(0, |tool| tool.calls);
+    if agent_calls > data.sessions.len().saturating_mul(5).max(5) {
+        findings.push(WasteFinding {
+            id: "ghost-agents".to_string(),
+            title: "High agent delegation count".to_string(),
+            impact: Impact::High,
+            tokens_saved: data.grand_total.total() / 8,
+            details: format!(
+                "{agent_calls} agent calls across {} sessions",
+                data.sessions.len()
+            ),
+            actions: vec![WasteAction {
+                label: "Close unused agent tasks and keep delegated scope narrow".to_string(),
+                command: None,
+            }],
+        });
+    }
+
+    findings.sort_by(|a, b| {
+        impact_weight(b.impact)
+            .cmp(&impact_weight(a.impact))
+            .then_with(|| b.tokens_saved.cmp(&a.tokens_saved))
+    });
+    let penalties: u8 = findings
+        .iter()
+        .map(|finding| match finding.impact {
+            Impact::High => 15,
+            Impact::Medium => 7,
+            Impact::Low => 3,
+        })
+        .sum();
+    let score = 100_u8.saturating_sub(penalties).max(20);
+    let grade = health_grade(score);
+    let potential_tokens_saved = findings.iter().map(|finding| finding.tokens_saved).sum();
+
+    OptimizeResult {
+        score,
+        grade,
+        potential_tokens_saved,
+        findings,
+    }
+}
+
+fn impact_weight(impact: Impact) -> u8 {
+    match impact {
+        Impact::High => 3,
+        Impact::Medium => 2,
+        Impact::Low => 1,
+    }
+}
+
+fn health_grade(score: u8) -> HealthGrade {
+    match score {
+        90..=100 => HealthGrade::A,
+        75..=89 => HealthGrade::B,
+        55..=74 => HealthGrade::C,
+        30..=54 => HealthGrade::D,
+        _ => HealthGrade::F,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelComparison {
+    pub model: String,
+    pub bucket: TokenBucket,
+    pub calls: usize,
+    pub edit_turns: usize,
+    pub one_shot_turns: usize,
+    pub retries: usize,
+    pub cost_per_call: Option<f64>,
+    pub tokens_per_call: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompareResult {
+    pub models: Vec<ModelComparison>,
+    pub winner: Option<String>,
+    pub low_data: bool,
+}
+
+pub fn compare_models(data: &UsageData) -> CompareResult {
+    let mut rows: Vec<ModelComparison> = data
+        .models
+        .iter()
+        .map(|model| {
+            let calls = model.bucket.call_count.max(1);
+            let edit_turns = data
+                .calls
+                .iter()
+                .filter(|call| call.model == model.model && has_edit_tool(&call.tools))
+                .count();
+            let retries = data
+                .calls
+                .iter()
+                .filter(|call| call.model == model.model)
+                .filter(|call| call.user_message.to_lowercase().contains("fix"))
+                .count();
+            let one_shot_turns = edit_turns.saturating_sub(retries);
+            ModelComparison {
+                model: model.model.clone(),
+                bucket: model.bucket.clone(),
+                calls,
+                edit_turns,
+                one_shot_turns,
+                retries,
+                cost_per_call: model.bucket.cost_usd.map(|cost| cost / calls as f64),
+                tokens_per_call: model.bucket.total() / calls as u64,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.one_shot_turns
+            .cmp(&a.one_shot_turns)
+            .then_with(|| a.retries.cmp(&b.retries))
+            .then_with(|| {
+                a.cost_per_call
+                    .unwrap_or(f64::MAX)
+                    .total_cmp(&b.cost_per_call.unwrap_or(f64::MAX))
+            })
+    });
+    let low_data = rows.iter().map(|row| row.calls).sum::<usize>() < 5 || rows.len() < 2;
+    let winner = rows.first().map(|row| row.model.clone());
+    CompareResult {
+        models: rows,
+        winner,
+        low_data,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct YieldResult {
+    pub productive_usd: f64,
+    pub reverted_usd: f64,
+    pub abandoned_usd: f64,
+    pub productive_sessions: usize,
+    pub reverted_sessions: usize,
+    pub abandoned_sessions: usize,
+}
+
+pub fn analyze_yield(data: &UsageData) -> YieldResult {
+    let mut result = YieldResult {
+        productive_usd: 0.0,
+        reverted_usd: 0.0,
+        abandoned_usd: 0.0,
+        productive_sessions: 0,
+        reverted_sessions: 0,
+        abandoned_sessions: 0,
+    };
+
+    for session in &data.sessions {
+        let cost = session.bucket.cost_usd.unwrap_or(0.0);
+        let has_git = data.calls.iter().any(|call| {
+            call.session_id == session.session_id
+                && call.bash_commands.iter().any(|cmd| cmd.trim_start().starts_with("git "))
+        });
+        let reverted = data.calls.iter().any(|call| {
+            call.session_id == session.session_id
+                && call.user_message.to_lowercase().contains("revert")
+        });
+        if reverted {
+            result.reverted_sessions += 1;
+            result.reverted_usd += cost;
+        } else if has_git {
+            result.productive_sessions += 1;
+            result.productive_usd += cost;
+        } else {
+            result.abandoned_sessions += 1;
+            result.abandoned_usd += cost;
+        }
+    }
+
+    result
+}
+
+struct SessionUsageAccumulator {
+    provider: String,
+    project: String,
+    session_id: String,
+    first_timestamp: DateTime<Utc>,
+    last_timestamp: DateTime<Utc>,
+    bucket: TokenBucket,
+}
+
+impl SessionUsageAccumulator {
+    fn into_usage(mut self) -> SessionUsage {
+        self.bucket.session_count = 1;
+        SessionUsage {
+            provider: self.provider,
+            project: self.project,
+            session_id: self.session_id,
+            first_timestamp: self.first_timestamp,
+            last_timestamp: self.last_timestamp,
+            bucket: self.bucket,
+        }
+    }
+}
+
+fn aggregate_weekly(daily: &[(NaiveDate, TokenBucket)]) -> Vec<(NaiveDate, TokenBucket)> {
+    let mut weekly_map: HashMap<NaiveDate, TokenBucket> = HashMap::new();
+
+    for (date, bucket) in daily {
+        let week_start = week_start_date(*date);
+        weekly_map.entry(week_start).or_default().merge(bucket);
+    }
+
+    weekly_map.into_iter().collect()
+}
+
+fn sorted_named_usage(map: HashMap<String, usize>) -> Vec<NamedUsage> {
+    let mut rows: Vec<_> =
+        map.into_iter().map(|(name, calls)| NamedUsage { name, calls }).collect();
+    rows.sort_by(|a, b| b.calls.cmp(&a.calls).then_with(|| a.name.cmp(&b.name)));
+    rows
+}
+
+fn project_matches(call: &ProviderCall, include: &[String], exclude: &[String]) -> bool {
+    let name = call.project.to_lowercase();
+    let path = call.project_path.to_lowercase();
+
+    if !include.is_empty() {
+        let matched = include
+            .iter()
+            .map(|pattern| pattern.to_lowercase())
+            .any(|pattern| name.contains(&pattern) || path.contains(&pattern));
+        if !matched {
+            return false;
+        }
+    }
+
+    if !exclude.is_empty() {
+        let matched = exclude
+            .iter()
+            .map(|pattern| pattern.to_lowercase())
+            .any(|pattern| name.contains(&pattern) || path.contains(&pattern));
+        if matched {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Returns the inclusive `(start, end)` instants for `period`, expressed
+/// in UTC for direct comparison against `ProviderCall.timestamp`.
+///
+/// The "day" anchor is the user's local calendar day (so "today" still
+/// means the user's wall-clock today across DST and timezone moves) —
+/// `start_of_day` / `end_of_day` build a local-midnight / local-23:59
+/// datetime first, then convert to UTC for the comparison surface.
+fn date_range_for_period(period: &UsagePeriod) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    let now = Local::now();
+    let today = now.date_naive();
+
+    match period {
+        UsagePeriod::All => None,
+        UsagePeriod::Today => Some(day_bounds(today)),
+        UsagePeriod::Week => Some((start_of_day(today - Duration::days(6)), end_of_day(today))),
+        UsagePeriod::ThirtyDays => {
+            Some((start_of_day(today - Duration::days(29)), end_of_day(today)))
+        }
+        UsagePeriod::LastNDays(n) => {
+            let n = (*n).max(1);
+            Some((
+                start_of_day(today - Duration::days(i64::from(n - 1))),
+                end_of_day(today),
+            ))
+        }
+        UsagePeriod::Month => {
+            let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today);
+            Some((start_of_day(first), end_of_day(today)))
+        }
+        UsagePeriod::SpecificMonth(anchor) => {
+            let first =
+                NaiveDate::from_ymd_opt(anchor.year(), anchor.month(), 1).unwrap_or(*anchor);
+            let last = last_day_of_month(anchor.year(), anchor.month()).unwrap_or(*anchor);
+            Some((start_of_day(first), end_of_day(last)))
+        }
+        UsagePeriod::SpecificQuarter(year, q) => {
+            let (first, last) = quarter_bounds(*year, *q);
+            Some((start_of_day(first), end_of_day(last)))
+        }
+        UsagePeriod::YearToDate => {
+            let first = NaiveDate::from_ymd_opt(today.year(), 1, 1).unwrap_or(today);
+            Some((start_of_day(first), end_of_day(today)))
+        }
+        UsagePeriod::Custom { from, to } => Some((start_of_day(*from), end_of_day(*to))),
+    }
+}
+
+/// Last calendar day of a `(year, month)`. Returns `None` if the inputs
+/// are out of chrono's representable range (year < -262_144 or > 262_143,
+/// month not in 1..=12). Previously this silently returned the 28th,
+/// which produced wrong-on-purpose results for callers that didn't
+/// notice — `Option` makes the failure explicit.
+pub fn last_day_of_month(year: i32, month: u32) -> Option<NaiveDate> {
+    // Reject obviously-invalid months up front so month=0 doesn't silently
+    // roll into the previous December (which the next-month-minus-one
+    // trick below would otherwise compute).
+    if !(1..=12).contains(&month) {
+        return None;
+    }
+    let (next_year, next_month) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    let next_first = NaiveDate::from_ymd_opt(next_year, next_month, 1)?;
+    Some(next_first - Duration::days(1))
+}
+
+/// First and last calendar days of `quarter` (1..=4) within `year`.
+/// Out-of-range quarters are clamped to the nearest valid quarter
+/// (`quarter < 1 -> Q1`, `quarter > 4 -> Q4`) via `clamp(1, 4)`.
+pub fn quarter_bounds(year: i32, quarter: u8) -> (NaiveDate, NaiveDate) {
+    let q = quarter.clamp(1, 4);
+    let start_month = (u32::from(q) - 1) * 3 + 1;
+    let end_month = start_month + 2;
+    let first = NaiveDate::from_ymd_opt(year, start_month, 1)
+        .unwrap_or_else(|| NaiveDate::from_ymd_opt(year, 1, 1).expect("valid Jan 1"));
+    // Quarter end-month is always 3, 6, 9, or 12 — last_day_of_month can
+    // only fail for an out-of-range `year`. In that case fall back to
+    // `first` so the bounds collapse to a single day rather than panic.
+    let last = last_day_of_month(year, end_month).unwrap_or(first);
+    (first, last)
+}
+
+/// Quarter (1..=4) containing `date`.
+pub fn quarter_of(date: NaiveDate) -> u8 {
+    ((date.month0() / 3) + 1) as u8
+}
+
+/// First day of the calendar month containing `date`. Falls back to
+/// `date` itself if chrono rejects the (year, month, 1) tuple, which is
+/// only possible at the extreme edges of the representable range.
+pub fn first_of_month(date: NaiveDate) -> NaiveDate {
+    NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap_or(date)
+}
+
+/// First day of the previous calendar month, wrapping the year at Jan.
+pub fn previous_month_first(anchor: NaiveDate) -> NaiveDate {
+    let (y, m) = if anchor.month() == 1 {
+        (anchor.year() - 1, 12)
+    } else {
+        (anchor.year(), anchor.month() - 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
+}
+
+/// First day of the next calendar month, wrapping the year at Dec.
+pub fn next_month_first(anchor: NaiveDate) -> NaiveDate {
+    let (y, m) = if anchor.month() == 12 {
+        (anchor.year() + 1, 1)
+    } else {
+        (anchor.year(), anchor.month() + 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(anchor)
+}
+
+/// `(year, quarter)` of the previous quarter, wrapping into the prior
+/// year at Q1.
+pub fn previous_quarter(year: i32, q: u8) -> (i32, u8) {
+    if q <= 1 { (year - 1, 4) } else { (year, q - 1) }
+}
+
+/// `(year, quarter)` of the next quarter, wrapping into the next year
+/// at Q4.
+pub fn next_quarter(year: i32, q: u8) -> (i32, u8) {
+    if q >= 4 { (year + 1, 1) } else { (year, q + 1) }
+}
+
+/// `(year, quarter)` containing `date`.
+pub fn current_quarter(date: NaiveDate) -> (i32, u8) {
+    (date.year(), quarter_of(date))
+}
+
+fn day_bounds(date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
+    (start_of_day(date), end_of_day(date))
+}
+
+/// Local-midnight on `date`, converted to UTC. The local interpretation
+/// is intentional: `date` originates from the user's calendar (`today`
+/// in the period helpers), so the bound has to anchor at local midnight
+/// to match how the user experiences "the day". Conversion to UTC
+/// happens last so the bound is directly comparable to the
+/// Utc-stored `ProviderCall.timestamp`.
+fn start_of_day(date: NaiveDate) -> DateTime<Utc> {
+    Local
+        .from_local_datetime(&date.and_hms_opt(0, 0, 0).expect("valid start of day"))
+        .single()
+        .unwrap_or_else(|| {
+            Local.from_utc_datetime(&date.and_hms_opt(0, 0, 0).expect("valid start of day"))
+        })
+        .with_timezone(&Utc)
+}
+
+/// Local-23:59:59.999 on `date`, converted to UTC. See `start_of_day`.
+fn end_of_day(date: NaiveDate) -> DateTime<Utc> {
+    Local
+        .from_local_datetime(&date.and_hms_milli_opt(23, 59, 59, 999).expect("valid end of day"))
+        .single()
+        .unwrap_or_else(|| {
+            Local.from_utc_datetime(
+                &date.and_hms_milli_opt(23, 59, 59, 999).expect("valid end of day"),
+            )
+        })
+        .with_timezone(&Utc)
+}
+
+fn parse_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(timestamp).map(|dt| dt.with_timezone(&Utc)).ok()
+}
+
+/// Compute the stable per-call id from `(path, offset)`.
+///
+/// FNV-1a 64-bit. Stable across runs and platforms, deterministic, and
+/// has no external dependency — that last property matters because the
+/// plugin's persistent SQLite cache (which originally pulled blake3 in)
+/// was retired in Phase 3.
+fn provider_call_id(path: &Path, offset: u64) -> u64 {
+    let key = format!("{}:{}", path.to_string_lossy(), offset);
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for byte in key.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+fn extract_claude_user_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    }
+}
+
+fn extract_claude_tools(content: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(items)) = content else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+        .filter_map(|item| item.get("name").and_then(Value::as_str))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn extract_bash_commands_from_claude_content(content: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(items)) = content else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter(|item| {
+            item.get("type").and_then(Value::as_str) == Some("tool_use")
+                && matches!(
+                    item.get("name").and_then(Value::as_str),
+                    Some("Bash" | "Shell")
+                )
+        })
+        .filter_map(|item| {
+            item.get("input").and_then(|input| input.get("command")).and_then(Value::as_str)
+        })
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn is_valid_codex_session(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Some(first_line) = content.lines().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+    let Ok(entry) = serde_json::from_str::<CodexEntry>(first_line) else {
+        return false;
+    };
+
+    entry.entry_type == "session_meta"
+        && entry
+            .payload
+            .and_then(|payload| payload.originator)
+            .is_some_and(|originator| originator.to_lowercase().starts_with("codex"))
+}
+
+fn is_date_component(path: &Path, len: usize) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.len() == len && name.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn sanitize_codex_project(cwd: &str) -> String {
+    cwd.trim_start_matches('/').replace('/', "-")
+}
+
+fn normalize_codex_tool(raw: &str) -> &str {
+    match raw {
+        "exec_command" => "Bash",
+        "read_file" => "Read",
+        "write_file" | "apply_diff" | "apply_patch" => "Edit",
+        "spawn_agent" | "close_agent" | "wait_agent" => "Agent",
+        "read_dir" => "Glob",
+        _ => raw,
+    }
+}
+
+fn resolve_codex_model(payload: Option<&CodexPayload>, session_model: Option<&str>) -> String {
+    payload
+        .and_then(|payload| payload.model.as_deref())
+        .or_else(|| {
+            payload
+                .and_then(|payload| payload.info.as_ref())
+                .and_then(|info| info.model.as_deref())
+        })
+        .or_else(|| {
+            payload
+                .and_then(|payload| payload.info.as_ref())
+                .and_then(|info| info.model_name.as_deref())
+        })
+        .or(session_model)
+        .unwrap_or("gpt-5")
+        .to_string()
+}
+
+fn clean_project_name(raw: &str, username: &str) -> String {
+    let prefixes = [
+        format!("-Users-{}-", username),
+        format!("Users-{}-", username),
+    ];
+    let mut name = raw.to_string();
+    for p in &prefixes {
+        if let Some(stripped) = name.strip_prefix(p.as_str()) {
+            name = stripped.to_string();
+            break;
+        }
+    }
+    if name.starts_with("-agents-in-a-box-worktrees-") {
+        name = name.replacen("-agents-in-a-box-worktrees-", "worktree/", 1);
+    }
+    if name.is_empty() {
+        raw.to_string()
+    } else {
+        name
+    }
+}
+
+fn unsanitize_project_path(raw: &str) -> String {
+    raw.replace('-', "/")
+}
+
+fn week_start_date(date: NaiveDate) -> NaiveDate {
+    let days_since_monday = date.weekday().num_days_from_monday();
+    date - Duration::days(i64::from(days_since_monday))
+}
+
+fn whoami_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn merge_cost(left: Option<f64>, right: Option<f64>) -> Option<f64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left + right),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn bucket_sort_value(bucket: &TokenBucket) -> f64 {
+    bucket.cost_usd.unwrap_or(bucket.total() as f64)
+}
+
+/// Sort `rows` in-place by bucket weight (descending), where each row's
+/// bucket is extracted via `key`. Centralises the cost-then-tokens
+/// ranking used across every usage panel (projects, sessions, models,
+/// branches, ...). The closure return type is `&TokenBucket` so callers
+/// can point at a field without cloning.
+fn sort_by_bucket_desc<T, F>(rows: &mut Vec<T>, key: F)
+where
+    F: Fn(&T) -> &TokenBucket,
+{
+    rows.sort_by(|a, b| {
+        bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a)))
+    });
+}
+
+/// Merge `bucket` into the entry at `key` in a `String -> TokenBucket`
+/// map, defaulting to an empty bucket when the key is absent. Centralises
+/// the model_map / branch_map merge pattern used inside `aggregate_calls`.
+fn add_bucket<K>(map: &mut HashMap<K, TokenBucket>, key: K, bucket: &TokenBucket)
+where
+    K: std::hash::Hash + Eq,
+{
+    map.entry(key).or_default().merge(bucket);
+}
+
+/// Increment the count at `key` in a `String -> usize` map, defaulting to
+/// zero when the key is absent. Centralises the tool/mcp/shell counter
+/// pattern used inside `aggregate_calls`.
+fn bump<K>(map: &mut HashMap<K, usize>, key: K)
+where
+    K: std::hash::Hash + Eq,
+{
+    *map.entry(key).or_default() += 1;
+}
+
+fn estimate_cost_usd(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    reasoning_tokens: u64,
+) -> Option<f64> {
+    let rates = model_rates(model)?;
+    Some(
+        input_tokens as f64 * rates.input
+            + (output_tokens + reasoning_tokens) as f64 * rates.output
+            + cache_creation_tokens as f64 * rates.cache_write
+            + cache_read_tokens as f64 * rates.cache_read,
+    )
+}
+
+struct ModelRates {
+    input: f64,
+    output: f64,
+    cache_write: f64,
+    cache_read: f64,
+}
+
+fn model_rates(model: &str) -> Option<ModelRates> {
+    let canonical = canonical_model_name(model);
+    let (input_per_million, output_per_million) = if canonical.starts_with("claude-opus") {
+        (15.0, 75.0)
+    } else if canonical.starts_with("claude-sonnet") || canonical.starts_with("claude-3-5-sonnet") {
+        (3.0, 15.0)
+    } else if canonical.starts_with("claude-haiku") || canonical.starts_with("claude-3-5-haiku") {
+        (0.8, 4.0)
+    } else if canonical.starts_with("gpt-5")
+        || canonical.starts_with("gpt-4.1")
+        || canonical.starts_with("gpt-4o")
+    {
+        (1.25, 10.0)
+    } else {
+        return None;
+    };
+
+    let input = input_per_million / 1_000_000.0;
+    let output = output_per_million / 1_000_000.0;
+    Some(ModelRates {
+        input,
+        output,
+        cache_write: input * 1.25,
+        cache_read: input * 0.1,
+    })
+}
+
+fn canonical_model_name(model: &str) -> String {
+    let without_prefix = model
+        .split('@')
+        .next()
+        .unwrap_or(model)
+        .trim_start_matches("anthropic/")
+        .trim_start_matches("openai/")
+        .to_string();
+
+    if without_prefix
+        .rsplit('-')
+        .next()
+        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        without_prefix
+            .rsplit_once('-')
+            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
+    } else {
+        without_prefix
+    }
+}
+
+/// Format a token count in human-readable form (e.g., "1.2B", "456M", "12K").
+pub fn format_tokens_short(n: u64) -> String {
+    if n >= 1_000_000_000 {
+        format!("{:.1}B", n as f64 / 1_000_000_000.0)
+    } else if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.0}K", n as f64 / 1_000.0)
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Format a token count with commas.
+#[allow(dead_code)]
+pub fn format_tokens_commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn last_day_of_month_handles_leap_years() {
+        // Leap year: Feb has 29 days.
+        assert_eq!(
+            last_day_of_month(2024, 2),
+            Some(NaiveDate::from_ymd_opt(2024, 2, 29).unwrap())
+        );
+        // Non-leap year: Feb has 28 days.
+        assert_eq!(
+            last_day_of_month(2023, 2),
+            Some(NaiveDate::from_ymd_opt(2023, 2, 28).unwrap())
+        );
+        // Century non-leap (divisible by 100 but not 400).
+        assert_eq!(
+            last_day_of_month(1900, 2),
+            Some(NaiveDate::from_ymd_opt(1900, 2, 28).unwrap())
+        );
+        // Quad-century leap (divisible by 400).
+        assert_eq!(
+            last_day_of_month(2000, 2),
+            Some(NaiveDate::from_ymd_opt(2000, 2, 29).unwrap())
+        );
+        // 31-day month.
+        assert_eq!(
+            last_day_of_month(2024, 1),
+            Some(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap())
+        );
+        // December rollover into next year.
+        assert_eq!(
+            last_day_of_month(2024, 12),
+            Some(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap())
+        );
+        // Out-of-range month returns None instead of silently wrong data.
+        assert_eq!(last_day_of_month(2024, 13), None);
+        assert_eq!(last_day_of_month(2024, 0), None);
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    fn roots(claude_projects_dir: Option<PathBuf>, codex_dir: Option<PathBuf>) -> UsageSourceRoots {
+        UsageSourceRoots {
+            claude_projects_dir,
+            codex_dir,
+        }
+    }
+
+    /// Per-test-process counter for ProviderCall.id. Tests that key
+    /// off id (analyze_turns, the precompute lookup) need each call to
+    /// have a distinct id; using an atomic counter keeps the helper
+    /// stateless from the caller's perspective.
+    static TEST_CALL_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+    fn next_test_call_id() -> u64 {
+        TEST_CALL_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Test-only convenience that wraps the shared `ProviderCallBuilder`
+    /// with the parameter shape this module's parser tests expect.
+    /// Picks gpt-5 for codex and claude-sonnet-4-5 otherwise; sets
+    /// output_tokens to a fixed 10 (the tests rely on that constant).
+    /// Each call gets a fresh `id` from `next_test_call_id` so
+    /// analyze_turns can key the result map without collisions.
+    fn provider_call(
+        provider: &str,
+        session_id: &str,
+        timestamp: &str,
+        message: &str,
+        tools: &[&str],
+        bash_commands: &[&str],
+        input_tokens: u64,
+    ) -> ProviderCall {
+        let model = if provider == "codex" { "gpt-5" } else { "claude-sonnet-4-5" };
+        crate::test_support::ProviderCallBuilder::new()
+            .with_id(next_test_call_id())
+            .with_provider(provider)
+            .with_model(model)
+            .with_session(session_id)
+            .with_timestamp(parse_timestamp(timestamp).unwrap())
+            .with_input_tokens(input_tokens)
+            .with_output_tokens(10)
+            .with_tools(tools)
+            .with_bash(bash_commands)
+            .with_user_message(message)
+            .build()
+    }
+
+    #[test]
+    fn parses_claude_fixture_and_preserves_daily_project_totals() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("-Users-stevie-agents-in-a-box");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","message":{"role":"user","content":"fix parser"}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:05Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"tool_use","name":"Read","input":{"file_path":"src/lib.rs"}},{"type":"tool_use","name":"Bash","input":{"command":"cargo test"}}],"usage":{"input_tokens":1000,"cache_creation_input_tokens":200,"cache_read_input_tokens":300,"output_tokens":400}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.daily.len(), 1);
+        assert_eq!(data.projects.len(), 1);
+        assert_eq!(data.grand_total.input_tokens, 1000);
+        assert_eq!(data.grand_total.cache_creation_tokens, 200);
+        assert_eq!(data.grand_total.cache_read_tokens, 300);
+        assert_eq!(data.grand_total.output_tokens, 400);
+        assert_eq!(data.grand_total.call_count, 1);
+        assert_eq!(data.grand_total.session_count, 1);
+        assert!(data.tools.iter().any(|tool| tool.name == "Read" && tool.calls == 1));
+        assert!(data.shell_commands.iter().any(|cmd| cmd.name == "cargo test" && cmd.calls == 1));
+    }
+
+    #[test]
+    fn branches_aggregate_only_from_calls_with_recorded_branch() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("-Users-stevie-myrepo");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","gitBranch":"main","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"a"}],"usage":{"input_tokens":100,"output_tokens":10}}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:01Z","sessionId":"s1","gitBranch":"main","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"b"}],"usage":{"input_tokens":50,"output_tokens":5}}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:02Z","sessionId":"s1","gitBranch":"feat/x","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"c"}],"usage":{"input_tokens":1000,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:03Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"d"}],"usage":{"input_tokens":99999,"output_tokens":99999}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        // 4 turns parsed but only 3 have a recorded branch — the 4th is
+        // missing gitBranch and must be excluded from `branches`. Note its
+        // huge token count: if we accidentally bucketed branchless calls
+        // under "(none)" it would dominate the sort and the assertion
+        // below would fail noisily.
+        assert_eq!(data.calls.len(), 4);
+        assert_eq!(data.branches.len(), 2, "only main and feat/x are recorded");
+
+        // Sorted largest first by total bucket value.
+        assert_eq!(data.branches[0].branch, "feat/x");
+        assert_eq!(data.branches[0].bucket.input_tokens, 1000);
+        assert_eq!(data.branches[1].branch, "main");
+        assert_eq!(data.branches[1].bucket.input_tokens, 150);
+    }
+
+    #[test]
+    fn claude_assistant_turn_carries_git_branch_through_parser() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("-Users-stevie-myrepo");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","gitBranch":"feat/x","message":{"role":"user","content":"go"}}
+{"type":"assistant","timestamp":"2026-04-10T09:00:05Z","sessionId":"s1","gitBranch":"feat/x","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":5}}}
+{"type":"assistant","timestamp":"2026-04-10T09:01:00Z","sessionId":"s1","gitBranch":"","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"again"}],"usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"assistant","timestamp":"2026-04-10T09:02:00Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"none"}],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.calls.len(), 3);
+        assert_eq!(data.calls[0].branch.as_deref(), Some("feat/x"));
+        assert_eq!(
+            data.calls[1].branch, None,
+            "empty gitBranch should normalize to None so empty doesn't leak as a real branch label",
+        );
+        assert_eq!(data.calls[2].branch, None, "missing gitBranch becomes None");
+    }
+
+    #[test]
+    fn parses_codex_fixture_and_normalizes_cached_input_tokens() {
+        let temp = tempdir().unwrap();
+        let codex_dir = temp.path().join(".codex");
+        let rollout = codex_dir.join("sessions/2026/04/10/rollout-1.jsonl");
+        write_file(
+            &rollout,
+            r#"{"type":"session_meta","payload":{"originator":"codex_cli","session_id":"codex-1","cwd":"/Users/stevie/work/project","model":"gpt-5"}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"implement thing"}]}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:01Z","payload":{"type":"function_call","name":"exec_command"}}
+{"type":"event_msg","timestamp":"2026-04-10T10:00:02Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":200,"reasoning_output_tokens":50},"total_token_usage":{"total_tokens":1650}}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Codex,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(None, Some(codex_dir)),
+        );
+
+        assert_eq!(data.calls.len(), 1);
+        let call = &data.calls[0];
+        assert_eq!(call.input_tokens, 600);
+        assert_eq!(call.cache_read_tokens, 400);
+        assert_eq!(call.output_tokens, 200);
+        assert_eq!(call.reasoning_tokens, 50);
+        assert_eq!(call.tools, vec!["Bash"]);
+        assert_eq!(call.user_message, "implement thing");
+    }
+
+    #[test]
+    fn codex_last_usage_advances_total_delta_baseline() {
+        let temp = tempdir().unwrap();
+        let codex_dir = temp.path().join(".codex");
+        let rollout = codex_dir.join("sessions/2026/04/10/rollout-1.jsonl");
+        write_file(
+            &rollout,
+            r#"{"type":"session_meta","payload":{"originator":"codex_cli","session_id":"codex-1","cwd":"/Users/stevie/work/project","model":"gpt-5"}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}}
+{"type":"event_msg","timestamp":"2026-04-10T10:00:01Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":200,"reasoning_output_tokens":50},"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1650}}}}
+{"type":"response_item","timestamp":"2026-04-10T10:00:02Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}}
+{"type":"event_msg","timestamp":"2026-04-10T10:00:03Z","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1300,"cached_input_tokens":450,"output_tokens":260,"reasoning_output_tokens":70,"total_tokens":2080}}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Codex,
+                period: UsagePeriod::All,
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(None, Some(codex_dir)),
+        );
+
+        assert_eq!(data.calls.len(), 2);
+        assert_eq!(data.grand_total.input_tokens, 850);
+        assert_eq!(data.grand_total.cache_read_tokens, 450);
+        assert_eq!(data.grand_total.output_tokens, 260);
+        assert_eq!(data.grand_total.reasoning_tokens, 70);
+    }
+
+    #[test]
+    fn date_filter_uses_assistant_call_timestamp() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("proj");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-09T23:59:00Z","sessionId":"s1","message":{"role":"user","content":"late ask"}}
+{"type":"assistant","timestamp":"2026-04-10T00:00:05Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":2}}}
+"#,
+        );
+
+        let day = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::Custom { from: day, to: day },
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.grand_total.call_count, 1);
+        assert_eq!(data.daily[0].0, day);
+    }
+
+    #[test]
+    fn custom_ranges_are_inclusive() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("proj");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T23:59:59+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"assistant","timestamp":"2026-04-11T00:00:00+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":10}}}
+"#,
+        );
+
+        let day = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::Custom { from: day, to: day },
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.grand_total.call_count, 1);
+        assert_eq!(data.grand_total.input_tokens, 1);
+    }
+
+    #[test]
+    fn inverted_custom_ranges_return_no_usage() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        let project_dir = claude_projects.join("proj");
+        write_file(
+            &project_dir.join("session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T12:00:00+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#,
+        );
+
+        let from = NaiveDate::from_ymd_opt(2026, 4, 11).unwrap();
+        let to = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::Custom { from, to },
+                include_projects: Vec::new(),
+                exclude_projects: Vec::new(),
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.grand_total.call_count, 0);
+        assert!(data.calls.is_empty());
+    }
+
+    #[test]
+    fn include_and_exclude_filters_apply_before_aggregation() {
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join(".claude/projects");
+        write_file(
+            &claude_projects.join("alpha-keep/session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#,
+        );
+        write_file(
+            &claude_projects.join("alpha-scratch/session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s2","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":10}}}
+"#,
+        );
+        write_file(
+            &claude_projects.join("beta/session.jsonl"),
+            r#"{"type":"assistant","timestamp":"2026-04-10T09:00:00Z","sessionId":"s3","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":100,"output_tokens":100}}}
+"#,
+        );
+
+        let data = parse_usage_for_with_roots(
+            UsageQuery {
+                provider_filter: UsageProviderFilter::Claude,
+                period: UsagePeriod::All,
+                include_projects: vec!["alpha".to_string()],
+                exclude_projects: vec!["scratch".to_string()],
+                filters: UsageFilters::default(),
+            },
+            &roots(Some(claude_projects), None),
+        );
+
+        assert_eq!(data.projects.len(), 1);
+        assert_eq!(data.projects[0].name, "alpha-keep");
+        assert_eq!(data.grand_total.input_tokens, 1);
+    }
+
+    #[test]
+    fn classifier_covers_core_tool_and_keyword_categories() {
+        let cases = [
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:00:00+01:00",
+                    "change code",
+                    &["Edit"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Coding,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:01:00+01:00",
+                    "fix parser bug",
+                    &["Edit"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Debugging,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:02:00+01:00",
+                    "implement feature",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Feature,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:03:00+01:00",
+                    "refactor usage cleanup",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Refactoring,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:04:00+01:00",
+                    "add test coverage",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Testing,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:05:00+01:00",
+                    "",
+                    &["Read"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Exploration,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:06:00+01:00",
+                    "",
+                    &["TodoWrite"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Planning,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:07:00+01:00",
+                    "",
+                    &["Agent"],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Delegation,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:08:00+01:00",
+                    "",
+                    &["Bash"],
+                    &["git status"],
+                    1,
+                ),
+                ActivityCategory::Git,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:09:00+01:00",
+                    "",
+                    &["Bash"],
+                    &["cargo test usage"],
+                    1,
+                ),
+                ActivityCategory::BuildDeploy,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:10:00+01:00",
+                    "brainstorm options",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Brainstorming,
+            ),
+            (
+                provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-10T09:11:00+01:00",
+                    "sounds reasonable",
+                    &[],
+                    &[],
+                    1,
+                ),
+                ActivityCategory::Conversation,
+            ),
+            (
+                provider_call("claude", "s1", "2026-04-10T09:12:00+01:00", "", &[], &[], 1),
+                ActivityCategory::General,
+            ),
+        ];
+
+        for (call, expected) in cases {
+            assert_eq!(classify_activity(&call), expected);
+        }
+    }
+
+    #[test]
+    fn retry_analysis_counts_edit_only_and_edit_bash_edit_cycle() {
+        let calls = vec![
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:00:00+01:00",
+                "implement feature",
+                &["Edit"],
+                &[],
+                10,
+            ),
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:01:00+01:00",
+                "",
+                &["Bash"],
+                &["cargo test usage"],
+                10,
+            ),
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:02:00+01:00",
+                "fix failing test",
+                &["Edit"],
+                &[],
+                10,
+            ),
+        ];
+
+        let analysis = analyze_turns(&calls);
+        // Lookups now key on ProviderCall.id (was positional idx); the
+        // helper assigns a fresh id per call from an atomic counter so
+        // we read the actual id off each call rather than guessing.
+        assert_eq!(analysis.get(&calls[0].id).unwrap().retries, 0);
+        assert!(analysis.get(&calls[0].id).unwrap().has_edits);
+        assert_eq!(analysis.get(&calls[2].id).unwrap().retries, 1);
+
+        let data = aggregate_calls(calls);
+        let edit_turns: usize = data.activities.iter().map(|activity| activity.edit_turns).sum();
+        let retries: usize = data.activities.iter().map(|activity| activity.retries).sum();
+        let one_shot_turns: usize =
+            data.activities.iter().map(|activity| activity.one_shot_turns).sum();
+
+        assert_eq!(edit_turns, 2);
+        assert_eq!(retries, 1);
+        assert_eq!(one_shot_turns, 1);
+    }
+
+    #[test]
+    fn aggregation_tracks_activity_totals_from_mixed_provider_calls() {
+        let data = aggregate_calls(vec![
+            provider_call(
+                "claude",
+                "claude-1",
+                "2026-04-10T09:00:00+01:00",
+                "implement feature",
+                &["Edit"],
+                &[],
+                100,
+            ),
+            provider_call(
+                "codex",
+                "codex-1",
+                "2026-04-10T10:00:00+01:00",
+                "research parser",
+                &["Read"],
+                &[],
+                200,
+            ),
+        ]);
+
+        assert_eq!(data.grand_total.call_count, 2);
+        assert_eq!(data.grand_total.input_tokens, 300);
+        assert_eq!(data.models.len(), 2);
+        assert!(data.projects.iter().any(|project| project.name == "alpha"));
+        assert!(data.tools.iter().any(|tool| tool.name == "Edit"));
+        assert!(data.tools.iter().any(|tool| tool.name == "Read"));
+
+        let feature = data
+            .activities
+            .iter()
+            .find(|activity| activity.category == ActivityCategory::Feature)
+            .unwrap();
+        assert_eq!(feature.turns, 1);
+        assert_eq!(feature.bucket.input_tokens, 100);
+
+        let exploration = data
+            .activities
+            .iter()
+            .find(|activity| activity.category == ActivityCategory::Exploration)
+            .unwrap();
+        assert_eq!(exploration.turns, 1);
+        assert_eq!(exploration.bucket.input_tokens, 200);
+    }
+
+    #[test]
+    fn plan_projection_covers_under_near_and_over_status() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let mut data = UsageData::default();
+        data.daily = vec![(
+            today,
+            TokenBucket {
+                cost_usd: Some(10.0),
+                ..TokenBucket::default()
+            },
+        )];
+        let mut plan = crate::config::UsagePlan {
+            id: crate::config::UsagePlanId::Custom,
+            monthly_usd: 100.0,
+            provider: crate::config::UsagePlanProvider::All,
+            reset_day: 12,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        };
+
+        assert_eq!(
+            project_plan_usage(&data, &plan, today).status,
+            PlanStatus::Under
+        );
+
+        plan.monthly_usd = 12.0;
+        assert_eq!(
+            project_plan_usage(&data, &plan, today).status,
+            PlanStatus::Near
+        );
+
+        plan.monthly_usd = 5.0;
+        assert_eq!(
+            project_plan_usage(&data, &plan, today).status,
+            PlanStatus::Over
+        );
+    }
+
+    #[test]
+    fn plan_projection_scopes_provider_and_counts_missing_days_as_zero() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let mut data = UsageData::default();
+        data.calls = vec![
+            ProviderCall {
+                provider: "claude".to_string(),
+                model: "claude-sonnet-4-5".to_string(),
+                session_id: "s1".to_string(),
+                project: "alpha".to_string(),
+                project_path: "/work/alpha".to_string(),
+                timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 10, 0, 0).unwrap(),
+                cost_usd: Some(70.0),
+                ..provider_call(
+                    "claude",
+                    "s1",
+                    "2026-04-29T10:00:00+01:00",
+                    "build",
+                    &[],
+                    &[],
+                    1,
+                )
+            },
+            ProviderCall {
+                provider: "codex".to_string(),
+                model: "gpt-5".to_string(),
+                session_id: "s2".to_string(),
+                project: "alpha".to_string(),
+                project_path: "/work/alpha".to_string(),
+                timestamp: Utc.with_ymd_and_hms(2026, 4, 29, 11, 0, 0).unwrap(),
+                cost_usd: Some(30.0),
+                ..provider_call(
+                    "codex",
+                    "s2",
+                    "2026-04-29T11:00:00+01:00",
+                    "build",
+                    &[],
+                    &[],
+                    1,
+                )
+            },
+        ];
+        let plan = crate::config::UsagePlan {
+            id: crate::config::UsagePlanId::Custom,
+            monthly_usd: 100.0,
+            provider: crate::config::UsagePlanProvider::Claude,
+            reset_day: 1,
+            set_at: "2026-04-29T00:00:00Z".to_string(),
+        };
+
+        let projection = project_plan_usage(&data, &plan, today);
+
+        assert_eq!(projection.spent_usd, 70.0);
+        assert_eq!(projection.projected_usd, 70.0);
+    }
+
+    #[test]
+    fn fixed_periods_cover_labeled_calendar_days() {
+        let week = date_range_for_period(&UsagePeriod::Week).unwrap();
+        let thirty = date_range_for_period(&UsagePeriod::ThirtyDays).unwrap();
+
+        // Bounds are Utc-stored but anchored at the user's local
+        // midnight; convert back to Local before reading the calendar
+        // day so the assertion is independent of the host offset.
+        let week_start = week.0.with_timezone(&Local).date_naive();
+        let week_end = week.1.with_timezone(&Local).date_naive();
+        let thirty_start = thirty.0.with_timezone(&Local).date_naive();
+        let thirty_end = thirty.1.with_timezone(&Local).date_naive();
+
+        assert_eq!((week_end - week_start).num_days() + 1, 7);
+        assert_eq!((thirty_end - thirty_start).num_days() + 1, 30);
+    }
+
+    #[test]
+    fn last_n_days_period_covers_n_calendar_days() {
+        for n in [1u32, 7, 14, 90] {
+            let (start, end) =
+                date_range_for_period(&UsagePeriod::LastNDays(n)).unwrap();
+            let start_d = start.with_timezone(&Local).date_naive();
+            let end_d = end.with_timezone(&Local).date_naive();
+            assert_eq!(
+                (end_d - start_d).num_days() + 1,
+                i64::from(n),
+                "n={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn specific_month_period_starts_on_day_one_and_ends_on_last_day() {
+        let anchor = NaiveDate::from_ymd_opt(2026, 4, 17).unwrap();
+        let (start, end) =
+            date_range_for_period(&UsagePeriod::SpecificMonth(anchor)).unwrap();
+        assert_eq!(
+            start.with_timezone(&Local).date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()
+        );
+        assert_eq!(
+            end.with_timezone(&Local).date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 30).unwrap()
+        );
+    }
+
+    #[test]
+    fn specific_quarter_q1_to_q4_cover_three_months_each() {
+        for q in 1u8..=4 {
+            let (start, end) =
+                date_range_for_period(&UsagePeriod::SpecificQuarter(2026, q)).unwrap();
+            let start_d = start.with_timezone(&Local).date_naive();
+            let end_d = end.with_timezone(&Local).date_naive();
+            // Q1 = 90 days (Jan 31 + Feb 28 + Mar 31), Q2 = 91, Q3 = 92, Q4 = 92.
+            let days = (end_d - start_d).num_days() + 1;
+            assert!((90..=92).contains(&days), "q={q} got {days} days");
+        }
+    }
+
+    #[test]
+    fn ytd_period_starts_on_jan_1() {
+        let (start, _) = date_range_for_period(&UsagePeriod::YearToDate).unwrap();
+        let start_d = start.with_timezone(&Local).date_naive();
+        assert_eq!(start_d.month(), 1);
+        assert_eq!(start_d.day(), 1);
+    }
+
+    #[test]
+    fn quarter_of_dispatches_jan_to_dec_correctly() {
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 1, 5).unwrap()), 1);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 3, 31).unwrap()), 1);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()), 2);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()), 3);
+        assert_eq!(quarter_of(NaiveDate::from_ymd_opt(2026, 12, 31).unwrap()), 4);
+    }
+
+    #[test]
+    fn optimize_compare_and_yield_return_stable_summaries() {
+        let calls = vec![
+            provider_call(
+                "claude",
+                "s1",
+                "2026-04-10T09:00:00+01:00",
+                "implement feature",
+                &["Read", "Edit", "Bash"],
+                &["git status"],
+                100,
+            ),
+            provider_call(
+                "codex",
+                "s2",
+                "2026-04-10T10:00:00+01:00",
+                "research parser",
+                &["Read"],
+                &[],
+                200,
+            ),
+        ];
+        let data = aggregate_calls(calls);
+
+        let optimize = optimize_usage(&data);
+        assert!(optimize.score <= 100);
+
+        let compare = compare_models(&data);
+        assert_eq!(compare.models.len(), 2);
+
+        let yield_result = analyze_yield(&data);
+        assert_eq!(yield_result.productive_sessions, 1);
+        assert_eq!(yield_result.abandoned_sessions, 1);
+    }
+
+    /// Two worktrees of the same upstream repo must collapse into a
+    /// single ProjectUsage row keyed by `owner/repo`. We materialise a
+    /// pair of throwaway repos on disk that share an `origin` so the
+    /// resolver attributes both worktrees to the same upstream id.
+    #[test]
+    fn aggregation_collapses_worktrees_with_shared_origin() {
+        let temp = tempdir().unwrap();
+        let wt_a = temp.path().join("wt-a");
+        let wt_b = temp.path().join("wt-b");
+
+        for wt in [&wt_a, &wt_b] {
+            let git_dir = wt.join(".git");
+            std::fs::create_dir_all(&git_dir).unwrap();
+            std::fs::write(
+                git_dir.join("config"),
+                "[remote \"origin\"]\n\turl = git@github.com:acme/widget.git\n",
+            )
+            .unwrap();
+        }
+
+        // Distinct sanitised project names — same upstream repo.
+        let mut call1 = provider_call(
+            "claude",
+            "s1",
+            "2026-04-10T09:00:00Z",
+            "edit",
+            &[],
+            &[],
+            100,
+        );
+        call1.project = "wt-a-folder".to_string();
+        call1.project_path = wt_a.to_string_lossy().into_owned();
+
+        let mut call2 = provider_call(
+            "claude",
+            "s2",
+            "2026-04-10T10:00:00Z",
+            "edit",
+            &[],
+            &[],
+            150,
+        );
+        call2.project = "wt-b-folder".to_string();
+        call2.project_path = wt_b.to_string_lossy().into_owned();
+
+        let data = aggregate_calls(vec![call1, call2]);
+        assert_eq!(data.projects.len(), 1, "worktrees should collapse");
+        let proj = &data.projects[0];
+        assert_eq!(proj.name, "acme/widget");
+        assert_eq!(proj.repo.as_deref(), Some("acme/widget"));
+        assert_eq!(proj.bucket.input_tokens, 250);
+    }
+
+    /// When a call's working directory has no resolvable upstream the
+    /// row falls back to the sanitised project name and `repo` stays
+    /// `None`.
+    #[test]
+    fn aggregation_falls_back_to_folder_when_no_origin() {
+        let temp = tempdir().unwrap();
+        let wt = temp.path().join("plain");
+        std::fs::create_dir_all(&wt).unwrap();
+        // No .git at all.
+
+        let mut call = provider_call(
+            "claude",
+            "s1",
+            "2026-04-10T09:00:00Z",
+            "edit",
+            &[],
+            &[],
+            100,
+        );
+        call.project = "plain-folder".to_string();
+        call.project_path = wt.to_string_lossy().into_owned();
+
+        let data = aggregate_calls(vec![call]);
+        assert_eq!(data.projects.len(), 1);
+        let proj = &data.projects[0];
+        assert_eq!(proj.name, "plain-folder");
+        assert!(proj.repo.is_none());
+    }
+
+    #[test]
+    fn collect_recent_within_keeps_only_entries_inside_cutoff() {
+        // Two assistant lines: one inside the 5h window, one well
+        // outside it. The walker must return only the inside-window
+        // call.
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join("projects");
+        let project_dir = claude_projects.join("-Users-stevie-fixture");
+        let now = Utc::now();
+        let inside = (now - Duration::hours(2)).to_rfc3339();
+        let outside = (now - Duration::hours(8)).to_rfc3339();
+        let payload = format!(
+            "{}\n{}\n",
+            format!(
+                r#"{{"type":"assistant","timestamp":"{outside}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":100,"output_tokens":50}}}}}}"#,
+            ),
+            format!(
+                r#"{{"type":"assistant","timestamp":"{inside}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":200,"output_tokens":75}}}}}}"#,
+            ),
+        );
+        write_file(&project_dir.join("session.jsonl"), &payload);
+
+        let cutoff = now - Duration::hours(5);
+        let calls = collect_recent_claude_calls_within_at(
+            &claude_projects,
+            cutoff,
+            Duration::hours(1),
+        );
+
+        assert_eq!(calls.len(), 1, "only the in-window call should survive");
+        let call = &calls[0];
+        assert_eq!(call.input_tokens, 200);
+        assert!(
+            call.timestamp >= cutoff,
+            "kept call must be within cutoff"
+        );
+    }
+
+    #[test]
+    fn collect_recent_within_skips_files_below_mtime_floor() {
+        // File with one in-window assistant entry, but its mtime is
+        // older than the (cutoff - grace) floor. Expectation: skipped.
+        let temp = tempdir().unwrap();
+        let claude_projects = temp.path().join("projects");
+        let project_dir = claude_projects.join("-Users-stevie-stale");
+        let now = Utc::now();
+        // Even though the line itself is in-window, an old mtime
+        // proves the file hasn't been written to recently — Claude
+        // would have updated mtime if it were still appending. The
+        // walker treats stale-mtime files as cold archives.
+        let in_window = (now - Duration::minutes(30)).to_rfc3339();
+        let payload = format!(
+            r#"{{"type":"assistant","timestamp":"{in_window}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":99,"output_tokens":1}}}}}}"#
+        );
+        let session = project_dir.join("session.jsonl");
+        write_file(&session, &payload);
+        // Backdate mtime to 24h ago — well past the (5h + 1h) gate.
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&session)
+            .unwrap();
+        let twenty_four_hours_ago = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(60 * 60 * 24);
+        f.set_modified(twenty_four_hours_ago).unwrap();
+
+        let cutoff = now - Duration::hours(5);
+        let calls = collect_recent_claude_calls_within_at(
+            &claude_projects,
+            cutoff,
+            Duration::hours(1),
+        );
+        assert!(
+            calls.is_empty(),
+            "files older than (cutoff - grace) should be skipped",
+        );
+    }
+
+    #[test]
+    fn collect_recent_within_returns_empty_when_dir_missing() {
+        let temp = tempdir().unwrap();
+        let projects = temp.path().join("does-not-exist");
+        let calls = collect_recent_claude_calls_within_at(
+            &projects,
+            Utc::now() - Duration::hours(5),
+            Duration::hours(1),
+        );
+        assert!(calls.is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/lib.rs
@@ -1,0 +1,40 @@
+//! ainb burndown plugin — daily/weekly/project usage analytics.
+//!
+//! Phase 7c: subprocess plugin built against `ainb-plugin-sdk-rust`.
+//! `src/main.rs` runs `Server::new(BurndownPlugin::default()).run_stdio()`;
+//! the modules below own the analytics domain (cache + report
+//! generation + CLI) and the [`plugin`] module wires them onto the
+//! SDK's `Plugin` trait.
+
+#![allow(dead_code)] // Lifted analytics surface — many entry points used only by CLI subcommands.
+// The cli/ui/data modules are a 1:1 port of the Phase 6c-cli host-side
+// burndown that ran inside ainb-tui. Style nits live with the original
+// code; the migration's value is the new subprocess shell, not a
+// refactor pass on 12k lines of legacy analytics. Re-tightening these
+// lints crate-by-crate is out of scope for Phase 7c.
+#![allow(
+    clippy::large_enum_variant,
+    clippy::derivable_impls,
+    clippy::manual_map,
+    clippy::map_unwrap_or,
+    clippy::unnecessary_map_or,
+    clippy::unnecessary_sort_by,
+    clippy::ptr_arg,
+    clippy::manual_pattern_char_comparison,
+    clippy::unnecessary_unwrap,
+    clippy::type_complexity
+)]
+
+pub mod cache;
+pub mod cli;
+pub mod config;
+pub mod data;
+pub mod live_window;
+pub mod output_format;
+pub mod plugin;
+pub mod ui;
+mod ui_helpers;
+pub mod wire;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/ainb-tui/crates/ainb-plugin-burndown/src/live_window.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/live_window.rs
@@ -1,0 +1,46 @@
+//! Plugin-local mirror of ainb-core::models::live_window.
+//!
+//! The 3-tier cascade (statusline cache + local 5h aggregation) lives
+//! on the host; the plugin receives a pre-computed `LiveWindow` value
+//! through the plugin context (or via a host-fn call) and renders it.
+//! Phase 3 ships the type + an empty default — wiring the cascade
+//! across the WASM boundary is a follow-up host-fn so we don't expand
+//! the plugin's capability surface.
+
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Source {
+    Tier1Cache,
+    Tier2Local,
+    #[default]
+    None,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LiveWindow {
+    pub five_hour_pct: Option<u8>,
+    pub seven_day_pct: Option<u8>,
+    pub today_cost_usd: Option<f64>,
+    pub resets_in: Option<Duration>,
+    pub context_pct: Option<u8>,
+    pub model: Option<String>,
+    pub source: Source,
+}
+
+impl LiveWindow {
+    pub fn empty() -> Self {
+        Self {
+            source: Source::None,
+            ..Default::default()
+        }
+    }
+}
+
+/// Phase 3 stub: returns an empty live window (Source::None). The host
+/// will hand a populated `LiveWindow` to the plugin via PluginEvent in
+/// a follow-up wiring commit; for now the UI renders the "wire the
+/// statusline" CTA fallback path.
+pub fn current() -> LiveWindow {
+    LiveWindow::empty()
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/main.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/main.rs
@@ -1,0 +1,27 @@
+//! Burndown plugin binary entry point.
+//!
+//! Spawned as a subprocess by `ainb-plugin-runtime`. Reads JSON-RPC
+//! frames from stdin, writes responses + reverse-call requests to
+//! stdout, logs to stderr (drained by the runtime's stderr forwarder).
+
+use ainb_plugin_burndown::plugin::BurndownPlugin;
+use ainb_plugin_sdk::Server;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Send tracing output to stderr so it doesn't pollute the
+    // JSON-RPC framing on stdout. The runtime forwards stderr lines
+    // into its host log.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .compact()
+        .init();
+
+    Server::new(BurndownPlugin::default()).run_stdio().await?;
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/output_format.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/output_format.rs
@@ -1,0 +1,15 @@
+//! Plugin-local mirror of `ainb-core::cli::OutputFormat`.
+//!
+//! The host's `ainb usage` clap dispatch passes the chosen output format
+//! to the plugin via the command registry; the plugin uses this enum to
+//! drive text/json/csv formatting in `cli::execute`.
+
+use clap::ValueEnum;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+    Csv,
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -1,0 +1,434 @@
+//! ABI v2 [`Plugin`] implementation for burndown.
+//!
+//! `BurndownPlugin` owns the in-memory analytics view + the latest
+//! `UsageData` snapshot pushed by the host on the `sessions.usage_data`
+//! topic. Render translates the existing ratatui `Buffer` painter into
+//! a wire `WireBuffer` cell stream; `cli_dispatch` re-parses argv via
+//! clap and falls back to `host.snapshot_get` when no event push has
+//! arrived yet.
+
+use ainb_plugin_sdk::{
+    Cell, CliOutput, Color, Coord, HostClient, Plugin, RenderParams, Result, SdkError,
+    WireBuffer,
+};
+use ainb_plugin_types_sessions::{UsageDataEvent, WIRE_VERSION};
+use async_trait::async_trait;
+use ratatui::buffer::Buffer as RBuffer;
+use ratatui::layout::Rect as RRect;
+use ratatui::style::{Color as RColor, Modifier as RModifier};
+
+use crate::cli::{UsageCommands, execute_for_plugin};
+use crate::data::usage::UsageData;
+use crate::output_format::OutputFormat;
+use crate::ui::{UsageTab, UsageViewState, render as render_ui};
+use crate::wire::wire_to_local;
+
+/// Static manifest TOML loaded at compile time. The Server uses this on
+/// `plugin/init` to echo `name`/`version` back to the host.
+const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// Default render viewport — the host sends an explicit one in
+/// `RenderParams.viewport`, but we fall back to this if a degenerate
+/// 0×0 ever arrives. Matches the historical 80×24 baseline.
+const FALLBACK_VIEWPORT: (u16, u16) = (80, 24);
+
+/// Burndown plugin state.
+#[derive(Default)]
+pub struct BurndownPlugin {
+    /// In-memory UI state — populated from cached snapshots and
+    /// CLI/event-driven tab switches.
+    ui: UsageViewState,
+    /// Most recent `UsageData` snapshot decoded from
+    /// `sessions.usage_data`.
+    data: Option<UsageData>,
+    /// Set when the most recent snapshot's wire `version` did not match
+    /// the crate's compiled [`WIRE_VERSION`]. Latched — the render path
+    /// surfaces an upgrade hint instead of the wait-spinner.
+    schema_mismatch: bool,
+}
+
+#[async_trait]
+impl Plugin for BurndownPlugin {
+    fn manifest(&self) -> &'static str {
+        MANIFEST_TOML
+    }
+
+    async fn on_init(&mut self, host: &HostClient, _granted: &[String]) -> Result<()> {
+        // Best-effort warm-load: ask the host for any snapshot already
+        // on the bus so the first render doesn't have to wait for the
+        // next publish. Failure is non-fatal — we'll still get pushed
+        // events via `handle_event`.
+        if let Ok(snap) = host.snapshot_get("sessions.usage_data").await {
+            if let Some(payload) = snap.payload {
+                self.ingest_usage_payload(host, &payload).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_event(
+        &mut self,
+        host: &HostClient,
+        params: ainb_plugin_sdk::HandleEventParams,
+    ) -> Result<()> {
+        if params.topic == "sessions.usage_data" {
+            self.ingest_usage_payload(host, &params.payload).await;
+        }
+        Ok(())
+    }
+
+    async fn render(&mut self, _host: &HostClient, params: RenderParams) -> Result<WireBuffer> {
+        let (w, h) = match (params.viewport.width, params.viewport.height) {
+            (0, _) | (_, 0) => FALLBACK_VIEWPORT,
+            (w, h) => (w, h),
+        };
+        let area = RRect {
+            x: 0,
+            y: 0,
+            width: w,
+            height: h,
+        };
+        let mut rbuf = RBuffer::empty(area);
+
+        if self.schema_mismatch && self.data.is_none() {
+            paint_schema_mismatch(&mut rbuf, area);
+        } else {
+            // Snapshot the UI state so we can paint without holding a
+            // mutable borrow on `self` for the whole call.
+            let mut ui = self.ui.clone();
+            ui.data = self.data.clone();
+            render_ui(&mut rbuf, area, &ui);
+        }
+        Ok(buffer_to_wire(&rbuf, area))
+    }
+
+    async fn cli_dispatch(
+        &mut self,
+        host: &HostClient,
+        namespace: &str,
+        argv: &[String],
+    ) -> Result<CliOutput> {
+        if namespace != "usage" {
+            return Ok(CliOutput {
+                stdout: Vec::new(),
+                stderr: format!("burndown: unknown namespace `{namespace}`\n").into_bytes(),
+                exit_code: 2,
+            });
+        }
+
+        // Pull `--format=<text|json|csv>` out of argv (host-level
+        // global flag) and strip it before clap parses the subcommand
+        // surface — clap doesn't declare it.
+        let format = extract_format(argv);
+        let stripped = strip_format_flag(argv);
+
+        // Make sure we have a snapshot. If the host hasn't pushed one
+        // yet, ask synchronously; bail with an actionable error if the
+        // session-reader plugin isn't installed.
+        if self.data.is_none() {
+            self.refresh_snapshot(host).await;
+        }
+        let Some(data) = self.data.clone() else {
+            return Ok(CliOutput {
+                stdout: Vec::new(),
+                stderr: b"error: usage analytics requires the session-reader plugin (install via 'ainb plugin install session-reader')\n".to_vec(),
+                exit_code: 1,
+            });
+        };
+
+        // Argv reshape: clap's `try_parse_from` expects argv[0] to be
+        // the program name. We feed it "usage" so subcommands like
+        // `report --json` parse naturally.
+        let mut clap_argv: Vec<String> = vec!["usage".to_string()];
+        clap_argv.extend(stripped);
+
+        use clap::Parser;
+        #[derive(Parser)]
+        #[command(name = "usage")]
+        struct UsageRoot {
+            #[command(subcommand)]
+            cmd: UsageCommands,
+        }
+
+        let parsed = match UsageRoot::try_parse_from(clap_argv) {
+            Ok(p) => p,
+            Err(e) => {
+                let msg = e.to_string();
+                let exit = if e.use_stderr() { 2 } else { 0 };
+                return Ok(CliOutput {
+                    stdout: Vec::new(),
+                    stderr: msg.into_bytes(),
+                    exit_code: exit,
+                });
+            }
+        };
+
+        match capture_stdout(|| execute_for_plugin(&data, parsed.cmd, format)) {
+            (Ok(()), out) => Ok(CliOutput {
+                stdout: out,
+                stderr: Vec::new(),
+                exit_code: 0,
+            }),
+            (Err(e), out) => Ok(CliOutput {
+                stdout: out,
+                stderr: format!("{e}\n").into_bytes(),
+                exit_code: 1,
+            }),
+        }
+    }
+}
+
+impl BurndownPlugin {
+    /// Decode a `sessions.usage_data` payload (msgpack-encoded
+    /// `UsageDataEvent`) and update local state. Notes wire-version
+    /// drift on the latched `schema_mismatch` flag.
+    async fn ingest_usage_payload(&mut self, host: &HostClient, payload: &[u8]) {
+        let event: UsageDataEvent = match rmp_serde::from_slice(payload) {
+            Ok(e) => e,
+            Err(e) => {
+                let _ = host
+                    .log_info(format!(
+                        "burndown: malformed sessions.usage_data payload: {e}"
+                    ))
+                    .await;
+                return;
+            }
+        };
+        if event.version != WIRE_VERSION {
+            self.schema_mismatch = true;
+            let _ = host
+                .log_info(format!(
+                    "burndown: sessions.usage_data wire version mismatch: got {}, expected {}",
+                    event.version, WIRE_VERSION
+                ))
+                .await;
+            return;
+        }
+        self.data = Some(wire_to_local(event.data));
+        self.schema_mismatch = false;
+    }
+
+    /// Pull the latest snapshot synchronously. Used by `cli_dispatch`
+    /// when no event push has arrived yet; failure is non-fatal — the
+    /// caller surfaces an actionable error.
+    async fn refresh_snapshot(&mut self, host: &HostClient) {
+        match host.snapshot_get("sessions.usage_data").await {
+            Ok(snap) => {
+                if let Some(payload) = snap.payload {
+                    self.ingest_usage_payload(host, &payload).await;
+                }
+            }
+            Err(SdkError::Rpc(_)) | Err(_) => {
+                // Treat any failure as "no data" — caller emits the
+                // install-session-reader hint.
+            }
+        }
+    }
+}
+
+fn paint_schema_mismatch(buf: &mut RBuffer, area: RRect) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    let msg =
+        "  ⚠ Schema mismatch — upgrade session-reader/burndown plugins to matching versions.";
+    let max = area.width as usize;
+    let truncated: String = msg.chars().take(max).collect();
+    buf.set_string(
+        area.x,
+        area.y,
+        truncated,
+        ratatui::style::Style::default(),
+    );
+}
+
+/// Convert a ratatui `Buffer` to the SDK's `WireBuffer` cell stream.
+///
+/// Iterates row-major so the resulting `Vec<(Coord, Cell)>` is
+/// deterministic between renders. Empty cells (default attrs and a
+/// blank symbol) are dropped to keep the wire payload sparse.
+fn buffer_to_wire(rbuf: &RBuffer, area: RRect) -> WireBuffer {
+    let mut wire = WireBuffer::new(area.width, area.height);
+    for y in 0..area.height {
+        for x in 0..area.width {
+            let cell = rbuf.get(area.x + x, area.y + y);
+            let symbol = cell.symbol();
+            let fg = ratatui_color(cell.fg);
+            let bg = ratatui_color(cell.bg);
+            let modifier = ratatui_modifiers(cell.modifier);
+            // Skip cells that wouldn't render anything visible — saves
+            // bytes on the wire and keeps the JSON sparse like the host
+            // expects.
+            if symbol == " " && fg.is_none() && bg.is_none() && modifier == 0 {
+                continue;
+            }
+            wire.push(
+                Coord::new(x, y),
+                Cell {
+                    symbol: symbol.to_string(),
+                    fg,
+                    bg,
+                    modifier,
+                },
+            );
+        }
+    }
+    wire
+}
+
+fn ratatui_color(c: RColor) -> Option<Color> {
+    match c {
+        RColor::Reset => None,
+        RColor::Black => Some(Color::rgb(0, 0, 0)),
+        RColor::Red => Some(Color::rgb(170, 0, 0)),
+        RColor::Green => Some(Color::rgb(0, 170, 0)),
+        RColor::Yellow => Some(Color::rgb(170, 170, 0)),
+        RColor::Blue => Some(Color::rgb(0, 0, 170)),
+        RColor::Magenta => Some(Color::rgb(170, 0, 170)),
+        RColor::Cyan => Some(Color::rgb(0, 170, 170)),
+        RColor::Gray => Some(Color::rgb(170, 170, 170)),
+        RColor::DarkGray => Some(Color::rgb(85, 85, 85)),
+        RColor::LightRed => Some(Color::rgb(255, 85, 85)),
+        RColor::LightGreen => Some(Color::rgb(85, 255, 85)),
+        RColor::LightYellow => Some(Color::rgb(255, 255, 85)),
+        RColor::LightBlue => Some(Color::rgb(85, 85, 255)),
+        RColor::LightMagenta => Some(Color::rgb(255, 85, 255)),
+        RColor::LightCyan => Some(Color::rgb(85, 255, 255)),
+        RColor::White => Some(Color::rgb(255, 255, 255)),
+        RColor::Indexed(_) => None,
+        RColor::Rgb(r, g, b) => Some(Color::rgb(r, g, b)),
+    }
+}
+
+fn ratatui_modifiers(m: RModifier) -> u16 {
+    let mut out = 0_u16;
+    if m.contains(RModifier::BOLD) {
+        out |= 1;
+    }
+    if m.contains(RModifier::DIM) {
+        out |= 2;
+    }
+    if m.contains(RModifier::ITALIC) {
+        out |= 4;
+    }
+    if m.contains(RModifier::UNDERLINED) {
+        out |= 8;
+    }
+    if m.contains(RModifier::REVERSED) {
+        out |= 16;
+    }
+    out
+}
+
+fn extract_format(argv: &[String]) -> OutputFormat {
+    let mut iter = argv.iter().peekable();
+    while let Some(a) = iter.next() {
+        if let Some(rest) = a.strip_prefix("--format=") {
+            return parse_format(rest);
+        }
+        if a == "--format" {
+            if let Some(next) = iter.peek() {
+                return parse_format(next);
+            }
+        }
+    }
+    OutputFormat::default()
+}
+
+fn strip_format_flag(argv: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(argv.len());
+    let mut i = 0;
+    while i < argv.len() {
+        let a = &argv[i];
+        if a == "--format" {
+            i += 1;
+            if i < argv.len() {
+                i += 1;
+            }
+            continue;
+        }
+        if a.starts_with("--format=") {
+            i += 1;
+            continue;
+        }
+        out.push(a.clone());
+        i += 1;
+    }
+    out
+}
+
+fn parse_format(s: &str) -> OutputFormat {
+    match s {
+        "json" => OutputFormat::Json,
+        "csv" => OutputFormat::Csv,
+        _ => OutputFormat::Text,
+    }
+}
+
+/// Run `f`, collecting anything it `println!`'d into a `Vec<u8>` in
+/// place of stdout. Stderr is unaffected — it still goes to the
+/// process's real stderr, which the runtime drains and forwards.
+///
+/// Implementation: redirect fd 1 to a tempfile via `dup2`, run `f`,
+/// restore the original stdout, then read the tempfile back. The
+/// tempfile drains synchronously (no pipe-buffer deadlock concern).
+/// Unix-only — Phase 7c plugins ship on the same targets the runtime
+/// already supports.
+///
+/// The legacy `cli` module emits its 9-subcommand report output via
+/// `println!` / `print!` (~80 sites). Refactoring each helper to take a
+/// `&mut impl Write` would touch a 1700-line file; this brief
+/// fd-redirect keeps the diff tight while still producing a captured
+/// stdout for the JSON-RPC `cli_dispatch` reply.
+#[cfg(unix)]
+fn capture_stdout<F: FnOnce() -> anyhow::Result<()>>(f: F) -> (anyhow::Result<()>, Vec<u8>) {
+    use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+    use std::os::fd::AsRawFd;
+
+    let mut buf = Vec::new();
+    let mut tmp = match tempfile::tempfile() {
+        Ok(f) => f,
+        Err(_) => return (f(), buf),
+    };
+
+    // SAFETY: dup/dup2/close are POSIX fd ops. We own fd 1 for the
+    // duration of this call (single-threaded inside the SDK's plugin
+    // mutex), so swapping it in and out is race-free.
+    unsafe {
+        let stdout_fd: libc::c_int = 1;
+        let saved = libc::dup(stdout_fd);
+        if saved < 0 {
+            return (f(), buf);
+        }
+        if libc::dup2(tmp.as_raw_fd(), stdout_fd) < 0 {
+            libc::close(saved);
+            return (f(), buf);
+        }
+        let _ = std::io::stdout().flush();
+        let result = f();
+        let _ = std::io::stdout().flush();
+        libc::dup2(saved, stdout_fd);
+        libc::close(saved);
+
+        let _ = tmp.seek(SeekFrom::Start(0));
+        let _ = tmp.read_to_end(&mut buf);
+        (result, buf)
+    }
+}
+
+#[cfg(not(unix))]
+fn capture_stdout<F: FnOnce() -> anyhow::Result<()>>(f: F) -> (anyhow::Result<()>, Vec<u8>) {
+    // Non-Unix targets fall back to no-capture. The plugin ships on
+    // macOS + Linux only in Phase 7c.
+    (f(), Vec::new())
+}
+
+/// Allow `set_tab` style commands once we wire them through the snapshot
+/// bus. Today this lets `tests/stdio_smoke.rs` exercise the lifecycle
+/// without depending on a session-reader installation.
+impl BurndownPlugin {
+    #[allow(dead_code)]
+    pub fn set_active_tab(&mut self, tab: UsageTab) {
+        self.ui.active_tab = tab;
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/test_support.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/test_support.rs
@@ -1,0 +1,120 @@
+//! Shared test fixtures for the burndown analytics pipeline.
+//!
+//! Centralised so a layout change to [`ProviderCall`] touches one
+//! builder rather than the inline literals scattered across `ui.rs`,
+//! `data/usage.rs`, and the integration tests under `tests/`.
+//!
+//! Compiled only under `#[cfg(test)]` — the helpers stay out of the
+//! release binary.
+
+use chrono::{DateTime, TimeZone, Utc};
+
+use crate::data::usage::ProviderCall;
+
+/// Fluent builder for [`ProviderCall`]. Each `with_*` method overrides
+/// the corresponding default so a test only mentions the fields it
+/// cares about.
+#[derive(Debug, Clone)]
+pub struct ProviderCallBuilder {
+    call: ProviderCall,
+}
+
+impl ProviderCallBuilder {
+    /// Construct a builder pre-filled with conservative defaults.
+    pub fn new() -> Self {
+        Self {
+            call: ProviderCall {
+                id: 0,
+                provider: "claude".to_string(),
+                model: "claude-sonnet-4-5".to_string(),
+                session_id: "s1".to_string(),
+                project: "alpha".to_string(),
+                project_path: "/work/alpha".to_string(),
+                timestamp: default_timestamp(),
+                input_tokens: 0,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                output_tokens: 0,
+                reasoning_tokens: 0,
+                cost_usd: None,
+                tools: Vec::new(),
+                bash_commands: Vec::new(),
+                user_message: String::new(),
+                branch: None,
+            },
+        }
+    }
+
+    pub fn with_id(mut self, v: u64) -> Self {
+        self.call.id = v;
+        self
+    }
+    pub fn with_provider(mut self, v: impl Into<String>) -> Self {
+        self.call.provider = v.into();
+        self
+    }
+    pub fn with_model(mut self, v: impl Into<String>) -> Self {
+        self.call.model = v.into();
+        self
+    }
+    pub fn with_session(mut self, v: impl Into<String>) -> Self {
+        self.call.session_id = v.into();
+        self
+    }
+    pub fn with_project(mut self, v: impl Into<String>) -> Self {
+        self.call.project = v.into();
+        self
+    }
+    pub fn with_project_path(mut self, v: impl Into<String>) -> Self {
+        self.call.project_path = v.into();
+        self
+    }
+    pub fn with_timestamp(mut self, v: DateTime<Utc>) -> Self {
+        self.call.timestamp = v;
+        self
+    }
+    pub fn with_input_tokens(mut self, v: u64) -> Self {
+        self.call.input_tokens = v;
+        self
+    }
+    pub fn with_output_tokens(mut self, v: u64) -> Self {
+        self.call.output_tokens = v;
+        self
+    }
+    pub fn with_cost(mut self, v: f64) -> Self {
+        self.call.cost_usd = Some(v);
+        self
+    }
+    pub fn with_tools(mut self, tools: &[&str]) -> Self {
+        self.call.tools = tools.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+    pub fn with_bash(mut self, cmds: &[&str]) -> Self {
+        self.call.bash_commands = cmds.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+    pub fn with_user_message(mut self, v: impl Into<String>) -> Self {
+        self.call.user_message = v.into();
+        self
+    }
+    pub fn with_branch(mut self, v: impl Into<String>) -> Self {
+        self.call.branch = Some(v.into());
+        self
+    }
+
+    pub fn build(self) -> ProviderCall {
+        self.call
+    }
+}
+
+impl Default for ProviderCallBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn default_timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 4, 29, 10, 0, 0)
+        .single()
+        .unwrap_or_else(Utc::now)
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -1,0 +1,4881 @@
+// ABOUTME: Usage analytics screen showing token consumption by day, week, and project.
+// Accessible via 'i' key from home screen or Stats sidebar item.
+
+use chrono::{Datelike, Local, NaiveDate};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph, Row, Table, Tabs},
+};
+
+use crate::data::usage::{
+    BranchUsage, current_quarter, first_of_month, next_month_first, next_quarter,
+    previous_month_first, previous_quarter,
+};
+use crate::data::{
+    ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsageFilterChip,
+    UsageFilters, UsagePeriod, UsageProviderFilter, UsageQuery, filter_usage_data,
+    format_tokens_short, optimize_usage,
+};
+
+// Color palette from TUI style guide
+const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
+const GOLD: Color = Color::Rgb(255, 215, 0);
+const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
+const DARK_BG: Color = Color::Rgb(25, 25, 35);
+const PANEL_BG: Color = Color::Rgb(30, 30, 40);
+const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
+const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+const BAR_COLOR: Color = Color::Rgb(80, 160, 230);
+const BAR_HIGH: Color = Color::Rgb(230, 120, 80);
+const BAR_MED: Color = Color::Rgb(200, 180, 80);
+const TERMINAL_BG: Color = Color::Rgb(13, 14, 18);
+const TERMINAL_PANEL: Color = Color::Rgb(17, 19, 26);
+const TERMINAL_BORDER: Color = Color::Rgb(130, 90, 70);
+const TERMINAL_ACCENT: Color = Color::Rgb(255, 184, 108);
+const TERMINAL_GOOD: Color = Color::Rgb(155, 216, 106);
+const TERMINAL_CYAN: Color = Color::Rgb(125, 211, 200);
+
+// Bar gradient thresholds: ratio of value/max above which a row is colored.
+const BAR_THRESHOLD_HIGH: f64 = 0.66;
+const BAR_THRESHOLD_MED: f64 = 0.33;
+
+/// Which agent provider's usage to show
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UsageProvider {
+    #[default]
+    Claude,
+    Codex,
+    Gemini,
+    Copilot,
+}
+
+impl UsageProvider {
+    fn all() -> &'static [UsageProvider] {
+        &[
+            UsageProvider::Claude,
+            UsageProvider::Codex,
+            UsageProvider::Gemini,
+            UsageProvider::Copilot,
+        ]
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            UsageProvider::Claude => "✻ Claude Code",
+            UsageProvider::Codex => "✦ Codex CLI",
+            UsageProvider::Gemini => "✨ Gemini CLI",
+            UsageProvider::Copilot => "🐙 Copilot",
+        }
+    }
+
+    fn short_label(&self) -> &'static str {
+        match self {
+            UsageProvider::Claude => "Claude",
+            UsageProvider::Codex => "Codex",
+            UsageProvider::Gemini => "Gemini",
+            UsageProvider::Copilot => "Copilot",
+        }
+    }
+
+    pub fn has_data(&self) -> bool {
+        matches!(self, UsageProvider::Claude | UsageProvider::Codex)
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            UsageProvider::Claude => UsageProvider::Codex,
+            UsageProvider::Codex => UsageProvider::Gemini,
+            UsageProvider::Gemini => UsageProvider::Copilot,
+            UsageProvider::Copilot => UsageProvider::Claude,
+        }
+    }
+
+    fn prev(&self) -> Self {
+        match self {
+            UsageProvider::Claude => UsageProvider::Copilot,
+            UsageProvider::Codex => UsageProvider::Claude,
+            UsageProvider::Gemini => UsageProvider::Codex,
+            UsageProvider::Copilot => UsageProvider::Gemini,
+        }
+    }
+}
+
+/// Which sub-tab is active in the usage view
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UsageTab {
+    #[default]
+    Burndown,
+    Daily,
+    Weekly,
+    Projects,
+    Optimize,
+}
+
+impl UsageTab {
+    fn all() -> &'static [UsageTab] {
+        &[
+            UsageTab::Burndown,
+            UsageTab::Daily,
+            UsageTab::Weekly,
+            UsageTab::Projects,
+            UsageTab::Optimize,
+        ]
+    }
+
+    fn title(&self) -> &'static str {
+        match self {
+            UsageTab::Burndown => "Burndown",
+            UsageTab::Daily => "Daily",
+            UsageTab::Weekly => "Weekly",
+            UsageTab::Projects => "By Project",
+            UsageTab::Optimize => "Optimize",
+        }
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            UsageTab::Burndown => UsageTab::Daily,
+            UsageTab::Daily => UsageTab::Weekly,
+            UsageTab::Weekly => UsageTab::Projects,
+            UsageTab::Projects => UsageTab::Optimize,
+            UsageTab::Optimize => UsageTab::Burndown,
+        }
+    }
+
+    fn prev(&self) -> Self {
+        match self {
+            UsageTab::Burndown => UsageTab::Optimize,
+            UsageTab::Daily => UsageTab::Burndown,
+            UsageTab::Weekly => UsageTab::Daily,
+            UsageTab::Projects => UsageTab::Weekly,
+            UsageTab::Optimize => UsageTab::Projects,
+        }
+    }
+}
+
+/// Live free-text input mode on the usage screen. Only `DateRange`
+/// remains — include/exclude project prompts were replaced by the
+/// picker-style chip strip (Enter / Shift+X) per the "no free text in
+/// TUI" principle. The variant is retained as a single-arm enum for
+/// forward compatibility (eg. CLI-driven advanced filters that may
+/// reintroduce a typed input later).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageInputMode {
+    DateRange,
+}
+
+/// Focusable panels on the Burndown dashboard for cross-filter pivot.
+///
+/// Order matters: it defines the Tab/BackTab traversal sequence. The
+/// brief specifies Daily Activity → By Project → Top Sessions → Live →
+/// By Activity → By Model → Named → Optimize → Leaderboard → Budget.
+/// We expand "Named" into the three concrete panels so every visible
+/// table is keyboard-reachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsagePanel {
+    DailyActivity,
+    ByProject,
+    ByBranch,
+    TopSessions,
+    Live,
+    ByActivity,
+    ByModel,
+    CoreTools,
+    ShellCommands,
+    McpServers,
+    Optimize,
+    Leaderboard,
+    Budget,
+}
+
+impl UsagePanel {
+    pub const ALL: [UsagePanel; 13] = [
+        UsagePanel::DailyActivity,
+        UsagePanel::ByProject,
+        UsagePanel::ByBranch,
+        UsagePanel::TopSessions,
+        UsagePanel::Live,
+        UsagePanel::ByActivity,
+        UsagePanel::ByModel,
+        UsagePanel::CoreTools,
+        UsagePanel::ShellCommands,
+        UsagePanel::McpServers,
+        UsagePanel::Optimize,
+        UsagePanel::Leaderboard,
+        UsagePanel::Budget,
+    ];
+
+    pub fn next(self) -> Self {
+        let idx = Self::ALL.iter().position(|p| *p == self).unwrap_or(0);
+        Self::ALL[(idx + 1) % Self::ALL.len()]
+    }
+
+    pub fn prev(self) -> Self {
+        let idx = Self::ALL.iter().position(|p| *p == self).unwrap_or(0);
+        let last = Self::ALL.len() - 1;
+        Self::ALL[if idx == 0 { last } else { idx - 1 }]
+    }
+
+    /// Human-readable panel name used in the zoom breadcrumb.
+    pub fn title(self) -> &'static str {
+        match self {
+            UsagePanel::DailyActivity => "Daily Activity",
+            UsagePanel::ByProject => "By Project",
+            UsagePanel::ByBranch => "By Branch",
+            UsagePanel::TopSessions => "Top Sessions",
+            UsagePanel::Live => "Live Session Ticker",
+            UsagePanel::ByActivity => "By Activity",
+            UsagePanel::ByModel => "By Model",
+            UsagePanel::CoreTools => "Core Tools",
+            UsagePanel::ShellCommands => "Shell Commands",
+            UsagePanel::McpServers => "MCP Servers",
+            UsagePanel::Optimize => "Optimization Recommendations",
+            UsagePanel::Leaderboard => "Agent Leaderboard",
+            UsagePanel::Budget => "Budget · Alerts",
+        }
+    }
+
+    /// Whether `Enter` on this panel maps a row onto a cross-filter.
+    /// Daily Activity, Optimize, and Budget are read-only — Enter is a
+    /// no-op there. Leaderboard maps the focused row onto the Project
+    /// filter (rows are projects).
+    pub fn enter_target(self) -> Option<UsageFilterTarget> {
+        match self {
+            UsagePanel::ByProject | UsagePanel::Leaderboard => Some(UsageFilterTarget::Project),
+            UsagePanel::ByActivity => Some(UsageFilterTarget::Activity),
+            UsagePanel::ByModel => Some(UsageFilterTarget::Model),
+            UsagePanel::TopSessions | UsagePanel::Live => Some(UsageFilterTarget::Session),
+            _ => None,
+        }
+    }
+}
+
+/// Which slot on `UsageFilters` a panel-row commits into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageFilterTarget {
+    Project,
+    Model,
+    Activity,
+    Session,
+}
+
+/// View state for the usage analytics screen.
+///
+// TODO(refactor): collapse the 4 zoom-related fields (zoom,
+// zoom_search_active, zoom_search_query, zoom_detail_open) into a
+// single `Option<ZoomState>` so the "in zoom" invariant lives in the
+// type system. Currently every zoom-related callsite has to remember
+// to check `self.zoom.is_some()` and the search/detail flags carry
+// stale values from prior zoom sessions. Deferred — touches every
+// zoom-related event handler and renderer; safer to land alongside
+// snapshot tests for the zoom view.
+#[derive(Debug, Clone)]
+pub struct UsageViewState {
+    pub provider: UsageProvider,
+    pub active_tab: UsageTab,
+    pub data: Option<UsageData>,
+    pub loading: bool,
+    pub scroll_offset: usize,
+    pub period: UsagePeriod,
+    pub provider_filter: UsageProviderFilter,
+    pub include_projects: Vec<String>,
+    pub exclude_projects: Vec<String>,
+    pub input_mode: Option<UsageInputMode>,
+    pub input_buffer: String,
+    /// Cross-filter chips set by the Burndown panel pivot or CLI flags.
+    /// These layer on top of include/exclude project globs (see
+    /// `models::usage::UsageFilters` for matching semantics).
+    pub filters: UsageFilters,
+    /// Currently-focused dashboard panel (Burndown only). `None` means
+    /// no focus — Tab moves between outer tabs as before.
+    pub focused_panel: Option<UsagePanel>,
+    /// Row indicator inside the focused panel. Clamped to the row count
+    /// of the focused panel's underlying collection at render time.
+    pub focus_row: usize,
+    /// When `Some`, the burndown view is rendered as a single full-area
+    /// zoomed panel for the given panel kind. Driven by the `z`
+    /// keybinding on Burndown; only meaningful when on Burndown.
+    pub zoom: Option<UsagePanel>,
+    /// True when the zoom view's `/` fuzzy-search overlay is active.
+    /// Resets on zoom exit (we deliberately do *not* persist a search
+    /// across zoom cycles — the brief is "search clears on zoom exit").
+    pub zoom_search_active: bool,
+    /// Live query buffer for the zoom-mode fuzzy search.
+    pub zoom_search_query: String,
+    /// True when the zoom view's `d` detail drawer is open. The drawer
+    /// occupies the bottom 40% of the zoom area and shows the full
+    /// row record for the focused row.
+    pub zoom_detail_open: bool,
+    /// Absolute oldest call day observed across the unfiltered call
+    /// set, monotonically narrowing across loads. Used to clamp
+    /// `step_period_back` independent of the currently-active period
+    /// (which restricts `data.daily` to the visible window and would
+    /// otherwise prevent stepping into earlier months/quarters).
+    ///
+    /// Updated on every load via `min(existing, new_min_from_data_calls)`
+    /// so a narrow period (eg. `SpecificMonth(May)`) cannot raise the
+    /// anchor above an earlier value seen during a wider load.
+    pub oldest_call_day: Option<NaiveDate>,
+}
+
+impl Default for UsageViewState {
+    fn default() -> Self {
+        Self {
+            provider: UsageProvider::Claude,
+            active_tab: UsageTab::Burndown,
+            data: None,
+            loading: false,
+            scroll_offset: 0,
+            period: UsagePeriod::Week,
+            provider_filter: UsageProviderFilter::All,
+            include_projects: Vec::new(),
+            exclude_projects: Vec::new(),
+            input_mode: None,
+            input_buffer: String::new(),
+            filters: UsageFilters::default(),
+            focused_panel: None,
+            focus_row: 0,
+            zoom: None,
+            zoom_search_active: false,
+            zoom_search_query: String::new(),
+            zoom_detail_open: false,
+            oldest_call_day: None,
+        }
+    }
+}
+
+/// Direction parameter for `step_period`. Internal — wrappers
+/// `step_period_back` / `step_period_forward` are the public API.
+#[derive(Debug, Clone, Copy)]
+enum StepDirection {
+    Back,
+    Forward,
+}
+
+impl UsageViewState {
+    pub fn next_provider(&mut self) {
+        self.provider = self.provider.next();
+        self.provider_filter = match self.provider {
+            UsageProvider::Claude => UsageProviderFilter::Claude,
+            UsageProvider::Codex => UsageProviderFilter::Codex,
+            UsageProvider::Gemini | UsageProvider::Copilot => UsageProviderFilter::All,
+        };
+        self.scroll_offset = 0;
+    }
+
+    pub fn prev_provider(&mut self) {
+        self.provider = self.provider.prev();
+        self.provider_filter = match self.provider {
+            UsageProvider::Claude => UsageProviderFilter::Claude,
+            UsageProvider::Codex => UsageProviderFilter::Codex,
+            UsageProvider::Gemini | UsageProvider::Copilot => UsageProviderFilter::All,
+        };
+        self.scroll_offset = 0;
+    }
+
+    pub fn cycle_provider_filter(&mut self) {
+        self.provider_filter = match self.provider_filter {
+            UsageProviderFilter::All => UsageProviderFilter::Claude,
+            UsageProviderFilter::Claude => UsageProviderFilter::Codex,
+            UsageProviderFilter::Codex => UsageProviderFilter::All,
+        };
+        self.scroll_offset = 0;
+    }
+
+    pub fn set_period(&mut self, period: UsagePeriod) {
+        self.period = period;
+        self.scroll_offset = 0;
+    }
+
+    /// Step the active Month or Quarter picker one unit back. Clamps
+    /// at `oldest_call_day` — the absolute oldest day observed across
+    /// the unfiltered call set — so the user can step from a narrow
+    /// period (eg. `SpecificMonth(May)`) into an earlier month, even
+    /// though `data.daily` only holds the May rows in that state.
+    /// Returns `true` when the period actually changed.
+    ///
+    /// No-op when the active period is not a Month/Quarter picker, or
+    /// when no data has been loaded yet (no oldest anchor to clamp
+    /// against — would let the user wander arbitrarily far back).
+    pub fn step_period_back(&mut self) -> bool {
+        let Some(oldest) = self.oldest_call_day else {
+            return false;
+        };
+        self.step_period(StepDirection::Back, oldest)
+    }
+
+    /// Step forward one unit. Clamps at the current real-world month
+    /// or quarter — never lets the user pick a future window.
+    pub fn step_period_forward(&mut self) -> bool {
+        let today = Local::now().date_naive();
+        self.step_period(StepDirection::Forward, today)
+    }
+
+    /// Shared body for back/forward stepping. `clamp_anchor` is the
+    /// extreme of the allowed range — the oldest data day for `Back`,
+    /// today for `Forward`.
+    fn step_period(&mut self, direction: StepDirection, clamp_anchor: NaiveDate) -> bool {
+        match self.period.clone() {
+            UsagePeriod::SpecificMonth(anchor) => {
+                let new_anchor = match direction {
+                    StepDirection::Back => previous_month_first(anchor),
+                    StepDirection::Forward => next_month_first(anchor),
+                };
+                let clamp = first_of_month(clamp_anchor);
+                let out_of_range = match direction {
+                    StepDirection::Back => new_anchor < clamp,
+                    StepDirection::Forward => new_anchor > clamp,
+                };
+                if out_of_range {
+                    return false;
+                }
+                self.period = UsagePeriod::SpecificMonth(new_anchor);
+                self.scroll_offset = 0;
+                true
+            }
+            UsagePeriod::SpecificQuarter(year, q) => {
+                let (new_year, new_q) = match direction {
+                    StepDirection::Back => previous_quarter(year, q),
+                    StepDirection::Forward => next_quarter(year, q),
+                };
+                let (cy, cq) = current_quarter(clamp_anchor);
+                let out_of_range = match direction {
+                    StepDirection::Back => (new_year, new_q) < (cy, cq),
+                    StepDirection::Forward => (new_year, new_q) > (cy, cq),
+                };
+                if out_of_range {
+                    return false;
+                }
+                self.period = UsagePeriod::SpecificQuarter(new_year, new_q);
+                self.scroll_offset = 0;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn next_tab(&mut self) {
+        self.active_tab = self.active_tab.next();
+        self.scroll_offset = 0;
+    }
+
+    pub fn prev_tab(&mut self) {
+        self.active_tab = self.active_tab.prev();
+        self.scroll_offset = 0;
+    }
+
+    pub fn scroll_up(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(1);
+    }
+
+    pub fn scroll_down(&mut self, max_rows: usize) {
+        if self.scroll_offset < max_rows.saturating_sub(1) {
+            self.scroll_offset += 1;
+        }
+    }
+
+    pub fn scroll_to_top(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    pub fn scroll_to_bottom(&mut self, max_rows: usize) {
+        self.scroll_offset = max_rows.saturating_sub(1);
+    }
+
+    pub fn page_up(&mut self, page_size: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(page_size);
+    }
+
+    pub fn page_down(&mut self, max_rows: usize, page_size: usize) {
+        self.scroll_offset = (self.scroll_offset + page_size).min(max_rows.saturating_sub(1));
+    }
+
+    pub fn row_count(&self) -> usize {
+        match &self.data {
+            None => 0,
+            Some(data) => match self.active_tab {
+                UsageTab::Daily => data.daily.len(),
+                UsageTab::Weekly => data.weekly.len(),
+                UsageTab::Projects => data.projects.len(),
+                UsageTab::Burndown => {
+                    data.daily.len()
+                        + data.projects.len()
+                        + data.sessions.len()
+                        + data.activities.len()
+                        + data.models.len()
+                }
+                UsageTab::Optimize => optimize_usage(data).findings.len(),
+            },
+        }
+    }
+
+    pub fn query(&self) -> UsageQuery {
+        UsageQuery {
+            period: self.period.clone(),
+            provider_filter: self.provider_filter,
+            include_projects: self.include_projects.clone(),
+            exclude_projects: self.exclude_projects.clone(),
+            // Cross-filters apply client-side via `filter_usage_data` after
+            // the (cached) parse, so we deliberately do NOT plumb them
+            // into the parse query — that would invalidate the cache key
+            // every time the user pivoted.
+            filters: UsageFilters::default(),
+        }
+    }
+
+    pub fn begin_input(&mut self, mode: UsageInputMode) {
+        self.input_mode = Some(mode);
+        self.input_buffer.clear();
+    }
+
+    pub fn input_char(&mut self, ch: char) {
+        self.input_buffer.push(ch);
+    }
+
+    pub fn input_backspace(&mut self) {
+        self.input_buffer.pop();
+    }
+
+    pub fn cancel_input(&mut self) {
+        self.input_mode = None;
+        self.input_buffer.clear();
+    }
+
+    pub fn submit_input(&mut self) -> Result<(), String> {
+        let value = self.input_buffer.trim().to_string();
+        match self.input_mode {
+            Some(UsageInputMode::DateRange) => {
+                let parts: Vec<_> = value
+                    .split(|ch| ch == '.' || ch == ',' || ch == ' ')
+                    .filter(|part| !part.is_empty())
+                    .collect();
+                if parts.len() != 2 {
+                    return Err("Use YYYY-MM-DD YYYY-MM-DD".to_string());
+                }
+                let from = chrono::NaiveDate::parse_from_str(parts[0], "%Y-%m-%d")
+                    .map_err(|_| "Invalid from date".to_string())?;
+                let to = chrono::NaiveDate::parse_from_str(parts[1], "%Y-%m-%d")
+                    .map_err(|_| "Invalid to date".to_string())?;
+                if from > to {
+                    return Err("From date must be before to date".to_string());
+                }
+                self.period = UsagePeriod::Custom { from, to };
+            }
+            None => {}
+        }
+        self.cancel_input();
+        Ok(())
+    }
+
+    /// Cycle the focus pointer to the next panel. If unfocused, focus
+    /// the first panel. Resets `focus_row` to 0.
+    pub fn focus_next_panel(&mut self) {
+        self.focused_panel = Some(match self.focused_panel {
+            Some(panel) => panel.next(),
+            None => UsagePanel::ALL[0],
+        });
+        self.focus_row = 0;
+    }
+
+    pub fn focus_prev_panel(&mut self) {
+        self.focused_panel = Some(match self.focused_panel {
+            Some(panel) => panel.prev(),
+            None => UsagePanel::ALL[UsagePanel::ALL.len() - 1],
+        });
+        self.focus_row = 0;
+    }
+
+    /// Drop focus entirely (no panel highlighted).
+    pub fn clear_focus(&mut self) {
+        self.focused_panel = None;
+        self.focus_row = 0;
+    }
+
+    /// Move the row indicator inside the focused panel. No-op when
+    /// nothing is focused. Clamping happens at render time once we know
+    /// the row count of the underlying collection.
+    pub fn focus_row_up(&mut self) {
+        self.focus_row = self.focus_row.saturating_sub(1);
+    }
+
+    pub fn focus_row_down(&mut self) {
+        // Saturate at usize::MAX is safe — render-side clamps to actual
+        // rows and the user sees no further movement.
+        self.focus_row = self.focus_row.saturating_add(1);
+    }
+
+    /// Filtered view of the parsed data, applying the active cross
+    /// filter chips. Cheap when no filters are set (clones the source).
+    pub fn filtered_data(&self) -> Option<UsageData> {
+        self.data.as_ref().map(|data| filter_usage_data(data, &self.filters))
+    }
+
+    /// Resolve the focused panel row to a `(target, value, owner_project)`
+    /// triple. Shared by include and exclude commit paths so both
+    /// dispatch tables stay in lock-step.
+    fn resolve_focused_row(&self) -> Option<(UsageFilterTarget, String, Option<String>)> {
+        let panel = self.focused_panel?;
+        let target = panel.enter_target()?;
+        let filtered = self.filtered_data()?;
+        let row_idx = self.focus_row;
+        // For Session rows we also need the owning project so we can
+        // auto-attach a project chip — session ids can collide across
+        // projects/providers because the aggregator key is
+        // `provider:project:session_id` but `filters.session` only holds
+        // the bare id. Other targets pass None as the second element.
+        match (target, panel) {
+            (UsageFilterTarget::Project, UsagePanel::Leaderboard | UsagePanel::ByProject) => {
+                filtered.projects.get(row_idx).map(|p| (target, p.name.clone(), None))
+            }
+            (UsageFilterTarget::Activity, _) => filtered
+                .activities
+                .get(row_idx)
+                .map(|a| (target, a.category.label().to_string(), None)),
+            (UsageFilterTarget::Model, _) => {
+                filtered.models.get(row_idx).map(|m| (target, m.model.clone(), None))
+            }
+            (UsageFilterTarget::Session, _) => filtered
+                .sessions
+                .get(row_idx)
+                .map(|s| (target, s.session_id.clone(), Some(s.project.clone()))),
+            _ => None,
+        }
+    }
+
+    /// Append the focused row of the focused panel as a chip. Returns
+    /// `true` if a chip was added (so callers can show feedback).
+    /// Requires `data` to be loaded; uses the unfiltered `data` to
+    /// resolve the row by index because that's what the user is
+    /// looking at when focus is active (we render from filtered_data
+    /// at draw time, which is the same source).
+    pub fn commit_focused_row(&mut self) -> bool {
+        let Some((target, value, owner_project)) = self.resolve_focused_row() else {
+            return false;
+        };
+        match target {
+            UsageFilterTarget::Project => {
+                if !self.filters.project.contains(&value) {
+                    self.filters.project.push(value);
+                }
+            }
+            UsageFilterTarget::Model => {
+                if !self.filters.model.contains(&value) {
+                    self.filters.model.push(value);
+                }
+            }
+            UsageFilterTarget::Activity => {
+                if !self.filters.activity.contains(&value) {
+                    self.filters.activity.push(value);
+                }
+            }
+            UsageFilterTarget::Session => {
+                if !self.filters.session.contains(&value) {
+                    self.filters.session.push(value);
+                }
+                if let Some(p) = owner_project {
+                    if !self.filters.project.contains(&p) {
+                        self.filters.project.push(p);
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    /// Append the focused row as an *exclude* chip. Mirror of
+    /// `commit_focused_row` that routes into the `exclude_*` filter
+    /// lists. Session rows do NOT auto-attach an owner-project exclude
+    /// — excluding the project because one of its sessions was excluded
+    /// would discard sibling sessions the user did not target.
+    pub fn commit_focused_row_exclude(&mut self) -> bool {
+        let Some((target, value, _owner_project)) = self.resolve_focused_row() else {
+            return false;
+        };
+        match target {
+            UsageFilterTarget::Project => {
+                if !self.filters.exclude_project.contains(&value) {
+                    self.filters.exclude_project.push(value);
+                }
+            }
+            UsageFilterTarget::Model => {
+                if !self.filters.exclude_model.contains(&value) {
+                    self.filters.exclude_model.push(value);
+                }
+            }
+            UsageFilterTarget::Activity => {
+                if !self.filters.exclude_activity.contains(&value) {
+                    self.filters.exclude_activity.push(value);
+                }
+            }
+            UsageFilterTarget::Session => {
+                if !self.filters.exclude_session.contains(&value) {
+                    self.filters.exclude_session.push(value);
+                }
+            }
+        }
+        true
+    }
+
+    /// Pop the most recently added cross-filter chip. Returns the
+    /// removed chip so the caller can echo it in the notification.
+    pub fn pop_filter_chip(&mut self) -> Option<UsageFilterChip> {
+        self.filters.pop_last()
+    }
+
+    /// Drop every cross-filter chip. Leaves include/exclude untouched.
+    pub fn clear_all_filter_chips(&mut self) {
+        self.filters.clear();
+    }
+
+    /// True when the burndown view is currently zoomed.
+    pub fn is_zoomed(&self) -> bool {
+        self.zoom.is_some()
+    }
+
+    /// Toggle full-screen zoom for the currently-focused panel. If no
+    /// panel is focused (Tab not pressed yet), the first focusable
+    /// dashboard panel is used so `z` works as a discoverable
+    /// "open up bigger" shortcut.
+    pub fn toggle_zoom(&mut self) {
+        if self.zoom.is_some() {
+            self.exit_zoom();
+        } else {
+            let target = self.focused_panel.unwrap_or(UsagePanel::ALL[0]);
+            self.zoom = Some(target);
+            self.focused_panel = Some(target);
+            self.focus_row = 0;
+            self.zoom_search_active = false;
+            self.zoom_search_query.clear();
+            self.zoom_detail_open = false;
+        }
+    }
+
+    /// Exit zoom mode and clear all zoom-scoped UI state (search query,
+    /// detail drawer). Does NOT clear filter chips.
+    pub fn exit_zoom(&mut self) {
+        self.zoom = None;
+        self.zoom_search_active = false;
+        self.zoom_search_query.clear();
+        self.zoom_detail_open = false;
+    }
+
+    /// Begin fuzzy-search input inside the zoomed panel. Preserves the
+    /// prior typed query so re-pressing `/` resumes editing where the
+    /// last search left off (vim / fzf convention). Esc (`zoom_cancel_search`)
+    /// is the path that drops the query entirely.
+    pub fn zoom_begin_search(&mut self) {
+        if self.zoom.is_some() {
+            self.zoom_search_active = true;
+        }
+    }
+
+    /// Cancel the active search and drop the partial query.
+    pub fn zoom_cancel_search(&mut self) {
+        self.zoom_search_active = false;
+        self.zoom_search_query.clear();
+    }
+
+    /// Commit the typed search query. Same effect as cancel for the
+    /// renderer (we filter by `zoom_search_query`); we just exit input
+    /// mode so further keys flow back to navigation.
+    pub fn zoom_commit_search(&mut self) {
+        self.zoom_search_active = false;
+    }
+
+    pub fn zoom_search_char(&mut self, ch: char) {
+        if self.zoom_search_active {
+            self.zoom_search_query.push(ch);
+        }
+    }
+
+    pub fn zoom_search_backspace(&mut self) {
+        if self.zoom_search_active {
+            self.zoom_search_query.pop();
+        }
+    }
+
+    pub fn toggle_zoom_detail(&mut self) {
+        if self.zoom.is_some() {
+            self.zoom_detail_open = !self.zoom_detail_open;
+        }
+    }
+
+    /// Esc precedence in the zoom view (highest first):
+    /// 1. close detail drawer
+    /// 2. cancel active search
+    /// 3. exit zoom
+    /// 4. pop a chip (caller falls through here when nothing else
+    ///    handled it — this method only consumes the first three).
+    ///
+    /// Returns `true` when Esc was consumed.
+    pub fn zoom_handle_esc(&mut self) -> bool {
+        if !self.is_zoomed() {
+            return false;
+        }
+        if self.zoom_detail_open {
+            self.zoom_detail_open = false;
+            return true;
+        }
+        if self.zoom_search_active {
+            self.zoom_cancel_search();
+            return true;
+        }
+        self.exit_zoom();
+        true
+    }
+}
+
+/// Render the usage analytics screen
+pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    // Main layout: header + provider selector + tabs + content + help bar
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Summary bar
+            Constraint::Length(3), // Provider selector
+            Constraint::Length(3), // Tab bar
+            Constraint::Min(0),    // Table content
+            Constraint::Length(2), // Help bar
+        ])
+        .split(area);
+
+    render_summary_bar(buf, layout[0], state);
+    render_provider_bar(buf, layout[1], state);
+    render_tab_bar(buf, layout[2], state);
+
+    if state.loading || state.data.is_none() {
+        render_loading(buf, layout[3]);
+    } else {
+        let data = state.data.as_ref().unwrap();
+        if data.calls.is_empty() && !state.provider.has_data() {
+            render_no_data(buf, layout[3], state);
+        } else {
+            match state.active_tab {
+                UsageTab::Daily => render_daily(buf, layout[3], data, state.scroll_offset),
+                UsageTab::Weekly => render_weekly(buf, layout[3], data, state.scroll_offset),
+                UsageTab::Projects => render_projects(buf, layout[3], data, state.scroll_offset),
+                UsageTab::Burndown => render_burndown(buf, layout[3], data, state),
+                UsageTab::Optimize => render_optimize(buf, layout[3], data),
+            }
+        }
+    }
+
+    render_help_bar(buf, layout[4], state);
+}
+
+fn render_summary_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let mut spans = vec![
+        Span::styled("📊 ", Style::default().fg(GOLD)),
+        Span::styled(
+            "Usage Analytics",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+    ];
+
+    if let Some(data) = &state.data {
+        let gt = &data.grand_total;
+        spans.extend_from_slice(&[
+            Span::styled("  │  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Total: ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(gt.total()),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" tokens", Style::default().fg(MUTED_GRAY)),
+            Span::styled("  │  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{}", data.daily.len()),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled(" days  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{}", data.projects.len()),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled(" projects  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{}", gt.session_count),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled(" sessions", Style::default().fg(MUTED_GRAY)),
+        ]);
+    } else if state.provider.has_data() {
+        spans.push(Span::styled(
+            "  │  Loading...",
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let paragraph = Paragraph::new(Line::from(spans)).block(block);
+    ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+fn render_provider_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let mut spans: Vec<Span> = vec![Span::styled(
+        "  Provider: ",
+        Style::default().fg(MUTED_GRAY),
+    )];
+
+    for (i, provider) in UsageProvider::all().iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled("  │  ", Style::default().fg(MUTED_GRAY)));
+        }
+
+        let is_active = *provider == state.provider;
+        let style = if is_active {
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else if provider.has_data() {
+            Style::default().fg(SOFT_WHITE)
+        } else {
+            Style::default().fg(MUTED_GRAY)
+        };
+
+        spans.push(Span::styled(provider.label(), style));
+    }
+
+    spans.push(Span::styled("    ", Style::default()));
+    spans.push(Span::styled(
+        "◀/▶",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(" switch", Style::default().fg(MUTED_GRAY)));
+    spans.push(Span::styled("  │  p ", Style::default().fg(GOLD)));
+    spans.push(Span::styled(
+        format!("filter: {}", provider_filter_label(state.provider_filter)),
+        Style::default().fg(MUTED_GRAY),
+    ));
+    spans.push(Span::styled("  │  ", Style::default().fg(MUTED_GRAY)));
+    spans.push(Span::styled(
+        period_label(&state.period),
+        Style::default().fg(SOFT_WHITE),
+    ));
+    if !state.include_projects.is_empty() || !state.exclude_projects.is_empty() {
+        spans.push(Span::styled(
+            "  │  filters active",
+            Style::default().fg(GOLD),
+        ));
+    }
+    if let Some(mode) = state.input_mode {
+        spans.push(Span::styled("  │  ", Style::default().fg(MUTED_GRAY)));
+        spans.push(Span::styled(
+            format!("{}: {}", input_label(mode), state.input_buffer),
+            Style::default().fg(GOLD),
+        ));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let paragraph = Paragraph::new(Line::from(spans)).block(block);
+    ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+fn render_no_data(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ", Style::default()),
+            Span::styled(
+                state.provider.label(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " usage tracking is not yet available.",
+                Style::default().fg(MUTED_GRAY),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Usage data parsing is currently supported for Claude Code and Codex.",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        )),
+        Line::from(Span::styled(
+            "  Other providers will be added as they expose session-level usage data.",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        )),
+    ];
+
+    let paragraph = Paragraph::new(lines);
+    ratatui::widgets::Widget::render(paragraph, inner, buf);
+}
+
+fn render_tab_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let titles: Vec<Line> = UsageTab::all()
+        .iter()
+        .map(|t| {
+            let style = if *t == state.active_tab {
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                Style::default().fg(MUTED_GRAY)
+            };
+            Line::from(Span::styled(t.title(), style))
+        })
+        .collect();
+
+    let idx = UsageTab::all().iter().position(|t| *t == state.active_tab).unwrap_or(0);
+    let tabs = Tabs::new(titles)
+        .select(idx)
+        .highlight_style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .divider(Span::styled(" │ ", Style::default().fg(MUTED_GRAY)))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(CORNFLOWER_BLUE))
+                .style(Style::default().bg(DARK_BG)),
+        );
+
+    ratatui::widgets::Widget::render(tabs, area, buf);
+}
+
+fn render_loading(buf: &mut Buffer, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    // Phase 6c: burndown no longer scans session files itself — the
+    // session-reader plugin owns the data plane and publishes
+    // `sessions.usage_data`. This empty state is what the user sees
+    // until the first event arrives (cold-cache scan ~5s) or
+    // permanently if session-reader is missing from `dist/plugins/`,
+    // which makes the data-flow gap detectable instead of silent.
+    let paragraph = Paragraph::new(Line::from(vec![Span::styled(
+        "  ⏳ Waiting for session-reader plugin...",
+        Style::default().fg(MUTED_GRAY),
+    )]))
+    .block(block);
+    ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+fn render_daily(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    if data.daily.is_empty() {
+        let p = Paragraph::new("  No usage data found.").style(Style::default().fg(MUTED_GRAY));
+        ratatui::widgets::Widget::render(p, inner, buf);
+        return;
+    }
+
+    // Split into table + bar chart
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(inner);
+
+    // Table
+    let header = Row::new(vec![
+        "Date", "Total", "Input", "Cache", "Output", "Sessions",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = chunks[0].height.saturating_sub(2) as usize;
+    let total_rows = data.daily.len();
+    // Default scroll to bottom (show most recent)
+    let effective_offset = if scroll_offset == 0 && total_rows > visible_rows {
+        total_rows.saturating_sub(visible_rows)
+    } else {
+        scroll_offset
+    };
+
+    let rows: Vec<Row> = data
+        .daily
+        .iter()
+        .skip(effective_offset)
+        .take(visible_rows)
+        .map(|(date, bucket)| {
+            Row::new(vec![
+                date.format("%Y-%m-%d").to_string(),
+                format_tokens_short(bucket.total()),
+                format_tokens_short(bucket.input_tokens),
+                format_tokens_short(bucket.cache_read_tokens + bucket.cache_creation_tokens),
+                format_tokens_short(bucket.output_tokens),
+                format!("{}", bucket.session_count),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(12),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+    ];
+
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
+
+    ratatui::widgets::Widget::render(table, chunks[0], buf);
+
+    // Bar chart (last N days that fit)
+    render_bar_chart(buf, chunks[1], data);
+}
+
+fn render_weekly(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    if data.weekly.is_empty() {
+        let p = Paragraph::new("  No usage data found.").style(Style::default().fg(MUTED_GRAY));
+        ratatui::widgets::Widget::render(p, inner, buf);
+        return;
+    }
+
+    let header = Row::new(vec![
+        "Week Start",
+        "Total",
+        "Input",
+        "Cache",
+        "Output",
+        "Sessions",
+        "Projects",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = inner.height.saturating_sub(2) as usize;
+    let total_rows = data.weekly.len();
+    let effective_offset = if scroll_offset == 0 && total_rows > visible_rows {
+        total_rows.saturating_sub(visible_rows)
+    } else {
+        scroll_offset
+    };
+
+    let rows: Vec<Row> = data
+        .weekly
+        .iter()
+        .skip(effective_offset)
+        .take(visible_rows)
+        .map(|(date, bucket)| {
+            Row::new(vec![
+                date.format("%Y-%m-%d").to_string(),
+                format_tokens_short(bucket.total()),
+                format_tokens_short(bucket.input_tokens),
+                format_tokens_short(bucket.cache_read_tokens + bucket.cache_creation_tokens),
+                format_tokens_short(bucket.output_tokens),
+                format!("{}", bucket.session_count),
+                format!("{}", bucket.project_count),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(12),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(8),
+    ];
+
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
+
+    ratatui::widgets::Widget::render(table, inner, buf);
+}
+
+fn render_projects(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    if data.projects.is_empty() {
+        let p = Paragraph::new("  No usage data found.").style(Style::default().fg(MUTED_GRAY));
+        ratatui::widgets::Widget::render(p, inner, buf);
+        return;
+    }
+
+    let header = Row::new(vec![
+        "#", "Project", "Total", "Input", "Cache", "Output", "Sessions",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = inner.height.saturating_sub(2) as usize;
+
+    let rows: Vec<Row> = data
+        .projects
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(visible_rows)
+        .map(|(i, proj)| {
+            let b = &proj.bucket;
+            Row::new(vec![
+                format!("{}", i + 1),
+                truncate_string(&proj.name, 40),
+                format_tokens_short(b.total()),
+                format_tokens_short(b.input_tokens),
+                format_tokens_short(b.cache_read_tokens + b.cache_creation_tokens),
+                format_tokens_short(b.output_tokens),
+                format!("{}", b.session_count),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(4),
+        Constraint::Min(20),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+    ];
+
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
+
+    ratatui::widgets::Widget::render(table, inner, buf);
+}
+
+fn render_burndown(buf: &mut Buffer, area: Rect, data: &UsageData, state: &UsageViewState) {
+    let block = Block::default()
+        .title(" [ Burndown ] ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(TERMINAL_BORDER))
+        .style(Style::default().bg(TERMINAL_BG));
+
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    if data.calls.is_empty() {
+        let p = Paragraph::new("  No usage data found for selected period/provider/filter.")
+            .style(Style::default().fg(MUTED_GRAY));
+        ratatui::widgets::Widget::render(p, inner, buf);
+        return;
+    }
+
+    // Apply cross-filter chips client-side. With no chips this is a
+    // cheap clone; with chips it re-aggregates from the in-memory call
+    // set so every panel and the header reflect the active pivot.
+    let filtered = filter_usage_data(data, &state.filters);
+    let view_data: &UsageData = if state.filters.any() { &filtered } else { data };
+
+    // Zoom takes the full inner area minus a small breadcrumb and an
+    // optional search box. Skip the dashboard grid entirely.
+    if let Some(panel) = state.zoom {
+        render_burndown_zoomed(buf, inner, view_data, state, panel);
+        return;
+    }
+
+    // Filter chip strip occupies one row when chips are active OR when
+    // a panel is focused (we want the affordance hint visible). When
+    // both are absent we still show the hint at low contrast so users
+    // discover the pivot.
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // header
+            Constraint::Length(2), // period+provider strip
+            Constraint::Length(1), // chip strip / hint
+            Constraint::Min(0),    // dashboard
+        ])
+        .split(inner);
+
+    render_burndown_header(buf, vertical[0], view_data, &state.period);
+    render_period_row(buf, vertical[1], state);
+    render_filter_chip_strip(buf, vertical[2], state);
+
+    if vertical[3].width >= 120 && vertical[3].height >= 22 {
+        render_dashboard_grid(buf, vertical[3], view_data, &state.period, state);
+    } else if vertical[3].width >= 96 {
+        render_dashboard_compact(buf, vertical[3], view_data, state);
+    } else {
+        render_dashboard_stack(buf, vertical[3], view_data, state);
+    }
+}
+
+/// Full-screen zoom for a single dashboard panel. The layout is:
+///
+/// ```text
+/// [ Zoomed: <panel name> ]   ◀ Esc back ▶
+/// / search query                              <- only when search active
+/// ┌───────────── panel body (all rows + extra cols) ─────────────┐
+/// │                                                              │
+/// └──────────────────────────────────────────────────────────────┘
+/// ┌──── Detail drawer ─────────── 40% bottom split, when open ──┐
+/// │                                                              │
+/// └──────────────────────────────────────────────────────────────┘
+/// ```
+fn render_burndown_zoomed(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) {
+    let search_h: u16 = if state.zoom_search_active || !state.zoom_search_query.is_empty() {
+        1
+    } else {
+        0
+    };
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // breadcrumb
+            Constraint::Length(search_h),
+            Constraint::Min(0), // body (and optional detail split)
+        ])
+        .split(area);
+
+    render_zoom_breadcrumb(buf, vertical[0], panel);
+    if search_h > 0 {
+        render_zoom_search_bar(buf, vertical[1], state);
+    }
+
+    // Optional 60/40 vertical split when the detail drawer is open.
+    let body_area = vertical[2];
+    let (panel_area, detail_area) = if state.zoom_detail_open {
+        let split = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(body_area);
+        (split[0], Some(split[1]))
+    } else {
+        (body_area, None)
+    };
+
+    render_zoom_panel_body(buf, panel_area, data, state, panel);
+
+    if let Some(detail) = detail_area {
+        render_zoom_detail_drawer(buf, detail, data, state, panel);
+    }
+}
+
+fn render_zoom_breadcrumb(buf: &mut Buffer, area: Rect, panel: UsagePanel) {
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" [ Zoomed: {} ] ", panel.title()),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("   ", Style::default()),
+        Span::styled("◀ Esc back ▶", Style::default().fg(MUTED_GRAY)),
+    ]);
+    ratatui::widgets::Widget::render(Paragraph::new(line), area, buf);
+}
+
+/// Score `haystack` against `query` with nucleo-matcher; `None` means
+/// no match. An empty query matches everything (returns `Some(0)`).
+///
+/// When either side carries non-ASCII codepoints we route through
+/// `Utf32String` so multibyte chars match natively. The previous code
+/// fed `Utf32Str::Ascii(haystack.as_bytes())` even when the query had
+/// non-ASCII content, which silently lost matches.
+fn fuzzy_score(matcher: &mut nucleo_matcher::Matcher, query: &str, haystack: &str) -> Option<u32> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let needle = nucleo_matcher::pattern::Pattern::parse(
+        query,
+        nucleo_matcher::pattern::CaseMatching::Smart,
+        nucleo_matcher::pattern::Normalization::Smart,
+    );
+    if query.is_ascii() && haystack.is_ascii() {
+        needle.score(
+            nucleo_matcher::Utf32Str::Ascii(haystack.as_bytes()),
+            matcher,
+        )
+    } else {
+        let utf32 = nucleo_matcher::Utf32String::from(haystack);
+        needle.score(utf32.slice(..), matcher)
+    }
+}
+
+/// Filter `rows` by a fuzzy-search query, preserving original order.
+/// Empty query returns all rows. The `label` closure projects each row
+/// to its primary search string (project name, session id, etc.).
+///
+/// Pattern parsing happens once before the filter loop (was per-call
+/// inside the filter via fuzzy_score). Worth doing because zoom-mode
+/// re-renders typing-rate (~10/s) over potentially 1k+ row sets.
+fn apply_zoom_filter<'a, T, F>(rows: &'a [T], query: &str, label: F) -> Vec<&'a T>
+where
+    F: Fn(&T) -> String,
+{
+    if query.is_empty() {
+        return rows.iter().collect();
+    }
+    let needle = nucleo_matcher::pattern::Pattern::parse(
+        query,
+        nucleo_matcher::pattern::CaseMatching::Smart,
+        nucleo_matcher::pattern::Normalization::Smart,
+    );
+    let query_ascii = query.is_ascii();
+    let mut matcher = nucleo_matcher::Matcher::new(nucleo_matcher::Config::DEFAULT);
+    rows.iter()
+        .filter_map(|row| {
+            let label = label(row);
+            let score = if query_ascii && label.is_ascii() {
+                needle.score(
+                    nucleo_matcher::Utf32Str::Ascii(label.as_bytes()),
+                    &mut matcher,
+                )
+            } else {
+                let utf32 = nucleo_matcher::Utf32String::from(label.as_str());
+                needle.score(utf32.slice(..), &mut matcher)
+            };
+            score.map(|_| row)
+        })
+        .collect()
+}
+
+fn render_zoom_search_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let cursor = if state.zoom_search_active { "_" } else { "" };
+    let line = Line::from(vec![
+        Span::styled(
+            " / ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            state.zoom_search_query.clone(),
+            Style::default().fg(SOFT_WHITE),
+        ),
+        Span::styled(cursor, Style::default().fg(GOLD)),
+    ]);
+    ratatui::widgets::Widget::render(Paragraph::new(line), area, buf);
+}
+
+/// Render the body of a zoomed panel — all rows visible, primary
+/// columns plus extras specific to the panel. Each row is filtered by
+/// `state.zoom_search_query` (fuzzy match on the row's primary label).
+///
+/// Per the brief, the headline panels (By Project, Top Sessions, By
+/// Model, By Activity, Daily Activity) get extra columns; everything
+/// else just renders the full untruncated row list inside the same
+/// focus-aware frame used by the dashboard renderers.
+#[allow(clippy::too_many_lines)]
+fn render_zoom_panel_body(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) {
+    let q = state.zoom_search_query.as_str();
+    match panel {
+        UsagePanel::ByProject => render_zoom_by_project(buf, area, data, state, q),
+        UsagePanel::ByBranch => render_zoom_by_branch(buf, area, data, state, q),
+        UsagePanel::TopSessions => render_zoom_top_sessions(buf, area, data, state, q),
+        UsagePanel::Live => render_zoom_top_sessions(buf, area, data, state, q),
+        UsagePanel::ByModel => render_zoom_by_model(buf, area, data, state, q),
+        UsagePanel::ByActivity => render_zoom_by_activity(buf, area, data, state, q),
+        UsagePanel::DailyActivity => render_zoom_daily_activity(buf, area, data, state, q),
+        UsagePanel::Leaderboard => render_zoom_by_project(buf, area, data, state, q),
+        UsagePanel::CoreTools => {
+            render_zoom_named(buf, area, "Core Tools", &data.tools, state, q)
+        }
+        UsagePanel::ShellCommands => render_zoom_named(
+            buf,
+            area,
+            "Shell Commands",
+            &data.shell_commands,
+            state,
+            q,
+        ),
+        UsagePanel::McpServers => {
+            render_zoom_named(buf, area, "MCP Servers", &data.mcp_servers, state, q)
+        }
+        UsagePanel::Optimize | UsagePanel::Budget => {
+            // These panels are summary cards rather than row lists. We
+            // reuse the standard renderers in a fullscreen frame.
+            let focus = FocusCtx::for_panel(state, panel);
+            if matches!(panel, UsagePanel::Optimize) {
+                render_optimize_compact_panel(buf, area, data, focus);
+            } else {
+                render_budget_panel(buf, area, data, &state.period, focus);
+            }
+        }
+    }
+}
+
+// TODO(refactor): the 5 render_zoom_* fns below all build a header,
+// truncate to area.height-2 visible rows, build per-row cells, and
+// hand a Table back to the frame. Extract a `render_zoom_table` helper
+// taking `ZoomTableSpec { headers, widths, rows }` once snapshot tests
+// exist to assert visual identity — without them a refactor risks
+// silent column-spacing/header-style drift.
+fn render_zoom_by_project(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.projects, query, |p| p.name.clone());
+    let header = Row::new(vec![
+        "#",
+        "Project",
+        "Cost",
+        "Tokens",
+        "Calls",
+        "Sessions",
+        "First seen",
+        "Last seen",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .enumerate()
+        .take(visible_rows)
+        .map(|(idx, project)| {
+            let b = &project.bucket;
+            let (first, last) = project_seen_window(data, &project.name);
+            Row::new(vec![
+                format!("{}", idx + 1),
+                project.path.clone(),
+                format_cost(b.cost_usd),
+                format_tokens_short(b.total()),
+                b.call_count.to_string(),
+                b.session_count.to_string(),
+                first,
+                last,
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(4),
+        Constraint::Min(20),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(8),
+        Constraint::Length(11),
+        Constraint::Length(11),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+/// Zoom view for the By Branch panel. `BranchUsage` carries only the
+/// branch label and a `TokenBucket`, so the zoom table is intentionally
+/// narrow — `Branch | Tokens | Cost` is everything we have. Search
+/// matches on the branch name.
+fn render_zoom_by_branch(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.branches, query, |b| b.branch.clone());
+    let header = Row::new(vec!["#", "Branch", "Tokens", "Cost"])
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
+
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .enumerate()
+        .take(visible_rows)
+        .map(|(idx, row)| {
+            let b = &row.bucket;
+            Row::new(vec![
+                format!("{}", idx + 1),
+                row.branch.clone(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(4),
+        Constraint::Min(20),
+        Constraint::Length(10),
+        Constraint::Length(10),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+fn render_zoom_top_sessions(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.sessions, query, |s| {
+        format!("{} {}", s.project, s.session_id)
+    });
+    let header = Row::new(vec![
+        "Provider",
+        "Project",
+        "Session",
+        "Cost",
+        "Tokens",
+        "Calls",
+        "Duration",
+        "Last seen",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .take(visible_rows)
+        .map(|sess| {
+            let b = &sess.bucket;
+            let dur = (sess.last_timestamp - sess.first_timestamp).num_seconds().max(0);
+            let dur_str = format_duration_min(dur as u64);
+            Row::new(vec![
+                sess.provider.clone(),
+                truncate_string(&sess.project, 24),
+                truncate_string(&sess.session_id, 18),
+                format_cost(b.cost_usd),
+                format_tokens_short(b.total()),
+                b.call_count.to_string(),
+                dur_str,
+                sess.last_timestamp.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string(),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(8),
+        Constraint::Length(24),
+        Constraint::Length(18),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(11),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+fn render_zoom_by_model(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.models, query, |m| m.model.clone());
+    let header = Row::new(vec![
+        "Model",
+        "Calls",
+        "Tokens",
+        "Cost",
+        "Cost/call",
+        "Top projects",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .take(visible_rows)
+        .map(|m| {
+            let b = &m.bucket;
+            let cost_per_call = b
+                .cost_usd
+                .map(|c| {
+                    if b.call_count == 0 {
+                        0.0
+                    } else {
+                        c / (b.call_count as f64)
+                    }
+                })
+                .map(|c| format!("${c:.4}"))
+                .unwrap_or_else(|| "—".to_string());
+            let top_projects = top_projects_for_model(data, &m.model, 3);
+            Row::new(vec![
+                m.model.clone(),
+                b.call_count.to_string(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+                cost_per_call,
+                top_projects,
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Min(20),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(11),
+        Constraint::Min(20),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+fn render_zoom_by_activity(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let rows = apply_zoom_filter(&data.activities, query, |a| a.category.label().to_string());
+    let header = Row::new(vec![
+        "Activity", "Turns", "Edit", "1-shot", "Retries", "Tokens", "Cost",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .take(visible_rows)
+        .map(|a| {
+            let b = &a.bucket;
+            Row::new(vec![
+                a.category.label().to_string(),
+                a.turns.to_string(),
+                a.edit_turns.to_string(),
+                a.one_shot_turns.to_string(),
+                a.retries.to_string(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(14),
+        Constraint::Length(7),
+        Constraint::Length(7),
+        Constraint::Length(7),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(10),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+fn render_zoom_daily_activity(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    _state: &UsageViewState,
+    query: &str,
+) {
+    // Daily rows are (date, bucket) tuples — search over the date string.
+    let rows: Vec<&(NaiveDate, crate::data::usage::TokenBucket)> = if query.is_empty() {
+        data.daily.iter().collect()
+    } else {
+        data.daily
+            .iter()
+            .filter(|(date, _)| date.format("%Y-%m-%d").to_string().contains(query))
+            .collect()
+    };
+    let header = Row::new(vec![
+        "Date", "Calls", "Sessions", "Projects", "Tokens", "Cost",
+    ])
+    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = rows
+        .iter()
+        .rev()
+        .take(visible_rows)
+        .map(|(date, b)| {
+            Row::new(vec![
+                date.format("%Y-%m-%d").to_string(),
+                b.call_count.to_string(),
+                b.session_count.to_string(),
+                b.project_count.to_string(),
+                format_tokens_short(b.total()),
+                format_cost(b.cost_usd),
+            ])
+            .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(11),
+        Constraint::Length(8),
+        Constraint::Length(9),
+        Constraint::Length(9),
+        Constraint::Length(10),
+        Constraint::Length(10),
+    ];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+fn render_zoom_named(
+    buf: &mut Buffer,
+    area: Rect,
+    title: &str,
+    rows: &[NamedUsage],
+    _state: &UsageViewState,
+    query: &str,
+) {
+    let filtered = apply_zoom_filter(rows, query, |n| n.name.clone());
+    let header = Row::new(vec![title, "Calls"])
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
+        .bottom_margin(1);
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let table_rows: Vec<Row> = filtered
+        .iter()
+        .take(visible_rows)
+        .map(|row| {
+            Row::new(vec![row.name.clone(), row.calls.to_string()])
+                .style(Style::default().fg(SOFT_WHITE))
+        })
+        .collect();
+    let widths = [Constraint::Min(20), Constraint::Length(10)];
+    let table = Table::new(table_rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(table, area, buf);
+}
+
+/// Render the detail drawer for the currently-selected row in the
+/// zoomed panel. Static info card; no extra fetching for PR-C.
+fn render_zoom_detail_drawer(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) {
+    let block = Block::default()
+        .title(" [ Detail ] ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(GOLD))
+        .style(Style::default().bg(TERMINAL_PANEL));
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    let lines = build_detail_lines(data, state, panel);
+    let paragraph = Paragraph::new(lines).style(Style::default().fg(SOFT_WHITE));
+    ratatui::widgets::Widget::render(paragraph, inner, buf);
+}
+
+fn build_detail_lines(
+    data: &UsageData,
+    state: &UsageViewState,
+    panel: UsagePanel,
+) -> Vec<Line<'static>> {
+    let row = state.focus_row;
+    let mut lines = Vec::new();
+    let kv = |k: &str, v: String| -> Line<'static> {
+        Line::from(vec![
+            Span::styled(format!(" {k:<14}"), Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                v,
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+        ])
+    };
+    match panel {
+        UsagePanel::ByProject | UsagePanel::Leaderboard => {
+            if let Some(p) = data.projects.get(row) {
+                lines.push(kv("Project", p.name.clone()));
+                lines.push(kv("Path", p.path.clone()));
+                lines.push(kv("Cost", format_cost(p.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(p.bucket.total())));
+                lines.push(kv("Calls", p.bucket.call_count.to_string()));
+                lines.push(kv("Sessions", p.bucket.session_count.to_string()));
+            }
+        }
+        UsagePanel::ByBranch => {
+            if let Some(b) = data.branches.get(row) {
+                lines.push(kv("Branch", b.branch.clone()));
+                lines.push(kv("Cost", format_cost(b.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(b.bucket.total())));
+                lines.push(kv("Calls", b.bucket.call_count.to_string()));
+            }
+        }
+        UsagePanel::TopSessions | UsagePanel::Live => {
+            if let Some(s) = data.sessions.get(row) {
+                lines.push(kv("Session", s.session_id.clone()));
+                lines.push(kv("Project", s.project.clone()));
+                lines.push(kv("Provider", s.provider.clone()));
+                lines.push(kv(
+                    "First seen",
+                    s.first_timestamp
+                        .with_timezone(&chrono::Local)
+                        .format("%Y-%m-%d %H:%M")
+                        .to_string(),
+                ));
+                lines.push(kv(
+                    "Last seen",
+                    s.last_timestamp
+                        .with_timezone(&chrono::Local)
+                        .format("%Y-%m-%d %H:%M")
+                        .to_string(),
+                ));
+                lines.push(kv("Cost", format_cost(s.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(s.bucket.total())));
+                lines.push(kv("Calls", s.bucket.call_count.to_string()));
+            }
+        }
+        UsagePanel::ByModel => {
+            if let Some(m) = data.models.get(row) {
+                lines.push(kv("Model", m.model.clone()));
+                lines.push(kv("Cost", format_cost(m.bucket.cost_usd)));
+                lines.push(kv("Tokens", format_tokens_short(m.bucket.total())));
+                lines.push(kv("Calls", m.bucket.call_count.to_string()));
+                lines.push(kv(
+                    "Top projects",
+                    top_projects_for_model(data, &m.model, 3),
+                ));
+            }
+        }
+        UsagePanel::ByActivity => {
+            if let Some(a) = data.activities.get(row) {
+                lines.push(kv("Activity", a.category.label().to_string()));
+                lines.push(kv("Turns", a.turns.to_string()));
+                lines.push(kv("Edit turns", a.edit_turns.to_string()));
+                lines.push(kv("1-shot turns", a.one_shot_turns.to_string()));
+                lines.push(kv("Retries", a.retries.to_string()));
+                lines.push(kv("Tokens", format_tokens_short(a.bucket.total())));
+                lines.push(kv("Cost", format_cost(a.bucket.cost_usd)));
+            }
+        }
+        UsagePanel::DailyActivity => {
+            if let Some((date, b)) = data.daily.iter().rev().nth(row) {
+                lines.push(kv("Date", date.format("%Y-%m-%d").to_string()));
+                lines.push(kv("Calls", b.call_count.to_string()));
+                lines.push(kv("Sessions", b.session_count.to_string()));
+                lines.push(kv("Projects", b.project_count.to_string()));
+                lines.push(kv("Tokens", format_tokens_short(b.total())));
+                lines.push(kv("Cost", format_cost(b.cost_usd)));
+            }
+        }
+        UsagePanel::CoreTools => detail_named(&mut lines, &data.tools, row, "Tool", &kv),
+        UsagePanel::ShellCommands => {
+            detail_named(&mut lines, &data.shell_commands, row, "Command", &kv)
+        }
+        UsagePanel::McpServers => {
+            detail_named(&mut lines, &data.mcp_servers, row, "MCP server", &kv)
+        }
+        UsagePanel::Optimize | UsagePanel::Budget => {
+            lines.push(Line::from(Span::styled(
+                "  No detail card for summary panels.",
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No row selected.",
+            Style::default().fg(MUTED_GRAY),
+        )));
+    }
+    lines
+}
+
+fn detail_named<F>(
+    lines: &mut Vec<Line<'static>>,
+    rows: &[NamedUsage],
+    idx: usize,
+    name_label: &str,
+    kv: &F,
+) where
+    F: Fn(&str, String) -> Line<'static>,
+{
+    if let Some(row) = rows.get(idx) {
+        lines.push(kv(name_label, row.name.clone()));
+        lines.push(kv("Calls", row.calls.to_string()));
+    }
+}
+
+/// First-seen / last-seen ISO dates for a project, derived from the
+/// session timeline. Empty strings when the project has no sessions.
+fn project_seen_window(data: &UsageData, project_name: &str) -> (String, String) {
+    let mut iter = data.sessions.iter().filter(|s| s.project == project_name);
+    let Some(first) = iter.next() else {
+        return (String::new(), String::new());
+    };
+    let mut min_ts = first.first_timestamp;
+    let mut max_ts = first.last_timestamp;
+    for s in iter {
+        if s.first_timestamp < min_ts {
+            min_ts = s.first_timestamp;
+        }
+        if s.last_timestamp > max_ts {
+            max_ts = s.last_timestamp;
+        }
+    }
+    (
+        min_ts.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string(),
+        max_ts.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string(),
+    )
+}
+
+/// Top `n` projects by call count for `model_name`, joined with "·".
+/// Returns "—" when the model has no calls in `data.calls`.
+///
+/// Reads from the precomputed `data.model_project_counts` index built
+/// during `aggregate_calls`. Render path is O(n) (constant) instead of
+/// O(N) over `data.calls` per call.
+fn top_projects_for_model(data: &UsageData, model_name: &str, n: usize) -> String {
+    let Some(rows) = data.model_project_counts.get(model_name) else {
+        return "—".to_string();
+    };
+    if rows.is_empty() {
+        return "—".to_string();
+    }
+    rows.iter().take(n).map(|(p, _)| p.clone()).collect::<Vec<_>>().join(" · ")
+}
+
+/// Render a duration (in seconds) as `1h 04m` / `42m` / `<1m` / `0m`.
+///
+/// Distinguishes a true zero duration (`first == last` timestamp, e.g. a
+/// session with one logged turn) from a positive sub-minute duration
+/// (rounded down to 0 minutes). Both used to render as `<1m`, which
+/// hid the zero case.
+fn format_duration_min(secs_total: u64) -> String {
+    if secs_total == 0 {
+        return "0m".to_string();
+    }
+    let min_total = secs_total / 60;
+    if min_total == 0 {
+        return "<1m".to_string();
+    }
+    let h = min_total / 60;
+    let m = min_total % 60;
+    if h > 0 {
+        format!("{h}h {m:02}m")
+    } else {
+        format!("{m}m")
+    }
+}
+
+/// `FocusCtx` packages the focus arguments threaded into every panel
+/// renderer. `Some(row_idx)` means the panel is focused and should
+/// render the highlighted row indicator at that index; `None` means
+/// "render normally".
+#[derive(Debug, Clone, Copy)]
+struct FocusCtx {
+    focused_row: Option<usize>,
+}
+
+impl FocusCtx {
+    fn for_panel(state: &UsageViewState, panel: UsagePanel) -> Self {
+        if state.focused_panel == Some(panel) {
+            Self {
+                focused_row: Some(state.focus_row),
+            }
+        } else {
+            Self { focused_row: None }
+        }
+    }
+    fn unfocused() -> Self {
+        Self { focused_row: None }
+    }
+    fn is_focused(self) -> bool {
+        self.focused_row.is_some()
+    }
+}
+
+fn render_dashboard_grid(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    period: &UsagePeriod,
+    state: &UsageViewState,
+) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(area);
+
+    // Row 0 widens to four columns so the headline "where my tokens
+    // went" cluster (Daily Activity | By Project | By Branch | Live)
+    // reads left-to-right. Rows 1–3 stay 3-column.
+    let top = four_columns(rows[0]);
+    render_daily_activity_panel(
+        buf,
+        top[0],
+        data,
+        FocusCtx::for_panel(state, UsagePanel::DailyActivity),
+    );
+    render_project_panel(
+        buf,
+        top[1],
+        &data.projects,
+        FocusCtx::for_panel(state, UsagePanel::ByProject),
+    );
+    render_branch_panel(
+        buf,
+        top[2],
+        &data.branches,
+        FocusCtx::for_panel(state, UsagePanel::ByBranch),
+    );
+    render_live_panel(
+        buf,
+        top[3],
+        &data.sessions,
+        FocusCtx::for_panel(state, UsagePanel::Live),
+    );
+
+    let middle = three_columns(rows[1]);
+    render_session_panel(
+        buf,
+        middle[0],
+        &data.sessions,
+        FocusCtx::for_panel(state, UsagePanel::TopSessions),
+    );
+    render_activity_panel(
+        buf,
+        middle[1],
+        &data.activities,
+        FocusCtx::for_panel(state, UsagePanel::ByActivity),
+    );
+    render_model_panel(
+        buf,
+        middle[2],
+        &data.models,
+        FocusCtx::for_panel(state, UsagePanel::ByModel),
+    );
+
+    let lower = three_columns(rows[2]);
+    render_named_panel(
+        buf,
+        lower[0],
+        "Core Tools",
+        &data.tools,
+        FocusCtx::for_panel(state, UsagePanel::CoreTools),
+    );
+    render_named_panel(
+        buf,
+        lower[1],
+        "Shell Commands",
+        &data.shell_commands,
+        FocusCtx::for_panel(state, UsagePanel::ShellCommands),
+    );
+    render_named_panel(
+        buf,
+        lower[2],
+        "MCP Servers",
+        &data.mcp_servers,
+        FocusCtx::for_panel(state, UsagePanel::McpServers),
+    );
+
+    let bottom = three_columns(rows[3]);
+    render_optimize_compact_panel(
+        buf,
+        bottom[0],
+        data,
+        FocusCtx::for_panel(state, UsagePanel::Optimize),
+    );
+    render_leaderboard_panel(
+        buf,
+        bottom[1],
+        data,
+        FocusCtx::for_panel(state, UsagePanel::Leaderboard),
+    );
+    render_budget_panel(
+        buf,
+        bottom[2],
+        data,
+        period,
+        FocusCtx::for_panel(state, UsagePanel::Budget),
+    );
+}
+
+fn render_dashboard_compact(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    state: &UsageViewState,
+) {
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+    let left = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(columns[0]);
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(columns[1]);
+
+    render_daily_activity_panel(
+        buf,
+        left[0],
+        data,
+        FocusCtx::for_panel(state, UsagePanel::DailyActivity),
+    );
+    render_project_panel(
+        buf,
+        left[1],
+        &data.projects,
+        FocusCtx::for_panel(state, UsagePanel::ByProject),
+    );
+    render_session_panel(
+        buf,
+        left[2],
+        &data.sessions,
+        FocusCtx::for_panel(state, UsagePanel::TopSessions),
+    );
+    render_live_panel(
+        buf,
+        left[3],
+        &data.sessions,
+        FocusCtx::for_panel(state, UsagePanel::Live),
+    );
+
+    render_activity_panel(
+        buf,
+        right[0],
+        &data.activities,
+        FocusCtx::for_panel(state, UsagePanel::ByActivity),
+    );
+    // Compact grid (≥96w, <120w): split row 1 of the right column to
+    // host By Model and By Branch side-by-side. Branches typically have
+    // few rows so a half-width column reads fine without redistributing
+    // the existing four-row vertical budget.
+    let row1 = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(right[1]);
+    render_model_panel(
+        buf,
+        row1[0],
+        &data.models,
+        FocusCtx::for_panel(state, UsagePanel::ByModel),
+    );
+    render_branch_panel(
+        buf,
+        row1[1],
+        &data.branches,
+        FocusCtx::for_panel(state, UsagePanel::ByBranch),
+    );
+    render_optimize_compact_panel(
+        buf,
+        right[2],
+        data,
+        FocusCtx::for_panel(state, UsagePanel::Optimize),
+    );
+    let tools = three_columns(right[3]);
+    render_named_panel(
+        buf,
+        tools[0],
+        "Core Tools",
+        &data.tools,
+        FocusCtx::for_panel(state, UsagePanel::CoreTools),
+    );
+    render_named_panel(
+        buf,
+        tools[1],
+        "Shell Commands",
+        &data.shell_commands,
+        FocusCtx::for_panel(state, UsagePanel::ShellCommands),
+    );
+    render_named_panel(
+        buf,
+        tools[2],
+        "MCP Servers",
+        &data.mcp_servers,
+        FocusCtx::for_panel(state, UsagePanel::McpServers),
+    );
+}
+
+fn render_dashboard_stack(buf: &mut Buffer, area: Rect, data: &UsageData, state: &UsageViewState) {
+    // Narrow-width stack (<96w): six equal-ish rows. ByBranch sits at
+    // the bottom so the pre-existing top-of-stack reading order
+    // (activity → projects → sessions → activity → models) is
+    // preserved.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(17),
+            Constraint::Percentage(17),
+            Constraint::Percentage(17),
+            Constraint::Percentage(17),
+            Constraint::Percentage(16),
+            Constraint::Percentage(16),
+        ])
+        .split(area);
+
+    render_daily_activity_panel(
+        buf,
+        chunks[0],
+        data,
+        FocusCtx::for_panel(state, UsagePanel::DailyActivity),
+    );
+    render_project_panel(
+        buf,
+        chunks[1],
+        &data.projects,
+        FocusCtx::for_panel(state, UsagePanel::ByProject),
+    );
+    render_session_panel(
+        buf,
+        chunks[2],
+        &data.sessions,
+        FocusCtx::for_panel(state, UsagePanel::TopSessions),
+    );
+    render_activity_panel(
+        buf,
+        chunks[3],
+        &data.activities,
+        FocusCtx::for_panel(state, UsagePanel::ByActivity),
+    );
+    render_model_panel(
+        buf,
+        chunks[4],
+        &data.models,
+        FocusCtx::for_panel(state, UsagePanel::ByModel),
+    );
+    render_branch_panel(
+        buf,
+        chunks[5],
+        &data.branches,
+        FocusCtx::for_panel(state, UsagePanel::ByBranch),
+    );
+}
+
+fn three_columns(area: Rect) -> std::rc::Rc<[Rect]> {
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
+        .split(area)
+}
+
+fn four_columns(area: Rect) -> std::rc::Rc<[Rect]> {
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(area)
+}
+
+fn render_burndown_header(buf: &mut Buffer, area: Rect, data: &UsageData, period: &UsagePeriod) {
+    let cost = format_cost(data.grand_total.cost_usd);
+    let cache_hit = cache_hit_percent(data);
+    let projected = projected_month_cost(data, period);
+    let lines = vec![
+        Line::from(vec![
+            Span::styled(
+                "◆ agents-in-a-box",
+                Style::default().fg(TERMINAL_ACCENT).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" · usage command center", Style::default().fg(MUTED_GRAY)),
+            Span::styled("    ", Style::default()),
+            Span::styled("● live", Style::default().fg(TERMINAL_GOOD)),
+        ]),
+        Line::from(vec![
+            Span::styled("Cost ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                cost,
+                Style::default().fg(TERMINAL_ACCENT).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Calls ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.grand_total.call_count.to_string(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Sessions ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.grand_total.session_count.to_string(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Projects ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.grand_total.project_count.to_string(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  Cache hit ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("{cache_hit:.1}%"),
+                Style::default().fg(TERMINAL_GOOD).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Tokens ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(data.grand_total.total()),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled("  Cache ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(
+                    data.grand_total.cache_creation_tokens + data.grand_total.cache_read_tokens,
+                ),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled("  In ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(data.grand_total.input_tokens),
+                Style::default().fg(TERMINAL_CYAN),
+            ),
+            Span::styled("  Out ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_tokens_short(data.grand_total.output_tokens),
+                Style::default().fg(TERMINAL_CYAN),
+            ),
+            Span::styled("  Projected month ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(format_cost(projected), Style::default().fg(TERMINAL_ACCENT)),
+        ]),
+    ];
+    ratatui::widgets::Widget::render(Paragraph::new(lines), area, buf);
+}
+
+/// Build the "Period: …  Provider: …" labelled strip.
+///
+/// Period strip layout:
+/// ```text
+/// Period: 1 Today  2 7d  3 30d  4 90d  5 YTD  [◀ Apr 2026 ▶ m Month]  [◀ Q2 2026 ▶ q Quarter]  a All  D advanced
+/// ```
+/// Active chip: bold + GOLD background. The Month/Quarter blocks render
+/// inline pickers when their variant is active — clicking ◀/▶ steps the
+/// underlying month or quarter back/forward.
+///
+/// Returned as a `Vec<Line>` so tests can assert chip ordering and
+/// active-marker placement without hitting the Frame.
+fn build_period_provider_strip(state: &UsageViewState) -> Vec<Line<'static>> {
+    let mut period_spans: Vec<Span<'static>> =
+        vec![Span::styled("Period: ", Style::default().fg(MUTED_GRAY))];
+
+    // Simple key-prefixed chips: 1 Today, 2 7d, 3 30d, 4 90d, 5 YTD.
+    // Each chip lights up for both the legacy variant (set by the TUI
+    // shortcut) and the equivalent LastNDays(N) variant (set by the
+    // CLI --last-n-days flag), so the active state is consistent
+    // regardless of which entry point selected the period.
+    let simple: [(&str, char, fn(&UsagePeriod) -> bool); 5] = [
+        ("Today", '1', |p| matches!(p, UsagePeriod::Today)),
+        ("7d", '2', |p| {
+            matches!(p, UsagePeriod::Week | UsagePeriod::LastNDays(7))
+        }),
+        ("30d", '3', |p| {
+            matches!(p, UsagePeriod::ThirtyDays | UsagePeriod::LastNDays(30))
+        }),
+        ("90d", '4', |p| matches!(p, UsagePeriod::LastNDays(90))),
+        ("YTD", '5', |p| matches!(p, UsagePeriod::YearToDate)),
+    ];
+    for (i, (label, key, is_active)) in simple.iter().enumerate() {
+        if i > 0 {
+            period_spans.push(Span::styled("  ", Style::default()));
+        }
+        period_spans.push(period_chip_span(label, *key, is_active(&state.period)));
+    }
+
+    // Stepable Month picker.
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.extend(build_step_picker_spans(
+        'm',
+        "Month",
+        &month_picker_label(&state.period),
+        matches!(state.period, UsagePeriod::SpecificMonth(_)),
+    ));
+
+    // Stepable Quarter picker.
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.extend(build_step_picker_spans(
+        'q',
+        "Quarter",
+        &quarter_picker_label(&state.period),
+        matches!(state.period, UsagePeriod::SpecificQuarter(..)),
+    ));
+
+    // Trailing All + advanced custom.
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.push(period_chip_span(
+        "All",
+        'a',
+        matches!(state.period, UsagePeriod::All),
+    ));
+    period_spans.push(Span::styled("  ", Style::default()));
+    period_spans.push(period_chip_span(
+        "advanced",
+        'D',
+        matches!(state.period, UsagePeriod::Custom { .. }),
+    ));
+
+    let mut provider_spans: Vec<Span<'static>> =
+        vec![Span::styled("Provider: ", Style::default().fg(MUTED_GRAY))];
+    let providers: [(&str, UsageProviderFilter); 3] = [
+        ("All", UsageProviderFilter::All),
+        ("Claude", UsageProviderFilter::Claude),
+        ("Codex", UsageProviderFilter::Codex),
+    ];
+    for (i, (label, value)) in providers.iter().enumerate() {
+        if i > 0 {
+            provider_spans.push(Span::styled("  ", Style::default()));
+        }
+        provider_spans.push(provider_chip_span(label, *value == state.provider_filter));
+    }
+    provider_spans.push(Span::styled("  (P)", Style::default().fg(MUTED_GRAY)));
+
+    // Two label rows so narrow terminals can wrap cleanly.
+    vec![Line::from(period_spans), Line::from(provider_spans)]
+}
+
+/// Render `[◀ <label> ▶ <key> <name>]` for the inline Month/Quarter
+/// pickers. Active variant gets the GOLD chip background; inactive
+/// renders as soft white text with hint key prefix.
+fn build_step_picker_spans(key: char, name: &str, label: &str, active: bool) -> Vec<Span<'static>> {
+    let style = if active {
+        Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(SOFT_WHITE)
+    };
+    let arrow_style = if active {
+        Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(MUTED_GRAY)
+    };
+    vec![
+        Span::styled("[", arrow_style),
+        Span::styled("◀ ", arrow_style),
+        Span::styled(label.to_string(), style),
+        Span::styled(" ▶", arrow_style),
+        Span::styled(format!(" {key} {name}"), style),
+        Span::styled("]", arrow_style),
+    ]
+}
+
+/// Label rendered inside the Month picker chip. When the active period
+/// is SpecificMonth we render its anchor; otherwise we render today's
+/// month so the user sees a sensible default before pressing `m`.
+fn month_picker_label(period: &UsagePeriod) -> String {
+    let anchor = match period {
+        UsagePeriod::SpecificMonth(d) => *d,
+        _ => Local::now().date_naive(),
+    };
+    anchor.format("%b %Y").to_string()
+}
+
+/// Label rendered inside the Quarter picker chip. Same fallback rule
+/// as `month_picker_label`.
+fn quarter_picker_label(period: &UsagePeriod) -> String {
+    let (year, q) = match period {
+        UsagePeriod::SpecificQuarter(y, q) => (*y, *q),
+        _ => {
+            let today = Local::now().date_naive();
+            (today.year(), crate::data::usage::quarter_of(today))
+        }
+    };
+    format!("Q{q} {year}")
+}
+
+fn period_chip_span(label: &str, key: char, active: bool) -> Span<'static> {
+    let text = format!(" {key} {label} ");
+    if active {
+        Span::styled(
+            text,
+            Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::styled(text, Style::default().fg(SOFT_WHITE))
+    }
+}
+
+fn provider_chip_span(label: &str, active: bool) -> Span<'static> {
+    let text = format!(" {label} ");
+    if active {
+        Span::styled(
+            text,
+            Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::styled(text, Style::default().fg(MUTED_GRAY))
+    }
+}
+
+fn render_period_row(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let lines = build_period_provider_strip(state);
+    ratatui::widgets::Widget::render(Paragraph::new(lines), area, buf);
+}
+
+/// Build the chip strip line shown directly under the period+provider
+/// strip. Active chips render as `[label=value]` in GOLD; with no
+/// chips, an instruction hint is shown so users discover the pivot.
+pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> =
+        vec![Span::styled("Filters: ", Style::default().fg(MUTED_GRAY))];
+    if !state.filters.any() {
+        spans.push(Span::styled(
+            "(none)",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ));
+        return Line::from(spans);
+    }
+    push_chip_group(&mut spans, "project", &state.filters.project);
+    push_chip_group(&mut spans, "model", &state.filters.model);
+    push_chip_group(&mut spans, "activity", &state.filters.activity);
+    push_chip_group(&mut spans, "session", &state.filters.session);
+    push_chip_group(&mut spans, "branch", &state.filters.branch);
+    push_exclude_chip_group(&mut spans, "project", &state.filters.exclude_project);
+    push_exclude_chip_group(&mut spans, "model", &state.filters.exclude_model);
+    push_exclude_chip_group(&mut spans, "activity", &state.filters.exclude_activity);
+    push_exclude_chip_group(&mut spans, "session", &state.filters.exclude_session);
+    push_exclude_chip_group(&mut spans, "branch", &state.filters.exclude_branch);
+    spans.push(Span::styled("  ·  ", Style::default().fg(MUTED_GRAY)));
+    spans.push(Span::styled(
+        "Esc",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(
+        " clear last  ",
+        Style::default().fg(MUTED_GRAY),
+    ));
+    spans.push(Span::styled(
+        "C",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(" clear all", Style::default().fg(MUTED_GRAY)));
+    Line::from(spans)
+}
+
+fn push_chip_group(spans: &mut Vec<Span<'static>>, label: &str, values: &[String]) {
+    for value in values {
+        let chip_text = format!(" {label}={value} ");
+        spans.push(Span::styled(
+            chip_text,
+            Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+    }
+}
+
+/// Exclude chips render with a leading `~` and a muted-orange fill so
+/// they are immediately distinguishable from include (gold) chips.
+/// They also pop first via Esc — see `UsageFilters::pop_last`.
+fn push_exclude_chip_group(spans: &mut Vec<Span<'static>>, label: &str, values: &[String]) {
+    for value in values {
+        let chip_text = format!(" ~{label}={value} ");
+        spans.push(Span::styled(
+            chip_text,
+            Style::default().fg(DARK_BG).bg(BAR_HIGH).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+    }
+}
+
+fn render_filter_chip_strip(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    let line = build_filter_chip_line(state);
+    ratatui::widgets::Widget::render(Paragraph::new(line), area, buf);
+}
+
+fn render_daily_activity_panel(buf: &mut Buffer, area: Rect, data: &UsageData, focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "Daily Activity", vec![], focus);
+        return;
+    }
+    let max = data
+        .daily
+        .iter()
+        .filter_map(|(_, bucket)| bucket.cost_usd)
+        .fold(0.0_f64, f64::max)
+        .max(1.0);
+    let rows_data: Vec<_> = data.daily.iter().rev().take(cap).collect();
+    let cost_w = rows_data
+        .iter()
+        .map(|(_, b)| format_cost(b.cost_usd).chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+    let calls_w = rows_data
+        .iter()
+        .map(|(_, b)| format!("{}c", b.call_count).chars().count())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let date_w = 5; // MM-DD
+    let bar_w = inner_w.saturating_sub(1 + date_w + 1 + cost_w + 1 + calls_w + 1).max(4);
+    let lines: Vec<Line> = rows_data
+        .into_iter()
+        .map(|(date, bucket)| {
+            let cost = bucket.cost_usd.unwrap_or(0.0);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(
+                    date.format("%m-%d").to_string(),
+                    Style::default().fg(MUTED_GRAY),
+                ),
+                Span::raw(" "),
+            ];
+            spans.extend(ratio_gradient_spans(cost, max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{:>w$}", format_cost(bucket.cost_usd), w = cost_w),
+                Style::default().fg(TERMINAL_ACCENT),
+            ));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{:>w$}", format!("{}c", bucket.call_count), w = calls_w),
+                Style::default().fg(MUTED_GRAY),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "Daily Activity", lines, focus);
+}
+
+fn render_project_panel(buf: &mut Buffer, area: Rect, rows: &[ProjectUsage], focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "By Project", vec![], focus);
+        return;
+    }
+    let max = rows
+        .iter()
+        .map(|row| row.bucket.cost_usd.unwrap_or(0.0))
+        .fold(0.0_f64, f64::max)
+        .max(1.0);
+    let value_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+    let label_w = ((inner_w as i32 - value_w as i32 - 4) / 2).clamp(10, 24) as usize;
+    let bar_w = inner_w.saturating_sub(1 + label_w + 1 + value_w + 1).max(4);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let cost = row.bucket.cost_usd.unwrap_or(0.0);
+            let label = pretty_project_name(&row.name, label_w);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::raw(" "),
+            ];
+            spans.extend(ratio_gradient_spans(cost, max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{:>w$}", format_cost(row.bucket.cost_usd), w = value_w),
+                Style::default().fg(TERMINAL_ACCENT),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "By Project", lines, focus);
+}
+
+/// Per-branch cost bars. Mirrors `render_project_panel` (same gradient
+/// layout / column widths) but skips the worktree-aware project label
+/// massaging — branch names are short already, so plain truncation is
+/// fine. Branchless calls were already dropped during aggregation
+/// (`UsageData.branches` only contains `Some(branch)` rows), so this
+/// panel never grows a misleading "(no branch)" bucket.
+fn render_branch_panel(buf: &mut Buffer, area: Rect, rows: &[BranchUsage], focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "By Branch", vec![], focus);
+        return;
+    }
+    let max = rows
+        .iter()
+        .map(|row| row.bucket.cost_usd.unwrap_or(0.0))
+        .fold(0.0_f64, f64::max)
+        .max(1.0);
+    let value_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+    let label_w = ((inner_w as i32 - value_w as i32 - 4) / 2).clamp(10, 24) as usize;
+    let bar_w = inner_w.saturating_sub(1 + label_w + 1 + value_w + 1).max(4);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let cost = row.bucket.cost_usd.unwrap_or(0.0);
+            let label = truncate_string(&row.branch, label_w);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::raw(" "),
+            ];
+            spans.extend(ratio_gradient_spans(cost, max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{:>w$}", format_cost(row.bucket.cost_usd), w = value_w),
+                Style::default().fg(TERMINAL_ACCENT),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "By Branch", lines, focus);
+}
+
+fn render_session_panel(buf: &mut Buffer, area: Rect, rows: &[SessionUsage], focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "Top Sessions", vec![], focus);
+        return;
+    }
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let value_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| format_tokens_short(r.bucket.total()).chars().count())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let label_w = ((inner_w as i32 - value_w as i32 - 4) / 2).clamp(10, 22) as usize;
+    let bar_w = inner_w.saturating_sub(1 + label_w + 1 + value_w + 1).max(4);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let label = pretty_project_name(&row.project, label_w);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::raw(" "),
+            ];
+            spans.extend(gradient_spans(row.bucket.total(), max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!(
+                    "{:>w$}",
+                    format_tokens_short(row.bucket.total()),
+                    w = value_w
+                ),
+                Style::default().fg(TERMINAL_CYAN),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "Top Sessions", lines, focus);
+}
+
+fn render_live_panel(buf: &mut Buffer, area: Rect, rows: &[SessionUsage], focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "Live Session Ticker", vec![], focus);
+        return;
+    }
+    let value_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+    let provider_w = 6;
+    // " ● " + label + " · " + provider + " · " + value
+    let prefix = 3 + 3 + provider_w + 3;
+    let label_w = inner_w.saturating_sub(prefix + value_w).max(8);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let label = pretty_project_name(&row.project, label_w);
+            let provider = truncate_string(&row.provider, provider_w);
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled("●", Style::default().fg(TERMINAL_GOOD)),
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::styled(" · ", Style::default().fg(MUTED_GRAY)),
+                Span::styled(
+                    format!("{:<w$}", provider, w = provider_w),
+                    Style::default().fg(TERMINAL_CYAN),
+                ),
+                Span::styled(" · ", Style::default().fg(MUTED_GRAY)),
+                Span::styled(
+                    format!("{:>w$}", format_cost(row.bucket.cost_usd), w = value_w),
+                    Style::default().fg(TERMINAL_ACCENT),
+                ),
+            ])
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "Live Session Ticker", lines, focus);
+}
+
+fn render_activity_panel(buf: &mut Buffer, area: Rect, rows: &[ActivityUsage], focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "By Activity", vec![], focus);
+        return;
+    }
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let label_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| r.category.label().chars().count())
+        .max()
+        .unwrap_or(8)
+        .clamp(8, 14);
+    let suffix_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| format!("{}t {}r", r.turns, r.retries).chars().count())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let bar_w = inner_w.saturating_sub(1 + label_w + 1 + suffix_w + 1).max(4);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(
+                    pad_label(row.category.label(), label_w),
+                    Style::default().fg(SOFT_WHITE),
+                ),
+                Span::raw(" "),
+            ];
+            spans.extend(gradient_spans(row.bucket.total(), max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!(
+                    "{:>w$}",
+                    format!("{}t {}r", row.turns, row.retries),
+                    w = suffix_w
+                ),
+                Style::default().fg(MUTED_GRAY),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "By Activity", lines, focus);
+}
+
+fn render_model_panel(buf: &mut Buffer, area: Rect, rows: &[ModelUsage], focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "By Model", vec![], focus);
+        return;
+    }
+    let max = rows.iter().map(|row| row.bucket.total()).max().unwrap_or(1);
+    let value_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| format_tokens_short(r.bucket.total()).chars().count())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let label_w = ((inner_w as i32 - value_w as i32 - 4) / 2).clamp(10, 22) as usize;
+    let bar_w = inner_w.saturating_sub(1 + label_w + 1 + value_w + 1).max(4);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let label = truncate_string(&row.model, label_w);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::raw(" "),
+            ];
+            spans.extend(gradient_spans(row.bucket.total(), max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!(
+                    "{:>w$}",
+                    format_tokens_short(row.bucket.total()),
+                    w = value_w
+                ),
+                Style::default().fg(TERMINAL_CYAN),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "By Model", lines, focus);
+}
+
+fn render_named_panel(
+    buf: &mut Buffer,
+    area: Rect,
+    title: &str,
+    rows: &[NamedUsage],
+    focus: FocusCtx,
+) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 14 {
+        render_panel_lines_with_focus(buf, area, title, vec![], focus);
+        return;
+    }
+    let max = rows.iter().map(|row| row.calls as u64).max().unwrap_or(1);
+    let value_w = rows
+        .iter()
+        .take(cap)
+        .map(|r| r.calls.to_string().chars().count())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let label_w = ((inner_w as i32 - value_w as i32 - 4) / 2).clamp(8, 22) as usize;
+    let bar_w = inner_w.saturating_sub(1 + label_w + 1 + value_w + 1).max(3);
+    let lines: Vec<Line> = rows
+        .iter()
+        .take(cap)
+        .map(|row| {
+            let label = truncate_string(&row.name, label_w);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::raw(" "),
+            ];
+            spans.extend(gradient_spans(row.calls as u64, max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{:>w$}", row.calls, w = value_w),
+                Style::default().fg(MUTED_GRAY),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, title, lines, focus);
+}
+
+fn render_optimize_compact_panel(buf: &mut Buffer, area: Rect, data: &UsageData, focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 {
+        render_panel_lines_with_focus(buf, area, "Optimization Recommendations", vec![], focus);
+        return;
+    }
+    let result = optimize_usage(data);
+    let mut lines: Vec<Line> = Vec::new();
+    let grade_color = match format!("{:?}", result.grade).as_str() {
+        "A" | "B" => TERMINAL_GOOD,
+        "C" => TERMINAL_ACCENT,
+        _ => BAR_HIGH,
+    };
+    lines.push(Line::from(vec![
+        Span::styled(" Health ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            format!("{:?}", result.grade),
+            Style::default().fg(grade_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" · score ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            result.score.to_string(),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" · save ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            format_tokens_short(result.potential_tokens_saved),
+            Style::default().fg(TERMINAL_GOOD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" tokens", Style::default().fg(MUTED_GRAY)),
+    ]));
+    let title_budget = inner_w.saturating_sub(8); // leading symbol + space + tag area
+    for finding in result.findings.iter().take(cap.saturating_sub(1)) {
+        let (sym, sym_color) = impact_marker(format!("{:?}", finding.impact).as_str());
+        let title = truncate_string(&finding.title, title_budget);
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                sym,
+                Style::default().fg(sym_color).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::styled(title, Style::default().fg(SOFT_WHITE)),
+        ]));
+    }
+    render_panel_lines_with_focus(buf, area, "Optimization Recommendations", lines, focus);
+}
+
+fn render_leaderboard_panel(buf: &mut Buffer, area: Rect, data: &UsageData, focus: FocusCtx) {
+    let cap = area.height.saturating_sub(2) as usize;
+    let inner_w = area.width.saturating_sub(2) as usize;
+    if cap == 0 || inner_w < 16 {
+        render_panel_lines_with_focus(buf, area, "Agent Leaderboard", vec![], focus);
+        return;
+    }
+    let max = data
+        .projects
+        .iter()
+        .map(|row| row.bucket.cost_usd.unwrap_or(0.0))
+        .fold(0.0_f64, f64::max)
+        .max(1.0);
+    let value_w = data
+        .projects
+        .iter()
+        .take(cap)
+        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+    // " 1 " (3) + label + " " + bar + " " + value
+    let rank_w = 2;
+    let label_w =
+        ((inner_w as i32 - value_w as i32 - rank_w as i32 - 5) / 2).clamp(10, 24) as usize;
+    let bar_w = inner_w.saturating_sub(1 + rank_w + 1 + label_w + 1 + value_w + 1).max(4);
+    let lines: Vec<Line> = data
+        .projects
+        .iter()
+        .enumerate()
+        .take(cap)
+        .map(|(idx, project)| {
+            let cost = project.bucket.cost_usd.unwrap_or(0.0);
+            let rank_color = match idx {
+                0 => GOLD,
+                1 => SOFT_WHITE,
+                2 => TERMINAL_ACCENT,
+                _ => MUTED_GRAY,
+            };
+            let label = pretty_project_name(&project.name, label_w);
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(
+                    format!("{:>w$}", idx + 1, w = rank_w),
+                    Style::default().fg(rank_color).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled(pad_label(&label, label_w), Style::default().fg(SOFT_WHITE)),
+                Span::raw(" "),
+            ];
+            spans.extend(ratio_gradient_spans(cost, max, bar_w));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{:>w$}", format_cost(project.bucket.cost_usd), w = value_w),
+                Style::default().fg(TERMINAL_ACCENT),
+            ));
+            Line::from(spans)
+        })
+        .collect();
+    render_panel_lines_with_focus(buf, area, "Agent Leaderboard", lines, focus);
+}
+
+fn render_budget_panel(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    period: &UsagePeriod,
+    focus: FocusCtx,
+) {
+    let inner_w = area.width.saturating_sub(2) as usize;
+    let spent = data.grand_total.cost_usd.unwrap_or(0.0);
+    let projected = projected_month_cost(data, period).unwrap_or(spent);
+    let cap_value = projected.max(spent).max(1.0) * 1.25;
+    let usage = ((projected / cap_value) * 100.0).min(100.0);
+
+    let bar_w = inner_w.saturating_sub(10).max(8); // " " + bar + " 80.0%"
+    let mut bar_spans = vec![Span::raw(" ")];
+    bar_spans.extend(ratio_gradient_spans(usage, 100.0, bar_w));
+    bar_spans.push(Span::raw(" "));
+    bar_spans.push(Span::styled(
+        format!("{usage:>4.1}%"),
+        Style::default()
+            .fg(if usage >= 85.0 {
+                BAR_HIGH
+            } else if usage >= 60.0 {
+                TERMINAL_ACCENT
+            } else {
+                TERMINAL_GOOD
+            })
+            .add_modifier(Modifier::BOLD),
+    ));
+
+    // Live OAuth-window header. Renders above the existing monthly-cap
+    // content. Drives the W keybind's CTA when no source is available.
+    let live = crate::live_window::current();
+    let mut lines: Vec<Line> = budget_live_header_lines(&live, inner_w);
+
+    lines.extend(vec![
+        Line::from(vec![
+            Span::styled(" Monthly cap ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_cost(Some(projected)),
+                Style::default().fg(TERMINAL_ACCENT).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" / ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_cost(Some(cap_value)),
+                Style::default().fg(SOFT_WHITE),
+            ),
+        ]),
+        Line::from(bar_spans),
+        Line::from(vec![
+            Span::styled(" Plan utilization ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format_cost(data.grand_total.cost_usd),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled(
+                format!("{:.1}%", cache_hit_percent(data)),
+                Style::default().fg(TERMINAL_GOOD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" cache hit · ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                data.daily.len().to_string(),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled(" days sampled", Style::default().fg(MUTED_GRAY)),
+        ]),
+    ]);
+    render_panel_lines_with_focus(buf, area, "Budget · Alerts", lines, focus);
+}
+
+/// Build the live-window header injected at the top of the Budget panel.
+/// Tier1 → two gradient bars + cost + reset countdown; Tier2 → 5h bar +
+/// upgrade hint; None → CTA pointing at the W keybind.
+fn budget_live_header_lines(
+    live: &crate::live_window::LiveWindow,
+    inner_w: usize,
+) -> Vec<Line<'static>> {
+    use crate::live_window::Source;
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let bar_w = inner_w.saturating_sub(12).max(8);
+
+    match live.source {
+        Source::Tier1Cache => {
+            if let Some(pct) = live.five_hour_pct {
+                out.push(live_bar_line("5h burn ", pct, bar_w));
+            }
+            if let Some(pct) = live.seven_day_pct {
+                out.push(live_bar_line("7d wnd  ", pct, bar_w));
+            }
+            let mut footer: Vec<Span<'static>> = Vec::new();
+            if let Some(cost) = live.today_cost_usd {
+                footer.push(Span::styled(" Today ", Style::default().fg(MUTED_GRAY)));
+                footer.push(Span::styled(
+                    format!("${cost:.2}"),
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ));
+            }
+            if let Some(d) = live.resets_in {
+                if !footer.is_empty() {
+                    footer.push(Span::styled(" · ", Style::default().fg(MUTED_GRAY)));
+                }
+                footer.push(Span::styled(" Resets in ", Style::default().fg(MUTED_GRAY)));
+                footer.push(Span::styled(
+                    format_hms(d),
+                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                ));
+            }
+            if !footer.is_empty() {
+                out.push(Line::from(footer));
+            }
+        }
+        Source::Tier2Local => {
+            if let Some(pct) = live.five_hour_pct {
+                out.push(live_bar_line("5h burn ", pct, bar_w));
+            }
+            out.push(Line::from(Span::styled(
+                " Wire statusline (W) for 7d window + cost",
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+        Source::None => {
+            out.push(Line::from(Span::styled(
+                " ⓘ Live OAuth window data not available.",
+                Style::default().fg(MUTED_GRAY),
+            )));
+            out.push(Line::from(vec![
+                Span::styled("    Press ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("[W]", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    " to wire up Claude Code statusline.",
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ]));
+            out.push(Line::from(Span::styled(
+                "    (Provides 5h burn, 7d window, cost, reset times)",
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+    }
+    out
+}
+
+fn live_bar_line(label: &'static str, pct: u8, bar_w: usize) -> Line<'static> {
+    let mut spans = vec![Span::styled(
+        format!(" {label}"),
+        Style::default().fg(MUTED_GRAY),
+    )];
+    spans.extend(ratio_gradient_spans(pct as f64, 100.0, bar_w));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        format!("{pct:>3}%"),
+        Style::default()
+            .fg(if pct >= 85 {
+                BAR_HIGH
+            } else if pct >= 60 {
+                TERMINAL_ACCENT
+            } else {
+                TERMINAL_GOOD
+            })
+            .add_modifier(Modifier::BOLD),
+    ));
+    Line::from(spans)
+}
+
+fn format_hms(d: std::time::Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    if h > 0 {
+        format!("{h}h {m:02}m")
+    } else {
+        format!("{m}m")
+    }
+}
+
+fn render_optimize(buf: &mut Buffer, area: Rect, data: &UsageData) {
+    let result = optimize_usage(data);
+    let mut lines = vec![
+        format!("Health {:?} ({}/100)", result.grade, result.score),
+        format!(
+            "Potential savings {} tokens",
+            format_tokens_short(result.potential_tokens_saved)
+        ),
+        String::new(),
+    ];
+    for finding in result.findings.iter().take(area.height.saturating_sub(5) as usize) {
+        lines.push(format!("{:?}: {}", finding.impact, finding.title));
+        lines.push(format!("  {}", truncate_string(&finding.details, 80)));
+        if let Some(action) = finding.actions.first() {
+            lines.push(format!(
+                "  Suggestion: {}",
+                truncate_string(&action.label, 80)
+            ));
+        }
+    }
+    render_panel(buf, area, "Optimize Findings", lines);
+}
+
+fn render_panel(buf: &mut Buffer, area: Rect, title: &str, rows: Vec<String>) {
+    let lines: Vec<Line> = if rows.is_empty() {
+        Vec::new()
+    } else {
+        rows.into_iter()
+            .map(|row| {
+                Line::from(Span::styled(
+                    format!(" {row}"),
+                    Style::default().fg(SOFT_WHITE),
+                ))
+            })
+            .collect()
+    };
+    render_panel_lines(buf, area, title, lines);
+}
+
+fn render_panel_lines(buf: &mut Buffer, area: Rect, title: &str, lines: Vec<Line<'_>>) {
+    render_panel_lines_with_focus(buf, area, title, lines, FocusCtx::unfocused());
+}
+
+/// Render variant that knows about focus: highlights the border in
+/// `BAR_HIGH` and replaces the leading-space cell on the focused row
+/// with a `▶` indicator. Row clamping is done here too — the state
+/// only knows about logical row index, not how many rows the panel is
+/// currently displaying.
+fn render_panel_lines_with_focus(
+    buf: &mut Buffer,
+    area: Rect,
+    title: &str,
+    mut lines: Vec<Line<'_>>,
+    focus: FocusCtx,
+) {
+    let border_color = if focus.is_focused() {
+        BAR_HIGH
+    } else {
+        TERMINAL_BORDER
+    };
+    let mut title_style = Style::default();
+    if focus.is_focused() {
+        title_style = title_style.fg(GOLD).add_modifier(Modifier::BOLD);
+    }
+
+    if let Some(row_idx) = focus.focused_row {
+        if !lines.is_empty() {
+            let clamped = row_idx.min(lines.len() - 1);
+            apply_row_indicator(&mut lines[clamped]);
+        }
+    }
+
+    let title_span = Span::styled(format!(" [ {title} ] "), title_style);
+    let block = Block::default()
+        .title(Line::from(title_span))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(border_color))
+        .style(Style::default().bg(TERMINAL_PANEL));
+    let final_lines = if lines.is_empty() {
+        vec![Line::from(Span::styled(
+            "  No data",
+            Style::default().fg(MUTED_GRAY),
+        ))]
+    } else {
+        lines
+    };
+    ratatui::widgets::Widget::render(Paragraph::new(final_lines).block(block), area, buf);
+}
+
+/// Replace the very first character of the line (which renderers
+/// reserve as a single-space gutter) with the `▶` glyph. Idempotent:
+/// if the line is empty we just append the indicator.
+fn apply_row_indicator(line: &mut Line<'_>) {
+    let style = Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD);
+    if line.spans.is_empty() {
+        line.spans.push(Span::styled("▶", style));
+        return;
+    }
+    // The first span is conventionally `Span::raw(" ")`. Replace it.
+    let first = line.spans.first().expect("checked non-empty");
+    if first.content.as_ref() == " " {
+        line.spans[0] = Span::styled("▶", style);
+    } else {
+        line.spans.insert(0, Span::styled("▶", style));
+    }
+}
+
+fn pick_bar_color(ratio: f64) -> Color {
+    if ratio >= BAR_THRESHOLD_HIGH {
+        BAR_HIGH
+    } else if ratio >= BAR_THRESHOLD_MED {
+        BAR_MED
+    } else {
+        BAR_COLOR
+    }
+}
+
+fn gradient_spans(value: u64, max: u64, width: usize) -> Vec<Span<'static>> {
+    let max = max.max(1);
+    let ratio = (value as f64) / (max as f64);
+    let filled = ((ratio.clamp(0.0, 1.0) * width as f64).round() as usize).min(width);
+    let color = pick_bar_color(ratio.clamp(0.0, 1.0));
+    let mut out = Vec::with_capacity(2);
+    if filled > 0 {
+        out.push(Span::styled("█".repeat(filled), Style::default().fg(color)));
+    }
+    let empty = width.saturating_sub(filled);
+    if empty > 0 {
+        out.push(Span::styled(
+            "░".repeat(empty),
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+    out
+}
+
+fn ratio_gradient_spans(value: f64, max: f64, width: usize) -> Vec<Span<'static>> {
+    let max = max.max(1e-9);
+    let ratio = (value / max).clamp(0.0, 1.0);
+    let filled = ((ratio * width as f64).round() as usize).min(width);
+    let color = pick_bar_color(ratio);
+    let mut out = Vec::with_capacity(2);
+    if filled > 0 {
+        out.push(Span::styled("▓".repeat(filled), Style::default().fg(color)));
+    }
+    let empty = width.saturating_sub(filled);
+    if empty > 0 {
+        out.push(Span::styled(
+            "░".repeat(empty),
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+    out
+}
+
+fn pad_label(label: &str, width: usize) -> String {
+    let len = label.chars().count();
+    if len >= width {
+        label.to_string()
+    } else {
+        let pad = width - len;
+        let mut out = String::with_capacity(label.len() + pad);
+        out.push_str(label);
+        for _ in 0..pad {
+            out.push(' ');
+        }
+        out
+    }
+}
+
+/// Render a project label that's friendly for Stevie's worktree
+/// layout. Recognises the `worktrees/<repo>_<branch>` and
+/// `user-repo-branch` patterns and renders them as `repo:branch`.
+/// Falls back to `shorten_project_name` for anything else.
+///
+/// Returns a string of at most `max_w` displayed characters.
+fn pretty_project_name(name: &str, max_w: usize) -> String {
+    if max_w == 0 {
+        return String::new();
+    }
+    if let Some(pretty) = try_pretty_repo_branch(name) {
+        if pretty.chars().count() <= max_w {
+            return pretty;
+        }
+        // Pretty form is still too long — apply tail-truncation on the
+        // branch portion, keeping the `repo:` prefix intact when we can.
+        if let Some((repo, branch)) = pretty.split_once(':') {
+            let repo_w = repo.chars().count();
+            // Need room for repo + ':' + at least 2 branch chars. With
+            // branch_w == 1 truncate_string returns just `…`, producing
+            // `repo:…` which conveys nothing — fall through to the
+            // generic shortener instead so we keep the repo name whole.
+            if repo_w + 3 <= max_w {
+                let branch_w = max_w - repo_w - 1;
+                let truncated_branch = truncate_string(branch, branch_w);
+                let combined = format!("{repo}:{truncated_branch}");
+                if combined.chars().count() <= max_w {
+                    return combined;
+                }
+            }
+        }
+        // Else fall through to the generic shortener on the pretty form.
+        return shorten_project_name(&pretty, max_w);
+    }
+    shorten_project_name(name, max_w)
+}
+
+/// Detect `<root>/worktrees/<repo>_<branch>` (sanitised, segment-style)
+/// or `user-repo-branch...` (dash-style) and emit `<repo>:<branch>`.
+/// Returns `None` if the input doesn't look like one of those patterns,
+/// so callers can fall back to a generic shortener.
+fn try_pretty_repo_branch(name: &str) -> Option<String> {
+    // Pattern A: worktree path. `clean_project_name` rewrites these to
+    // `worktree/<user>_<repo>_<branch>` for Claude sources, and the
+    // raw `worktrees/<...>` form may also reach us via project_path.
+    let after_worktree = name
+        .rsplit_once("worktree/")
+        .map(|(_, tail)| tail)
+        .or_else(|| name.rsplit_once("worktrees/").map(|(_, tail)| tail));
+    if let Some(tail) = after_worktree {
+        let stem = tail.split('/').next().unwrap_or(tail);
+        // Worktree convention is underscore-separated user/repo/branch
+        // (the repo and branch may legitimately contain dashes).
+        if let Some(pretty) = repo_branch_from_token(stem, '_') {
+            return Some(pretty);
+        }
+    }
+
+    // Pattern B: a single token with `user-repo-branch...` shape.
+    // Only opt in when there are at least 3 dash-separated parts AND
+    // no slashes/underscores — otherwise we'd misformat ordinary
+    // `org/repo` names or interfere with the worktree path above.
+    if !name.contains('/') && !name.contains('_') && name.matches('-').count() >= 2 {
+        if let Some(pretty) = repo_branch_from_token(name, '-') {
+            return Some(pretty);
+        }
+    }
+
+    None
+}
+
+/// Decompose `user{sep}repo{sep}branch...` into `repo:branch` using the
+/// caller-chosen `sep`. Returns `None` for tokens with fewer than three
+/// parts. The branch portion is rejoined with `-` for readability so
+/// `feat_codeburn` and `feat-codeburn` both render the same.
+fn repo_branch_from_token(token: &str, sep: char) -> Option<String> {
+    let parts: Vec<&str> = token.split(sep).collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let repo = parts[1];
+    let branch = parts[2..].join("-");
+    if repo.is_empty() || branch.is_empty() {
+        return None;
+    }
+    Some(format!("{repo}:{branch}"))
+}
+
+fn shorten_project_name(name: &str, max_w: usize) -> String {
+    if name.chars().count() <= max_w {
+        return name.to_string();
+    }
+    // Strip well-known prefixes that add no value.
+    let stripped = name
+        .strip_prefix("worktrees/")
+        .or_else(|| name.strip_prefix("worktree/"))
+        .unwrap_or(name);
+    if stripped.chars().count() <= max_w {
+        return stripped.to_string();
+    }
+    // Keep the last 2 path segments, ellipse the front.
+    let segs: Vec<&str> = stripped.split('/').collect();
+    if segs.len() >= 2 {
+        let last = segs.last().copied().unwrap_or("");
+        let combined = if segs.len() >= 3 {
+            format!("…/{}/{}", segs[segs.len() - 2], last)
+        } else {
+            format!("…/{}", last)
+        };
+        if combined.chars().count() <= max_w {
+            return combined;
+        }
+        // Keep tail of last segment.
+        let tail_w = max_w.saturating_sub(2); // "…/"
+        let last_count = last.chars().count();
+        if tail_w > 0 && last_count > tail_w {
+            let skip = last_count - tail_w;
+            let suffix: String = last.chars().skip(skip).collect();
+            return format!("…/{suffix}");
+        }
+        if combined.chars().count() <= max_w + 4 {
+            return truncate_string(&combined, max_w);
+        }
+    }
+    truncate_string(stripped, max_w)
+}
+
+fn impact_marker(impact: &str) -> (&'static str, Color) {
+    match impact {
+        "High" => ("!!", BAR_HIGH),
+        "Medium" => ("!", TERMINAL_ACCENT),
+        _ => ("·", MUTED_GRAY),
+    }
+}
+
+fn cache_hit_percent(data: &UsageData) -> f64 {
+    let cache_reads = data.grand_total.cache_read_tokens;
+    let denominator = data.grand_total.input_tokens
+        + data.grand_total.cache_creation_tokens
+        + data.grand_total.cache_read_tokens;
+    if denominator == 0 {
+        0.0
+    } else {
+        cache_reads as f64 * 100.0 / denominator as f64
+    }
+}
+
+fn projected_month_cost(data: &UsageData, period: &UsagePeriod) -> Option<f64> {
+    let spent = data.grand_total.cost_usd?;
+    let elapsed_days = elapsed_days_for_period(period, data)?;
+    if elapsed_days == 0 {
+        return Some(spent);
+    }
+    Some(spent / elapsed_days as f64 * 30.0)
+}
+
+fn elapsed_days_for_period(period: &UsagePeriod, data: &UsageData) -> Option<u64> {
+    match period {
+        UsagePeriod::Today => Some(1),
+        UsagePeriod::Week => Some(7),
+        UsagePeriod::ThirtyDays => Some(30),
+        UsagePeriod::LastNDays(n) => Some(u64::from((*n).max(1))),
+        UsagePeriod::Month => {
+            let today = Local::now().date_naive();
+            let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1)?;
+            Some((today - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::SpecificMonth(anchor) => {
+            let first = NaiveDate::from_ymd_opt(anchor.year(), anchor.month(), 1)?;
+            let last = crate::data::usage::last_day_of_month(anchor.year(), anchor.month())?;
+            Some((last - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::SpecificQuarter(year, q) => {
+            let (first, last) = crate::data::usage::quarter_bounds(*year, *q);
+            Some((last - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::YearToDate => {
+            let today = Local::now().date_naive();
+            let first = NaiveDate::from_ymd_opt(today.year(), 1, 1)?;
+            Some((today - first).num_days().max(0) as u64 + 1)
+        }
+        UsagePeriod::Custom { from, to } => {
+            if to < from {
+                Some(0)
+            } else {
+                Some((*to - *from).num_days() as u64 + 1)
+            }
+        }
+        UsagePeriod::All => {
+            let first = data.daily.first().map(|(date, _)| *date)?;
+            let last = data.daily.last().map(|(date, _)| *date).unwrap_or(first);
+            Some((last - first).num_days().max(0) as u64 + 1)
+        }
+    }
+}
+
+fn render_bar_chart(buf: &mut Buffer, area: Rect, data: &UsageData) {
+    if area.width < 4 || area.height < 4 {
+        return;
+    }
+
+    let chart_height = area.height.saturating_sub(2) as usize; // leave room for labels
+    let bar_width = 2_u16;
+    let gap = 1_u16;
+    let num_bars = ((area.width.saturating_sub(2)) / (bar_width + gap)) as usize;
+
+    // Take last N days
+    let start = data.daily.len().saturating_sub(num_bars);
+    let slice = &data.daily[start..];
+
+    if slice.is_empty() {
+        return;
+    }
+
+    let max_val = slice.iter().map(|(_, b)| b.total()).max().unwrap_or(1).max(1);
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Title
+    lines.push(Line::from(Span::styled(
+        format!(" Last {} days", slice.len()),
+        Style::default().fg(MUTED_GRAY),
+    )));
+
+    // Build bars row by row (top to bottom)
+    for row in 0..chart_height {
+        let threshold = max_val as f64 * (chart_height - row) as f64 / chart_height as f64;
+        let mut spans = vec![Span::raw(" ")];
+        for (_date, bucket) in slice {
+            let val = bucket.total() as f64;
+            let ch = if val >= threshold { "█" } else { " " };
+            let color = if val >= max_val as f64 * 0.8 {
+                BAR_HIGH
+            } else if val >= max_val as f64 * 0.4 {
+                BAR_MED
+            } else {
+                BAR_COLOR
+            };
+            spans.push(Span::styled(
+                format!("{ch:>width$}", width = bar_width as usize),
+                Style::default().fg(color),
+            ));
+            spans.push(Span::raw(" ")); // gap
+        }
+        lines.push(Line::from(spans));
+    }
+
+    // X-axis labels (show day-of-month for last few)
+    let mut label_spans = vec![Span::raw(" ")];
+    for (date, _) in slice {
+        let day = format!("{:>2}", date.format("%d"));
+        label_spans.push(Span::styled(day, Style::default().fg(MUTED_GRAY)));
+        label_spans.push(Span::raw(" "));
+    }
+    lines.push(Line::from(label_spans));
+
+    let paragraph = Paragraph::new(lines);
+    ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
+    // When zoomed, swap to a focused help string so the user has the
+    // zoom-only affordances visible.
+    if state.is_zoomed() {
+        let spans = vec![
+            Span::styled(" /", Style::default().fg(GOLD)),
+            Span::styled(" search  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("d", Style::default().fg(GOLD)),
+            Span::styled(" detail  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("z/Esc", Style::default().fg(GOLD)),
+            Span::styled(" back  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("j/k", Style::default().fg(GOLD)),
+            Span::styled(" row  ", Style::default().fg(MUTED_GRAY)),
+        ];
+        let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(DARK_BG));
+        ratatui::widgets::Widget::render(paragraph, area, buf);
+        return;
+    }
+
+    let on_burndown = matches!(state.active_tab, UsageTab::Burndown);
+    let mut spans = vec![
+        Span::styled(" ◀/▶ p", Style::default().fg(GOLD)),
+        Span::styled(" provider  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            "1 Today  2 7d  3 30d  4 90d  5 YTD  m Month  q Quarter  a All  D advanced  ",
+            Style::default().fg(MUTED_GRAY),
+        ),
+    ];
+    if on_burndown {
+        // Burndown view: z zoom; Tab pivots panels; Enter/X commit chips; C clears.
+        spans.extend_from_slice(&[
+            Span::styled("z", Style::default().fg(GOLD)),
+            Span::styled(" zoom  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Tab", Style::default().fg(GOLD)),
+            Span::styled(" focus  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Enter", Style::default().fg(GOLD)),
+            Span::styled(" add  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("X", Style::default().fg(GOLD)),
+            Span::styled(" exclude  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Esc", Style::default().fg(GOLD)),
+            Span::styled(" pop  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("C", Style::default().fg(GOLD)),
+            Span::styled(" clear  ", Style::default().fg(MUTED_GRAY)),
+        ]);
+    } else {
+        spans.extend_from_slice(&[
+            Span::styled("Tab", Style::default().fg(GOLD)),
+            Span::styled(" view  ", Style::default().fg(MUTED_GRAY)),
+        ]);
+    }
+    spans.extend_from_slice(&[
+        Span::styled("j/k", Style::default().fg(GOLD)),
+        Span::styled(" scroll  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("r/R", Style::default().fg(GOLD)),
+        Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Esc", Style::default().fg(GOLD)),
+        Span::styled(" back", Style::default().fg(MUTED_GRAY)),
+    ]);
+    let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(DARK_BG));
+    ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+fn truncate_string(s: &str, max_len: usize) -> String {
+    crate::ui_helpers::truncate_with_ellipsis(s, max_len).into_owned()
+}
+
+fn provider_filter_label(filter: UsageProviderFilter) -> &'static str {
+    match filter {
+        UsageProviderFilter::All => "All",
+        UsageProviderFilter::Claude => "Claude",
+        UsageProviderFilter::Codex => "Codex",
+    }
+}
+
+fn period_label(period: &UsagePeriod) -> String {
+    match period {
+        UsagePeriod::Today => "Today".to_string(),
+        UsagePeriod::Week => "7d".to_string(),
+        UsagePeriod::ThirtyDays => "30d".to_string(),
+        UsagePeriod::LastNDays(n) => format!("{n}d"),
+        UsagePeriod::Month => "Month".to_string(),
+        UsagePeriod::SpecificMonth(anchor) => anchor.format("%b %Y").to_string(),
+        UsagePeriod::SpecificQuarter(year, q) => format!("Q{q} {year}"),
+        UsagePeriod::YearToDate => "YTD".to_string(),
+        UsagePeriod::All => "All".to_string(),
+        UsagePeriod::Custom { from, to } => format!("{from} to {to}"),
+    }
+}
+
+fn input_label(mode: UsageInputMode) -> &'static str {
+    match mode {
+        UsageInputMode::DateRange => "date range",
+    }
+}
+
+fn format_cost(cost: Option<f64>) -> String {
+    cost.map(|value| format!("${value:.2}"))
+        .unwrap_or_else(|| "cost n/a".to_string())
+}
+
+#[cfg(test)]
+mod period_provider_strip_tests {
+    use super::*;
+
+    fn flatten(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect::<String>()
+    }
+
+    fn highlighted_chip(line: &Line<'_>) -> Option<String> {
+        line.spans
+            .iter()
+            .find(|s| s.style.bg == Some(GOLD))
+            .map(|s| s.content.trim().to_string())
+    }
+
+    #[test]
+    fn period_row_lists_all_options_with_key_hints() {
+        let mut state = UsageViewState::default();
+        state.period = UsagePeriod::Week;
+        let lines = build_period_provider_strip(&state);
+        assert_eq!(lines.len(), 2);
+        let row = flatten(&lines[0]);
+        for needle in [
+            "Period:",
+            "1 Today",
+            "2 7d",
+            "3 30d",
+            "4 90d",
+            "5 YTD",
+            "m Month",
+            "q Quarter",
+            "a All",
+            "D advanced",
+        ] {
+            assert!(row.contains(needle), "missing `{needle}` in {row}");
+        }
+    }
+
+    #[test]
+    fn period_row_highlights_active_period() {
+        let mut state = UsageViewState::default();
+        state.period = UsagePeriod::Today;
+        let lines = build_period_provider_strip(&state);
+        let active = highlighted_chip(&lines[0]).expect("a period chip should be highlighted");
+        assert!(active.contains("Today"), "got {active}");
+    }
+
+    #[test]
+    fn period_row_highlights_90d_chip_when_last_n_days_90() {
+        let mut state = UsageViewState::default();
+        state.period = UsagePeriod::LastNDays(90);
+        let lines = build_period_provider_strip(&state);
+        let active = highlighted_chip(&lines[0]).expect("90d should be highlighted");
+        assert!(active.contains("90d"), "got {active}");
+    }
+
+    #[test]
+    fn provider_row_highlights_active_provider_filter() {
+        let mut state = UsageViewState::default();
+        state.provider_filter = UsageProviderFilter::Codex;
+        let lines = build_period_provider_strip(&state);
+        let active = highlighted_chip(&lines[1]).expect("a provider chip should be highlighted");
+        assert_eq!(active, "Codex");
+    }
+}
+
+#[cfg(test)]
+mod pretty_project_tests {
+    use super::*;
+
+    #[test]
+    fn worktree_path_renders_repo_colon_branch() {
+        let name = "worktree/stevengonsalvez_agents-in-a-box_feat_codeburn";
+        assert_eq!(
+            pretty_project_name(name, 40),
+            "agents-in-a-box:feat-codeburn"
+        );
+    }
+
+    #[test]
+    fn dashed_session_token_renders_repo_colon_branch() {
+        let name = "stevengonsalvez-biolift-feat-all";
+        assert_eq!(pretty_project_name(name, 40), "biolift:feat-all");
+    }
+
+    #[test]
+    fn ordinary_path_falls_back_to_shorten() {
+        let name = "/Users/stevie/work/project";
+        // Falls back: name has slashes, shouldn't trip the dash heuristic.
+        // Just assert we did not produce a "repo:branch" colon form.
+        let out = pretty_project_name(name, 40);
+        assert!(!out.contains(':') || out.contains("/"));
+    }
+
+    #[test]
+    fn truncates_branch_when_pretty_form_overflows() {
+        let name = "worktree/u_repository_very-long-feature-branch-name";
+        let out = pretty_project_name(name, 16);
+        // "repository:" is 11 chars, leaves 5 for branch (with truncate ellipsis).
+        assert!(out.starts_with("repository:"), "got {out}");
+        assert!(out.chars().count() <= 16, "got {out}");
+    }
+
+    #[test]
+    fn empty_max_w_returns_empty() {
+        assert_eq!(pretty_project_name("worktree/a_b_c", 0), "");
+    }
+
+    #[test]
+    fn two_dash_segments_do_not_misclassify() {
+        // "org-repo" — only 1 dash, must NOT match user-repo-branch shape.
+        let name = "org-repo";
+        assert_eq!(pretty_project_name(name, 40), "org-repo");
+    }
+}
+
+#[cfg(test)]
+mod cross_filter_tests {
+    use super::*;
+    use crate::data::usage::{
+        ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, SessionUsage, TokenBucket,
+    };
+    use chrono::Utc;
+
+    fn bucket(call_count: usize) -> TokenBucket {
+        TokenBucket {
+            input_tokens: 100,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 50,
+            reasoning_tokens: 0,
+            session_count: 1,
+            project_count: 1,
+            call_count,
+            cost_usd: Some(call_count as f64),
+        }
+    }
+
+    /// Build a fixture UsageData with two projects, two models, two
+    /// activities and two sessions — enough surface for the
+    /// commit_focused_row dispatch table.
+    fn fixture() -> UsageData {
+        let now = Utc::now();
+        UsageData {
+            daily: vec![],
+            weekly: vec![],
+            projects: vec![
+                ProjectUsage {
+                    name: "alpha".into(),
+                    path: "/work/alpha".into(),
+                    bucket: bucket(3),
+                    repo: None,
+                },
+                ProjectUsage {
+                    name: "beta".into(),
+                    path: "/work/beta".into(),
+                    bucket: bucket(2),
+                    repo: None,
+                },
+            ],
+            grand_total: bucket(5),
+            calls: vec![],
+            sessions: vec![
+                SessionUsage {
+                    provider: "claude".into(),
+                    project: "alpha".into(),
+                    session_id: "sess-A".into(),
+                    first_timestamp: now,
+                    last_timestamp: now,
+                    bucket: bucket(3),
+                },
+                SessionUsage {
+                    provider: "claude".into(),
+                    project: "beta".into(),
+                    session_id: "sess-B".into(),
+                    first_timestamp: now,
+                    last_timestamp: now,
+                    bucket: bucket(2),
+                },
+            ],
+            models: vec![
+                ModelUsage {
+                    model: "claude-opus-4".into(),
+                    bucket: bucket(3),
+                },
+                ModelUsage {
+                    model: "claude-sonnet-4".into(),
+                    bucket: bucket(2),
+                },
+            ],
+            activities: vec![
+                ActivityUsage {
+                    category: ActivityCategory::Coding,
+                    bucket: bucket(3),
+                    turns: 3,
+                    retries: 0,
+                    edit_turns: 3,
+                    one_shot_turns: 3,
+                },
+                ActivityUsage {
+                    category: ActivityCategory::Conversation,
+                    bucket: bucket(2),
+                    turns: 2,
+                    retries: 0,
+                    edit_turns: 0,
+                    one_shot_turns: 0,
+                },
+            ],
+            tools: vec![],
+            mcp_servers: vec![],
+            shell_commands: vec![],
+            branches: vec![],
+            model_project_counts: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn tab_cycles_panel_focus_in_documented_order() {
+        let mut state = UsageViewState::default();
+        assert!(state.focused_panel.is_none());
+        for panel in UsagePanel::ALL {
+            state.focus_next_panel();
+            assert_eq!(state.focused_panel, Some(panel));
+        }
+        // Wrap around back to the first.
+        state.focus_next_panel();
+        assert_eq!(state.focused_panel, Some(UsagePanel::ALL[0]));
+    }
+
+    #[test]
+    fn shift_tab_from_unfocused_jumps_to_last_panel() {
+        let mut state = UsageViewState::default();
+        state.focus_prev_panel();
+        assert_eq!(
+            state.focused_panel,
+            Some(UsagePanel::ALL[UsagePanel::ALL.len() - 1])
+        );
+    }
+
+    #[test]
+    fn enter_on_by_project_row_sets_project_filter() {
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.focus_row = 1; // beta
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.project, vec!["beta".to_string()]);
+    }
+
+    #[test]
+    fn enter_on_top_session_row_sets_session_filter() {
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::TopSessions);
+        state.focus_row = 0;
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.session, vec!["sess-A".to_string()]);
+    }
+
+    #[test]
+    fn cross_project_session_id_collision_attaches_owning_project_chip() {
+        // Two sessions with the same id "s1" but different owning
+        // projects — exactly the case that prompted carrying the
+        // session row's project on commit_focused_row. The first
+        // commit must attach the alpha project chip; a subsequent
+        // pop+commit on a beta-owned row must attach beta.
+        let now = Utc::now();
+        let session_alpha = SessionUsage {
+            provider: "claude".into(),
+            project: "alpha".into(),
+            session_id: "s1".into(),
+            first_timestamp: now,
+            last_timestamp: now,
+            bucket: bucket(3),
+        };
+        let session_beta = SessionUsage {
+            provider: "claude".into(),
+            project: "beta".into(),
+            session_id: "s1".into(),
+            first_timestamp: now,
+            last_timestamp: now,
+            bucket: bucket(2),
+        };
+        let mut data = fixture();
+        data.sessions = vec![session_alpha, session_beta];
+
+        let mut state = UsageViewState::default();
+        state.data = Some(data);
+        state.focused_panel = Some(UsagePanel::TopSessions);
+        state.focus_row = 0;
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.session, vec!["s1".to_string()]);
+        assert_eq!(state.filters.project, vec!["alpha".to_string()]);
+
+        // Pop both chips and target the beta row.
+        state.filters.clear();
+        state.focus_row = 1;
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.session, vec!["s1".to_string()]);
+        assert_eq!(state.filters.project, vec!["beta".to_string()]);
+    }
+
+    #[test]
+    fn enter_on_by_model_row_sets_model_filter() {
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::ByModel);
+        state.focus_row = 0;
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.model, vec!["claude-opus-4".to_string()]);
+    }
+
+    #[test]
+    fn enter_on_by_activity_row_sets_activity_filter() {
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::ByActivity);
+        state.focus_row = 1; // Conversation
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.activity, vec!["Conversation".to_string()]);
+    }
+
+    #[test]
+    fn enter_on_daily_activity_row_is_noop() {
+        // Brief: read-only panels — Enter is a no-op.
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::DailyActivity);
+        state.focus_row = 0;
+        assert!(!state.commit_focused_row());
+        assert!(state.filters.is_empty());
+    }
+
+    /// Tab traversal contract: ByBranch sits immediately after ByProject
+    /// in the focusable-panel sequence so the row 0 "where my tokens
+    /// went" cluster (Daily Activity → By Project → By Branch) reads
+    /// left-to-right when users walk the dashboard with Tab.
+    #[test]
+    fn branch_panel_in_panel_all_after_by_project() {
+        let proj_idx = UsagePanel::ALL
+            .iter()
+            .position(|p| *p == UsagePanel::ByProject)
+            .expect("ByProject in ALL");
+        assert_eq!(
+            UsagePanel::ALL[proj_idx + 1],
+            UsagePanel::ByBranch,
+            "ByBranch must follow ByProject in the traversal order"
+        );
+    }
+
+    #[test]
+    fn tab_traversal_visits_branch_panel_after_project() {
+        let mut state = UsageViewState::default();
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.focus_next_panel();
+        assert_eq!(state.focused_panel, Some(UsagePanel::ByBranch));
+    }
+
+    /// Brief: branches are display-only for this PR — no chip pivot.
+    #[test]
+    fn enter_on_by_branch_row_is_noop() {
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::ByBranch);
+        state.focus_row = 0;
+        assert!(!state.commit_focused_row());
+        assert!(state.filters.is_empty());
+    }
+
+    /// Smoke test: render_branch_panel must not panic on a small frame
+    /// with a couple of synthetic BranchUsage rows, and must produce a
+    /// non-empty buffer (i.e. it actually drew something).
+    #[test]
+    fn render_branch_panel_smoke() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let rows = vec![
+            BranchUsage {
+                branch: "main".to_string(),
+                bucket: bucket(3),
+            },
+            BranchUsage {
+                branch: "feat/burndown-branches-panel".to_string(),
+                bucket: bucket(2),
+            },
+        ];
+
+        let backend = TestBackend::new(60, 8);
+        let mut terminal = Terminal::new(backend).expect("test backend");
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                render_branch_panel(frame.buffer_mut(), area, &rows, FocusCtx::unfocused());
+            })
+            .expect("render_branch_panel must not panic");
+
+        let buffer = terminal.backend().buffer();
+        let flat: String = (0..buffer.area().height)
+            .flat_map(|y| (0..buffer.area().width).map(move |x| (x, y)))
+            .map(|(x, y)| buffer.get(x, y).symbol().to_string())
+            .collect();
+        assert!(flat.contains("By Branch"), "panel title missing: {flat}");
+        assert!(flat.contains("main"), "branch label missing: {flat}");
+    }
+
+    #[test]
+    fn enter_on_leaderboard_maps_to_project_filter() {
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::Leaderboard);
+        state.focus_row = 0; // alpha (rendered from filtered_data.projects)
+        assert!(state.commit_focused_row());
+        assert_eq!(state.filters.project, vec!["alpha".to_string()]);
+    }
+
+    #[test]
+    fn esc_pops_last_chip_and_chip_strip_reflects_remaining() {
+        let mut state = UsageViewState::default();
+        state.filters.project.push("alpha".into());
+        state.filters.model.push("opus".into());
+        state.filters.branch.push("main".into());
+
+        // First pop -> branch (rightmost in the strip; pop order is
+        // branch → session → activity → model → project).
+        let removed = state.pop_filter_chip();
+        assert!(matches!(removed, Some(UsageFilterChip::Branch(v)) if v == "main"));
+        assert!(state.filters.branch.is_empty());
+
+        // The chip strip must show every surviving chip — including the
+        // branch chip while it was set. Render symmetry: the chip the
+        // user sees rightmost is the one Esc removes next.
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("project=alpha"), "got {flat}");
+        assert!(flat.contains("model=opus"), "got {flat}");
+        assert!(!flat.contains("branch="), "branch chip lingered: {flat}");
+
+        // Second pop -> model.
+        let removed = state.pop_filter_chip();
+        assert!(matches!(removed, Some(UsageFilterChip::Model(v)) if v == "opus"));
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("project=alpha"), "got {flat}");
+        assert!(flat.contains("Esc") && flat.contains("C"), "got {flat}");
+
+        // Third pop -> project. With no chips left we fall back to
+        // the discoverability hint.
+        assert!(state.pop_filter_chip().is_some());
+        assert!(state.filters.is_empty());
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("(none)"), "got {flat}");
+    }
+
+    /// Tripwire: every `UsageFilterChip` variant must render in
+    /// `build_filter_chip_line`. If a new variant is added without a
+    /// `push_chip_group` call this test fails — the PR-D regression where
+    /// `branch` chips set via `--branch` were invisible but still consumed
+    /// `Esc` is exactly what this guards against.
+    #[test]
+    fn every_filter_chip_variant_renders_in_strip() {
+        let mut state = UsageViewState::default();
+        state.filters.project.push("p".into());
+        state.filters.model.push("m".into());
+        state.filters.activity.push("Coding".into());
+        state.filters.session.push("s".into());
+        state.filters.branch.push("b".into());
+
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        for needle in [
+            "project=p",
+            "model=m",
+            "activity=Coding",
+            "session=s",
+            "branch=b",
+        ] {
+            assert!(flat.contains(needle), "chip strip missing {needle}: {flat}");
+        }
+    }
+
+    #[test]
+    fn x_on_by_project_row_adds_exclude_chip_and_filter_drops_project() {
+        use crate::data::usage::{UsageData, UsageFilters, filter_usage_data};
+        use crate::test_support::ProviderCallBuilder;
+        use std::collections::HashMap;
+
+        let mut state = UsageViewState::default();
+        state.data = Some(fixture());
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.focus_row = 1; // beta
+        assert!(state.commit_focused_row_exclude());
+        assert_eq!(state.filters.exclude_project, vec!["beta".to_string()]);
+        assert!(
+            state.filters.project.is_empty(),
+            "include side must be untouched"
+        );
+
+        // End-to-end: filter_usage_data must drop calls matching the
+        // exclude project, leaving only the alpha call.
+        let calls = vec![
+            ProviderCallBuilder::new().with_project("alpha").build(),
+            ProviderCallBuilder::new().with_project("beta").build(),
+        ];
+        let data = UsageData {
+            daily: vec![],
+            weekly: vec![],
+            projects: vec![],
+            grand_total: TokenBucket::default(),
+            calls,
+            sessions: vec![],
+            models: vec![],
+            activities: vec![],
+            tools: vec![],
+            mcp_servers: vec![],
+            shell_commands: vec![],
+            branches: vec![],
+            model_project_counts: HashMap::new(),
+        };
+        let mut filters = UsageFilters::default();
+        filters.exclude_project.push("beta".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 1);
+        assert_eq!(filtered.calls[0].project, "alpha");
+    }
+
+    #[test]
+    fn step_period_back_uses_oldest_call_day_not_data_daily() {
+        // The picker must clamp at the absolute oldest call day (which
+        // tracks the unfiltered call set across loads), not at
+        // `data.daily.first()` — when the active period is
+        // `SpecificMonth(May)`, `data.daily` only has May rows so the
+        // old clamp-at-data path would refuse to step into April even
+        // though April is in range.
+        use crate::data::usage::UsagePeriod;
+        let mut state = UsageViewState::default();
+        state.oldest_call_day = NaiveDate::from_ymd_opt(2026, 4, 1);
+        state.period = UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap());
+
+        assert!(
+            state.step_period_back(),
+            "April is in range; back must succeed"
+        );
+        assert_eq!(
+            state.period,
+            UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 4, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn step_period_back_clamps_when_oldest_is_inside_target_month() {
+        // April 1 < May 15, so stepping back from May lands on April 1,
+        // which is BEFORE the oldest known day — must refuse the step.
+        use crate::data::usage::UsagePeriod;
+        let mut state = UsageViewState::default();
+        state.oldest_call_day = NaiveDate::from_ymd_opt(2026, 5, 15);
+        state.period = UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap());
+
+        assert!(
+            !state.step_period_back(),
+            "April predates oldest May 15; back must fail"
+        );
+        assert_eq!(
+            state.period,
+            UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn step_period_back_returns_false_when_no_data_loaded() {
+        // Without an oldest anchor the user could wander arbitrarily
+        // far back; refuse to step until at least one load has populated
+        // `oldest_call_day`.
+        use crate::data::usage::UsagePeriod;
+        let mut state = UsageViewState::default();
+        state.oldest_call_day = None;
+        state.period = UsagePeriod::SpecificMonth(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap());
+        assert!(!state.step_period_back());
+    }
+
+    #[test]
+    fn clear_all_drops_every_chip() {
+        let mut state = UsageViewState::default();
+        state.filters.project.push("alpha".into());
+        state.filters.model.push("opus".into());
+        state.filters.activity.push("Coding".into());
+        state.filters.session.push("sess-1".into());
+        state.clear_all_filter_chips();
+        assert!(state.filters.is_empty());
+    }
+
+    #[test]
+    fn z_toggles_zoom_state_and_records_focused_panel() {
+        let mut state = UsageViewState::default();
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.toggle_zoom();
+        assert_eq!(state.zoom, Some(UsagePanel::ByProject));
+        assert!(state.is_zoomed());
+        state.toggle_zoom();
+        assert!(state.zoom.is_none());
+        assert!(!state.is_zoomed());
+    }
+
+    #[test]
+    fn z_without_focus_picks_first_panel() {
+        let mut state = UsageViewState::default();
+        assert!(state.focused_panel.is_none());
+        state.toggle_zoom();
+        assert_eq!(state.zoom, Some(UsagePanel::ALL[0]));
+        assert_eq!(state.focused_panel, Some(UsagePanel::ALL[0]));
+    }
+
+    #[test]
+    fn slash_enters_search_mode_and_typing_appends() {
+        let mut state = UsageViewState::default();
+        state.toggle_zoom();
+        state.zoom_begin_search();
+        assert!(state.zoom_search_active);
+        state.zoom_search_char('a');
+        state.zoom_search_char('l');
+        state.zoom_search_char('p');
+        assert_eq!(state.zoom_search_query, "alp");
+        state.zoom_commit_search();
+        assert!(!state.zoom_search_active);
+        assert_eq!(state.zoom_search_query, "alp");
+    }
+
+    #[test]
+    fn esc_priority_is_detail_then_search_then_zoom_exit() {
+        let mut state = UsageViewState::default();
+        state.toggle_zoom();
+        state.zoom_detail_open = true;
+        state.zoom_search_active = true;
+        state.zoom_search_query.push('x');
+
+        // 1st Esc -> close detail.
+        assert!(state.zoom_handle_esc());
+        assert!(!state.zoom_detail_open);
+        assert!(state.zoom_search_active, "search still active");
+
+        // 2nd Esc -> cancel search.
+        assert!(state.zoom_handle_esc());
+        assert!(!state.zoom_search_active);
+        assert!(state.zoom_search_query.is_empty());
+
+        // 3rd Esc -> exit zoom.
+        assert!(state.zoom_handle_esc());
+        assert!(!state.is_zoomed());
+
+        // 4th Esc -> not consumed; caller falls through to chip pop.
+        assert!(!state.zoom_handle_esc());
+    }
+
+    #[test]
+    fn d_toggles_detail_drawer_when_zoomed() {
+        let mut state = UsageViewState::default();
+        state.toggle_zoom();
+        assert!(!state.zoom_detail_open);
+        state.toggle_zoom_detail();
+        assert!(state.zoom_detail_open);
+        state.toggle_zoom_detail();
+        assert!(!state.zoom_detail_open);
+    }
+
+    #[test]
+    fn fuzzy_filter_matches_substring_when_query_present() {
+        let projects = vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+            "alphabet".to_string(),
+        ];
+        let out = apply_zoom_filter(&projects, "alp", |s| s.clone());
+        assert_eq!(out.len(), 2, "alpha + alphabet should both match");
+    }
+
+    #[test]
+    fn fuzzy_filter_empty_query_returns_all() {
+        let projects = vec!["alpha".to_string(), "beta".to_string()];
+        let out = apply_zoom_filter(&projects, "", |s| s.clone());
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn focus_ctx_for_panel_only_marks_matching_panel() {
+        let mut state = UsageViewState::default();
+        state.focused_panel = Some(UsagePanel::ByProject);
+        state.focus_row = 4;
+        let by_proj = FocusCtx::for_panel(&state, UsagePanel::ByProject);
+        let by_model = FocusCtx::for_panel(&state, UsagePanel::ByModel);
+        assert!(by_proj.is_focused());
+        assert_eq!(by_proj.focused_row, Some(4));
+        assert!(!by_model.is_focused());
+        assert!(by_model.focused_row.is_none());
+    }
+}
+
+#[cfg(test)]
+mod cli_parity_tests {
+    use crate::data::usage::{
+        ActivityCategory, ActivityUsage, ModelUsage, ProjectUsage, ProviderCall, SessionUsage,
+        TokenBucket, UsageData, UsageFilters, filter_usage_data,
+    };
+    use chrono::Utc;
+
+    fn call(project: &str, model: &str, session: &str) -> ProviderCall {
+        crate::test_support::ProviderCallBuilder::new()
+            .with_model(model)
+            .with_session(session)
+            .with_project(project)
+            .with_project_path(format!("/work/{project}"))
+            .with_timestamp(Utc::now())
+            .with_input_tokens(100)
+            .with_output_tokens(50)
+            .with_cost(1.0)
+            .with_tools(&["Edit"])
+            .with_user_message("tidy")
+            .build()
+    }
+
+    fn data_with_calls(calls: Vec<ProviderCall>) -> UsageData {
+        // Ad-hoc UsageData wrapping `calls`. We don't need the
+        // aggregates here — the CLI parity contract is "filtering
+        // re-aggregates from data.calls" and that's what
+        // filter_usage_data does internally.
+        UsageData {
+            calls,
+            ..UsageData::default()
+        }
+    }
+
+    #[test]
+    fn project_filter_excludes_other_projects_and_changes_totals() {
+        let data = data_with_calls(vec![
+            call("alpha", "opus", "s1"),
+            call("alpha", "opus", "s2"),
+            call("beta", "opus", "s3"),
+        ]);
+        let mut filters = UsageFilters::default();
+        filters.project.push("alpha".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 2);
+        assert!(filtered.projects.iter().all(|p| p.name == "alpha"));
+        assert_eq!(
+            filtered.grand_total.cost_usd,
+            Some(2.0),
+            "cost should reflect only the surviving 2 calls"
+        );
+    }
+
+    #[test]
+    fn multiple_project_values_or_combine() {
+        let data = data_with_calls(vec![
+            call("alpha", "opus", "s1"),
+            call("beta", "opus", "s2"),
+            call("gamma", "opus", "s3"),
+        ]);
+        let mut filters = UsageFilters::default();
+        filters.project.push("alpha".into());
+        filters.project.push("beta".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 2);
+    }
+
+    #[test]
+    fn project_and_model_and_combine() {
+        let data = data_with_calls(vec![
+            call("alpha", "opus", "s1"),
+            call("alpha", "sonnet", "s2"),
+            call("beta", "opus", "s3"),
+        ]);
+        let mut filters = UsageFilters::default();
+        filters.project.push("alpha".into());
+        filters.model.push("opus".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 1);
+        assert_eq!(filtered.calls[0].session_id, "s1");
+    }
+
+    #[test]
+    fn empty_filters_clones_data_through() {
+        let data = data_with_calls(vec![call("alpha", "opus", "s1")]);
+        let filtered = filter_usage_data(&data, &UsageFilters::default());
+        // No filters -> identical surface.
+        assert_eq!(filtered.calls.len(), data.calls.len());
+    }
+
+    #[test]
+    fn activity_filter_matches_classified_label() {
+        // "Edit" tool -> Coding category. So filtering by activity =
+        // "Coding" keeps the call; filtering by "Git" drops it.
+        let data = data_with_calls(vec![call("alpha", "opus", "s1")]);
+        let mut keep = UsageFilters::default();
+        keep.activity.push("Coding".into());
+        let kept = filter_usage_data(&data, &keep);
+        assert_eq!(kept.calls.len(), 1);
+
+        let mut drop = UsageFilters::default();
+        drop.activity.push("Git".into());
+        let dropped = filter_usage_data(&data, &drop);
+        assert_eq!(dropped.calls.len(), 0);
+    }
+
+    #[test]
+    fn branch_filter_keeps_only_matching_branch_and_drops_branchless_calls() {
+        let mut on_main = call("alpha", "opus", "s1");
+        on_main.branch = Some("main".into());
+        let mut on_feat = call("alpha", "opus", "s2");
+        on_feat.branch = Some("feat/x".into());
+        let no_branch = call("alpha", "opus", "s3"); // branch: None
+
+        let data = data_with_calls(vec![on_main, on_feat, no_branch]);
+
+        let mut filters = UsageFilters::default();
+        filters.branch.push("feat/x".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 1, "only feat/x survives");
+        assert_eq!(filtered.calls[0].session_id, "s2");
+
+        // Branchless calls must NOT match a non-empty branch filter — even
+        // a generic "main" filter excludes calls that have no recorded
+        // branch (codex turns, Claude turns outside a git repo).
+        let mut main_only = UsageFilters::default();
+        main_only.branch.push("main".into());
+        let only_main = filter_usage_data(&data, &main_only);
+        assert_eq!(only_main.calls.len(), 1);
+        assert!(only_main.calls.iter().all(|c| c.branch.as_deref() == Some("main")));
+    }
+
+    #[test]
+    fn session_filter_keeps_only_matching_session_id() {
+        let data = data_with_calls(vec![
+            call("alpha", "opus", "s1"),
+            call("alpha", "opus", "s2"),
+        ]);
+        let mut filters = UsageFilters::default();
+        filters.session.push("s2".into());
+        let filtered = filter_usage_data(&data, &filters);
+        assert_eq!(filtered.calls.len(), 1);
+        assert_eq!(filtered.calls[0].session_id, "s2");
+    }
+
+    /// Doc test the README contract: the JSON `overview.cost_usd`
+    /// produced by `ainb usage report --project X --format json`
+    /// equals `filter_usage_data(unfiltered, {project: [X]})
+    /// .grand_total.cost_usd`. We exercise the model-side helper
+    /// directly here; the CLI's `query_from_args` -> `load_usage` ->
+    /// `parse_usage_for_with_roots_and_cache` chain wraps this
+    /// helper after the period+include/exclude pre-pass, so any
+    /// future regression in either layer trips this assertion.
+    #[test]
+    fn report_overview_cost_matches_filter_helper() {
+        let data = data_with_calls(vec![
+            call("alpha", "opus", "s1"),
+            call("alpha", "opus", "s2"),
+            call("beta", "opus", "s3"),
+        ]);
+        let mut filters = UsageFilters::default();
+        filters.project.push("alpha".into());
+        let filtered = filter_usage_data(&data, &filters);
+        let overview_cost = filtered.overview().cost_usd;
+        assert_eq!(overview_cost, Some(2.0));
+    }
+
+    // Silence dead_code warnings on the helper imports for fixtures
+    // that aren't yet exercised by a top-level assertion. They pull
+    // their weight via type inference for the `data_with_calls`
+    // signature and round-out the reusable fixture API.
+    #[allow(dead_code)]
+    fn _types(
+        _: ActivityUsage,
+        _: ActivityCategory,
+        _: ModelUsage,
+        _: ProjectUsage,
+        _: SessionUsage,
+        _: TokenBucket,
+    ) {
+    }
+}
+
+#[cfg(test)]
+mod budget_live_header_tests {
+    use super::*;
+    use crate::live_window::{LiveWindow, Source};
+    use std::time::Duration;
+
+    fn flat(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref().to_string()))
+            .collect::<Vec<_>>()
+            .join(" | ")
+    }
+
+    #[test]
+    fn cta_lines_rendered_when_source_is_none() {
+        let live = LiveWindow::empty();
+        let lines = budget_live_header_lines(&live, 60);
+        let text = flat(&lines);
+        assert!(text.contains("[W]"), "CTA must mention W key: {text}");
+        assert!(text.contains("statusline"), "CTA copy missing: {text}");
+    }
+
+    #[test]
+    fn tier1_renders_two_bars_plus_cost_and_reset() {
+        let live = LiveWindow {
+            five_hour_pct: Some(40),
+            seven_day_pct: Some(8),
+            today_cost_usd: Some(3.21),
+            resets_in: Some(Duration::from_secs(2 * 3600 + 30 * 60)),
+            context_pct: None,
+            model: None,
+            source: Source::Tier1Cache,
+        };
+        let lines = budget_live_header_lines(&live, 60);
+        let text = flat(&lines);
+        assert!(text.contains("5h burn"));
+        assert!(text.contains("7d wnd"));
+        assert!(text.contains("$3.21"));
+        assert!(text.contains("2h 30m"));
+    }
+
+    #[test]
+    fn tier2_renders_5h_bar_and_upgrade_hint_only() {
+        let live = LiveWindow {
+            five_hour_pct: Some(20),
+            seven_day_pct: None,
+            today_cost_usd: None,
+            resets_in: None,
+            context_pct: None,
+            model: None,
+            source: Source::Tier2Local,
+        };
+        let lines = budget_live_header_lines(&live, 60);
+        let text = flat(&lines);
+        assert!(text.contains("5h burn"));
+        assert!(!text.contains("7d wnd"));
+        assert!(text.contains("Wire statusline"));
+    }
+
+    #[test]
+    fn format_hms_zero_yields_zero_minutes() {
+        assert_eq!(format_hms(Duration::ZERO), "0m");
+    }
+
+    #[test]
+    fn format_hms_under_one_hour_omits_h_field() {
+        assert_eq!(format_hms(Duration::from_secs(45 * 60)), "45m");
+    }
+
+    #[test]
+    fn format_hms_pads_minutes_when_hours_present() {
+        assert_eq!(format_hms(Duration::from_secs(3 * 3600 + 5 * 60)), "3h 05m");
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui_helpers.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui_helpers.rs
@@ -1,0 +1,20 @@
+//! Plugin-local copy of small UI helpers. ainb-core's
+//! `crate::widgets::truncate_with_ellipsis` is duplicated here so the
+//! plugin doesn't depend on the host crate.
+
+use std::borrow::Cow;
+
+/// Truncate `s` to fit within `max_len` columns, replacing the tail
+/// with an ellipsis when truncation occurs.
+pub fn truncate_with_ellipsis(s: &str, max_len: usize) -> Cow<'_, str> {
+    if s.chars().count() <= max_len {
+        Cow::Borrowed(s)
+    } else if max_len == 0 {
+        Cow::Borrowed("")
+    } else {
+        let take = max_len.saturating_sub(1);
+        let mut out: String = s.chars().take(take).collect();
+        out.push('…');
+        Cow::Owned(out)
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/wire.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/wire.rs
@@ -1,0 +1,157 @@
+//! Wire-to-local schema conversion for `sessions.usage_data` snapshots.
+//!
+//! `ainb-plugin-types-sessions` carries the deterministic on-the-wire
+//! shape that session-reader publishes. Burndown's CLI + render
+//! pipeline runs against the legacy [`crate::data::usage::UsageData`]
+//! shape (richer activity taxonomy, `HashMap` for fast project lookup).
+//! This module owns the one-direction translation.
+//!
+//! Field-for-field identical except:
+//! * `Provider` is an enum on the wire, a `String` locally — emit
+//!   `provider.as_str().to_string()`.
+//! * `model_project_counts` is `Vec<(String, …)>` (deterministic
+//!   ordering for byte-stable msgpack) on the wire, `HashMap<String, …>`
+//!   locally for cheap render-time lookup.
+//! * `ActivityCategory` taxonomy diverges (6 wire buckets vs. 12+
+//!   legacy variants) — best-effort map with `Conversation` as the
+//!   `Other` fallback. Lossy but the JSON output stays well-formed.
+
+use crate::data::usage::{self as L, UsageData};
+use ainb_plugin_types_sessions as W;
+
+fn bucket(b: W::TokenBucket) -> L::TokenBucket {
+    L::TokenBucket {
+        input_tokens: b.input_tokens,
+        cache_creation_tokens: b.cache_creation_tokens,
+        cache_read_tokens: b.cache_read_tokens,
+        output_tokens: b.output_tokens,
+        reasoning_tokens: b.reasoning_tokens,
+        session_count: b.session_count,
+        project_count: b.project_count,
+        call_count: b.call_count,
+        cost_usd: b.cost_usd,
+    }
+}
+
+fn category(c: W::ActivityCategory) -> L::ActivityCategory {
+    match c {
+        W::ActivityCategory::Code => L::ActivityCategory::Coding,
+        W::ActivityCategory::Docs => L::ActivityCategory::Conversation,
+        W::ActivityCategory::Debug => L::ActivityCategory::Debugging,
+        W::ActivityCategory::Refactor => L::ActivityCategory::Refactoring,
+        W::ActivityCategory::Test => L::ActivityCategory::Testing,
+        W::ActivityCategory::Other => L::ActivityCategory::Conversation,
+    }
+}
+
+/// Convert a wire `UsageData` (from `sessions.usage_data`) into
+/// burndown's local shape.
+pub fn wire_to_local(w: W::UsageData) -> UsageData {
+    L::UsageData {
+        daily: w.daily.into_iter().map(|(d, b)| (d, bucket(b))).collect(),
+        weekly: w
+            .weekly
+            .into_iter()
+            .map(|(d, b)| (d, bucket(b)))
+            .collect(),
+        projects: w
+            .projects
+            .into_iter()
+            .map(|p| L::ProjectUsage {
+                name: p.name,
+                path: p.path,
+                bucket: bucket(p.bucket),
+                repo: p.repo,
+            })
+            .collect(),
+        grand_total: bucket(w.grand_total),
+        calls: w
+            .calls
+            .into_iter()
+            .map(|c| L::ProviderCall {
+                id: c.id,
+                provider: c.provider.as_str().to_string(),
+                model: c.model,
+                session_id: c.session_id,
+                project: c.project,
+                project_path: c.project_path,
+                timestamp: c.timestamp,
+                input_tokens: c.input_tokens,
+                cache_creation_tokens: c.cache_creation_tokens,
+                cache_read_tokens: c.cache_read_tokens,
+                output_tokens: c.output_tokens,
+                reasoning_tokens: c.reasoning_tokens,
+                cost_usd: c.cost_usd,
+                tools: c.tools,
+                bash_commands: c.bash_commands,
+                user_message: c.user_message,
+                branch: c.branch,
+            })
+            .collect(),
+        sessions: w
+            .sessions
+            .into_iter()
+            .map(|s| L::SessionUsage {
+                provider: s.provider.as_str().to_string(),
+                project: s.project,
+                session_id: s.session_id,
+                first_timestamp: s.first_timestamp,
+                last_timestamp: s.last_timestamp,
+                bucket: bucket(s.bucket),
+            })
+            .collect(),
+        models: w
+            .models
+            .into_iter()
+            .map(|m| L::ModelUsage {
+                model: m.model,
+                bucket: bucket(m.bucket),
+            })
+            .collect(),
+        activities: w
+            .activities
+            .into_iter()
+            .map(|a| L::ActivityUsage {
+                category: category(a.category),
+                bucket: bucket(a.bucket),
+                turns: a.turns,
+                retries: a.retries,
+                edit_turns: a.edit_turns,
+                one_shot_turns: a.one_shot_turns,
+            })
+            .collect(),
+        tools: w
+            .tools
+            .into_iter()
+            .map(|n| L::NamedUsage {
+                name: n.name,
+                calls: n.calls,
+            })
+            .collect(),
+        mcp_servers: w
+            .mcp_servers
+            .into_iter()
+            .map(|n| L::NamedUsage {
+                name: n.name,
+                calls: n.calls,
+            })
+            .collect(),
+        shell_commands: w
+            .shell_commands
+            .into_iter()
+            .map(|n| L::NamedUsage {
+                name: n.name,
+                calls: n.calls,
+            })
+            .collect(),
+        branches: w
+            .branches
+            .into_iter()
+            .map(|b| L::BranchUsage {
+                branch: b.branch,
+                bucket: bucket(b.bucket),
+            })
+            .collect(),
+        model_project_counts: w.model_project_counts.into_iter().collect(),
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
@@ -1,0 +1,188 @@
+//! End-to-end smoke test for the burndown subprocess plugin.
+//!
+//! Spawns the `ainb-plugin-burndown` binary the same way the runtime
+//! would, drives it with Content-Length-framed JSON-RPC requests over
+//! stdin/stdout, and asserts:
+//!
+//! 1. `plugin/init` returns `name=burndown, version=2.0.0` (matches the
+//!    `[plugin]` section of `plugin.toml`) — proves the SDK's
+//!    manifest-echo path is wired.
+//! 2. `plugin/render` with a 40×4 viewport returns a `WireBuffer` of
+//!    matching dimensions — proves the dispatcher and the render path
+//!    are alive without a `sessions.usage_data` snapshot pre-loaded.
+//! 3. `plugin/shutdown` is acknowledged and the process exits within a
+//!    short window — proves graceful shutdown.
+//!
+//! Run with `cargo test -p ainb-plugin-burndown --test stdio_smoke`.
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const FRAME_HEADER_PREFIX: &str = "Content-Length: ";
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_ainb-plugin-burndown")
+}
+
+fn encode(value: &Value) -> Vec<u8> {
+    let body = serde_json::to_vec(value).expect("serialize body");
+    let mut out = format!("{FRAME_HEADER_PREFIX}{}\r\n\r\n", body.len()).into_bytes();
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Read one Content-Length-framed JSON body from `r`. Bounded by
+/// `deadline` so a hung plugin doesn't wedge the test runner.
+fn read_frame<R: Read>(r: &mut R, deadline: Instant) -> Option<Value> {
+    // Hand-roll a tiny header reader so we don't pull in tokio/bytes
+    // for what's already a 100-line test.
+    let mut buf = Vec::new();
+    let mut byte = [0_u8; 1];
+    let mut content_length: Option<usize> = None;
+    loop {
+        if Instant::now() > deadline {
+            panic!("timed out reading frame header; got so far: {buf:?}");
+        }
+        match r.read(&mut byte) {
+            Ok(0) => return None,
+            Ok(_) => buf.push(byte[0]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(e) => panic!("stdout read error: {e}"),
+        }
+        if buf.ends_with(b"\r\n\r\n") {
+            // End of headers.
+            let headers = String::from_utf8_lossy(&buf[..buf.len() - 4]);
+            for line in headers.split("\r\n") {
+                if let Some(rest) = line.strip_prefix(FRAME_HEADER_PREFIX) {
+                    content_length = Some(rest.trim().parse().expect("Content-Length numeric"));
+                }
+            }
+            break;
+        }
+    }
+    let len = content_length.expect("frame missing Content-Length header");
+    let mut body = vec![0_u8; len];
+    let mut read = 0;
+    while read < len {
+        if Instant::now() > deadline {
+            panic!("timed out reading frame body of {len} bytes (got {read})");
+        }
+        match r.read(&mut body[read..]) {
+            Ok(0) => panic!("EOF mid-body at {read}/{len}"),
+            Ok(n) => read += n,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(e) => panic!("stdout read error: {e}"),
+        }
+    }
+    Some(serde_json::from_slice(&body).expect("body must decode as JSON"))
+}
+
+#[test]
+fn init_render_shutdown_round_trip() {
+    let mut child = Command::new(binary_path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn burndown plugin");
+
+    let mut stdin = child.stdin.take().expect("stdin handle");
+    let mut stdout = child.stdout.take().expect("stdout handle");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    // 1. plugin/init
+    let init = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "plugin/init",
+        "params": {
+            "manifest_path": "/tmp/burndown/manifest.toml",
+            "granted_capabilities": ["read_sessions", "write_plugin_data", "event_bus"],
+            "abi_version": 2
+        }
+    });
+    stdin.write_all(&encode(&init)).expect("write init");
+    stdin.flush().expect("flush init");
+
+    // Burndown's `on_init` calls `host.snapshot_get("sessions.usage_data")`
+    // to warm-load any existing snapshot. The SDK awaits `on_init`
+    // before sending the init reply, so the test sees the reverse-call
+    // *first*. Answer it with an empty payload so init can complete.
+    let rev = read_frame(&mut stdout, deadline).expect("reverse-call request");
+    assert_eq!(rev["method"], "host/snapshot/get", "reverse: {rev}");
+    let rev_id = rev["id"].as_i64().expect("reverse request must have id");
+    let rev_reply = json!({
+        "jsonrpc": "2.0",
+        "id": rev_id,
+        "result": { "payload": null, "version": 0 }
+    });
+    stdin
+        .write_all(&encode(&rev_reply))
+        .expect("write reverse reply");
+    stdin.flush().expect("flush reverse reply");
+
+    // Now the init reply itself.
+    let resp = read_frame(&mut stdout, deadline).expect("init response");
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 1);
+    let result = resp.get("result").expect("init must succeed");
+    assert_eq!(result["name"], "burndown", "manifest name echo: {resp}");
+    assert_eq!(result["version"], "2.0.0", "manifest version echo: {resp}");
+
+    // 2. plugin/render
+    let render = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "plugin/render",
+        "params": {
+            "viewport": { "width": 40_u16, "height": 4_u16 },
+            "generation": 0_u64
+        }
+    });
+    stdin.write_all(&encode(&render)).expect("write render");
+    stdin.flush().expect("flush render");
+
+    let resp = read_frame(&mut stdout, deadline).expect("render response");
+    assert_eq!(resp["id"], 2);
+    let result = resp.get("result").expect("render must succeed");
+    let buffer = result.get("buffer").expect("render result has buffer");
+    assert_eq!(buffer["width"], 40, "render buffer width: {resp}");
+    assert_eq!(buffer["height"], 4, "render buffer height: {resp}");
+    assert!(
+        buffer["cells"].is_array(),
+        "render buffer cells must be array"
+    );
+
+    // 3. plugin/shutdown — notification, no response expected.
+    let shutdown = json!({
+        "jsonrpc": "2.0",
+        "method": "plugin/shutdown",
+        "params": {}
+    });
+    stdin.write_all(&encode(&shutdown)).expect("write shutdown");
+    stdin.flush().expect("flush shutdown");
+    drop(stdin);
+
+    // Wait up to 5s for the process to exit on its own.
+    let exit_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                assert!(
+                    status.success() || status.code() == Some(0),
+                    "plugin exited non-zero: {status:?}"
+                );
+                return;
+            }
+            None if Instant::now() > exit_deadline => {
+                let _ = child.kill();
+                panic!("plugin did not exit within 5s of shutdown notification");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 7c-burndown — migrate burndown plugin to subprocess + ABI v2.

Bead: `agents-in-a-box-141`. Sister: `agents-in-a-box-4is` (session-reader, separate PR).

## What changed

- `crates/ainb-plugin-burndown/Cargo.toml` — drop `crate-type = ["cdylib"]`, drop `wasm32-wasip1` target, add `[[bin]]`. Becomes a regular Rust binary using `ainb-plugin-sdk-rust::Server::run_stdio()`.
- Source ported from Phase 6c analytics surface, re-implementing as a subprocess plugin.
- Plugin trait: `manifest()` (ABI v2), `handle_event()` (subscribes to `sessions.usage_data`), `render()` (cell-based WireBuffer), `cli_dispatch()` (burndown report).
- 188-line stdio smoke test verifying init/render/shutdown round-trip.

## Commits (5 atomic)

- `c593bf0` build(plugin-burndown): subprocess bin Cargo.toml + workspace member
- `1bff9f1` feat(plugin-burndown): port Phase 6c analytics source to subprocess crate
- `fb69cdd` feat(plugin-burndown): implement SDK Plugin trait + main entry point
- `3289233` feat(plugin-burndown): manifest v2 with lazy lifecycle + snapshot subscribe
- `d3cb260` test(plugin-burndown): stdio JSON-RPC init/render/shutdown round-trip

## Architectural gates

| gate | result |
|---|---|
| zero wasmi imports | ✅ |
| zero ainb-plugin-api imports | ✅ |
| `[[bin]]` not cdylib | ✅ |
| host target (no wasm32-wasip1) | ✅ |
| wire types from ainb-plugin-protocol | ✅ |

## Test plan

- [x] `cargo build -p ainb-plugin-burndown`
- [x] `cargo build --release -p ainb-plugin-burndown`
- [x] `cargo test -p ainb-plugin-burndown` (stdio smoke + unit tests)
- [x] `cargo clippy -p ainb-plugin-burndown -- -D warnings`
- [x] `cargo test --workspace` (1 pre-existing failure `test_previous_session`, NOT touched by this branch)

Bead: `agents-in-a-box-141`
