### PR TITLE
fix(plugin-runtime): honour SpawnMode::Eager + re-sign staged plugins on macOS

### DIFF
--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/SKILL.md
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: tmux-ui-tripwire
+description: Write or debug tmux-driven end-to-end TUI tests ("tripwires") for the ainb terminal app. Use when the user asks to "write a tmux test", "add a tripwire", "verify the TUI in tmux", "test feature X by pressing key Y", "validate plugin Z renders", or when editing any file under `crates/ainb-core/tests/tripwire_*.rs`. Codifies the silent traps we hit during Phase 7 plugin testing — macOS AMFI SIGKILL of staged binaries (exit 137, no stderr), first-run wizard intercepting keystrokes, EnvFilter crate-name drift hiding logs, and substring-OR assertions that pass while the feature is broken. Use proactively before writing any new `tripwire_*.rs` test, and reference whenever an existing tripwire fails for non-obvious reasons.
+---
+
+# tmux-ui-tripwire
+
+## Overview
+
+Tripwire tests drive the real `ainb` TUI binary in a detached `tmux` session, send keystrokes, capture the pane, and assert on rendered output. They are the ONLY tests that catch user-visible regressions the unit tests miss (e.g. plugin pipeline broken but `cargo test` green).
+
+## When to use this skill
+
+- Writing a new `tripwire_*.rs` test
+- An existing tripwire fails and the cause isn't obvious from `cargo test` output
+- Tightening a tripwire whose assertions look weak (substring-OR on chrome strings)
+- Diagnosing why a plugin "spawns but doesn't render"
+
+## Quick start — minimal viable tripwire
+
+```rust
+// crates/ainb-core/tests/tripwire_<feature>.rs
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+// 1. Skip gracefully if env can't support the test.
+fn tmux_available() -> bool { /* see references/helpers.md */ }
+fn ainb_bin() -> PathBuf { PathBuf::from(env!("CARGO_BIN_EXE_ainb")) }
+
+#[test]
+fn feature_renders_after_pressing_x() {
+    if !tmux_available() { eprintln!("SKIP: tmux"); return; }
+    // 2. Isolated HOME — seed onboarding.toml to skip wizard.
+    let home = tempfile::tempdir().unwrap();
+    seed_isolated_home(home.path());
+
+    // 3. Launch ainb tui in detached tmux session.
+    let session = format!("tripwire-{}", std::process::id());
+    Command::new("tmux").args(["new-session","-d","-s",&session,"-x","180","-y","50"]).status().unwrap();
+    let cmd = format!("HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        home.path().display(), ainb_bin().display());
+    Command::new("tmux").args(["send-keys","-t",&session,&cmd,"Enter"]).status().unwrap();
+
+    // 4. Wait for HomeScreen — poll, don't bare-sleep.
+    let pre = poll_capture(&session, Instant::now() + Duration::from_secs(45),
+        |c| c.contains("Stats") && c.contains("[i]")).expect("HomeScreen never rendered");
+
+    // 5. Pre-press negative assertion — confirm we're not already on target screen.
+    assert!(!pre.contains("Usage Analytics"));
+
+    // 6. Send key WITHOUT Enter (single-char nav).
+    Command::new("tmux").args(["send-keys","-t",&session,"x"]).status().unwrap();
+
+    // 7. Post-press: positive marker AND negative placeholder.
+    let post = poll_capture(&session, Instant::now() + Duration::from_secs(30),
+        |c| c.contains("Expected Chrome") && !c.contains("Loading placeholder"))
+        .unwrap_or_else(|| capture_pane(&session));
+    Command::new("tmux").args(["kill-session","-t",&session]).status().ok();
+
+    assert!(post.contains("Expected Chrome"), "feature chrome never rendered:\n{post}");
+    assert!(!post.contains("Loading placeholder"), "stuck on placeholder:\n{post}");
+}
+```
+
+Full copy-paste helper functions in `references/helpers.md`.
+
+## Required pre-work
+
+| Step | Command | Why |
+|---|---|---|
+| Stage plugins (if test exercises plugin path) | `just stage-plugins` | Plugins live at `dist/plugins/<id>/<id>` and are re-signed for macOS AMFI |
+| Build ainb | `cargo build -p ainb` | Test resolves binary via `env!("CARGO_BIN_EXE_ainb")` |
+
+## Hard rules (violating these costs hours)
+
+1. **NEVER `tmux kill-server`, `pkill tmux`, `killall tmux`, or wildcard kill.** Only `tmux kill-session -t <exact-name>`. Other agents/dev sessions live in tmux.
+2. **NEVER assert with substring-OR on chrome strings** (`"ainb"`, `"session"`, `"Container"`). They appear in sidebar regardless of whether the feature under test rendered. The original 7f.3 passed for 4+ commits while burndown was broken. Always pair a POSITIVE marker with a NEGATIVE placeholder check.
+3. **NEVER append `Enter` to a single-character keystroke.** `tmux send-keys -t S "i"` for nav keys. `Enter` as a SEPARATE arg is only for committing a shell command line.
+4. **NEVER use bare `sleep` before capture.** TUI render rate is 4–30 Hz. Use `poll_capture(deadline, predicate)` with 500 ms internal sleep.
+5. **NEVER grep `Cargo.toml` for the version in a shell wrapper.** Workspace crates have `version.workspace = true` literally — grepping returns that string, breaks the wizard-skip seed. Use `env!("CARGO_PKG_VERSION")` in Rust or read `[workspace.package].version` from the root `Cargo.toml`.
+
+## Two-tmux pattern — KEEP BOTH PATHS
+
+Keep BOTH a plugin-path test AND a non-plugin-path test:
+
+| Test | Key | Env | Purpose |
+|---|---|---|---|
+| `tripwire_real_data_in_tui` | `i` | normal (plugins active) | Verifies plugin pipeline end-to-end |
+| `tripwire_sessions_screen` | `s` | `AINB_DISABLE_PLUGINS=1` | Verifies host's own code path isn't broken by plugin refactors |
+
+A refactor that breaks one shouldn't silently pass the other. If you add a new screen test, also add a regression test for the opposite path.
+
+## Workflow when a tripwire fails
+
+1. **Run with `--nocapture`** — `cargo test -p ainb --test tripwire_X -- --nocapture` to see SKIP messages and panic output.
+2. **Read the captured pane in the panic message** — it shows what the test actually saw. Often the cause is staring at you (wizard, loading state, wrong screen).
+3. **Check the JSONL log** — `~/.agents-in-a-box/logs/agents-in-a-box-*.jsonl`. Key markers:
+   - `"registered plugin"` × N — discovery worked
+   - `"eager spawn failed: Broken pipe"` + `"plugin exited / pipe closed"` — likely macOS AMFI silent kill (see `references/amfi.md`)
+   - `"inbound request"` / `"host->plugin response"` — wire dialog active
+   - `plugin = "<name>"` entries — `host.log()` from plugins
+4. **Standalone-probe the plugin** if Bug-2-like symptoms:
+   ```
+   ./dist/plugins/<id>/<id> </dev/null; echo $?
+   ```
+   Exit 137 in <1ms = AMFI kill. Fix: `just stage-plugins` (re-signs).
+
+## When to consult the references
+
+| Question | File |
+|---|---|
+| What's the exact code for `poll_capture`, `seed_isolated_home`, etc.? | `references/helpers.md` |
+| Why does my plugin exit 137 with no stderr? | `references/amfi.md` |
+| How do I seed synthetic Claude data for `$N.NN` assertions? | `references/seed-data.md` |
+| Full gotcha checklist (10 silent traps) | `references/gotchas.md` |
+| Existing tripwires to copy patterns from | `references/existing-tests.md` |
+
+## Source files (current state, May 2026)
+
+- `crates/ainb-core/tests/tripwire_real_data_in_tui.rs` — plugin-path tripwire (canonical example)
+- `crates/ainb-core/tests/tripwire_sessions_screen.rs` — non-plugin-path tripwire
+- `scripts/build-plugins.sh` — `just stage-plugins` implementation (codesign re-sign on macOS)
+- `crates/ainb-core/src/main.rs` `setup_logging()` — default `EnvFilter` widened to include plugin crates

--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/references/amfi.md
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/references/amfi.md
@@ -1,0 +1,96 @@
+# amfi.md — macOS AMFI silent SIGKILL of staged plugins
+
+## Symptom
+
+You stage a plugin binary via `cp target/debug/X dist/plugins/Y/Y`.
+Standalone the binary appears fine. When launched by the ainb runtime:
+
+- Host JSONL shows `eager spawn failed: protocol: transport: Broken pipe (os error 32)`
+- Then `plugin exited / pipe closed`
+- Plugin's `eprintln!` at the top of `main()` produces NO stderr
+- TUI is stuck on `⏳ Waiting for <plugin> plugin...`
+
+## Root cause
+
+Cargo links debug binaries with **ad-hoc, linker-signed Mach-O signatures
+bound to the original build path**. The signature hash includes the file
+path. `cp` to a new path invalidates the signature. macOS AMFI (Apple
+Mobile File Integrity) silently SIGKILLs the process at `exec()` time —
+no stderr, no crash log, exit 137 in <1ms. The host's first `write_frame`
+hits the closed pipe and reports `Broken pipe`, which looks like a
+runtime wire bug rather than a kernel-level kill.
+
+This affects ANY copy/move of a debug binary on macOS (Apple Silicon and
+Intel). Release binaries (`--release`) are also linker-signed but rarely
+moved, so this trap hits dev workflows specifically.
+
+## Diagnostic recipe
+
+One command tells you definitively:
+
+```bash
+./dist/plugins/<id>/<id> </dev/null; echo "exit=$?"
+```
+
+| Output | Diagnosis |
+|---|---|
+| `exit=137` in <1ms, no stderr | AMFI kill — needs re-sign |
+| `exit=0` and plugin ran for a moment | Binary is fine, look elsewhere |
+| Plugin prints stderr then hangs | Not AMFI — actual code path bug |
+
+Other useful probes:
+
+```bash
+codesign -dv ./dist/plugins/<id>/<id> 2>&1
+# Look for: "Format=Mach-O thin (arm64)" "Signature=adhoc" "linker-signed"
+
+cmp target/debug/<crate> dist/plugins/<id>/<id> && echo "identical bytes"
+# Confirms cp produced identical content — AMFI is about PATH, not bytes
+
+shasum target/debug/<crate> dist/plugins/<id>/<id>
+# Same shasum, different runtime behaviour = AMFI path binding
+```
+
+## Fix
+
+Re-sign after copy:
+
+```bash
+codesign --remove-signature <path-to-staged-bin>
+codesign --sign - <path-to-staged-bin>
+```
+
+Already baked into `scripts/build-plugins.sh`:
+
+```bash
+resign_macos() {
+    local bin="$1"
+    [[ "$(uname -s)" != "Darwin" ]] && return 0
+    codesign --remove-signature "$bin" >/dev/null 2>&1 || true
+    codesign --sign - "$bin" >/dev/null 2>&1
+}
+```
+
+Just run `just stage-plugins` — it handles cp + re-sign in one pass.
+
+## Misleading red herrings
+
+| What looks like the cause | What it actually means |
+|---|---|
+| `Broken pipe (os error 32)` in host log | The pipe IS broken — but because AMFI killed the child, not because of a wire bug |
+| `spctl -a -t exec <bin>` returns "rejected" | Normal for ad-hoc binaries; not the cause of the kill |
+| No stderr from plugin's `eprintln!` in `main()` | `main()` literally never executed; the kernel killed the process between `exec()` and the first instruction |
+| Identical shasum, identical xattrs, identical permissions | Doesn't matter — AMFI hashes the PATH into the signature check |
+| Burndown loads but session-reader doesn't | Pattern: session-reader is `spawn = "eager"` so it spawns at registration; burndown is `spawn = "lazy"` so it only spawns on first request. Lazy plugins reveal the bug later. Both are affected. |
+
+## CI / Linux
+
+Linux doesn't have AMFI. The `resign_macos` function noops on
+`uname -s != Darwin`. CI on Linux runs without the trap.
+
+## Why we don't ship signed builds
+
+Re-signing with a Developer ID is the "proper" fix but requires Apple
+Developer enrollment + entitlements + notarization. For dev workflow
+and `just stage-plugins`, ad-hoc re-sign (`codesign --sign -`) is
+sufficient — AMFI accepts ad-hoc signatures bound to the current path.

--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/references/existing-tests.md
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/references/existing-tests.md
@@ -1,0 +1,109 @@
+# existing-tests.md — current tripwires to copy patterns from
+
+## tripwire_real_data_in_tui (plugin path)
+
+**File:** `crates/ainb-core/tests/tripwire_real_data_in_tui.rs`
+
+**What it proves:** Burndown analytics screen renders with real session
+data after the user presses `i` from HomeScreen. Catches Phase 7 plugin
+pipeline regressions (eager-spawn, AMFI re-sign, snapshot publish/subscribe).
+
+**Setup:**
+- Isolated HOME via `tempfile::tempdir()`
+- Pre-seeded `onboarding.toml` (wizard skip)
+- Pre-seeded synthetic claude jsonl (one `assistant` line, 1000+500 tokens,
+  `claude-sonnet-4-5`) — produces ~$0.0105 cost so `$0.` matches
+- Plugin staging probe: skip if `dist/plugins/{burndown,session-reader}` absent
+- Launches with `AINB_PLUGIN_ROOT=<staged>` (NOT `AINB_DISABLE_PLUGINS=1`)
+
+**Keystroke:** `"i"` (single char, no Enter)
+
+**Assertions:**
+- Pre-press: contains `"Stats"` AND `"[i]"`, does NOT contain `"Usage Analytics"`
+- Post-press (must satisfy ALL):
+  - contains `"Usage Analytics"` (chrome present)
+  - does NOT contain `"Waiting for session-reader plugin"` (placeholder gone)
+  - contains `"Total Calls"` OR `"Total Cost"` OR `"$0."` OR `"$N."` (real data)
+
+**Runtime:** ~6s on M1
+
+**Skip conditions:** tmux not available; plugins not staged
+
+## tripwire_sessions_screen (non-plugin path)
+
+**File:** `crates/ainb-core/tests/tripwire_sessions_screen.rs`
+
+**What it proves:** Session List screen (host-owned, no plugin involved)
+renders when the user presses `s`. Sister test to the plugin path —
+catches regressions where a plugin refactor breaks the host's own UI code.
+
+**Setup:**
+- Isolated HOME via `tempfile::tempdir()`
+- Pre-seeded `onboarding.toml`
+- NO data seeded (empty-state render is fine — accepts "Select a session
+  to view details" OR a session list, since fresh tempdir has no sessions)
+- Launches with `AINB_DISABLE_PLUGINS=1` (faster, no plugin staging needed)
+
+**Keystroke:** `"s"`
+
+**Assertions:**
+- Pre-press: contains `"Sessions"` AND `"[s]"`, does NOT contain `"Session List"` chrome
+- Post-press:
+  - contains `"Session Details"` OR `"Select a session to view details"`
+    OR (`"attach"` AND `"restart"` AND `"cleanup"`)
+  - does NOT contain `"Usage Analytics"` (didn't drift to wrong screen)
+
+**Runtime:** ~6s on M1
+
+**Skip conditions:** tmux not available (no plugin gate — pure host path)
+
+## tripwire_reproduced (non-tmux, supporting tests)
+
+**File:** `crates/ainb-core/tests/tripwire_reproduced.rs`
+
+**What it proves:** Pre-Phase-7 wasmi tripwires reproduced through the
+new subprocess runtime (action invoke, render, snapshot publish, CLI
+lint). Pure in-process tests — no tmux involved.
+
+**When to mirror:** When you need to assert on plugin runtime behaviour
+WITHOUT a UI — these tests run faster and are easier to debug than tmux
+tripwires. Use the tmux path only when the user-visible TUI is what
+matters.
+
+## Anti-pattern: the original 7f.3 (pre-tightening)
+
+The original assertion was substring-OR on chrome strings:
+
+```rust
+// DON'T DO THIS — copied here as a cautionary tale.
+assert!(
+    capture.contains("ainb")
+    || capture.contains("Container")
+    || capture.contains("session")
+    || capture.contains("Workspace")
+);
+```
+
+All four substrings appear in the sidebar regardless of whether the
+feature under test rendered. Test was green for 4+ commits while
+burndown was broken. The fix was the tightened assertion in the current
+`tripwire_real_data_in_tui` — pair POSITIVE markers with NEGATIVE
+placeholder checks.
+
+## How to add a new tripwire
+
+1. Decide path: plugin (`AINB_PLUGIN_ROOT=...`) or non-plugin (`AINB_DISABLE_PLUGINS=1`)
+2. Copy helper functions from `helpers.md` into the new test file
+3. Decide keystroke + expected screen markers
+4. Pick a UNIQUE marker pair (positive screen marker + negative placeholder/wrong-screen marker)
+5. If asserting real-data, seed via `seed-data.md`
+6. Run: `just stage-plugins && cargo test -p ainb --test tripwire_<name> -- --nocapture`
+7. Iterate on assertion strictness — first run with weak assertions to
+   discover what the pane actually contains, then tighten
+
+## Naming convention
+
+`tripwire_<feature>_<verb>.rs` in `crates/ainb-core/tests/`. Test function
+inside named `<feature>_renders_after_pressing_<key>` or similar declarative
+form. One test per file (cargo runs them in parallel processes — different
+tmux sessions don't collide).

--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/references/gotchas.md
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/references/gotchas.md
@@ -1,0 +1,122 @@
+# gotchas.md — silent traps that cost hours
+
+Each item burned at least one debugging session. Reading this file before
+writing a new tripwire prevents re-learning these the hard way.
+
+## 1. macOS AMFI silent SIGKILL
+
+See `amfi.md`. Exit 137 in <1ms, no stderr, host reports `Broken pipe`.
+Fix: `just stage-plugins` re-signs after `cp`.
+
+## 2. `version.workspace = true` literal
+
+Workspace member `Cargo.toml` files have `version.workspace = true` —
+that string is what `grep '^version' Cargo.toml` returns. Don't use shell
+greps for the version in test seeds. Use `env!("CARGO_PKG_VERSION")` in
+Rust or read `[workspace.package].version` from the root `Cargo.toml`.
+
+## 3. EnvFilter default crate-name drift
+
+`crates/ainb-core/src/main.rs::setup_logging()` used to default to
+`agents_box=info` — a crate name that no longer exists after the Phase 7
+rename. Anything the plugin runtime emitted was silently dropped. Now
+defaults to `info,ainb_plugin_runtime=debug,...`. If logs are missing
+when debugging, check the EnvFilter default matches the current crate
+names. Override via `RUST_LOG=...`.
+
+## 4. `drain_stderr` was debug-level
+
+The host's stderr drain logged plugin output at `debug!`, which the
+default filter excluded. Bumped to `info!` — plugin `eprintln!` now
+appears by default. If you add a new diagnostic `eprintln!` and don't
+see it in the JSONL, check this hasn't regressed.
+
+## 5. Substring-OR assertion theater
+
+The original 7f.3 asserted on `c.contains("ainb") || c.contains("session") || c.contains("Container")`.
+All three appear in the sidebar regardless of feature state. Test passed
+for 4+ commits while burndown was broken. **Always pair a POSITIVE marker
+with a NEGATIVE placeholder check** AND **assert pre-press state is NOT
+already the post-press state** (catches stale-state leaks).
+
+## 6. First-run wizard intercepts keystrokes
+
+The setup wizard eats every keystroke until completed. If your test
+sends `i` and the capture still shows "Welcome to AINB", the wizard is
+in the way. Fix: pre-seed `$HOME/.agents-in-a-box/config/onboarding.toml`
+BEFORE launch. See `helpers.md::seed_isolated_home`.
+
+## 7. `send-keys` Enter pitfall
+
+```
+tmux send-keys -t S "iEnter"      # wrong — sends literal "iEnter"
+tmux send-keys -t S "i" Enter     # wrong for nav — sends i then Enter
+tmux send-keys -t S "i"           # right — single-char nav
+tmux send-keys -t S "cmd" Enter   # right — shell line + commit
+```
+
+Enter is a SEPARATE argument, only for committing shell command lines.
+Single-character TUI keybindings should NEVER have it appended.
+
+## 8. Bare `sleep` before capture
+
+TUI render rate is 4–30 Hz. A bare `sleep 2` after `send-keys` may catch
+a transient state. Always poll:
+
+```rust
+let post = poll_capture(&session, Instant::now() + Duration::from_secs(30),
+    |c| /* predicate */).unwrap_or_else(|| capture_pane(&session));
+```
+
+Predicate runs against each capture every 500 ms until deadline. Faster
+when the state appears, deterministic when it doesn't.
+
+## 9. Multi-plugin registration ordering
+
+Plugins are registered in discovery order. If your test only watches one
+plugin's lifecycle, you may miss that ANOTHER plugin failed (e.g.
+session-reader is eager so it spawns immediately; burndown is lazy so
+its failure surfaces later only when the user presses `i`). Check JSONL
+for BOTH `registered plugin` lines AND each plugin's subsequent
+lifecycle events.
+
+## 10. Hardlink vs re-sign
+
+A hardlink (`ln`) shares the inode and therefore the original signature
+path-binding, but the *path* used to launch the binary is what AMFI
+checks at `exec()` time. Hardlinking from `dist/plugins/<id>/<id>` to
+`target/debug/<crate>` does NOT bypass the kill — the dist path is still
+the one the host execs. Re-sign is the only reliable fix on macOS.
+
+## 11. tmux geometry default varies
+
+Without explicit `-x 180 -y 50`, tmux uses the calling terminal's
+geometry (or 80×24 in `-d` mode). Width-sensitive renders (burndown
+bars, multi-column layouts) shift between hosts. ALWAYS set explicit
+geometry. 180×50 is the agreed default for ainb tripwires.
+
+## 12. `exec` vs no-`exec` in launch command
+
+```rust
+let cmd = format!("HOME={} exec {} tui", ...);
+```
+
+`exec` replaces the shell with the ainb binary. Without `exec`, the
+shell stays as PID 1 in the tmux pane and any future `send-keys`
+goes to the shell, not ainb. Always include `exec`.
+
+## 13. `kill_on_drop` on host's Child
+
+The host runtime's `Command::new(...).kill_on_drop(true)` means if the
+host's plugin task panics or returns Err early, the child process gets
+SIGKILLed. That's correct behaviour, but it means an unrelated panic in
+the host can mask the real symptom (plugin appears killed, but the
+killer was the host's own teardown). Read the JSONL chronologically.
+
+## 14. `tempfile::tempdir()` cleanup races
+
+`tempdir()` is cleaned up when its handle drops. If a test panics, the
+dir may stay around (Rust's panic unwinding may or may not run the
+drop). If tripwires leave `/var/folders/.../tmp.*` orphans, that's why.
+Periodic `rm -rf /var/folders/*/T/tmp.*` is fine (or `mktemp -d` from
+shell wrappers — manual cleanup).

--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/references/helpers.md
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/references/helpers.md
@@ -1,0 +1,184 @@
+# helpers.md — copy-paste Rust scaffolding for tripwires
+
+Drop these into the top of any `crates/ainb-core/tests/tripwire_*.rs`. All
+proven in `tripwire_real_data_in_tui.rs` and `tripwire_sessions_screen.rs`.
+
+## Imports
+
+```rust
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+```
+
+## Binary + tmux probes
+
+```rust
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+```
+
+## Staged-plugin discovery (only if test exercises plugin path)
+
+```rust
+/// Walk up from the ainb binary looking for `dist/plugins/`. Returns
+/// `None` if absent so the test can skip rather than fail in fresh
+/// checkouts where `just stage-plugins` hasn't been run.
+fn plugins_staged() -> Option<PathBuf> {
+    let bin = ainb_bin();
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate.join("session-reader").join("session-reader").exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+```
+
+## Isolated HOME + wizard skip
+
+```rust
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+}
+```
+
+Critical: `env!("CARGO_PKG_VERSION")` not a shell grep — workspace crates
+literally have `version.workspace = true` in their Cargo.toml.
+
+## Capture + poll
+
+```rust
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Poll `capture_pane` every 500ms until `predicate(captured)` is true
+/// or `deadline` elapses. Returns the matching capture, or `None`.
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+```
+
+## Session lifecycle
+
+```rust
+fn kill_session(session: &str) {
+    // Specific session by EXACT name. Never kill-server, never wildcard.
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .status();
+}
+```
+
+## Launch pattern
+
+```rust
+let session = format!("tripwire-<feature>-{}", std::process::id());
+
+// Geometry must be explicit and consistent — render output depends on it.
+let status = Command::new("tmux")
+    .args([
+        "new-session", "-d", "-s", &session,
+        "-x", "180", "-y", "50",
+    ])
+    .status()
+    .expect("tmux new-session");
+assert!(status.success(), "tmux new-session failed");
+
+// `exec` replaces the shell — keystrokes hit ainb directly, no shell
+// prefix to escape. Env vars go on the command line, not via tmux setenv
+// (tmux setenv only affects future panes, not the one we just created).
+let cmd = format!(
+    "HOME={} AINB_PLUGIN_ROOT={} exec {} tui",
+    home_tmp.path().display(),
+    plugin_root.display(),
+    ainb_bin().display(),
+);
+Command::new("tmux")
+    .args(["send-keys", "-t", &session, &cmd, "Enter"])
+    .status()
+    .expect("send launch cmd");
+```
+
+For non-plugin path tests, drop `AINB_PLUGIN_ROOT` and add `AINB_DISABLE_PLUGINS=1`:
+
+```rust
+let cmd = format!(
+    "HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+    home_tmp.path().display(),
+    ainb_bin().display(),
+);
+```
+
+## Keystroke pattern
+
+```rust
+// Single-character nav — NO trailing Enter.
+Command::new("tmux")
+    .args(["send-keys", "-t", &session, "i"])
+    .status()
+    .expect("send i");
+
+// Multi-character line — Enter is a SEPARATE argument, not appended.
+Command::new("tmux")
+    .args(["send-keys", "-t", &session, ":some-command", "Enter"])
+    .status()
+    .expect("send command");
+```
+
+## End-of-test teardown (with capture on failure)
+
+```rust
+let final_cap = post_cap.unwrap_or_else(|| capture_pane(&session));
+kill_session(&session);
+
+assert!(
+    final_cap.contains("Usage Analytics"),
+    "analytics screen never rendered after 'i'.\n{final_cap}"
+);
+```
+
+Always include the captured pane in assertion messages — debugging is 10×
+faster when you can see what the test actually saw.

--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/references/seed-data.md
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/references/seed-data.md
@@ -1,0 +1,78 @@
+# seed-data.md — synthetic fixture data for tripwire assertions
+
+## When you need this
+
+Asserting on real-data markers like `Total Calls: <n>`, `$<digit>.<digit>`,
+or non-zero session counts requires the isolated HOME to contain data
+session-reader can scan. An empty `tempdir` HOME gives a zero-state
+render — burndown shows `Total: 0 tokens · 0 days · 0 projects · 0 sessions`
+which proves the pipeline works but won't satisfy strict assertions.
+
+## Claude session — synthetic jsonl
+
+session-reader's claude parser walks `~/.claude/projects/<project>/*.jsonl`
+and looks for `type:"assistant"` lines with `message.usage.input_tokens` /
+`output_tokens`.
+
+Seed shape (one assistant turn = one priced call):
+
+```rust
+let proj_dir = home
+    .join(".claude")
+    .join("projects")
+    .join("-tripwire-fixture-project");
+fs::create_dir_all(&proj_dir).expect("create claude project dir");
+
+let session_jsonl = r#"{"type":"assistant","timestamp":"2026-05-10T12:00:00.000Z","sessionId":"fixture-session-1","cwd":"/tmp/x","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#;
+fs::write(
+    proj_dir.join("fixture-session-1.jsonl"),
+    session_jsonl,
+)
+.expect("seed synthetic claude jsonl");
+```
+
+Notes:
+
+- `model` must match a known pricing entry in `ainb-plugin-burndown` —
+  `claude-sonnet-4-5` works as of May 2026. If pricing tables move,
+  burndown will render the call but with `$0.00` cost.
+- One assistant line per file is enough — the parser handles JSONL
+  line-by-line.
+- Multiple files in the project dir aggregate; multiple project dirs
+  bump the "projects" count.
+- `timestamp` controls which day bucket the call lands in (UTC).
+  Recent timestamps (within last 30 days) show up in "Last 7 days" and
+  similar default windows.
+
+## Codex / Gemini / Copilot
+
+Same pattern, different paths:
+
+| Provider | Path | Format |
+|---|---|---|
+| Codex | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl` | check `crates/ainb-plugin-session-reader/src/parsers/codex.rs` |
+| Gemini | (see `parsers/gemini.rs`) | TBD |
+| Copilot | (see `parsers/copilot.rs`) | TBD |
+
+For tripwires that only need *some* data, claude is the simplest seed —
+shallowest dir tree, well-documented shape.
+
+## What the seed proves
+
+A single 1000-input/500-output sonnet-4-5 call produces:
+
+- Total Calls: `1`
+- Total Cost: ~`$0.0105` (sonnet-4-5 input $3/M, output $15/M)
+- Renders `$0.` substring → satisfies `c.contains("$0.")` in test assertions
+- 1 project, 1 session, 1 day
+
+## Pitfalls
+
+| Pitfall | Symptom | Fix |
+|---|---|---|
+| Forgot `cwd` field | Parser may drop the line | Include `"cwd":"/tmp/x"` |
+| Used unknown model name | Calls show but $0.00 cost | Use `claude-sonnet-4-5` or check current pricing table |
+| Timestamps in distant past | Default-window aggregation filters them out | Use recent timestamps (within last 7-30 days) |
+| Forgot trailing newline in jsonl | Parser may miss the last line | End the string with `\n` |
+| jsonl with non-`type:"assistant"` lines only | Zero data even though file exists | Need at least one assistant turn with usage |

--- a/ainb-tui/.claude/skills/tmux-ui-tripwire/scripts/diagnose-tripwire.sh
+++ b/ainb-tui/.claude/skills/tmux-ui-tripwire/scripts/diagnose-tripwire.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# diagnose-tripwire.sh — run when a tripwire fails for unclear reasons.
+#
+# Walks through the common silent-trap diagnostics:
+#   1. Verify staged plugin binaries are AMFI-clean (exit !=137 standalone)
+#   2. Tail the latest JSONL log for plugin lifecycle events
+#   3. Show what onboarding.toml the test would seed
+#
+# Usage:
+#   ./diagnose-tripwire.sh                 # runs all checks
+#   ./diagnose-tripwire.sh amfi            # AMFI standalone probe only
+#   ./diagnose-tripwire.sh logs            # last log tail only
+#
+# Run from the ainb-tui workspace root.
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."  # ainb-tui workspace root
+
+CHECK="${1:-all}"
+
+probe_amfi() {
+    echo "=== AMFI standalone probe ==="
+    # AMFI-killed binaries exit 137 in <1ms with no stderr, regardless
+    # of whether stdin is empty. Healthy binaries with </dev/null read
+    # EOF and exit cleanly (0), or wait for input until timeout.
+    for bin in dist/plugins/*/[!.]*; do
+        [[ -x "$bin" && ! -d "$bin" ]] || continue
+        local name="$(basename "$bin")"
+        # Run with /dev/null stdin and a 1s ceiling. Track wall time —
+        # AMFI kills are instant; honest exits take at least a few ms.
+        local start ms exit_code stderr_size
+        start=$(perl -e 'use Time::HiRes qw(time); print int(time()*1000)')
+        ./"$bin" </dev/null >/dev/null 2>/tmp/.amfi-probe.stderr &
+        local pid=$!
+        # Wait up to 1s — if it's still alive, kill it.
+        local waited=0
+        while [[ $waited -lt 10 ]] && kill -0 "$pid" 2>/dev/null; do
+            sleep 0.1
+            waited=$((waited + 1))
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            exit_code="killed-by-us"
+        else
+            wait "$pid" 2>/dev/null
+            exit_code=$?
+        fi
+        ms=$(($(perl -e 'use Time::HiRes qw(time); print int(time()*1000)') - start))
+        stderr_size=$(wc -c </tmp/.amfi-probe.stderr 2>/dev/null | tr -d ' ')
+
+        if [[ "$exit_code" == "137" && "$ms" -lt 100 && "$stderr_size" == "0" ]]; then
+            echo "  ❌ $name: exit=137 in ${ms}ms, no stderr — AMFI silent kill"
+            echo "       Fix: just stage-plugins   (re-signs with codesign --sign -)"
+        elif [[ "$exit_code" == "0" || "$exit_code" == "killed-by-us" ]]; then
+            echo "  ✅ $name: ran ${ms}ms, exit=$exit_code"
+        else
+            echo "  ⚠  $name: exit=$exit_code in ${ms}ms (stderr: ${stderr_size}B)"
+        fi
+    done
+    rm -f /tmp/.amfi-probe.stderr
+}
+
+probe_logs() {
+    echo "=== Latest JSONL log key events ==="
+    local log_dir="$HOME/.agents-in-a-box/logs"
+    if [[ ! -d "$log_dir" ]]; then
+        echo "  (no logs at $log_dir — has ainb tui run?)"
+        return
+    fi
+    local latest
+    latest=$(ls -t "$log_dir"/*.jsonl 2>/dev/null | head -1 || true)
+    if [[ -z "$latest" ]]; then
+        echo "  (no jsonl files in $log_dir)"
+        return
+    fi
+    echo "  Log: $latest"
+    if command -v jq >/dev/null 2>&1; then
+        jq -r 'select(.fields.message | test("plugin|spawn|broken|pipe|exit|on_init|inbound|host->plugin"; "i"))
+               | "  \(.timestamp[11:23]) [\(.level)] plugin=\(.fields.plugin // "?") \(.fields.message)"' \
+           "$latest" 2>/dev/null | head -30
+    else
+        echo "  (install jq for filtered output)"
+        head -30 "$latest"
+    fi
+}
+
+probe_wizard_seed() {
+    echo "=== Wizard-skip onboarding.toml the test should seed ==="
+    local ver
+    ver=$(awk '/^\[workspace\.package\]/{p=1} p && /^version *=/{gsub(/[" ]/,"",$3); print $3; exit}' Cargo.toml)
+    cat <<EOF
+  completed = true
+  completed_at = "2026-05-11T00:00:00+00:00"
+  version = "$ver"
+  skipped_dependencies = []
+  git_directories = []
+EOF
+    echo "  ↑ write this to \$HOME_TEMP/.agents-in-a-box/config/onboarding.toml"
+}
+
+case "$CHECK" in
+    amfi)   probe_amfi ;;
+    logs)   probe_logs ;;
+    wizard) probe_wizard_seed ;;
+    all|*)
+        probe_amfi
+        echo
+        probe_logs
+        echo
+        probe_wizard_seed
+        ;;
+esac

--- a/ainb-tui/.gitignore
+++ b/ainb-tui/.gitignore
@@ -40,7 +40,13 @@ Thumbs.db
 
 # Agents Box specific
 .agents-box/
-.claude/
+# Override parent .gitignore's blanket `.claude/` ignore so project-local
+# skills travel with the repo. Re-include the directory FIRST (git can't
+# unignore children if the parent is excluded), then ignore everything
+# inside it except `skills/`.
+!.claude/
+.claude/*
+!.claude/skills/
 worktrees/
 
 # Testing

--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -62,6 +62,14 @@ impl Screen for PluginScreen {
         self.screen_id
     }
     fn render(&mut self, frame: &mut Frame, area: Rect, state: &mut AppState) {
+        // Stash the allocated size so the next tick of
+        // `App::tick_plugin_renders` can ask the plugin for a buffer that
+        // actually fills this area. Without this the plugin renders into
+        // its fallback (80×24) and everything outside that rect stays blank.
+        state
+            .plugin_render_areas
+            .insert(self.screen_id.to_string(), (area.width, area.height));
+
         let Some(wire) = state.pending_plugin_renders.get(self.screen_id) else {
             let placeholder = ratatui::widgets::Paragraph::new(format!(
                 "[plugin {}: rendering...]",

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2102,6 +2102,15 @@ pub struct AppState {
         ainb_plugin_runtime::WireBuffer,
     >,
 
+    /// Last `(width, height)` `PluginScreen::render` was handed for each
+    /// screen id. `tick_plugin_renders` reads this and forwards it to
+    /// `handle.render(..)` so the plugin paints at the actual allocated
+    /// size instead of falling back to its hard-coded default. One-frame
+    /// stale is fine — the first frame still uses the plugin's fallback,
+    /// every subsequent frame matches the host's layout.
+    pub plugin_render_areas:
+        std::collections::HashMap<crate::app::screens::ScreenId, (u16, u16)>,
+
     /// Cached result of `detect_statusline_status()` paired with the time
     /// it was read. Refreshed lazily through
     /// [`AppState::statusline_status_cached`] on a 15s TTL so the global
@@ -2692,6 +2701,7 @@ impl Default for AppState {
             session_recovery_state: crate::components::SessionRecoveryState::default(),
 
             pending_plugin_renders: std::collections::HashMap::new(),
+            plugin_render_areas: std::collections::HashMap::new(),
 
             statusline_status_cache: None,
 
@@ -9730,10 +9740,19 @@ impl App {
             // Kick off the next render so the frame is ready by the
             // following tick. The returned oneshot is intentionally
             // dropped — the cache pickup happens via `try_recv_render`.
-            let viewport = ainb_plugin_runtime::Viewport {
-                width: 0,
-                height: 0,
-            };
+            //
+            // Viewport comes from the previous frame's allocated area
+            // (stashed by `PluginScreen::render`). Falls back to (0, 0)
+            // before the first paint — the plugin treats that as "use
+            // your own fallback size", which keeps the first frame
+            // sensible until the area cache fills in.
+            let (width, height) = self
+                .state
+                .plugin_render_areas
+                .get(*screen_id)
+                .copied()
+                .unwrap_or((0, 0));
+            let viewport = ainb_plugin_runtime::Viewport { width, height };
             let _ = handle.render(&pid, viewport, 0);
         }
     }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -1236,8 +1236,11 @@ fn setup_logging() {
                 .with_ansi(false),
         )
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "agents_box=info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                "info,ainb=info,ainb_core=info,ainb_plugin_runtime=debug,\
+                 ainb_plugin_session_reader=debug,ainb_plugin_burndown=debug"
+                    .into()
+            }),
         )
         .init();
 }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_real_data_in_tui.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_real_data_in_tui.rs
@@ -1,18 +1,35 @@
-//! Tripwire 7f.3: Real data renders in TUI (not just headers).
+//! Tripwire 7f.3: Real data renders in TUI when user opens analytics.
 //!
-//! Launches the real `ainb tui` binary in a tmux session, drives key
-//! presses to navigate to the analytics/usage view, captures the pane
-//! content, and asserts that REAL DATA is rendered — not just a
-//! "Usage Analytics" header or "Waiting for session-reader plugin..."
-//! placeholder.
+//! The original 7f.3 passed on substring-OR of chrome strings ("ainb",
+//! "session", "Container") that appear in the sidebar/wizard regardless
+//! of whether burndown plugin rendered any data. This rewrite tightens
+//! the test:
 //!
-//! This closes the gap that let placeholder text pass earlier validation.
-//! Architectural constraint: uses real `ainb tui` as a subprocess + tmux.
+//! 1. Pre-seeds `~/.agents-in-a-box/config/onboarding.toml` (in an
+//!    isolated `HOME`) so the setup wizard is skipped and the
+//!    HomeScreen renders directly. The wizard would otherwise eat the
+//!    first key press and never reach the analytics screen.
+//! 2. Asserts the pre-`i` capture **lacks** the analytics chrome
+//!    ("Usage Analytics") so we know we're starting from the
+//!    HomeScreen, not stuck on a stale analytics view.
+//! 3. Sends the real "open analytics" keybinding — lowercase `i` —
+//!    as declared in `crate::app::events`'s HomeScreen V2 handler.
+//! 4. Asserts the post-`i` capture contains analytics chrome AND
+//!    real data ("Total Calls", "Total Cost", or a `$<digit>` cost
+//!    string) AND **must not** contain the placeholder
+//!    `"Waiting for session-reader plugin"` — the exact failure mode
+//!    that the original test allowed through.
+//!
+//! Skips gracefully if `tmux` isn't on `$PATH` — useful in CI runners
+//! without tmux. Also skips when `dist/plugins/{burndown,session-reader}`
+//! aren't staged because the plugin flow can't be exercised without
+//! both binaries present.
 
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn ainb_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
@@ -26,110 +43,197 @@ fn tmux_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Walk up from the ainb binary looking for the `dist/plugins/`
+/// staging dir produced by the dev workflow. Returns `None` if absent
+/// so the test can skip rather than fail in fresh checkouts that
+/// haven't built and staged plugins yet.
+fn plugins_staged() -> Option<PathBuf> {
+    let bin = ainb_bin();
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate
+                .join("session-reader")
+                .join("session-reader")
+                .exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "{ts}"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ts = "2026-05-11T00:00:00+00:00",
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+}
+
 fn capture_pane(session: &str) -> String {
-    let output = Command::new("tmux")
+    let out = Command::new("tmux")
         .args(["capture-pane", "-t", session, "-p"])
         .output()
         .expect("tmux capture-pane");
-    String::from_utf8_lossy(&output.stdout).to_string()
+    String::from_utf8_lossy(&out.stdout).to_string()
 }
 
-fn send_keys(session: &str, keys: &str) {
-    Command::new("tmux")
-        .args(["send-keys", "-t", session, keys, ""])
-        .status()
-        .expect("tmux send-keys");
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
 }
 
+fn kill_session(session: &str) {
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .status();
+}
+
+// Currently red because of a second Phase 7 bug uncovered alongside
+// the eager-spawn miss: session-reader sends host/snapshot/subscribe
+// during its own on_init, the host receives the request, but the
+// plugin never observes the subscribe-response and consequently
+// never reaches its first publish — burndown stays on
+// "Waiting for session-reader plugin..." forever.
+//
+// The eager-spawn fix in this PR is necessary scaffolding (without
+// it, session-reader never even starts). The remaining stall is a
+// host→plugin response-delivery defect that is out of scope for the
+// eager-spawn change. Drop the `#[ignore]` once that bug is fixed.
 #[test]
-fn tui_renders_real_analytics_data() {
+#[ignore = "BUG: session-reader subscribe-response delivery stalls — host/snapshot/subscribe request reaches host but response never reaches plugin, blocking on_init publish"]
+fn tui_renders_real_analytics_data_after_pressing_i() {
     if !tmux_available() {
         eprintln!("SKIP: tmux not available");
         return;
     }
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!(
+            "SKIP: dist/plugins/{{burndown,session-reader}} not staged — \
+             run `just stage-plugins` or build then copy binaries first"
+        );
+        return;
+    };
 
-    let session_name = format!("tripwire-tui-{}", std::process::id());
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+
+    let session = format!("tripwire-tui-{}", std::process::id());
     let ainb = ainb_bin();
-    let tmp = tempfile::tempdir().unwrap();
 
-    // Start ainb tui in a tmux session with isolated config.
     let status = Command::new("tmux")
         .args([
             "new-session",
             "-d",
             "-s",
-            &session_name,
+            &session,
             "-x",
-            "120",
+            "180",
             "-y",
-            "40",
+            "50",
         ])
         .status()
-        .expect("create tmux session");
-    assert!(status.success(), "failed to create tmux session");
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
 
-    // Send the ainb tui command.
     let cmd = format!(
-        "HOME={} AINB_DISABLE_PLUGINS=0 {} tui 2>/dev/null",
-        tmp.path().display(),
+        "HOME={} AINB_PLUGIN_ROOT={} exec {} tui",
+        home_tmp.path().display(),
+        plugin_root.display(),
         ainb.display()
     );
-    send_keys(&session_name, &cmd);
-    send_keys(&session_name, "Enter");
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("send launch cmd");
 
-    // Wait for TUI to initialize.
-    thread::sleep(Duration::from_secs(2));
-
-    // Try to navigate to analytics/usage view.
-    // The TUI uses tab/number keys for navigation. Try common patterns:
-    // 'u' for usage, '3' or '4' for analytics tab, or arrow keys.
-    for key in &["3", "4", "u", "Tab", "Tab"] {
-        send_keys(&session_name, key);
-        thread::sleep(Duration::from_millis(300));
-    }
-
-    // Capture and analyze pane content.
-    thread::sleep(Duration::from_secs(1));
-    let capture = capture_pane(&session_name);
-
-    // Clean up tmux session.
-    let _ = Command::new("tmux")
-        .args(["kill-session", "-t", &session_name])
-        .status();
-
-    // The TUI must render SOMETHING beyond empty placeholders.
-    // Accept any of these as evidence of real data rendering:
-    let has_real_content = capture.contains("Total Calls")
-        || capture.contains("Total Cost")
-        || capture.contains("ainb")
-        || capture.contains("Sessions")
-        || capture.contains("session")
-        || capture.contains("Workspace")
-        || capture.contains("workspace")
-        || capture.contains("Container")
-        || capture.contains("Active");
-
-    // Must NOT be just the placeholder.
-    let is_placeholder = capture.contains("Waiting for session-reader plugin")
-        || capture.contains("No data available")
-        || capture.trim().is_empty();
-
-    if is_placeholder && !has_real_content {
+    // Wait until HomeScreen sidebar appears — the unique marker is the
+    // gold-coloured "Stats" sidebar tile with its `[i]` hotkey hint.
+    let home_deadline = Instant::now() + Duration::from_secs(45);
+    let pre_cap = poll_capture(&session, home_deadline, |c| c.contains("Stats")
+        && c.contains("[i]"));
+    let Some(pre) = pre_cap else {
+        let last = capture_pane(&session);
+        kill_session(&session);
         panic!(
-            "TUI rendered only placeholder content. Capture:\n---\n{capture}\n---\n\
-             Expected real data (Total Calls, project names, session info, etc.)"
+            "HomeScreen never rendered; last capture:\n---\n{last}\n---"
         );
-    }
-
-    // If TUI crashed or never rendered, capture will be empty or show shell prompt.
-    let rendered_tui = capture.contains('│')
-        || capture.contains('─')
-        || capture.contains("ainb")
-        || capture.contains('[')
-        || has_real_content;
-
+    };
+    // Sanity: pre-press capture must NOT be on the analytics screen.
     assert!(
-        rendered_tui,
-        "TUI did not render at all. Capture:\n---\n{capture}\n---"
+        !pre.contains("Usage Analytics"),
+        "pre-key capture already on analytics — wizard/state leaked.\n{pre}"
+    );
+
+    // Drive the real keybinding: lowercase `i` opens stats.
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, "i"])
+        .status()
+        .expect("send i");
+
+    // Wait until burndown actually renders real numbers. We allow up
+    // to 30s for session-reader's first scan + publish. The success
+    // markers are real data cues — Total Calls/Cost/$N — not chrome.
+    let data_deadline = Instant::now() + Duration::from_secs(30);
+    let post_cap = poll_capture(&session, data_deadline, |c| {
+        let has_real_marker = c.contains("Total Calls")
+            || c.contains("Total Cost")
+            || c.contains("$0.")
+            || c.contains("$1.")
+            || c.contains("$2.")
+            || c.contains("$3.")
+            || c.contains("$4.")
+            || c.contains("$5.")
+            || c.contains("$6.")
+            || c.contains("$7.")
+            || c.contains("$8.")
+            || c.contains("$9.");
+        let still_loading = c.contains("Waiting for session-reader plugin");
+        has_real_marker && !still_loading
+    });
+
+    let final_cap = post_cap.unwrap_or_else(|| capture_pane(&session));
+    kill_session(&session);
+
+    // 1) Must have reached the analytics screen (chrome present).
+    assert!(
+        final_cap.contains("Usage Analytics"),
+        "analytics screen never rendered after 'i'.\n{final_cap}"
+    );
+    // 2) Must NOT be stuck on the placeholder — the bug we're catching.
+    assert!(
+        !final_cap.contains("Waiting for session-reader plugin"),
+        "burndown stuck on session-reader placeholder — \
+         eager-spawn / snapshot-publish wiring is broken.\n{final_cap}"
+    );
+    // 3) Must contain at least one real-data marker.
+    let real_marker_present = final_cap.contains("Total Calls")
+        || final_cap.contains("Total Cost")
+        || (final_cap.contains('$')
+            && final_cap.chars().any(|c| c.is_ascii_digit()));
+    assert!(
+        real_marker_present,
+        "analytics rendered but no real data markers found \
+         (expected 'Total Calls', 'Total Cost', or '$<digit>').\n{final_cap}"
     );
 }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_real_data_in_tui.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_real_data_in_tui.rs
@@ -79,6 +79,24 @@ git_directories = []
         ver = env!("CARGO_PKG_VERSION"),
     );
     fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    // Seed one synthetic claude session so session-reader has real data
+    // to publish. Without this, burndown still renders (zero state) and
+    // the placeholder is gone — that proves the plugin pipeline — but
+    // we want the strict-mode assertion to bite: real `$N.NN` cost
+    // strings can only show up when there are non-zero tokens to price.
+    let proj_dir = home
+        .join(".claude")
+        .join("projects")
+        .join("-tripwire-fixture-project");
+    fs::create_dir_all(&proj_dir).expect("create claude project dir");
+    let session_jsonl = r#"{"type":"assistant","timestamp":"2026-05-10T12:00:00.000Z","sessionId":"fixture-session-1","cwd":"/tmp/x","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#;
+    fs::write(
+        proj_dir.join("fixture-session-1.jsonl"),
+        session_jsonl,
+    )
+    .expect("seed synthetic claude jsonl");
 }
 
 fn capture_pane(session: &str) -> String {
@@ -109,19 +127,21 @@ fn kill_session(session: &str) {
         .status();
 }
 
-// Currently red because of a second Phase 7 bug uncovered alongside
-// the eager-spawn miss: session-reader sends host/snapshot/subscribe
-// during its own on_init, the host receives the request, but the
-// plugin never observes the subscribe-response and consequently
-// never reaches its first publish — burndown stays on
-// "Waiting for session-reader plugin..." forever.
+// The "Waiting for session-reader plugin..." stall was two layered bugs:
+//   1. The runtime ignored `manifest.lifecycle.spawn = "eager"`, so
+//      session-reader was never started (fixed in plugin_task.rs via
+//      `Command::EnsureSpawned`).
+//   2. macOS AMFI silently SIGKILLed every staged plugin binary at exec
+//      (exit 137, no stderr) because cargo's ad-hoc linker signature is
+//      bound to the original build path; `cp` to dist/plugins/ broke it.
+//      Fixed by `scripts/build-plugins.sh` re-signing after stage (via
+//      `codesign --remove-signature` + `codesign --sign -`).
 //
-// The eager-spawn fix in this PR is necessary scaffolding (without
-// it, session-reader never even starts). The remaining stall is a
-// host→plugin response-delivery defect that is out of scope for the
-// eager-spawn change. Drop the `#[ignore]` once that bug is fixed.
+// Asserts the panel renders real-data chrome (Total Calls / Total Cost /
+// `$<digit>`) and crucially is NOT stuck on the placeholder. Requires
+// `just stage-plugins` (or `./scripts/build-plugins.sh`) so dist/plugins/
+// contains the AMFI-friendly re-signed binaries.
 #[test]
-#[ignore = "BUG: session-reader subscribe-response delivery stalls — host/snapshot/subscribe request reaches host but response never reaches plugin, blocking on_init publish"]
 fn tui_renders_real_analytics_data_after_pressing_i() {
     if !tmux_available() {
         eprintln!("SKIP: tmux not available");

--- a/ainb-tui/crates/ainb-core/tests/tripwire_sessions_screen.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_sessions_screen.rs
@@ -1,0 +1,163 @@
+//! Tripwire 7f.5: Sessions screen renders when user presses `s`.
+//!
+//! Sister to 7f.3 — protects the non-plugin path. The host owns the
+//! sessions screen directly (no plugin involvement), so this gate
+//! ensures the eager-spawn + plugin runtime work didn't regress
+//! the rest of the TUI. Same wizard-skip + tmux dance as 7f.3.
+//!
+//! Pressing `s` on the HomeScreen fires `AppEvent::GoToSessionList`
+//! per `crates/ainb-core/src/app/events.rs` HomeScreen handler.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).unwrap();
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).unwrap();
+}
+
+/// Markers unique to the Session List screen (post-`s` navigation).
+/// Verified against an actual capture: the screen renders a session
+/// list panel plus a "Session Details" sub-panel, with toolbar
+/// footers that are not present on the HomeScreen.
+fn is_on_sessions_screen(c: &str) -> bool {
+    c.contains("Session Details")
+        || c.contains("Select a session to view details")
+        || c.contains("attach")
+            && c.contains("restart")
+            && c.contains("cleanup")
+}
+
+fn capture(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("capture");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let c = capture(session);
+        if ok(&c) {
+            return Some(c);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+
+#[test]
+fn tui_sessions_screen_renders_after_pressing_s() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+
+    let session = format!("tripwire-sess-{}", std::process::id());
+    let ainb = ainb_bin();
+
+    let status = Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &session,
+            "-x",
+            "180",
+            "-y",
+            "50",
+        ])
+        .status()
+        .expect("new-session");
+    assert!(status.success());
+
+    // No plugins needed — sessions screen is host-owned. Pass
+    // `AINB_DISABLE_PLUGINS=1` so the test doesn't depend on the
+    // plugin staging layout and finishes faster.
+    let cmd = format!(
+        "HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        home_tmp.path().display(),
+        ainb.display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("launch");
+
+    let home_deadline = Instant::now() + Duration::from_secs(45);
+    let pre = poll(&session, home_deadline, |c| {
+        c.contains("Sessions") && c.contains("[s]")
+    });
+    let Some(pre_cap) = pre else {
+        let last = capture(&session);
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &session])
+            .status();
+        panic!("HomeScreen never rendered; last:\n{last}");
+    };
+    assert!(
+        !pre_cap.contains("Session List") && !pre_cap.contains("session_list"),
+        "pre-key capture already on sessions screen — state leaked\n{pre_cap}"
+    );
+
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, "s"])
+        .status()
+        .expect("send s");
+
+    // Wait for sessions screen markers. Per the layout in
+    // `components/session_list.rs`, the screen renders a panel with
+    // either a session list or an empty-state hint — accept either
+    // because a fresh tempdir HOME has no sessions yet.
+    let nav_deadline = Instant::now() + Duration::from_secs(20);
+    let post = poll(&session, nav_deadline, |c| is_on_sessions_screen(c));
+
+    let final_cap = post.unwrap_or_else(|| capture(&session));
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", &session])
+        .status();
+
+    let on_sessions = is_on_sessions_screen(&final_cap);
+    assert!(
+        on_sessions,
+        "sessions screen never rendered after 's'.\n{final_cap}"
+    );
+    // Regression cross-check: must not be analytics by accident.
+    assert!(
+        !final_cap.contains("Usage Analytics"),
+        "navigation drifted to analytics instead of sessions.\n{final_cap}"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -11,7 +11,9 @@ use ainb_plugin_sdk::{
     Cell, CliOutput, Color, Coord, HostClient, Plugin, RenderParams, Result, SdkError,
     WireBuffer,
 };
-use ainb_plugin_types_sessions::{UsageDataEvent, WIRE_VERSION};
+use ainb_plugin_types_sessions::{
+    UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
+};
 use async_trait::async_trait;
 use ratatui::buffer::Buffer as RBuffer;
 use ratatui::layout::Rect as RRect;
@@ -32,15 +34,34 @@ const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 /// 0×0 ever arrives. Matches the historical 80×24 baseline.
 const FALLBACK_VIEWPORT: (u16, u16) = (80, 24);
 
+/// Disposition of one [`UsageDataEvent`] chunk after
+/// [`BurndownPlugin::apply_chunk_pure`] processes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChunkOutcome {
+    /// Chunk accepted; sequence not yet final.
+    Buffered,
+    /// `is_final = true` chunk completed the sequence; `self.data` is
+    /// now live.
+    Finalised,
+    /// Follow-on chunk arrived without a preceding `chunk_index = 0`
+    /// — dropped, accumulator state unchanged.
+    DroppedFollowOn,
+}
+
 /// Burndown plugin state.
 #[derive(Default)]
 pub struct BurndownPlugin {
     /// In-memory UI state — populated from cached snapshots and
     /// CLI/event-driven tab switches.
     ui: UsageViewState,
-    /// Most recent `UsageData` snapshot decoded from
+    /// Most recent fully-assembled `UsageData` snapshot decoded from
     /// `sessions.usage_data`.
     data: Option<UsageData>,
+    /// Accumulator for the in-flight chunked publish (if any). Reset
+    /// on `chunk_index == 0`, appended-to on follow-on chunks,
+    /// finalised + moved into `self.data` on `is_final = true`. See
+    /// [`UsageDataEvent`] docs for the chunking protocol.
+    pending: Option<WireUsageData>,
     /// Set when the most recent snapshot's wire `version` did not match
     /// the crate's compiled [`WIRE_VERSION`]. Latched — the render path
     /// surfaces an upgrade hint instead of the wait-spinner.
@@ -54,15 +75,22 @@ impl Plugin for BurndownPlugin {
     }
 
     async fn on_init(&mut self, host: &HostClient, _granted: &[String]) -> Result<()> {
-        // Best-effort warm-load: ask the host for any snapshot already
-        // on the bus so the first render doesn't have to wait for the
-        // next publish. Failure is non-fatal — we'll still get pushed
-        // events via `handle_event`.
-        if let Ok(snap) = host.snapshot_get("sessions.usage_data").await {
-            if let Some(payload) = snap.payload {
-                self.ingest_usage_payload(host, &payload).await;
-            }
-        }
+        // Subscribe up front so chunked publishes from session-reader
+        // arrive via `handle_event`. The snapshot store only retains
+        // the most recent publish, so for >1-chunk snapshots a passive
+        // `snapshot_get` would miss every chunk except the last.
+        let _ = host.snapshot_subscribe("sessions.usage_data").await;
+
+        // Trigger a fresh publish. Eager-spawned session-reader runs
+        // its first publish during its own `on_init`, which races
+        // with us — burndown can subscribe mid-stream and end up
+        // missing chunk 0 of the in-flight sequence. Publishing on
+        // the `sessions.refresh_request` topic asks session-reader
+        // to rescan and re-publish from scratch, this time with us
+        // already subscribed. Best-effort: failure is non-fatal.
+        let _ = host
+            .snapshot_publish("sessions.refresh_request", bytes::Bytes::new())
+            .await;
         Ok(())
     }
 
@@ -180,8 +208,13 @@ impl Plugin for BurndownPlugin {
 
 impl BurndownPlugin {
     /// Decode a `sessions.usage_data` payload (msgpack-encoded
-    /// `UsageDataEvent`) and update local state. Notes wire-version
-    /// drift on the latched `schema_mismatch` flag.
+    /// `UsageDataEvent`) and update local state. Handles chunked
+    /// publishes: chunk 0 resets the accumulator, follow-on chunks
+    /// append their `calls` slice, and `is_final = true` moves the
+    /// accumulator into `self.data`. Single-chunk publishes (the v1
+    /// path, plus small `$HOME`s) take exactly the same code path
+    /// because their defaults are `chunk_index = 0, is_final = true`.
+    /// Notes wire-version drift on the latched `schema_mismatch` flag.
     async fn ingest_usage_payload(&mut self, host: &HostClient, payload: &[u8]) {
         let event: UsageDataEvent = match rmp_serde::from_slice(payload) {
             Ok(e) => e,
@@ -204,8 +237,52 @@ impl BurndownPlugin {
                 .await;
             return;
         }
-        self.data = Some(wire_to_local(event.data));
-        self.schema_mismatch = false;
+        self.apply_chunk(event, host).await;
+    }
+
+    /// Drive the chunk accumulator. Logs to `host` on protocol misuse
+    /// (follow-on chunk with no in-flight publish); calls into the
+    /// pure [`Self::apply_chunk_pure`] for the actual state transition
+    /// so unit tests can hit every branch without a `HostClient`.
+    async fn apply_chunk(&mut self, event: UsageDataEvent, host: &HostClient) {
+        let chunk_index = event.chunk_index;
+        let outcome = self.apply_chunk_pure(event);
+        if matches!(outcome, ChunkOutcome::DroppedFollowOn) {
+            let _ = host
+                .log_info(format!(
+                    "burndown: dropped follow-on chunk {chunk_index} (no in-flight publish)"
+                ))
+                .await;
+        }
+    }
+
+    /// Pure version of [`Self::apply_chunk`] — no host I/O. Returns
+    /// the disposition so the async wrapper can log the misuse path.
+    fn apply_chunk_pure(&mut self, event: UsageDataEvent) -> ChunkOutcome {
+        if event.chunk_index == 0 {
+            // Fresh publish sequence — seed the accumulator with the
+            // full aggregates + first call slice. Any prior in-flight
+            // accumulator is discarded (the publisher abandoned it).
+            self.pending = Some(event.data);
+        } else {
+            // Append `calls` onto the in-flight accumulator. If we
+            // missed chunk 0 (subscriber joined late or sequence got
+            // reordered), drop the chunk — partial data without
+            // aggregates is worse than no data.
+            match self.pending.as_mut() {
+                Some(acc) => acc.calls.extend(event.data.calls),
+                None => return ChunkOutcome::DroppedFollowOn,
+            }
+        }
+
+        if event.is_final {
+            if let Some(assembled) = self.pending.take() {
+                self.data = Some(wire_to_local(assembled));
+                self.schema_mismatch = false;
+                return ChunkOutcome::Finalised;
+            }
+        }
+        ChunkOutcome::Buffered
     }
 
     /// Pull the latest snapshot synchronously. Used by `cli_dispatch`
@@ -430,5 +507,128 @@ impl BurndownPlugin {
     #[allow(dead_code)]
     pub fn set_active_tab(&mut self, tab: UsageTab) {
         self.ui.active_tab = tab;
+    }
+}
+
+#[cfg(test)]
+mod chunk_accumulator_tests {
+    use super::*;
+    use ainb_plugin_types_sessions::{
+        ProjectUsage, Provider, ProviderCall, TokenBucket, WIRE_VERSION,
+    };
+    use chrono::{DateTime, Utc};
+
+    fn fake_call(id: u64) -> ProviderCall {
+        ProviderCall {
+            id,
+            provider: Provider::Claude,
+            model: "claude-sonnet".into(),
+            session_id: "s".into(),
+            project: "p".into(),
+            project_path: "/tmp".into(),
+            timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+            input_tokens: 1,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 1,
+            reasoning_tokens: 0,
+            cost_usd: None,
+            tools: vec![],
+            bash_commands: vec![],
+            user_message: String::new(),
+            branch: None,
+        }
+    }
+
+    fn chunk(idx: u32, is_final: bool, calls: Vec<ProviderCall>) -> UsageDataEvent {
+        let mut data = WireUsageData::default();
+        data.calls = calls;
+        if idx == 0 {
+            // Plant an aggregate so we can assert chunk 0 seeds the
+            // accumulator with the full payload.
+            data.projects = vec![ProjectUsage {
+                name: "p".into(),
+                path: "/tmp".into(),
+                bucket: TokenBucket::default(),
+                repo: None,
+            }];
+        }
+        UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns: 0,
+            partial: false,
+            chunk_index: idx,
+            is_final,
+            data,
+        }
+    }
+
+    #[test]
+    fn single_chunk_finalises_immediately() {
+        let mut p = BurndownPlugin::default();
+        let outcome =
+            p.apply_chunk_pure(chunk(0, true, vec![fake_call(1), fake_call(2)]));
+        assert_eq!(outcome, ChunkOutcome::Finalised);
+        assert!(p.pending.is_none());
+        let d = p.data.as_ref().expect("snapshot finalised");
+        assert_eq!(d.calls.len(), 2);
+    }
+
+    #[test]
+    fn three_chunk_sequence_accumulates_then_finalises() {
+        let mut p = BurndownPlugin::default();
+        assert_eq!(
+            p.apply_chunk_pure(chunk(0, false, vec![fake_call(1)])),
+            ChunkOutcome::Buffered
+        );
+        assert_eq!(
+            p.apply_chunk_pure(chunk(1, false, vec![fake_call(2)])),
+            ChunkOutcome::Buffered
+        );
+        // Mid-flight: no live data yet.
+        assert!(p.data.is_none());
+        assert_eq!(
+            p.apply_chunk_pure(chunk(2, true, vec![fake_call(3)])),
+            ChunkOutcome::Finalised
+        );
+        let d = p.data.as_ref().expect("snapshot finalised");
+        assert_eq!(d.calls.len(), 3);
+        // Calls arrive in chunk order.
+        assert_eq!(d.calls[0].id, 1);
+        assert_eq!(d.calls[2].id, 3);
+    }
+
+    #[test]
+    fn follow_on_chunk_without_chunk_zero_is_dropped() {
+        let mut p = BurndownPlugin::default();
+        assert_eq!(
+            p.apply_chunk_pure(chunk(1, true, vec![fake_call(1)])),
+            ChunkOutcome::DroppedFollowOn
+        );
+        assert!(p.data.is_none(), "must not finalise from a stray chunk");
+        assert!(p.pending.is_none());
+    }
+
+    #[test]
+    fn new_chunk_zero_discards_in_flight_accumulator() {
+        let mut p = BurndownPlugin::default();
+        let _ = p.apply_chunk_pure(chunk(0, false, vec![fake_call(1)]));
+        let _ = p.apply_chunk_pure(chunk(1, false, vec![fake_call(2)]));
+        // Publisher abandoned and started over.
+        assert_eq!(
+            p.apply_chunk_pure(chunk(0, true, vec![fake_call(99)])),
+            ChunkOutcome::Finalised
+        );
+        let d = p.data.as_ref().unwrap();
+        assert_eq!(d.calls.len(), 1, "old accumulator was discarded");
+        assert_eq!(d.calls[0].id, 99);
+    }
+
+    #[test]
+    fn finalising_clears_schema_mismatch_flag() {
+        let mut p = BurndownPlugin::default();
+        p.schema_mismatch = true;
+        let _ = p.apply_chunk_pure(chunk(0, true, vec![fake_call(1)]));
+        assert!(!p.schema_mismatch);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
@@ -108,22 +108,42 @@ fn init_render_shutdown_round_trip() {
     stdin.write_all(&encode(&init)).expect("write init");
     stdin.flush().expect("flush init");
 
-    // Burndown's `on_init` calls `host.snapshot_get("sessions.usage_data")`
-    // to warm-load any existing snapshot. The SDK awaits `on_init`
-    // before sending the init reply, so the test sees the reverse-call
-    // *first*. Answer it with an empty payload so init can complete.
-    let rev = read_frame(&mut stdout, deadline).expect("reverse-call request");
-    assert_eq!(rev["method"], "host/snapshot/get", "reverse: {rev}");
-    let rev_id = rev["id"].as_i64().expect("reverse request must have id");
-    let rev_reply = json!({
+    // Burndown's `on_init` issues two reverse calls in order before
+    // returning: (1) `host/snapshot/subscribe` to the usage_data topic
+    // (request — expects a reply), then (2) `host/snapshot/publish` on
+    // the refresh_request topic to kick session-reader (notification —
+    // no reply). The SDK awaits `on_init` before replying to
+    // `plugin/init`, so both reverse calls land before the init
+    // response.
+    let rev1 = read_frame(&mut stdout, deadline).expect("subscribe reverse-call");
+    assert_eq!(
+        rev1["method"], "host/snapshot/subscribe",
+        "reverse #1: {rev1}"
+    );
+    let rev1_id = rev1["id"].as_i64().expect("reverse request must have id");
+    let rev1_reply = json!({
         "jsonrpc": "2.0",
-        "id": rev_id,
-        "result": { "payload": null, "version": 0 }
+        "id": rev1_id,
+        "result": {}
     });
     stdin
-        .write_all(&encode(&rev_reply))
-        .expect("write reverse reply");
-    stdin.flush().expect("flush reverse reply");
+        .write_all(&encode(&rev1_reply))
+        .expect("write subscribe reply");
+    stdin.flush().expect("flush subscribe reply");
+
+    let rev2 = read_frame(&mut stdout, deadline).expect("publish notification");
+    assert_eq!(
+        rev2["method"], "host/snapshot/publish",
+        "reverse #2: {rev2}"
+    );
+    assert_eq!(
+        rev2["params"]["topic"], "sessions.refresh_request",
+        "reverse #2 topic: {rev2}"
+    );
+    assert!(
+        rev2.get("id").is_none(),
+        "refresh_request publish must be a notification (no id): {rev2}"
+    );
 
     // Now the init reply itself.
     let resp = read_frame(&mut stdout, deadline).expect("init response");

--- a/ainb-tui/crates/ainb-plugin-protocol/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-protocol/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 thiserror = { workspace = true }
 bytes = { version = "1.6", features = ["serde"] }
+base64 = "0.22"
 
 # Local lint config rather than `workspace = true` because the
 # workspace-level lints declare lint groups (clippy::all, ::pedantic,

--- a/ainb-tui/crates/ainb-plugin-protocol/src/params.rs
+++ b/ainb-tui/crates/ainb-plugin-protocol/src/params.rs
@@ -339,34 +339,76 @@ pub struct NetworkFetchResult {
 // (de)serialise bytes::Bytes as a JSON array of u8 (no base64 layer).
 // =====================================================================
 
+/// Binary payloads ride the JSON-RPC envelope as **base64 strings**.
+///
+/// serde_json's default for `&[u8]` (and `Vec<u8>`) is a JSON array of
+/// numbers — `[12, 34, 56, ...]` — which costs 3-4 ASCII chars per
+/// byte. For the session-reader → burndown handoff that ballooned a
+/// ~25 MB msgpack snapshot to ~80 MB of JSON, exceeding the host
+/// framer's `MAX_BODY_BYTES = 16 MiB` and OOMing the plugin process
+/// mid-write. Base64 costs ~1.33 chars per byte — fits the budget and
+/// matches how JSON-RPC servers in the wild ship binary blobs.
+///
+/// The deserializer also accepts the legacy byte-array shape so older
+/// peers (host paired with an older plugin, or vice versa) keep
+/// working across the version bump.
 mod bytes_serde {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
     use bytes::Bytes;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{de::Error as _, Deserialize, Deserializer, Serializer};
 
     pub(super) fn serialize<S: Serializer>(b: &Bytes, s: S) -> Result<S::Ok, S::Error> {
-        b.as_ref().serialize(s)
+        s.serialize_str(&B64.encode(b.as_ref()))
     }
 
     pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Bytes, D::Error> {
-        let v = Vec::<u8>::deserialize(d)?;
-        Ok(Bytes::from(v))
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            B64(String),
+            Bytes(Vec<u8>),
+        }
+        match Repr::deserialize(d)? {
+            Repr::B64(s) => B64
+                .decode(s.as_bytes())
+                .map(Bytes::from)
+                .map_err(D::Error::custom),
+            Repr::Bytes(v) => Ok(Bytes::from(v)),
+        }
     }
 }
 
 mod opt_bytes_serde {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
     use bytes::Bytes;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{de::Error as _, Deserialize, Deserializer, Serializer};
 
     // serde's serialize_with signature requires `&Option<T>` here —
     // can't reshape to the otherwise-idiomatic `Option<&T>`.
     #[allow(clippy::ref_option)]
     pub(super) fn serialize<S: Serializer>(b: &Option<Bytes>, s: S) -> Result<S::Ok, S::Error> {
-        b.as_ref().map(bytes::Bytes::as_ref).serialize(s)
+        match b.as_ref() {
+            Some(bytes) => s.serialize_str(&B64.encode(bytes.as_ref())),
+            None => s.serialize_none(),
+        }
     }
 
     pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Bytes>, D::Error> {
-        let v = Option::<Vec<u8>>::deserialize(d)?;
-        Ok(v.map(Bytes::from))
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            B64(String),
+            Bytes(Vec<u8>),
+        }
+        let opt = Option::<Repr>::deserialize(d)?;
+        match opt {
+            None => Ok(None),
+            Some(Repr::B64(s)) => B64
+                .decode(s.as_bytes())
+                .map(|v| Some(Bytes::from(v)))
+                .map_err(D::Error::custom),
+            Some(Repr::Bytes(v)) => Ok(Some(Bytes::from(v))),
+        }
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
@@ -20,7 +20,7 @@ use parking_lot::RwLock;
 use tokio::sync::oneshot;
 
 use crate::error::RuntimeError;
-use crate::plugin_task::Command;
+use crate::plugin_task::{Command, InboxMap};
 use crate::registry::{ChannelRegistry, RegisteredPlugin};
 use crate::runtime::PluginHandle;
 use crate::snapshot::SnapshotStore;
@@ -36,6 +36,9 @@ pub(crate) struct HandleInner {
     pub(crate) snapshots: SnapshotStore,
     pub(crate) channels: ChannelRegistry,
     pub(crate) plugins: Arc<RwLock<HashMap<PluginId, Arc<PluginHandle>>>>,
+    /// Lightweight fan-out map (plugin_id → Inbox). Mirrors `plugins`
+    /// for the publish path; see [`crate::plugin_task::InboxMap`].
+    pub(crate) inboxes: InboxMap,
     pub(crate) config: RuntimeConfig,
 }
 
@@ -229,12 +232,17 @@ impl RuntimeHandle {
             let (inbox, cache, state) = crate::plugin_task::spawn(
                 arc.clone(),
                 self.inner.snapshots.clone(),
+                self.inner.inboxes.clone(),
                 self.inner.config,
                 &self.inner.tokio,
             );
             if eager {
                 let _ = inbox.send(crate::plugin_task::Command::EnsureSpawned);
             }
+            self.inner
+                .inboxes
+                .write()
+                .insert(arc.id.clone(), inbox.clone());
             self.inner.plugins.write().insert(
                 arc.id.clone(),
                 Arc::new(PluginHandle {

--- a/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
@@ -212,18 +212,29 @@ impl RuntimeHandle {
             .collect()
     }
 
-    /// Discover plugins under `root` and register each.
+    /// Discover plugins under `root` and register each. When a
+    /// plugin's manifest declares `[lifecycle].spawn = "eager"` the
+    /// task is poked with `EnsureSpawned` so the child process is
+    /// launched immediately — required for pure-publisher plugins
+    /// (e.g. session-reader) that no caller drives directly.
     pub fn discover(&self, root: &Path) -> Result<Vec<RegisteredPlugin>, RuntimeError> {
         let plugins = crate::registry::discover(root)?;
         for p in &plugins {
             self.inner.channels.register(p.clone());
             let arc = Arc::new(p.clone());
+            let eager = matches!(
+                arc.manifest.lifecycle.spawn,
+                ainb_plugin_protocol::manifest::SpawnMode::Eager
+            );
             let (inbox, cache, state) = crate::plugin_task::spawn(
                 arc.clone(),
                 self.inner.snapshots.clone(),
                 self.inner.config,
                 &self.inner.tokio,
             );
+            if eager {
+                let _ = inbox.send(crate::plugin_task::Command::EnsureSpawned);
+            }
             self.inner.plugins.write().insert(
                 arc.id.clone(),
                 Arc::new(PluginHandle {

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -405,11 +405,16 @@ impl PluginTask {
             }
         };
         match parsed {
-            Inbound::Response { id, result } => self.handle_response(id, result).await,
+            Inbound::Response { id, result } => {
+                debug!(plugin = %self.plugin.id, id, ok = result.is_ok(), "inbound response");
+                self.handle_response(id, result).await;
+            }
             Inbound::Request { id, method, params } => {
+                debug!(plugin = %self.plugin.id, id, method = %method, "inbound request");
                 self.handle_host_request(id, &method, params).await;
             }
             Inbound::Notification { method, params } => {
+                debug!(plugin = %self.plugin.id, method = %method, "inbound notification");
                 self.handle_host_notification(&method, params);
             }
         }
@@ -503,9 +508,13 @@ impl PluginTask {
             },
         };
         if let Some(cs) = &mut self.child {
-            if let Err(e) = write_frame(&mut cs.stdin, &body).await {
-                warn!(plugin = %self.plugin.id, "write response: {e}");
+            debug!(plugin = %self.plugin.id, id, bytes = body.len(), "host->plugin response: writing");
+            match write_frame(&mut cs.stdin, &body).await {
+                Ok(()) => debug!(plugin = %self.plugin.id, id, "host->plugin response: write_frame OK"),
+                Err(e) => warn!(plugin = %self.plugin.id, id, "write response: {e}"),
             }
+        } else {
+            warn!(plugin = %self.plugin.id, id, "host->plugin response: child missing, dropping response");
         }
     }
 
@@ -702,6 +711,10 @@ async fn read_inbound(child: &mut Option<ChildState>) -> InboundEvent {
 async fn drain_stderr(plugin: PluginId, stderr: tokio::process::ChildStderr) {
     let mut reader = BufReader::new(stderr).lines();
     while let Ok(Some(line)) = reader.next_line().await {
-        debug!(plugin = %plugin, stream = "stderr", "{line}");
+        // info! so plugin stderr (e.g. eprintln from session-reader)
+        // surfaces in the host JSONL by default. Plugins are expected
+        // to use host.log() for normal logging — stderr is for unstructured
+        // diagnostics that should not be filtered out.
+        info!(plugin = %plugin, stream = "stderr", "{line}");
     }
 }

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -131,10 +131,17 @@ pub enum Command {
 /// Inbox a [`crate::RuntimeHandle`] uses to drive the task.
 pub type Inbox = mpsc::UnboundedSender<Command>;
 
+/// Map of `plugin_id → inbox` used by [`PluginTask`] to fan out
+/// subscriber notifications when a plugin issues `host/snapshot/publish`.
+/// Shared (clone-able `Arc`) with `Runtime`, which maintains it
+/// alongside the public plugin handle map.
+pub type InboxMap = Arc<parking_lot::RwLock<HashMap<PluginId, Inbox>>>;
+
 /// Spawn a per-plugin task and return its inbox + render cache.
 pub fn spawn(
     plugin: Arc<RegisteredPlugin>,
     snapshots: SnapshotStore,
+    inboxes: InboxMap,
     config: RuntimeConfig,
     handle: &tokio::runtime::Handle,
 ) -> (Inbox, RenderCache, Arc<parking_lot::RwLock<LifecycleState>>) {
@@ -144,6 +151,7 @@ pub fn spawn(
     let task = PluginTask {
         plugin,
         snapshots,
+        inboxes,
         config,
         cache: cache.clone(),
         state: state.clone(),
@@ -173,13 +181,24 @@ struct ChildState {
     pid: i32,
     child: Child,
     stdin: tokio::process::ChildStdin,
-    stdout: BufReader<tokio::process::ChildStdout>,
+    /// Inbound-frame channel filled by [`spawn_stdout_reader`]. We
+    /// can't read from `stdout` inside the per-plugin `tokio::select!`
+    /// loop because `BufReader::read_line` / `read_exact` are NOT
+    /// cancel-safe — a partial body would get re-interpreted as a
+    /// header on the next iteration. See Bug A in
+    /// `fix/runtime-eager-spawn`.
+    inbound_rx: mpsc::UnboundedReceiver<InboundEvent>,
+    stdout_reader: tokio::task::JoinHandle<()>,
     stderr_drain: tokio::task::JoinHandle<()>,
 }
 
 struct PluginTask {
     plugin: Arc<RegisteredPlugin>,
     snapshots: SnapshotStore,
+    /// Subscriber fan-out map (shared with `Runtime`). Used only when
+    /// the plugin issues `host/snapshot/publish` — we look up each
+    /// subscriber's inbox and forward a `Command::HandleEvent`.
+    inboxes: InboxMap,
     config: RuntimeConfig,
     cache: RenderCache,
     state: Arc<parking_lot::RwLock<LifecycleState>>,
@@ -207,7 +226,7 @@ impl PluginTask {
                     Some(Command::Shutdown) | None => { self.shutdown().await; break; }
                     Some(c) => self.handle_command(c).await,
                 },
-                inbound = read_inbound(&mut self.child) => {
+                inbound = next_inbound(&mut self.child) => {
                     match inbound {
                         InboundEvent::Frame(body) => self.handle_inbound(&body).await,
                         InboundEvent::Eof | InboundEvent::Error => self.handle_exit().await,
@@ -349,11 +368,14 @@ impl PluginTask {
             .map_err(|_| RuntimeError::Wire(format!("pid {pid_u32} doesn't fit in i32")))?;
         let plugin_name = self.plugin.id.clone();
         let stderr_drain = tokio::spawn(drain_stderr(plugin_name, stderr));
+        let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
+        let stdout_reader = spawn_stdout_reader(BufReader::new(stdout), inbound_tx);
         self.child = Some(ChildState {
             pid,
             child,
             stdin,
-            stdout: BufReader::new(stdout),
+            inbound_rx,
+            stdout_reader,
             stderr_drain,
         });
         self.send_init().await?;
@@ -546,7 +568,29 @@ impl PluginTask {
                     warn!(plugin = %self.plugin.id, "bad snapshot publish");
                     return;
                 };
-                let _ = self.snapshots.publish(Topic::from(p.topic), p.payload);
+                let topic = Topic::from(p.topic);
+                let payload = p.payload;
+                let _ = self.snapshots.publish(topic.clone(), payload.clone());
+                // Fan out to every subscriber — the snapshot store
+                // only retains the *latest* publish, so chunked publishes
+                // (session-reader → burndown) would lose all but the
+                // last chunk if we relied on a passive snapshot_get.
+                let subs = self.snapshots.subscribers(&topic);
+                if !subs.is_empty() {
+                    let inboxes = self.inboxes.read();
+                    for sub in subs {
+                        // Don't echo back to the publisher.
+                        if sub == self.plugin.id {
+                            continue;
+                        }
+                        if let Some(inbox) = inboxes.get(&sub) {
+                            let _ = inbox.send(Command::HandleEvent {
+                                topic: topic.clone(),
+                                payload: payload.clone(),
+                            });
+                        }
+                    }
+                }
             }
             methods::HOST_LOG => {
                 let Ok(p) = serde_json::from_value::<LogParams>(params) else {
@@ -579,6 +623,7 @@ impl PluginTask {
         }
         if let Some(cs) = self.child.take() {
             cs.stderr_drain.abort();
+            cs.stdout_reader.abort();
         }
         self.record_failure();
         if self.is_quarantine_due() {
@@ -664,6 +709,7 @@ impl PluginTask {
             let _ = cs.child.start_kill();
             let _ = cs.child.wait().await;
             cs.stderr_drain.abort();
+            cs.stdout_reader.abort();
         }
         self.snapshots.unsubscribe_all(&self.plugin.id);
     }
@@ -682,24 +728,56 @@ fn collect_granted_capabilities(m: &ainb_plugin_protocol::manifest::Manifest) ->
     out
 }
 
-/// What `read_inbound` returns. Single non-async classification; the
-/// outer `select!` re-polls.
+/// What the stdout reader pushes into the per-plugin inbound channel.
+/// `mpsc::recv` IS cancel-safe (drops at the start of the await), so
+/// the outer `select!` loop can read these without losing partial-
+/// frame state — unlike `read_line`/`read_exact` on `BufReader`.
+#[derive(Debug)]
 enum InboundEvent {
     Frame(Vec<u8>),
     Eof,
     Error,
 }
 
-async fn read_inbound(child: &mut Option<ChildState>) -> InboundEvent {
-    match child {
-        Some(cs) => match read_frame(&mut cs.stdout).await {
-            Ok(Some(body)) => InboundEvent::Frame(body),
-            Ok(None) => InboundEvent::Eof,
-            Err(e) => {
-                tracing::warn!("frame decode err: {e}");
-                InboundEvent::Error
+/// Spawn a task that reads framed inbounds from `stdout` and pushes
+/// them onto `tx`. Exits on EOF or unrecoverable decode error. Owns
+/// the `BufReader` for its lifetime, which guarantees no cross-await
+/// cancellation can corrupt the framer state — the original culprit
+/// for the "header block exceeded 8192 bytes" stalls under chunked
+/// publish workloads.
+fn spawn_stdout_reader(
+    mut reader: BufReader<tokio::process::ChildStdout>,
+    tx: mpsc::UnboundedSender<InboundEvent>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match read_frame(&mut reader).await {
+                Ok(Some(body)) => {
+                    if tx.send(InboundEvent::Frame(body)).is_err() {
+                        return;
+                    }
+                }
+                Ok(None) => {
+                    let _ = tx.send(InboundEvent::Eof);
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("frame decode err: {e}");
+                    let _ = tx.send(InboundEvent::Error);
+                    return;
+                }
             }
-        },
+        }
+    })
+}
+
+async fn next_inbound(child: &mut Option<ChildState>) -> InboundEvent {
+    match child {
+        Some(cs) => cs
+            .inbound_rx
+            .recv()
+            .await
+            .unwrap_or(InboundEvent::Eof),
         None => {
             // No child — park forever (until select! wakes us via cmd
             // or timer). pending() never resolves.

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -121,6 +121,11 @@ pub enum Command {
     /// part of the public API surface.
     #[doc(hidden)]
     InjectKill,
+    /// Best-effort wake: spawn the child if not already running. Used
+    /// by `Runtime::register` to honour `manifest.lifecycle.spawn = "eager"`.
+    /// No reply — failures are recorded on the task's failure ledger
+    /// and surface through `RuntimeHandle::lifecycle_state`.
+    EnsureSpawned,
 }
 
 /// Inbox a [`crate::RuntimeHandle`] uses to drive the task.
@@ -295,6 +300,11 @@ impl PluginTask {
             Command::InjectKill => {
                 if let Some(cs) = &mut self.child {
                     let _ = cs.child.start_kill();
+                }
+            }
+            Command::EnsureSpawned => {
+                if let Err(e) = self.ensure_running().await {
+                    warn!(plugin = %self.plugin.id, "eager spawn failed: {e}");
                 }
             }
         }

--- a/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
@@ -88,16 +88,27 @@ impl Runtime {
 
     /// Register an already-resolved [`RegisteredPlugin`]. Spawns its
     /// per-plugin task in `Idle` state — first request lazy-spawns
-    /// the process.
+    /// the process. When the manifest declares
+    /// `[lifecycle].spawn = "eager"`, an `EnsureSpawned` command is
+    /// dispatched immediately so the child is launched without
+    /// waiting for a first request. Required for pure-publisher
+    /// plugins (e.g. session-reader) that no caller drives directly.
     pub fn register(&self, plugin: RegisteredPlugin) {
         let arc = Arc::new(plugin);
         self.channels.register((*arc).clone());
+        let eager = matches!(
+            arc.manifest.lifecycle.spawn,
+            ainb_plugin_protocol::manifest::SpawnMode::Eager
+        );
         let (inbox, cache, state) = plugin_task::spawn(
             arc.clone(),
             self.snapshots.clone(),
             self.config,
             self.tokio.handle(),
         );
+        if eager {
+            let _ = inbox.send(plugin_task::Command::EnsureSpawned);
+        }
         let handle = Arc::new(PluginHandle {
             inbox,
             cache,

--- a/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Runtime as TokioRuntime;
 
 use crate::error::RuntimeError;
 use crate::handle::{HandleInner, RuntimeHandle};
-use crate::plugin_task::{self, Inbox, RenderCache};
+use crate::plugin_task::{self, Inbox, InboxMap, RenderCache};
 use crate::registry::{self, ChannelRegistry, RegisteredPlugin};
 use crate::snapshot::SnapshotStore;
 use crate::types::{LifecycleState, PluginId, RuntimeConfig};
@@ -35,6 +35,11 @@ pub struct Runtime {
     channels: ChannelRegistry,
     /// Per-plugin handles.
     plugins: Arc<RwLock<HashMap<PluginId, Arc<PluginHandle>>>>,
+    /// Lightweight fan-out map: `plugin_id → Inbox`. Kept in sync with
+    /// `plugins`. Plugin tasks hold a clone so they can deliver
+    /// `Command::HandleEvent` to subscribers on `host/snapshot/publish`
+    /// without taking a dependency on the public `PluginHandle` type.
+    inboxes: InboxMap,
     /// Tunables.
     config: RuntimeConfig,
 }
@@ -56,11 +61,13 @@ impl Runtime {
         let channels = ChannelRegistry::new();
         let plugins: Arc<RwLock<HashMap<PluginId, Arc<PluginHandle>>>> =
             Arc::new(RwLock::new(HashMap::new()));
+        let inboxes: InboxMap = Arc::new(parking_lot::RwLock::new(HashMap::new()));
         let handle = RuntimeHandle::new(HandleInner {
             tokio: tokio.handle().clone(),
             snapshots: snapshots.clone(),
             channels: channels.clone(),
             plugins: plugins.clone(),
+            inboxes: inboxes.clone(),
             config,
         });
         Ok((
@@ -69,6 +76,7 @@ impl Runtime {
                 snapshots,
                 channels,
                 plugins,
+                inboxes,
                 config,
             },
             handle,
@@ -103,12 +111,14 @@ impl Runtime {
         let (inbox, cache, state) = plugin_task::spawn(
             arc.clone(),
             self.snapshots.clone(),
+            self.inboxes.clone(),
             self.config,
             self.tokio.handle(),
         );
         if eager {
             let _ = inbox.send(plugin_task::Command::EnsureSpawned);
         }
+        self.inboxes.write().insert(arc.id.clone(), inbox.clone());
         let handle = Arc::new(PluginHandle {
             inbox,
             cache,

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
@@ -266,3 +266,120 @@ fn handle_is_send_and_clone() {
     assert_send_clone::<ainb_plugin_runtime::RuntimeHandle>();
     let _: Arc<dyn Send + Sync> = Arc::new(()) as Arc<dyn Send + Sync>;
 }
+
+// Eager-spawn regression: manifest declaring `spawn = "eager"` must
+// cause the runtime to launch the plugin process immediately at
+// registration time, without waiting for a first request. Without
+// this guarantee any pure-publisher plugin (e.g. session-reader)
+// never starts and downstream consumers stall on snapshot fetch.
+#[test]
+fn eager_spawn_starts_process_without_first_request() {
+    let (rt, handle) = build_runtime();
+    let mut manifest = fixture_manifest();
+    manifest.lifecycle.spawn = SpawnMode::Eager;
+    manifest.plugin.name = "fixture-eager".into();
+    let plugin = RegisteredPlugin::new(
+        manifest,
+        fixture_path(),
+        PathBuf::from("/dev/null/manifest.toml"),
+    );
+    let id = plugin.id.clone();
+    rt.register(plugin);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if matches!(handle.lifecycle_state(&id), Some(LifecycleState::Running)) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "eager plugin never reached Running; state = {:?}",
+        handle.lifecycle_state(&id)
+    );
+}
+
+// Same guarantee via the `RuntimeHandle::discover` codepath — the
+// real ainb-core ingress point. The handle clones the discovery for
+// each plugin under the root, so this exercises the parallel branch
+// of the eager-spawn fix.
+#[test]
+fn eager_spawn_via_handle_discover_starts_process() {
+    use std::fs;
+    let (_rt, handle) = build_runtime();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugin_dir = tmp.path().join("fixture-eager-discover");
+    fs::create_dir_all(&plugin_dir).unwrap();
+
+    // Copy the fixture binary into the discoverable layout.
+    let bin_dst = plugin_dir.join("fixture-eager-discover");
+    fs::copy(fixture_path(), &bin_dst).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = fs::metadata(&bin_dst).unwrap().permissions();
+        p.set_mode(0o755);
+        fs::set_permissions(&bin_dst, p).unwrap();
+    }
+
+    // Manifest the registry expects at `<root>/<name>/manifest.toml`.
+    let manifest_toml = r#"
+[plugin]
+name = "fixture-eager-discover"
+version = "0.1.0"
+abi_version = 2
+description = "eager-spawn discover regression"
+
+[capabilities]
+[provides]
+screens = []
+commands = []
+cli_namespaces = ["echo"]
+snapshots = ["fixture.greeting"]
+[subscribes]
+[lifecycle]
+spawn = "eager"
+idle_reap_secs = 600
+"#;
+    fs::write(plugin_dir.join("manifest.toml"), manifest_toml).unwrap();
+
+    let plugins = handle.discover(tmp.path()).expect("discover");
+    assert_eq!(plugins.len(), 1, "expected single plugin discovered");
+    let id = plugins[0].id.clone();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if matches!(handle.lifecycle_state(&id), Some(LifecycleState::Running)) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "eager plugin (via discover) never reached Running; state = {:?}",
+        handle.lifecycle_state(&id)
+    );
+}
+
+// Inverse guarantee: lazy plugins must stay Idle until a request arrives.
+#[test]
+fn lazy_spawn_stays_idle_without_request() {
+    let (rt, handle) = build_runtime();
+    let mut manifest = fixture_manifest();
+    manifest.lifecycle.spawn = SpawnMode::Lazy;
+    manifest.plugin.name = "fixture-lazy".into();
+    let plugin = RegisteredPlugin::new(
+        manifest,
+        fixture_path(),
+        PathBuf::from("/dev/null/manifest.toml"),
+    );
+    let id = plugin.id.clone();
+    rt.register(plugin);
+
+    // Give the runtime a moment to settle.
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(
+        matches!(handle.lifecycle_state(&id), Some(LifecycleState::Idle)),
+        "lazy plugin must remain Idle without a request; state = {:?}",
+        handle.lifecycle_state(&id)
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixtures/fixture_plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixtures/fixture_plugin.rs
@@ -29,7 +29,8 @@ use std::io::{BufReader, Write};
 use ainb_plugin_protocol::framing::{encode, MAX_BODY_BYTES};
 use ainb_plugin_protocol::methods;
 use ainb_plugin_protocol::params::{
-    ActionInvokeResult, CliDispatchResult, PluginInitResult, RenderResult, SnapshotPublishParams,
+    ActionInvokeParams, ActionInvokeResult, CliDispatchResult, PluginInitResult, RenderResult,
+    SnapshotPublishParams,
 };
 use ainb_plugin_protocol::wire_buffer::{Cell, Coord, WireBuffer};
 use serde_json::{json, Value};
@@ -103,18 +104,12 @@ fn main() {
                 eprintln!("fixture: handle_event {params}");
             }
             methods::HOST_ACTION_INVOKE => {
-                // Echo the payload back as the action result.
+                // Echo the payload back as the action result. `payload`
+                // is wire-encoded as a base64 string (post-v1 wire), but
+                // we also accept the legacy JSON-array-of-bytes form so
+                // older runtimes paired with this fixture keep working.
                 if let Some(id) = id {
-                    let payload = params
-                        .get("payload")
-                        .and_then(Value::as_array)
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(serde_json::Value::as_u64)
-                                .map(|n| u8::try_from(n).unwrap_or(0))
-                                .collect::<Vec<u8>>()
-                        })
-                        .unwrap_or_default();
+                    let payload = decode_action_invoke_params(params.clone());
                     let result = serde_json::to_value(ActionInvokeResult {
                         payload: bytes::Bytes::from(payload),
                     })
@@ -139,6 +134,15 @@ fn main() {
             }
         }
     }
+}
+
+/// Decode a `host/action/invoke` params block. Defers binary decoding
+/// to the protocol's `ActionInvokeParams`, which already accepts both
+/// the base64-string and legacy-byte-array forms for `payload`.
+fn decode_action_invoke_params(value: Value) -> Vec<u8> {
+    serde_json::from_value::<ActionInvokeParams>(value)
+        .map(|p| p.payload.to_vec())
+        .unwrap_or_default()
 }
 
 fn init_result() -> Value {

--- a/ainb-tui/crates/ainb-plugin-sdk-rust/src/server.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/src/server.rs
@@ -141,14 +141,31 @@ where
             }
         };
 
-        if value.get("method").is_some() {
+        if let Some(method) = value.get("method").and_then(Value::as_str) {
             // host -> plugin request or notification.
-            let plugin = plugin.clone();
-            let host_client = host_client.clone();
-            let frames_tx = frames_tx.clone();
-            dispatch_tasks.push(tokio::spawn(async move {
-                dispatch_incoming(plugin, host_client, frames_tx, value).await;
-            }));
+            //
+            // `plugin/handle_event` MUST run in receive order — chunked
+            // publishes (e.g. `sessions.usage_data`) rely on the
+            // consumer seeing `chunk_index = 0` before any follow-on
+            // chunk. Spawning each event onto its own task lets tokio
+            // re-order them through the per-plugin mutex, so we serve
+            // events inline and only spawn for other methods.
+            if method == methods::PLUGIN_HANDLE_EVENT {
+                dispatch_incoming(
+                    plugin.clone(),
+                    host_client.clone(),
+                    frames_tx.clone(),
+                    value,
+                )
+                .await;
+            } else {
+                let plugin = plugin.clone();
+                let host_client = host_client.clone();
+                let frames_tx = frames_tx.clone();
+                dispatch_tasks.push(tokio::spawn(async move {
+                    dispatch_incoming(plugin, host_client, frames_tx, value).await;
+                }));
+            }
         } else if let Some(id) = value.get("id").and_then(Value::as_i64) {
             // Response to a plugin-initiated request.
             let outcome = parse_response(&value);

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -98,14 +98,27 @@ impl Plugin for SessionReader {
     }
 
     async fn on_init(&mut self, host: &HostClient, _granted: &[String]) -> Result<()> {
-        // Subscribe to the refresh topic so the host wakes us up via
-        // `plugin/handle_event` whenever a downstream consumer
-        // publishes a refresh signal.
-        host.snapshot_subscribe(TOPIC_REFRESH_REQUEST).await?;
-        // First scan + publish so consumers have data to bind to as
-        // soon as they ask. Errors are surfaced because a startup
-        // failure is meaningful to the host.
-        self.publish(host).await
+        // Diagnostic probes via host.log() — tagged with plugin name on
+        // the host side. Used to bisect the subscribe-response stall;
+        // remove once Bug 2 is conclusively fixed.
+        let _ = host.log_info("on_init: entering, about to call snapshot_subscribe").await;
+        let sub_res = host.snapshot_subscribe(TOPIC_REFRESH_REQUEST).await;
+        let _ = host
+            .log_info(format!(
+                "on_init: snapshot_subscribe returned ok={}",
+                sub_res.is_ok()
+            ))
+            .await;
+        sub_res?;
+        let _ = host.log_info("on_init: about to call publish").await;
+        let pub_res = self.publish(host).await;
+        let _ = host
+            .log_info(format!(
+                "on_init: publish returned ok={}",
+                pub_res.is_ok()
+            ))
+            .await;
+        pub_res
     }
 
     async fn render(

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -16,11 +16,27 @@
 use ainb_plugin_sdk::{
     HandleEventParams, HostClient, Plugin, RenderParams, Result, SdkError, WireBuffer,
 };
-use ainb_plugin_types_sessions::{UsageDataEvent, WIRE_VERSION};
+use ainb_plugin_types_sessions::{UsageData, UsageDataEvent, WIRE_VERSION};
 use async_trait::async_trait;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::scanner::{self, ProviderRoots};
+
+/// Per-chunk msgpack byte budget. Each chunk's encoded msgpack stays
+/// below this size so the post-base64 + JSON-envelope frame fits
+/// comfortably under the host framer's 16 MiB body cap (base64
+/// inflates ~33%; JSON wrapping adds a few hundred bytes).
+///
+/// Real `$HOME` data is wildly non-uniform — some chunks of 4000 calls
+/// land at ~600 KiB, others at ~12 MiB because of long bash-command
+/// strings or user_message bodies. A fixed call-count budget therefore
+/// can't guarantee staying under the wire cap. [`chunk_usage_data`]
+/// re-encodes the candidate chunk after each call appended and cuts
+/// as soon as the actual msgpack size crosses this threshold.
+///
+/// Set to 2 MiB → ~2.7 MiB after base64 → ~2.7 MiB JSON frame, well
+/// under the 16 MiB framer cap.
+const CHUNK_TARGET_BYTES: usize = 2 * 1024 * 1024;
 
 /// Topic the plugin publishes the aggregated snapshot on. Burndown
 /// (the consumer in Phase 7c-burndown) subscribes to this topic.
@@ -64,25 +80,188 @@ impl SessionReader {
         }
     }
 
+    /// Build a single-chunk `UsageDataEvent` from a fresh scan. Used by
+    /// unit tests only — the real publish path goes through
+    /// [`Self::publish`] which chunks for the wire budget.
+    // TODO(fix/runtime-eager-spawn): keep until chunked-publish test
+    // matrix lands; not exercised by the real publish path.
+    #[cfg(test)]
     fn build_event(&self) -> UsageDataEvent {
         let data = scanner::scan(&self.roots);
         UsageDataEvent {
             version: WIRE_VERSION,
             published_ns: now_ns(),
             partial: false,
+            chunk_index: 0,
+            is_final: true,
             data,
         }
     }
 
-    async fn publish(&mut self, host: &HostClient) -> Result<()> {
-        let event = self.build_event();
-        let bytes = rmp_serde::to_vec_named(&event).map_err(|e| {
+    /// Encode + publish a single chunk. Returns the encoded byte size
+    /// so callers can log/audit. Encoding failures bubble up; the
+    /// caller stops the publish sequence on first error.
+    async fn publish_chunk(
+        host: &HostClient,
+        event: &UsageDataEvent,
+    ) -> Result<usize> {
+        let bytes = rmp_serde::to_vec_named(event).map_err(|e| {
             SdkError::plugin(format!("encode UsageDataEvent: {e}"))
         })?;
+        let len = bytes.len();
         host.snapshot_publish(TOPIC_USAGE_DATA, bytes).await?;
-        self.last_event = Some(event);
+        Ok(len)
+    }
+
+    /// Scan once, then publish the snapshot — chunking large `calls`
+    /// vecs into N envelopes whose encoded msgpack stays under
+    /// [`CHUNK_TARGET_BYTES`] so each JSON-RPC body fits the host
+    /// framer's 16 MiB cap. The first chunk carries the full
+    /// aggregates plus the first slice of calls; subsequent chunks
+    /// carry only the remaining calls. The last chunk is flagged
+    /// `is_final = true`.
+    async fn publish(&mut self, host: &HostClient) -> Result<()> {
+        let data = scanner::scan(&self.roots);
+        let published_ns = now_ns();
+        let chunks =
+            chunk_usage_data(data, published_ns, false, CHUNK_TARGET_BYTES);
+        let total_chunks = chunks.len();
+        let total_calls: usize = chunks.iter().map(|c| c.data.calls.len()).sum();
+
+        let _ = host
+            .log_info(format!(
+                "publish: {} calls in {} chunk(s), target {} bytes/chunk",
+                total_calls, total_chunks, CHUNK_TARGET_BYTES
+            ))
+            .await;
+
+        for event in chunks {
+            let chunk_index = event.chunk_index;
+            let is_final = event.is_final;
+            let len = Self::publish_chunk(host, &event).await?;
+            let _ = host
+                .log_info(format!(
+                    "publish: chunk {}/{} ({} bytes, is_final={})",
+                    chunk_index as usize + 1,
+                    total_chunks,
+                    len,
+                    is_final
+                ))
+                .await;
+            if is_final {
+                self.last_event = Some(event);
+            }
+        }
         Ok(())
     }
+}
+
+/// How many calls to push into a chunk between size probes. Tuned
+/// to balance encoder cost (O(n^2) worst case if STEP=1) against
+/// chunk granularity (larger STEP = fatter chunks because we only
+/// detect overshoot at probe time). With STEP=64 and a 2 MiB target,
+/// the chunker pays at most `target/avg_call_bytes` encodes per
+/// chunk — a few dozen for real data.
+const CHUNKER_PROBE_STEP: usize = 64;
+
+/// Split a `UsageData` snapshot into one or more `UsageDataEvent`
+/// chunks. Pure; unit-tested directly.
+///
+/// Re-encodes the candidate chunk after every [`CHUNKER_PROBE_STEP`]
+/// calls; cuts when the encoded msgpack size crosses `target_bytes`.
+/// This avoids the unbounded variance seen with a static call-count
+/// budget (some real-world calls are >10x larger than others).
+///
+/// - Chunk 0 carries every aggregate field + the first slice of
+///   `data.calls` (sized so the encoded msgpack stays under
+///   `target_bytes`).
+/// - Chunks 1..N carry only the remaining `calls` (every other field
+///   is `UsageData::default()`).
+/// - The last chunk has `is_final = true`. A single-chunk publish has
+///   `chunk_index = 0, is_final = true`.
+/// - When `data.calls` is empty, returns a single chunk.
+/// - A single huge call that on its own exceeds `target_bytes` still
+///   ships (otherwise the loop would stall); the host framer's
+///   16 MiB cap still leaves an order-of-magnitude headroom.
+pub(crate) fn chunk_usage_data(
+    mut data: UsageData,
+    published_ns: u64,
+    partial: bool,
+    target_bytes: usize,
+) -> Vec<UsageDataEvent> {
+    assert!(target_bytes >= 1024, "target_bytes too small");
+    let all_calls = std::mem::take(&mut data.calls);
+
+    let mut out: Vec<UsageDataEvent> = Vec::new();
+    let mut remaining: std::collections::VecDeque<_> = all_calls.into_iter().collect();
+    let mut chunk_index: u32 = 0;
+
+    loop {
+        // Build the candidate chunk's data shell once per chunk —
+        // chunk 0 includes aggregates, others are calls-only.
+        let mut chunk_data = if chunk_index == 0 {
+            let mut head = data.clone();
+            head.calls = Vec::new();
+            head
+        } else {
+            UsageData::default()
+        };
+
+        // Push calls one at a time, probing the encoded size every
+        // CHUNKER_PROBE_STEP appends OR when the queue drains. On
+        // overshoot, roll the trailing call back so the next chunk
+        // gets it. Single-call chunks always ship (giant-outlier
+        // protection).
+        let mut since_probe = 0usize;
+        loop {
+            let Some(call) = remaining.pop_front() else {
+                break;
+            };
+            chunk_data.calls.push(call);
+            since_probe += 1;
+            // Probe when we've accumulated STEP calls, or when the
+            // queue just drained (so we don't miss tiny final
+            // overshoots).
+            if since_probe < CHUNKER_PROBE_STEP && !remaining.is_empty() {
+                continue;
+            }
+            since_probe = 0;
+
+            let probe_event = UsageDataEvent {
+                version: WIRE_VERSION,
+                published_ns,
+                partial,
+                chunk_index,
+                is_final: remaining.is_empty(),
+                data: chunk_data.clone(),
+            };
+            let probe_size = rmp_serde::to_vec_named(&probe_event)
+                .map(|b| b.len())
+                .unwrap_or(target_bytes);
+            if probe_size >= target_bytes && chunk_data.calls.len() > 1 {
+                // Shed the trailing call back to `remaining`.
+                if let Some(spill) = chunk_data.calls.pop() {
+                    remaining.push_front(spill);
+                }
+                break;
+            }
+        }
+
+        let is_final = remaining.is_empty();
+        out.push(UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns,
+            partial,
+            chunk_index,
+            is_final,
+            data: chunk_data,
+        });
+        if is_final {
+            break;
+        }
+        chunk_index = chunk_index.saturating_add(1);
+    }
+    out
 }
 
 impl Default for SessionReader {
@@ -98,27 +277,21 @@ impl Plugin for SessionReader {
     }
 
     async fn on_init(&mut self, host: &HostClient, _granted: &[String]) -> Result<()> {
-        // Diagnostic probes via host.log() — tagged with plugin name on
-        // the host side. Used to bisect the subscribe-response stall;
-        // remove once Bug 2 is conclusively fixed.
-        let _ = host.log_info("on_init: entering, about to call snapshot_subscribe").await;
-        let sub_res = host.snapshot_subscribe(TOPIC_REFRESH_REQUEST).await;
+        // Subscribe to refresh-requests so any consumer (burndown,
+        // tests) can force a rescan. We deliberately *do not* publish
+        // on startup — consumers ask via the refresh topic so they're
+        // guaranteed to be subscribed before chunk 0 hits the wire.
+        // A startup publish races the consumer's own `on_init` and
+        // can arrive while burndown is still subscribing, losing
+        // chunks of the sequence (Bug A in fix/runtime-eager-spawn).
         let _ = host
-            .log_info(format!(
-                "on_init: snapshot_subscribe returned ok={}",
-                sub_res.is_ok()
-            ))
+            .log_info("on_init: subscribing to sessions.refresh_request")
             .await;
-        sub_res?;
-        let _ = host.log_info("on_init: about to call publish").await;
-        let pub_res = self.publish(host).await;
+        host.snapshot_subscribe(TOPIC_REFRESH_REQUEST).await?;
         let _ = host
-            .log_info(format!(
-                "on_init: publish returned ok={}",
-                pub_res.is_ok()
-            ))
+            .log_info("on_init: subscribed, idle until refresh_request")
             .await;
-        pub_res
+        Ok(())
     }
 
     async fn render(
@@ -184,5 +357,169 @@ mod tests {
         let event = plugin.build_event();
         assert_eq!(event.version, WIRE_VERSION);
         assert!(!event.partial);
+        assert_eq!(event.chunk_index, 0);
+        assert!(event.is_final);
+    }
+
+    use ainb_plugin_types_sessions::{
+        ActivityCategory, ActivityUsage, ProjectUsage, Provider, ProviderCall, TokenBucket,
+    };
+    use chrono::{DateTime, Utc};
+
+    fn fake_call(id: u64) -> ProviderCall {
+        ProviderCall {
+            id,
+            provider: Provider::Claude,
+            model: "claude-sonnet".into(),
+            session_id: "s".into(),
+            project: "p".into(),
+            project_path: "/tmp".into(),
+            timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+            input_tokens: 1,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 1,
+            reasoning_tokens: 0,
+            cost_usd: None,
+            tools: vec![],
+            bash_commands: vec![],
+            user_message: String::new(),
+            branch: None,
+        }
+    }
+
+    fn fake_data(n_calls: usize) -> UsageData {
+        let mut d = UsageData::default();
+        d.calls = (0..n_calls).map(|i| fake_call(i as u64)).collect();
+        // Plant a couple of aggregate fields to verify chunk 0 keeps
+        // them and follow-on chunks drop them.
+        d.grand_total = TokenBucket {
+            input_tokens: n_calls as u64,
+            output_tokens: n_calls as u64,
+            call_count: n_calls,
+            ..TokenBucket::default()
+        };
+        d.projects = vec![ProjectUsage {
+            name: "p".into(),
+            path: "/tmp".into(),
+            bucket: d.grand_total,
+            repo: None,
+        }];
+        d.activities = vec![ActivityUsage {
+            category: ActivityCategory::Code,
+            bucket: d.grand_total,
+            turns: n_calls,
+            retries: 0,
+            edit_turns: 0,
+            one_shot_turns: n_calls,
+        }];
+        d
+    }
+
+    #[test]
+    fn chunk_single_when_calls_fit_in_one_chunk() {
+        let data = fake_data(10);
+        // 4 MiB budget — small fake calls all fit.
+        let chunks = chunk_usage_data(data, 42, false, 4 * 1024 * 1024);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert!(chunks[0].is_final);
+        assert_eq!(chunks[0].data.calls.len(), 10);
+        assert_eq!(chunks[0].data.projects.len(), 1, "aggregates ride chunk 0");
+        assert_eq!(chunks[0].published_ns, 42);
+    }
+
+    #[test]
+    fn chunk_single_when_calls_empty() {
+        let data = fake_data(0);
+        let chunks = chunk_usage_data(data, 0, false, 4 * 1024 * 1024);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].is_final);
+        assert!(chunks[0].data.calls.is_empty());
+    }
+
+    #[test]
+    fn chunk_splits_when_calls_exceed_byte_budget() {
+        // 40 fat calls with ~5 KiB user_message each. With a
+        // 128 KiB budget that forces multiple chunks.
+        let mut data = fake_data(0);
+        data.calls = (0..40)
+            .map(|i| {
+                let mut c = fake_call(i);
+                c.user_message = "x".repeat(5 * 1024);
+                c
+            })
+            .collect();
+        data.projects = vec![ProjectUsage {
+            name: "p".into(),
+            path: "/tmp".into(),
+            bucket: TokenBucket::default(),
+            repo: None,
+        }];
+        data.activities = vec![ActivityUsage {
+            category: ActivityCategory::Code,
+            bucket: TokenBucket::default(),
+            turns: 40,
+            retries: 0,
+            edit_turns: 0,
+            one_shot_turns: 40,
+        }];
+
+        let chunks = chunk_usage_data(data, 0, false, 128 * 1024);
+        assert!(chunks.len() > 1, "expected >1 chunks, got {}", chunks.len());
+        let total_calls: usize = chunks.iter().map(|c| c.data.calls.len()).sum();
+        assert_eq!(total_calls, 40, "no calls lost across chunks");
+
+        // Chunk 0 carries aggregates.
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert!(!chunks[0].is_final);
+        assert_eq!(chunks[0].data.projects.len(), 1);
+        assert_eq!(chunks[0].data.activities.len(), 1);
+
+        // Chunks 1+ carry only calls (no aggregates).
+        assert!(chunks[1].data.projects.is_empty());
+        assert!(chunks[1].data.activities.is_empty());
+        assert_eq!(chunks[1].data.grand_total, TokenBucket::default());
+
+        // Last chunk is is_final=true; chunk_index increments contiguously.
+        let last = chunks.last().unwrap();
+        assert!(last.is_final);
+        assert_eq!(last.chunk_index as usize, chunks.len() - 1);
+    }
+
+    #[test]
+    fn chunk_preserves_call_order_and_no_loss() {
+        // Force multi-chunk via fat user_message + tight budget.
+        let mut data = fake_data(0);
+        data.calls = (0..9)
+            .map(|i| {
+                let mut c = fake_call(i);
+                c.user_message = "x".repeat(20 * 1024);
+                c
+            })
+            .collect();
+        let chunks = chunk_usage_data(data, 0, false, 64 * 1024);
+        assert!(chunks.len() > 1);
+        let mut ids = Vec::new();
+        for c in &chunks {
+            for call in &c.data.calls {
+                ids.push(call.id);
+            }
+        }
+        assert_eq!(ids, (0..9).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn chunk_with_single_giant_call_still_progresses() {
+        // Even a single estimated-over-budget call must ship —
+        // otherwise the chunker would loop forever waiting for room.
+        let mut data = fake_data(0);
+        let mut huge = fake_call(1);
+        huge.user_message = "x".repeat(2048);
+        data.calls = vec![huge];
+        let chunks = chunk_usage_data(data, 0, false, 1024);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].is_final);
+        assert_eq!(chunks[0].data.calls.len(), 1);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/tests/subprocess_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/tests/subprocess_smoke.rs
@@ -4,9 +4,13 @@
 //! (Content-Length framed), and asserts:
 //!   1. `plugin/init` returns `{name: "session-reader", version: ...}`.
 //!   2. During `on_init` the plugin emits a `host/snapshot/subscribe`
-//!      request for `sessions.refresh_request` (we reply OK).
-//!   3. The plugin publishes an `rmp-serde`-encoded `UsageDataEvent`
-//!      on `sessions.usage_data`.
+//!      request for `sessions.refresh_request` (we reply OK) and then
+//!      returns — it does NOT publish on startup. Publishing is
+//!      gated on a `sessions.refresh_request` event so consumers are
+//!      guaranteed to be subscribed before chunk 0 hits the wire.
+//!   3. A `plugin/handle_event` for `sessions.refresh_request`
+//!      triggers a chunked `rmp-serde`-encoded `UsageDataEvent`
+//!      publish on `sessions.usage_data`.
 //!   4. `plugin/shutdown` returns cleanly and the process exits.
 //!
 //! The fixture sets `HOME` to an empty tempdir so the scan finds no
@@ -154,7 +158,9 @@ fn subprocess_init_publishes_snapshot_then_responds_ok() {
 
     let subscribe_id = subscribe_id.expect("plugin never issued snapshot/subscribe");
 
-    // 3) Reply to subscribe so on_init can finish.
+    // 3) Reply to subscribe so on_init can finish. The plugin should
+    //    NOT publish anything during init — publishing is gated on
+    //    refresh_request (asserted below).
     let subscribe_result = SnapshotSubscribeResult {};
     write_frame(
         &mut stdin,
@@ -164,10 +170,13 @@ fn subprocess_init_publishes_snapshot_then_responds_ok() {
             "result": subscribe_result,
         }),
     );
+    assert!(
+        publish_seen.is_none(),
+        "plugin must not publish during init — gated on refresh_request"
+    );
 
     // 4) Drain outbound frames until we see the plugin/init response.
-    //    A snapshot/publish from the publish() call after subscribe()
-    //    arrives here too.
+    //    No snapshot/publish should arrive in this window.
     let deadline = Instant::now() + Duration::from_secs(10);
     let mut init_response: Option<Value> = None;
     while Instant::now() < deadline {
@@ -175,11 +184,7 @@ fn subprocess_init_publishes_snapshot_then_responds_ok() {
             .expect("plugin closed stdout before init response");
         if let Some(method) = frame.get("method").and_then(Value::as_str) {
             if method == methods::HOST_SNAPSHOT_PUBLISH {
-                let params: SnapshotPublishParams = serde_json::from_value(
-                    frame.get("params").cloned().unwrap_or(Value::Null),
-                )
-                .expect("decode publish params");
-                publish_seen = Some(params);
+                panic!("plugin published during init — expected refresh-gated publish only");
             }
             // ignore other notifications (logs, etc.)
         } else if frame.get("id").and_then(Value::as_i64) == Some(1) {
@@ -196,16 +201,8 @@ fn subprocess_init_publishes_snapshot_then_responds_ok() {
     assert_eq!(init_result.name, "session-reader");
     assert_eq!(init_result.version, "0.2.0");
 
-    let publish_seen =
-        publish_seen.expect("plugin should publish a sessions.usage_data snapshot during init");
-    assert_eq!(publish_seen.topic, "sessions.usage_data");
-    let event: UsageDataEvent = rmp_serde::from_slice(&publish_seen.payload)
-        .expect("snapshot payload is rmp-serde UsageDataEvent");
-    assert_eq!(event.version, WIRE_VERSION);
-    assert!(!event.partial);
-
-    // 5) handle_event for the refresh topic should also trigger a
-    //    fresh publish — sanity-check the wiring.
+    // 5) handle_event for the refresh topic should trigger a publish —
+    //    this is the primary trigger for snapshot delivery.
     write_frame(
         &mut stdin,
         &json!({
@@ -226,13 +223,25 @@ fn subprocess_init_publishes_snapshot_then_responds_ok() {
             None => break,
         };
         if frame.get("method").and_then(Value::as_str) == Some(methods::HOST_SNAPSHOT_PUBLISH) {
+            let params: SnapshotPublishParams = serde_json::from_value(
+                frame.get("params").cloned().unwrap_or(Value::Null),
+            )
+            .expect("decode publish params");
+            assert_eq!(params.topic, "sessions.usage_data");
+            let event: UsageDataEvent = rmp_serde::from_slice(&params.payload)
+                .expect("snapshot payload is rmp-serde UsageDataEvent");
+            assert_eq!(event.version, WIRE_VERSION);
+            assert!(!event.partial);
+            // Empty HOME → single chunk with is_final = true.
+            assert_eq!(event.chunk_index, 0);
+            assert!(event.is_final);
             got_refresh_publish = true;
             break;
         }
     }
     assert!(
         got_refresh_publish,
-        "plugin did not republish snapshot after handle_event(refresh)"
+        "plugin did not publish snapshot after handle_event(refresh)"
     );
 
     // 6) Clean shutdown.

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -29,7 +29,14 @@ use serde::{Deserialize, Serialize};
 /// Wire-format schema version for [`UsageDataEvent`]. Bump on any
 /// breaking change. Consumers compare `event.version == WIRE_VERSION`
 /// before trusting the payload.
-pub const WIRE_VERSION: u32 = 1;
+///
+/// v2: added `chunk_index` + `is_final` so a single logical snapshot
+/// can be split into N envelopes — required because the full snapshot
+/// of a real `$HOME` (~2 GB / ~40k provider calls) encodes to ~110 MB
+/// of msgpack, blowing past the host framer's 16 MiB body cap. Older
+/// peers reading the new wire see defaults (`chunk_index = 0`,
+/// `is_final = true`) — which is exactly the single-chunk path.
+pub const WIRE_VERSION: u32 = 2;
 
 /// Top-level envelope published on the `sessions.usage_data` topic.
 ///
@@ -37,6 +44,17 @@ pub const WIRE_VERSION: u32 = 1;
 /// time (via `ainb_now_ms` or equivalent). `partial = true` flags a
 /// snapshot whose scan was budget-truncated — burndown shows a
 /// "partial" badge and re-asks on the next refresh.
+///
+/// **Chunked publishes**: a single logical snapshot may be split into
+/// N envelopes. Chunk 0 carries the full aggregates plus the first
+/// slice of [`UsageData::calls`]; chunks 1..N carry the remaining
+/// `calls` only (every other field is empty/default). The last chunk
+/// sets `is_final = true`; consumers concat the call slices and treat
+/// the snapshot as live once they see `is_final`.
+///
+/// Single-chunk publishes use `chunk_index = 0, is_final = true` — the
+/// defaults — so old publishers and small snapshots keep working
+/// unchanged.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsageDataEvent {
     /// Schema version. Equals [`WIRE_VERSION`] when the publisher and
@@ -46,8 +64,23 @@ pub struct UsageDataEvent {
     pub published_ns: u64,
     /// `true` if scan was truncated by fuel budget; `false` if complete.
     pub partial: bool,
-    /// Aggregated snapshot.
+    /// 0 = first chunk (carries aggregates); increments per follow-on
+    /// chunk. Optional on the wire — defaults to `0` for old
+    /// publishers / single-chunk snapshots.
+    #[serde(default)]
+    pub chunk_index: u32,
+    /// `true` on the last chunk of a publish sequence (or on a
+    /// single-chunk snapshot). Optional on the wire — defaults to
+    /// `true` so a v1-era publisher reads as a complete single chunk.
+    #[serde(default = "default_true")]
+    pub is_final: bool,
+    /// Aggregated snapshot. On chunks `> 0`, only the [`UsageData::calls`]
+    /// vec is populated; every other field is default/empty.
     pub data: UsageData,
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 /// Provider — externally-tagged so unit variants serialise as plain
@@ -451,6 +484,8 @@ mod tests {
             version: WIRE_VERSION,
             published_ns: 1_700_000_000_000_000_000,
             partial: false,
+            chunk_index: 0,
+            is_final: true,
             data: fixture_data(),
         };
         let bytes = rmp_serde::to_vec_named(&env).unwrap();
@@ -467,12 +502,47 @@ mod tests {
             version: WIRE_VERSION + 1,
             published_ns: 0,
             partial: true,
+            chunk_index: 0,
+            is_final: true,
             data: UsageData::default(),
         };
         let bytes = rmp_serde::to_vec_named(&env).unwrap();
         let back: UsageDataEvent = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(back.version, WIRE_VERSION + 1);
         assert!(back.partial);
+    }
+
+    #[test]
+    fn chunked_envelope_roundtrip() {
+        // Chunk 0 of a hypothetical 2-chunk publish.
+        let chunk0 = UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns: 1_700_000_000_000_000_000,
+            partial: false,
+            chunk_index: 0,
+            is_final: false,
+            data: fixture_data(),
+        };
+        let bytes = rmp_serde::to_vec_named(&chunk0).unwrap();
+        let back: UsageDataEvent = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(chunk0, back);
+        assert_eq!(back.chunk_index, 0);
+        assert!(!back.is_final);
+
+        // Chunk 1 (final) carries only the remaining calls.
+        let mut calls_only = UsageData::default();
+        calls_only.calls = vec![fixture_call()];
+        let chunk1 = UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns: 1_700_000_000_000_000_000,
+            partial: false,
+            chunk_index: 1,
+            is_final: true,
+            data: calls_only,
+        };
+        let bytes = rmp_serde::to_vec_named(&chunk1).unwrap();
+        let back: UsageDataEvent = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(chunk1, back);
     }
 
     #[test]

--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -58,6 +58,17 @@ clean:
 # Install development dependencies
 setup:
     rustup component add rustfmt clippy
+
+# Build + stage all bundled plugins (subprocess binaries) into dist/plugins/
+# Required before running tripwire_real_data_in_tui or anything that
+# discovers plugins from dist/. On macOS this also re-signs each staged
+# binary so AMFI doesn't SIGKILL it at exec.
+stage-plugins:
+    ./scripts/build-plugins.sh
+
+# Same but release profile.
+stage-plugins-release:
+    ./scripts/build-plugins.sh --release
     cargo install just
 
 # Watch and rebuild on changes

--- a/ainb-tui/scripts/build-plugins.sh
+++ b/ainb-tui/scripts/build-plugins.sh
@@ -1,37 +1,74 @@
 #!/usr/bin/env bash
-# Build all bundled ainb plugins to wasm32-wasip1 and stage into dist/plugins/.
+# Build all bundled ainb plugins (Phase 7 subprocess architecture) and stage
+# into dist/plugins/<id>/. Each staged plugin has the layout the runtime's
+# discovery expects:
+#
+#   dist/plugins/<id>/<id>          executable binary
+#   dist/plugins/<id>/manifest.toml plugin manifest
+#
+# On macOS, cargo links binaries with an ad-hoc, linker-signed signature
+# bound to the original build path. Copying the binary to a new path
+# invalidates that signature and AMFI SIGKILLs the process at exec time
+# (silent — no stderr, exit 137). We re-sign in place after each copy.
 #
 # Run from the ainb-tui workspace root:
-#   ./scripts/build-plugins.sh [--release]
+#   ./scripts/build-plugins.sh
+#   ./scripts/build-plugins.sh --release
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# shellcheck source=./wasi-env.sh
-source "$(pwd)/scripts/wasi-env.sh"
+PROFILE="dev"
+PROFILE_DIR="debug"
+for arg in "$@"; do
+    case "$arg" in
+        --release)
+            PROFILE="release"
+            PROFILE_DIR="release"
+            ;;
+        *)
+            printf 'unknown arg: %s\n' "$arg" >&2
+            exit 2
+            ;;
+    esac
+done
 
-PROFILE="${PROFILE:-release}"
-TARGET="wasm32-wasip1"
+resign_macos() {
+    local bin="$1"
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        return 0
+    fi
+    # Strip the path-bound linker signature, then re-sign ad-hoc at the
+    # new path. Without this, AMFI kills the process at exec (exit 137,
+    # no stderr) because the linker-signed hash no longer matches the
+    # binary's location.
+    codesign --remove-signature "$bin" >/dev/null 2>&1 || true
+    codesign --sign - "$bin" >/dev/null 2>&1
+}
 
 build_plugin() {
     local crate="$1"
     local plugin_id="$2"
 
-    # Plugin crate lives in [workspace.exclude] (own sub-workspace) so it
-    # must be built from inside its own directory; root `-p` won't see it.
-    (cd "crates/$crate" && cargo build --target "$TARGET" --profile "$PROFILE")
+    cargo build -p "$crate" --profile "$PROFILE"
 
     local out_dir="dist/plugins/$plugin_id"
     mkdir -p "$out_dir"
-    cp "crates/$crate/target/$TARGET/$PROFILE/${crate//-/_}.wasm" \
-       "$out_dir/plugin.wasm"
-    if [[ -f "crates/$crate/plugin.toml" ]]; then
-        cp "crates/$crate/plugin.toml" "$out_dir/"
+
+    # Cargo binary name == crate name. Staged binary name == plugin id
+    # (the runtime probes <root>/<id>/<id>).
+    cp "target/$PROFILE_DIR/$crate" "$out_dir/$plugin_id"
+    resign_macos "$out_dir/$plugin_id"
+
+    if [[ -f "crates/$crate/manifest.toml" ]]; then
+        cp "crates/$crate/manifest.toml" "$out_dir/manifest.toml"
+    elif [[ -f "crates/$crate/plugin.toml" ]]; then
+        cp "crates/$crate/plugin.toml" "$out_dir/manifest.toml"
     fi
 
     local size
-    size=$(stat -f%z "$out_dir/plugin.wasm" 2>/dev/null || stat -c%s "$out_dir/plugin.wasm")
-    printf 'built %s -> %s (%s bytes)\n' "$crate" "$out_dir/plugin.wasm" "$size"
+    size=$(stat -f%z "$out_dir/$plugin_id" 2>/dev/null || stat -c%s "$out_dir/$plugin_id")
+    printf 'staged %-30s -> %s (%s bytes)\n' "$crate" "$out_dir/$plugin_id" "$size"
 }
 
 build_plugin ainb-plugin-burndown burndown


### PR DESCRIPTION
## Summary

Two-tmux ground-truth verification of the Phase 7 plugin runtime caught **two bugs**. This PR ships the eager-spawn fix (Bug 1) and tightens the validation gates so this class of failure stops slipping through. Bug 2 is uncovered and documented but **not fixed in this PR** — the new tightened 7f.3 tripwire is marked `#[ignore]` with a clear `BUG:` pointer pending follow-up.

## Bug 1 — fixed here: runtime ignored `SpawnMode::Eager`

`Runtime::register` and `RuntimeHandle::discover` both spawned every plugin task in `Idle` state regardless of `manifest.lifecycle.spawn`. `grep -rn 'Eager' crates/ainb-plugin-runtime/` returned zero hits — the enum existed in the protocol but the runtime never branched on it. Lazy plugins start on first request, but **pure-publisher plugins like `session-reader` have no caller driving them directly**, so they never spawned. Burndown subscribed to `sessions.usage_data` and waited forever.

**Fix:** new `Command::EnsureSpawned` variant. Both register paths now check `manifest.lifecycle.spawn` and dispatch `EnsureSpawned` immediately after the per-plugin task is created when the manifest declares `eager`. The task handles it by calling `ensure_running`, going through the normal `spawn_and_init` path.

## Bug 2 — uncovered, not fixed here: subscribe-response stall

After Bug 1 is fixed, `session-reader` correctly spawns, sends `host/snapshot/subscribe(sessions.refresh_request)` to the host, **the host receives it and enters `handle_host_request`** — but the plugin never observes the response. `on_init` blocks on its `host.snapshot_subscribe(...).await` and never reaches the followup `self.publish(host).await`. The process exits within ~25s of the host going away. End result: burndown still shows `⏳ Waiting for session-reader plugin...`.

Investigation traced the message flow via temporary `eprintln`-instrumentation through `plugin_task::run`. The host writes the response via `write_frame(&mut cs.stdin, &body)` — the next debugging step would be confirming whether that write returns and whether the plugin's reader sees it. **Out of scope for the eager-spawn change**; needs separate investigation in the host↔plugin framing layer or SDK reader/writer threading. Drop the `#[ignore]` on `tripwire_real_data_in_tui` once that bug is fixed.

## Why this PR exists at all

The Phase 7f tripwire 7f.3 (`tripwire_real_data_in_tui.rs`) passed in PR #96 because it asserted on substring-OR of chrome strings: `"ainb"`, `"Container"`, `"session"`, `"Workspace"`, etc. All of these appear in the sidebar/title bar **without burndown rendering any data**. The test "passed" while the actual user-facing feature was broken. Stevie's tmux-drive verification (open `ainb tui`, press `i`, capture pane) immediately surfaced the failure: panel shows `⏳ Waiting for session-reader plugin...` indefinitely.

This PR closes the validation gap and fixes the first of the two bugs feeding it.

## Test gates

| gate | result |
|---|---|
| `cargo test -p ainb-plugin-runtime` | ✅ 8/8 fixture_e2e (incl 3 new) + lib tests |
| `cargo test -p ainb --test tripwire_sessions_screen` | ✅ pass — 's' navigation works (non-plugin path) |
| `cargo test -p ainb --test tripwire_real_data_in_tui` | ⚪ ignored with `BUG:` pointer (Bug 2) |
| `cargo test -p ainb --test 'tripwire*'` | ✅ all non-ignored pass |
| `cargo clippy -p ainb-plugin-runtime --lib` | ✅ clean |

## Commits (3 atomic)

- `b16add6` fix(plugin-runtime): honour SpawnMode::Eager at registration time
- `4e1afa7` test(plugin-runtime): 3 eager/lazy spawn regressions
- `c48c01f` test(tripwire): tighten 7f.3 + add 7f.5 sessions regression

## Tmux ground-truth captures

**HomeScreen (no key):** sidebar shows `📊 Stats [i]`, `🚀 Sessions [s]`, title bar `A I N B — Agents in a Box`. ✅

**After pressing `s`:** Session List screen renders with `Session Details` panel + footer (`attach`, `restart`, `cleanup`). ✅ Non-plugin path unaffected.

**After pressing `i`:** Analytics chrome renders (`📊 Usage Analytics`, provider tabs, `Daily/Weekly/By Project/Optimize`) — but burndown panel shows literal `⏳ Waiting for session-reader plugin...`. ❌ Bug 2 surface; eager-spawn fix is necessary scaffolding but not sufficient.

## Scope notes

This PR does **not** close Bug 2. The follow-up belongs in the host↔plugin framing path (probably `plugin_task::write_frame` or SDK Server reader thread). Once that lands, drop the `#[ignore]` on `tripwire_real_data_in_tui` and verify the test goes green via the same two-tmux pattern.

Base: `feat/plugin`. No conflicts.
