### PR TITLE
feat(plugin-session-reader): SQLite usage cache

### DIFF
--- a/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
@@ -26,6 +26,15 @@ rmp-serde = "1.3"
 bytes = { version = "1.6", features = ["serde"] }
 tracing = { workspace = true }
 
+# Cache module: persistent per-file parse cache lives only on native
+# targets. Subprocess plugins compile native; the cfg gate inside
+# src/cache.rs is precautionary so a future wasm32 build doesn't drag
+# in rusqlite/bincode.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rusqlite = { workspace = true }
+bincode = { workspace = true }
+thiserror = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 toml = { workspace = true }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -1,0 +1,464 @@
+//! Persistent per-file parse cache for the session-reader plugin.
+//!
+//! Each entry keys on the absolute path of a provider session file and
+//! stores the parsed `Vec<ProviderCall>` plus the `(mtime, size)` tuple
+//! the parser saw at the time of insertion. On the next scan the cache
+//! short-circuits the parse when the on-disk file still has the same
+//! `(mtime, size)`; on mismatch the parser is re-run and the row is
+//! overwritten with a fresh fingerprint.
+//!
+//! The on-disk format is the simplest thing that satisfies the plugin
+//! plan's Phase 5 contract — schema v1, FNV-1a 64 content fingerprint,
+//! `PRAGMA user_version` migration. The richer offset / append-aware
+//! cache in `ainb-core/src/usage_cache/` exists for the main TUI; the
+//! plugin owns its own data dir per the `write_plugin_data` capability
+//! and keeps the cache shape decoupled.
+//!
+//! ## Cache path
+//!
+//! `${XDG_DATA_HOME or ~/.local/share}/ainb/plugins/data/session-reader/usage.sqlite`
+//!
+//! `AINB_HOME` overrides both XDG_DATA_HOME and the home fallback so
+//! tests can point the cache at a temp dir without leaking into a real
+//! user profile.
+//!
+//! ## WASM
+//!
+//! Gated behind `#[cfg(not(target_arch = "wasm32"))]` as a precaution.
+//! Subprocess plugins compile native today, but the cfg-gate keeps a
+//! hypothetical wasm32 cdylib path from pulling rusqlite.
+
+#![cfg(not(target_arch = "wasm32"))]
+// `insert`/`clear` take `&mut self` to model exclusive write access at
+// the type level, even though `rusqlite::Connection::execute` itself
+// only requires `&Connection`. Future schema migrations expect to
+// mutate the connection state, so the API contract is forward-looking.
+#![allow(clippy::needless_pass_by_ref_mut)]
+// `u64` fingerprint stored in an `INTEGER` column via `from_ne_bytes`
+// is an intentional bit-pattern reinterpretation, not a numeric cast.
+#![allow(clippy::cast_possible_wrap)]
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ainb_plugin_types_sessions::ProviderCall;
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+
+use crate::fnv::fnv1a_64;
+
+/// Current on-disk schema version. Bumping this triggers the v0→vN
+/// migration block in [`UsageCache::migrate`].
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// Cache error surface.
+#[derive(Debug, thiserror::Error)]
+pub enum CacheError {
+    /// I/O error opening the DB file or its parent directory.
+    #[error("cache I/O: {0}")]
+    Io(#[from] std::io::Error),
+    /// SQLite connection / query / migration failure.
+    #[error("cache sqlite: {0}")]
+    Sql(#[from] rusqlite::Error),
+    /// bincode encode/decode failure on the parsed-calls blob.
+    #[error("cache encode: {0}")]
+    Encode(#[from] bincode::Error),
+}
+
+/// Persistent per-file parse cache.
+///
+/// A single connection per scan is fine — the plugin's scanner walks
+/// providers in series and the connection is not shared across threads.
+pub struct UsageCache {
+    conn: Connection,
+}
+
+impl UsageCache {
+    /// Open (or create) the cache DB at `path`. Applies pragmas and
+    /// runs any pending schema migrations.
+    ///
+    /// On any I/O or SQL failure the caller is expected to log and
+    /// fall back to a cache-less parse — never let cache failure break
+    /// the scan.
+    pub fn open(path: &Path) -> Result<Self, CacheError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        // WAL keeps reads non-blocking and lets the writer proceed
+        // without a global lock — the cache is read-mostly with bursts
+        // of writes during a fresh scan. `synchronous=NORMAL` is the
+        // WAL-recommended balance: durable across crashes, not power
+        // loss, which matches a derived cache.
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+        Self::migrate(&conn)?;
+        Ok(Self { conn })
+    }
+
+    /// Look up a cache row. Returns `Some` only when (a) a row exists
+    /// for `path` and (b) both `mtime` and `size` match exactly.
+    ///
+    /// Mismatch on either field misses — the caller re-parses and
+    /// `insert`s the fresh result, overwriting the stale row.
+    pub fn lookup(
+        &self,
+        path: &str,
+        mtime: u64,
+        size: u64,
+    ) -> Result<Option<Vec<ProviderCall>>, CacheError> {
+        let row: Option<(i64, i64, Vec<u8>)> = self
+            .conn
+            .query_row(
+                "SELECT mtime, size, parsed FROM file_cache WHERE path = ?1",
+                params![path],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, Vec<u8>>(2)?)),
+            )
+            .optional()?;
+
+        let Some((stored_mtime, stored_size, blob)) = row else {
+            return Ok(None);
+        };
+
+        // Cast through u64 because the column is INTEGER (i64) but
+        // the caller hands us u64 — both `mtime_nanos` and `size`
+        // fit comfortably for any real file.
+        if stored_mtime as u64 != mtime || stored_size as u64 != size {
+            return Ok(None);
+        }
+
+        let calls: Vec<ProviderCall> = bincode::deserialize(&blob)?;
+        Ok(Some(calls))
+    }
+
+    /// Upsert a cache row. `calls` is bincode-serialized; the FNV-1a 64
+    /// fingerprint is computed over the same bytes the caller used to
+    /// drive the parse (typically the file contents).
+    pub fn insert(
+        &mut self,
+        path: &str,
+        mtime: u64,
+        size: u64,
+        fingerprint: u64,
+        calls: &[ProviderCall],
+    ) -> Result<(), CacheError> {
+        let blob = bincode::serialize(calls)?;
+        let cached_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        self.conn.execute(
+            "INSERT INTO file_cache (path, mtime, size, fingerprint, parsed, cached_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(path) DO UPDATE SET
+                mtime       = excluded.mtime,
+                size        = excluded.size,
+                fingerprint = excluded.fingerprint,
+                parsed      = excluded.parsed,
+                cached_at   = excluded.cached_at",
+            params![
+                path,
+                i64::try_from(mtime).unwrap_or(i64::MAX),
+                i64::try_from(size).unwrap_or(i64::MAX),
+                i64::from_ne_bytes(fingerprint.to_ne_bytes()),
+                blob,
+                cached_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Drop every cached row. Schema row (PRAGMA user_version) is
+    /// preserved so re-opens don't trigger another migration.
+    pub fn clear(&mut self) -> Result<(), CacheError> {
+        self.conn.execute("DELETE FROM file_cache", [])?;
+        // VACUUM is a tidiness operation; failure here doesn't matter.
+        if let Err(err) = self.conn.execute("VACUUM", []) {
+            tracing::warn!("session-reader cache VACUUM after clear failed: {err}");
+        }
+        Ok(())
+    }
+
+    /// Apply v0→v1 schema migration using `PRAGMA user_version`.
+    /// Future bumps append additional `if version < N` blocks before
+    /// the final `pragma_update`.
+    fn migrate(conn: &Connection) -> Result<(), CacheError> {
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap_or(0);
+
+        if version < 1 {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS file_cache (
+                     path        TEXT    PRIMARY KEY,
+                     mtime       INTEGER NOT NULL,
+                     size        INTEGER NOT NULL,
+                     fingerprint INTEGER NOT NULL,
+                     parsed      BLOB    NOT NULL,
+                     cached_at   INTEGER NOT NULL
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_mtime ON file_cache(mtime);",
+            )?;
+        }
+
+        if version != SCHEMA_VERSION {
+            conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
+        }
+        Ok(())
+    }
+}
+
+/// Compute the FNV-1a 64 fingerprint of `bytes`. Wrapper over
+/// [`crate::fnv::fnv1a_64`] so the cache module doesn't leak the
+/// helper through callers' import paths.
+#[must_use]
+pub fn fingerprint(bytes: &[u8]) -> u64 {
+    fnv1a_64(bytes)
+}
+
+/// Resolve the default cache DB path:
+/// `${AINB_HOME or XDG_DATA_HOME or ~/.local/share}/ainb/plugins/data/session-reader/usage.sqlite`.
+///
+/// `AINB_HOME` is honored first specifically so tests can point the
+/// cache at a temp dir without touching the real user profile (the
+/// flag also documents itself as a test-only override).
+#[must_use]
+pub fn default_db_path() -> Option<PathBuf> {
+    let base = if let Some(home) = std::env::var_os("AINB_HOME") {
+        PathBuf::from(home)
+    } else if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+        PathBuf::from(xdg)
+    } else {
+        let home = std::env::var_os("HOME")?;
+        PathBuf::from(home).join(".local").join("share")
+    };
+    Some(
+        base.join("ainb")
+            .join("plugins")
+            .join("data")
+            .join("session-reader")
+            .join("usage.sqlite"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_plugin_types_sessions::{Provider, ProviderCall};
+    use chrono::{DateTime, Utc};
+    use tempfile::TempDir;
+
+    fn fake_call(id: u64) -> ProviderCall {
+        ProviderCall {
+            id,
+            provider: Provider::Claude,
+            model: "claude-sonnet".into(),
+            session_id: "s".into(),
+            project: "p".into(),
+            project_path: "/tmp/p".into(),
+            timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+            input_tokens: 10,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 20,
+            reasoning_tokens: 0,
+            cost_usd: Some(0.001),
+            tools: vec!["Read".into()],
+            bash_commands: vec![],
+            user_message: "hi".into(),
+            branch: Some("main".into()),
+        }
+    }
+
+    fn open_in_tmp() -> (TempDir, UsageCache) {
+        let dir = TempDir::new().expect("tempdir");
+        let db = dir.path().join("usage.sqlite");
+        let cache = UsageCache::open(&db).expect("open cache");
+        (dir, cache)
+    }
+
+    #[test]
+    fn open_creates_parent_dirs_and_db() {
+        let dir = TempDir::new().expect("tempdir");
+        let nested = dir.path().join("a").join("b").join("usage.sqlite");
+        let _cache = UsageCache::open(&nested).expect("open cache");
+        assert!(nested.exists(), "DB file created at {nested:?}");
+    }
+
+    #[test]
+    fn insert_then_lookup_hits_for_same_mtime_and_size() {
+        let (_dir, mut cache) = open_in_tmp();
+        let calls = vec![fake_call(1), fake_call(2)];
+        cache
+            .insert("/tmp/a.jsonl", 42, 100, 0xDEADBEEF, &calls)
+            .expect("insert");
+
+        let hit = cache
+            .lookup("/tmp/a.jsonl", 42, 100)
+            .expect("lookup")
+            .expect("hit");
+        assert_eq!(hit.len(), 2);
+        assert_eq!(hit[0].id, 1);
+        assert_eq!(hit[1].id, 2);
+    }
+
+    #[test]
+    fn lookup_misses_when_mtime_differs() {
+        let (_dir, mut cache) = open_in_tmp();
+        cache
+            .insert("/tmp/a.jsonl", 42, 100, 0, &[fake_call(1)])
+            .expect("insert");
+
+        let miss = cache
+            .lookup("/tmp/a.jsonl", 43, 100)
+            .expect("lookup");
+        assert!(miss.is_none(), "mtime mismatch must miss");
+    }
+
+    #[test]
+    fn lookup_misses_when_size_differs() {
+        let (_dir, mut cache) = open_in_tmp();
+        cache
+            .insert("/tmp/a.jsonl", 42, 100, 0, &[fake_call(1)])
+            .expect("insert");
+
+        let miss = cache
+            .lookup("/tmp/a.jsonl", 42, 101)
+            .expect("lookup");
+        assert!(miss.is_none(), "size mismatch must miss");
+    }
+
+    #[test]
+    fn lookup_misses_for_unknown_path() {
+        let (_dir, cache) = open_in_tmp();
+        let miss = cache.lookup("/tmp/never.jsonl", 0, 0).expect("lookup");
+        assert!(miss.is_none());
+    }
+
+    #[test]
+    fn fingerprint_persists_through_insert() {
+        let (_dir, mut cache) = open_in_tmp();
+        let fp = fingerprint(b"some-file-bytes");
+        cache
+            .insert("/tmp/a.jsonl", 1, 2, fp, &[fake_call(1)])
+            .expect("insert");
+
+        // Read fingerprint back out via raw SQL to assert it was
+        // stored byte-stably (reinterpret cast through ne_bytes).
+        let stored: i64 = cache
+            .conn
+            .query_row(
+                "SELECT fingerprint FROM file_cache WHERE path = ?1",
+                params!["/tmp/a.jsonl"],
+                |row| row.get(0),
+            )
+            .expect("select");
+        let recovered = u64::from_ne_bytes(stored.to_ne_bytes());
+        assert_eq!(recovered, fp);
+    }
+
+    #[test]
+    fn migrate_sets_user_version_to_one() {
+        let (_dir, cache) = open_in_tmp();
+        let version: i64 = cache
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("pragma");
+        assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn migrate_creates_idx_mtime_index() {
+        let (_dir, cache) = open_in_tmp();
+        let count: i64 = cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_mtime'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query");
+        assert_eq!(count, 1, "idx_mtime index exists");
+    }
+
+    #[test]
+    fn reopen_is_idempotent() {
+        let dir = TempDir::new().expect("tempdir");
+        let db = dir.path().join("usage.sqlite");
+        {
+            let mut c = UsageCache::open(&db).expect("open 1");
+            c.insert("/p", 1, 2, 3, &[fake_call(7)]).expect("insert");
+        }
+        {
+            let c = UsageCache::open(&db).expect("open 2");
+            let hit = c.lookup("/p", 1, 2).expect("lookup").expect("hit");
+            assert_eq!(hit[0].id, 7);
+        }
+    }
+
+    #[test]
+    fn clear_drops_rows_but_preserves_schema_version() {
+        let (_dir, mut cache) = open_in_tmp();
+        cache
+            .insert("/tmp/a.jsonl", 1, 1, 0, &[fake_call(1)])
+            .expect("insert");
+        cache.clear().expect("clear");
+        let miss = cache.lookup("/tmp/a.jsonl", 1, 1).expect("lookup");
+        assert!(miss.is_none(), "clear drops rows");
+
+        let version: i64 = cache
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("pragma");
+        assert_eq!(version, SCHEMA_VERSION, "clear preserves schema version");
+    }
+
+    #[test]
+    fn insert_overwrites_stale_row() {
+        let (_dir, mut cache) = open_in_tmp();
+        cache
+            .insert("/tmp/a.jsonl", 1, 1, 0, &[fake_call(1)])
+            .expect("insert v1");
+        cache
+            .insert("/tmp/a.jsonl", 2, 2, 0, &[fake_call(2), fake_call(3)])
+            .expect("insert v2");
+
+        let hit = cache
+            .lookup("/tmp/a.jsonl", 2, 2)
+            .expect("lookup")
+            .expect("hit");
+        assert_eq!(hit.len(), 2);
+        assert_eq!(hit[0].id, 2);
+        assert_eq!(hit[1].id, 3);
+
+        // Original (mtime=1, size=1) row is gone.
+        let stale = cache.lookup("/tmp/a.jsonl", 1, 1).expect("lookup");
+        assert!(stale.is_none());
+    }
+
+    // `default_db_path` reads `AINB_HOME` / `XDG_DATA_HOME` / `HOME`
+    // directly via `std::env::var_os`. The crate is `#[forbid(unsafe_code)]`
+    // so we can't mutate the process env from a test; the override
+    // path is exercised by the host's integration tests where the
+    // plugin is spawned with `AINB_HOME` already set in the
+    // subprocess environment.
+    #[test]
+    fn default_db_path_returns_expected_suffix_when_home_set() {
+        if std::env::var_os("HOME").is_none()
+            && std::env::var_os("XDG_DATA_HOME").is_none()
+            && std::env::var_os("AINB_HOME").is_none()
+        {
+            return;
+        }
+        let resolved = default_db_path().expect("path");
+        assert!(
+            resolved.ends_with("ainb/plugins/data/session-reader/usage.sqlite"),
+            "resolved path has expected suffix: {resolved:?}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
@@ -13,6 +13,8 @@
 
 use ainb_plugin_sdk::{Server, SdkError};
 
+#[cfg(not(target_arch = "wasm32"))]
+mod cache;
 mod fnv;
 mod parsers;
 mod plugin;

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
@@ -50,6 +50,24 @@ struct ClaudeUsage {
 /// degrade to an empty result; per-file failures are logged via
 /// `tracing::warn` and skipped.
 pub fn parse_dir(projects_root: &Path) -> Vec<ProviderCall> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        parse_dir_cached(projects_root, &mut None)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        parse_dir_uncached(projects_root)
+    }
+}
+
+/// Cache-aware variant of [`parse_dir`]. `cache: None` is equivalent to
+/// the no-cache path; a `Some(cache)` short-circuits per-file parses
+/// when `(mtime, size)` matches the stored row.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_dir_cached(
+    projects_root: &Path,
+    cache: &mut Option<crate::cache::UsageCache>,
+) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
     let project_entries = match std::fs::read_dir(projects_root) {
         Ok(entries) => entries,
@@ -79,16 +97,43 @@ pub fn parse_dir(projects_root: &Path) -> Vec<ProviderCall> {
             if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
                 continue;
             }
-            let content = match std::fs::read_to_string(&path) {
-                Ok(c) => c,
-                Err(err) => {
-                    tracing::warn!(
-                        path = %path.display(),
-                        error = %err,
-                        "session-reader/claude: skip unreadable file"
-                    );
-                    continue;
-                }
+            let path_str = path.to_string_lossy().into_owned();
+            let project_path_str = project_path.to_string_lossy().into_owned();
+            let project = project.clone();
+            let file_calls = super::read_file_cached(&path, cache, |content| {
+                parse_source(&path_str, &project, &project_path_str, content)
+            });
+            calls.extend(file_calls);
+        }
+    }
+    calls
+}
+
+/// Uncached walk used by the wasm32 build (where the cache module is
+/// stubbed out). Kept private; the public API stays `parse_dir`.
+#[cfg(target_arch = "wasm32")]
+fn parse_dir_uncached(projects_root: &Path) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
+    let project_entries = match std::fs::read_dir(projects_root) {
+        Ok(entries) => entries,
+        Err(_) => return calls,
+    };
+    for project_entry in project_entries.flatten() {
+        let project_path = project_entry.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let project = path_basename(&project_path);
+        let Ok(session_entries) = std::fs::read_dir(&project_path) else {
+            continue;
+        };
+        for session_entry in session_entries.flatten() {
+            let path = session_entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
             };
             let path_str = path.to_string_lossy().into_owned();
             let project_path_str = project_path.to_string_lossy().into_owned();

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
@@ -60,6 +60,25 @@ struct CodexTokenUsage {
 
 /// Walk `<sessions_root>/<YYYY>/<MM>/<DD>/rollout-*.jsonl`.
 pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        parse_dir_cached(sessions_root, &mut None)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        parse_dir_uncached(sessions_root)
+    }
+}
+
+/// Cache-aware variant of [`parse_dir`]. Per-file cache misses still
+/// run the `is_valid_codex_session` heuristic — non-Codex rollouts
+/// resolve to an empty `Vec` which the cache stores so we don't re-read
+/// the file on the next scan.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_dir_cached(
+    sessions_root: &Path,
+    cache: &mut Option<crate::cache::UsageCache>,
+) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
     let years = match std::fs::read_dir(sessions_root) {
         Ok(d) => d,
@@ -108,16 +127,65 @@ pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
                     if !basename.starts_with("rollout-") || !basename.ends_with(".jsonl") {
                         continue;
                     }
-                    let content = match std::fs::read_to_string(&path) {
-                        Ok(c) => c,
-                        Err(err) => {
-                            tracing::warn!(
-                                path = %path.display(),
-                                error = %err,
-                                "session-reader/codex: skip unreadable file"
-                            );
-                            continue;
+                    let path_str = path.to_string_lossy().into_owned();
+                    let file_calls = super::read_file_cached(&path, cache, |content| {
+                        if !is_valid_codex_session(content) {
+                            return Vec::new();
                         }
+                        parse_source(&path_str, content)
+                    });
+                    calls.extend(file_calls);
+                }
+            }
+        }
+    }
+    calls
+}
+
+/// Uncached walk used by the wasm32 build (where the cache module is
+/// stubbed out). Kept private; the public API stays `parse_dir`.
+#[cfg(target_arch = "wasm32")]
+fn parse_dir_uncached(sessions_root: &Path) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
+    let years = match std::fs::read_dir(sessions_root) {
+        Ok(d) => d,
+        Err(_) => return calls,
+    };
+    for year_entry in years.flatten() {
+        let year_path = year_entry.path();
+        if !is_date_component(&year_path, 4) {
+            continue;
+        }
+        let Ok(months) = std::fs::read_dir(&year_path) else {
+            continue;
+        };
+        for month_entry in months.flatten() {
+            let month_path = month_entry.path();
+            if !is_date_component(&month_path, 2) {
+                continue;
+            }
+            let Ok(days) = std::fs::read_dir(&month_path) else {
+                continue;
+            };
+            for day_entry in days.flatten() {
+                let day_path = day_entry.path();
+                if !is_date_component(&day_path, 2) {
+                    continue;
+                }
+                let Ok(files) = std::fs::read_dir(&day_path) else {
+                    continue;
+                };
+                for file_entry in files.flatten() {
+                    let path = file_entry.path();
+                    let basename = path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or_default();
+                    if !basename.starts_with("rollout-") || !basename.ends_with(".jsonl") {
+                        continue;
+                    }
+                    let Ok(content) = std::fs::read_to_string(&path) else {
+                        continue;
                     };
                     if !is_valid_codex_session(&content) {
                         continue;

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
@@ -21,3 +21,85 @@ pub(crate) fn parse_timestamp(timestamp: &str) -> Option<chrono::DateTime<chrono
         .map(|dt| dt.with_timezone(&chrono::Utc))
         .ok()
 }
+
+/// `(mtime_nanos, size_bytes)` for `path`. Returns `None` when stat
+/// fails (file vanished, permission denied) — caller must fall back
+/// to a normal read.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn stat_for_cache(path: &std::path::Path) -> Option<(u64, u64)> {
+    use std::time::UNIX_EPOCH;
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))?;
+    Some((mtime, meta.len()))
+}
+
+/// Cache-aware read-and-parse for one provider session file.
+///
+/// 1. `stat(path)` → `(mtime, size)`.
+/// 2. If a cache is supplied and `lookup(path, mtime, size)` hits, return
+///    the cached `Vec<ProviderCall>` with no filesystem read.
+/// 3. Otherwise read the file, call `parse(&content)`, hash the bytes
+///    with FNV-1a 64, and persist `(mtime, size, fingerprint, parsed)`
+///    via `cache.insert`.
+///
+/// Any cache I/O / SQL failure is logged at `warn` and the call falls
+/// through to a fresh parse — the cache is never allowed to break the
+/// scan.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn read_file_cached<F>(
+    path: &std::path::Path,
+    cache: &mut Option<crate::cache::UsageCache>,
+    parse: F,
+) -> Vec<ainb_plugin_types_sessions::ProviderCall>
+where
+    F: FnOnce(&str) -> Vec<ainb_plugin_types_sessions::ProviderCall>,
+{
+    let path_str = path.to_string_lossy().into_owned();
+    let stat = stat_for_cache(path);
+
+    if let (Some(cache_ref), Some((mtime, size))) = (cache.as_ref(), stat) {
+        match cache_ref.lookup(&path_str, mtime, size) {
+            Ok(Some(hit)) => return hit,
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "session-reader cache: lookup failed; re-parsing"
+                );
+            }
+        }
+    }
+
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(err) => {
+            // Identical degrade-to-empty contract as the un-cached path.
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "session-reader: skip unreadable file"
+            );
+            return Vec::new();
+        }
+    };
+
+    let calls = parse(&content);
+
+    if let (Some(cache_ref), Some((mtime, size))) = (cache.as_mut(), stat) {
+        let fingerprint = crate::cache::fingerprint(content.as_bytes());
+        if let Err(err) = cache_ref.insert(&path_str, mtime, size, fingerprint, &calls) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "session-reader cache: insert failed"
+            );
+        }
+    }
+
+    calls
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -55,9 +55,19 @@ mod manifest_text {
 /// follow-up render or refresh can republish without re-running the
 /// scan if no source files changed (rescan is still cheap on the
 /// freshness path — we always rescan on `sessions.refresh_request`).
+///
+/// `cache` is opened lazily on the first publish so a host that grants
+/// the plugin without `write_plugin_data` (or where the DB path can't
+/// be resolved) still functions — every scan just runs uncached.
 pub struct SessionReader {
     last_event: Option<UsageDataEvent>,
     roots: ProviderRoots,
+    #[cfg(not(target_arch = "wasm32"))]
+    cache: Option<crate::cache::UsageCache>,
+    /// Set to `true` once we've attempted (and possibly failed) to open
+    /// the cache so we don't retry on every publish.
+    #[cfg(not(target_arch = "wasm32"))]
+    cache_init: bool,
 }
 
 impl SessionReader {
@@ -67,6 +77,10 @@ impl SessionReader {
         Self {
             last_event: None,
             roots: ProviderRoots::defaults(),
+            #[cfg(not(target_arch = "wasm32"))]
+            cache: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            cache_init: false,
         }
     }
 
@@ -77,6 +91,39 @@ impl SessionReader {
         Self {
             last_event: None,
             roots,
+            #[cfg(not(target_arch = "wasm32"))]
+            cache: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            cache_init: false,
+        }
+    }
+
+    /// Open the cache on first use, swallowing any error so the scan
+    /// still runs cache-less. Subsequent calls are a no-op.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn ensure_cache(&mut self) {
+        if self.cache_init {
+            return;
+        }
+        self.cache_init = true;
+        let Some(path) = crate::cache::default_db_path() else {
+            tracing::warn!(
+                "session-reader: cache path unresolved (AINB_HOME / XDG_DATA_HOME / HOME all unset); scanning uncached"
+            );
+            return;
+        };
+        match crate::cache::UsageCache::open(&path) {
+            Ok(cache) => {
+                tracing::debug!(path = %path.display(), "session-reader cache opened");
+                self.cache = Some(cache);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "session-reader: cache open failed; scanning uncached"
+                );
+            }
         }
     }
 
@@ -95,6 +142,22 @@ impl SessionReader {
             chunk_index: 0,
             is_final: true,
             data,
+        }
+    }
+
+    /// Cache-aware scan helper used by [`Self::publish`]. Lazily opens
+    /// the on-disk cache (best-effort) and threads it through the
+    /// per-file parse path; on wasm32 the cache module is absent so we
+    /// fall through to the uncached `scanner::scan`.
+    fn scan_now(&mut self) -> ainb_plugin_types_sessions::UsageData {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.ensure_cache();
+            scanner::scan_with_cache(&self.roots, &mut self.cache)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            scanner::scan(&self.roots)
         }
     }
 
@@ -121,7 +184,7 @@ impl SessionReader {
     /// carry only the remaining calls. The last chunk is flagged
     /// `is_final = true`.
     async fn publish(&mut self, host: &HostClient) -> Result<()> {
-        let data = scanner::scan(&self.roots);
+        let data = self.scan_now();
         let published_ns = now_ns();
         let chunks =
             chunk_usage_data(data, published_ns, false, CHUNK_TARGET_BYTES);

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -58,13 +58,50 @@ impl ProviderRoots {
 }
 
 /// Run every provider parser, aggregate, return a snapshot.
+///
+/// Cache-less convenience wrapper around [`scan_with_cache`] for
+/// callers that don't want persistence (tests, the wasm32 build).
 pub fn scan(roots: &ProviderRoots) -> UsageData {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        scan_with_cache(roots, &mut None)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let mut all_calls = Vec::new();
+        if let Some(root) = &roots.claude_projects {
+            all_calls.extend(crate::parsers::claude::parse_dir(root));
+        }
+        if let Some(root) = &roots.codex_sessions {
+            all_calls.extend(crate::parsers::codex::parse_dir(root));
+        }
+        if let Some(root) = &roots.gemini_sessions {
+            all_calls.extend(crate::parsers::gemini::parse_dir(root));
+        }
+        if let Some(root) = &roots.copilot_sessions {
+            all_calls.extend(crate::parsers::copilot::parse_dir(root));
+        }
+        aggregate(all_calls)
+    }
+}
+
+/// Cache-aware scan. Pass `Some(cache)` to short-circuit per-file parses
+/// when `(mtime, size)` matches the previous run; `None` is equivalent
+/// to the legacy [`scan`] call site.
+///
+/// Gemini and Copilot parsers are stubs that don't read files; they're
+/// invoked without the cache.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn scan_with_cache(
+    roots: &ProviderRoots,
+    cache: &mut Option<crate::cache::UsageCache>,
+) -> UsageData {
     let mut all_calls = Vec::new();
     if let Some(root) = &roots.claude_projects {
-        all_calls.extend(crate::parsers::claude::parse_dir(root));
+        all_calls.extend(crate::parsers::claude::parse_dir_cached(root, cache));
     }
     if let Some(root) = &roots.codex_sessions {
-        all_calls.extend(crate::parsers::codex::parse_dir(root));
+        all_calls.extend(crate::parsers::codex::parse_dir_cached(root, cache));
     }
     if let Some(root) = &roots.gemini_sessions {
         all_calls.extend(crate::parsers::gemini::parse_dir(root));


### PR DESCRIPTION
## Summary

Phase 5 of `plugin-interactive-keys-and-cache.md`: ports the host's
`usage_cache` pattern into the session-reader plugin so cold rescans
on a warm cache short-circuit per-file parses.

Closes bead **agents-in-a-box-8q1.5**.

### What's in the change

- **New `cache.rs` module** (`#[cfg(not(target_arch = \"wasm32\"))]`): SQLite-backed per-file parse cache.
  - Schema v1: `file_cache(path PK, mtime, size, fingerprint, parsed BLOB, cached_at)` + `idx_mtime` index.
  - Migration via `PRAGMA user_version` (v0→v1 = create table).
  - `UsageCache::open/lookup/insert/clear` API.
  - FNV-1a 64 content fingerprint reuses `crate::fnv` — keeps blake3 (and its SIMD intrinsics) out of the subprocess binary.
  - Cache path: `${AINB_HOME or XDG_DATA_HOME or ~/.local/share}/ainb/plugins/data/session-reader/usage.sqlite`. `AINB_HOME` wins so tests can point at a temp dir.
- **`parsers::read_file_cached`** helper: stat → cache.lookup → on miss, read + parse + fingerprint + cache.insert. Any cache error logs at `warn` and falls through to the uncached parse path.
- **Claude + Codex parsers** expose `parse_dir_cached(root, &mut Option<UsageCache>)` alongside the existing `parse_dir(root)`. Non-Codex rollouts cache an empty `Vec` so we don't re-read them on the next scan.
- **Scanner**: new `scan_with_cache(roots, cache)`; `scan(roots)` stays available and delegates with `cache: None`.
- **`SessionReader`** opens the cache lazily on the first `publish`, retrying neither on open failure nor on per-file SQL errors.

### Dependencies

- `rusqlite` (workspace) — gated `cfg(not(target_arch = \"wasm32\"))`.
- `bincode` (workspace) — same gate.
- `thiserror` (workspace) — same gate.
- Manifest already declared `write_plugin_data = true`; no manifest change needed.

### Tests

`cargo test -p ainb-plugin-session-reader` → **50/50 green**.

11 new cache tests:

- open / parent-dir creation
- lookup hit on matching `(mtime, size)`
- lookup miss on mtime mismatch
- lookup miss on size mismatch
- lookup miss on unknown path
- fingerprint persists through insert (byte-stable through ne_bytes reinterpret)
- migrate sets `PRAGMA user_version = 1`
- migrate creates the `idx_mtime` index
- reopen is idempotent (no second migration)
- clear drops rows but preserves schema version
- insert overwrites stale row
- default_db_path returns the expected suffix when `HOME` is set

Existing subprocess smoke test still passes — no wire-publish behavior change.

### Manual gate (per plan §Phase 5)

Real-$HOME first-run vs second-run wall-time measurement is a manual smoke (not CI). The bead is `In Review` once this PR opens; the burndown integration / progress UX lands in Phase 6 (next bead).