### PR TITLE
fix(host): decouple event-poll cadence from app.tick() cadence (unbreaks tripwires)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -203,16 +203,25 @@ async fn run_tui_loop(
     layout: &mut LayoutComponent,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) -> Result<()> {
-    // 33 ms ≈ 30 fps. Lower bound on perceived input latency for any
-    // event the loop has to poll for — including plugin re-renders
-    // gated by the per-plugin `take_render_dirty` flag (see
-    // `App::tick_plugin_renders`). At 250 ms (the prior value) a
-    // keystroke that hit a plugin took up to one tick to round-trip
-    // and another tick to repaint, producing 250-500 ms of visible
-    // lag. The dirty-gate keeps the render kick storm-free so this
-    // faster tick is cheap.
+    // Event-poll cadence: how often we wake up to check for a keystroke
+    // or paste event. Drives the "time-to-first-response" for any input
+    // the user generates — including keystrokes routed to plugin
+    // screens via `App::tick_plugin_renders` and its `take_render_dirty`
+    // gate. Set to ~30 fps so a keystroke lands in the next iter
+    // (< 33 ms) rather than the next 250 ms window.
     let tick_rate = Duration::from_millis(33);
+    // App-tick cadence: how often we run the heavy host-side periodic
+    // work (mascot animation, OAuth refresh check, tmux preview
+    // capture, async action dispatch, log streaming refresh,
+    // workspace/skills load checks). These are coarse-grained and
+    // expensive — running them every 33 ms would starve the event
+    // loop, stall key processing, and burn CPU. 250 ms is the
+    // pre-perf-PR cadence; keeping it isolates the tick-rate cut
+    // to only the event-poll path that actually affects perceived
+    // latency. See `last_app_tick` below.
+    let app_tick_rate = Duration::from_millis(250);
     let mut last_tick = Instant::now();
+    let mut last_app_tick = Instant::now();
 
     // Startup guard: Ignore key events for the first 100ms to prevent stray keypresses
     // from triggering actions (e.g., buffered 'n' key opening New Session dialog)
@@ -363,7 +372,7 @@ async fn run_tui_loop(
                                 match app.tick().await {
                                     Ok(()) => {
                                         info!(">>> Immediate tick completed successfully");
-                                        last_tick = Instant::now();
+                                        last_app_tick = Instant::now();
                                         // Force UI refresh
                                         terminal.draw(|frame| {
                                             layout.render(frame, &mut app.state);
@@ -527,7 +536,13 @@ async fn run_tui_loop(
             EventHandler::process_event(pending_event, &mut app.state);
         }
 
-        if last_tick.elapsed() >= tick_rate {
+        // Update last_tick on every iteration so the event-poll timeout
+        // stays accurate. The heavy work below is gated on a SEPARATE
+        // `last_app_tick` so it runs at app_tick_rate (250 ms) even
+        // though the poll cadence is much faster (33 ms).
+        last_tick = Instant::now();
+
+        if last_app_tick.elapsed() >= app_tick_rate {
             // Update mascot animation on home screen
             app.state.home_screen_v2_state.tick_mascot();
 
@@ -1183,7 +1198,7 @@ async fn run_tui_loop(
 
             match app.tick().await {
                 Ok(()) => {
-                    last_tick = Instant::now();
+                    last_app_tick = Instant::now();
 
                     // Check if UI needs immediate refresh after async operations
                     if app.needs_ui_refresh() {
@@ -1197,7 +1212,7 @@ async fn run_tui_loop(
                     use tracing::error;
                     error!("Error during app tick: {}", e);
                     // Continue running instead of crashing
-                    last_tick = Instant::now();
+                    last_app_tick = Instant::now();
                 }
             }
         }


### PR DESCRIPTION
## Summary

PR #110 introduced a 250 ms → 33 ms event-poll cadence to cut plugin-render latency. But the SAME `last_tick` clock also gated `app.tick().await` — the heavy host-side periodic work (mascot animation, OAuth refresh check, tmux preview capture, async action dispatch, log streaming refresh, workspace/skills load checks). Running that 30×/sec instead of 4×/sec starved the event loop: when `app.tick()` took longer than 33 ms (docker probes, tmux ops), every subsequent `event::poll` fired with `timeout=0` (non-blocking), and keys arriving mid-tick stalled in the PTY until the loop caught up. The HomeScreen → Burndown screen switch flaked because the `i` keystroke sat in the buffer past the test's 30 s data deadline.

**Bisect:** pre-#110 (5e11a4f^) → 5/5 pass. At #110 (5e11a4f) → 1/3 pass (flaky). Reverting `tick_rate` to 250 ms on top of #110 → 5/5 pass (proves tick_rate is the regression). With decoupled `app_tick_rate` (this PR) → 5/5 pass.

## What changed

- Renamed/added a second clock: `tick_rate = 33 ms` (event-poll, drives "time-to-first-response") and `app_tick_rate = 250 ms` (heavy host-side work — same pre-#110 cadence).
- Added `last_app_tick: Instant` alongside `last_tick`.
- Changed the heavy-work gate from `last_tick.elapsed() >= tick_rate` to `last_app_tick.elapsed() >= app_tick_rate`.
- `last_tick` is now reset once per loop iteration so the next poll has a fresh 33 ms budget.
- Updated all `last_tick = Instant::now();` lines inside the heavy-work block (and the immediate-tick branch for `NewSession/SearchWorkspace/ConfirmationConfirm`) to update `last_app_tick` instead.

The fast plugin-render path still benefits from the 33 ms poll cadence — render kicks land in the next iter (< 33 ms) rather than the next 250 ms window. The expensive periodic work runs at the pre-#110 cadence so it doesn't starve the loop.

## Test plan

- [x] `tripwire_real_data_in_tui` × 5 runs → 5/5 pass (7-13 s; pre-fix was 1/3 with 36 s timeouts)
- [x] `tripwire_burndown_keys` × 1 run → pass (15.9 s)
- [x] `cargo test -p ainb-plugin-runtime --test fixture_e2e` → 10/10 pass (including `render_dirty_flag_is_event_driven`)
- [x] `cargo build -p ainb --release` clean

## Why a hotfix and not a revert

The dirty-gate, filter cache, and render-dirty flag from #110 are all correct and load-bearing for the perf improvement. Only the *coupled* `tick_rate` change was the regression. Decoupling preserves the 7.5× responsiveness win for plugin renders while restoring the pre-#110 budget for `app.tick()`.