### PR TITLE
fix(plugin-burndown): wire period + provider filters into render (grafana-style global filter)

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -29,7 +29,7 @@ use crate::cache::{Cache, ParseHint, ParseResult};
 /// `LastNDays`) to keep the existing CLI `PeriodArg` enum, JSON
 /// serialisation, and downstream tests stable.
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UsagePeriod {
     Today,
@@ -59,7 +59,7 @@ impl Default for UsagePeriod {
 
 /// Provider filter shared by TUI and CLI report queries.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UsageProviderFilter {
     #[default]
@@ -1811,7 +1811,31 @@ fn build_model_project_counts(
 /// The activity filter compares against the per-call classified category
 /// label (see `ActivityCategory::label()`), case-sensitive.
 pub fn filter_usage_data(data: &UsageData, filters: &UsageFilters) -> UsageData {
-    if filters.is_empty() {
+    filter_usage_data_full(data, filters, &UsagePeriod::All, UsageProviderFilter::All)
+}
+
+/// Apply the full filter surface — cross-filter chips, period date range,
+/// and provider — in a single re-aggregation pass.
+///
+/// This is the grafana-style pivot the render path uses: period and
+/// provider were UI selectors with no data binding pre-PR A (they
+/// repainted the chip strip but the dashboard widgets ignored them).
+/// Here all three filters compose into the same call-level predicate
+/// and the result is re-aggregated once, so every panel reflects the
+/// active pivot.
+///
+/// The no-op early return covers the common idle case (no chips, no
+/// period selected beyond `All`, provider = All) and keeps that path
+/// at the same cost as the pre-PR-A `filter_usage_data`.
+pub fn filter_usage_data_full(
+    data: &UsageData,
+    filters: &UsageFilters,
+    period: &UsagePeriod,
+    provider_filter: UsageProviderFilter,
+) -> UsageData {
+    let period_range = date_range_for_period(period);
+    let provider_active = !matches!(provider_filter, UsageProviderFilter::All);
+    if filters.is_empty() && period_range.is_none() && !provider_active {
         return data.clone();
     }
     // Precompute analyze_turns once on the *unfiltered* call set so
@@ -1824,7 +1848,23 @@ pub fn filter_usage_data(data: &UsageData, filters: &UsageFilters) -> UsageData 
     let filtered_calls: Vec<ProviderCall> = data
         .calls
         .iter()
-        .filter(|call| filters.matches(call, classify_activity(call)))
+        .filter(|call| {
+            // Chip filters (project / model / activity / session / branch).
+            if !filters.matches(call, classify_activity(call)) {
+                return false;
+            }
+            // Provider filter (Right/Left arrow on the TUI).
+            if !provider_filter.includes(&call.provider) {
+                return false;
+            }
+            // Period filter (1/2/3/a or specific month/quarter).
+            if let Some((start, end)) = period_range {
+                if call.timestamp < start || call.timestamp > end {
+                    return false;
+                }
+            }
+            true
+        })
         .cloned()
         .collect();
     aggregate_calls_with_analysis(filtered_calls, Some(&turn_analysis))
@@ -4055,5 +4095,149 @@ mod tests {
             Duration::hours(1),
         );
         assert!(calls.is_empty());
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // filter_usage_data_full coverage (PR A)
+    //
+    // Pre-PR-A the period & provider selectors were UI-only — they
+    // repainted the chip strip but the dashboard widgets ignored them.
+    // These tests pin the new grafana-style global filter behaviour.
+    // ────────────────────────────────────────────────────────────────
+
+    use crate::test_support::ProviderCallBuilder;
+
+    fn calls_aggregated(calls: Vec<ProviderCall>) -> UsageData {
+        aggregate_calls(calls)
+    }
+
+    #[test]
+    fn filter_usage_data_full_filters_by_provider_for_codex() {
+        let now = Utc::now();
+        let claude_call = ProviderCallBuilder::new()
+            .with_id(1)
+            .with_provider("claude")
+            .with_project("alpha")
+            .with_timestamp(now)
+            .with_input_tokens(100)
+            .with_output_tokens(50)
+            .build();
+        let codex_call = ProviderCallBuilder::new()
+            .with_id(2)
+            .with_provider("codex")
+            .with_project("beta")
+            .with_timestamp(now)
+            .with_input_tokens(200)
+            .with_output_tokens(100)
+            .build();
+        let data = calls_aggregated(vec![claude_call, codex_call]);
+        assert_eq!(data.calls.len(), 2);
+
+        let filtered = filter_usage_data_full(
+            &data,
+            &UsageFilters::default(),
+            &UsagePeriod::All,
+            UsageProviderFilter::Codex,
+        );
+        assert_eq!(filtered.calls.len(), 1, "only codex call should survive");
+        assert_eq!(filtered.calls[0].provider, "codex");
+        assert_eq!(filtered.projects.len(), 1);
+        assert_eq!(filtered.projects[0].name, "beta");
+    }
+
+    #[test]
+    fn filter_usage_data_full_filters_by_period_today_excludes_old_call() {
+        let now = Utc::now();
+        let old = now - Duration::days(40);
+        let recent_call = ProviderCallBuilder::new()
+            .with_id(1)
+            .with_timestamp(now)
+            .with_input_tokens(100)
+            .build();
+        let stale_call = ProviderCallBuilder::new()
+            .with_id(2)
+            .with_timestamp(old)
+            .with_input_tokens(999)
+            .build();
+        let data = calls_aggregated(vec![recent_call, stale_call]);
+        assert_eq!(data.calls.len(), 2);
+
+        let filtered = filter_usage_data_full(
+            &data,
+            &UsageFilters::default(),
+            &UsagePeriod::Today,
+            UsageProviderFilter::All,
+        );
+        assert_eq!(filtered.calls.len(), 1, "only today's call should survive");
+        assert_eq!(filtered.calls[0].id, 1);
+    }
+
+    #[test]
+    fn filter_usage_data_full_composes_chip_period_provider_filters() {
+        let now = Utc::now();
+        let old = now - Duration::days(40);
+        // alpha + claude + today — survives all filters
+        let keep = ProviderCallBuilder::new()
+            .with_id(1)
+            .with_provider("claude")
+            .with_project("alpha")
+            .with_timestamp(now)
+            .build();
+        // alpha + claude + old — dropped by period
+        let drop_period = ProviderCallBuilder::new()
+            .with_id(2)
+            .with_provider("claude")
+            .with_project("alpha")
+            .with_timestamp(old)
+            .build();
+        // beta + claude + today — dropped by project chip
+        let drop_chip = ProviderCallBuilder::new()
+            .with_id(3)
+            .with_provider("claude")
+            .with_project("beta")
+            .with_timestamp(now)
+            .build();
+        // alpha + codex + today — dropped by provider filter
+        let drop_provider = ProviderCallBuilder::new()
+            .with_id(4)
+            .with_provider("codex")
+            .with_project("alpha")
+            .with_timestamp(now)
+            .build();
+        let data = calls_aggregated(vec![keep, drop_period, drop_chip, drop_provider]);
+        assert_eq!(data.calls.len(), 4);
+
+        let mut chip_filters = UsageFilters::default();
+        chip_filters.project.push("alpha".to_string());
+
+        let filtered = filter_usage_data_full(
+            &data,
+            &chip_filters,
+            &UsagePeriod::Today,
+            UsageProviderFilter::Claude,
+        );
+        assert_eq!(filtered.calls.len(), 1, "only id=1 satisfies all 3 filters");
+        assert_eq!(filtered.calls[0].id, 1);
+    }
+
+    #[test]
+    fn filter_usage_data_full_no_op_when_everything_default() {
+        // No chips, period=All, provider=All — the function must return
+        // the data unchanged (cheap clone path) so empty-state callers
+        // hit the fast path.
+        let call = ProviderCallBuilder::new()
+            .with_id(7)
+            .with_timestamp(Utc::now())
+            .with_input_tokens(42)
+            .build();
+        let data = calls_aggregated(vec![call]);
+        let filtered = filter_usage_data_full(
+            &data,
+            &UsageFilters::default(),
+            &UsagePeriod::All,
+            UsageProviderFilter::All,
+        );
+        assert_eq!(filtered.calls.len(), 1);
+        assert_eq!(filtered.calls[0].id, 7);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -84,26 +84,31 @@ pub struct BurndownPlugin {
     /// invalidate when the underlying call set changes without
     /// hashing the (potentially huge) `UsageData`.
     data_generation: u64,
-    /// `filter_usage_data(self.data, ui.filters)` is the dominant
-    /// per-render cost (`analyze_turns` walks every call to build a
-    /// session timeline, then the aggregate pass rebuilds every
-    /// per-day/per-project/per-model rollup). It's also pure: the
-    /// output depends only on `(data, filters)`. We cache the
-    /// most-recent result keyed by `(data_generation, filters_hash)`
-    /// so idle re-renders (between keystrokes) and repeated renders
-    /// on the same filter state are O(1) instead of O(N).
+    /// `filter_usage_data_full(self.data, ui.filters, ui.period,
+    /// ui.provider_filter)` is the dominant per-render cost
+    /// (`analyze_turns` walks every call to build a session timeline,
+    /// then the aggregate pass rebuilds every per-day/per-project/
+    /// per-model rollup). It's also pure: the output depends only on
+    /// `(data, filters, period, provider_filter)`. We cache the
+    /// most-recent result keyed by `(data_generation, inputs_hash)` —
+    /// inputs_hash mixes filters + period + provider — so idle
+    /// re-renders (between keystrokes) and repeated renders on the
+    /// same filter state are O(1) instead of O(N).
     filter_cache: Option<FilterCacheEntry>,
 }
 
 /// One-deep filter-cache slot. A single entry is enough because
 /// burndown renders synchronously and a key-press always switches to
-/// at most one filter+period state per render. Keeping the cache size
-/// at 1 avoids invalidation logic and bounds memory at 2× the largest
-/// `UsageData` snapshot.
+/// at most one (filters, period, provider) state per render. Keeping
+/// the cache size at 1 avoids invalidation logic and bounds memory at
+/// 2× the largest `UsageData` snapshot.
 #[derive(Debug, Clone)]
 struct FilterCacheEntry {
     data_generation: u64,
-    filters_hash: u64,
+    /// Hash of `(filters, period, provider_filter)` — the full input
+    /// surface to `filter_usage_data_full`. Renamed from `filters_hash`
+    /// when period + provider joined the cache key in PR A.
+    inputs_hash: u64,
     filtered: std::sync::Arc<crate::data::usage::UsageData>,
 }
 
@@ -447,7 +452,7 @@ impl BurndownPlugin {
             Self::hash_filter_inputs(&self.ui.filters, &self.ui.period, self.ui.provider_filter);
         let key = (self.data_generation, inputs_hash);
         if let Some(entry) = self.filter_cache.as_ref() {
-            if entry.data_generation == key.0 && entry.filters_hash == key.1 {
+            if entry.data_generation == key.0 && entry.inputs_hash == key.1 {
                 return Some(entry.filtered.clone());
             }
         }
@@ -459,7 +464,7 @@ impl BurndownPlugin {
         ));
         self.filter_cache = Some(FilterCacheEntry {
             data_generation: key.0,
-            filters_hash: key.1,
+            inputs_hash: key.1,
             filtered: filtered.clone(),
         });
         Some(filtered)

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -402,40 +402,60 @@ impl BurndownPlugin {
 
     /// Hash a `UsageFilters` snapshot to a u64. Used by the filter
     /// cache key — `UsageFilters` is `Eq + Hash` so this is a pure
-    /// function of the chip set.
-    fn hash_filters(filters: &crate::data::usage::UsageFilters) -> u64 {
+    /// function of the chip set, period, and provider filter — all three
+    /// inputs to `filter_usage_data_full` so the cache key invalidates
+    /// when ANY of them change.
+    fn hash_filter_inputs(
+        filters: &crate::data::usage::UsageFilters,
+        period: &crate::data::usage::UsagePeriod,
+        provider_filter: crate::data::usage::UsageProviderFilter,
+    ) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut h = std::collections::hash_map::DefaultHasher::new();
         filters.hash(&mut h);
+        period.hash(&mut h);
+        provider_filter.hash(&mut h);
         h.finish()
     }
 
     /// Resolve the filtered view of `self.data` for the current
-    /// `self.ui.filters`. Cached by `(data_generation, filters_hash)`
-    /// — repeated renders on the same key state are O(1).
+    /// `self.ui.filters` + `self.ui.period` + `self.ui.provider_filter`.
+    /// Cached by `(data_generation, inputs_hash)` — repeated renders
+    /// on the same key state are O(1).
     ///
     /// Returns `None` when there is no data yet (the render path
-    /// already paints the wait/skeleton screen in that case).
+    /// already paints the wait/skeleton screen in that case) or when
+    /// every filter dimension is at its default ("no-op" — render
+    /// path uses the raw `data` reference).
     fn cached_filtered(
         &mut self,
     ) -> Option<std::sync::Arc<crate::data::usage::UsageData>> {
         let data = self.data.as_ref()?;
-        // No-op fast path: empty filter set. The render path falls
+        // No-op fast path: nothing to filter. The render path falls
         // back to the raw `data` reference and never consults the
         // cache, so don't bother building one.
-        if self.ui.filters.is_empty() {
+        let any_active = self.ui.filters.any()
+            || !matches!(self.ui.period, crate::data::usage::UsagePeriod::All)
+            || !matches!(
+                self.ui.provider_filter,
+                crate::data::usage::UsageProviderFilter::All
+            );
+        if !any_active {
             return None;
         }
-        let filters_hash = Self::hash_filters(&self.ui.filters);
-        let key = (self.data_generation, filters_hash);
+        let inputs_hash =
+            Self::hash_filter_inputs(&self.ui.filters, &self.ui.period, self.ui.provider_filter);
+        let key = (self.data_generation, inputs_hash);
         if let Some(entry) = self.filter_cache.as_ref() {
             if entry.data_generation == key.0 && entry.filters_hash == key.1 {
                 return Some(entry.filtered.clone());
             }
         }
-        let filtered = std::sync::Arc::new(crate::data::usage::filter_usage_data(
+        let filtered = std::sync::Arc::new(crate::data::usage::filter_usage_data_full(
             data,
             &self.ui.filters,
+            &self.ui.period,
+            self.ui.provider_filter,
         ));
         self.filter_cache = Some(FilterCacheEntry {
             data_generation: key.0,

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -18,7 +18,7 @@ use crate::data::usage::{
 };
 use crate::data::{
     ActivityUsage, ModelUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsageFilterChip,
-    UsageFilters, UsagePeriod, UsageProviderFilter, UsageQuery, filter_usage_data,
+    UsageFilters, UsagePeriod, UsageProviderFilter, UsageQuery, filter_usage_data_full,
     format_tokens_short, optimize_usage,
 };
 
@@ -625,17 +625,22 @@ impl UsageViewState {
         self.focus_row = self.focus_row.saturating_add(1);
     }
 
-    /// Filtered view of the parsed data, applying the active cross
-    /// filter chips. Cheap when no filters are set (clones the
-    /// source). Reuses [`Self::cached_filtered`] when the plugin
-    /// supplied a pre-computed Arc, otherwise recomputes inline —
-    /// callers that need the cache benefit must populate
-    /// `cached_filtered` before invoking this method.
+    /// Filtered view of the parsed data, applying the full filter
+    /// surface — cross-filter chips, period date range, and provider
+    /// selector — so callers like `resolve_focused_row` see the same
+    /// pivot the dashboard panels render. Cheap when no filters/period/
+    /// provider is active (clones the source). Reuses
+    /// [`Self::cached_filtered`] when the plugin supplied a
+    /// pre-computed Arc, otherwise recomputes inline — callers that
+    /// need the cache benefit must populate `cached_filtered` before
+    /// invoking this method.
     pub fn filtered_data(&self) -> Option<UsageData> {
         if let Some(arc) = self.cached_filtered.as_ref() {
             return Some((**arc).clone());
         }
-        self.data.as_ref().map(|data| filter_usage_data(data, &self.filters))
+        self.data.as_ref().map(|data| {
+            filter_usage_data_full(data, &self.filters, &self.period, self.provider_filter)
+        })
     }
 
     /// Resolve the focused panel row to a `(target, value, owner_project)`
@@ -1370,25 +1375,37 @@ fn render_burndown(buf: &mut Buffer, area: Rect, data: &UsageData, state: &Usage
         return;
     }
 
-    // Apply cross-filter chips client-side. With no chips this is a
-    // cheap clone; with chips it re-aggregates from the in-memory call
-    // set so every panel and the header reflect the active pivot.
+    // Apply the full filter surface client-side: cross-filter chips
+    // (project/model/activity/session/branch), the period date range
+    // (1/2/3/a or specific month/quarter), and the provider selector
+    // (Right/Left arrow). All three feed `filter_usage_data_full`,
+    // which re-aggregates from the in-memory call set so every panel
+    // and the header reflect the active pivot — grafana-style global
+    // filters.
     //
     // Fast path: if the plugin pre-populated `cached_filtered`, reuse
     // the Arc without re-running `analyze_turns` + the aggregate
     // pivot. Drops per-render cost from O(N) to O(1) for repeated
-    // renders on the same filter state, which is the steady-state of
-    // any interaction (chord-key resize, redraw on tick, etc).
+    // renders on the same filter state.
     //
     // Slow path (`filtered_owned` populated): no cache hit, so
     // recompute inline. Tests and the CLI snapshot path land here.
-    let filtered_owned: Option<UsageData> =
-        if state.filters.any() && state.cached_filtered.is_none() {
-            Some(filter_usage_data(data, &state.filters))
-        } else {
-            None
-        };
-    let view_data: &UsageData = if state.filters.any() {
+    let any_filter_active = state.filters.any()
+        || !matches!(state.period, UsagePeriod::All)
+        || !matches!(state.provider_filter, UsageProviderFilter::All);
+    let filtered_owned: Option<UsageData> = if any_filter_active
+        && state.cached_filtered.is_none()
+    {
+        Some(filter_usage_data_full(
+            data,
+            &state.filters,
+            &state.period,
+            state.provider_filter,
+        ))
+    } else {
+        None
+    };
+    let view_data: &UsageData = if any_filter_active {
         state
             .cached_filtered
             .as_deref()
@@ -4267,6 +4284,10 @@ mod cross_filter_tests {
     fn enter_on_by_project_row_sets_project_filter() {
         let mut state = UsageViewState::default();
         state.data = Some(fixture());
+        // Fixture uses pre-aggregated projects/sessions with `calls: vec![]`,
+        // so re-aggregation via the period filter would zero out the rows.
+        // Bypass period filtering — this test is about Enter→chip dispatch.
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByProject);
         state.focus_row = 1; // beta
         assert!(state.commit_focused_row());
@@ -4277,6 +4298,7 @@ mod cross_filter_tests {
     fn enter_on_top_session_row_sets_session_filter() {
         let mut state = UsageViewState::default();
         state.data = Some(fixture());
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::TopSessions);
         state.focus_row = 0;
         assert!(state.commit_focused_row());
@@ -4312,6 +4334,7 @@ mod cross_filter_tests {
 
         let mut state = UsageViewState::default();
         state.data = Some(data);
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::TopSessions);
         state.focus_row = 0;
         assert!(state.commit_focused_row());
@@ -4330,6 +4353,7 @@ mod cross_filter_tests {
     fn enter_on_by_model_row_sets_model_filter() {
         let mut state = UsageViewState::default();
         state.data = Some(fixture());
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByModel);
         state.focus_row = 0;
         assert!(state.commit_focused_row());
@@ -4340,6 +4364,7 @@ mod cross_filter_tests {
     fn enter_on_by_activity_row_sets_activity_filter() {
         let mut state = UsageViewState::default();
         state.data = Some(fixture());
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByActivity);
         state.focus_row = 1; // Conversation
         assert!(state.commit_focused_row());
@@ -4433,6 +4458,7 @@ mod cross_filter_tests {
     fn enter_on_leaderboard_maps_to_project_filter() {
         let mut state = UsageViewState::default();
         state.data = Some(fixture());
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::Leaderboard);
         state.focus_row = 0; // alpha (rendered from filtered_data.projects)
         assert!(state.commit_focused_row());
@@ -4513,6 +4539,7 @@ mod cross_filter_tests {
 
         let mut state = UsageViewState::default();
         state.data = Some(fixture());
+        state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByProject);
         state.focus_row = 1; // beta
         assert!(state.commit_focused_row_exclude());


### PR DESCRIPTION
## Summary

Stevie discovered post-#110/#112 that the period (1/2/3/a) and provider (Right/Left) selectors in burndown were **UI-only**: pressing them repainted the chip strip but the dashboard widgets ignored them entirely. The dashboard always rendered the full `data` snapshot.

This was a pre-existing defect — not a regression from the perf PRs. They just made the UI snappy enough that the broken filtering became noticeable.

## Fix

Add `filter_usage_data_full(data, filters, period, provider_filter)` in `crates/ainb-plugin-burndown/src/data/usage.rs`. Single-pass re-aggregation that composes all three filter dimensions:

```rust
data.calls.iter().filter(|call| {
    filters.matches(call, classify_activity(call))      // chip filters
    && provider_filter.includes(&call.provider)         // provider
    && period_range.is_none_or(|(s, e)| s <= ts <= e)   // period date range
})
```

Wire it through:

- **`render_burndown`** (`crates/ainb-plugin-burndown/src/ui.rs`) — pass period + provider; detect "any filter active" across all 3 (was just `state.filters.any()`).
- **`UsageViewState::filtered_data`** (same file) — so `resolve_focused_row` (drill-down via Enter, PR C territory) sees the same pivot as the dashboard.
- **Plugin filter cache** (`crates/ainb-plugin-burndown/src/plugin.rs`) — hash includes period + provider; renamed `hash_filters` → `hash_filter_inputs`. Cache invalidates on period or provider switch.

Derive `Hash` on `UsagePeriod` and `UsageProviderFilter` so they feed into the cache key.

`filter_usage_data` (old signature) kept as a thin wrapper for back-compat with the ~14 existing test callers.

## Test plan

- [x] 4 new unit tests on `filter_usage_data_full`: provider-only filter, period-only filter, three-way composition, no-op clone path
- [x] 7 pre-existing chip-commit tests get an explicit `state.period = UsagePeriod::All` because they use a fixture with `calls: vec![]` and pre-aggregated rows — the old chip-only filter was a no-op for them; the new path re-aggregates from calls
- [x] `cargo test -p ainb-plugin-burndown` → 136/136 pass
- [x] `cargo test -p ainb-plugin-runtime --test fixture_e2e` → 10/10 pass (unchanged)
- [x] `tripwire_real_data_in_tui` → 1/1 in 5.68s
- [x] `tripwire_burndown_keys` → 1/1 in 15.95s

## Why this is PR A of 3

Stevie's report flagged 4 defects + a data-architecture question:

| # | Defect | This PR |
|---|---|---|
| A | Period filter not wired to all widgets | ✅ Fixed |
| A | Provider filter shows same data for codex | ✅ Fixed |
| B | Activity + MCP widgets empty | Next PR (data origin) |
| C | Enter drill-down behaviour | Next PR (verification) |
| - | SQLite usage | Documented: session-reader uses SQLite for incremental scan; burndown is pure in-memory consumer |

PRs B and C will land separately so each one is reviewable and revertable.