### PR TITLE
feat(plugin-runtime): host forwards keystrokes to focused plugin

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -737,9 +737,20 @@ impl EventHandler {
             return Self::handle_changelog_keys(key_event, state);
         }
 
-        // Analytics screen owns its own key handling inside the burndown
-        // plugin. Until plugin-key forwarding is wired, keys on this screen
-        // fall through to the default handler (Esc back to home, etc.).
+        // Plugin-owned screens (Analytics → burndown today) forward
+        // keystrokes down `plugin/handle_key` so the plugin's own UI
+        // state (period chip, focused panel, zoom, filter stack) can
+        // react. The forwarder returns `Handled` for non-reserved
+        // keys; reserved keys (`Ctrl+C`, `?`, `H`) and screens with
+        // no associated plugin fall through to the global handler
+        // below. See `screens::builtin::forward_key_to_focused_plugin`
+        // for the reservation list and the crossterm → wire
+        // translation.
+        if let crate::app::screens::EventOutcome::Handled =
+            crate::app::screens::builtin::forward_key_to_focused_plugin(state, &key_event)
+        {
+            return None;
+        }
 
         // Handle skills browser view
         if state.current_screen == screen_ids::SKILLS {

--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -2,7 +2,7 @@
 
 use ratatui::{Frame, layout::Rect};
 
-use super::{Screen, ids};
+use super::{EventOutcome, Screen, ids};
 use crate::app::AppState;
 use crate::components::{
     AgentSelectionComponent, AttachedTerminalComponent, AuthProviderPopupComponent,
@@ -57,6 +57,133 @@ impl PluginScreen {
     }
 }
 
+/// Static screen → plugin routing table. The `state.rs` render tick
+/// already maps the same way; both call sites read this so the
+/// authoritative list lives in one place.
+///
+/// Keep this list in sync with `tick_plugin_renders` in `app/state.rs`.
+pub const PLUGIN_SCREENS: &[(&str, &str)] = &[(ids::ANALYTICS, "burndown")];
+
+/// Resolve the plugin id that owns `screen_id`, if any.
+#[must_use]
+pub fn plugin_id_for_screen(screen_id: &str) -> Option<&'static str> {
+    PLUGIN_SCREENS
+        .iter()
+        .find_map(|(s, p)| (*s == screen_id).then_some(*p))
+}
+
+/// Convert a `crossterm::event::KeyEvent` into the portable wire
+/// shape consumed by `plugin/handle_key`. Returns `None` for keys we
+/// don't model on the wire (e.g. media keys, mouse events surfaced as
+/// `KeyEvent::Modifier`-only no-ops on some terminals) so callers can
+/// silently drop them rather than fabricate a wire shape.
+#[must_use]
+pub fn crossterm_to_protocol_key(
+    key: &crossterm::event::KeyEvent,
+) -> Option<ainb_plugin_runtime::KeyEvent> {
+    use ainb_plugin_runtime::{
+        KEY_MOD_ALT, KEY_MOD_CTRL, KEY_MOD_SHIFT, KEY_MOD_SUPER, KeyCode as ProtocolKey,
+        KeyEvent as ProtocolEvent, KeyKind as ProtocolKind,
+    };
+    use crossterm::event::{KeyCode as CtKey, KeyEventKind as CtKind, KeyModifiers as CtMods};
+
+    let code = match key.code {
+        CtKey::Char(c) => ProtocolKey::Char { ch: c },
+        CtKey::Enter => ProtocolKey::Enter,
+        CtKey::Tab => ProtocolKey::Tab,
+        CtKey::BackTab => ProtocolKey::BackTab,
+        CtKey::Esc => ProtocolKey::Esc,
+        CtKey::Backspace => ProtocolKey::Backspace,
+        CtKey::Delete => ProtocolKey::Delete,
+        CtKey::Up => ProtocolKey::Up,
+        CtKey::Down => ProtocolKey::Down,
+        CtKey::Left => ProtocolKey::Left,
+        CtKey::Right => ProtocolKey::Right,
+        CtKey::Home => ProtocolKey::Home,
+        CtKey::End => ProtocolKey::End,
+        CtKey::PageUp => ProtocolKey::PageUp,
+        CtKey::PageDown => ProtocolKey::PageDown,
+        CtKey::F(n) => ProtocolKey::F { n },
+        _ => return None,
+    };
+
+    let mut mods: u8 = 0;
+    if key.modifiers.contains(CtMods::SHIFT) {
+        mods |= KEY_MOD_SHIFT;
+    }
+    if key.modifiers.contains(CtMods::CONTROL) {
+        mods |= KEY_MOD_CTRL;
+    }
+    if key.modifiers.contains(CtMods::ALT) {
+        mods |= KEY_MOD_ALT;
+    }
+    if key.modifiers.contains(CtMods::SUPER) {
+        mods |= KEY_MOD_SUPER;
+    }
+
+    let kind = match key.kind {
+        CtKind::Press => ProtocolKind::Press,
+        CtKind::Repeat => ProtocolKind::Repeat,
+        CtKind::Release => ProtocolKind::Release,
+    };
+
+    Some(ProtocolEvent { code, mods, kind })
+}
+
+/// `true` if the host reserves this key — it MUST NOT be forwarded to
+/// the plugin and MUST fall through to the central dispatch.
+///
+/// The reservation list is deliberately small:
+///
+/// - `Ctrl+C` → host quit (always).
+/// - `?` / `H` → help toggle (already short-circuited above
+///   `handle_key_event`'s plugin branch, but listed here for parity in
+///   the `PluginScreen` trait impl path).
+///
+/// `Esc`, `q`, `a`, `Tab`, `Enter`, etc. are NOT reserved — the
+/// burndown plugin re-binds them to period switches, filter pops,
+/// panel focus, and zoom toggles. Letting the host swallow them would
+/// make the screen uninteractive.
+#[must_use]
+pub fn is_host_reserved_key(key: &crossterm::event::KeyEvent) -> bool {
+    use crossterm::event::{KeyCode as CtKey, KeyModifiers as CtMods};
+    match key.code {
+        CtKey::Char('c') if key.modifiers.contains(CtMods::CONTROL) => true,
+        CtKey::Char('?' | 'H') => true,
+        _ => false,
+    }
+}
+
+/// Try to forward `key` to the plugin owning `current_screen`. Returns
+/// `Handled` if the host claimed it (plugin forwarder ran or the host
+/// reservation list bailed us out), `NotHandled` if the caller's
+/// upstream key dispatch should run instead (no plugin owns this
+/// screen, or no plugin runtime is initialised yet).
+pub fn forward_key_to_focused_plugin(
+    state: &mut AppState,
+    key: &crossterm::event::KeyEvent,
+) -> EventOutcome {
+    let Some(plugin_name) = plugin_id_for_screen(&state.current_screen) else {
+        return EventOutcome::NotHandled;
+    };
+    if is_host_reserved_key(key) {
+        // Host claims this key — let the central dispatch in
+        // `events.rs` resolve it to Quit / ToggleHelp / etc.
+        return EventOutcome::NotHandled;
+    }
+    let Some(runtime) = state.plugin_runtime.as_ref() else {
+        return EventOutcome::NotHandled;
+    };
+    let Some(protocol_key) = crossterm_to_protocol_key(key) else {
+        // Unmodelled key (e.g. media keys) — silently drop. Better
+        // than forging a wire shape.
+        return EventOutcome::Handled;
+    };
+    let pid = ainb_plugin_runtime::PluginId::from(plugin_name);
+    let _ = runtime.send_key(&pid, state.current_screen.clone(), protocol_key);
+    EventOutcome::Handled
+}
+
 impl Screen for PluginScreen {
     fn id(&self) -> &str {
         self.screen_id
@@ -96,6 +223,14 @@ impl Screen for PluginScreen {
                     .add_modifier(modifier_bits_to_modifiers(cell.modifier)),
             );
         }
+    }
+
+    fn handle_key(
+        &mut self,
+        state: &mut AppState,
+        key: &crossterm::event::KeyEvent,
+    ) -> EventOutcome {
+        forward_key_to_focused_plugin(state, key)
     }
 }
 
@@ -470,5 +605,122 @@ mod tests {
         assert!(!r.contains(ids::SESSION_LIST));
         assert!(!r.contains(ids::NEW_SESSION));
         assert!(!r.contains(ids::CLAUDE_CHAT));
+    }
+
+    #[test]
+    fn crossterm_to_protocol_translates_char_and_mods() {
+        use ainb_plugin_runtime::{
+            KEY_MOD_CTRL, KEY_MOD_SHIFT, KeyCode as ProtocolKey, KeyKind as ProtocolKind,
+        };
+        use crossterm::event::{
+            KeyCode as CtKey, KeyEvent as CtEvent, KeyEventKind, KeyEventState, KeyModifiers,
+        };
+
+        // Plain '1' → Char { ch: '1' }, no mods, Press.
+        let ev = CtEvent {
+            code: CtKey::Char('1'),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+        let p = crossterm_to_protocol_key(&ev).expect("char key translates");
+        assert_eq!(p.code, ProtocolKey::Char { ch: '1' });
+        assert_eq!(p.mods, 0);
+        assert_eq!(p.kind, ProtocolKind::Press);
+
+        // Ctrl+Shift+'z' → Char { ch: 'z' } with both bits set.
+        let ev = CtEvent {
+            code: CtKey::Char('z'),
+            modifiers: KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+        let p = crossterm_to_protocol_key(&ev).expect("modified char translates");
+        assert_eq!(p.code, ProtocolKey::Char { ch: 'z' });
+        assert_eq!(p.mods, KEY_MOD_CTRL | KEY_MOD_SHIFT);
+    }
+
+    #[test]
+    fn crossterm_to_protocol_translates_named_keys() {
+        use ainb_plugin_runtime::KeyCode as ProtocolKey;
+        use crossterm::event::{
+            KeyCode as CtKey, KeyEvent as CtEvent, KeyEventKind, KeyEventState, KeyModifiers,
+        };
+
+        let cases = [
+            (CtKey::Enter, ProtocolKey::Enter),
+            (CtKey::Tab, ProtocolKey::Tab),
+            (CtKey::BackTab, ProtocolKey::BackTab),
+            (CtKey::Esc, ProtocolKey::Esc),
+            (CtKey::Backspace, ProtocolKey::Backspace),
+            (CtKey::Delete, ProtocolKey::Delete),
+            (CtKey::Up, ProtocolKey::Up),
+            (CtKey::Down, ProtocolKey::Down),
+            (CtKey::Left, ProtocolKey::Left),
+            (CtKey::Right, ProtocolKey::Right),
+            (CtKey::Home, ProtocolKey::Home),
+            (CtKey::End, ProtocolKey::End),
+            (CtKey::PageUp, ProtocolKey::PageUp),
+            (CtKey::PageDown, ProtocolKey::PageDown),
+            (CtKey::F(7), ProtocolKey::F { n: 7 }),
+        ];
+
+        for (ct, expected) in cases {
+            let ev = CtEvent {
+                code: ct,
+                modifiers: KeyModifiers::NONE,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::empty(),
+            };
+            let p = crossterm_to_protocol_key(&ev)
+                .unwrap_or_else(|| panic!("translation missing for {ct:?}"));
+            assert_eq!(p.code, expected, "wrong protocol code for {ct:?}");
+        }
+    }
+
+    #[test]
+    fn host_reserves_ctrl_c_and_help_keys() {
+        use crossterm::event::{
+            KeyCode as CtKey, KeyEvent as CtEvent, KeyEventKind, KeyEventState, KeyModifiers,
+        };
+
+        let mk = |code, mods| CtEvent {
+            code,
+            modifiers: mods,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        };
+
+        // Reserved.
+        assert!(is_host_reserved_key(&mk(CtKey::Char('c'), KeyModifiers::CONTROL)));
+        assert!(is_host_reserved_key(&mk(CtKey::Char('?'), KeyModifiers::NONE)));
+        assert!(is_host_reserved_key(&mk(CtKey::Char('H'), KeyModifiers::NONE)));
+
+        // NOT reserved — these belong to the plugin on the analytics
+        // screen (period switches, focus, filters, zoom).
+        for k in [
+            CtKey::Esc,
+            CtKey::Char('q'),
+            CtKey::Char('a'),
+            CtKey::Char('1'),
+            CtKey::Char('2'),
+            CtKey::Char('z'),
+            CtKey::Enter,
+            CtKey::Tab,
+            CtKey::BackTab,
+        ] {
+            assert!(
+                !is_host_reserved_key(&mk(k, KeyModifiers::NONE)),
+                "host must not reserve {k:?} — plugin owns it"
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_id_for_screen_resolves_analytics() {
+        assert_eq!(plugin_id_for_screen(ids::ANALYTICS), Some("burndown"));
+        // Non-plugin screens return None so the forwarder bails early.
+        assert_eq!(plugin_id_for_screen(ids::HOME), None);
+        assert_eq!(plugin_id_for_screen("nonsense"), None);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/screens/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/mod.rs
@@ -64,6 +64,21 @@ pub trait Screen: Send {
     fn handle_event(&mut self, _state: &mut AppState) -> EventOutcome {
         EventOutcome::NotHandled
     }
+
+    /// Hook for a screen to consume a single raw key event before the
+    /// global key handler runs. Default: `NotHandled` (screen abstains —
+    /// let the central dispatch in `app::events` do its thing).
+    ///
+    /// Plugin-owned screens (see `PluginScreen`) override this to
+    /// translate the crossterm event into the portable wire shape and
+    /// forward it down `plugin/handle_key`.
+    fn handle_key(
+        &mut self,
+        _state: &mut AppState,
+        _key: &crossterm::event::KeyEvent,
+    ) -> EventOutcome {
+        EventOutcome::NotHandled
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2111,6 +2111,17 @@ pub struct AppState {
     pub plugin_render_areas:
         std::collections::HashMap<crate::app::screens::ScreenId, (u16, u16)>,
 
+    /// Cheap Send + Clone façade onto the plugin runtime, populated by
+    /// `App::init`. `None` when running plugin-free (e.g. tests, or
+    /// installs that haven't completed bundled-plugin discovery yet).
+    ///
+    /// Lives on `AppState` rather than `App` so the key-dispatch path
+    /// in `app::events::handle_key_event` can forward keystrokes to
+    /// the focused plugin without needing access to `App`. `App` still
+    /// owns the underlying `Runtime` via `plugin_runtime_owner` so the
+    /// tokio executor is torn down when `App` drops.
+    pub plugin_runtime: Option<ainb_plugin_runtime::RuntimeHandle>,
+
     /// Cached result of `detect_statusline_status()` paired with the time
     /// it was read. Refreshed lazily through
     /// [`AppState::statusline_status_cached`] on a 15s TTL so the global
@@ -2702,6 +2713,7 @@ impl Default for AppState {
 
             pending_plugin_renders: std::collections::HashMap::new(),
             plugin_render_areas: std::collections::HashMap::new(),
+            plugin_runtime: None,
 
             statusline_status_cache: None,
 
@@ -9674,13 +9686,10 @@ pub struct App {
     pub state: AppState,
     /// Owning handle to the plugin runtime's tokio executor. Held by `App`
     /// so dropping `App` joins every plugin task and tears down the runtime.
-    /// `None` until [`App::init`] runs. Kept private — the TUI always goes
-    /// through `plugin_runtime` (the cheap Send + Clone façade).
+    /// `None` until [`App::init`] runs. The cheap Send + Clone façade lives
+    /// on `state.plugin_runtime` so dispatchers reach it without needing
+    /// access to `App`.
     plugin_runtime_owner: Option<ainb_plugin_runtime::Runtime>,
-    /// Send + Clone runtime handle the TUI render thread holds. Every
-    /// surface method on this is non-blocking (`try_recv_render`,
-    /// `snapshot_get`) so the ratatui draw thread never `.await`s.
-    pub plugin_runtime: Option<ainb_plugin_runtime::RuntimeHandle>,
 }
 
 impl App {
@@ -9688,7 +9697,6 @@ impl App {
         Self {
             state: AppState::new(),
             plugin_runtime_owner: None,
-            plugin_runtime: None,
         }
     }
 
@@ -9707,7 +9715,10 @@ impl App {
     /// no-op when discovery returned empty; once 7c lands, the screen
     /// routing table below populates again.
     pub fn tick_plugin_renders(&mut self) {
-        let Some(handle) = self.plugin_runtime.as_ref() else {
+        // Clone the cheap Send + Clone handle so we can hold a reference
+        // to the runtime while also mutably borrowing the various
+        // `state.*` plugin caches below.
+        let Some(handle) = self.state.plugin_runtime.clone() else {
             return;
         };
 
@@ -9770,7 +9781,7 @@ impl App {
                     warn!(plugin = %name, error = %err, "plugin failed to load");
                 }
                 self.plugin_runtime_owner = Some(runtime);
-                self.plugin_runtime = Some(handle);
+                self.state.plugin_runtime = Some(handle);
             }
             Err(e) => {
                 warn!(error = %e, "plugin runtime init failed — running plugin-free");

--- a/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
@@ -11,9 +11,10 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use ainb_plugin_protocol::params::Viewport;
+use ainb_plugin_protocol::params::{HandleKeyParams, Viewport};
 use ainb_plugin_protocol::wire_buffer::WireBuffer;
 use bytes::Bytes;
 use parking_lot::RwLock;
@@ -31,6 +32,7 @@ use crate::types::{
 /// Internal wiring shared between [`crate::Runtime`] and every clone
 /// of [`RuntimeHandle`].
 #[derive(Clone)]
+#[allow(missing_debug_implementations)]
 pub(crate) struct HandleInner {
     pub(crate) tokio: tokio::runtime::Handle,
     pub(crate) snapshots: SnapshotStore,
@@ -40,6 +42,13 @@ pub(crate) struct HandleInner {
     /// for the publish path; see [`crate::plugin_task::InboxMap`].
     pub(crate) inboxes: InboxMap,
     pub(crate) config: RuntimeConfig,
+    /// Monotonic counter the host bumps once per `send_key` call.
+    /// Stamped into `HandleKeyParams.generation`; the plugin echoes it
+    /// back via the next `plugin/render` so the host has a freshness
+    /// witness. Shared across every clone of the handle so the same
+    /// sequence works regardless of which `RuntimeHandle` queued the
+    /// keystroke.
+    pub(crate) key_generation: Arc<AtomicU64>,
 }
 
 /// Send + Clone runtime façade. The TUI thread should hold one of
@@ -47,6 +56,17 @@ pub(crate) struct HandleInner {
 #[derive(Clone)]
 pub struct RuntimeHandle {
     inner: HandleInner,
+}
+
+impl std::fmt::Debug for RuntimeHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Opaque on purpose — the inner has tokio + lock primitives
+        // that aren't `Debug`. Surface the plugin count, which is the
+        // only state likely to be useful in a panic backtrace.
+        f.debug_struct("RuntimeHandle")
+            .field("plugins", &self.inner.plugins.read().len())
+            .finish()
+    }
 }
 
 impl RuntimeHandle {
@@ -172,6 +192,41 @@ impl RuntimeHandle {
     #[must_use]
     pub fn snapshot_get(&self, topic: &str) -> Option<Bytes> {
         self.inner.snapshots.payload(&Topic::from(topic))
+    }
+
+    /// Forward a single normalized key event to the plugin owning the
+    /// focused screen. Non-blocking — the per-plugin tokio task picks
+    /// the command up off its mpsc inbox and writes the
+    /// `plugin/handle_key` notification frame.
+    ///
+    /// The host allocates a monotonic `generation` per call (shared
+    /// across all clones of [`RuntimeHandle`]) so the plugin can echo
+    /// it back via the next `plugin/render` and the host can prove the
+    /// keystroke landed before the frame was painted.
+    ///
+    /// Returns `false` if the plugin is unknown or the task is gone;
+    /// the keystroke is dropped on the floor in either case. Caller is
+    /// expected to surface a soft error or simply ignore — interactive
+    /// keys are tolerant of loss compared to snapshots.
+    pub fn send_key(
+        &self,
+        plugin_id: &PluginId,
+        screen_id: impl Into<String>,
+        key: ainb_plugin_protocol::params::KeyEvent,
+    ) -> bool {
+        let Some(handle) = self.lookup(plugin_id) else {
+            return false;
+        };
+        let generation = self.inner.key_generation.fetch_add(1, Ordering::Relaxed);
+        let params = HandleKeyParams {
+            screen_id: screen_id.into(),
+            key,
+            generation,
+        };
+        handle
+            .inbox
+            .send(Command::HandleKey { params })
+            .is_ok()
     }
 
     /// Publish a snapshot from the host side. Non-blocking. Subscriber

--- a/ainb-tui/crates/ainb-plugin-runtime/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/lib.rs
@@ -44,4 +44,7 @@ pub use types::{
 // crate directly. Single source of truth still lives in the protocol
 // crate — these are passthrough only.
 pub use ainb_plugin_protocol::wire_buffer::WireBuffer;
-pub use ainb_plugin_protocol::params::Viewport;
+pub use ainb_plugin_protocol::params::{
+    HandleKeyParams, KEY_MOD_ALT, KEY_MOD_CTRL, KEY_MOD_SHIFT, KEY_MOD_SUPER, KeyCode, KeyEvent,
+    KeyKind, Viewport,
+};

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -19,9 +19,9 @@ use ainb_plugin_protocol::errors::RpcError;
 use ainb_plugin_protocol::methods;
 use ainb_plugin_protocol::params::{
     ActionInvokeParams, ActionInvokeResult, CliDispatchParams, CliDispatchResult,
-    HandleEventParams, LogParams, PluginInitParams, PluginInitResult, PluginShutdownParams,
-    RenderParams, RenderResult, SnapshotGetParams, SnapshotGetResult, SnapshotPublishParams,
-    SnapshotSubscribeParams, SnapshotSubscribeResult, Viewport,
+    HandleEventParams, HandleKeyParams, LogParams, PluginInitParams, PluginInitResult,
+    PluginShutdownParams, RenderParams, RenderResult, SnapshotGetParams, SnapshotGetResult,
+    SnapshotPublishParams, SnapshotSubscribeParams, SnapshotSubscribeResult, Viewport,
 };
 use ainb_plugin_protocol::wire_buffer::WireBuffer;
 use bytes::Bytes;
@@ -111,6 +111,18 @@ pub enum Command {
         topic: Topic,
         /// Snapshot bytes.
         payload: Bytes,
+    },
+    /// Forward a `plugin/handle_key` notification (single keystroke
+    /// destined for the focused plugin screen). Ordering vs other
+    /// inbox traffic is preserved by the per-plugin mpsc inbox, and
+    /// the SDK server re-uses the inline-dispatch path for the same
+    /// reason — multi-key sequences would lose their semantics
+    /// otherwise. See `plugin_task.rs::handle_command` for the wire
+    /// translation.
+    HandleKey {
+        /// Pre-built params with screen_id, key, and host-allocated
+        /// generation counter.
+        params: HandleKeyParams,
     },
     /// Send `plugin/shutdown` and reap the process.
     Shutdown,
@@ -307,6 +319,20 @@ impl PluginTask {
                 })
                 .expect("HandleEventParams is serializable");
                 let _ = self.send_notification(methods::PLUGIN_HANDLE_EVENT, params).await;
+            }
+            Command::HandleKey { params } => {
+                // Drop on idle, same policy as `HandleEvent`. A key
+                // pressed before the plugin process is even spawned
+                // has no plausible destination — the user almost
+                // certainly won't expect it to be replayed once the
+                // process is up.
+                if self.child.is_none() {
+                    debug!(plugin = %self.plugin.id, "handle_key dropped (idle)");
+                    return;
+                }
+                let json = serde_json::to_value(params)
+                    .expect("HandleKeyParams is serializable");
+                let _ = self.send_notification(methods::PLUGIN_HANDLE_KEY, json).await;
             }
             Command::Reload => {
                 self.failures.clear();

--- a/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
@@ -69,6 +69,7 @@ impl Runtime {
             plugins: plugins.clone(),
             inboxes: inboxes.clone(),
             config,
+            key_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         });
         Ok((
             Self {

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
@@ -129,6 +129,55 @@ fn render_and_cli_round_trip() {
 }
 
 #[test]
+fn send_key_forwards_handle_key_notification() {
+    let (rt, handle) = build_runtime();
+    let id = register_fixture(&rt);
+
+    // Lazy-spawn the plugin so there's a stdin to write to.
+    drop(handle.render(&id, Viewport::new(20, 5), 0));
+
+    // Send a single key. Fixture re-publishes the params as a snapshot.
+    let key = ainb_plugin_runtime::KeyEvent {
+        code: ainb_plugin_runtime::KeyCode::Char { ch: '1' },
+        mods: 0,
+        kind: ainb_plugin_runtime::KeyKind::Press,
+    };
+    // Retry briefly in case the spawn hasn't completed yet — `send_key`
+    // drops on idle (the plugin task hasn't transitioned to Running),
+    // which would race with the lazy-spawn we just kicked off.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if handle.send_key(&id, "ainb_analytics", key.clone()) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut payload = None;
+    while std::time::Instant::now() < deadline {
+        if let Some(p) = handle.snapshot_get("fixture.last_key") {
+            payload = Some(p);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let bytes = payload.expect("fixture never re-published last_key snapshot");
+    let decoded: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("fixture payload is JSON");
+
+    // Wire shape: { screen_id, key: { code: {type:"char", ch:"1"}, mods, kind }, generation }
+    assert_eq!(decoded["screen_id"], "ainb_analytics");
+    assert_eq!(decoded["key"]["code"]["type"], "char");
+    assert_eq!(decoded["key"]["code"]["ch"], "1");
+    assert_eq!(decoded["key"]["kind"], "press");
+    assert!(
+        decoded["generation"].is_u64(),
+        "generation should be present and numeric"
+    );
+}
+
+#[test]
 fn snapshot_round_trip() {
     let (rt, handle) = build_runtime();
     let id = register_fixture(&rt);

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixtures/fixture_plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixtures/fixture_plugin.rs
@@ -103,6 +103,16 @@ fn main() {
                 // Notification — log to stderr so the host's stderr drain sees it.
                 eprintln!("fixture: handle_event {params}");
             }
+            methods::PLUGIN_HANDLE_KEY => {
+                // Notification — re-publish the raw params as a
+                // snapshot the host integration test can poll. The
+                // shape is exactly what came in over the wire so the
+                // test can assert byte-for-byte equality without
+                // round-tripping any types.
+                eprintln!("fixture: handle_key {params}");
+                let bytes = serde_json::to_vec(&params).expect("params re-serialise");
+                publish_snapshot(&mut writer, "fixture.last_key", &bytes);
+            }
             methods::HOST_ACTION_INVOKE => {
                 // Echo the payload back as the action result. `payload`
                 // is wire-encoded as a base64 string (post-v1 wire), but


### PR DESCRIPTION
## Summary

Phase 3 of the burndown interactive-keys plan. Wires the host side of the keystroke pipeline so keys pressed on a plugin-owned screen (currently just `analytics` → burndown) reach the plugin via `plugin/handle_key`. Pairs with the SDK trait method shipped in Phase 2 (PR #101) and the wire surface from Phase 1 (PR #98).

End-to-end path now in place:

```
crossterm::KeyEvent
  ↓
PluginScreen::handle_key / forward_key_to_focused_plugin
  ↓                           (crossterm → wire translation, host reservations)
RuntimeHandle::send_key
  ↓                           (allocates generation, enqueues Command::HandleKey)
PluginTask (per-plugin tokio task)
  ↓                           (serialises to plugin/handle_key notification)
plugin stdin → SDK Server → Plugin::handle_key
```

### Commits

1. `c5672e8` feat(core): add Screen::handle_key trait stub
2. `7d710f5` feat(plugin-runtime): wire send_key through host → plugin pipeline
3. `c2a4649` refactor(core): move plugin_runtime handle from App to AppState
4. `d14f5c3` feat(core): PluginScreen translates crossterm keys + reserves host bindings
5. `7c949d8` feat(core): route keys through focused plugin before global dispatch

### Host reservation list (NOT forwarded)

Deliberately tiny — the burndown plugin re-binds most of the alphabet, so the host hands all but the truly-global escapes to the plugin:

- `Ctrl+C` → host quit (always).
- `?` / `H` → help toggle (already short-circuited above the forwarder).

Everything else — `Esc`, `q`, `a`, `Tab`, `Enter`, period digits, `z`, etc. — reaches the plugin.

Refs bead `agents-in-a-box-8q1.3` and plan `ainb-tui/plans/plugin-interactive-keys-and-cache.md` §Phase 3.

## Test plan

- [x] `cargo test -p ainb --lib app::screens::builtin` — 5 passed (4 new + 1 pre-existing).
  - Char + Shift|Ctrl byte-stable translation.
  - Full named-key matrix: Enter, Tab, BackTab, Esc, Backspace, Delete, arrows, Home/End, PageUp/PageDown, F(n).
  - Host reservation list (reserves Ctrl+C, `?`, `H`; does NOT reserve `q`, `Esc`, `Tab`, etc.).
  - `plugin_id_for_screen` returns Some only for plugin-owned screens.
- [x] `cargo test -p ainb-plugin-runtime --test fixture_e2e` — 9 passed (1 new + 8 pre-existing).
  - `send_key_forwards_handle_key_notification`: sends `Char('1')` to the fixture plugin, polls for the `fixture.last_key` snapshot the fixture re-publishes, asserts wire shape end-to-end (`screen_id`, tagged `KeyCode::Char`, `kind: press`, monotonic `generation`). Proves the keystroke survived the full host → mpsc → tokio task → stdin → JSON-RPC round trip.
- [x] `cargo test -p ainb-plugin-protocol` — 37 passed (regression check on Phase 1 surface).
- [x] `cargo test -p ainb-plugin-sdk-rust` — 12 passed (regression check on Phase 2 trait + ordering).
- [x] `cargo build -p ainb` — green; the pre-existing `test_previous_session` failure noted in PR #101 is still upstream-only (touches `ainb-core::app::state` session-list logic, unrelated to anything in this PR).

## Out of scope

Burndown plugin dispatch (mapping `1` → period::Today, `Tab` → focus_next_panel, etc.) lands in Phase 4 (bead `agents-in-a-box-8q1.4`). Today the plugin trait method is still the default no-op shipped in Phase 2 — keys reach the plugin but it doesn't react yet.