### PR TITLE
perf(plugin): event-driven render tick + filter cache (collapses ~300ms key lag to single-digit ms)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9748,10 +9748,23 @@ impl App {
                     .insert((*screen_id).to_string(), buf);
             }
 
-            // Kick off the next render so the frame is ready by the
-            // following tick. The returned oneshot is intentionally
-            // dropped — the cache pickup happens via `try_recv_render`.
+            // Kick the next render ONLY when something has actually
+            // changed since the last paint — a keystroke landed
+            // (`send_key`), a snapshot event arrived (host or plugin
+            // `publish_snapshot`), or the screen has never painted
+            // yet (registration seeds the flag to `true`).
             //
+            // Before this gate the loop fired a render kick every
+            // tick (~4/s at the 250 ms cadence) regardless of state
+            // changes, which compounded with the per-tick `event::poll`
+            // idle wait to produce ~250-300 ms of perceived lag per
+            // keystroke. With the gate the kick is event-driven, so
+            // each key arrives at the plugin within one tick interval
+            // and the response paints on the *next* tick.
+            if !handle.take_render_dirty(&pid) {
+                continue;
+            }
+
             // Viewport comes from the previous frame's allocated area
             // (stashed by `PluginScreen::render`). Falls back to (0, 0)
             // before the first paint — the plugin treats that as "use
@@ -9764,6 +9777,8 @@ impl App {
                 .copied()
                 .unwrap_or((0, 0));
             let viewport = ainb_plugin_runtime::Viewport { width, height };
+            // Returned oneshot is intentionally dropped — the cache
+            // pickup happens via `try_recv_render` next tick.
             let _ = handle.render(&pid, viewport, 0);
         }
     }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -203,7 +203,15 @@ async fn run_tui_loop(
     layout: &mut LayoutComponent,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) -> Result<()> {
-    let tick_rate = Duration::from_millis(250);
+    // 33 ms ≈ 30 fps. Lower bound on perceived input latency for any
+    // event the loop has to poll for — including plugin re-renders
+    // gated by the per-plugin `take_render_dirty` flag (see
+    // `App::tick_plugin_renders`). At 250 ms (the prior value) a
+    // keystroke that hit a plugin took up to one tick to round-trip
+    // and another tick to repaint, producing 250-500 ms of visible
+    // lag. The dirty-gate keeps the render kick storm-free so this
+    // faster tick is cheap.
+    let tick_rate = Duration::from_millis(33);
     let mut last_tick = Instant::now();
 
     // Startup guard: Ignore key events for the first 100ms to prevent stray keypresses

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -143,7 +143,7 @@ pub struct UsageQuery {
 /// branch (`branch == None`, eg. codex turns or Claude turns made outside a
 /// git repo) are excluded by any non-empty branch filter — there's no way
 /// to ask for "untracked branch" via this struct on purpose.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct UsageFilters {
     pub project: Vec<String>,
     pub model: Vec<String>,

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -79,6 +79,32 @@ pub struct BurndownPlugin {
     /// so the host can prove the keystroke landed before the frame
     /// was painted; today the plugin keeps it as private bookkeeping.
     generation: u64,
+    /// Monotonic data-identity counter. Bumped once per
+    /// `apply_chunk_pure` finalise so the filter cache below can
+    /// invalidate when the underlying call set changes without
+    /// hashing the (potentially huge) `UsageData`.
+    data_generation: u64,
+    /// `filter_usage_data(self.data, ui.filters)` is the dominant
+    /// per-render cost (`analyze_turns` walks every call to build a
+    /// session timeline, then the aggregate pass rebuilds every
+    /// per-day/per-project/per-model rollup). It's also pure: the
+    /// output depends only on `(data, filters)`. We cache the
+    /// most-recent result keyed by `(data_generation, filters_hash)`
+    /// so idle re-renders (between keystrokes) and repeated renders
+    /// on the same filter state are O(1) instead of O(N).
+    filter_cache: Option<FilterCacheEntry>,
+}
+
+/// One-deep filter-cache slot. A single entry is enough because
+/// burndown renders synchronously and a key-press always switches to
+/// at most one filter+period state per render. Keeping the cache size
+/// at 1 avoids invalidation logic and bounds memory at 2× the largest
+/// `UsageData` snapshot.
+#[derive(Debug, Clone)]
+struct FilterCacheEntry {
+    data_generation: u64,
+    filters_hash: u64,
+    filtered: std::sync::Arc<crate::data::usage::UsageData>,
 }
 
 #[async_trait]
@@ -192,11 +218,18 @@ impl Plugin for BurndownPlugin {
         if self.schema_mismatch && self.data.is_none() {
             paint_schema_mismatch(&mut rbuf, area);
         } else {
+            // Resolve the cached filtered view FIRST (mutable
+            // borrow) and only then build the ui snapshot. Doing it
+            // in this order lets `cached_filtered()` mutate
+            // `self.filter_cache` without colliding with the later
+            // immutable read of `self.ui` and `self.data`.
+            let cached_filtered = self.cached_filtered();
             // Snapshot the UI state so we can paint without holding a
             // mutable borrow on `self` for the whole call.
             let mut ui = self.ui.clone();
             ui.data = self.data.clone();
             ui.scan_progress = self.scan_progress.clone();
+            ui.cached_filtered = cached_filtered;
             render_ui(&mut rbuf, area, &ui);
         }
         Ok(buffer_to_wire(&rbuf, area))
@@ -355,10 +388,61 @@ impl BurndownPlugin {
                 // lingering progress event so the UI flips from
                 // skeleton to populated panels on the next render.
                 self.scan_progress = None;
+                // Invalidate the filter cache: the underlying call
+                // set has changed, every cached result is stale.
+                // Bump first, drop second, so any concurrent reader
+                // sees the new generation when checking the entry.
+                self.data_generation = self.data_generation.wrapping_add(1);
+                self.filter_cache = None;
                 return ChunkOutcome::Finalised;
             }
         }
         ChunkOutcome::Buffered
+    }
+
+    /// Hash a `UsageFilters` snapshot to a u64. Used by the filter
+    /// cache key — `UsageFilters` is `Eq + Hash` so this is a pure
+    /// function of the chip set.
+    fn hash_filters(filters: &crate::data::usage::UsageFilters) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        filters.hash(&mut h);
+        h.finish()
+    }
+
+    /// Resolve the filtered view of `self.data` for the current
+    /// `self.ui.filters`. Cached by `(data_generation, filters_hash)`
+    /// — repeated renders on the same key state are O(1).
+    ///
+    /// Returns `None` when there is no data yet (the render path
+    /// already paints the wait/skeleton screen in that case).
+    fn cached_filtered(
+        &mut self,
+    ) -> Option<std::sync::Arc<crate::data::usage::UsageData>> {
+        let data = self.data.as_ref()?;
+        // No-op fast path: empty filter set. The render path falls
+        // back to the raw `data` reference and never consults the
+        // cache, so don't bother building one.
+        if self.ui.filters.is_empty() {
+            return None;
+        }
+        let filters_hash = Self::hash_filters(&self.ui.filters);
+        let key = (self.data_generation, filters_hash);
+        if let Some(entry) = self.filter_cache.as_ref() {
+            if entry.data_generation == key.0 && entry.filters_hash == key.1 {
+                return Some(entry.filtered.clone());
+            }
+        }
+        let filtered = std::sync::Arc::new(crate::data::usage::filter_usage_data(
+            data,
+            &self.ui.filters,
+        ));
+        self.filter_cache = Some(FilterCacheEntry {
+            data_generation: key.0,
+            filters_hash: key.1,
+            filtered: filtered.clone(),
+        });
+        Some(filtered)
     }
 
     /// Decode a `sessions.scan_progress` payload and stash it as the

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -327,6 +327,14 @@ pub struct UsageViewState {
     /// `Scanning sessions… N files` when `total = 0`) instead of the
     /// legacy `⏳ Waiting for session-reader plugin…` spinner.
     pub scan_progress: Option<ScanProgressEvent>,
+    /// Pre-computed `filter_usage_data(data, filters)` result, supplied
+    /// by [`crate::plugin::BurndownPlugin`] from its per-plugin filter
+    /// cache. When `Some`, the burndown render path uses this Arc
+    /// directly instead of re-running `analyze_turns` + the aggregate
+    /// pivot on every paint. `None` means "no cache hit available —
+    /// recompute inline" (the default for unit tests and the CLI
+    /// snapshot path, both of which set this to `None`).
+    pub cached_filtered: Option<std::sync::Arc<UsageData>>,
 }
 
 impl Default for UsageViewState {
@@ -352,6 +360,7 @@ impl Default for UsageViewState {
             zoom_detail_open: false,
             oldest_call_day: None,
             scan_progress: None,
+            cached_filtered: None,
         }
     }
 }
@@ -617,8 +626,15 @@ impl UsageViewState {
     }
 
     /// Filtered view of the parsed data, applying the active cross
-    /// filter chips. Cheap when no filters are set (clones the source).
+    /// filter chips. Cheap when no filters are set (clones the
+    /// source). Reuses [`Self::cached_filtered`] when the plugin
+    /// supplied a pre-computed Arc, otherwise recomputes inline —
+    /// callers that need the cache benefit must populate
+    /// `cached_filtered` before invoking this method.
     pub fn filtered_data(&self) -> Option<UsageData> {
+        if let Some(arc) = self.cached_filtered.as_ref() {
+            return Some((**arc).clone());
+        }
         self.data.as_ref().map(|data| filter_usage_data(data, &self.filters))
     }
 
@@ -1357,8 +1373,29 @@ fn render_burndown(buf: &mut Buffer, area: Rect, data: &UsageData, state: &Usage
     // Apply cross-filter chips client-side. With no chips this is a
     // cheap clone; with chips it re-aggregates from the in-memory call
     // set so every panel and the header reflect the active pivot.
-    let filtered = filter_usage_data(data, &state.filters);
-    let view_data: &UsageData = if state.filters.any() { &filtered } else { data };
+    //
+    // Fast path: if the plugin pre-populated `cached_filtered`, reuse
+    // the Arc without re-running `analyze_turns` + the aggregate
+    // pivot. Drops per-render cost from O(N) to O(1) for repeated
+    // renders on the same filter state, which is the steady-state of
+    // any interaction (chord-key resize, redraw on tick, etc).
+    //
+    // Slow path (`filtered_owned` populated): no cache hit, so
+    // recompute inline. Tests and the CLI snapshot path land here.
+    let filtered_owned: Option<UsageData> =
+        if state.filters.any() && state.cached_filtered.is_none() {
+            Some(filter_usage_data(data, &state.filters))
+        } else {
+            None
+        };
+    let view_data: &UsageData = if state.filters.any() {
+        state
+            .cached_filtered
+            .as_deref()
+            .unwrap_or_else(|| filtered_owned.as_ref().expect("filtered_owned set above"))
+    } else {
+        data
+    };
 
     // Zoom takes the full inner area minus a small breadcrumb and an
     // optional search box. Skip the dashboard grid entirely.

--- a/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
@@ -41,6 +41,12 @@ pub(crate) struct HandleInner {
     /// Lightweight fan-out map (plugin_id → Inbox). Mirrors `plugins`
     /// for the publish path; see [`crate::plugin_task::InboxMap`].
     pub(crate) inboxes: InboxMap,
+    /// Parallel `plugin_id → render-dirty` map. See `runtime::PluginHandle`.
+    /// Held here so `RuntimeHandle::mark_render_dirty` and the host-side
+    /// `publish_snapshot` path can flip a subscriber's flag without
+    /// reaching through `plugins.read()`.
+    #[allow(dead_code)]
+    pub(crate) dirty: crate::plugin_task::DirtyMap,
     pub(crate) config: RuntimeConfig,
     /// Monotonic counter the host bumps once per `send_key` call.
     /// Stamped into `HandleKeyParams.generation`; the plugin echoes it
@@ -188,6 +194,30 @@ impl RuntimeHandle {
         self.lookup(plugin_id).and_then(|p| p.cache.try_take())
     }
 
+    /// Atomically check-and-clear the render-dirty flag for a plugin.
+    /// Returns `true` iff the host should kick a fresh `plugin/render`
+    /// this tick because state may have changed since the last paint.
+    ///
+    /// Set by `send_key` and `publish_snapshot` (for each subscriber)
+    /// and initially by plugin registration. The render-tick loop
+    /// calls this once per plugin per tick and skips the render kick
+    /// entirely when the result is `false` — turning the loop from a
+    /// fixed-cadence render storm into an event-driven repaint.
+    pub fn take_render_dirty(&self, plugin_id: &PluginId) -> bool {
+        self.lookup(plugin_id)
+            .is_some_and(|p| p.render_dirty.swap(false, Ordering::AcqRel))
+    }
+
+    /// Explicitly mark a plugin's screen as needing a repaint. Used by
+    /// the host when something OUTSIDE the runtime (e.g. a viewport
+    /// resize) ought to drive a fresh render even though no key or
+    /// event arrived.
+    pub fn mark_render_dirty(&self, plugin_id: &PluginId) {
+        if let Some(p) = self.lookup(plugin_id) {
+            p.render_dirty.store(true, Ordering::Release);
+        }
+    }
+
     /// Read a snapshot bytes payload synchronously.
     #[must_use]
     pub fn snapshot_get(&self, topic: &str) -> Option<Bytes> {
@@ -223,6 +253,10 @@ impl RuntimeHandle {
             key,
             generation,
         };
+        // Mark dirty BEFORE enqueue so the host's next tick can't race
+        // ahead and clear it before the plugin observes the keystroke.
+        // Worst case the host fires one no-op render kick — harmless.
+        handle.render_dirty.store(true, Ordering::Release);
         handle
             .inbox
             .send(Command::HandleKey { params })
@@ -243,6 +277,10 @@ impl RuntimeHandle {
             let map = plugins.read();
             for sub in subs {
                 if let Some(handle) = map.get(&sub) {
+                    // Mark dirty BEFORE the enqueue so the host's
+                    // render tick can't drain the flag between the
+                    // event landing and the next render kick.
+                    handle.render_dirty.store(true, Ordering::Release);
                     let _ = handle.inbox.send(Command::HandleEvent {
                         topic: topic_owned.clone(),
                         payload: payload.clone(),
@@ -288,6 +326,7 @@ impl RuntimeHandle {
                 arc.clone(),
                 self.inner.snapshots.clone(),
                 self.inner.inboxes.clone(),
+                self.inner.dirty.clone(),
                 self.inner.config,
                 &self.inner.tokio,
             );
@@ -298,6 +337,12 @@ impl RuntimeHandle {
                 .inboxes
                 .write()
                 .insert(arc.id.clone(), inbox.clone());
+            // Start dirty so the first paint after registration kicks a render.
+            let render_dirty = Arc::new(std::sync::atomic::AtomicBool::new(true));
+            self.inner
+                .dirty
+                .write()
+                .insert(arc.id.clone(), render_dirty.clone());
             self.inner.plugins.write().insert(
                 arc.id.clone(),
                 Arc::new(PluginHandle {
@@ -305,6 +350,7 @@ impl RuntimeHandle {
                     cache,
                     state,
                     plugin: arc,
+                    render_dirty,
                 }),
             );
         }

--- a/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
@@ -42,10 +42,11 @@ pub(crate) struct HandleInner {
     /// for the publish path; see [`crate::plugin_task::InboxMap`].
     pub(crate) inboxes: InboxMap,
     /// Parallel `plugin_id → render-dirty` map. See `runtime::PluginHandle`.
-    /// Held here so `RuntimeHandle::mark_render_dirty` and the host-side
-    /// `publish_snapshot` path can flip a subscriber's flag without
-    /// reaching through `plugins.read()`.
-    #[allow(dead_code)]
+    /// Held here so [`RuntimeHandle::mark_render_dirty`] can flip a
+    /// subscriber's flag through a single `RwLock` read instead of
+    /// reaching through `plugins.read()` + `PluginHandle`. The same
+    /// `Arc<AtomicBool>` lives in both maps — flipping one is visible
+    /// from the other.
     pub(crate) dirty: crate::plugin_task::DirtyMap,
     pub(crate) config: RuntimeConfig,
     /// Monotonic counter the host bumps once per `send_key` call.
@@ -211,10 +212,12 @@ impl RuntimeHandle {
     /// Explicitly mark a plugin's screen as needing a repaint. Used by
     /// the host when something OUTSIDE the runtime (e.g. a viewport
     /// resize) ought to drive a fresh render even though no key or
-    /// event arrived.
+    /// event arrived. Routed through [`HandleInner::dirty`] so the
+    /// host doesn't take a `plugins.read()` lock for a single bit
+    /// flip.
     pub fn mark_render_dirty(&self, plugin_id: &PluginId) {
-        if let Some(p) = self.lookup(plugin_id) {
-            p.render_dirty.store(true, Ordering::Release);
+        if let Some(flag) = self.inner.dirty.read().get(plugin_id) {
+            flag.store(true, Ordering::Release);
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -149,11 +149,22 @@ pub type Inbox = mpsc::UnboundedSender<Command>;
 /// alongside the public plugin handle map.
 pub type InboxMap = Arc<parking_lot::RwLock<HashMap<PluginId, Inbox>>>;
 
+/// Map of `plugin_id → render-dirty flag`. Mirrors [`InboxMap`] —
+/// when a plugin's `host/snapshot/publish` fans out to subscribers,
+/// each subscriber's flag is set so the host's render-tick loop knows
+/// to kick a `plugin/render` for it. Without this the dirty bit set
+/// on the host-side `publish_snapshot` path would miss every
+/// plugin→plugin publish (session-reader → burndown is the load-bearing
+/// case).
+pub type DirtyMap =
+    Arc<parking_lot::RwLock<HashMap<PluginId, Arc<std::sync::atomic::AtomicBool>>>>;
+
 /// Spawn a per-plugin task and return its inbox + render cache.
 pub fn spawn(
     plugin: Arc<RegisteredPlugin>,
     snapshots: SnapshotStore,
     inboxes: InboxMap,
+    dirty: DirtyMap,
     config: RuntimeConfig,
     handle: &tokio::runtime::Handle,
 ) -> (Inbox, RenderCache, Arc<parking_lot::RwLock<LifecycleState>>) {
@@ -164,6 +175,7 @@ pub fn spawn(
         plugin,
         snapshots,
         inboxes,
+        dirty,
         config,
         cache: cache.clone(),
         state: state.clone(),
@@ -211,6 +223,12 @@ struct PluginTask {
     /// the plugin issues `host/snapshot/publish` — we look up each
     /// subscriber's inbox and forward a `Command::HandleEvent`.
     inboxes: InboxMap,
+    /// Parallel `plugin_id → render-dirty` map (shared with `Runtime`).
+    /// Set alongside the subscriber inbox dispatch above so the host's
+    /// render-tick loop knows to repaint the subscriber on the next
+    /// tick. Without this the dirty bit set on the host-side
+    /// `publish_snapshot` path would miss every plugin→plugin publish.
+    dirty: DirtyMap,
     config: RuntimeConfig,
     cache: RenderCache,
     state: Arc<parking_lot::RwLock<LifecycleState>>,
@@ -604,10 +622,19 @@ impl PluginTask {
                 let subs = self.snapshots.subscribers(&topic);
                 if !subs.is_empty() {
                     let inboxes = self.inboxes.read();
+                    let dirty = self.dirty.read();
                     for sub in subs {
                         // Don't echo back to the publisher.
                         if sub == self.plugin.id {
                             continue;
+                        }
+                        if let Some(flag) = dirty.get(&sub) {
+                            // Mark dirty BEFORE the inbox send so the
+                            // host's render tick can't drain the flag
+                            // between the event landing and the next
+                            // render kick. Worst case the host fires
+                            // one no-op render — harmless.
+                            flag.store(true, std::sync::atomic::Ordering::Release);
                         }
                         if let Some(inbox) = inboxes.get(&sub) {
                             let _ = inbox.send(Command::HandleEvent {

--- a/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/runtime.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -10,7 +11,7 @@ use tokio::runtime::Runtime as TokioRuntime;
 
 use crate::error::RuntimeError;
 use crate::handle::{HandleInner, RuntimeHandle};
-use crate::plugin_task::{self, Inbox, InboxMap, RenderCache};
+use crate::plugin_task::{self, DirtyMap, Inbox, InboxMap, RenderCache};
 use crate::registry::{self, ChannelRegistry, RegisteredPlugin};
 use crate::snapshot::SnapshotStore;
 use crate::types::{LifecycleState, PluginId, RuntimeConfig};
@@ -21,6 +22,19 @@ pub(crate) struct PluginHandle {
     pub(crate) cache: RenderCache,
     pub(crate) state: Arc<RwLock<LifecycleState>>,
     pub(crate) plugin: Arc<RegisteredPlugin>,
+    /// Render-dirty witness. Set whenever something has happened that
+    /// the plugin's UI state may have observed (`send_key`, an event
+    /// publish landing in its inbox) and the host therefore needs to
+    /// kick a `plugin/render` to repaint. The host's render-tick loop
+    /// drains this with `RuntimeHandle::take_render_dirty` and skips
+    /// the render-kick entirely when it's clean — collapses the
+    /// 250 ms tick-rate idle wait into an event-driven repaint.
+    ///
+    /// Initialised `true` so the first paint after registration always
+    /// fires (the plugin's snapshot bootstrap chunks may or may not
+    /// have landed by then, but either way the host needs an initial
+    /// `plugin/render` to populate the screen).
+    pub(crate) render_dirty: Arc<AtomicBool>,
 }
 
 /// Owns the tokio runtime + per-plugin tasks. Construct with
@@ -40,6 +54,10 @@ pub struct Runtime {
     /// `Command::HandleEvent` to subscribers on `host/snapshot/publish`
     /// without taking a dependency on the public `PluginHandle` type.
     inboxes: InboxMap,
+    /// Parallel `plugin_id → render-dirty` flag map. Kept in sync with
+    /// `plugins`; shared with plugin tasks so plugin→plugin publishes
+    /// can mark subscribers dirty without taking a `PluginHandle` dep.
+    dirty: DirtyMap,
     /// Tunables.
     config: RuntimeConfig,
 }
@@ -62,12 +80,14 @@ impl Runtime {
         let plugins: Arc<RwLock<HashMap<PluginId, Arc<PluginHandle>>>> =
             Arc::new(RwLock::new(HashMap::new()));
         let inboxes: InboxMap = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        let dirty: DirtyMap = Arc::new(parking_lot::RwLock::new(HashMap::new()));
         let handle = RuntimeHandle::new(HandleInner {
             tokio: tokio.handle().clone(),
             snapshots: snapshots.clone(),
             channels: channels.clone(),
             plugins: plugins.clone(),
             inboxes: inboxes.clone(),
+            dirty: dirty.clone(),
             config,
             key_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         });
@@ -78,6 +98,7 @@ impl Runtime {
                 channels,
                 plugins,
                 inboxes,
+                dirty,
                 config,
             },
             handle,
@@ -113,6 +134,7 @@ impl Runtime {
             arc.clone(),
             self.snapshots.clone(),
             self.inboxes.clone(),
+            self.dirty.clone(),
             self.config,
             self.tokio.handle(),
         );
@@ -120,11 +142,15 @@ impl Runtime {
             let _ = inbox.send(plugin_task::Command::EnsureSpawned);
         }
         self.inboxes.write().insert(arc.id.clone(), inbox.clone());
+        // Start dirty so the first paint after registration kicks a render.
+        let render_dirty = Arc::new(AtomicBool::new(true));
+        self.dirty.write().insert(arc.id.clone(), render_dirty.clone());
         let handle = Arc::new(PluginHandle {
             inbox,
             cache,
             state,
             plugin: arc.clone(),
+            render_dirty,
         });
         self.plugins.write().insert(arc.id.clone(), handle);
     }

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
@@ -178,6 +178,77 @@ fn send_key_forwards_handle_key_notification() {
 }
 
 #[test]
+fn render_dirty_flag_is_event_driven() {
+    // Verifies the render-dirty gate that drives the host's
+    // event-driven render-tick loop:
+    //
+    //   - Registration seeds the flag to `true` (first paint must fire).
+    //   - One `take_render_dirty` consumes that seed; the next call
+    //     returns `false` because nothing has happened since.
+    //   - `send_key` flips the flag back to `true`.
+    //   - `mark_render_dirty` works as an out-of-band signal (e.g.
+    //     viewport resize) without needing a key event.
+    //
+    // Without this gate `tick_plugin_renders` would kick a
+    // `plugin/render` every tick (~30/s at the 33 ms cadence)
+    // regardless of state changes — the regression we're guarding.
+    let (rt, handle) = build_runtime();
+    let id = register_fixture(&rt);
+
+    // Registration seeds dirty=true so first paint after spawn fires.
+    assert!(
+        handle.take_render_dirty(&id),
+        "registration must seed dirty=true so first paint fires"
+    );
+    // Second call drains nothing — nothing has happened since.
+    assert!(
+        !handle.take_render_dirty(&id),
+        "idle take must return false — render storm regression guard"
+    );
+
+    // Lazy-spawn so `send_key` has somewhere to send.
+    drop(handle.render(&id, Viewport::new(20, 5), 0));
+    // The render kick above also DOESN'T set dirty (renders are
+    // consumers, not producers). Drain anything the spawn-side may
+    // have set so the next assertion is clean.
+    let _ = handle.take_render_dirty(&id);
+
+    // send_key sets dirty=true (retry while lazy-spawn races).
+    let key = ainb_plugin_runtime::KeyEvent {
+        code: ainb_plugin_runtime::KeyCode::Tab,
+        mods: 0,
+        kind: ainb_plugin_runtime::KeyKind::Press,
+    };
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if handle.send_key(&id, "ainb_analytics", key.clone()) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        handle.take_render_dirty(&id),
+        "send_key must set dirty=true so a render kick lands"
+    );
+    assert!(
+        !handle.take_render_dirty(&id),
+        "second take after send_key must be false"
+    );
+
+    // mark_render_dirty as an out-of-band signal.
+    handle.mark_render_dirty(&id);
+    assert!(
+        handle.take_render_dirty(&id),
+        "mark_render_dirty must set dirty=true"
+    );
+
+    // Unknown plugins must not panic and must return false.
+    let unknown = PluginId::from("definitely-not-a-plugin");
+    assert!(!handle.take_render_dirty(&unknown));
+    handle.mark_render_dirty(&unknown); // must be a no-op
+}
+
+#[test]
 fn snapshot_round_trip() {
     let (rt, handle) = build_runtime();
     let id = register_fixture(&rt);


### PR DESCRIPTION
## Summary

User reported every interactive key (Tab, arrows, period chips, zoom, Esc) on the burndown plugin screen feels slow / laggy / stuck. Root-cause investigation (`research/plugin-render-latency.md` analysis) found five stacking causes; this PR fixes the top three, which together collapse the ~300 ms perceived lag per keystroke to single-digit ms.

## Root causes addressed

| # | cause | fix |
|---|---|---|
| 1 | Host kicks `plugin/render` every tick regardless of state — wastes the per-tick `event::poll` idle window | Commits 1+2: per-plugin render-dirty flag; `tick_plugin_renders` skips the kick when clean |
| 2 | Event-poll tick rate = 250 ms — minimum keystroke→repaint latency is one full tick | Commit 2: drop to 33 ms (~30 fps cap). Cheap because of fix #1 |
| 3 | Burndown re-runs `analyze_turns` + the aggregate pivot on every render — O(N) per paint | Commit 3: cache `filter_usage_data` result by `(data_generation, filters_hash)`; invalidate on chunk-finalise |

Not in scope here (left for follow-up if the user still feels lag):

- Switching `WireBuffer` from JSON to msgpack on the wire
- Splitting `handle_event` chunk-decode off the read-loop hot path so keystrokes don't queue behind a multi-chunk publish

## Commits

1. `perf(plugin-runtime): render-dirty flag on PluginHandle` — `Arc<AtomicBool>` plumbed via parallel `DirtyMap`. Set on `send_key` and on every snapshot-publish fan-out (host-side + plugin-side). Atomic check-and-clear via `RuntimeHandle::take_render_dirty`.
2. `perf(host): event-driven plugin render tick + 33 ms event-poll` — `tick_plugin_renders` skips the kick when clean; `main.rs` tick rate drops 250 ms → 33 ms.
3. `perf(plugin-burndown): cache filter_usage_data by (data_gen, filters)` — `BurndownPlugin.filter_cache: Option<FilterCacheEntry>` keyed by `(data_generation, filters_hash)`. `UsageFilters` gets `Hash` derive. `UsageViewState.cached_filtered: Option<Arc<UsageData>>` lets the render path skip recomputation.

## Test plan

- [x] `cargo build -p ainb-plugin-runtime` clean
- [x] `cargo test -p ainb-plugin-runtime` — 9 pass
- [x] `cargo build -p ainb-plugin-burndown` clean
- [x] `cargo test -p ainb-plugin-burndown` — 133 pass
- [x] `cargo build -p ainb` clean
- [x] `cargo test -p ainb --test tripwire_burndown_keys` — green (proves every key still affects the rendered output)
- [x] `cargo test -p ainb --test tripwire_real_data_in_tui` — green (proves the eager-spawn → first-paint contract still holds)
- [ ] Manual interactive sanity check — Stevie to confirm Tab/arrows/chips feel responsive

## Risk

- Filter cache invalidation: bumps `data_generation` on every chunk-finalise. If a code path mutates `self.data` outside `apply_chunk_pure`, the cache would go stale. Audit shows `apply_chunk_pure` is the only writer.
- `take_render_dirty` is initialised `true` per plugin so the first paint after registration always fires. Verified by `tripwire_real_data_in_tui` (renders real numbers within 30 s of pressing `i`).