### PR TITLE
feat(plugin-sdk-rust): Plugin::handle_key trait + inline dispatch

### DIFF
--- a/ainb-tui/crates/ainb-plugin-sdk-rust/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/src/lib.rs
@@ -43,10 +43,11 @@ pub use ainb_plugin_protocol::{
     params::{
         ActionInvokeParams, ActionInvokeResult, CliDispatchParams, CliDispatchResult,
         FsDirEntry, FsReadDirParams, FsReadDirResult, FsReadFileParams, FsReadFileResult,
-        HandleEventParams, LogLevel, LogParams, NetworkFetchParams, NetworkFetchResult,
-        PluginInitParams, PluginInitResult, PluginShutdownParams, PluginShutdownResult,
-        RenderParams, RenderResult, SnapshotGetParams, SnapshotGetResult, SnapshotPublishParams,
-        SnapshotSubscribeParams, SnapshotSubscribeResult, Viewport,
+        HandleEventParams, HandleKeyParams, KEY_MOD_ALT, KEY_MOD_CTRL, KEY_MOD_SHIFT,
+        KEY_MOD_SUPER, KeyCode, KeyEvent, KeyKind, LogLevel, LogParams, NetworkFetchParams,
+        NetworkFetchResult, PluginInitParams, PluginInitResult, PluginShutdownParams,
+        PluginShutdownResult, RenderParams, RenderResult, SnapshotGetParams, SnapshotGetResult,
+        SnapshotPublishParams, SnapshotSubscribeParams, SnapshotSubscribeResult, Viewport,
     },
     wire_buffer::{Cell, Color, Coord, WireBuffer},
 };

--- a/ainb-tui/crates/ainb-plugin-sdk-rust/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/src/plugin.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 
 use crate::{HostClient, Result};
 use ainb_plugin_protocol::{
-    params::{HandleEventParams, RenderParams},
+    params::{HandleEventParams, HandleKeyParams, RenderParams},
     wire_buffer::WireBuffer,
 };
 
@@ -84,6 +84,22 @@ pub trait Plugin: Send + 'static {
     /// by the runtime but do not surface to the host that produced the
     /// event.
     async fn handle_event(&mut self, host: &HostClient, params: HandleEventParams) -> Result<()> {
+        let _ = (host, params);
+        Ok(())
+    }
+
+    /// Receive a single normalized key event the host has forwarded.
+    ///
+    /// Notification — the host does not wait on a response and ignores
+    /// errors. Default is a no-op so plugins that don't own interactive
+    /// keys (e.g. session-reader) get nothing on the wire by virtue of
+    /// the host only forwarding keys to the focused plugin.
+    ///
+    /// Ordering: the server dispatches this handler inline, on the same
+    /// task as the reader loop, so multi-key sequences arrive in send
+    /// order. Plugins MUST NOT spawn the handler body — see
+    /// [`Server`](crate::Server) source for why.
+    async fn handle_key(&mut self, host: &HostClient, params: HandleKeyParams) -> Result<()> {
         let _ = (host, params);
         Ok(())
     }

--- a/ainb-tui/crates/ainb-plugin-sdk-rust/src/server.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/src/server.rs
@@ -35,8 +35,9 @@ use ainb_plugin_protocol::{
     framing,
     methods,
     params::{
-        CliDispatchParams, CliDispatchResult, HandleEventParams, PluginInitParams,
-        PluginInitResult, PluginShutdownParams, PluginShutdownResult, RenderParams, RenderResult,
+        CliDispatchParams, CliDispatchResult, HandleEventParams, HandleKeyParams,
+        PluginInitParams, PluginInitResult, PluginShutdownParams, PluginShutdownResult,
+        RenderParams, RenderResult,
     },
     Manifest, RpcError,
 };
@@ -144,13 +145,16 @@ where
         if let Some(method) = value.get("method").and_then(Value::as_str) {
             // host -> plugin request or notification.
             //
-            // `plugin/handle_event` MUST run in receive order — chunked
-            // publishes (e.g. `sessions.usage_data`) rely on the
-            // consumer seeing `chunk_index = 0` before any follow-on
-            // chunk. Spawning each event onto its own task lets tokio
-            // re-order them through the per-plugin mutex, so we serve
-            // events inline and only spawn for other methods.
-            if method == methods::PLUGIN_HANDLE_EVENT {
+            // `plugin/handle_event` and `plugin/handle_key` MUST run in
+            // receive order — chunked publishes (e.g.
+            // `sessions.usage_data`) rely on the consumer seeing
+            // `chunk_index = 0` before any follow-on chunk, and key
+            // sequences (`1`, `2`, `Tab`, `Esc`) would lose their
+            // semantics if dispatched out of order. Spawning each
+            // notification onto its own task lets tokio re-order them
+            // through the per-plugin mutex, so we serve these inline
+            // and only spawn for other methods.
+            if method == methods::PLUGIN_HANDLE_EVENT || method == methods::PLUGIN_HANDLE_KEY {
                 dispatch_incoming(
                     plugin.clone(),
                     host_client.clone(),
@@ -406,6 +410,11 @@ async fn handle_method<P: Plugin>(
         methods::PLUGIN_HANDLE_EVENT => {
             let p: HandleEventParams = decode_params(params)?;
             plugin.lock().await.handle_event(host, p).await?;
+            Ok(Value::Null)
+        }
+        methods::PLUGIN_HANDLE_KEY => {
+            let p: HandleKeyParams = decode_params(params)?;
+            plugin.lock().await.handle_key(host, p).await?;
             Ok(Value::Null)
         }
         methods::PLUGIN_CLI_DISPATCH => {

--- a/ainb-tui/crates/ainb-plugin-sdk-rust/tests/handle_key_ordering.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/tests/handle_key_ordering.rs
@@ -1,0 +1,119 @@
+//! Integration test for `plugin/handle_key` ordering.
+//!
+//! Asserts that the SDK server preserves send-order across a 5-key
+//! notification burst. Inline dispatch (see [`Server`] internals) is
+//! load-bearing here: a tokio-spawned-per-handler implementation would
+//! re-order acquisitions of the per-plugin mutex and the plugin would
+//! observe `Tab` before `Char('2')`, breaking interactive UI semantics.
+//!
+//! Mirrors the regression guard the in-tree `handle_event` ordering fix
+//! introduced (commit `4ad7b46`) but covers the new key path.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+use ainb_plugin_sdk::{
+    methods, HandleEventParams, HandleKeyParams, HostClient, KeyCode, KeyEvent, Plugin,
+    RenderParams, Result, Server, WireBuffer,
+};
+
+/// Records every `handle_key` invocation in arrival order.
+struct RecorderPlugin {
+    keys: Arc<Mutex<Vec<KeyEvent>>>,
+}
+
+#[async_trait]
+impl Plugin for RecorderPlugin {
+    fn manifest(&self) -> &'static str {
+        "[plugin]\nname = \"recorder\"\nversion = \"0.0.0\"\nabi_version = 2\n"
+    }
+
+    async fn render(&mut self, _host: &HostClient, _p: RenderParams) -> Result<WireBuffer> {
+        Ok(WireBuffer::new(0, 0))
+    }
+
+    async fn handle_event(&mut self, _host: &HostClient, _p: HandleEventParams) -> Result<()> {
+        Ok(())
+    }
+
+    async fn handle_key(&mut self, _host: &HostClient, p: HandleKeyParams) -> Result<()> {
+        self.keys.lock().await.push(p.key);
+        Ok(())
+    }
+}
+
+fn frame_notification(method: &str, params: Value) -> Vec<u8> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+    });
+    let bytes = serde_json::to_vec(&body).unwrap();
+    ainb_plugin_protocol::framing::encode(&bytes)
+}
+
+fn key_params(screen_id: &str, code: KeyCode, generation: u64) -> Value {
+    serde_json::to_value(HandleKeyParams {
+        screen_id: screen_id.into(),
+        key: KeyEvent {
+            code,
+            mods: 0,
+            kind: Default::default(),
+        },
+        generation,
+    })
+    .unwrap()
+}
+
+#[tokio::test]
+async fn five_sequential_handle_keys_preserve_order() {
+    let (mut host_side, plugin_side) = tokio::io::duplex(64 * 1024);
+    let (plugin_read, plugin_write) = tokio::io::split(plugin_side);
+
+    let keys: Arc<Mutex<Vec<KeyEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let plugin = RecorderPlugin { keys: keys.clone() };
+    let server_task = tokio::spawn(Server::new(plugin).run(plugin_read, plugin_write));
+
+    // Five notifications: '1' -> '2' -> '3' -> Tab -> Esc.
+    // generation bumps so the plugin can echo it via the next render
+    // (we don't render here — just assert receive order).
+    let sequence = [
+        KeyCode::Char { ch: '1' },
+        KeyCode::Char { ch: '2' },
+        KeyCode::Char { ch: '3' },
+        KeyCode::Tab,
+        KeyCode::Esc,
+    ];
+
+    for (i, code) in sequence.iter().enumerate() {
+        host_side
+            .write_all(&frame_notification(
+                methods::PLUGIN_HANDLE_KEY,
+                key_params("ainb_analytics", code.clone(), i as u64),
+            ))
+            .await
+            .unwrap();
+    }
+    host_side.shutdown().await.unwrap();
+
+    // Drain anything the plugin writes back (nothing expected — handle_key
+    // is a notification with no response and the plugin emits no logs).
+    let mut host_read = BufReader::new(host_side);
+    let mut buf = Vec::new();
+    let _ = tokio::io::AsyncReadExt::read_to_end(&mut host_read, &mut buf).await;
+
+    let _ = server_task.await.unwrap();
+
+    let observed = keys.lock().await.clone();
+    assert_eq!(observed.len(), 5, "expected 5 handle_key calls, got {}", observed.len());
+    let observed_codes: Vec<KeyCode> = observed.into_iter().map(|k| k.code).collect();
+    assert_eq!(
+        observed_codes,
+        sequence.to_vec(),
+        "handle_key order was not preserved — sequence broke at: {observed_codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the burndown interactive-keys plan. Wires the protocol method shipped in Phase 1 (PR #98) into the Rust SDK so plugins can opt into receiving keystrokes via a trait method, and the server dispatcher actually delivers them.

- **`crates/ainb-plugin-sdk-rust/src/plugin.rs`** — add `async fn handle_key(&mut self, host, params) -> Result<()>` on the `Plugin` trait, default no-op body. Plugins that don't care (e.g. session-reader) keep compiling untouched.
- **`crates/ainb-plugin-sdk-rust/src/server.rs`** — decode `HandleKeyParams` in `handle_method`, forward to `Plugin::handle_key`, return `Value::Null`. Extends the existing inline-dispatch short-circuit so `plugin/handle_key` joins `plugin/handle_event` on the reader-loop task instead of being spawned — same ordering argument as commit 4ad7b46 (a tokio-spawned-per-handler implementation would re-order acquisitions of the per-plugin mutex and the plugin would observe `Tab` before `Char('2')`).
- **`crates/ainb-plugin-sdk-rust/src/lib.rs`** — re-export `HandleKeyParams`, `KeyEvent`, `KeyCode`, `KeyKind`, and the four `KEY_MOD_*` constants so plugin authors only need this crate.
- **`crates/ainb-plugin-sdk-rust/tests/handle_key_ordering.rs`** — new integration test: a recorder plugin captures the 5-key burst `Char('1') → Char('2') → Char('3') → Tab → Esc` and asserts the observed order matches send order.

Refs bead `agents-in-a-box-8q1.2` and plan `ainb-tui/plans/plugin-interactive-keys-and-cache.md` §Phase 2.

## Test plan

- [x] `cargo test -p ainb-plugin-sdk-rust` — 12 passed, 0 failed (1 new integration test + 11 pre-existing lib tests).
- [x] `cargo test -p ainb-plugin-protocol` — 37 passed, 0 failed (sanity check on the Phase 1 surface).
- [x] Ordering test runs the SDK server end-to-end over `tokio::io::duplex` and confirms the plugin observed all 5 keys in the order `[Char('1'), Char('2'), Char('3'), Tab, Esc]`.
- [ ] `cargo test --workspace` has one pre-existing failure unrelated to this PR: `ainb-core::test_app_state::test_previous_session` (assertion on session-list wrap-around — same failure reproducible on `origin/feat/plugin-interactive-keys` without my commits, last touched at `774f9ae` in `refactor(components): delete in-tree usage UI`). My SDK changes don't touch `app/state.rs` or anything session-list-related.

## Out of scope

Host forwarder + crossterm → `KeyEvent` translation table land in Phase 3 (bead `agents-in-a-box-8q1.3`). Burndown dispatch lands in Phase 4.