### PR TITLE
feat(plugin-testkit): Phase 7d — in-process harness for plugin authors

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/ainb-plugin-runtime",
     "crates/ainb-plugin-sdk-rust",
     "crates/ainb-plugin-session-reader",
+    "crates/ainb-plugin-testkit",
     "crates/ainb-plugin-types-sessions",
     "xtask",
 ]

--- a/ainb-tui/crates/ainb-plugin-testkit/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-testkit/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "ainb-plugin-testkit"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "In-process harness for testing ainb plugins. Drives a Plugin trait impl over tokio::io::DuplexStream — no subprocess, no fixtures on disk."
+categories = ["development-tools", "development-tools::testing"]
+keywords = ["ainb", "plugin", "testing", "harness", "json-rpc"]
+
+[lib]
+name = "ainb_plugin_testkit"
+path = "src/lib.rs"
+
+[dependencies]
+ainb-plugin-protocol = { path = "../ainb-plugin-protocol" }
+ainb-plugin-sdk-rust = { path = "../ainb-plugin-sdk-rust" }
+
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+bytes = { version = "1.6", features = ["serde"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+async-trait = "0.1"
+tokio = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"
+unused_imports = "warn"
+unused_variables = "warn"
+dead_code = "warn"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+module_name_repetitions = "allow"
+similar_names = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+significant_drop_tightening = "allow"
+significant_drop_in_scrutinee = "allow"

--- a/ainb-tui/crates/ainb-plugin-testkit/src/error.rs
+++ b/ainb-tui/crates/ainb-plugin-testkit/src/error.rs
@@ -1,0 +1,59 @@
+//! Testkit-side error type.
+//!
+//! Distinct from [`ainb_plugin_sdk::SdkError`] because the harness
+//! owns its own failure modes (timeouts, missing responses, framing
+//! decode failures on the host side) that aren't plugin errors.
+
+use ainb_plugin_protocol::{ProtocolError, RpcError};
+
+/// Result alias used throughout the testkit public API.
+pub type HarnessResult<T> = std::result::Result<T, HarnessError>;
+
+/// Failures the harness can surface to a test.
+///
+/// All variants are designed to short-circuit a `#[tokio::test]` via
+/// `?` — the harness intentionally does not panic on its own, so test
+/// authors decide whether to `unwrap()` or to assert a specific
+/// [`HarnessError`] shape.
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessError {
+    /// JSON serialise / deserialise failed in test code or in a frame
+    /// the harness produced.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Stdio framing failed — usually means the plugin hung up
+    /// mid-frame or wrote a malformed Content-Length header.
+    #[error("framing error: {0}")]
+    Protocol(#[from] ProtocolError),
+
+    /// The plugin returned a JSON-RPC `error` envelope to a request
+    /// the test issued.
+    #[error("rpc error from plugin: {0:?}")]
+    Rpc(Box<RpcError>),
+
+    /// I/O failure on the in-memory duplex pipe. Almost always means
+    /// the server task panicked or dropped the writer half.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `recv_*` exhausted the supplied timeout without seeing a
+    /// matching frame.
+    #[error("timed out after {0:?} waiting for {1}")]
+    Timeout(std::time::Duration, String),
+
+    /// The harness saw EOF on the plugin->host pipe while still
+    /// expecting a response — the server task usually exited.
+    #[error("plugin closed pipe before responding to id={0}")]
+    UnexpectedEof(i64),
+
+    /// Catch-all for assertion failures inside the harness.
+    #[error("assertion failed: {0}")]
+    Assertion(String),
+}
+
+impl From<RpcError> for HarnessError {
+    fn from(e: RpcError) -> Self {
+        Self::Rpc(Box::new(e))
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-testkit/src/harness.rs
+++ b/ainb-tui/crates/ainb-plugin-testkit/src/harness.rs
@@ -1,0 +1,832 @@
+//! In-process [`Harness`] that drives a [`Plugin`] over a
+//! [`tokio::io::DuplexStream`].
+//!
+//! The harness mirrors what the host-side
+//! [`ainb_plugin_runtime`](https://docs.rs/ainb-plugin-runtime) does in
+//! production, minus the subprocess. The SDK [`Server`] runs on a
+//! background tokio task; the harness writes raw JSON-RPC frames into
+//! one half of the duplex pair and reads frames from the other half.
+//!
+//! ## Why a single buffered reader?
+//!
+//! Plugins can emit unsolicited frames at any time — `host/log`
+//! notifications, `host/snapshot/publish` notifications, and
+//! `host/snapshot/get` requests during a render. The harness owns the
+//! only reader, so it must demultiplex:
+//!
+//! 1. Frames with a `result`/`error` and an `id` matching an
+//!    outstanding test-issued request resolve that request.
+//! 2. Frames with a `method` (with or without `id`) are recorded as
+//!    [`ObservedFrame`]s for assertion APIs to inspect later.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::io::{
+    AsyncReadExt, AsyncWriteExt, BufReader, DuplexStream, ReadHalf, WriteHalf,
+};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+use ainb_plugin_protocol::{
+    framing,
+    methods,
+    params::{HandleEventParams, PluginInitParams, RenderParams, RenderResult, Viewport},
+    ProtocolError, RpcError, WireBuffer,
+};
+use ainb_plugin_sdk::{Plugin, Server};
+
+use crate::error::{HarnessError, HarnessResult};
+
+/// Buffer size for the in-memory duplex pipe. Mirrors the value the
+/// SDK uses in its own integration tests so framing edge cases match.
+const DUPLEX_BUF_BYTES: usize = 64 * 1024;
+
+/// Default timeout for `recv_*` calls. Tests can override via the
+/// explicit [`Harness::recv_with_timeout`] entry point.
+pub const DEFAULT_RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One frame the plugin emitted that wasn't a response to an outgoing
+/// request — i.e. a plugin-initiated notification or a plugin-initiated
+/// request waiting for a host reply.
+#[derive(Debug, Clone)]
+pub struct ObservedFrame {
+    /// JSON-RPC method name (e.g. `host/snapshot/publish`).
+    pub method: String,
+    /// Raw params value as it came across the wire. Tests usually
+    /// `serde_json::from_value` this into a typed struct.
+    pub params: Value,
+    /// Some(id) if this is a request awaiting a response, None for a
+    /// notification.
+    pub id: Option<i64>,
+}
+
+impl ObservedFrame {
+    /// True iff this frame is a notification (no `id`).
+    #[must_use]
+    pub const fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+
+    /// True iff this frame is a request awaiting a host reply.
+    #[must_use]
+    pub const fn is_request(&self) -> bool {
+        self.id.is_some()
+    }
+}
+
+/// Spawn `plugin` on a background tokio task and return a [`Harness`]
+/// connected to its stdio.
+///
+/// Must be called from inside a tokio runtime — `#[tokio::test]` is
+/// the canonical caller. The plugin starts running immediately; the
+/// first thing the test should do is [`Harness::init`].
+pub fn run_plugin<P: Plugin>(plugin: P) -> Harness {
+    let (host_side, plugin_side) = tokio::io::duplex(DUPLEX_BUF_BYTES);
+    let (plugin_read, plugin_write) = tokio::io::split(plugin_side);
+    let server_task = tokio::spawn(async move {
+        Server::new(plugin).run(plugin_read, plugin_write).await
+    });
+    let (host_read, host_write) = tokio::io::split(host_side);
+    Harness {
+        server_task: Some(server_task),
+        plugin_in: Some(host_write),
+        plugin_out: BufReader::new(host_read),
+        next_id: AtomicI64::new(1),
+        observed: VecDeque::new(),
+    }
+}
+
+/// In-process JSON-RPC harness for a single [`Plugin`].
+///
+/// Drop the harness to stop the plugin without the clean
+/// `plugin/shutdown` round-trip; prefer [`Harness::close`] in tests
+/// that want a clean exit.
+pub struct Harness {
+    server_task: Option<JoinHandle<ainb_plugin_sdk::Result<()>>>,
+    plugin_in: Option<WriteHalf<DuplexStream>>,
+    plugin_out: BufReader<ReadHalf<DuplexStream>>,
+    next_id: AtomicI64,
+    observed: VecDeque<ObservedFrame>,
+}
+
+impl Harness {
+    fn alloc_id(&self) -> i64 {
+        self.next_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Send a request `{method, id, params}` and return the matching
+    /// `result`. Plugin-initiated frames seen on the way are buffered
+    /// in [`observed`](Self::observed_frames) so later assertions can
+    /// inspect them.
+    pub async fn send_request<M, P>(&mut self, method: M, params: P) -> HarnessResult<Value>
+    where
+        M: AsRef<str>,
+        P: serde::Serialize,
+    {
+        let id = self.alloc_id();
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method.as_ref(),
+            "params": serde_json::to_value(params)?,
+        });
+        self.write_frame(&body).await?;
+        self.recv_response_for(id, DEFAULT_RECV_TIMEOUT).await
+    }
+
+    /// Send a notification (no `id`). Notifications never produce a
+    /// reply — fire-and-forget.
+    pub async fn send_notification<M, P>(&mut self, method: M, params: P) -> HarnessResult<()>
+    where
+        M: AsRef<str>,
+        P: serde::Serialize,
+    {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method.as_ref(),
+            "params": serde_json::to_value(params)?,
+        });
+        self.write_frame(&body).await
+    }
+
+    /// Send a `plugin/handle_event` notification with `topic` and a
+    /// raw byte `payload`. Convenience wrapper around
+    /// [`Self::send_notification`].
+    pub async fn send_event<T: Into<String>>(
+        &mut self,
+        topic: T,
+        payload: impl Into<bytes::Bytes>,
+    ) -> HarnessResult<()> {
+        let params = HandleEventParams {
+            topic: topic.into(),
+            payload: payload.into(),
+        };
+        self.send_notification(methods::PLUGIN_HANDLE_EVENT, params).await
+    }
+
+    /// Reply to a plugin-issued request with a `result` value.
+    ///
+    /// Use this when a plugin you are testing issues
+    /// `host.snapshot_get(...)` mid-handler — pull the request out of
+    /// [`Self::recv_request`], fabricate the reply, and call this.
+    pub async fn respond<R: serde::Serialize>(
+        &mut self,
+        id: i64,
+        result: R,
+    ) -> HarnessResult<()> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": serde_json::to_value(result)?,
+        });
+        self.write_frame(&body).await
+    }
+
+    /// Reply to a plugin-issued request with an `error` envelope.
+    pub async fn respond_error(
+        &mut self,
+        id: i64,
+        error: RpcError,
+    ) -> HarnessResult<()> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": error,
+        });
+        self.write_frame(&body).await
+    }
+
+    /// Wait up to `timeout` for the next plugin-initiated frame
+    /// (request or notification). Returns immediately if there is
+    /// already one buffered.
+    pub async fn recv_observed(
+        &mut self,
+        timeout: Duration,
+    ) -> HarnessResult<ObservedFrame> {
+        if let Some(frame) = self.observed.pop_front() {
+            return Ok(frame);
+        }
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| {
+                    HarnessError::Timeout(timeout, "plugin-initiated frame".into())
+                })?;
+            tokio::select! {
+                () = tokio::time::sleep(remaining) => {
+                    return Err(HarnessError::Timeout(
+                        timeout,
+                        "plugin-initiated frame".into(),
+                    ));
+                }
+                frame = read_one_frame(&mut self.plugin_out) => {
+                    match frame? {
+                        Some(value) => match classify(&value) {
+                            FrameKind::PluginInitiated(obs) => return Ok(obs),
+                            FrameKind::Response { .. } => {
+                                // Stash response for whoever is waiting on it.
+                                // For the simple recv_observed path we just drop
+                                // — there is no test pattern that calls this
+                                // while a response is outstanding.
+                                tracing::warn!(
+                                    "harness recv_observed dropped stray response: {value}"
+                                );
+                            }
+                            FrameKind::Garbage => {
+                                tracing::warn!("harness ignored garbage frame: {value}");
+                            }
+                        },
+                        None => {
+                            return Err(HarnessError::Timeout(
+                                timeout,
+                                "plugin-initiated frame (EOF)".into(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Wait up to `timeout` for the next plugin-initiated *request*
+    /// (notifications are buffered and skipped). Use this when a
+    /// plugin under test issues `host.snapshot_get(...)` and you need
+    /// to feed it a fake reply.
+    pub async fn recv_request(
+        &mut self,
+        timeout: Duration,
+    ) -> HarnessResult<ObservedFrame> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| {
+                    HarnessError::Timeout(timeout, "plugin-initiated request".into())
+                })?;
+            let frame = self.recv_observed(remaining).await?;
+            if frame.is_request() {
+                return Ok(frame);
+            }
+            // Notification — keep it in the log for later assertions.
+            self.observed.push_back(frame);
+        }
+    }
+
+    /// Borrow the buffered list of plugin-initiated frames seen so
+    /// far. Useful for after-the-fact assertions.
+    #[must_use]
+    pub const fn observed_frames(&self) -> &VecDeque<ObservedFrame> {
+        &self.observed
+    }
+
+    /// Drop everything in the observed log. Tests that loop over
+    /// multiple renders can call this between iterations.
+    pub fn clear_observed(&mut self) {
+        self.observed.clear();
+    }
+
+    /// Pump all currently-readable frames into the observed log
+    /// without blocking past `quiet_for`. Lets a test wait for the
+    /// plugin to be "settled" before asserting publish topics.
+    pub async fn drain_until_quiet(&mut self, quiet_for: Duration) -> HarnessResult<()> {
+        loop {
+            match tokio::time::timeout(quiet_for, read_one_frame(&mut self.plugin_out)).await {
+                Ok(Ok(Some(value))) => match classify(&value) {
+                    FrameKind::PluginInitiated(obs) => self.observed.push_back(obs),
+                    FrameKind::Response { .. } | FrameKind::Garbage => {
+                        tracing::warn!("drain_until_quiet ignored frame: {value}");
+                    }
+                },
+                Ok(Ok(None)) | Err(_) => return Ok(()), // EOF or quiet long enough
+                Ok(Err(e)) => return Err(e),
+            }
+        }
+    }
+
+    /// Send a `plugin/init` request with the canonical empty params
+    /// (no granted capabilities, ABI v2). Returns the
+    /// `PluginInitResult` echoed back from the plugin's manifest.
+    pub async fn init(&mut self) -> HarnessResult<Value> {
+        let params = PluginInitParams {
+            manifest_path: "/in-process/manifest.toml".into(),
+            granted_capabilities: Vec::new(),
+            abi_version: 2,
+        };
+        self.send_request(methods::PLUGIN_INIT, params).await
+    }
+
+    /// Send `plugin/render` with `viewport`, deserialise the buffer,
+    /// and return it. Doesn't perform any equality assertions —
+    /// callers that want byte-stable comparison build that on top.
+    pub async fn render(&mut self, viewport: Viewport) -> HarnessResult<WireBuffer> {
+        let params = RenderParams {
+            viewport,
+            generation: 0,
+        };
+        let value = self.send_request(methods::PLUGIN_RENDER, params).await?;
+        let result: RenderResult = serde_json::from_value(value)?;
+        Ok(result.buffer)
+    }
+
+    /// Replay assertion: render the plugin twice with `viewport` and
+    /// require the buffers to be byte-identical.
+    ///
+    /// Catches accidental nondeterminism — e.g. a plugin that mixes
+    /// `Instant::now()` into its rendered text.
+    pub async fn assert_render_round_trip(&mut self, viewport: Viewport) -> HarnessResult<()> {
+        let first = self.render(viewport).await?;
+        let second = self.render(viewport).await?;
+        if first != second {
+            return Err(HarnessError::Assertion(format!(
+                "render at viewport {viewport:?} was non-deterministic across two calls"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Replay assertion: drain pending frames briefly, then assert
+    /// that the plugin published a snapshot for `topic` at least once
+    /// in this session.
+    ///
+    /// Drains for a 100ms quiet window so plugins that publish during
+    /// `on_init` or after a `handle_event` are covered without
+    /// requiring the test to manually drain.
+    pub async fn assert_publishes_topic(&mut self, topic: &str) -> HarnessResult<()> {
+        self.drain_until_quiet(Duration::from_millis(100)).await?;
+        let found = self.observed.iter().any(|f| {
+            f.method == methods::HOST_SNAPSHOT_PUBLISH
+                && f.params.get("topic").and_then(Value::as_str) == Some(topic)
+        });
+        if !found {
+            return Err(HarnessError::Assertion(format!(
+                "expected at least one host/snapshot/publish for topic={topic:?} — saw {} other frames",
+                self.observed.len()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Send a clean `plugin/shutdown` notification, close the writer
+    /// half so the server's read loop exits, and await the background
+    /// task.
+    pub async fn close(mut self) -> HarnessResult<()> {
+        // Notification, not request — matches what the runtime does.
+        let _ = self
+            .send_notification(methods::PLUGIN_SHUTDOWN, serde_json::json!({}))
+            .await;
+        if let Some(mut writer) = self.plugin_in.take() {
+            let _ = writer.shutdown().await;
+        }
+        if let Some(task) = self.server_task.take() {
+            match task.await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(e)) => Err(HarnessError::Assertion(format!(
+                    "plugin server task ended with error: {e}"
+                ))),
+                Err(join_err) => Err(HarnessError::Assertion(format!(
+                    "plugin server task panicked: {join_err}"
+                ))),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn write_frame(&mut self, body: &Value) -> HarnessResult<()> {
+        let writer = self
+            .plugin_in
+            .as_mut()
+            .ok_or_else(|| HarnessError::Assertion("harness writer already closed".into()))?;
+        let bytes = serde_json::to_vec(body)?;
+        writer.write_all(&framing::encode(&bytes)).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+
+    async fn recv_response_for(
+        &mut self,
+        id: i64,
+        timeout: Duration,
+    ) -> HarnessResult<Value> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| HarnessError::Timeout(timeout, format!("response for id={id}")))?;
+            let read = tokio::time::timeout(remaining, read_one_frame(&mut self.plugin_out)).await;
+            let value = match read {
+                Ok(Ok(Some(v))) => v,
+                Ok(Ok(None)) => return Err(HarnessError::UnexpectedEof(id)),
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {
+                    return Err(HarnessError::Timeout(timeout, format!("response for id={id}")));
+                }
+            };
+            match classify(&value) {
+                FrameKind::Response {
+                    id: rid,
+                    outcome,
+                } if rid == id => match outcome {
+                    Ok(v) => return Ok(v),
+                    Err(rpc) => return Err(HarnessError::Rpc(Box::new(rpc))),
+                },
+                FrameKind::Response { id: rid, .. } => {
+                    tracing::warn!("harness ignored stale response for id={rid}");
+                }
+                FrameKind::PluginInitiated(obs) => self.observed.push_back(obs),
+                FrameKind::Garbage => {
+                    tracing::warn!("harness ignored garbage frame: {value}");
+                }
+            }
+        }
+    }
+
+    /// Recv with caller-supplied timeout — escape hatch for tests
+    /// that need to override [`DEFAULT_RECV_TIMEOUT`].
+    pub async fn recv_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> HarnessResult<ObservedFrame> {
+        self.recv_observed(timeout).await
+    }
+}
+
+/// Inbound frame discriminator used by both `send_request` and
+/// `recv_observed`. The `Garbage` variant exists so we can log+skip
+/// instead of panicking on a malformed frame the SDK would already
+/// have logged anyway.
+enum FrameKind {
+    Response {
+        id: i64,
+        outcome: Result<Value, RpcError>,
+    },
+    PluginInitiated(ObservedFrame),
+    Garbage,
+}
+
+#[allow(clippy::option_if_let_else)]
+fn classify(value: &Value) -> FrameKind {
+    let id = value.get("id").and_then(Value::as_i64);
+    let method = value.get("method").and_then(Value::as_str);
+    match (method, id) {
+        (Some(m), id_opt) => FrameKind::PluginInitiated(ObservedFrame {
+            method: m.to_string(),
+            params: value.get("params").cloned().unwrap_or(Value::Null),
+            id: id_opt,
+        }),
+        (None, Some(id)) => {
+            let outcome = if let Some(err) = value.get("error") {
+                let parsed: Result<RpcError, _> = serde_json::from_value(err.clone());
+                Err(parsed.unwrap_or_else(|e| {
+                    RpcError::new(
+                        ainb_plugin_protocol::errors::INVALID_PARAMS,
+                        format!("malformed error envelope: {e}"),
+                    )
+                }))
+            } else if let Some(result) = value.get("result") {
+                Ok(result.clone())
+            } else {
+                Err(RpcError::new(
+                    ainb_plugin_protocol::errors::INVALID_PARAMS,
+                    "response missing both result and error",
+                ))
+            };
+            FrameKind::Response { id, outcome }
+        }
+        _ => FrameKind::Garbage,
+    }
+}
+
+/// Read a single Content-Length framed body from the duplex pipe.
+///
+/// Returns `Ok(None)` only on a clean EOF *between* frames — an EOF
+/// inside the header block or body is surfaced as a
+/// [`ProtocolError::Decode`].
+async fn read_one_frame<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+) -> HarnessResult<Option<Value>> {
+    use tokio::io::AsyncBufReadExt;
+
+    const HEADER_BUDGET: usize = 8 * 1024;
+
+    let mut content_length: Option<usize> = None;
+    let mut header_bytes_seen = 0usize;
+    let mut any_byte_read = false;
+
+    loop {
+        let mut line = String::new();
+        let n = reader
+            .read_line(&mut line)
+            .await
+            .map_err(|e| HarnessError::Protocol(ProtocolError::Transport(e)))?;
+
+        if n == 0 {
+            if any_byte_read {
+                return Err(HarnessError::Protocol(ProtocolError::Decode(
+                    "unexpected EOF inside header block".into(),
+                )));
+            }
+            return Ok(None);
+        }
+        any_byte_read = true;
+        header_bytes_seen += n;
+        if header_bytes_seen > HEADER_BUDGET {
+            return Err(HarnessError::Protocol(ProtocolError::Decode(format!(
+                "header block exceeded {HEADER_BUDGET} bytes"
+            ))));
+        }
+        if !line.ends_with("\r\n") {
+            return Err(HarnessError::Protocol(ProtocolError::Decode(format!(
+                "header line not CRLF-terminated: {line:?}"
+            ))));
+        }
+        let trimmed = line.trim_end_matches("\r\n");
+        if trimmed.is_empty() {
+            let len = content_length.ok_or_else(|| {
+                HarnessError::Protocol(ProtocolError::Decode(
+                    "missing Content-Length header".into(),
+                ))
+            })?;
+            if len > framing::MAX_BODY_BYTES {
+                return Err(HarnessError::Protocol(ProtocolError::Decode(format!(
+                    "Content-Length {len} exceeds MAX_BODY_BYTES {}",
+                    framing::MAX_BODY_BYTES
+                ))));
+            }
+            let mut body = vec![0u8; len];
+            reader
+                .read_exact(&mut body)
+                .await
+                .map_err(|e| HarnessError::Protocol(ProtocolError::Transport(e)))?;
+            let value: Value = serde_json::from_slice(&body)?;
+            return Ok(Some(value));
+        }
+        let Some((name, value)) = trimmed.split_once(':') else {
+            return Err(HarnessError::Protocol(ProtocolError::Decode(format!(
+                "malformed header line: {trimmed:?}"
+            ))));
+        };
+        let name = name.trim();
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("Content-Length") {
+            let parsed: usize = value.parse().map_err(|_| {
+                HarnessError::Protocol(ProtocolError::Decode(format!(
+                    "non-numeric Content-Length: {value:?}"
+                )))
+            })?;
+            content_length = Some(parsed);
+        } else {
+            return Err(HarnessError::Protocol(ProtocolError::Decode(format!(
+                "unsupported header: {name}"
+            ))));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_plugin_protocol::wire_buffer::{Cell, Coord};
+    use ainb_plugin_sdk::{HostClient, Result as SdkResult};
+    use async_trait::async_trait;
+
+    /// Tiny in-tree fixture mirroring `ainb-plugin-runtime`'s subprocess
+    /// fixture: render returns a 1×1 `X`, `on_init` publishes a `hello`
+    /// snapshot to `fixture.greeting`. Used to prove the harness
+    /// drives a real Plugin trait impl correctly.
+    struct TestkitFixture;
+
+    #[async_trait]
+    impl Plugin for TestkitFixture {
+        fn manifest(&self) -> &'static str {
+            "[plugin]\nname = \"fixture\"\nversion = \"0.1.0\"\nabi_version = 2\n"
+        }
+        async fn on_init(
+            &mut self,
+            host: &HostClient,
+            _granted: &[String],
+        ) -> SdkResult<()> {
+            host.snapshot_publish("fixture.greeting", bytes::Bytes::from_static(b"hello"))
+                .await
+        }
+        async fn render(
+            &mut self,
+            _host: &HostClient,
+            _params: RenderParams,
+        ) -> SdkResult<WireBuffer> {
+            let mut buf = WireBuffer::new(1, 1);
+            buf.push(Coord::new(0, 0), Cell::new("X"));
+            Ok(buf)
+        }
+    }
+
+    #[tokio::test]
+    async fn init_render_shutdown_round_trip() {
+        let mut h = run_plugin(TestkitFixture);
+        let init = h.init().await.expect("init ok");
+        assert_eq!(init["name"], "fixture");
+        assert_eq!(init["version"], "0.1.0");
+
+        let buf = h.render(Viewport::new(80, 24)).await.expect("render ok");
+        assert_eq!(buf.width, 1);
+        assert_eq!(buf.height, 1);
+
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn assert_publishes_topic_picks_up_init_snapshot() {
+        let mut h = run_plugin(TestkitFixture);
+        h.init().await.expect("init ok");
+        h.assert_publishes_topic("fixture.greeting")
+            .await
+            .expect("on_init publish observed");
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn assert_render_round_trip_passes_for_pure_render() {
+        let mut h = run_plugin(TestkitFixture);
+        h.init().await.expect("init ok");
+        h.assert_render_round_trip(Viewport::new(10, 4))
+            .await
+            .expect("render is deterministic");
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn unknown_method_surfaces_as_rpc_error() {
+        let mut h = run_plugin(TestkitFixture);
+        h.init().await.expect("init ok");
+        let err = h
+            .send_request("plugin/no-such-method", serde_json::json!({}))
+            .await
+            .expect_err("expected RPC error for bogus method");
+        match err {
+            HarnessError::Rpc(rpc) => {
+                assert_eq!(rpc.code, ainb_plugin_protocol::errors::METHOD_NOT_FOUND);
+            }
+            other => panic!("expected Rpc, got {other:?}"),
+        }
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn send_event_routes_to_handle_event_default_no_op() {
+        // The default handle_event implementation in the SDK is a
+        // no-op — we just need to prove the notification frame
+        // travels and the plugin doesn't crash.
+        let mut h = run_plugin(TestkitFixture);
+        h.init().await.expect("init ok");
+        h.send_event("any.topic", bytes::Bytes::from_static(b"v"))
+            .await
+            .expect("notification accepted");
+        // Render after the event still works → loop didn't deadlock.
+        h.render(Viewport::new(1, 1)).await.expect("render ok");
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn render_round_trip_assertion_fails_on_nondeterminism() {
+        struct Wobbly {
+            counter: u32,
+        }
+        #[async_trait]
+        impl Plugin for Wobbly {
+            fn manifest(&self) -> &'static str {
+                "[plugin]\nname = \"wobbly\"\nversion = \"0.0.0\"\nabi_version = 2\n"
+            }
+            async fn render(
+                &mut self,
+                _h: &HostClient,
+                _p: RenderParams,
+            ) -> SdkResult<WireBuffer> {
+                self.counter += 1;
+                let mut b = WireBuffer::new(1, 1);
+                b.push(
+                    Coord::new(0, 0),
+                    Cell::new(format!("{}", self.counter % 10)),
+                );
+                Ok(b)
+            }
+        }
+
+        let mut h = run_plugin(Wobbly { counter: 0 });
+        h.init().await.expect("init ok");
+        let err = h
+            .assert_render_round_trip(Viewport::new(1, 1))
+            .await
+            .expect_err("non-deterministic render should fail");
+        match err {
+            HarnessError::Assertion(msg) => assert!(msg.contains("non-deterministic")),
+            other => panic!("expected Assertion, got {other:?}"),
+        }
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn assert_publishes_topic_misses_when_no_publish_happens() {
+        struct Quiet;
+        #[async_trait]
+        impl Plugin for Quiet {
+            fn manifest(&self) -> &'static str {
+                "[plugin]\nname = \"quiet\"\nversion = \"0.0.0\"\nabi_version = 2\n"
+            }
+            async fn render(
+                &mut self,
+                _h: &HostClient,
+                _p: RenderParams,
+            ) -> SdkResult<WireBuffer> {
+                Ok(WireBuffer::new(1, 1))
+            }
+        }
+        let mut h = run_plugin(Quiet);
+        h.init().await.expect("init ok");
+        let err = h
+            .assert_publishes_topic("never.published")
+            .await
+            .expect_err("no publish should fail assertion");
+        match err {
+            HarnessError::Assertion(msg) => assert!(msg.contains("never.published")),
+            other => panic!("expected Assertion, got {other:?}"),
+        }
+        h.close().await.expect("clean close");
+    }
+
+    #[tokio::test]
+    async fn recv_request_round_trips_plugin_initiated_call() {
+        // Plugin calls host.snapshot_get during render, expects a fake
+        // reply from the harness.
+        struct NeedsSnapshot;
+        #[async_trait]
+        impl Plugin for NeedsSnapshot {
+            fn manifest(&self) -> &'static str {
+                "[plugin]\nname = \"needs\"\nversion = \"0.0.0\"\nabi_version = 2\n"
+            }
+            async fn render(
+                &mut self,
+                host: &HostClient,
+                _: RenderParams,
+            ) -> SdkResult<WireBuffer> {
+                let snap = host.snapshot_get("topic.x").await?;
+                let mut b = WireBuffer::new(1, 1);
+                b.push(Coord::new(0, 0), Cell::new(format!("v{}", snap.version)));
+                Ok(b)
+            }
+        }
+
+        let mut h = run_plugin(NeedsSnapshot);
+        h.init().await.expect("init ok");
+
+        // Kick off render in a child task so we can answer the
+        // snapshot/get request the plugin issues mid-handler.
+        let render_send = tokio::spawn({
+            // We can't move &mut self into another task — instead,
+            // drive the request/response interleave directly:
+            async {}
+        });
+        drop(render_send);
+
+        // Send render manually so we control the loop.
+        let id = h.alloc_id();
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": methods::PLUGIN_RENDER,
+            "params": serde_json::to_value(RenderParams {
+                viewport: Viewport::new(1, 1),
+                generation: 0,
+            }).unwrap(),
+        });
+        h.write_frame(&body).await.unwrap();
+
+        // Pick up the plugin->host snapshot/get request.
+        let req = h
+            .recv_request(Duration::from_secs(2))
+            .await
+            .expect("plugin issued a request");
+        assert_eq!(req.method, methods::HOST_SNAPSHOT_GET);
+        assert_eq!(req.params["topic"], "topic.x");
+        let req_id = req.id.expect("plugin request has id");
+        h.respond(
+            req_id,
+            serde_json::json!({"payload": null, "version": 9}),
+        )
+        .await
+        .unwrap();
+
+        // Now the render response arrives.
+        let resp = h
+            .recv_response_for(id, Duration::from_secs(2))
+            .await
+            .expect("render response");
+        let result: RenderResult = serde_json::from_value(resp).unwrap();
+        assert_eq!(result.buffer.width, 1);
+
+        h.close().await.expect("clean close");
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-testkit/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-testkit/src/lib.rs
@@ -1,0 +1,93 @@
+//! In-process testing harness for ainb plugins.
+//!
+//! Plugin authors write a [`Plugin`](ainb_plugin_sdk::Plugin) impl, hand
+//! it to [`run_plugin`], and drive it from test code without spawning a
+//! subprocess. The harness wires the plugin into the SDK's stdio
+//! [`Server`](ainb_plugin_sdk::Server) over a [`tokio::io::DuplexStream`]
+//! pair, so the entire JSON-RPC + Content-Length framing path is
+//! exercised exactly as it would be in production — only the OS
+//! pipe is replaced.
+//!
+//! ## Why
+//!
+//! Subprocess plugin tests need a built binary on disk, an env var for
+//! the path, and a working multi-process tokio runtime. That is fine for
+//! end-to-end gates, but it is the wrong shape for a plugin author who
+//! just wants to assert "render with viewport (80, 24) returns a 1×1
+//! buffer". The testkit replaces all of that with a single function call.
+//!
+//! ## Quick smoke test in <30 lines
+//!
+//! ```no_run
+//! use ainb_plugin_testkit::{run_plugin, Viewport};
+//! use ainb_plugin_sdk::{HostClient, Plugin, Result};
+//! use ainb_plugin_sdk::{RenderParams, WireBuffer, Cell, Coord};
+//! use async_trait::async_trait;
+//!
+//! struct MyPlugin;
+//!
+//! #[async_trait]
+//! impl Plugin for MyPlugin {
+//!     fn manifest(&self) -> &'static str {
+//!         "[plugin]\nname = \"my\"\nversion = \"0.1.0\"\nabi_version = 2\n"
+//!     }
+//!     async fn render(&mut self, _h: &HostClient, _p: RenderParams) -> Result<WireBuffer> {
+//!         let mut b = WireBuffer::new(1, 1);
+//!         b.push(Coord::new(0, 0), Cell::new("X"));
+//!         Ok(b)
+//!     }
+//! }
+//!
+//! # tokio_test_runtime(async {
+//! let mut h = run_plugin(MyPlugin);
+//! h.init().await.unwrap();
+//! h.assert_render_round_trip(Viewport::new(1, 1)).await;
+//! h.close().await;
+//! # });
+//! # fn tokio_test_runtime<F: std::future::Future>(_: F) {}
+//! ```
+//!
+//! ## Architectural gates
+//!
+//! - **No `wasmi`** — subprocess-only world.
+//! - **No `ainb-plugin-api`** — the legacy in-tree wasm trait crate is
+//!   gone for testkit's purposes.
+//! - **Wire types come from [`ainb_plugin_protocol`]** (via the SDK
+//!   re-exports). Test code that needs `Manifest`, `RpcError`,
+//!   `WireBuffer`, etc. imports them from this crate so it never has to
+//!   know whether they live in protocol or sdk.
+//!
+//! ## Module map
+//!
+//! - [`harness`] — the [`Harness`] struct + [`run_plugin`] entry point
+//! - [`error`]   — testkit-specific [`HarnessError`]
+//! - re-exports — wire types from `ainb_plugin_protocol`
+
+#![doc(html_root_url = "https://docs.rs/ainb-plugin-testkit/0.1.0")]
+
+pub mod error;
+pub mod harness;
+
+pub use error::{HarnessError, HarnessResult};
+pub use harness::{run_plugin, Harness, ObservedFrame};
+
+// Re-export wire types from the protocol so test code only depends on
+// this crate. Mirrors the SDK's re-export surface so test authors don't
+// have to learn whether a type lives in protocol vs sdk.
+pub use ainb_plugin_protocol::{
+    errors::{
+        ACTION_TIMEOUT, CAPABILITY_DENIED, INVALID_PARAMS, MANIFEST_VALIDATION, METHOD_NOT_FOUND,
+        ProtocolError, RpcError,
+    },
+    manifest::Manifest,
+    methods,
+    params::{
+        ActionInvokeParams, ActionInvokeResult, CliDispatchParams, CliDispatchResult, FsDirEntry,
+        FsReadDirParams, FsReadDirResult, FsReadFileParams, FsReadFileResult, HandleEventParams,
+        LogLevel, LogParams, NetworkFetchParams, NetworkFetchResult, PluginInitParams,
+        PluginInitResult, PluginShutdownParams, PluginShutdownResult, RenderParams, RenderResult,
+        SnapshotGetParams, SnapshotGetResult, SnapshotPublishParams, SnapshotSubscribeParams,
+        SnapshotSubscribeResult, Viewport,
+    },
+    wire_buffer::{Cell, Color, Coord, WireBuffer},
+};

--- a/ainb-tui/crates/ainb-plugin-testkit/tests/fixture_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-testkit/tests/fixture_smoke.rs
@@ -1,0 +1,186 @@
+//! Smoke test: drive an SDK-based plugin with the same shape as the
+//! `ainb-plugin-runtime` subprocess fixture, end-to-end.
+//!
+//! The runtime's fixture binary
+//! (`crates/ainb-plugin-runtime/tests/fixtures/fixture_plugin.rs`) is a
+//! hand-rolled stdio loop with no SDK dependency — it exists to prove
+//! the runtime can speak the wire protocol against any conforming
+//! peer. This test mirrors the *behaviour* of that fixture inside the
+//! testkit's harness:
+//!
+//! - on init, publish snapshot `fixture.greeting` = `b"hello"`
+//! - on `plugin/render`, return a 1×1 buffer with `X` at (0, 0)
+//! - on `plugin/cli_dispatch`, return `stdout = "ok\n"`, exit code 0
+//! - clean shutdown
+//!
+//! If this test passes, third-party plugin authors can write the same
+//! shape against [`ainb_plugin_testkit::run_plugin`] without a single
+//! subprocess spawn.
+
+use std::time::Duration;
+
+use ainb_plugin_testkit::{
+    methods, run_plugin, CliDispatchParams, CliDispatchResult, HarnessError, RenderResult,
+    Viewport, WireBuffer,
+};
+use ainb_plugin_sdk::{CliOutput, HostClient, Plugin, Result as SdkResult};
+use ainb_plugin_protocol::params::RenderParams;
+use ainb_plugin_protocol::wire_buffer::{Cell, Coord};
+use async_trait::async_trait;
+
+struct FixturePlugin;
+
+#[async_trait]
+impl Plugin for FixturePlugin {
+    fn manifest(&self) -> &'static str {
+        "[plugin]\nname = \"fixture\"\nversion = \"0.1.0\"\nabi_version = 2\n"
+    }
+
+    async fn on_init(
+        &mut self,
+        host: &HostClient,
+        _granted: &[String],
+    ) -> SdkResult<()> {
+        host.snapshot_publish("fixture.greeting", bytes::Bytes::from_static(b"hello"))
+            .await
+    }
+
+    async fn render(
+        &mut self,
+        _host: &HostClient,
+        _params: RenderParams,
+    ) -> SdkResult<WireBuffer> {
+        let mut buf = WireBuffer::new(1, 1);
+        buf.push(Coord::new(0, 0), Cell::new("X"));
+        Ok(buf)
+    }
+
+    async fn cli_dispatch(
+        &mut self,
+        _host: &HostClient,
+        _namespace: &str,
+        _argv: &[String],
+    ) -> SdkResult<CliOutput> {
+        Ok(CliOutput::ok(b"ok\n".to_vec()))
+    }
+}
+
+#[tokio::test]
+async fn fixture_plugin_full_behaviour_round_trip() -> Result<(), HarnessError> {
+    let mut h = run_plugin(FixturePlugin);
+
+    // 1. init
+    let init = h.init().await?;
+    assert_eq!(init["name"], "fixture");
+    assert_eq!(init["version"], "0.1.0");
+
+    // 2. on_init published a snapshot — the assertion drains briefly.
+    h.assert_publishes_topic("fixture.greeting").await?;
+
+    // 3. render returns the expected 1×1 X buffer.
+    let buf = h.render(Viewport::new(80, 24)).await?;
+    assert_eq!(buf.width, 1);
+    assert_eq!(buf.height, 1);
+    assert_eq!(buf.cells.len(), 1);
+
+    // 4. cli_dispatch returns "ok\n" with exit 0.
+    let value = h
+        .send_request(
+            methods::PLUGIN_CLI_DISPATCH,
+            CliDispatchParams {
+                namespace: "fixture".into(),
+                argv: vec!["status".into()],
+            },
+        )
+        .await?;
+    let cli: CliDispatchResult = serde_json::from_value(value)?;
+    assert_eq!(&cli.stdout[..], b"ok\n");
+    assert_eq!(cli.exit_code, 0);
+
+    // 5. round-trip determinism.
+    h.assert_render_round_trip(Viewport::new(8, 4)).await?;
+
+    h.close().await
+}
+
+#[tokio::test]
+async fn harness_surfaces_default_cli_dispatch_unknown_namespace() -> Result<(), HarnessError> {
+    // A plugin that does NOT override cli_dispatch falls back to the
+    // SDK default (exit 2, stderr "plugin does not handle namespace ...").
+    struct NoCli;
+    #[async_trait]
+    impl Plugin for NoCli {
+        fn manifest(&self) -> &'static str {
+            "[plugin]\nname = \"no-cli\"\nversion = \"0.0.0\"\nabi_version = 2\n"
+        }
+        async fn render(
+            &mut self,
+            _h: &HostClient,
+            _p: RenderParams,
+        ) -> SdkResult<WireBuffer> {
+            Ok(WireBuffer::new(0, 0))
+        }
+    }
+
+    let mut h = run_plugin(NoCli);
+    h.init().await?;
+    let value = h
+        .send_request(
+            methods::PLUGIN_CLI_DISPATCH,
+            CliDispatchParams {
+                namespace: "anything".into(),
+                argv: vec![],
+            },
+        )
+        .await?;
+    let cli: CliDispatchResult = serde_json::from_value(value)?;
+    assert_eq!(cli.exit_code, 2);
+    assert!(String::from_utf8_lossy(&cli.stderr).contains("anything"));
+    h.close().await
+}
+
+#[tokio::test]
+async fn close_unblocks_when_plugin_did_no_work() -> Result<(), HarnessError> {
+    // Edge case: prove that `close` works even on a freshly-spawned
+    // plugin that never received init. Catches regressions where
+    // shutdown notification handling depends on prior state.
+    struct Bare;
+    #[async_trait]
+    impl Plugin for Bare {
+        fn manifest(&self) -> &'static str {
+            "[plugin]\nname = \"bare\"\nversion = \"0.0.0\"\nabi_version = 2\n"
+        }
+        async fn render(
+            &mut self,
+            _h: &HostClient,
+            _p: RenderParams,
+        ) -> SdkResult<WireBuffer> {
+            Ok(WireBuffer::new(0, 0))
+        }
+    }
+
+    let h = run_plugin(Bare);
+    tokio::time::timeout(Duration::from_secs(2), h.close())
+        .await
+        .map_err(|_| HarnessError::Assertion("close hung past 2s".into()))?
+}
+
+#[tokio::test]
+async fn render_result_is_typed_decodable() -> Result<(), HarnessError> {
+    // Prove that send_request returns a Value the user can decode into
+    // the typed RenderResult from the re-exported wire types.
+    let mut h = run_plugin(FixturePlugin);
+    h.init().await?;
+    let value = h
+        .send_request(
+            methods::PLUGIN_RENDER,
+            RenderParams {
+                viewport: Viewport::new(2, 2),
+                generation: 0,
+            },
+        )
+        .await?;
+    let result: RenderResult = serde_json::from_value(value)?;
+    assert_eq!(result.buffer.width, 1);
+    h.close().await
+}


### PR DESCRIPTION
## Summary

Phase 7d-testkit — `ainb-plugin-testkit` crate. In-process harness for plugin authors to write smoke tests against their Plugin impl without spawning a subprocess.

Bead: `agents-in-a-box-bnz`. Sister: `agents-in-a-box-ci3` (CLI watch/tail/lint, separate PR).

## Surface

```rust
pub fn run_plugin<P: Plugin>(plugin: P) -> Harness;

impl Harness {
    fn init(...) -> Result<()>;
    fn render(viewport) -> Result<RenderOutcome>;
    fn send_request(method, params) -> Result<Response>;
    fn send_notification(method, params) -> Result<()>;
    fn send_event(topic, payload) -> Result<()>;
    fn recv_request() -> Result<ObservedFrame>;
    fn recv_observed() -> Result<ObservedFrame>;
    fn respond(id, result) -> Result<()>;
    fn respond_error(id, code, message) -> Result<()>;
    fn close() -> Result<()>;
    fn drain_until_quiet(timeout) -> Vec<ObservedFrame>;
    fn observed_frames() -> &[ObservedFrame];
    fn clear_observed();

    // Replay assertions
    fn assert_render_round_trip(viewport) -> Result<()>;
    fn assert_publishes_topic(topic: &str) -> Result<()>;
}

pub struct ObservedFrame { method, params, id, is_notification, is_request }
pub enum HarnessError { ... } pub type HarnessResult<T> = ...;
```

Re-exports: `Manifest`, `RpcError`, `ProtocolError`, all params/wire_buffer types, method constants, error code constants — so test code only needs `ainb-plugin-testkit` as dep.

## Architecture

In-process harness over `tokio::io::DuplexStream`. Spawns the SDK's `Server::new(plugin).run_stdio()` on one half; test code drives the other half. Zero subprocess overhead → fast tests.

`P: Plugin` bound enforces `Send + 'static`.

## Commits (2 atomic)

- `29296be` feat(plugin-testkit): scaffold ainb-plugin-testkit crate with in-process Harness
- `a1af6a0` test(plugin-testkit): smoke test mirroring runtime fixture-plugin behaviour

## Architectural gates (all PASS)

| gate | result |
|---|---|
| zero wasmi imports | ✅ |
| zero ainb-plugin-api imports | ✅ |
| wire types from ainb-plugin-protocol (via SDK re-export) | ✅ |
| `[lib]` only, no `[[bin]]` | ✅ |
| `Send + 'static` enforced via `P: Plugin` trait bound | ✅ |

## Test plan

- [x] `cargo build -p ainb-plugin-testkit` ✅
- [x] `cargo clippy -p ainb-plugin-testkit --all-targets -- -D warnings` ✅
- [x] `cargo test -p ainb-plugin-testkit` — 8 unit (harness::tests) + 4 integration (fixture_smoke.rs) + 1 doc test ✅

## Workspace caveat

50/51 workspace tests passed. 1 env-flake on `git_operations::test_repository_current_branch_detection` (gpg signing OOM under parallel rustc load with sister agent's build); passes in isolation, unrelated to testkit. Same pre-existing `test_previous_session` failure inherited from `40ec952` parent.

Bead: `agents-in-a-box-bnz`
