### PR TITLE
feat(plugin-protocol): add plugin/handle_key wire surface

### DIFF
--- a/ainb-tui/crates/ainb-plugin-protocol/src/methods.rs
+++ b/ainb-tui/crates/ainb-plugin-protocol/src/methods.rs
@@ -23,6 +23,11 @@ pub const PLUGIN_RENDER: &str = "plugin/render";
 /// Host pushes a snapshot/event update. Notification — no response expected.
 pub const PLUGIN_HANDLE_EVENT: &str = "plugin/handle_event";
 
+/// Host forwards a single key event to the plugin owning the focused screen.
+/// Notification — no response expected. Ordering is preserved across the same
+/// transport as `plugin/handle_event` so key sequences arrive in send order.
+pub const PLUGIN_HANDLE_KEY: &str = "plugin/handle_key";
+
 /// Host dispatches a CLI namespace + argv to the plugin; plugin replies with stdout/stderr/exit.
 pub const PLUGIN_CLI_DISPATCH: &str = "plugin/cli_dispatch";
 
@@ -66,6 +71,7 @@ pub const ALL_METHODS: &[&str] = &[
     PLUGIN_SHUTDOWN,
     PLUGIN_RENDER,
     PLUGIN_HANDLE_EVENT,
+    PLUGIN_HANDLE_KEY,
     PLUGIN_CLI_DISPATCH,
     HOST_SNAPSHOT_GET,
     HOST_SNAPSHOT_PUBLISH,
@@ -95,10 +101,20 @@ mod tests {
             PLUGIN_SHUTDOWN,
             PLUGIN_RENDER,
             PLUGIN_HANDLE_EVENT,
+            PLUGIN_HANDLE_KEY,
             PLUGIN_CLI_DISPATCH,
         ] {
             assert!(m.starts_with("plugin/"), "{m} missing plugin/ namespace");
         }
+    }
+
+    #[test]
+    fn all_methods_contains_plugin_handle_key() {
+        assert!(
+            ALL_METHODS.contains(&PLUGIN_HANDLE_KEY),
+            "PLUGIN_HANDLE_KEY missing from ALL_METHODS registry"
+        );
+        assert_eq!(PLUGIN_HANDLE_KEY, "plugin/handle_key");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-protocol/src/params.rs
+++ b/ainb-tui/crates/ainb-plugin-protocol/src/params.rs
@@ -119,6 +119,114 @@ pub struct HandleEventParams {
 }
 
 // =====================================================================
+// plugin/handle_key
+// =====================================================================
+
+/// Normalized key event delivered from host → plugin.
+///
+/// Host translates the terminal-specific event (e.g. `crossterm::event::KeyEvent`)
+/// into this portable representation exactly once, so non-Rust plugins can
+/// participate without depending on crossterm.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyEvent {
+    /// Logical key pressed.
+    pub code: KeyCode,
+    /// Bitmask of active modifiers — see [`KEY_MOD_SHIFT`], [`KEY_MOD_CTRL`],
+    /// [`KEY_MOD_ALT`], [`KEY_MOD_SUPER`].
+    #[serde(default)]
+    pub mods: u8,
+    /// Whether this is the initial press, an auto-repeat, or a release.
+    #[serde(default)]
+    pub kind: KeyKind,
+}
+
+/// Logical key identity. Wire tag is `type`, variants `snake_case` —
+/// `Char { ch }` is `{"type":"char","ch":"1"}`, `BackTab` is `{"type":"back_tab"}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum KeyCode {
+    /// Printable character key.
+    Char {
+        /// The character pressed.
+        ch: char,
+    },
+    /// Enter / Return.
+    Enter,
+    /// Tab.
+    Tab,
+    /// Shift-Tab (reverse tab).
+    BackTab,
+    /// Escape.
+    Esc,
+    /// Backspace.
+    Backspace,
+    /// Delete (forward delete).
+    Delete,
+    /// Up arrow.
+    Up,
+    /// Down arrow.
+    Down,
+    /// Left arrow.
+    Left,
+    /// Right arrow.
+    Right,
+    /// Home.
+    Home,
+    /// End.
+    End,
+    /// Page Up.
+    PageUp,
+    /// Page Down.
+    PageDown,
+    /// Function key F1..F24.
+    F {
+        /// Function number (1-based).
+        n: u8,
+    },
+}
+
+/// Press / repeat / release. `Press` is the default — older peers that
+/// omit the field decode as `Press`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyKind {
+    /// Initial key-down.
+    #[default]
+    Press,
+    /// Auto-repeated key-down while held.
+    Repeat,
+    /// Key-up.
+    Release,
+}
+
+/// Shift modifier bit for [`KeyEvent::mods`].
+pub const KEY_MOD_SHIFT: u8 = 0b0001;
+/// Control modifier bit for [`KeyEvent::mods`].
+pub const KEY_MOD_CTRL: u8 = 0b0010;
+/// Alt / Option modifier bit for [`KeyEvent::mods`].
+pub const KEY_MOD_ALT: u8 = 0b0100;
+/// Super / Command / Windows modifier bit for [`KeyEvent::mods`].
+pub const KEY_MOD_SUPER: u8 = 0b1000;
+
+/// `plugin/handle_key` params (notification). Host forwards keys the
+/// host hasn't reserved (e.g. global navigation) to the plugin owning
+/// the currently focused screen.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandleKeyParams {
+    /// Plugin-defined screen identifier (e.g. `ainb_analytics`). Lets a
+    /// plugin host multiple screens and dispatch by id without extra
+    /// per-key bookkeeping on the host.
+    pub screen_id: String,
+    /// The key event itself.
+    pub key: KeyEvent,
+    /// Monotonic counter the host increments per forwarded key. The plugin
+    /// is expected to echo the value back via [`RenderParams::generation`]
+    /// on the next render, giving the host a freshness witness that the
+    /// key has been observed.
+    pub generation: u64,
+}
+
+// =====================================================================
 // plugin/cli_dispatch
 // =====================================================================
 
@@ -533,5 +641,95 @@ mod tests {
     fn log_level_lowercased_on_wire() {
         let s = serde_json::to_string(&LogLevel::Warn).unwrap();
         assert_eq!(s, "\"warn\"");
+    }
+
+    #[test]
+    fn handle_key_params_round_trip_ctrl_shift_press() {
+        // Plan §Phase 1 gate: HandleKeyParams { Char('1'), SHIFT|CTRL, Press }
+        // round-trips byte-stable.
+        let params = HandleKeyParams {
+            screen_id: "ainb_analytics".into(),
+            key: KeyEvent {
+                code: KeyCode::Char { ch: '1' },
+                mods: KEY_MOD_SHIFT | KEY_MOD_CTRL,
+                kind: KeyKind::Press,
+            },
+            generation: 42,
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        let back: HandleKeyParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(params, back);
+        // Second encode of the decoded value must produce the same bytes.
+        let json2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(json, json2, "encode is not byte-stable across decode");
+    }
+
+    #[test]
+    fn key_code_wire_tag_and_payload() {
+        // Wire tag is `type`, variants snake_case.
+        let s = serde_json::to_string(&KeyCode::Char { ch: 'z' }).unwrap();
+        assert_eq!(s, r#"{"type":"char","ch":"z"}"#);
+        let s = serde_json::to_string(&KeyCode::BackTab).unwrap();
+        assert_eq!(s, r#"{"type":"back_tab"}"#);
+        let s = serde_json::to_string(&KeyCode::PageDown).unwrap();
+        assert_eq!(s, r#"{"type":"page_down"}"#);
+        let s = serde_json::to_string(&KeyCode::F { n: 7 }).unwrap();
+        assert_eq!(s, r#"{"type":"f","n":7}"#);
+    }
+
+    #[test]
+    fn key_kind_defaults_to_press_when_absent() {
+        // Older peers that omit `kind` decode as Press.
+        let j = r#"{"code":{"type":"enter"}}"#;
+        let ev: KeyEvent = serde_json::from_str(j).unwrap();
+        assert_eq!(ev.kind, KeyKind::Press);
+        assert_eq!(ev.mods, 0);
+        assert_eq!(ev.code, KeyCode::Enter);
+    }
+
+    #[test]
+    fn key_mod_bits_are_independent() {
+        // Each modifier occupies its own bit; OR-ing all four is 0b1111.
+        let all = KEY_MOD_SHIFT | KEY_MOD_CTRL | KEY_MOD_ALT | KEY_MOD_SUPER;
+        assert_eq!(all, 0b1111);
+        assert_eq!(KEY_MOD_SHIFT & KEY_MOD_CTRL, 0);
+        assert_eq!(KEY_MOD_ALT & KEY_MOD_SUPER, 0);
+    }
+
+    #[test]
+    fn handle_key_params_round_trip_each_code() {
+        // Exercise the full KeyCode variant matrix through round-trip.
+        let codes = [
+            KeyCode::Char { ch: 'a' },
+            KeyCode::Enter,
+            KeyCode::Tab,
+            KeyCode::BackTab,
+            KeyCode::Esc,
+            KeyCode::Backspace,
+            KeyCode::Delete,
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Home,
+            KeyCode::End,
+            KeyCode::PageUp,
+            KeyCode::PageDown,
+            KeyCode::F { n: 12 },
+        ];
+        for code in codes {
+            let params = HandleKeyParams {
+                screen_id: "s".into(),
+                key: KeyEvent {
+                    code: code.clone(),
+                    mods: 0,
+                    kind: KeyKind::Press,
+                },
+                generation: 1,
+            };
+            let j = serde_json::to_string(&params).unwrap();
+            let back: HandleKeyParams = serde_json::from_str(&j).unwrap();
+            assert_eq!(params, back, "round-trip failed for {code:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the burndown interactive-keys plan: add the `plugin/handle_key` JSON-RPC method and the portable `KeyEvent` / `KeyCode` / `KeyKind` types it carries. Pure-additive wire change — no existing methods or types touched.

- `crates/ainb-plugin-protocol/src/methods.rs` — register `PLUGIN_HANDLE_KEY = "plugin/handle_key"`, append to `ALL_METHODS`.
- `crates/ainb-plugin-protocol/src/params.rs` — introduce `HandleKeyParams`, `KeyEvent`, `KeyCode` (tagged enum, `snake_case` wire form), `KeyKind` (defaulting to `Press`), and `KEY_MOD_{SHIFT,CTRL,ALT,SUPER}` bitmask constants.

Method is a notification (no response), parallel to `plugin/handle_event`. Ordering is preserved across the same transport so multi-key sequences arrive in send order (matching the inline-dispatch fix already shipped for `handle_event`).

Refs bead `agents-in-a-box-8q1.1` and plan `ainb-tui/plans/plugin-interactive-keys-and-cache.md` §Phase 1.

## Test plan

- [x] `cargo test -p ainb-plugin-protocol` — 37 passed, 0 failed (5 new tests).
- [x] Serde round-trip: `HandleKeyParams { Char('1'), SHIFT|CTRL, Press }` byte-stable across encode → decode → re-encode.
- [x] Full `KeyCode` variant matrix round-trips (Char, Enter, Tab, BackTab, Esc, Backspace, Delete, arrows, Home/End, PageUp/PageDown, F).
- [x] Wire shape verified: `{"type":"char","ch":"z"}`, `{"type":"back_tab"}`, `{"type":"page_down"}`.
- [x] `KeyKind` defaults to `Press` when the field is absent (forward-compat for older peers).
- [x] Modifier bits are independent (`SHIFT|CTRL|ALT|SUPER == 0b1111`).
- [x] `ALL_METHODS.contains(&PLUGIN_HANDLE_KEY)` asserted.
- [x] Downstream crates (`ainb-plugin-sdk-rust`) still build clean.

## Out of scope

SDK trait method, host forwarder, and burndown dispatch land in Phases 2–4. Bead `agents-in-a-box-8q1.2` is the immediate follow-up.