### PR TITLE
feat(plugin-burndown): wire keys to UI state via handle_key

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -8,9 +8,10 @@
 //! arrived yet.
 
 use ainb_plugin_sdk::{
-    Cell, CliOutput, Color, Coord, HostClient, Plugin, RenderParams, Result, SdkError,
-    WireBuffer,
+    Cell, CliOutput, Color, Coord, HandleKeyParams, HostClient, KeyCode, Plugin, RenderParams,
+    Result, SdkError, WireBuffer,
 };
+use crate::data::usage::UsagePeriod;
 use ainb_plugin_types_sessions::{
     ScanProgressEvent, UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
 };
@@ -71,6 +72,13 @@ pub struct BurndownPlugin {
     /// renders before the first `sessions.usage_data` chunk lands.
     /// Cleared once a chunked publish finalises into `self.data`.
     scan_progress: Option<ScanProgressEvent>,
+    /// Freshness witness — bumped once per `handle_key` invocation
+    /// that actually mutated `self.ui`. The host's next
+    /// `plugin/render` will see the updated state. Future host
+    /// versions may echo this value via `RenderParams.generation`
+    /// so the host can prove the keystroke landed before the frame
+    /// was painted; today the plugin keeps it as private bookkeeping.
+    generation: u64,
 }
 
 #[async_trait]
@@ -117,6 +125,53 @@ impl Plugin for BurndownPlugin {
                 self.ingest_scan_progress(host, &params.payload).await;
             }
             _ => {}
+        }
+        Ok(())
+    }
+
+    /// Dispatch a single keystroke forwarded by the host's
+    /// `PluginScreen::handle_key`.
+    ///
+    /// The plan in `ainb-tui/plans/plugin-interactive-keys-and-cache.md`
+    /// §Phase 4 enumerates the canonical key → UI binding. A few binds
+    /// were renamed during implementation to match what actually
+    /// exists in `ui.rs`:
+    ///
+    /// - `Esc` → `pop_filter_chip` (plan: `pop_filter`).
+    /// - `C`   → `clear_all_filter_chips` (plan: `clear_filters`).
+    /// - `d` when zoomed → `toggle_zoom_detail` (plan: `zoom_toggle_detail`).
+    ///
+    /// Two bindings were dropped because the existing UI API needs
+    /// context the dispatch can't provide without inventing new
+    /// methods:
+    ///
+    /// - `j` scroll-down: `scroll_down(max_rows)` is row-count-aware.
+    /// - `D` advanced custom period: `UsagePeriod::Custom { from, to }`
+    ///   has no sensible default range from a single key press.
+    ///
+    /// Generation is bumped only when the dispatch matched a binding,
+    /// so unmapped keys won't trigger an avoidable re-render.
+    async fn handle_key(&mut self, host: &HostClient, params: HandleKeyParams) -> Result<()> {
+        // Refresh is the one binding that needs the host. Everything
+        // else mutates `self.ui` only, so it lives in the pure helper
+        // below for testability.
+        let handled = match params.key.code {
+            KeyCode::Char { ch: 'r' | 'R' } => {
+                // Ask session-reader to re-publish from scratch. Best
+                // effort — failure is silently dropped, the existing
+                // snapshot stays on screen.
+                let _ = host
+                    .snapshot_publish("sessions.refresh_request", bytes::Bytes::new())
+                    .await;
+                true
+            }
+            _ => self.dispatch_key_pure(&params.key.code),
+        };
+        // Plan-mandated invariant: only bump generation when the
+        // dispatch matched a binding, so unmapped keys can't trigger
+        // an avoidable re-render.
+        if handled {
+            self.generation = self.generation.wrapping_add(1);
         }
         Ok(())
     }
@@ -547,6 +602,62 @@ impl BurndownPlugin {
     #[allow(dead_code)]
     pub fn set_active_tab(&mut self, tab: UsageTab) {
         self.ui.active_tab = tab;
+    }
+
+    /// Pure version of the `handle_key` match — applies every
+    /// non-host-touching binding to `self.ui` and returns whether
+    /// the key was claimed. Lets unit tests exercise the dispatch
+    /// without spinning up a `HostClient`.
+    ///
+    /// The `r`/`R` refresh binding is intentionally NOT here; it
+    /// lives in the async `handle_key` because it needs the host.
+    fn dispatch_key_pure(&mut self, code: &KeyCode) -> bool {
+        use chrono::{Datelike, Local};
+
+        match *code {
+            KeyCode::Char { ch: '1' } => self.ui.set_period(UsagePeriod::Today),
+            KeyCode::Char { ch: '2' } => self.ui.set_period(UsagePeriod::Week),
+            KeyCode::Char { ch: '3' } => self.ui.set_period(UsagePeriod::ThirtyDays),
+            KeyCode::Char { ch: '4' } => self.ui.set_period(UsagePeriod::LastNDays(90)),
+            KeyCode::Char { ch: '5' } => self.ui.set_period(UsagePeriod::YearToDate),
+            KeyCode::Char { ch: 'm' } => self.ui.set_period(UsagePeriod::Month),
+            KeyCode::Char { ch: 'q' } => {
+                // No plain `Quarter` variant exists — use today's
+                // calendar quarter as the anchor, matching how the
+                // chip-row picker visualises the active quarter.
+                let today = Local::now().date_naive();
+                let year = today.year();
+                // `Datelike::month()` is 1..=12 → quarter 1..=4.
+                let q = u8::try_from((today.month() - 1) / 3 + 1).unwrap_or(1);
+                self.ui.set_period(UsagePeriod::SpecificQuarter(year, q));
+            }
+            KeyCode::Char { ch: 'a' } => self.ui.set_period(UsagePeriod::All),
+            KeyCode::Left => self.ui.prev_provider(),
+            KeyCode::Right => self.ui.next_provider(),
+            KeyCode::Tab => self.ui.focus_next_panel(),
+            KeyCode::BackTab => self.ui.focus_prev_panel(),
+            KeyCode::Char { ch: 'z' } => self.ui.toggle_zoom(),
+            KeyCode::Char { ch: '/' } if self.ui.is_zoomed() => self.ui.zoom_begin_search(),
+            KeyCode::Char { ch: 'd' } if self.ui.is_zoomed() => self.ui.toggle_zoom_detail(),
+            KeyCode::Enter => {
+                let _ = self.ui.commit_focused_row();
+            }
+            KeyCode::Char { ch: 'X' } => {
+                let _ = self.ui.commit_focused_row_exclude();
+            }
+            KeyCode::Char { ch: 'C' } => self.ui.clear_all_filter_chips(),
+            KeyCode::Esc => {
+                if self.ui.is_zoomed() {
+                    let _ = self.ui.zoom_handle_esc();
+                } else {
+                    let _ = self.ui.pop_filter_chip();
+                }
+            }
+            KeyCode::Char { ch: 'p' } => self.ui.cycle_provider_filter(),
+            KeyCode::Char { ch: 'k' } => self.ui.scroll_up(),
+            _ => return false,
+        }
+        true
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -662,6 +662,175 @@ impl BurndownPlugin {
 }
 
 #[cfg(test)]
+mod handle_key_dispatch_tests {
+    use super::*;
+    use ainb_plugin_sdk::KeyCode;
+
+    fn ch(c: char) -> KeyCode {
+        KeyCode::Char { ch: c }
+    }
+
+    #[test]
+    fn period_keys_map_to_expected_variants() {
+        let cases: &[(KeyCode, UsagePeriod)] = &[
+            (ch('1'), UsagePeriod::Today),
+            (ch('2'), UsagePeriod::Week),
+            (ch('3'), UsagePeriod::ThirtyDays),
+            (ch('4'), UsagePeriod::LastNDays(90)),
+            (ch('5'), UsagePeriod::YearToDate),
+            (ch('m'), UsagePeriod::Month),
+            (ch('a'), UsagePeriod::All),
+        ];
+        for (code, expected) in cases {
+            let mut p = BurndownPlugin::default();
+            assert!(p.dispatch_key_pure(code), "binding missing for {code:?}");
+            assert_eq!(
+                p.ui.period, *expected,
+                "period mismatch after dispatching {code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn quarter_key_anchors_on_today() {
+        use chrono::{Datelike, Local};
+        let today = Local::now().date_naive();
+        let expected_q = u8::try_from((today.month() - 1) / 3 + 1).unwrap();
+
+        let mut p = BurndownPlugin::default();
+        assert!(p.dispatch_key_pure(&ch('q')));
+        match p.ui.period {
+            UsagePeriod::SpecificQuarter(year, q) => {
+                assert_eq!(year, today.year());
+                assert_eq!(q, expected_q);
+            }
+            other => panic!("expected SpecificQuarter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arrow_keys_advance_provider_filter() {
+        // `next_provider` / `prev_provider` walk a 4-state internal
+        // `UsageProvider` enum and derive `provider_filter` from it.
+        // Asserting a round-trip is brittle — Gemini/Copilot both map
+        // back to `All`, so Left after one Right doesn't return to
+        // the starting filter. Just confirm each arrow claims the
+        // key and mutates state at least once.
+        let mut p = BurndownPlugin::default();
+        let starting = p.ui.provider_filter;
+        assert!(p.dispatch_key_pure(&KeyCode::Right));
+        let after_right = p.ui.provider_filter;
+        let mut p = BurndownPlugin::default();
+        assert!(p.dispatch_key_pure(&KeyCode::Left));
+        let after_left = p.ui.provider_filter;
+        assert!(
+            after_right != starting || after_left != starting,
+            "at least one arrow direction must mutate provider_filter from default {starting:?}"
+        );
+    }
+
+    #[test]
+    fn tab_cycles_focused_panel() {
+        let mut p = BurndownPlugin::default();
+        let before = p.ui.focused_panel;
+        assert!(p.dispatch_key_pure(&KeyCode::Tab));
+        let after = p.ui.focused_panel;
+        assert_ne!(before, after, "Tab must change focused panel");
+    }
+
+    #[test]
+    fn z_toggles_zoom_state() {
+        let mut p = BurndownPlugin::default();
+        assert!(!p.ui.is_zoomed());
+        // First need a focused panel so toggle_zoom has something to
+        // zoom into.
+        let _ = p.dispatch_key_pure(&KeyCode::Tab);
+        assert!(p.dispatch_key_pure(&ch('z')));
+        assert!(p.ui.is_zoomed(), "z must zoom into focused panel");
+        assert!(p.dispatch_key_pure(&ch('z')));
+        assert!(!p.ui.is_zoomed(), "second z must un-zoom");
+    }
+
+    #[test]
+    fn slash_only_dispatches_while_zoomed() {
+        let mut p = BurndownPlugin::default();
+        // Not zoomed → `/` is unbound (returns false, no generation bump).
+        assert!(!p.dispatch_key_pure(&ch('/')));
+        // Zoom in.
+        let _ = p.dispatch_key_pure(&KeyCode::Tab);
+        assert!(p.dispatch_key_pure(&ch('z')));
+        assert!(p.ui.is_zoomed());
+        // Now zoomed → `/` claims the key.
+        assert!(p.dispatch_key_pure(&ch('/')));
+    }
+
+    #[test]
+    fn esc_pops_filter_when_not_zoomed_and_unzooms_when_zoomed() {
+        let mut p = BurndownPlugin::default();
+        // Not zoomed: Esc claims the key (no-op against an empty
+        // filter stack, but still bumps generation).
+        assert!(p.dispatch_key_pure(&KeyCode::Esc));
+
+        // Zoomed: Esc should also claim, and un-zoom.
+        let _ = p.dispatch_key_pure(&KeyCode::Tab);
+        assert!(p.dispatch_key_pure(&ch('z')));
+        assert!(p.ui.is_zoomed());
+        assert!(p.dispatch_key_pure(&KeyCode::Esc));
+        assert!(!p.ui.is_zoomed(), "Esc must exit zoom");
+    }
+
+    #[test]
+    fn k_scrolls_up() {
+        // Even on an empty state `scroll_up` is a no-op `saturating_sub` —
+        // the binding still claims the key. We're really asserting the
+        // dispatch wiring rather than the scroll math.
+        let mut p = BurndownPlugin::default();
+        assert!(p.dispatch_key_pure(&ch('k')));
+    }
+
+    #[test]
+    fn unmapped_keys_are_not_claimed() {
+        let mut p = BurndownPlugin::default();
+        // 'D' (advanced/custom) was deliberately dropped — needs a date range.
+        assert!(!p.dispatch_key_pure(&ch('D')));
+        // 'j' was dropped — `scroll_down` needs a row-count we can't
+        // know from the dispatch.
+        assert!(!p.dispatch_key_pure(&ch('j')));
+        // Random Unicode key.
+        assert!(!p.dispatch_key_pure(&ch('🚀')));
+        // F-key.
+        assert!(!p.dispatch_key_pure(&KeyCode::F { n: 5 }));
+    }
+
+    #[test]
+    fn generation_bumps_only_when_dispatch_handled() {
+        // We can't drive the async `handle_key` without a HostClient,
+        // but we can replicate its bookkeeping using the pure helper
+        // — which is what `handle_key` does for every non-`r` binding.
+        let mut p = BurndownPlugin::default();
+        let g0 = p.generation;
+
+        // Handled key → bump.
+        let handled = p.dispatch_key_pure(&ch('1'));
+        if handled {
+            p.generation = p.generation.wrapping_add(1);
+        }
+        assert_eq!(p.generation, g0 + 1, "handled key must bump generation");
+
+        // Unmapped key → no bump.
+        let handled = p.dispatch_key_pure(&ch('j'));
+        if handled {
+            p.generation = p.generation.wrapping_add(1);
+        }
+        assert_eq!(
+            p.generation,
+            g0 + 1,
+            "unmapped key must NOT bump generation"
+        );
+    }
+}
+
+#[cfg(test)]
 mod chunk_accumulator_tests {
     use super::*;
     use ainb_plugin_types_sessions::{


### PR DESCRIPTION
## Summary

Phase 4 of the burndown interactive-keys plan. Now that the host forwards keystrokes (PR #103) and the SDK has a trait hook (PR #101), this PR teaches the burndown plugin to actually react: every key from plan §Phase 4 is wired to an existing `UsageViewState` method.

After this lands the full Wave 1 → Wave 4 pipeline is functional end-to-end — pressing `1` on the Analytics screen will switch the period chip, `Tab` will cycle the focused panel, etc. The remaining work (Wave 5 progress UX, Wave 7 fixtures, Wave 8 tripwire) layers tests + UX on top of a working dispatch.

### Key → UI binding (plan §Phase 4)

| Key | Action |
|---|---|
| `1`/`2`/`3`/`4`/`5` | `set_period(Today/Week/ThirtyDays/LastNDays(90)/YearToDate)` |
| `m` | `set_period(Month)` |
| `q` | `set_period(SpecificQuarter(today.year, current_quarter))` |
| `a` | `set_period(All)` |
| `Left` / `Right` | `prev_provider` / `next_provider` |
| `Tab` / `BackTab` | `focus_next_panel` / `focus_prev_panel` |
| `z` | `toggle_zoom` |
| `/` (zoomed) | `zoom_begin_search` |
| `d` (zoomed) | `toggle_zoom_detail` |
| `Enter` | `commit_focused_row` |
| `X` | `commit_focused_row_exclude` |
| `C` | `clear_all_filter_chips` |
| `Esc` | zoomed → `zoom_handle_esc`; else → `pop_filter_chip` |
| `r` / `R` | `host.snapshot_publish(\"sessions.refresh_request\", &[])` |
| `p` | `cycle_provider_filter` |
| `k` | `scroll_up` |

### Audit notes (deviations from plan)

Per the leader's rule (\"No new UI methods invented — must use what's already in ui.rs\"), three plan names were renamed to match `ui.rs`:

- `clear_filters` → `clear_all_filter_chips`
- `pop_filter`    → `pop_filter_chip`
- `zoom_toggle_detail` → `toggle_zoom_detail`

Two bindings were dropped rather than invent methods:

- `j` (scroll-down): `scroll_down(max_rows)` needs a row count the dispatch doesn't have.
- `D` (advanced/custom): `UsagePeriod::Custom { from, to }` has no sensible default range from a single key press.

`q` has no plain `UsagePeriod::Quarter` — anchored on the current calendar quarter via `chrono::Local::now()`, matching how the chip-row picker visualises the active quarter.

### Implementation pattern

Non-host bindings live in a pure `dispatch_key_pure(&KeyCode) -> bool` helper (mirrors the existing `apply_chunk_pure`), so unit tests exercise the dispatch table without a `HostClient`. The `r`/`R` refresh binding stays in the async `handle_key`. Generation only bumps when a binding matched — unmapped keys can't trigger avoidable re-renders.

### Commits

1. `e684c14` feat(plugin-burndown): wire keys to UI state via handle_key
2. `0a9a037` test(plugin-burndown): per-key unit tests for handle_key dispatch

Refs bead `agents-in-a-box-8q1.4` and plan `ainb-tui/plans/plugin-interactive-keys-and-cache.md` §Phase 4.

## Test plan

- [x] \`cargo test -p ainb-plugin-burndown --lib\` — **132 passed** (10 new + 122 pre-existing).
  - `period_keys_map_to_expected_variants` — Today/Week/ThirtyDays/LastNDays(90)/YearToDate/Month/All.
  - `quarter_key_anchors_on_today` — SpecificQuarter matches chrono::Local::now().
  - `arrow_keys_advance_provider_filter` — both directions claim and mutate.
  - `tab_cycles_focused_panel` — focused_panel changes.
  - `z_toggles_zoom_state` — toggles on/off via is_zoomed().
  - `slash_only_dispatches_while_zoomed` — guarded binding.
  - `esc_pops_filter_when_not_zoomed_and_unzooms_when_zoomed` — both Esc paths.
  - `k_scrolls_up` — wired.
  - `unmapped_keys_are_not_claimed` — D, j, random Unicode, F(5) all return false.
  - `generation_bumps_only_when_dispatch_handled` — plan-mandated invariant.
- [x] `cargo test -p ainb-plugin-burndown` — 132 lib + 1 stdio_smoke integration = all green.
- [x] `cargo test -p ainb-plugin-protocol -p ainb-plugin-sdk-rust -p ainb-plugin-runtime` — regression check on Waves 1/2/3 (50+ tests across the three crates, all green).
- [x] `cargo build -p ainb-plugin-burndown` — clean.

The pre-existing `ainb-core::test_previous_session` failure noted in PRs #101/#103 is unchanged — touches session-list logic, unrelated to anything in this PR.

## Out of scope

Wave 5 (skeleton + scan progress UX) and Wave 8 (tripwire e2e covering keys through tmux) are separate beads. After this lands, all four serial waves of the plugin pipeline are functional and the parallel tracks can finish at their own pace.