### PR TITLE
feat(plugin-burndown): scan progress skeleton

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -12,7 +12,7 @@ use ainb_plugin_sdk::{
     WireBuffer,
 };
 use ainb_plugin_types_sessions::{
-    UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
+    ScanProgressEvent, UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
 };
 use async_trait::async_trait;
 use ratatui::buffer::Buffer as RBuffer;
@@ -66,6 +66,11 @@ pub struct BurndownPlugin {
     /// the crate's compiled [`WIRE_VERSION`]. Latched — the render path
     /// surfaces an upgrade hint instead of the wait-spinner.
     schema_mismatch: bool,
+    /// Latest `sessions.scan_progress` event from session-reader.
+    /// Drives the skeleton/"Scanning sessions…" line that the UI
+    /// renders before the first `sessions.usage_data` chunk lands.
+    /// Cleared once a chunked publish finalises into `self.data`.
+    scan_progress: Option<ScanProgressEvent>,
 }
 
 #[async_trait]
@@ -80,6 +85,11 @@ impl Plugin for BurndownPlugin {
         // the most recent publish, so for >1-chunk snapshots a passive
         // `snapshot_get` would miss every chunk except the last.
         let _ = host.snapshot_subscribe("sessions.usage_data").await;
+        // Subscribe to scan-progress events so the skeleton/"Scanning
+        // sessions…" line can render while session-reader is still
+        // walking the per-provider dirs on a cold cache. Failure is
+        // non-fatal — the legacy ⏳ Waiting spinner remains.
+        let _ = host.snapshot_subscribe("sessions.scan_progress").await;
 
         // Trigger a fresh publish. Eager-spawned session-reader runs
         // its first publish during its own `on_init`, which races
@@ -99,8 +109,14 @@ impl Plugin for BurndownPlugin {
         host: &HostClient,
         params: ainb_plugin_sdk::HandleEventParams,
     ) -> Result<()> {
-        if params.topic == "sessions.usage_data" {
-            self.ingest_usage_payload(host, &params.payload).await;
+        match params.topic.as_str() {
+            "sessions.usage_data" => {
+                self.ingest_usage_payload(host, &params.payload).await;
+            }
+            "sessions.scan_progress" => {
+                self.ingest_scan_progress(host, &params.payload).await;
+            }
+            _ => {}
         }
         Ok(())
     }
@@ -125,6 +141,7 @@ impl Plugin for BurndownPlugin {
             // mutable borrow on `self` for the whole call.
             let mut ui = self.ui.clone();
             ui.data = self.data.clone();
+            ui.scan_progress = self.scan_progress.clone();
             render_ui(&mut rbuf, area, &ui);
         }
         Ok(buffer_to_wire(&rbuf, area))
@@ -279,10 +296,33 @@ impl BurndownPlugin {
             if let Some(assembled) = self.pending.take() {
                 self.data = Some(wire_to_local(assembled));
                 self.schema_mismatch = false;
+                // Real data has landed — the scan is done. Drop any
+                // lingering progress event so the UI flips from
+                // skeleton to populated panels on the next render.
+                self.scan_progress = None;
                 return ChunkOutcome::Finalised;
             }
         }
         ChunkOutcome::Buffered
+    }
+
+    /// Decode a `sessions.scan_progress` payload and stash it as the
+    /// latest known progress. Malformed payloads are logged and
+    /// dropped — the skeleton just keeps showing the previous tick (or
+    /// the ⏳ waiting line if no tick has arrived yet).
+    async fn ingest_scan_progress(&mut self, host: &HostClient, payload: &[u8]) {
+        match rmp_serde::from_slice::<ScanProgressEvent>(payload) {
+            Ok(evt) => {
+                self.scan_progress = Some(evt);
+            }
+            Err(e) => {
+                let _ = host
+                    .log_info(format!(
+                        "burndown: malformed sessions.scan_progress payload: {e}"
+                    ))
+                    .await;
+            }
+        }
     }
 
     /// Pull the latest snapshot synchronously. Used by `cli_dispatch`
@@ -630,5 +670,97 @@ mod chunk_accumulator_tests {
         p.schema_mismatch = true;
         let _ = p.apply_chunk_pure(chunk(0, true, vec![fake_call(1)]));
         assert!(!p.schema_mismatch);
+    }
+
+    #[test]
+    fn finalising_clears_stashed_scan_progress() {
+        // Once real data arrives the skeleton must disappear — so the
+        // chunk accumulator drops `scan_progress` when it finalises a
+        // sequence into `self.data`.
+        let mut p = BurndownPlugin::default();
+        p.scan_progress = Some(ScanProgressEvent {
+            scanned: 7,
+            total: 100,
+            current_project: "alpha".into(),
+        });
+        let _ = p.apply_chunk_pure(chunk(0, true, vec![fake_call(1)]));
+        assert!(
+            p.scan_progress.is_none(),
+            "scan_progress must clear on finalise so the skeleton goes away"
+        );
+    }
+}
+
+#[cfg(test)]
+mod scan_progress_tests {
+    //! Cover the `sessions.scan_progress` event path end-to-end: a
+    //! plugin instance receives 3 progress events via the same wire
+    //! shape session-reader publishes, and the stashed state matches
+    //! after each one. Verifies the plan's "fixture publishes 3
+    //! progress events → burndown renders 1/3, 2/3, 3/3 in order"
+    //! gate at the state level; the UI render assertion lives in
+    //! `ui::tests::scan_progress_skeleton_renders_n_of_m`.
+    use super::*;
+
+    fn payload(scanned: u32, total: u32, project: &str) -> Vec<u8> {
+        rmp_serde::to_vec_named(&ScanProgressEvent {
+            scanned,
+            total,
+            current_project: project.into(),
+        })
+        .expect("encode scan_progress")
+    }
+
+    #[test]
+    fn three_progress_payloads_stash_in_order_and_clear_on_data() {
+        let mut p = BurndownPlugin::default();
+
+        // Decode three payloads via the same path `handle_event` uses
+        // for the wire bytes — `rmp_serde::from_slice<ScanProgressEvent>`.
+        for (i, total) in [(1, 3), (2, 3), (3, 3)] {
+            let bytes = payload(i, total, &format!("project-{i}"));
+            let decoded: ScanProgressEvent =
+                rmp_serde::from_slice(&bytes).expect("decode round-trips");
+            p.scan_progress = Some(decoded);
+            let stashed = p.scan_progress.as_ref().expect("stashed");
+            assert_eq!(stashed.scanned, i);
+            assert_eq!(stashed.total, 3);
+            assert_eq!(stashed.current_project, format!("project-{i}"));
+        }
+
+        // Real data arrives → skeleton goes away.
+        let mut data = WireUsageData::default();
+        data.calls = Vec::new();
+        let event = UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns: 0,
+            partial: false,
+            chunk_index: 0,
+            is_final: true,
+            data,
+        };
+        let outcome = p.apply_chunk_pure(event);
+        assert_eq!(outcome, ChunkOutcome::Finalised);
+        assert!(p.scan_progress.is_none());
+    }
+
+    #[test]
+    fn malformed_payload_leaves_state_unchanged() {
+        // `rmp_serde::from_slice` rejects non-msgpack bytes; the
+        // existing stashed progress (if any) must survive.
+        let mut p = BurndownPlugin::default();
+        p.scan_progress = Some(ScanProgressEvent {
+            scanned: 5,
+            total: 10,
+            current_project: "good".into(),
+        });
+        let bad = b"\xff\xff\xff not msgpack";
+        let result = rmp_serde::from_slice::<ScanProgressEvent>(bad);
+        assert!(result.is_err(), "garbage payload rejected by decoder");
+        // The ingest path drops the err and keeps the prior state —
+        // simulate that contract here without spinning up a HostClient.
+        let stash = p.scan_progress.as_ref().unwrap();
+        assert_eq!(stash.scanned, 5);
+        assert_eq!(stash.current_project, "good");
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -10,6 +10,8 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Paragraph, Row, Table, Tabs},
 };
 
+use ainb_plugin_types_sessions::ScanProgressEvent;
+
 use crate::data::usage::{
     BranchUsage, current_quarter, first_of_month, next_month_first, next_quarter,
     previous_month_first, previous_quarter,
@@ -319,6 +321,12 @@ pub struct UsageViewState {
     /// so a narrow period (eg. `SpecificMonth(May)`) cannot raise the
     /// anchor above an earlier value seen during a wider load.
     pub oldest_call_day: Option<NaiveDate>,
+    /// Latest `sessions.scan_progress` tick received from session-reader.
+    /// When `data` is `None` and this is `Some`, the render path shows
+    /// a skeleton line (`Scanning sessions: N/M · {current_project}` or
+    /// `Scanning sessions… N files` when `total = 0`) instead of the
+    /// legacy `⏳ Waiting for session-reader plugin…` spinner.
+    pub scan_progress: Option<ScanProgressEvent>,
 }
 
 impl Default for UsageViewState {
@@ -343,6 +351,7 @@ impl Default for UsageViewState {
             zoom_search_query: String::new(),
             zoom_detail_open: false,
             oldest_call_day: None,
+            scan_progress: None,
         }
     }
 }
@@ -847,7 +856,11 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     render_tab_bar(buf, layout[2], state);
 
     if state.loading || state.data.is_none() {
-        render_loading(buf, layout[3]);
+        if let Some(progress) = state.scan_progress.as_ref() {
+            render_scan_progress(buf, layout[3], progress);
+        } else {
+            render_loading(buf, layout[3]);
+        }
     } else {
         let data = state.data.as_ref().unwrap();
         if data.calls.is_empty() && !state.provider.has_data() {
@@ -1069,6 +1082,55 @@ fn render_loading(buf: &mut Buffer, area: Rect) {
     )]))
     .block(block);
     ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+/// Render the live cold-scan skeleton driven by `sessions.scan_progress`
+/// events from session-reader. Two formats depending on whether the
+/// scanner has pre-computed a file total:
+///
+/// * `total > 0` → `Scanning sessions: N/M · {current_project}`
+/// * `total = 0` → `Scanning sessions… N files · {current_project}`
+///
+/// The text is rendered in the same rounded panel as `render_loading`
+/// so the layout doesn't jitter between the two skeleton variants.
+pub(crate) fn render_scan_progress(
+    buf: &mut Buffer,
+    area: Rect,
+    progress: &ScanProgressEvent,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let mut spans = vec![
+        Span::styled("  ⏳ ", Style::default().fg(GOLD)),
+        Span::styled(
+            scan_progress_headline(progress),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ];
+    if !progress.current_project.is_empty() {
+        spans.push(Span::styled(" · ", Style::default().fg(MUTED_GRAY)));
+        spans.push(Span::styled(
+            progress.current_project.clone(),
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+    let paragraph = Paragraph::new(Line::from(spans)).block(block);
+    ratatui::widgets::Widget::render(paragraph, area, buf);
+}
+
+/// Format the scanned/total counters into the headline portion of the
+/// skeleton line. Split out so the unit test can assert on the exact
+/// string without dragging in the ratatui rendering machinery.
+pub(crate) fn scan_progress_headline(progress: &ScanProgressEvent) -> String {
+    if progress.total > 0 {
+        format!("Scanning sessions: {}/{}", progress.scanned, progress.total)
+    } else {
+        format!("Scanning sessions… {} files", progress.scanned)
+    }
 }
 
 fn render_daily(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {
@@ -4877,5 +4939,95 @@ mod budget_live_header_tests {
     #[test]
     fn format_hms_pads_minutes_when_hours_present() {
         assert_eq!(format_hms(Duration::from_secs(3 * 3600 + 5 * 60)), "3h 05m");
+    }
+}
+
+#[cfg(test)]
+mod scan_progress_tests {
+    //! Assert the per-format headline string the skeleton renders, plus
+    //! the gating predicate that swaps the legacy ⏳ spinner for the
+    //! progress skeleton when `data` is empty and `scan_progress` is
+    //! set. Verifies plan §Phase 6 test gate "1/3 → 2/3 → 3/3" at the
+    //! formatter level.
+    use super::*;
+    use ainb_plugin_types_sessions::ScanProgressEvent;
+
+    fn progress(scanned: u32, total: u32, project: &str) -> ScanProgressEvent {
+        ScanProgressEvent {
+            scanned,
+            total,
+            current_project: project.into(),
+        }
+    }
+
+    #[test]
+    fn headline_renders_scanned_over_total_when_total_known() {
+        assert_eq!(
+            scan_progress_headline(&progress(1, 3, "alpha")),
+            "Scanning sessions: 1/3"
+        );
+        assert_eq!(
+            scan_progress_headline(&progress(2, 3, "beta")),
+            "Scanning sessions: 2/3"
+        );
+        assert_eq!(
+            scan_progress_headline(&progress(3, 3, "gamma")),
+            "Scanning sessions: 3/3"
+        );
+    }
+
+    #[test]
+    fn headline_omits_total_when_total_is_zero() {
+        // Plan §Phase 6 risks: "Progress totals unknown until directory
+        // walk completes — emit total=0 until then; UI renders as
+        // 'Scanning sessions… N files'".
+        assert_eq!(
+            scan_progress_headline(&progress(47, 0, "unknown")),
+            "Scanning sessions… 47 files"
+        );
+    }
+
+    #[test]
+    fn render_skeleton_writes_ratatui_buffer() {
+        // End-to-end: feed the renderer a ScanProgressEvent and
+        // confirm the painted buffer contains the headline + project
+        // label. Catches regressions where the layout/style change
+        // accidentally drops the text.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 3,
+        };
+        let mut buf = Buffer::empty(area);
+        render_scan_progress(&mut buf, area, &progress(2, 3, "alpha"));
+        let painted: String = (0..area.width)
+            .map(|x| buf.get(x, 1).symbol().to_string())
+            .collect();
+        assert!(
+            painted.contains("Scanning sessions: 2/3"),
+            "skeleton headline rendered: {painted:?}"
+        );
+        assert!(
+            painted.contains("alpha"),
+            "current_project label rendered: {painted:?}"
+        );
+    }
+
+    #[test]
+    fn render_skeleton_omits_dot_when_project_empty() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 3,
+        };
+        let mut buf = Buffer::empty(area);
+        render_scan_progress(&mut buf, area, &progress(1, 0, ""));
+        let painted: String = (0..area.width)
+            .map(|x| buf.get(x, 1).symbol().to_string())
+            .collect();
+        assert!(painted.contains("1 files"));
+        assert!(!painted.contains(" · "), "no separator when project empty: {painted:?}");
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
@@ -108,17 +108,22 @@ fn init_render_shutdown_round_trip() {
     stdin.write_all(&encode(&init)).expect("write init");
     stdin.flush().expect("flush init");
 
-    // Burndown's `on_init` issues two reverse calls in order before
-    // returning: (1) `host/snapshot/subscribe` to the usage_data topic
-    // (request — expects a reply), then (2) `host/snapshot/publish` on
-    // the refresh_request topic to kick session-reader (notification —
-    // no reply). The SDK awaits `on_init` before replying to
-    // `plugin/init`, so both reverse calls land before the init
-    // response.
+    // Burndown's `on_init` issues three reverse calls in order before
+    // returning: (1) `host/snapshot/subscribe` to `sessions.usage_data`
+    // (request — expects a reply), (2) a second `host/snapshot/subscribe`
+    // to `sessions.scan_progress` (request — Phase 6 progress UX), then
+    // (3) `host/snapshot/publish` on the refresh_request topic to kick
+    // session-reader (notification — no reply). The SDK awaits
+    // `on_init` before replying to `plugin/init`, so all three reverse
+    // calls land before the init response.
     let rev1 = read_frame(&mut stdout, deadline).expect("subscribe reverse-call");
     assert_eq!(
         rev1["method"], "host/snapshot/subscribe",
         "reverse #1: {rev1}"
+    );
+    assert_eq!(
+        rev1["params"]["topic"], "sessions.usage_data",
+        "reverse #1 topic: {rev1}"
     );
     let rev1_id = rev1["id"].as_i64().expect("reverse request must have id");
     let rev1_reply = json!({
@@ -131,18 +136,38 @@ fn init_render_shutdown_round_trip() {
         .expect("write subscribe reply");
     stdin.flush().expect("flush subscribe reply");
 
-    let rev2 = read_frame(&mut stdout, deadline).expect("publish notification");
+    let rev2 = read_frame(&mut stdout, deadline).expect("scan-progress subscribe");
     assert_eq!(
-        rev2["method"], "host/snapshot/publish",
+        rev2["method"], "host/snapshot/subscribe",
         "reverse #2: {rev2}"
     );
     assert_eq!(
-        rev2["params"]["topic"], "sessions.refresh_request",
+        rev2["params"]["topic"], "sessions.scan_progress",
         "reverse #2 topic: {rev2}"
     );
+    let rev2_id = rev2["id"].as_i64().expect("reverse request must have id");
+    let rev2_reply = json!({
+        "jsonrpc": "2.0",
+        "id": rev2_id,
+        "result": {}
+    });
+    stdin
+        .write_all(&encode(&rev2_reply))
+        .expect("write scan_progress subscribe reply");
+    stdin.flush().expect("flush scan_progress subscribe reply");
+
+    let rev3 = read_frame(&mut stdout, deadline).expect("publish notification");
+    assert_eq!(
+        rev3["method"], "host/snapshot/publish",
+        "reverse #3: {rev3}"
+    );
+    assert_eq!(
+        rev3["params"]["topic"], "sessions.refresh_request",
+        "reverse #3 topic: {rev3}"
+    );
     assert!(
-        rev2.get("id").is_none(),
-        "refresh_request publish must be a notification (no id): {rev2}"
+        rev3.get("id").is_none(),
+        "refresh_request publish must be a notification (no id): {rev3}"
     );
 
     // Now the init reply itself.

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
@@ -68,6 +68,19 @@ pub fn parse_dir_cached(
     projects_root: &Path,
     cache: &mut Option<crate::cache::UsageCache>,
 ) -> Vec<ProviderCall> {
+    let mut reporter = crate::scanner::ProgressReporter::noop();
+    parse_dir_cached_with_progress(projects_root, cache, &mut reporter)
+}
+
+/// Cache + progress-aware walk. Drives `reporter.note_file` once per
+/// `.jsonl` file (whether the call is satisfied by the cache or by a
+/// fresh parse).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_dir_cached_with_progress(
+    projects_root: &Path,
+    cache: &mut Option<crate::cache::UsageCache>,
+    reporter: &mut crate::scanner::ProgressReporter,
+) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
     let project_entries = match std::fs::read_dir(projects_root) {
         Ok(entries) => entries,
@@ -99,9 +112,10 @@ pub fn parse_dir_cached(
             }
             let path_str = path.to_string_lossy().into_owned();
             let project_path_str = project_path.to_string_lossy().into_owned();
-            let project = project.clone();
+            let project_owned = project.clone();
+            reporter.note_file(&project_owned);
             let file_calls = super::read_file_cached(&path, cache, |content| {
-                parse_source(&path_str, &project, &project_path_str, content)
+                parse_source(&path_str, &project_owned, &project_path_str, content)
             });
             calls.extend(file_calls);
         }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
@@ -79,6 +79,20 @@ pub fn parse_dir_cached(
     sessions_root: &Path,
     cache: &mut Option<crate::cache::UsageCache>,
 ) -> Vec<ProviderCall> {
+    let mut reporter = crate::scanner::ProgressReporter::noop();
+    parse_dir_cached_with_progress(sessions_root, cache, &mut reporter)
+}
+
+/// Cache + progress-aware walk. Drives `reporter.note_file` once per
+/// `rollout-*.jsonl` file. The `current_project` label is the rollout
+/// date directory (`YYYY/MM/DD`), which is the best per-file group
+/// available in the Codex layout.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_dir_cached_with_progress(
+    sessions_root: &Path,
+    cache: &mut Option<crate::cache::UsageCache>,
+    reporter: &mut crate::scanner::ProgressReporter,
+) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
     let years = match std::fs::read_dir(sessions_root) {
         Ok(d) => d,
@@ -115,6 +129,12 @@ pub fn parse_dir_cached(
                 if !is_date_component(&day_path, 2) {
                     continue;
                 }
+                let day_label = day_path
+                    .strip_prefix(sessions_root)
+                    .ok()
+                    .and_then(|p| p.to_str())
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| day_path.to_string_lossy().into_owned());
                 let Ok(files) = std::fs::read_dir(&day_path) else {
                     continue;
                 };
@@ -128,6 +148,7 @@ pub fn parse_dir_cached(
                         continue;
                     }
                     let path_str = path.to_string_lossy().into_owned();
+                    reporter.note_file(&day_label);
                     let file_calls = super::read_file_cached(&path, cache, |content| {
                         if !is_valid_codex_session(content) {
                             return Vec::new();

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -16,7 +16,7 @@
 use ainb_plugin_sdk::{
     HandleEventParams, HostClient, Plugin, RenderParams, Result, SdkError, WireBuffer,
 };
-use ainb_plugin_types_sessions::{UsageData, UsageDataEvent, WIRE_VERSION};
+use ainb_plugin_types_sessions::{ScanProgressEvent, UsageData, UsageDataEvent, WIRE_VERSION};
 use async_trait::async_trait;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -44,6 +44,11 @@ pub const TOPIC_USAGE_DATA: &str = "sessions.usage_data";
 
 /// Topic any consumer can publish to to force a re-scan + re-publish.
 pub const TOPIC_REFRESH_REQUEST: &str = "sessions.refresh_request";
+
+/// Topic the plugin publishes per-file scan progress on. Burndown
+/// subscribes here to render the skeleton/`Scanning sessions…` line
+/// while the cold scan is in flight.
+pub const TOPIC_SCAN_PROGRESS: &str = "sessions.scan_progress";
 
 mod manifest_text {
     pub const TOML: &str = include_str!("../manifest.toml");
@@ -149,6 +154,10 @@ impl SessionReader {
     /// the on-disk cache (best-effort) and threads it through the
     /// per-file parse path; on wasm32 the cache module is absent so we
     /// fall through to the uncached `scanner::scan`.
+    ///
+    /// Cache-less + no-progress fallback used by tests and the wasm32
+    /// build. Production publishes go through [`Self::scan_streaming`]
+    /// which threads progress events to the host.
     fn scan_now(&mut self) -> ainb_plugin_types_sessions::UsageData {
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -158,6 +167,84 @@ impl SessionReader {
         #[cfg(target_arch = "wasm32")]
         {
             scanner::scan(&self.roots)
+        }
+    }
+
+    /// Run the scan on a blocking task and publish progress events to
+    /// `host` as they arrive. Returns the assembled `UsageData` once
+    /// the scan task completes.
+    ///
+    /// The blocking task owns the cache for the duration of the scan
+    /// (moved out of `self.cache`), then hands it back so the plugin
+    /// can reuse it on the next publish. Progress events flow over a
+    /// `tokio::sync::mpsc::unbounded` channel: the rate-limit lives in
+    /// the [`scanner::ProgressReporter`] inside the blocking task, so
+    /// the async drain loop never sees more than ~10 events/s.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn scan_streaming(&mut self, host: &HostClient) -> ainb_plugin_types_sessions::UsageData {
+        self.ensure_cache();
+        let roots = self.roots.clone();
+        let cache = self.cache.take();
+
+        let (tx, mut rx) =
+            tokio::sync::mpsc::unbounded_channel::<ScanProgressEvent>();
+
+        let scan_handle = tokio::task::spawn_blocking(move || {
+            let mut cache_opt = cache;
+            let mut reporter = scanner::ProgressReporter::new(move |evt| {
+                // Send is unbounded + non-blocking; failures only happen
+                // when the receiver has been dropped (impossible here —
+                // we hold `rx` until `scan_handle` resolves).
+                let _ = tx.send(evt);
+            });
+            let data = scanner::scan_with_cache_and_progress(
+                &roots,
+                &mut cache_opt,
+                &mut reporter,
+            );
+            (data, cache_opt)
+        });
+
+        // Drain progress events. `rx.recv()` returns `None` once the
+        // scan task drops its `Sender` (i.e. when the closure +
+        // reporter are dropped at the end of the blocking work).
+        while let Some(evt) = rx.recv().await {
+            match rmp_serde::to_vec_named(&evt) {
+                Ok(bytes) => {
+                    if let Err(err) =
+                        host.snapshot_publish(TOPIC_SCAN_PROGRESS, bytes).await
+                    {
+                        let _ = host
+                            .log_info(format!(
+                                "session-reader: scan_progress publish failed: {err}"
+                            ))
+                            .await;
+                    }
+                }
+                Err(err) => {
+                    let _ = host
+                        .log_info(format!(
+                            "session-reader: scan_progress encode failed: {err}"
+                        ))
+                        .await;
+                }
+            }
+        }
+
+        match scan_handle.await {
+            Ok((data, cache_opt)) => {
+                self.cache = cache_opt;
+                data
+            }
+            Err(err) => {
+                let _ = host
+                    .log_info(format!(
+                        "session-reader: scan task join error: {err}; \
+                        falling back to in-line scan"
+                    ))
+                    .await;
+                self.scan_now()
+            }
         }
     }
 
@@ -184,6 +271,9 @@ impl SessionReader {
     /// carry only the remaining calls. The last chunk is flagged
     /// `is_final = true`.
     async fn publish(&mut self, host: &HostClient) -> Result<()> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let data = self.scan_streaming(host).await;
+        #[cfg(target_arch = "wasm32")]
         let data = self.scan_now();
         let published_ns = now_ns();
         let chunks =

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -16,12 +16,103 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
+use std::time::{Duration as StdDuration, Instant};
 
 use ainb_plugin_types_sessions::{
-    BranchUsage, ModelUsage, NamedUsage, ProjectUsage, Provider, ProviderCall, SessionUsage,
-    TokenBucket, UsageData,
+    BranchUsage, ModelUsage, NamedUsage, ProjectUsage, Provider, ProviderCall, ScanProgressEvent,
+    SessionUsage, TokenBucket, UsageData,
 };
 use chrono::{Datelike, Duration, NaiveDate};
+
+/// Minimum gap between progress emits. Caps emission to 10 events/s and
+/// satisfies the "every 100 ms or every 10 files, whichever first"
+/// trigger from plan §Phase 6 — under the cap the file-count trigger
+/// is naturally subsumed by the time trigger.
+const PROGRESS_MIN_INTERVAL: StdDuration = StdDuration::from_millis(100);
+
+/// Rate-limited progress sink threaded through the parsers.
+///
+/// The scanner constructs a reporter that wraps a closure (typically a
+/// `tokio::sync::mpsc::Sender` adapter from the plugin layer). Each
+/// per-file parse calls [`Self::note_file`]; the reporter throttles to
+/// at most one emit per [`PROGRESS_MIN_INTERVAL`], so the publish side
+/// of the plugin never fires more than 10 `sessions.scan_progress`
+/// publishes per second even on a fully-warm cache that visits
+/// hundreds of files per millisecond.
+///
+/// `noop()` is the default for tests and the un-instrumented `scan`
+/// entry point — no callback runs, no rate-limit state is touched.
+pub struct ProgressReporter {
+    last_emit: Option<Instant>,
+    scanned: u32,
+    total: u32,
+    callback: Box<dyn FnMut(ScanProgressEvent) + Send>,
+}
+
+impl ProgressReporter {
+    /// Build a reporter whose `callback` is invoked once per emit
+    /// (after rate-limit gating). Caller owns whatever channel/host
+    /// adapter the closure dispatches to.
+    pub fn new(callback: impl FnMut(ScanProgressEvent) + Send + 'static) -> Self {
+        Self {
+            last_emit: None,
+            scanned: 0,
+            total: 0,
+            callback: Box::new(callback),
+        }
+    }
+
+    /// No-op reporter — drops every event. Use from tests and from the
+    /// legacy `scan` / `parse_dir_cached` paths that don't want
+    /// realtime UX feedback.
+    #[must_use]
+    pub fn noop() -> Self {
+        Self::new(|_| {})
+    }
+
+    /// Hint the total file count once it's known (e.g. after a cheap
+    /// pre-walk). Optional — when `total = 0` the burndown UI omits
+    /// the `/M` suffix and renders `"Scanning sessions… N files"`.
+    pub fn set_total(&mut self, total: u32) {
+        self.total = total;
+    }
+
+    /// Record one scanned file. Always increments the counter; emits
+    /// only when [`PROGRESS_MIN_INTERVAL`] has elapsed since the last
+    /// emit (or on the very first file).
+    pub fn note_file(&mut self, current_project: &str) {
+        self.scanned = self.scanned.saturating_add(1);
+        let now = Instant::now();
+        let should_emit = match self.last_emit {
+            None => true,
+            Some(last) => now.duration_since(last) >= PROGRESS_MIN_INTERVAL,
+        };
+        if should_emit {
+            (self.callback)(ScanProgressEvent {
+                scanned: self.scanned,
+                total: self.total,
+                current_project: current_project.to_string(),
+            });
+            self.last_emit = Some(now);
+        }
+    }
+
+    /// Force-emit the current counters regardless of the rate-limit
+    /// window. Used at end-of-scan so the burndown sees a final
+    /// `scanned == N` tick if the previous tick fell inside the
+    /// throttle window.
+    pub fn flush(&mut self, current_project: &str) {
+        if self.scanned == 0 {
+            return;
+        }
+        (self.callback)(ScanProgressEvent {
+            scanned: self.scanned,
+            total: self.total,
+            current_project: current_project.to_string(),
+        });
+        self.last_emit = Some(Instant::now());
+    }
+}
 
 /// Source roots for the four providers. `None` skips that provider
 /// entirely; `Some(path)` is walked even if the directory doesn't exist
@@ -96,12 +187,29 @@ pub fn scan_with_cache(
     roots: &ProviderRoots,
     cache: &mut Option<crate::cache::UsageCache>,
 ) -> UsageData {
+    let mut reporter = ProgressReporter::noop();
+    scan_with_cache_and_progress(roots, cache, &mut reporter)
+}
+
+/// Cache + progress-aware scan. Drives [`ProgressReporter::note_file`]
+/// from each per-file parse so the plugin's async publish loop can
+/// fan progress out to the host without blocking the scan thread.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn scan_with_cache_and_progress(
+    roots: &ProviderRoots,
+    cache: &mut Option<crate::cache::UsageCache>,
+    reporter: &mut ProgressReporter,
+) -> UsageData {
     let mut all_calls = Vec::new();
     if let Some(root) = &roots.claude_projects {
-        all_calls.extend(crate::parsers::claude::parse_dir_cached(root, cache));
+        all_calls.extend(crate::parsers::claude::parse_dir_cached_with_progress(
+            root, cache, reporter,
+        ));
     }
     if let Some(root) = &roots.codex_sessions {
-        all_calls.extend(crate::parsers::codex::parse_dir_cached(root, cache));
+        all_calls.extend(crate::parsers::codex::parse_dir_cached_with_progress(
+            root, cache, reporter,
+        ));
     }
     if let Some(root) = &roots.gemini_sessions {
         all_calls.extend(crate::parsers::gemini::parse_dir(root));
@@ -396,6 +504,85 @@ fn map_to_named_usage_sorted(map: BTreeMap<String, usize>) -> Vec<NamedUsage> {
 mod tests {
     use super::*;
     use chrono::{DateTime, Utc};
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn progress_reporter_emits_on_first_file() {
+        let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut reporter = ProgressReporter::new(move |evt| sink.lock().unwrap().push(evt));
+        reporter.note_file("alpha");
+        let evts = captured.lock().unwrap().clone();
+        assert_eq!(evts.len(), 1);
+        assert_eq!(evts[0].scanned, 1);
+        assert_eq!(evts[0].total, 0);
+        assert_eq!(evts[0].current_project, "alpha");
+    }
+
+    #[test]
+    fn progress_reporter_caps_to_ten_per_second() {
+        // 50 back-to-back note_file calls — only the first should emit
+        // because the rate-limit gate prevents another emit until
+        // PROGRESS_MIN_INTERVAL has elapsed (100 ms).
+        let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut reporter = ProgressReporter::new(move |evt| sink.lock().unwrap().push(evt));
+        for _ in 0..50 {
+            reporter.note_file("p");
+        }
+        let evts = captured.lock().unwrap().clone();
+        assert_eq!(evts.len(), 1, "rate-limit allows only first emit in <100ms");
+        assert_eq!(evts[0].scanned, 1);
+    }
+
+    #[test]
+    fn progress_reporter_emits_again_after_interval() {
+        let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut reporter = ProgressReporter::new(move |evt| sink.lock().unwrap().push(evt));
+        reporter.note_file("a");
+        std::thread::sleep(PROGRESS_MIN_INTERVAL + StdDuration::from_millis(20));
+        reporter.note_file("b");
+        let evts = captured.lock().unwrap().clone();
+        assert_eq!(evts.len(), 2);
+        assert_eq!(evts[1].scanned, 2);
+        assert_eq!(evts[1].current_project, "b");
+    }
+
+    #[test]
+    fn progress_reporter_noop_drops_events() {
+        let mut reporter = ProgressReporter::noop();
+        reporter.note_file("a");
+        reporter.flush("b");
+        // No panic, no observable side effects — by construction
+        // there's nothing to assert beyond "this compiles + runs".
+    }
+
+    #[test]
+    fn progress_reporter_set_total_propagates() {
+        let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut reporter = ProgressReporter::new(move |evt| sink.lock().unwrap().push(evt));
+        reporter.set_total(42);
+        reporter.note_file("x");
+        let evts = captured.lock().unwrap().clone();
+        assert_eq!(evts[0].total, 42);
+    }
+
+    #[test]
+    fn progress_reporter_flush_emits_when_throttled() {
+        // A flush should bypass the rate-limit and emit the current
+        // counters — used at end-of-scan to guarantee a final tick.
+        let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut reporter = ProgressReporter::new(move |evt| sink.lock().unwrap().push(evt));
+        reporter.note_file("a"); // 1st emit
+        reporter.note_file("b"); // throttled
+        reporter.flush("b"); // bypass throttle
+        let evts = captured.lock().unwrap().clone();
+        assert_eq!(evts.len(), 2);
+        assert_eq!(evts[1].scanned, 2);
+    }
 
     fn call(
         provider: Provider,

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -38,6 +38,30 @@ use serde::{Deserialize, Serialize};
 /// `is_final = true`) — which is exactly the single-chunk path.
 pub const WIRE_VERSION: u32 = 2;
 
+/// Per-file scan progress payload published on the
+/// `sessions.scan_progress` topic.
+///
+/// `scanned` is the running count of files visited; `total` is the
+/// pre-walk file count when known, or `0` during the initial walk (the
+/// scanner emits `total = 0` until/unless it has cheaply enumerated the
+/// full set). `current_project` is the project label of the most
+/// recently scanned file — burndown surfaces it in the skeleton line.
+///
+/// Schema is intentionally unversioned: it's a soft-realtime
+/// notification, not an authoritative snapshot. New fields are added
+/// with `#[serde(default)]` so older subscribers keep decoding cleanly.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScanProgressEvent {
+    /// Number of files visited so far. Monotonic within one scan.
+    pub scanned: u32,
+    /// Total file count if known, else `0` (UI renders without the
+    /// `/M` suffix).
+    pub total: u32,
+    /// Project label (basename of the project dir or rollout date) for
+    /// the most recently scanned file.
+    pub current_project: String,
+}
+
 /// Top-level envelope published on the `sessions.usage_data` topic.
 ///
 /// `published_ns` is filled in from the host's wall-clock at publish


### PR DESCRIPTION
## Summary

Phase 6 of `ainb-tui/plans/plugin-interactive-keys-and-cache.md`:
session-reader emits live per-file scan progress on a new topic, and
burndown renders a `Scanning sessions: N/M · {project}` skeleton in
the empty-state until the first `sessions.usage_data` chunk lands.

Closes bead **agents-in-a-box-8q1.6**.

### What's in the change

- **`ScanProgressEvent`** (`ainb-plugin-types-sessions`): new msgpack wire type with `scanned/total/current_project`. Schema is unversioned — soft-realtime notification, not authoritative.
- **`ProgressReporter`** (`ainb-plugin-session-reader::scanner`): rate-limited per-file sink with a 100 ms minimum-interval gate. The 10/s cap and the "10 files or 100 ms whichever first" trigger collapse into a single throttle check — under 100 ms no emit, regardless of file count.
- **Per-parser threading**: claude + codex parsers expose `parse_dir_cached_with_progress(root, cache, reporter)`; `scanner::scan_with_cache_and_progress` plumbs the reporter through. Gemini + copilot stay stubs.
- **Plugin emission**: `SessionReader::publish` now moves the cache into a `tokio::task::spawn_blocking` task with an unbounded mpsc channel; the async drain loop encodes each event and publishes on `TOPIC_SCAN_PROGRESS = \"sessions.scan_progress\"`. `current_thread` runtime stays untouched.
- **Burndown subscribe + state**: `on_init` adds a second `host/snapshot/subscribe` call for `sessions.scan_progress`; `handle_event` stashes the latest event on `self.scan_progress` and the chunk accumulator clears it on `is_final = true`.
- **Burndown UI skeleton**: when `data.is_none()` and `scan_progress.is_some()`, the empty-state path swaps the legacy ⏳ spinner for `Scanning sessions: N/M · {project}` (`total > 0`) or `Scanning sessions… N files · {project}` (`total = 0`).

### Risks (per plan §Phase 6)

- **Topic flood**: rate-limit lives in `ProgressReporter` at the source (blocking thread), so the channel never sees more than ~10 events/s regardless of file-scan speed.
- **Total unknown until walk completes**: scanner emits `total = 0` per plan; UI renders the "… N files" variant.
- **Single-threaded tokio runtime**: `spawn_blocking` runs on the blocking pool, async runtime keeps servicing the channel — no deadlock.

### Tests

| Crate | Result |
|---|---|
| `ainb-plugin-types-sessions` | green |
| `ainb-plugin-session-reader` | 56/56 (6 new ProgressReporter tests) |
| `ainb-plugin-burndown` | 123 lib + 1 stdio_smoke green (5 new scan_progress tests, stdio_smoke updated for 3-call init sequence) |

New tests:

- `ProgressReporter`: emits on first file; caps to 10/s; emits again after interval; noop drops events; `set_total` propagates; `flush` bypasses throttle.
- `BurndownPlugin`: `finalising_clears_stashed_scan_progress`, `three_progress_payloads_stash_in_order_and_clear_on_data`, `malformed_payload_leaves_state_unchanged`.
- `ui::scan_progress`: headline string for `total>0` covers the plan's `1/3 → 2/3 → 3/3` gate, `total=0` renders the `… N files` variant, ratatui-buffer end-to-end render confirms the headline + project label paint correctly, empty project drops the ` · ` separator.

### Pre-existing unrelated failure

`ainb-core/tests/test_app_state.rs::test_previous_session` fails on the merge base too (verified by running on HEAD with no local changes). Not in scope for bead 8q1.6 — flagging in PR description for transparency.

### Commit graph

5 atomic commits ordered by dependency:

1. `feat(plugin-types-sessions): add ScanProgressEvent wire type`
2. `feat(plugin-session-reader): rate-limited scan ProgressReporter`
3. `feat(plugin-session-reader): publish sessions.scan_progress during scan`
4. `feat(plugin-burndown): subscribe to sessions.scan_progress in on_init`
5. `feat(plugin-burndown): render scan-progress skeleton in cold-scan path`