### PR TITLE
feat(plugin-session-reader): Phase 7c — migrate session-reader to subprocess plugin

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/ainb-plugin-protocol",
     "crates/ainb-plugin-runtime",
     "crates/ainb-plugin-sdk-rust",
+    "crates/ainb-plugin-session-reader",
     "crates/ainb-plugin-types-sessions",
     "xtask",
 ]

--- a/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "ainb-plugin-session-reader"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Session-reader plugin for ainb — walks per-provider log dirs and publishes sessions.usage_data over JSON-RPC stdio."
+categories = ["development-tools"]
+keywords = ["ainb", "plugin", "session", "usage"]
+
+[[bin]]
+name = "ainb-plugin-session-reader"
+path = "src/main.rs"
+
+[dependencies]
+ainb-plugin-sdk-rust = { path = "../ainb-plugin-sdk-rust" }
+ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
+
+tokio = { workspace = true }
+async-trait = "0.1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+rmp-serde = "1.3"
+bytes = { version = "1.6", features = ["serde"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+toml = { workspace = true }
+ainb-plugin-protocol = { path = "../ainb-plugin-protocol" }
+
+[[test]]
+name = "subprocess_smoke"
+path = "tests/subprocess_smoke.rs"
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"
+unused_imports = "warn"
+unused_variables = "warn"
+dead_code = "warn"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+module_name_repetitions = "allow"
+similar_names = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"

--- a/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
@@ -51,3 +51,48 @@ similar_names = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+# Ported parser/aggregator code: precision-loss casts on cumulative
+# token counts and cost USD computations are intentional (we don't
+# need 64-bit integer dollars).
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"
+cast_possible_truncation = "allow"
+# `let X = match Y { Some(x) => x, _ => continue }` pattern reads
+# more naturally than `let-else` for the codex multi-arm streaming
+# parser.
+single_match_else = "allow"
+option_if_let_else = "allow"
+# Nursery's `missing_const_for_fn` flags every constructor; not
+# worth the per-method tagging.
+missing_const_for_fn = "allow"
+# The aggregator function fans out by design — splitting it would
+# obscure the merge order rather than clarify it.
+too_many_lines = "allow"
+# `field: tokens` postfix is the wire-schema name; can't rename.
+struct_field_names = "allow"
+# Plain `a * b + c` is more readable than `f64::mul_add` for cost.
+suboptimal_flops = "allow"
+# Ported parser code uses idioms (let-Some, manual map_or, Clone::clone
+# on String fields, .ends_with(".jsonl") on file extensions) that
+# pre-date these clippy lints. Preferring no-op style churn to a
+# blanket allow keeps the diff vs. the 6b cdylib readable.
+single_match = "allow"
+manual_let_else = "allow"
+case_sensitive_file_extension_comparisons = "allow"
+assigning_clones = "allow"
+or_fun_call = "allow"
+unnecessary_sort_by = "allow"
+iter_kv_map = "allow"
+manual_map = "allow"
+pub_use = "allow"
+redundant_pub_crate = "allow"
+manual_unwrap_or = "allow"
+manual_unwrap_or_default = "allow"
+map_unwrap_or = "allow"
+doc_markdown = "allow"
+unnecessary_map_or = "allow"
+# Smoke test panics inside `if let` branches when the plugin emits
+# unexpected frames — that's intentional, the test is the assertion.
+panic_in_result_fn = "allow"
+manual_assert = "allow"
+if_then_some_else_none = "allow"

--- a/ainb-tui/crates/ainb-plugin-session-reader/manifest.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/manifest.toml
@@ -1,0 +1,37 @@
+# ainb session-reader plugin manifest (ABI v2 / subprocess).
+#
+# Pure data-plane plugin: walks per-provider session logs, aggregates a
+# UsageData snapshot, publishes it on the `sessions.usage_data` topic.
+# No UI surface and no CLI namespace — downstream plugins (burndown)
+# consume the snapshot via `host/snapshot/get` or `plugin/handle_event`.
+
+[plugin]
+name = "session-reader"
+version = "0.2.0"
+abi_version = 2
+description = "Walks per-provider session logs and publishes sessions.usage_data"
+
+[capabilities]
+# Read raw Claude / Codex / Gemini / Copilot session histories.
+read_claude_logs = true
+read_codex_logs = true
+# Publish on the snapshot bus.
+event_bus = true
+# Cache the parsed snapshot under the plugin's own data dir.
+write_plugin_data = true
+# No network. No subprocess.
+network = []
+spawn_subprocess = false
+
+[provides]
+# No screens, no slash commands, no CLI namespaces. Pure data plane.
+snapshots = ["sessions.usage_data"]
+
+[subscribes]
+# Refresh trigger: any publisher on this topic prompts a re-scan.
+snapshots = ["sessions.refresh_request"]
+
+[lifecycle]
+# Eager: the host needs the first snapshot ready before burndown asks.
+spawn = "eager"
+idle_reap_secs = 600

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/fnv.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/fnv.rs
@@ -1,0 +1,69 @@
+//! Inline FNV-1a 64-bit hash.
+//!
+//! Used as a non-cryptographic dedupe id for [`ProviderCall`]s
+//! constructed from `(file_path, byte_offset)` tuples. Inlining the
+//! 7-line hash drops blake3 + its SIMD intrinsics from the binary,
+//! per `reference_inline_fnv_drop_blake3`.
+//!
+//! [`ProviderCall`]: ainb_plugin_types_sessions::ProviderCall
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// FNV-1a 64-bit hash of `bytes`.
+#[must_use]
+pub fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash = FNV_OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Stable provider-call id from `path:offset`.
+#[must_use]
+pub fn provider_call_id(path: &str, offset: u64) -> u64 {
+    let mut buf = Vec::with_capacity(path.len() + 24);
+    buf.extend_from_slice(path.as_bytes());
+    buf.push(b':');
+    buf.extend_from_slice(offset.to_string().as_bytes());
+    fnv1a_64(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_offset_basis() {
+        assert_eq!(fnv1a_64(b""), FNV_OFFSET);
+    }
+
+    #[test]
+    fn known_values_match_reference() {
+        assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+    }
+
+    #[test]
+    fn provider_call_id_is_stable_for_same_input() {
+        let a = provider_call_id("/tmp/x.jsonl", 42);
+        let b = provider_call_id("/tmp/x.jsonl", 42);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn provider_call_id_differs_on_offset_change() {
+        let a = provider_call_id("/tmp/x.jsonl", 42);
+        let b = provider_call_id("/tmp/x.jsonl", 43);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn provider_call_id_differs_on_path_change() {
+        let a = provider_call_id("/tmp/x.jsonl", 42);
+        let b = provider_call_id("/tmp/y.jsonl", 42);
+        assert_ne!(a, b);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
@@ -1,0 +1,24 @@
+//! Session-reader plugin entry point — runs the SDK Server over stdio.
+//!
+//! Phase 7c: subprocess + ABI v2. The plugin walks per-provider session
+//! logs (Claude/Codex/Gemini/Copilot) directly via [`std::fs`] (the host
+//! enforces the `read_claude_logs` / `read_codex_logs` capabilities at
+//! manifest-grant time, not at every fs read), aggregates the resulting
+//! calls into a [`UsageData`] snapshot, and publishes the snapshot under
+//! the `sessions.usage_data` topic for downstream consumers (burndown).
+//!
+//! [`UsageData`]: ainb_plugin_types_sessions::UsageData
+
+#![forbid(unsafe_code)]
+
+use ainb_plugin_sdk::{Server, SdkError};
+
+mod fnv;
+mod parsers;
+mod plugin;
+mod scanner;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), SdkError> {
+    Server::new(plugin::SessionReader::new()).run_stdio().await
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
@@ -1,0 +1,338 @@
+//! Claude Code JSONL parser.
+//!
+//! Phase 7c port of the Phase 6b parser. Filesystem reads use
+//! [`std::fs`] directly — the host gates whether the plugin can spawn
+//! at all via the `read_claude_logs` capability, so per-call gating is
+//! redundant in the subprocess model.
+//!
+//! Layout: `<projects_root>/<project>/<session>.jsonl`. Two-level walk:
+//! outer dir lists per-project subdirs; inner dir lists session files.
+
+use std::path::{Path, PathBuf};
+
+use ainb_plugin_types_sessions::{Provider, ProviderCall};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::fnv::provider_call_id;
+
+use super::{estimate_cost_usd, parse_timestamp};
+
+#[derive(Deserialize)]
+struct ClaudeLine {
+    #[serde(rename = "type")]
+    msg_type: Option<String>,
+    timestamp: Option<String>,
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+    cwd: Option<String>,
+    #[serde(rename = "gitBranch")]
+    git_branch: Option<String>,
+    message: Option<ClaudeMessage>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeMessage {
+    content: Option<Value>,
+    model: Option<String>,
+    usage: Option<ClaudeUsage>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeUsage {
+    input_tokens: Option<u64>,
+    cache_creation_input_tokens: Option<u64>,
+    cache_read_input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+}
+
+/// Walk `<projects_root>/<project>/<session>.jsonl`. Missing roots
+/// degrade to an empty result; per-file failures are logged via
+/// `tracing::warn` and skipped.
+pub fn parse_dir(projects_root: &Path) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
+    let project_entries = match std::fs::read_dir(projects_root) {
+        Ok(entries) => entries,
+        Err(err) => {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    path = %projects_root.display(),
+                    error = %err,
+                    "session-reader/claude: read projects root failed"
+                );
+            }
+            return calls;
+        }
+    };
+
+    for project_entry in project_entries.flatten() {
+        let project_path = project_entry.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let project = path_basename(&project_path);
+        let Ok(session_entries) = std::fs::read_dir(&project_path) else {
+            continue;
+        };
+        for session_entry in session_entries.flatten() {
+            let path = session_entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(err) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "session-reader/claude: skip unreadable file"
+                    );
+                    continue;
+                }
+            };
+            let path_str = path.to_string_lossy().into_owned();
+            let project_path_str = project_path.to_string_lossy().into_owned();
+            calls.extend(parse_source(&path_str, &project, &project_path_str, &content));
+        }
+    }
+    calls
+}
+
+/// Parse one JSONL file's worth of bytes into [`ProviderCall`]s.
+/// Public so unit tests can drive synthetic fixtures without touching
+/// the filesystem.
+pub fn parse_source(
+    path: &str,
+    project: &str,
+    project_path: &str,
+    content: &str,
+) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
+    let mut current_user_message = String::new();
+    let mut offset: u64 = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line_offset = offset;
+        offset += chunk.len() as u64;
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
+        if let Some(call) = parse_line(
+            line,
+            path,
+            project,
+            project_path,
+            &mut current_user_message,
+            line_offset,
+        ) {
+            calls.push(call);
+        }
+    }
+    calls
+}
+
+fn parse_line(
+    line: &str,
+    path: &str,
+    project: &str,
+    project_path: &str,
+    current_user_message: &mut String,
+    line_offset: u64,
+) -> Option<ProviderCall> {
+    let parsed: ClaudeLine = serde_json::from_str(line).ok()?;
+    match parsed.msg_type.as_deref() {
+        Some("user") => {
+            if let Some(message) = parsed.message {
+                *current_user_message = extract_user_text(message.content.as_ref());
+            }
+            None
+        }
+        Some("assistant") => {
+            let message = parsed.message?;
+            let usage = message.usage?;
+            let timestamp = parsed.timestamp.as_deref().and_then(parse_timestamp)?;
+
+            let model = message.model.unwrap_or_else(|| "claude-unknown".to_string());
+            let tools = extract_tools(message.content.as_ref());
+            let bash_commands = extract_bash_commands(message.content.as_ref());
+            let input_tokens = usage.input_tokens.unwrap_or(0);
+            let output_tokens = usage.output_tokens.unwrap_or(0);
+            let cache_creation_tokens = usage.cache_creation_input_tokens.unwrap_or(0);
+            let cache_read_tokens = usage.cache_read_input_tokens.unwrap_or(0);
+            let cost_usd = estimate_cost_usd(
+                &model,
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                0,
+            );
+
+            Some(ProviderCall {
+                id: provider_call_id(path, line_offset),
+                provider: Provider::Claude,
+                model,
+                session_id: parsed
+                    .session_id
+                    .unwrap_or_else(|| path_filestem(path).unwrap_or_else(|| "unknown".into())),
+                project: project.to_string(),
+                project_path: parsed.cwd.unwrap_or_else(|| project_path.to_string()),
+                timestamp,
+                input_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                output_tokens,
+                reasoning_tokens: 0,
+                cost_usd,
+                tools,
+                bash_commands,
+                user_message: current_user_message.clone(),
+                branch: parsed.git_branch.filter(|b| !b.is_empty()),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn extract_user_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    }
+}
+
+fn extract_tools(content: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(items)) = content else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+        .filter_map(|item| item.get("name").and_then(Value::as_str))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn extract_bash_commands(content: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(items)) = content else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter(|item| {
+            item.get("type").and_then(Value::as_str) == Some("tool_use")
+                && matches!(
+                    item.get("name").and_then(Value::as_str),
+                    Some("Bash" | "Shell")
+                )
+        })
+        .filter_map(|item| {
+            item.get("input")
+                .and_then(|input| input.get("command"))
+                .and_then(Value::as_str)
+        })
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn path_basename(path: &Path) -> String {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .map_or_else(|| path.to_string_lossy().into_owned(), ToString::to_string)
+}
+
+fn path_filestem(path: &str) -> Option<String> {
+    let name = Path::new(path).file_name()?.to_str()?;
+    Some(name.split('.').next().unwrap_or(name).to_string())
+}
+
+// Silences the unused-import lint if no tests reference PathBuf.
+#[allow(dead_code)]
+fn _unused() -> Option<PathBuf> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assistant_line() -> &'static str {
+        r#"{"type":"assistant","timestamp":"2026-05-09T10:00:00Z","sessionId":"sess-1","cwd":"/tmp/proj","gitBranch":"main","message":{"model":"claude-3-5-sonnet","content":[{"type":"text","text":"hi"},{"type":"tool_use","name":"Read"}],"usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":50}}}"#
+    }
+
+    fn user_line() -> &'static str {
+        r#"{"type":"user","timestamp":"2026-05-09T09:59:00Z","message":{"content":[{"type":"text","text":"do a thing"}]}}"#
+    }
+
+    #[test]
+    fn parses_assistant_turn_into_provider_call() {
+        let content = format!("{}\n{}\n", user_line(), assistant_line());
+        let calls = parse_source("/tmp/sess-1.jsonl", "proj", "/tmp/proj", &content);
+        assert_eq!(calls.len(), 1);
+        let call = &calls[0];
+        assert_eq!(call.provider, Provider::Claude);
+        assert_eq!(call.model, "claude-3-5-sonnet");
+        assert_eq!(call.input_tokens, 100);
+        assert_eq!(call.output_tokens, 200);
+        assert_eq!(call.cache_read_tokens, 50);
+        assert_eq!(call.user_message, "do a thing");
+        assert_eq!(call.tools, vec!["Read".to_string()]);
+        assert_eq!(call.branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn skips_invalid_jsonl_lines() {
+        let content = format!("not json\n{}\n", assistant_line());
+        let calls = parse_source("/tmp/sess.jsonl", "proj", "/tmp/proj", &content);
+        assert_eq!(calls.len(), 1);
+    }
+
+    #[test]
+    fn ignores_assistant_turns_without_usage() {
+        let line = r#"{"type":"assistant","timestamp":"2026-05-09T10:00:00Z","message":{"model":"claude-3-5-sonnet"}}"#;
+        let calls = parse_source("/tmp/x.jsonl", "p", "/tmp/p", &format!("{line}\n"));
+        assert_eq!(calls.len(), 0);
+    }
+
+    #[test]
+    fn empty_branch_field_drops_to_none() {
+        let line = r#"{"type":"assistant","timestamp":"2026-05-09T10:00:00Z","gitBranch":"","message":{"model":"claude-3-5-sonnet","usage":{"input_tokens":1,"output_tokens":1}}}"#;
+        let calls = parse_source("/tmp/x.jsonl", "p", "/tmp/p", &format!("{line}\n"));
+        assert_eq!(calls[0].branch, None);
+    }
+
+    #[test]
+    fn provider_call_ids_are_distinct_per_line() {
+        let content = format!("{a}\n{a}\n", a = assistant_line());
+        let calls = parse_source("/tmp/x.jsonl", "p", "/tmp/p", &content);
+        assert_eq!(calls.len(), 2);
+        assert_ne!(calls[0].id, calls[1].id);
+    }
+
+    #[test]
+    fn missing_root_returns_empty_without_panic() {
+        let calls = parse_dir(Path::new("/this/does/not/exist"));
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn parse_dir_walks_two_levels_and_collects_calls() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project_dir = tmp.path().join("my-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let session_path = project_dir.join("abc.jsonl");
+        std::fs::write(
+            &session_path,
+            format!("{}\n{}\n", user_line(), assistant_line()),
+        )
+        .unwrap();
+        // Non-jsonl file alongside should be skipped.
+        std::fs::write(project_dir.join("ignore.txt"), b"junk").unwrap();
+        let calls = parse_dir(tmp.path());
+        assert_eq!(calls.len(), 1, "expected one call from one assistant line");
+        assert_eq!(calls[0].project, "my-project");
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
@@ -8,7 +8,7 @@
 //! Layout: `<projects_root>/<project>/<session>.jsonl`. Two-level walk:
 //! outer dir lists per-project subdirs; inner dir lists session files.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use ainb_plugin_types_sessions::{Provider, ProviderCall};
 use serde::Deserialize;
@@ -247,12 +247,6 @@ fn path_basename(path: &Path) -> String {
 fn path_filestem(path: &str) -> Option<String> {
     let name = Path::new(path).file_name()?.to_str()?;
     Some(name.split('.').next().unwrap_or(name).to_string())
-}
-
-// Silences the unused-import lint if no tests reference PathBuf.
-#[allow(dead_code)]
-fn _unused() -> Option<PathBuf> {
-    None
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
@@ -1,0 +1,431 @@
+//! Codex session parser.
+//!
+//! Phase 7c port. Directory layout:
+//! `<sessions_root>/<YYYY>/<MM>/<DD>/rollout-*.jsonl`.
+
+use std::path::Path;
+
+use ainb_plugin_types_sessions::{Provider, ProviderCall};
+use serde::Deserialize;
+
+use crate::fnv::provider_call_id;
+
+use super::{estimate_cost_usd, parse_timestamp};
+
+#[derive(Deserialize)]
+struct CodexEntry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    timestamp: Option<String>,
+    payload: Option<CodexPayload>,
+}
+
+#[derive(Deserialize)]
+struct CodexPayload {
+    #[serde(rename = "type")]
+    payload_type: Option<String>,
+    role: Option<String>,
+    cwd: Option<String>,
+    originator: Option<String>,
+    session_id: Option<String>,
+    model: Option<String>,
+    name: Option<String>,
+    content: Option<Vec<CodexContent>>,
+    info: Option<CodexInfo>,
+}
+
+#[derive(Deserialize)]
+struct CodexContent {
+    #[serde(rename = "type")]
+    content_type: Option<String>,
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CodexInfo {
+    model: Option<String>,
+    model_name: Option<String>,
+    last_token_usage: Option<CodexTokenUsage>,
+    total_token_usage: Option<CodexTokenUsage>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+struct CodexTokenUsage {
+    input_tokens: Option<u64>,
+    cached_input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    reasoning_output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+/// Walk `<sessions_root>/<YYYY>/<MM>/<DD>/rollout-*.jsonl`.
+pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
+    let years = match std::fs::read_dir(sessions_root) {
+        Ok(d) => d,
+        Err(err) => {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    path = %sessions_root.display(),
+                    error = %err,
+                    "session-reader/codex: read sessions root failed"
+                );
+            }
+            return calls;
+        }
+    };
+
+    for year_entry in years.flatten() {
+        let year_path = year_entry.path();
+        if !is_date_component(&year_path, 4) {
+            continue;
+        }
+        let Ok(months) = std::fs::read_dir(&year_path) else {
+            continue;
+        };
+        for month_entry in months.flatten() {
+            let month_path = month_entry.path();
+            if !is_date_component(&month_path, 2) {
+                continue;
+            }
+            let Ok(days) = std::fs::read_dir(&month_path) else {
+                continue;
+            };
+            for day_entry in days.flatten() {
+                let day_path = day_entry.path();
+                if !is_date_component(&day_path, 2) {
+                    continue;
+                }
+                let Ok(files) = std::fs::read_dir(&day_path) else {
+                    continue;
+                };
+                for file_entry in files.flatten() {
+                    let path = file_entry.path();
+                    let basename = path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or_default();
+                    if !basename.starts_with("rollout-") || !basename.ends_with(".jsonl") {
+                        continue;
+                    }
+                    let content = match std::fs::read_to_string(&path) {
+                        Ok(c) => c,
+                        Err(err) => {
+                            tracing::warn!(
+                                path = %path.display(),
+                                error = %err,
+                                "session-reader/codex: skip unreadable file"
+                            );
+                            continue;
+                        }
+                    };
+                    if !is_valid_codex_session(&content) {
+                        continue;
+                    }
+                    let path_str = path.to_string_lossy().into_owned();
+                    calls.extend(parse_source(&path_str, &content));
+                }
+            }
+        }
+    }
+    calls
+}
+
+/// Parse one rollout file into [`ProviderCall`]s. Public for tests.
+#[allow(clippy::too_many_lines)]
+pub fn parse_source(path: &str, content: &str) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
+    let mut session_id = path_filestem(path).unwrap_or_else(|| "unknown".to_string());
+    let mut session_model: Option<String> = None;
+    let mut cwd = "unknown".to_string();
+    let mut project = "unknown".to_string();
+    let mut previous_cumulative_total = 0_u64;
+    let mut previous_input = 0_u64;
+    let mut previous_cached = 0_u64;
+    let mut previous_output = 0_u64;
+    let mut previous_reasoning = 0_u64;
+    let mut pending_tools: Vec<String> = Vec::new();
+    let mut pending_user_message = String::new();
+
+    let mut offset: u64 = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line_offset = offset;
+        offset += chunk.len() as u64;
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
+        let entry: CodexEntry = match serde_json::from_str(line) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+
+        let payload = entry.payload.as_ref();
+
+        if entry.entry_type == "session_meta" {
+            if let Some(payload) = payload {
+                if let Some(id) = &payload.session_id {
+                    session_id = id.clone();
+                }
+                if let Some(model) = &payload.model {
+                    session_model = Some(model.clone());
+                }
+                if let Some(session_cwd) = &payload.cwd {
+                    cwd = session_cwd.clone();
+                    project = sanitize_project(session_cwd);
+                }
+            }
+            continue;
+        }
+
+        if entry.entry_type == "turn_context" {
+            if let Some(model) = payload.and_then(|p| p.model.as_ref()) {
+                session_model = Some(model.clone());
+            }
+            continue;
+        }
+
+        if entry.entry_type == "response_item"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("function_call")
+        {
+            if let Some(raw_name) = payload.and_then(|p| p.name.as_deref()) {
+                pending_tools.push(normalize_tool(raw_name).to_string());
+            }
+            continue;
+        }
+
+        if entry.entry_type == "event_msg"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("patch_apply_end")
+        {
+            pending_tools.push("Edit".to_string());
+            continue;
+        }
+
+        if entry.entry_type == "response_item"
+            && payload.and_then(|p| p.payload_type.as_deref()) == Some("message")
+            && payload.and_then(|p| p.role.as_deref()) == Some("user")
+        {
+            let texts = payload
+                .and_then(|p| p.content.as_ref())
+                .map(|content| {
+                    content
+                        .iter()
+                        .filter(|item| item.content_type.as_deref() == Some("input_text"))
+                        .filter_map(|item| item.text.as_deref())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            if !texts.is_empty() {
+                pending_user_message = texts;
+            }
+            continue;
+        }
+
+        if entry.entry_type != "event_msg"
+            || payload.and_then(|p| p.payload_type.as_deref()) != Some("token_count")
+        {
+            continue;
+        }
+
+        let Some(info) = payload.and_then(|p| p.info.as_ref()) else {
+            continue;
+        };
+
+        let cumulative_total = info
+            .total_token_usage
+            .and_then(|usage| usage.total_tokens)
+            .unwrap_or(0);
+        if cumulative_total > 0 && cumulative_total == previous_cumulative_total {
+            continue;
+        }
+        previous_cumulative_total = cumulative_total;
+
+        let (input_tokens, cached_tokens, output_tokens, reasoning_tokens) =
+            if let Some(last) = info.last_token_usage {
+                let input = last.input_tokens.unwrap_or(0);
+                let cached = last.cached_input_tokens.unwrap_or(0);
+                let output = last.output_tokens.unwrap_or(0);
+                let reasoning = last.reasoning_output_tokens.unwrap_or(0);
+
+                if let Some(total) = info.total_token_usage {
+                    previous_input = total.input_tokens.unwrap_or(previous_input + input);
+                    previous_cached =
+                        total.cached_input_tokens.unwrap_or(previous_cached + cached);
+                    previous_output = total.output_tokens.unwrap_or(previous_output + output);
+                    previous_reasoning = total
+                        .reasoning_output_tokens
+                        .unwrap_or(previous_reasoning + reasoning);
+                } else {
+                    previous_input += input;
+                    previous_cached += cached;
+                    previous_output += output;
+                    previous_reasoning += reasoning;
+                }
+
+                (input, cached, output, reasoning)
+            } else if let Some(total) = info.total_token_usage {
+                let input = total.input_tokens.unwrap_or(0).saturating_sub(previous_input);
+                let cached = total
+                    .cached_input_tokens
+                    .unwrap_or(0)
+                    .saturating_sub(previous_cached);
+                let output = total.output_tokens.unwrap_or(0).saturating_sub(previous_output);
+                let reasoning = total
+                    .reasoning_output_tokens
+                    .unwrap_or(0)
+                    .saturating_sub(previous_reasoning);
+
+                previous_input = total.input_tokens.unwrap_or(0);
+                previous_cached = total.cached_input_tokens.unwrap_or(0);
+                previous_output = total.output_tokens.unwrap_or(0);
+                previous_reasoning = total.reasoning_output_tokens.unwrap_or(0);
+
+                (input, cached, output, reasoning)
+            } else {
+                continue;
+            };
+
+        if input_tokens + cached_tokens + output_tokens + reasoning_tokens == 0 {
+            continue;
+        }
+
+        let Some(timestamp) = entry.timestamp.as_deref().and_then(parse_timestamp) else {
+            continue;
+        };
+
+        let uncached_input_tokens = input_tokens.saturating_sub(cached_tokens);
+        let model = resolve_model(payload, session_model.as_deref());
+        let cost_usd = estimate_cost_usd(
+            &model,
+            uncached_input_tokens,
+            output_tokens + reasoning_tokens,
+            0,
+            cached_tokens,
+            0,
+        );
+
+        calls.push(ProviderCall {
+            id: provider_call_id(path, line_offset),
+            provider: Provider::Codex,
+            model,
+            session_id: session_id.clone(),
+            project: project.clone(),
+            project_path: cwd.clone(),
+            timestamp,
+            input_tokens: uncached_input_tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens: cached_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cost_usd,
+            tools: std::mem::take(&mut pending_tools),
+            bash_commands: Vec::new(),
+            user_message: std::mem::take(&mut pending_user_message),
+            branch: None,
+        });
+    }
+    calls
+}
+
+fn is_valid_codex_session(content: &str) -> bool {
+    let Some(first_line) = content.lines().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+    let Ok(entry) = serde_json::from_str::<CodexEntry>(first_line) else {
+        return false;
+    };
+    entry.entry_type == "session_meta"
+        && entry
+            .payload
+            .and_then(|payload| payload.originator)
+            .is_some_and(|originator| originator.to_lowercase().starts_with("codex"))
+}
+
+fn is_date_component(path: &Path, len: usize) -> bool {
+    let Some(basename) = path.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    basename.len() == len && basename.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn sanitize_project(cwd: &str) -> String {
+    cwd.trim_start_matches('/').replace('/', "-")
+}
+
+fn normalize_tool(raw: &str) -> &str {
+    match raw {
+        "exec_command" => "Bash",
+        "read_file" => "Read",
+        "write_file" | "apply_diff" | "apply_patch" => "Edit",
+        "spawn_agent" | "close_agent" | "wait_agent" => "Agent",
+        "read_dir" => "Glob",
+        _ => raw,
+    }
+}
+
+fn resolve_model(payload: Option<&CodexPayload>, session_model: Option<&str>) -> String {
+    payload
+        .and_then(|payload| payload.model.as_deref())
+        .or_else(|| {
+            payload
+                .and_then(|payload| payload.info.as_ref())
+                .and_then(|info| info.model.as_deref())
+        })
+        .or_else(|| {
+            payload
+                .and_then(|payload| payload.info.as_ref())
+                .and_then(|info| info.model_name.as_deref())
+        })
+        .or(session_model)
+        .unwrap_or("gpt-5")
+        .to_string()
+}
+
+fn path_filestem(path: &str) -> Option<String> {
+    let name = Path::new(path).file_name()?.to_str()?;
+    Some(name.split('.').next().unwrap_or(name).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> String {
+        let lines = [
+            r#"{"type":"session_meta","timestamp":"2026-05-09T10:00:00Z","payload":{"session_id":"sess-1","originator":"codex","model":"gpt-5","cwd":"/tmp/codex"}}"#,
+            r#"{"type":"event_msg","timestamp":"2026-05-09T10:00:01Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":500,"reasoning_output_tokens":0},"total_token_usage":{"total_tokens":1500}}}}"#,
+        ];
+        lines.join("\n") + "\n"
+    }
+
+    #[test]
+    fn parses_session_meta_then_token_count() {
+        let calls = parse_source("/tmp/rollout-1.jsonl", &fixture());
+        assert_eq!(calls.len(), 1);
+        let c = &calls[0];
+        assert_eq!(c.provider, Provider::Codex);
+        assert_eq!(c.model, "gpt-5");
+        assert_eq!(c.session_id, "sess-1");
+        assert_eq!(c.project, "tmp-codex");
+        assert_eq!(c.input_tokens, 800);
+        assert_eq!(c.cache_read_tokens, 200);
+        assert_eq!(c.output_tokens, 500);
+    }
+
+    #[test]
+    fn rejects_non_codex_originator() {
+        let line = r#"{"type":"session_meta","payload":{"originator":"someone-else"}}"#;
+        assert!(!is_valid_codex_session(&format!("{line}\n")));
+    }
+
+    #[test]
+    fn skips_unparseable_lines() {
+        let content = format!("nope\n{}", fixture());
+        let calls = parse_source("/tmp/rollout-1.jsonl", &content);
+        assert_eq!(calls.len(), 1);
+    }
+
+    #[test]
+    fn missing_root_returns_empty_without_panic() {
+        let calls = parse_dir(Path::new("/this/does/not/exist"));
+        assert!(calls.is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/copilot.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/copilot.rs
@@ -1,0 +1,41 @@
+//! GitHub Copilot Chat session parser — best-effort scaffold.
+//!
+//! Phase 7c port: still a stub. See [`super::gemini`] for the
+//! deferred-implementation rationale.
+
+use std::path::Path;
+
+use ainb_plugin_types_sessions::ProviderCall;
+
+/// Walk `<sessions_root>/...` for Copilot session logs. Best-effort no-op.
+pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
+    match std::fs::read_dir(sessions_root) {
+        Ok(_entries) => {
+            tracing::debug!(
+                path = %sessions_root.display(),
+                "session-reader/copilot: parser stub — no rows emitted"
+            );
+            Vec::new()
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::warn!(
+                path = %sessions_root.display(),
+                error = %err,
+                "session-reader/copilot: read sessions dir failed"
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_root_returns_empty_without_panic() {
+        let calls = parse_dir(Path::new("/this/does/not/exist"));
+        assert!(calls.is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/cost.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/cost.rs
@@ -1,0 +1,105 @@
+//! Cost estimation. Lifted verbatim from the Phase 6b plugin so the
+//! Phase 7c subprocess port produces the same dollar figures for the
+//! same input as the wasm cdylib it replaces.
+
+struct ModelRates {
+    input: f64,
+    output: f64,
+    cache_write: f64,
+    cache_read: f64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn estimate_cost_usd(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    reasoning_tokens: u64,
+) -> Option<f64> {
+    let rates = model_rates(model)?;
+    Some(
+        input_tokens as f64 * rates.input
+            + (output_tokens + reasoning_tokens) as f64 * rates.output
+            + cache_creation_tokens as f64 * rates.cache_write
+            + cache_read_tokens as f64 * rates.cache_read,
+    )
+}
+
+fn model_rates(model: &str) -> Option<ModelRates> {
+    let canonical = canonical_model_name(model);
+    let (input_per_million, output_per_million) = if canonical.starts_with("claude-opus") {
+        (15.0, 75.0)
+    } else if canonical.starts_with("claude-sonnet") || canonical.starts_with("claude-3-5-sonnet") {
+        (3.0, 15.0)
+    } else if canonical.starts_with("claude-haiku") || canonical.starts_with("claude-3-5-haiku") {
+        (0.8, 4.0)
+    } else if canonical.starts_with("gpt-5")
+        || canonical.starts_with("gpt-4.1")
+        || canonical.starts_with("gpt-4o")
+    {
+        (1.25, 10.0)
+    } else {
+        return None;
+    };
+
+    let input = input_per_million / 1_000_000.0;
+    let output = output_per_million / 1_000_000.0;
+    Some(ModelRates {
+        input,
+        output,
+        cache_write: input * 1.25,
+        cache_read: input * 0.1,
+    })
+}
+
+fn canonical_model_name(model: &str) -> String {
+    let without_prefix = model
+        .split('@')
+        .next()
+        .unwrap_or(model)
+        .trim_start_matches("anthropic/")
+        .trim_start_matches("openai/")
+        .to_string();
+
+    if without_prefix
+        .rsplit('-')
+        .next()
+        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        without_prefix
+            .rsplit_once('-')
+            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
+    } else {
+        without_prefix
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_model_returns_none() {
+        assert!(estimate_cost_usd("totally-made-up", 100, 100, 0, 0, 0).is_none());
+    }
+
+    #[test]
+    fn claude_sonnet_priced_at_3_15_per_million() {
+        let cost = estimate_cost_usd("claude-3-5-sonnet", 1_000_000, 0, 0, 0, 0);
+        assert!((cost.unwrap() - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn gpt_5_priced_at_1_25_10_per_million() {
+        let cost = estimate_cost_usd("gpt-5", 1_000_000, 0, 0, 0, 0);
+        assert!((cost.unwrap() - 1.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn date_stamped_claude_strips_to_canonical() {
+        let cost = estimate_cost_usd("claude-3-5-sonnet-20241022", 1_000_000, 0, 0, 0, 0);
+        assert!((cost.unwrap() - 3.0).abs() < 1e-6);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/gemini.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/gemini.rs
@@ -1,0 +1,43 @@
+//! Gemini Code Assist session parser — best-effort scaffold.
+//!
+//! Phase 7c port: still a stub. We probe the root with [`std::fs::read_dir`]
+//! so a permission failure or missing directory is logged once and we
+//! return an empty vec. Real parser deferred until the Gemini Code
+//! Assist client surfaces a stable on-disk log format.
+
+use std::path::Path;
+
+use ainb_plugin_types_sessions::ProviderCall;
+
+/// Walk `<sessions_root>/...` for Gemini session logs. Best-effort no-op.
+pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
+    match std::fs::read_dir(sessions_root) {
+        Ok(_entries) => {
+            tracing::debug!(
+                path = %sessions_root.display(),
+                "session-reader/gemini: parser stub — no rows emitted"
+            );
+            Vec::new()
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::warn!(
+                path = %sessions_root.display(),
+                error = %err,
+                "session-reader/gemini: read sessions dir failed"
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_root_returns_empty_without_panic() {
+        let calls = parse_dir(Path::new("/this/does/not/exist"));
+        assert!(calls.is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
@@ -1,0 +1,23 @@
+//! Per-provider JSONL parsers.
+//!
+//! Each provider module exposes a `parse_dir(root: &Path) -> Vec<ProviderCall>`
+//! entry point. The implementations are best-effort: a single broken
+//! file logs a warning and gets skipped, but the rest of the directory
+//! keeps parsing. A directory that doesn't exist or is unreadable
+//! returns an empty vec without error — that's how Gemini / Copilot
+//! stubs degrade cleanly when the user doesn't use those providers.
+
+pub mod claude;
+pub mod codex;
+pub mod copilot;
+pub mod cost;
+pub mod gemini;
+
+pub(crate) use cost::estimate_cost_usd;
+
+/// Common helper: parse an RFC 3339 timestamp into UTC.
+pub(crate) fn parse_timestamp(timestamp: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .ok()
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -54,10 +54,10 @@ impl SessionReader {
         }
     }
 
-    /// Construct with explicit roots — used by integration tests that
-    /// need to point the plugin at a tempdir fixture instead of `$HOME`.
+    /// Construct with explicit roots — used by unit tests.
+    #[cfg(test)]
     #[must_use]
-    pub fn with_roots(roots: ProviderRoots) -> Self {
+    pub(crate) fn with_roots(roots: ProviderRoots) -> Self {
         Self {
             last_event: None,
             roots,

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -1,0 +1,175 @@
+//! Session-reader [`Plugin`] implementation.
+//!
+//! Pure data-plane plugin: no UI, no CLI namespace. On startup
+//! ([`Plugin::on_init`]) it scans the four provider directories,
+//! aggregates a [`UsageData`] snapshot, and publishes it on the
+//! `sessions.usage_data` topic. While running it answers
+//! [`SnapshotGet`](`HostClient::snapshot_get`)-style requests by simply
+//! republishing the cached snapshot — but since the host already
+//! tracks the latest publish per topic, plugins typically just rely on
+//! the host's snapshot store. We re-scan when the host pushes a
+//! `sessions.refresh_request` event.
+//!
+//! [`Plugin`]: ainb_plugin_sdk::Plugin
+//! [`UsageData`]: ainb_plugin_types_sessions::UsageData
+
+use ainb_plugin_sdk::{
+    HandleEventParams, HostClient, Plugin, RenderParams, Result, SdkError, WireBuffer,
+};
+use ainb_plugin_types_sessions::{UsageDataEvent, WIRE_VERSION};
+use async_trait::async_trait;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::scanner::{self, ProviderRoots};
+
+/// Topic the plugin publishes the aggregated snapshot on. Burndown
+/// (the consumer in Phase 7c-burndown) subscribes to this topic.
+pub const TOPIC_USAGE_DATA: &str = "sessions.usage_data";
+
+/// Topic any consumer can publish to to force a re-scan + re-publish.
+pub const TOPIC_REFRESH_REQUEST: &str = "sessions.refresh_request";
+
+mod manifest_text {
+    pub const TOML: &str = include_str!("../manifest.toml");
+}
+
+/// Plugin state.
+///
+/// Holds the most recently published [`UsageDataEvent`] in memory so a
+/// follow-up render or refresh can republish without re-running the
+/// scan if no source files changed (rescan is still cheap on the
+/// freshness path — we always rescan on `sessions.refresh_request`).
+pub struct SessionReader {
+    last_event: Option<UsageDataEvent>,
+    roots: ProviderRoots,
+}
+
+impl SessionReader {
+    /// Build a fresh reader with the canonical default provider roots.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            last_event: None,
+            roots: ProviderRoots::defaults(),
+        }
+    }
+
+    /// Construct with explicit roots — used by integration tests that
+    /// need to point the plugin at a tempdir fixture instead of `$HOME`.
+    #[must_use]
+    pub fn with_roots(roots: ProviderRoots) -> Self {
+        Self {
+            last_event: None,
+            roots,
+        }
+    }
+
+    fn build_event(&self) -> UsageDataEvent {
+        let data = scanner::scan(&self.roots);
+        UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns: now_ns(),
+            partial: false,
+            data,
+        }
+    }
+
+    async fn publish(&mut self, host: &HostClient) -> Result<()> {
+        let event = self.build_event();
+        let bytes = rmp_serde::to_vec_named(&event).map_err(|e| {
+            SdkError::plugin(format!("encode UsageDataEvent: {e}"))
+        })?;
+        host.snapshot_publish(TOPIC_USAGE_DATA, bytes).await?;
+        self.last_event = Some(event);
+        Ok(())
+    }
+}
+
+impl Default for SessionReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Plugin for SessionReader {
+    fn manifest(&self) -> &'static str {
+        manifest_text::TOML
+    }
+
+    async fn on_init(&mut self, host: &HostClient, _granted: &[String]) -> Result<()> {
+        // Subscribe to the refresh topic so the host wakes us up via
+        // `plugin/handle_event` whenever a downstream consumer
+        // publishes a refresh signal.
+        host.snapshot_subscribe(TOPIC_REFRESH_REQUEST).await?;
+        // First scan + publish so consumers have data to bind to as
+        // soon as they ask. Errors are surfaced because a startup
+        // failure is meaningful to the host.
+        self.publish(host).await
+    }
+
+    async fn render(
+        &mut self,
+        _host: &HostClient,
+        _params: RenderParams,
+    ) -> Result<WireBuffer> {
+        // No UI surface — return an empty 0×0 buffer. The host's render
+        // path tolerates empty buffers from headless plugins.
+        Ok(WireBuffer::new(0, 0))
+    }
+
+    async fn handle_event(
+        &mut self,
+        host: &HostClient,
+        params: HandleEventParams,
+    ) -> Result<()> {
+        if params.topic == TOPIC_REFRESH_REQUEST {
+            tracing::info!("session-reader: refresh requested — rescanning");
+            return self.publish(host).await;
+        }
+        tracing::debug!(topic = %params.topic, "session-reader: ignoring unrelated event");
+        Ok(())
+    }
+}
+
+fn now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_toml_parses_as_abi_v2() {
+        let m: ainb_plugin_sdk::Manifest =
+            toml::from_str(manifest_text::TOML).expect("manifest TOML parses");
+        assert_eq!(m.plugin.name, "session-reader");
+        assert_eq!(m.plugin.abi_version, 2);
+        assert!(
+            m.provides
+                .snapshots
+                .iter()
+                .any(|t| t == TOPIC_USAGE_DATA),
+            "expected manifest to declare publishing topic"
+        );
+        assert!(
+            m.subscribes
+                .snapshots
+                .iter()
+                .any(|t| t == TOPIC_REFRESH_REQUEST),
+            "expected manifest to subscribe to refresh topic"
+        );
+    }
+
+    #[test]
+    fn build_event_has_correct_wire_version_and_partial_flag() {
+        let plugin = SessionReader::with_roots(ProviderRoots::default());
+        let event = plugin.build_event();
+        assert_eq!(event.version, WIRE_VERSION);
+        assert!(!event.partial);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -15,7 +15,7 @@
 //!   classification pass that operates over session timelines.
 
 use std::collections::{BTreeMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use ainb_plugin_types_sessions::{
     BranchUsage, ModelUsage, NamedUsage, ProjectUsage, Provider, ProviderCall, SessionUsage,
@@ -353,12 +353,6 @@ fn map_to_named_usage_sorted(map: BTreeMap<String, usize>) -> Vec<NamedUsage> {
         .collect();
     rows.sort_by(|a, b| b.calls.cmp(&a.calls).then(a.name.cmp(&b.name)));
     rows
-}
-
-// Silences the unused-import lint on Path when only PathBuf is used in tests.
-#[allow(dead_code)]
-fn _path_in_scope(p: &Path) -> &Path {
-    p
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -1,0 +1,487 @@
+//! Per-provider scan orchestrator + UsageData aggregator.
+//!
+//! Walks the four providers in turn, aggregates the resulting calls
+//! into a [`UsageData`] snapshot. Per-provider failures are best-effort:
+//! a parse error or unreadable file degrades that provider's
+//! contribution to whatever was successfully read but lets the others
+//! through.
+//!
+//! ## Aggregator notes
+//!
+//! - Daily / weekly bucketing is UTC. The display layer can convert.
+//! - Project key is the call's `project` field as-is — no upstream-repo
+//!   resolution; two worktrees of the same upstream stay separate.
+//! - `activities` and `mcp_servers` are intentionally empty pending a
+//!   classification pass that operates over session timelines.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use ainb_plugin_types_sessions::{
+    BranchUsage, ModelUsage, NamedUsage, ProjectUsage, Provider, ProviderCall, SessionUsage,
+    TokenBucket, UsageData,
+};
+use chrono::{Datelike, Duration, NaiveDate};
+
+/// Source roots for the four providers. `None` skips that provider
+/// entirely; `Some(path)` is walked even if the directory doesn't exist
+/// (parsers degrade to empty in that case).
+#[derive(Debug, Clone, Default)]
+pub struct ProviderRoots {
+    /// `~/.claude/projects/` — outer dir is per-project subdirs.
+    pub claude_projects: Option<PathBuf>,
+    /// `~/.codex/sessions/` — `<YYYY>/<MM>/<DD>/rollout-*.jsonl`.
+    pub codex_sessions: Option<PathBuf>,
+    /// Gemini Code Assist sessions root.
+    pub gemini_sessions: Option<PathBuf>,
+    /// `~/.config/github-copilot/sessions/`.
+    pub copilot_sessions: Option<PathBuf>,
+}
+
+impl ProviderRoots {
+    /// Construct with the canonical default paths under the current
+    /// user's home directory. Falls back silently when `$HOME` is not
+    /// set — every provider becomes `None`.
+    #[must_use]
+    pub fn defaults() -> Self {
+        let home = std::env::var_os("HOME").map(PathBuf::from);
+        match home {
+            Some(home) => Self {
+                claude_projects: Some(home.join(".claude/projects")),
+                codex_sessions: Some(home.join(".codex/sessions")),
+                gemini_sessions: Some(home.join(".gemini/sessions")),
+                copilot_sessions: Some(home.join(".config/github-copilot/sessions")),
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+/// Run every provider parser, aggregate, return a snapshot.
+pub fn scan(roots: &ProviderRoots) -> UsageData {
+    let mut all_calls = Vec::new();
+    if let Some(root) = &roots.claude_projects {
+        all_calls.extend(crate::parsers::claude::parse_dir(root));
+    }
+    if let Some(root) = &roots.codex_sessions {
+        all_calls.extend(crate::parsers::codex::parse_dir(root));
+    }
+    if let Some(root) = &roots.gemini_sessions {
+        all_calls.extend(crate::parsers::gemini::parse_dir(root));
+    }
+    if let Some(root) = &roots.copilot_sessions {
+        all_calls.extend(crate::parsers::copilot::parse_dir(root));
+    }
+    aggregate(all_calls)
+}
+
+/// Pure aggregation: `Vec<ProviderCall>` → `UsageData`.
+#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
+pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
+    if calls.is_empty() {
+        return UsageData::default();
+    }
+
+    calls.sort_by_key(|c| c.timestamp);
+
+    let mut daily: BTreeMap<NaiveDate, BucketAccumulator> = BTreeMap::new();
+    let mut weekly: BTreeMap<NaiveDate, BucketAccumulator> = BTreeMap::new();
+    let mut projects: BTreeMap<String, ProjectAccumulator> = BTreeMap::new();
+    let mut sessions: BTreeMap<String, SessionAccumulator> = BTreeMap::new();
+    let mut models: BTreeMap<String, BucketAccumulator> = BTreeMap::new();
+    let mut branches: BTreeMap<String, BucketAccumulator> = BTreeMap::new();
+    let mut tools: BTreeMap<String, usize> = BTreeMap::new();
+    let mut shell_commands: BTreeMap<String, usize> = BTreeMap::new();
+    let mut model_project_counts: BTreeMap<String, BTreeMap<String, usize>> = BTreeMap::new();
+    let mut grand_total = TokenBucket::default();
+
+    for call in &calls {
+        let bucket = call_bucket(call);
+        let day = call.timestamp.date_naive();
+        let week = week_start(day);
+        let session_key = format!(
+            "{}:{}:{}",
+            call.provider.as_str(),
+            call.project,
+            call.session_id
+        );
+
+        merge(&mut grand_total, &bucket);
+
+        daily
+            .entry(day)
+            .or_default()
+            .ingest(&bucket, &call.project, &session_key);
+        weekly
+            .entry(week)
+            .or_default()
+            .ingest(&bucket, &call.project, &session_key);
+        models
+            .entry(call.model.clone())
+            .or_default()
+            .ingest(&bucket, &call.project, &session_key);
+        if let Some(branch) = call.branch.as_deref().filter(|b| !b.is_empty()) {
+            branches
+                .entry(branch.to_string())
+                .or_default()
+                .ingest(&bucket, &call.project, &session_key);
+        }
+
+        let project = projects
+            .entry(call.project.clone())
+            .or_insert_with(|| ProjectAccumulator {
+                path: call.project_path.clone(),
+                bucket: TokenBucket::default(),
+                sessions: HashSet::new(),
+            });
+        project.path = call.project_path.clone();
+        project.sessions.insert(session_key.clone());
+        merge(&mut project.bucket, &bucket);
+
+        let session = sessions
+            .entry(session_key.clone())
+            .or_insert_with(|| SessionAccumulator {
+                provider: call.provider,
+                project: call.project.clone(),
+                session_id: call.session_id.clone(),
+                first_timestamp: call.timestamp,
+                last_timestamp: call.timestamp,
+                bucket: TokenBucket::default(),
+            });
+        if call.timestamp < session.first_timestamp {
+            session.first_timestamp = call.timestamp;
+        }
+        if call.timestamp > session.last_timestamp {
+            session.last_timestamp = call.timestamp;
+        }
+        merge(&mut session.bucket, &bucket);
+
+        for tool in &call.tools {
+            *tools.entry(tool.clone()).or_insert(0) += 1;
+        }
+        for cmd in &call.bash_commands {
+            *shell_commands.entry(cmd.clone()).or_insert(0) += 1;
+        }
+        *model_project_counts
+            .entry(call.model.clone())
+            .or_default()
+            .entry(call.project.clone())
+            .or_insert(0) += 1;
+    }
+
+    grand_total.call_count = calls.len();
+    grand_total.session_count = sessions.len();
+    grand_total.project_count = projects.len();
+
+    UsageData {
+        daily: daily
+            .into_iter()
+            .map(|(d, mut a)| {
+                a.bucket.session_count = a.sessions.len();
+                a.bucket.project_count = a.projects.len();
+                (d, a.bucket)
+            })
+            .collect(),
+        weekly: weekly
+            .into_iter()
+            .map(|(d, mut a)| {
+                a.bucket.session_count = a.sessions.len();
+                a.bucket.project_count = a.projects.len();
+                (d, a.bucket)
+            })
+            .collect(),
+        projects: sort_by_total_desc(
+            projects
+                .into_iter()
+                .map(|(name, mut p)| {
+                    p.bucket.session_count = p.sessions.len();
+                    p.bucket.project_count = 1;
+                    ProjectUsage {
+                        name,
+                        path: p.path,
+                        bucket: p.bucket,
+                        repo: None,
+                    }
+                })
+                .collect(),
+            |p| p.bucket,
+        ),
+        grand_total,
+        calls: calls.clone(),
+        sessions: sort_sessions_by_recency(
+            sessions
+                .into_iter()
+                .map(|(_k, s)| SessionUsage {
+                    provider: s.provider,
+                    project: s.project,
+                    session_id: s.session_id,
+                    first_timestamp: s.first_timestamp,
+                    last_timestamp: s.last_timestamp,
+                    bucket: s.bucket,
+                })
+                .collect(),
+        ),
+        models: sort_by_total_desc(
+            models
+                .into_iter()
+                .map(|(model, mut a)| {
+                    a.bucket.session_count = a.sessions.len();
+                    a.bucket.project_count = a.projects.len();
+                    ModelUsage {
+                        model,
+                        bucket: a.bucket,
+                    }
+                })
+                .collect(),
+            |m| m.bucket,
+        ),
+        activities: Vec::new(),
+        tools: map_to_named_usage_sorted(tools),
+        mcp_servers: Vec::new(),
+        shell_commands: map_to_named_usage_sorted(shell_commands),
+        branches: sort_by_total_desc(
+            branches
+                .into_iter()
+                .map(|(branch, mut a)| {
+                    a.bucket.session_count = a.sessions.len();
+                    a.bucket.project_count = a.projects.len();
+                    BranchUsage {
+                        branch,
+                        bucket: a.bucket,
+                    }
+                })
+                .collect(),
+            |b| b.bucket,
+        ),
+        model_project_counts: model_project_counts
+            .into_iter()
+            .map(|(model, projects)| {
+                let mut rows: Vec<(String, usize)> = projects.into_iter().collect();
+                rows.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+                (model, rows)
+            })
+            .collect(),
+    }
+}
+
+#[derive(Default)]
+struct BucketAccumulator {
+    bucket: TokenBucket,
+    sessions: HashSet<String>,
+    projects: HashSet<String>,
+}
+
+impl BucketAccumulator {
+    fn ingest(&mut self, bucket: &TokenBucket, project: &str, session_key: &str) {
+        merge(&mut self.bucket, bucket);
+        self.sessions.insert(session_key.to_string());
+        self.projects.insert(project.to_string());
+    }
+}
+
+struct ProjectAccumulator {
+    path: String,
+    bucket: TokenBucket,
+    sessions: HashSet<String>,
+}
+
+struct SessionAccumulator {
+    provider: Provider,
+    project: String,
+    session_id: String,
+    first_timestamp: chrono::DateTime<chrono::Utc>,
+    last_timestamp: chrono::DateTime<chrono::Utc>,
+    bucket: TokenBucket,
+}
+
+fn call_bucket(call: &ProviderCall) -> TokenBucket {
+    TokenBucket {
+        input_tokens: call.input_tokens,
+        cache_creation_tokens: call.cache_creation_tokens,
+        cache_read_tokens: call.cache_read_tokens,
+        output_tokens: call.output_tokens,
+        reasoning_tokens: call.reasoning_tokens,
+        session_count: 0,
+        project_count: 0,
+        call_count: 1,
+        cost_usd: call.cost_usd,
+    }
+}
+
+fn merge(into: &mut TokenBucket, from: &TokenBucket) {
+    into.input_tokens += from.input_tokens;
+    into.cache_creation_tokens += from.cache_creation_tokens;
+    into.cache_read_tokens += from.cache_read_tokens;
+    into.output_tokens += from.output_tokens;
+    into.reasoning_tokens += from.reasoning_tokens;
+    into.call_count += from.call_count;
+    into.cost_usd = match (into.cost_usd, from.cost_usd) {
+        (Some(a), Some(b)) => Some(a + b),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+}
+
+fn week_start(date: NaiveDate) -> NaiveDate {
+    let days = date.weekday().num_days_from_monday();
+    date - Duration::days(i64::from(days))
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn sort_by_total_desc<T, F>(mut rows: Vec<T>, key: F) -> Vec<T>
+where
+    F: Fn(&T) -> TokenBucket,
+{
+    rows.sort_by(|a, b| {
+        let av = key(a).cost_usd.unwrap_or(key(a).total() as f64);
+        let bv = key(b).cost_usd.unwrap_or(key(b).total() as f64);
+        bv.total_cmp(&av)
+    });
+    rows
+}
+
+fn sort_sessions_by_recency(mut rows: Vec<SessionUsage>) -> Vec<SessionUsage> {
+    rows.sort_by(|a, b| b.last_timestamp.cmp(&a.last_timestamp));
+    rows
+}
+
+fn map_to_named_usage_sorted(map: BTreeMap<String, usize>) -> Vec<NamedUsage> {
+    let mut rows: Vec<NamedUsage> = map
+        .into_iter()
+        .map(|(name, calls)| NamedUsage { name, calls })
+        .collect();
+    rows.sort_by(|a, b| b.calls.cmp(&a.calls).then(a.name.cmp(&b.name)));
+    rows
+}
+
+// Silences the unused-import lint on Path when only PathBuf is used in tests.
+#[allow(dead_code)]
+fn _path_in_scope(p: &Path) -> &Path {
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    fn call(
+        provider: Provider,
+        project: &str,
+        session: &str,
+        ts: i64,
+        input: u64,
+        output: u64,
+        cost: Option<f64>,
+    ) -> ProviderCall {
+        ProviderCall {
+            id: ts as u64,
+            provider,
+            model: "m".into(),
+            session_id: session.into(),
+            project: project.into(),
+            project_path: format!("/tmp/{project}"),
+            timestamp: DateTime::<Utc>::from_timestamp(ts, 0).unwrap(),
+            input_tokens: input,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: output,
+            reasoning_tokens: 0,
+            cost_usd: cost,
+            tools: vec!["Read".into()],
+            bash_commands: vec![],
+            user_message: String::new(),
+            branch: Some("main".into()),
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_default_usage_data() {
+        let data = aggregate(Vec::new());
+        assert_eq!(data, UsageData::default());
+    }
+
+    #[test]
+    fn aggregates_grand_total_correctly() {
+        let calls = vec![
+            call(Provider::Claude, "p", "s1", 1_700_000_000, 10, 20, Some(0.001)),
+            call(Provider::Claude, "p", "s1", 1_700_000_001, 30, 40, Some(0.002)),
+        ];
+        let data = aggregate(calls);
+        assert_eq!(data.grand_total.input_tokens, 40);
+        assert_eq!(data.grand_total.output_tokens, 60);
+        assert_eq!(data.grand_total.call_count, 2);
+        assert_eq!(data.grand_total.session_count, 1);
+        assert_eq!(data.grand_total.project_count, 1);
+        assert_eq!(data.grand_total.cost_usd, Some(0.003));
+    }
+
+    #[test]
+    fn projects_sorted_by_cost_descending() {
+        let calls = vec![
+            call(Provider::Claude, "small", "s1", 1, 10, 10, Some(0.001)),
+            call(Provider::Claude, "big", "s2", 2, 1000, 1000, Some(1.0)),
+        ];
+        let data = aggregate(calls);
+        assert_eq!(data.projects.len(), 2);
+        assert_eq!(data.projects[0].name, "big");
+        assert_eq!(data.projects[1].name, "small");
+    }
+
+    #[test]
+    fn sessions_sorted_by_last_timestamp_descending() {
+        let calls = vec![
+            call(Provider::Claude, "p", "old", 1_700_000_000, 1, 1, None),
+            call(Provider::Claude, "p", "new", 1_700_000_500, 1, 1, None),
+        ];
+        let data = aggregate(calls);
+        assert_eq!(data.sessions[0].session_id, "new");
+        assert_eq!(data.sessions[1].session_id, "old");
+    }
+
+    #[test]
+    fn branches_only_track_non_empty_strings() {
+        let mut a = call(Provider::Claude, "p", "s1", 1, 1, 1, None);
+        a.branch = Some(String::new());
+        let calls = vec![a];
+        let data = aggregate(calls);
+        assert!(data.branches.is_empty());
+    }
+
+    #[test]
+    fn model_project_counts_are_deterministically_sorted() {
+        let calls = vec![
+            call(Provider::Claude, "alpha", "s1", 1, 1, 1, None),
+            call(Provider::Claude, "beta", "s2", 2, 1, 1, None),
+            call(Provider::Claude, "alpha", "s3", 3, 1, 1, None),
+        ];
+        let data = aggregate(calls);
+        assert_eq!(data.model_project_counts.len(), 1);
+        let (_, rows) = &data.model_project_counts[0];
+        assert_eq!(rows[0], ("alpha".into(), 2));
+        assert_eq!(rows[1], ("beta".into(), 1));
+    }
+
+    #[test]
+    fn weekly_bucket_groups_by_iso_monday() {
+        // 1700000000 == 2023-11-14 22:13:20 UTC = Tuesday
+        // Week start = 2023-11-13 (Monday).
+        let calls = vec![call(Provider::Claude, "p", "s1", 1_700_000_000, 1, 1, None)];
+        let data = aggregate(calls);
+        assert_eq!(data.weekly.len(), 1);
+        assert_eq!(
+            data.weekly[0].0,
+            NaiveDate::from_ymd_opt(2023, 11, 13).unwrap()
+        );
+    }
+
+    #[test]
+    fn defaults_constructor_returns_some_when_home_is_set() {
+        if std::env::var_os("HOME").is_some() {
+            let r = ProviderRoots::defaults();
+            assert!(r.claude_projects.is_some());
+            assert!(r.codex_sessions.is_some());
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/tests/subprocess_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/tests/subprocess_smoke.rs
@@ -1,0 +1,278 @@
+//! Subprocess smoke test for the session-reader plugin.
+//!
+//! Spawns the built binary, drives the JSON-RPC handshake by hand
+//! (Content-Length framed), and asserts:
+//!   1. `plugin/init` returns `{name: "session-reader", version: ...}`.
+//!   2. During `on_init` the plugin emits a `host/snapshot/subscribe`
+//!      request for `sessions.refresh_request` (we reply OK).
+//!   3. The plugin publishes an `rmp-serde`-encoded `UsageDataEvent`
+//!      on `sessions.usage_data`.
+//!   4. `plugin/shutdown` returns cleanly and the process exits.
+//!
+//! The fixture sets `HOME` to an empty tempdir so the scan finds no
+//! provider data (parsers degrade to empty `Vec<ProviderCall>` for
+//! non-existent dirs). The published `UsageDataEvent` is still valid —
+//! `data` is `UsageData::default()` and `version == WIRE_VERSION`.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use ainb_plugin_protocol::{
+    framing,
+    methods,
+    params::{
+        HandleEventParams, PluginInitResult, PluginShutdownResult, SnapshotPublishParams,
+        SnapshotSubscribeResult,
+    },
+};
+use ainb_plugin_types_sessions::{UsageDataEvent, WIRE_VERSION};
+use serde_json::{json, Value};
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_ainb-plugin-session-reader"))
+}
+
+fn write_frame<W: Write>(w: &mut W, body: &Value) {
+    let bytes = serde_json::to_vec(body).expect("serialize JSON-RPC body");
+    let frame = framing::encode(&bytes);
+    w.write_all(&frame).expect("write frame");
+    w.flush().expect("flush stdin");
+}
+
+fn read_frame<R: BufRead>(r: &mut R) -> Option<Value> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        let n = r.read_line(&mut line).expect("read header line");
+        if n == 0 {
+            return None;
+        }
+        if !line.ends_with("\r\n") {
+            panic!("header not CRLF terminated: {line:?}");
+        }
+        let trimmed = line.trim_end_matches("\r\n");
+        if trimmed.is_empty() {
+            let len = content_length.expect("missing Content-Length header");
+            let mut body = vec![0u8; len];
+            r.read_exact(&mut body).expect("read body");
+            return Some(serde_json::from_slice(&body).expect("parse JSON body"));
+        }
+        let (name, value) = trimmed
+            .split_once(':')
+            .unwrap_or_else(|| panic!("malformed header: {trimmed:?}"));
+        if name.trim().eq_ignore_ascii_case("Content-Length") {
+            content_length = Some(value.trim().parse().expect("numeric Content-Length"));
+        } else {
+            panic!("unsupported header: {name}");
+        }
+    }
+}
+
+#[test]
+fn subprocess_init_publishes_snapshot_then_responds_ok() {
+    // Empty HOME so ProviderRoots::defaults() points at non-existent
+    // dirs. Parsers degrade to empty without erroring.
+    let home = tempfile::tempdir().expect("tempdir HOME");
+
+    let mut child = Command::new(binary_path())
+        .env("HOME", home.path())
+        // Mute the plugin's tracing output — keeps the assertion log clean.
+        .env("RUST_LOG", "off")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn session-reader binary");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+    // 1) Send plugin/init.
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": methods::PLUGIN_INIT,
+            "params": {
+                "manifest_path": "/dev/null/manifest.toml",
+                "granted_capabilities": [
+                    "read_claude_logs",
+                    "read_codex_logs",
+                    "event_bus",
+                    "write_plugin_data"
+                ],
+                "abi_version": 2,
+            },
+        }),
+    );
+
+    // 2) The plugin's on_init issues host/snapshot/subscribe before
+    //    returning. Drain frames until we see it; publish frames in
+    //    between are fine. Bound the loop so a hang fails the test
+    //    rather than wedging CI.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut publish_seen: Option<SnapshotPublishParams> = None;
+    let mut subscribe_id: Option<i64> = None;
+
+    while Instant::now() < deadline {
+        let frame = match read_frame(&mut stdout) {
+            Some(v) => v,
+            None => panic!("plugin closed stdout before subscribe"),
+        };
+
+        if let Some(method) = frame.get("method").and_then(Value::as_str) {
+            match method {
+                m if m == methods::HOST_SNAPSHOT_SUBSCRIBE => {
+                    let id = frame.get("id").and_then(Value::as_i64).expect(
+                        "snapshot/subscribe should be a request with id",
+                    );
+                    let topic = frame
+                        .get("params")
+                        .and_then(|p| p.get("topic"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    assert_eq!(topic, "sessions.refresh_request");
+                    subscribe_id = Some(id);
+                    break;
+                }
+                m if m == methods::HOST_SNAPSHOT_PUBLISH => {
+                    let params: SnapshotPublishParams = serde_json::from_value(
+                        frame.get("params").cloned().unwrap_or(Value::Null),
+                    )
+                    .expect("decode snapshot/publish params");
+                    publish_seen = Some(params);
+                }
+                m if m == methods::HOST_LOG => { /* ignore log notifications */ }
+                other => panic!("unexpected outbound method during init: {other}"),
+            }
+        } else if frame.get("id").is_some() {
+            panic!("unexpected response frame before subscribe: {frame}");
+        }
+    }
+
+    let subscribe_id = subscribe_id.expect("plugin never issued snapshot/subscribe");
+
+    // 3) Reply to subscribe so on_init can finish.
+    let subscribe_result = SnapshotSubscribeResult {};
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": subscribe_id,
+            "result": subscribe_result,
+        }),
+    );
+
+    // 4) Drain outbound frames until we see the plugin/init response.
+    //    A snapshot/publish from the publish() call after subscribe()
+    //    arrives here too.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut init_response: Option<Value> = None;
+    while Instant::now() < deadline {
+        let frame = read_frame(&mut stdout)
+            .expect("plugin closed stdout before init response");
+        if let Some(method) = frame.get("method").and_then(Value::as_str) {
+            if method == methods::HOST_SNAPSHOT_PUBLISH {
+                let params: SnapshotPublishParams = serde_json::from_value(
+                    frame.get("params").cloned().unwrap_or(Value::Null),
+                )
+                .expect("decode publish params");
+                publish_seen = Some(params);
+            }
+            // ignore other notifications (logs, etc.)
+        } else if frame.get("id").and_then(Value::as_i64) == Some(1) {
+            init_response = Some(frame);
+            break;
+        }
+    }
+
+    let init_response = init_response.expect("no plugin/init response within deadline");
+    assert!(init_response.get("error").is_none(), "init failed: {init_response}");
+    let result_value = init_response.get("result").cloned().expect("init result");
+    let init_result: PluginInitResult =
+        serde_json::from_value(result_value).expect("decode PluginInitResult");
+    assert_eq!(init_result.name, "session-reader");
+    assert_eq!(init_result.version, "0.2.0");
+
+    let publish_seen =
+        publish_seen.expect("plugin should publish a sessions.usage_data snapshot during init");
+    assert_eq!(publish_seen.topic, "sessions.usage_data");
+    let event: UsageDataEvent = rmp_serde::from_slice(&publish_seen.payload)
+        .expect("snapshot payload is rmp-serde UsageDataEvent");
+    assert_eq!(event.version, WIRE_VERSION);
+    assert!(!event.partial);
+
+    // 5) handle_event for the refresh topic should also trigger a
+    //    fresh publish — sanity-check the wiring.
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": methods::PLUGIN_HANDLE_EVENT,
+            "params": HandleEventParams {
+                topic: "sessions.refresh_request".into(),
+                payload: bytes::Bytes::from_static(b""),
+            },
+        }),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut got_refresh_publish = false;
+    while Instant::now() < deadline {
+        let frame = match read_frame(&mut stdout) {
+            Some(v) => v,
+            None => break,
+        };
+        if frame.get("method").and_then(Value::as_str) == Some(methods::HOST_SNAPSHOT_PUBLISH) {
+            got_refresh_publish = true;
+            break;
+        }
+    }
+    assert!(
+        got_refresh_publish,
+        "plugin did not republish snapshot after handle_event(refresh)"
+    );
+
+    // 6) Clean shutdown.
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": methods::PLUGIN_SHUTDOWN,
+            "params": {},
+        }),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut shutdown_ok = false;
+    while Instant::now() < deadline {
+        let frame = match read_frame(&mut stdout) {
+            Some(v) => v,
+            None => break,
+        };
+        if frame.get("id").and_then(Value::as_i64) == Some(99) {
+            assert!(frame.get("error").is_none(), "shutdown failed: {frame}");
+            let _: PluginShutdownResult = serde_json::from_value(
+                frame.get("result").cloned().unwrap_or(Value::Null),
+            )
+            .expect("decode PluginShutdownResult");
+            shutdown_ok = true;
+            break;
+        }
+    }
+    assert!(shutdown_ok, "no plugin/shutdown response within deadline");
+
+    drop(stdin);
+
+    // Drain stderr so the kill-on-drop doesn't panic on a SIGPIPE write.
+    let _ = child.stderr.as_mut().map(|s| {
+        let mut sink = Vec::new();
+        let _ = s.read_to_end(&mut sink);
+    });
+
+    let status = child.wait().expect("wait child");
+    assert!(status.success(), "child exited non-zero: {status:?}");
+}


### PR DESCRIPTION
## Summary

Phase 7c-session-reader — migrate session-reader plugin to subprocess + ABI v2.

Bead: `agents-in-a-box-4is`. Sister: `agents-in-a-box-141` (burndown, separate PR).

## What changed

- `crates/ainb-plugin-session-reader/Cargo.toml` — drop `crate-type = ["cdylib"]`, drop `wasm32-wasip1` target, add `[[bin]]`. Becomes a regular Rust binary using `ainb-plugin-sdk-rust::Server::run_stdio()`.
- Parser/scanner/cache logic preserved; only entry point swapped.
- Plugin trait: `manifest()` (ABI v2, declares `sessions.usage_data` topic), `handle_event()` (sessions.refresh_request → re-scan), `render()` (no-op, data provider only), `cli_dispatch()` (no namespaces).
- Eager spawn on init: publishes `sessions.usage_data` snapshot before burndown's first request — guarantees burndown sees data on startup.
- 278-line subprocess smoke test.

## Commits (7 atomic)

- `239935d` feat: scaffold subprocess crate (ABI v2)
- `dde6ded` feat: port FNV-1a hash + per-provider parsers
- `25e0a13` feat: port scan + UsageData aggregator
- `c540df6` feat: Plugin trait impl + main.rs entry
- `0fd003c` chore: trim dead helpers + gate `with_roots` to test
- `dd8ef4a` chore: tune clippy lints + add toml dev-dep
- `1502bcc` test: subprocess JSON-RPC smoke

## Architectural gates

| gate | result |
|---|---|
| zero wasmi imports | ✅ |
| zero ainb-plugin-api imports | ✅ |
| `[[bin]]` not cdylib | ✅ |
| host target (no wasm32-wasip1) | ✅ |
| wire types from ainb-plugin-protocol | ✅ |

## Test plan

- [x] `cargo build -p ainb-plugin-session-reader` ✅
- [x] `cargo build --release -p ainb-plugin-session-reader` ✅
- [x] `cargo test -p ainb-plugin-session-reader` — 32 unit + 1 subprocess smoke ✅
- [x] `cargo clippy -p ainb-plugin-session-reader --all-targets -- -D warnings` ✅
- [x] `cargo test --workspace` — 1 pre-existing failure `test_previous_session` (verified via `git log 40ec952..HEAD -- crates/ainb-core/` shows zero commits from this branch)

## Snapshot contract

Plugin publishes `sessions.usage_data` topic carrying `UsageDataEvent` (rmp-serde encoded). Subscribers (burndown) receive on `handle_event`. Publish triggered by:
1. plugin init (eager scan)
2. host event `sessions.refresh_request`

Bead: `agents-in-a-box-4is`
