### PR TITLE
docs: add Fleet Lambda overlay cleanup + provenance docs

### DIFF
--- a/toolkit/docs/fleet-lambda/README.md
+++ b/toolkit/docs/fleet-lambda/README.md
@@ -1,0 +1,14 @@
+# Fleet Lambda Overlay Docs
+
+This directory holds the tracked planning/docs layer for Fleet Lambda overlay cleanup.
+
+## Files
+- `overlay-ownership-matrix.md` — current artifact classification and boundary rules
+- `bank-provenance-design.md` — observability design for BANK lookups, injections, and correction joins
+- `migration-plan.md` — phased migration path from runtime/backup drift to clean repo ownership
+
+## Operating rule
+
+Runtime paths are deployment targets.
+Code repos are source-of-truth.
+Backup repos hold non-code/manual state only.

--- a/toolkit/docs/fleet-lambda/bank-provenance-design.md
+++ b/toolkit/docs/fleet-lambda/bank-provenance-design.md
@@ -1,0 +1,92 @@
+# BANK Provenance Design
+
+## Goal
+
+Make BANK retrieval traceable end-to-end:
+- what was searched
+- what was injected
+- what later correlated with a correction
+- which retrieved hits were useful vs noisy
+
+## Existing wiring
+
+`injection_history.py` already exists as helper state:
+- writer: `bank_lookup.py` calls `injection_history.record(...)`
+- reader: `correction_detector.py` calls `injection_history.recent(session_id)`
+
+This means join substrate already exists. Missing piece is **durable observability**.
+
+## Required event types
+
+### 1. `lookup`
+Emitted when BANK evaluates candidate hits.
+
+Required fields:
+- `ts`
+- `session_id`
+- `agent`
+- `query` or `keywords`
+- `candidate_hit_ids`
+- `selected_hit_ids`
+- `score_summary`
+- `token_budget`
+- `source = bank_lookup`
+
+### 2. `injection`
+Emitted when selected hits are actually injected into context.
+
+Required fields:
+- `ts`
+- `session_id`
+- `injection_id`
+- `selected_hit_ids`
+- `rendered_count`
+- `approx_tokens_used`
+- `source = bank_lookup`
+
+### 3. `correction_after_injection`
+Emitted when downstream correction logic joins a correction with a recent injection.
+
+Required fields:
+- `ts`
+- `session_id`
+- `correction_id`
+- `matched_injection_id`
+- `matched_hit_ids`
+- `confidence`
+- `matched_signals`
+- `source = correction_detector`
+
+### 4. optional `retrieval_feedback`
+Derived signal: useful, noisy, superseded, or neutral.
+
+## Sink decision
+
+Default recommendation:
+- append durable JSONL under shared learnings/runtime area for simplicity and diffability
+- optional later mirror/index into sqlite for aggregation
+
+Suggested runtime sink names:
+- `~/.clan/learnings/bank-lookups.jsonl`
+- `~/.clan/learnings/bank-injections.jsonl`
+- `~/.clan/learnings/corrections-after-injection.jsonl`
+
+## Operator queries needed
+
+- show recent lookups for session
+- show injection trail for session
+- show correction joins for session
+- show hit usefulness summary over time
+
+## Important shape rule
+
+Do **not** turn `injection_history.py` into a hook just to make it visible.
+Keep it as helper plumbing. Emit durable events around it instead.
+
+## Success condition
+
+Given a session id, operator can answer:
+1. what BANK looked up
+2. what got injected
+3. what later triggered correction
+4. which hits helped vs polluted context

--- a/toolkit/docs/fleet-lambda/migration-plan.md
+++ b/toolkit/docs/fleet-lambda/migration-plan.md
@@ -1,0 +1,58 @@
+# Fleet Lambda Overlay Migration Plan
+
+## Canonical boundary
+
+### Code repos own
+- fleet hook source code
+- tests
+- schemas/specs
+- behavior docs
+- install/sync scripts
+- backup/restore script source when maintained as code
+
+### Runtime owns
+- deployed copies under `~/.hermes/plugins/` and `~/.hermes/bin/`
+- ledgers under `~/.clan/learnings/`
+- generated sqlite indexes and caches
+
+### Backup repo owns
+- manual profile/config snapshots
+- DR copies of non-code machine state
+- backup indexes/manifests
+
+## Recommended next moves
+
+### Phase 1 — docs + boundary freeze
+1. Land ownership matrix and provenance design docs.
+2. Freeze claim that backup repo is canonical for validator/spec code.
+3. Audit every doc line that implies live validation exists.
+
+### Phase 2 — source extraction
+1. Choose canonical code home for fleet overlay source.
+2. Copy live-authored hook/plugin code into that repo.
+3. Copy or rewrite maintained runtime scripts into same code repo.
+4. Add tests and sync/install scripts.
+
+### Phase 3 — validator truth
+1. If schema validation matters, restore `spec_validator.py` plus schema tree in canonical code repo.
+2. Add tests.
+3. Wire it live only after verification.
+4. Otherwise delete stale docs/spec claims.
+
+### Phase 4 — provenance implementation
+1. Emit `lookup`, `injection`, and `correction_after_injection` events.
+2. Add session-level inspection tooling.
+3. Add usefulness/noise rollup later if signal quality is good.
+
+## Smallest safe implementation slice
+
+If full migration is too big for one pass:
+1. keep runtime code untouched
+2. land docs + boundaries first
+3. add provenance event sink design next
+4. then cut code moves in separate PRs
+
+## Current call
+
+This repo now holds the planning/docs layer for Fleet Lambda overlay cleanup.
+Actual runtime source migration still needs explicit canonical code-home decision before broad file moves.

--- a/toolkit/docs/fleet-lambda/overlay-ownership-matrix.md
+++ b/toolkit/docs/fleet-lambda/overlay-ownership-matrix.md
@@ -1,0 +1,75 @@
+# Fleet Lambda Overlay Ownership Matrix
+
+## Decision summary
+
+- **Canonical code lives in code repos.**
+- **Backup repos hold non-code/manual/runtime-authored state only.**
+- **Live runtime paths are deployment targets, not authoring surfaces.**
+- **Unwired or backup-only code must either be restored properly or removed from claims.**
+
+## Classification buckets
+
+- **CODE-SOURCE** — authored source code, tests, schemas, docs for behavior
+- **RUNTIME-STATE** — generated or live machine state
+- **BACKUP-ONLY** — disaster-recovery copy of non-code/manual state
+- **DEAD-OR-DRIFT** — stale, misleading, unwired, or duplicated artifacts
+
+## Current artifact map
+
+| Path | Role today | Correct class | Canonical home | Action |
+|---|---|---:|---|---|
+| `~/.hermes/plugins/fleet-hooks/*.py` | live fleet hook code | CODE-SOURCE + runtime deploy target | code repo, then synced into runtime | move source ownership out of runtime; keep runtime copy generated/synced |
+| `~/.hermes/plugins/fleet-hooks/plugin.yaml` | live plugin manifest | CODE-SOURCE + runtime deploy target | code repo | same as above |
+| `~/.hermes/plugins/fleet-hooks/injection_history.py` | helper state module used by live hooks | CODE-SOURCE + runtime deploy target | code repo | keep; add observable outputs around it |
+| `~/.hermes/bin/*.py` | live ops/runtime scripts | mixed | code repo for maintained scripts; runtime path as install target | split authored scripts from generated wrappers |
+| `~/.clan/learnings/*.jsonl` | shared ledgers | RUNTIME-STATE | runtime/shared state | keep out of code repo except schema/docs/examples |
+| `~/.clan/learnings/bank.db` | retrieval index | RUNTIME-STATE | runtime/shared state | do not version as canonical source |
+| `~/.clan/bin/*` | utility scripts | CODE-SOURCE if maintained, else local ops | code repo or bootstrap bundle source | audit one-by-one |
+| `~/d/git/hermes-fleet-backup/plugins/fleet-hooks/spec_validator.py` | backup-only validator | DEAD-OR-DRIFT until restored | code repo if kept | restore properly or delete claim |
+| `~/d/git/hermes-fleet-backup/plugins/fleet-hooks-spec/` | backup-only schemas/spec | DEAD-OR-DRIFT until restored | code repo if kept | restore properly or delete claim |
+| `~/d/git/hermes-fleet-backup/docs/*` | mixed architecture docs | CODE-SOURCE docs, but misplaced | code repo | move docs to code repo |
+| `~/d/git/hermes-fleet-backup/profiles/*` | backup of manual profile/config state | BACKUP-ONLY | backup repo | keep |
+| `~/d/git/hermes-fleet-backup/backup*.json` | backup manifests/indexes | BACKUP-ONLY | backup repo | keep |
+| `~/d/git/hermes-fleet-backup/backup.sh` / `restore.sh` | DR orchestration scripts | CODE-SOURCE if maintained | code repo, then copied if needed | move source ownership out of backup repo |
+
+## Live wired modules confirmed
+
+Live plugin registry currently wires:
+- `acp_metrics`
+- `bank_lookup`
+- `circuit_breaker`
+- `correction_detector`
+- `discovery_context`
+- `inbox_enforcer`
+- `learning_sync`
+- `learning_verifier`
+- `manifest_context`
+- `session_rules`
+
+`injection_history.py` is **not** a hook module, but **is** live internal plumbing used by `bank_lookup.py` and `correction_detector.py`.
+
+## Keep / simplify / kill
+
+### Keep
+- `manifest_context`
+- `session_rules`
+- `inbox_enforcer`
+- `acp_metrics`
+- `circuit_breaker`
+- `bank_lookup`
+- `discovery_context`
+- `injection_history`
+
+### Simplify
+- `correction_detector`
+- `learning_sync`
+- `learning_verifier`
+
+### Restore-or-kill
+- `spec_validator.py`
+- `fleet-hooks-spec/`
+- any doc claims that validation is live when runtime does not load it
+
+## Boundary rule
+
+**Runtime is where code runs. Repo is where code lives. Backup is where machine/manual state survives.**


### PR DESCRIPTION
## Summary
- add Fleet Lambda overlay ownership matrix
- add BANK provenance design doc
- add phased migration plan
- add docs index for this cleanup slice

## Notes
- backup repos should hold non-code/manual runtime state only
- code/spec/docs should live in canonical code repos
- `injection_history` stays helper plumbing; observability should be emitted around it, not by making it a hook

## Paths
- `toolkit/docs/fleet-lambda/README.md`
- `toolkit/docs/fleet-lambda/overlay-ownership-matrix.md`
- `toolkit/docs/fleet-lambda/bank-provenance-design.md`
- `toolkit/docs/fleet-lambda/migration-plan.md`