### PR TITLE
feat(ainb-tui): numeric attach shortcuts on sessions screen

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -808,6 +808,32 @@ impl EventHandler {
                 tracing::info!("[ACTION] 'a' key pressed - AttachTmuxSession requested");
                 Some(AppEvent::AttachTmuxSession)
             }
+            // The badge-to-position mapping is recomputed on every render —
+            // digit N attaches to whatever is at that position *now*, not a
+            // fixed session ID.
+            KeyCode::Char(d)
+                if matches!(d, '1'..='9')
+                    && !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                let n = (d as u8 - b'0') as usize;
+                let items = state.attachable_items_in_order();
+                if let Some(target) = items.get(n - 1).copied() {
+                    tracing::info!(
+                        "[ACTION] digit '{}' pressed - attach to position {} ({:?})",
+                        d,
+                        n,
+                        target
+                    );
+                    state.select_attachable(target);
+                    Some(AppEvent::AttachTmuxSession)
+                } else {
+                    Some(AppEvent::ShowNotification(format!(
+                        "No session at position {}",
+                        n
+                    )))
+                }
+            }
             KeyCode::Enter => {
                 // Enter on a Stopped interactive session = resume it.
                 // Enter on a Running session = attach (mirrors 'a').

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -26,6 +26,16 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
+/// Location of an attachable row inside `AppState`, independent of the
+/// row's current visible position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachableRef {
+    WorkspaceSession { workspace_idx: usize, session_idx: usize },
+    WorkspaceShell { workspace_idx: usize },
+    SshSession { ssh_idx: usize },
+    OtherTmux { other_idx: usize },
+}
+
 /// Text editor with cursor support for boss mode prompts
 #[derive(Debug, Clone)]
 pub struct TextEditor {
@@ -4322,6 +4332,93 @@ impl AppState {
     pub fn selected_workspace(&self) -> Option<&Workspace> {
         let workspace_idx = self.selected_workspace_index?;
         self.workspaces.get(workspace_idx)
+    }
+
+    /// Every attachable leaf row in the *current* render order.
+    /// Numbers shown next to sessions are 1-based positions into this Vec —
+    /// recomputed on every render, so reordering or filtering refreshes them.
+    pub fn attachable_items_in_order(&self) -> Vec<AttachableRef> {
+        let mut out = Vec::new();
+
+        for (workspace_idx, workspace) in self.workspaces.iter().enumerate() {
+            let is_selected_workspace = self.selected_workspace_index == Some(workspace_idx);
+            let is_expanded = is_selected_workspace || self.expand_all_workspaces;
+
+            // Match session_list: workspaces with no visible content are hidden
+            // entirely, and collapsed workspaces don't contribute their leaves.
+            let any_visible = workspace.sessions.iter().any(|s| self.session_passes_filter(s))
+                || workspace.shell_session.is_some();
+            if !any_visible || !is_expanded {
+                continue;
+            }
+
+            for (session_idx, session) in workspace.sessions.iter().enumerate() {
+                if !self.session_passes_filter(session) {
+                    continue;
+                }
+                out.push(AttachableRef::WorkspaceSession {
+                    workspace_idx,
+                    session_idx,
+                });
+            }
+
+            if workspace.shell_session.is_some() {
+                out.push(AttachableRef::WorkspaceShell { workspace_idx });
+            }
+        }
+
+        if !self.ssh_sessions.is_empty() && self.ssh_sessions_expanded {
+            for ssh_idx in 0..self.ssh_sessions.len() {
+                out.push(AttachableRef::SshSession { ssh_idx });
+            }
+        }
+
+        if !self.other_tmux_sessions.is_empty() && self.other_tmux_expanded {
+            for other_idx in 0..self.other_tmux_sessions.len() {
+                out.push(AttachableRef::OtherTmux { other_idx });
+            }
+        }
+
+        out
+    }
+
+    /// Move the active selection to the referenced attachable item,
+    /// clearing the other section selectors so the exclusive-selection
+    /// invariant holds.
+    pub fn select_attachable(&mut self, target: AttachableRef) {
+        match target {
+            AttachableRef::WorkspaceSession {
+                workspace_idx,
+                session_idx,
+            } => {
+                self.selected_workspace_index = Some(workspace_idx);
+                self.selected_session_index = Some(session_idx);
+                self.shell_selected = false;
+                self.selected_ssh_session_index = None;
+                self.selected_other_tmux_index = None;
+            }
+            AttachableRef::WorkspaceShell { workspace_idx } => {
+                self.selected_workspace_index = Some(workspace_idx);
+                self.selected_session_index = None;
+                self.shell_selected = true;
+                self.selected_ssh_session_index = None;
+                self.selected_other_tmux_index = None;
+            }
+            AttachableRef::SshSession { ssh_idx } => {
+                self.selected_workspace_index = None;
+                self.selected_session_index = None;
+                self.shell_selected = false;
+                self.selected_other_tmux_index = None;
+                self.selected_ssh_session_index = Some(ssh_idx);
+            }
+            AttachableRef::OtherTmux { other_idx } => {
+                self.selected_workspace_index = None;
+                self.selected_session_index = None;
+                self.shell_selected = false;
+                self.selected_ssh_session_index = None;
+                self.selected_other_tmux_index = Some(other_idx);
+            }
+        }
     }
 
     pub fn next_session(&mut self) {

--- a/ainb-tui/src/components/session_list.rs
+++ b/ainb-tui/src/components/session_list.rs
@@ -23,6 +23,34 @@ const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 use crate::app::AppState;
 use crate::models::{SessionMode, SessionStatus, ShellSessionStatus, Workspace};
 
+/// Width of the leading badge slot rendered before every list row.
+/// Two characters: a digit (or space) and a trailing space separator.
+const BADGE_SLOT_WIDTH: usize = 2;
+
+/// Highest attach-shortcut index that fits in a single keystroke.
+const MAX_BADGE: usize = 9;
+
+/// Empty slot for non-attachable rows (workspace headers, separators,
+/// section headers) and for attachable rows past `MAX_BADGE`.
+fn empty_badge() -> Span<'static> {
+    Span::raw(" ".repeat(BADGE_SLOT_WIDTH))
+}
+
+/// Gold-bold badge for the next attachable row. Advances the caller's
+/// counter; returns an empty slot once `MAX_BADGE` has been exhausted so
+/// the column position never shifts.
+fn next_badge(attach_no: &mut usize) -> Span<'static> {
+    *attach_no += 1;
+    if *attach_no <= MAX_BADGE {
+        Span::styled(
+            format!("{} ", *attach_no),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        empty_badge()
+    }
+}
+
 pub struct SessionListComponent {
     list_state: ListState,
 }
@@ -176,6 +204,12 @@ impl SessionListComponent {
                                     Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
                                 ),
                                 Span::styled(" filter ", Style::default().fg(MUTED_GRAY)),
+                                Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
+                                Span::styled(
+                                    " 1-9",
+                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                                ),
+                                Span::styled(" attach ", Style::default().fg(MUTED_GRAY)),
                             ])
                         },
                     ),
@@ -191,6 +225,10 @@ impl SessionListComponent {
 
         // Load favorites to check which workspaces are starred
         let favorites = crate::config::FavoritesStore::load();
+
+        // Must stay in lockstep with AppState::attachable_items_in_order;
+        // divergence would attach the wrong session for a given digit.
+        let mut attach_no: usize = 0;
 
         for (workspace_idx, workspace) in state.workspaces.iter().enumerate() {
             let is_selected_workspace = state.selected_workspace_index == Some(workspace_idx);
@@ -270,6 +308,7 @@ impl SessionListComponent {
             let star_indicator = if is_favorite { "⭐ " } else { "" };
 
             let workspace_line = Line::from(vec![
+                empty_badge(),
                 Span::styled(workspace_symbol, Style::default().fg(symbol_color)),
                 Span::styled(
                     " 📁 ",
@@ -368,7 +407,7 @@ impl SessionListComponent {
                     };
 
                     let session_line = Line::from(vec![
-                        Span::styled(" ", Style::default()),
+                        next_badge(&mut attach_no),
                         checkbox,
                         Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
                         Span::styled(format!(" {} ", status_indicator), Style::default()),
@@ -416,6 +455,7 @@ impl SessionListComponent {
                     };
 
                     let shell_line = Line::from(vec![
+                        next_badge(&mut attach_no),
                         Span::styled("  ", Style::default()),
                         Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
                         Span::styled(
@@ -464,6 +504,7 @@ impl SessionListComponent {
             };
 
             let ssh_header = Line::from(vec![
+                empty_badge(),
                 Span::styled(ssh_symbol, Style::default().fg(ssh_header_color)),
                 Span::styled(" 🔐 ", Style::default().fg(ssh_header_color)),
                 Span::styled(
@@ -525,6 +566,7 @@ impl SessionListComponent {
                     };
 
                     let session_line = Line::from(vec![
+                        next_badge(&mut attach_no),
                         Span::styled("  ", Style::default()),
                         Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
                         Span::styled(format!(" {} ", status_icon), Style::default()),
@@ -569,6 +611,7 @@ impl SessionListComponent {
             };
 
             let other_header = Line::from(vec![
+                empty_badge(),
                 Span::styled(other_symbol, Style::default().fg(header_color)),
                 Span::styled(" 🖥️ ", Style::default().fg(header_color)),
                 Span::styled(
@@ -615,9 +658,11 @@ impl SessionListComponent {
                     // Check if this session is being renamed
                     let is_being_renamed = is_selected && state.other_tmux_rename_mode;
 
+                    let badge = next_badge(&mut attach_no);
                     let session_line = if is_being_renamed {
                         // Show inline rename input
                         Line::from(vec![
+                            badge,
                             Span::styled("  ", Style::default()),
                             Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
                             Span::styled(format!(" {} ", status), Style::default()),
@@ -629,6 +674,7 @@ impl SessionListComponent {
                         ])
                     } else {
                         Line::from(vec![
+                            badge,
                             Span::styled("  ", Style::default()),
                             Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
                             Span::styled(format!(" {} ", status), Style::default()),


### PR DESCRIPTION
## Summary

- Renders a gold **1-9** badge in the left margin of every attachable row on the sessions screen (workspace sessions, workspace shells, SSH sessions, Other tmux).
- Pressing the digit in the Sessions pane selects that row and dispatches `AttachTmuxSession` — one keystroke from list to attached.
- Badge mapping is **positional**, not by session ID: `AppState::attachable_items_in_order()` is recomputed on every render, so filtering, expanding a different workspace, or reordering simply re-numbers the slots. Rows past nine keep a blank slot (columns stay aligned) and remain reachable via arrows + Enter.

## How it's wired

- `src/app/state.rs` — `AttachableRef` enum + `attachable_items_in_order()` (mirrors render order, respects filter/expand) + `select_attachable()` (sets selection coords + clears other section selectors).
- `src/components/session_list.rs` — `next_badge()` / `empty_badge()` helpers threaded into every row builder; default help bar gains `1-9 attach`.
- `src/app/events.rs` — Sessions-focus handler catches `KeyCode::Char('1'..='9')` (no Ctrl/Alt), looks up the Nth `AttachableRef`, mutates selection, fires `AppEvent::AttachTmuxSession`. Out-of-range digits surface a `ShowNotification` instead of attaching.

## Test plan

- [x] `cargo check` clean (no new warnings)
- [x] `cargo test --lib` → 676 passed / 0 failed / 15 ignored
- [ ] Manual: open TUI, press `1`–`9` on rows with badges → attaches to the right session
- [ ] Manual: cycle filter with `Shift+F` → badges re-number to match the new visible set
- [ ] Manual: collapse/expand workspaces → badges reflect the currently-rendered leaves
- [ ] Manual: pressing a digit beyond the visible count → "No session at position N" notification, no attach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numeric keyboard shortcuts (digits 1-9) for quick attachment to tmux sessions directly from the session list.
  * Numeric badges now appear next to each attachable session item for quick reference.
  * Help text updated to display the available digit-key range for session attachment shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/109)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->