### PR TITLE
fix(plugin-burndown): rebuild activities + mcp_servers on wire ingest

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -1795,6 +1795,62 @@ fn build_model_project_counts(
         .collect()
 }
 
+/// Re-derive the `activities`, `mcp_servers`, and `tools` columns of an
+/// already-parsed `UsageData` from `data.calls`.
+///
+/// session-reader publishes empty `activities` and `mcp_servers` arrays
+/// on the wire (see the comment in `crates/ainb-plugin-session-reader/
+/// src/scanner.rs`: classification is the consumer's job). It also
+/// emits raw tool names into `tools` without splitting the `mcp__server__*`
+/// prefix into a separate MCP-server row. Burndown owns the richer
+/// activity taxonomy (12+ buckets vs. the wire schema's 6) and the
+/// mcp/tool split, so we recompute those three columns here using the
+/// raw call set the producer ships intact.
+///
+/// Other columns (daily/weekly/projects/sessions/models/branches/
+/// shell_commands/grand_total/model_project_counts) are left as the
+/// producer published them — re-aggregating those would risk
+/// timezone shifts and other cross-platform drift for no gain.
+pub fn rebuild_activity_and_mcp_columns(data: &mut UsageData) {
+    let turn_analysis = analyze_turns(&data.calls);
+    let mut activity_map: HashMap<ActivityCategory, ActivityAccumulator> = HashMap::new();
+    let mut tool_map: HashMap<String, usize> = HashMap::new();
+    let mut mcp_map: HashMap<String, usize> = HashMap::new();
+
+    for call in &data.calls {
+        let bucket = call.bucket();
+        let analysis = turn_analysis.get(&call.id).copied().unwrap_or_else(|| TurnAnalysis {
+            category: classify_activity(call),
+            retries: 0,
+            has_edits: has_edit_tool(&call.tools),
+        });
+        let activity = activity_map.entry(analysis.category).or_default();
+        activity.bucket.merge(&bucket);
+        activity.turns += 1;
+        activity.retries += analysis.retries;
+        if analysis.has_edits {
+            activity.edit_turns += 1;
+            if analysis.retries == 0 {
+                activity.one_shot_turns += 1;
+            }
+        }
+
+        for tool in &call.tools {
+            if let Some(server) =
+                tool.strip_prefix("mcp__").and_then(|rest| rest.split("__").next())
+            {
+                bump(&mut mcp_map, server.to_string());
+            } else {
+                bump(&mut tool_map, tool.clone());
+            }
+        }
+    }
+
+    data.activities = sorted_activities(activity_map);
+    data.mcp_servers = sorted_named_usage(mcp_map);
+    data.tools = sorted_named_usage(tool_map);
+}
+
 /// Filter an already-parsed `UsageData` by exact-match cross-filters.
 ///
 /// Returns a new `UsageData` with `calls`, `daily`, `weekly`, `projects`,
@@ -4218,6 +4274,78 @@ mod tests {
         );
         assert_eq!(filtered.calls.len(), 1, "only id=1 satisfies all 3 filters");
         assert_eq!(filtered.calls[0].id, 1);
+    }
+
+    #[test]
+    fn rebuild_activity_and_mcp_columns_splits_mcp_prefix_from_tools() {
+        // Simulate a wire snapshot where the producer (session-reader)
+        // shipped raw tool names with the mcp__ prefix unsplit. Burndown's
+        // rebuild must route those into mcp_servers and leave only plain
+        // tools in `tools`.
+        let now = Utc::now();
+        let call = ProviderCallBuilder::new()
+            .with_id(1)
+            .with_timestamp(now)
+            .with_input_tokens(10)
+            .with_tools(&["Read", "Bash", "mcp__github__create_issue", "mcp__github__list_prs"])
+            .build();
+        let mut data = UsageData::default();
+        data.calls = vec![call];
+
+        rebuild_activity_and_mcp_columns(&mut data);
+
+        let tool_names: Vec<&str> = data.tools.iter().map(|n| n.name.as_str()).collect();
+        assert!(tool_names.contains(&"Read"), "Read survives as a plain tool");
+        assert!(tool_names.contains(&"Bash"), "Bash survives as a plain tool");
+        assert!(
+            !tool_names.iter().any(|name| name.starts_with("mcp__")),
+            "no mcp__ tools should leak into the tools column: {tool_names:?}"
+        );
+        let mcp_names: Vec<&str> = data.mcp_servers.iter().map(|n| n.name.as_str()).collect();
+        assert_eq!(
+            mcp_names,
+            vec!["github"],
+            "two mcp__github__* tools collapse to a single github server row"
+        );
+        assert_eq!(data.mcp_servers[0].calls, 2);
+    }
+
+    #[test]
+    fn rebuild_activity_and_mcp_columns_populates_activities_when_wire_was_empty() {
+        // session-reader publishes activities as Vec::new(). After
+        // rebuild, the call's tools + message should land in a populated
+        // activity row using burndown's richer taxonomy.
+        let now = Utc::now();
+        let call = ProviderCallBuilder::new()
+            .with_id(1)
+            .with_timestamp(now)
+            .with_input_tokens(50)
+            .with_tools(&["Edit", "Write"])
+            .with_user_message("fix the bug in the parser")
+            .build();
+        let mut data = UsageData::default();
+        data.calls = vec![call];
+
+        assert!(data.activities.is_empty(), "wire shipped empty activities");
+        rebuild_activity_and_mcp_columns(&mut data);
+
+        assert!(
+            !data.activities.is_empty(),
+            "rebuild should populate at least one activity row"
+        );
+        let total_turns: usize = data.activities.iter().map(|a| a.turns).sum();
+        assert_eq!(total_turns, 1, "single call should contribute one turn");
+    }
+
+    #[test]
+    fn rebuild_activity_and_mcp_columns_handles_empty_calls() {
+        // Defensive: empty calls (no data yet) must not panic and must
+        // leave all three columns empty.
+        let mut data = UsageData::default();
+        rebuild_activity_and_mcp_columns(&mut data);
+        assert!(data.activities.is_empty());
+        assert!(data.mcp_servers.is_empty());
+        assert!(data.tools.is_empty());
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/wire.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/wire.rs
@@ -46,8 +46,15 @@ fn category(c: W::ActivityCategory) -> L::ActivityCategory {
 
 /// Convert a wire `UsageData` (from `sessions.usage_data`) into
 /// burndown's local shape.
+///
+/// After the field-for-field copy, `rebuild_activity_and_mcp_columns`
+/// re-derives the `activities`, `mcp_servers`, and `tools` columns
+/// from `calls`: session-reader ships those three intentionally empty
+/// (or, for `tools`, with the mcp prefix unsplit) because activity
+/// classification + mcp routing live in the consumer's richer
+/// taxonomy. See the helper's docstring for the full rationale.
 pub fn wire_to_local(w: W::UsageData) -> UsageData {
-    L::UsageData {
+    let mut local = L::UsageData {
         daily: w.daily.into_iter().map(|(d, b)| (d, bucket(b))).collect(),
         weekly: w
             .weekly
@@ -153,5 +160,7 @@ pub fn wire_to_local(w: W::UsageData) -> UsageData {
             })
             .collect(),
         model_project_counts: w.model_project_counts.into_iter().collect(),
-    }
+    };
+    L::rebuild_activity_and_mcp_columns(&mut local);
+    local
 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -11,8 +11,14 @@
 //! - Daily / weekly bucketing is UTC. The display layer can convert.
 //! - Project key is the call's `project` field as-is — no upstream-repo
 //!   resolution; two worktrees of the same upstream stay separate.
-//! - `activities` and `mcp_servers` are intentionally empty pending a
-//!   classification pass that operates over session timelines.
+//! - `activities` and `mcp_servers` are intentionally empty here.
+//!   session-reader publishes the raw call set (with `tools` +
+//!   `bash_commands` per call) and leaves activity classification and
+//!   mcp-server attribution to the consumer. Each subscriber owns
+//!   that taxonomy because the right buckets are consumer-specific
+//!   (burndown uses 12 buckets; the wire schema only carries 6). See
+//!   `ainb-plugin-burndown::data::usage::rebuild_activity_and_mcp_columns`
+//!   for the reference implementation.
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

Fixes defect 4 of the burndown plugin extraction (\"activity + MCP server widgets are empty\"). The widgets show data on \`main\` but went empty on \`feat/plugin\` because the v2 wire pipeline (session-reader → sessions.usage_data → burndown) ships:

- \`activities\`: \`Vec::new()\` (deliberately — wire schema's 6-bucket ActivityCategory is leaner than burndown's 12)
- \`mcp_servers\`: \`Vec::new()\` (same reason)
- \`tools\`: raw tool names with \`mcp__server__tool\` prefix unsplit

Burndown's render path consumes these columns directly, so without consumer-side classification the panels render zero data despite the calls being present.

## Changes

- New \`rebuild_activity_and_mcp_columns\` helper in \`data/usage.rs\` that walks \`data.calls\` once, runs burndown's existing \`classify_activity\` + \`analyze_turns\`, and rebuilds three columns: \`activities\`, \`mcp_servers\`, \`tools\` (mcp prefix routed to mcp_servers).
- \`wire_to_local\` calls the rebuild after copying the wire snapshot — so the consumer's richer taxonomy lands on every ingest.
- Comment in \`session-reader/scanner.rs\` updated: classification was \`pending\` per the old comment, now properly states it's intentionally consumer-owned.

Daily/weekly/projects/sessions/models/branches/shell_commands/grand_total/model_project_counts are left untouched — re-aggregating those would risk timezone shifts (UTC at producer, Local at consumer) with no functional gain.

## Test plan

- [x] 3 new unit tests in \`data/usage.rs\`:
  - \`rebuild_activity_and_mcp_columns_splits_mcp_prefix_from_tools\` — verifies \`mcp__github__*\` tools route to \`mcp_servers\` row and leave \`tools\` column with plain names only
  - \`rebuild_activity_and_mcp_columns_populates_activities_when_wire_was_empty\` — verifies classification populates at least one activity row from a wire-empty start
  - \`rebuild_activity_and_mcp_columns_handles_empty_calls\` — defensive no-panic check
- [x] Full crate green: \`cargo test -p ainb-plugin-burndown\` → 139+1 tests pass
- [x] Workspace lib tests green
- [x] tmux walkthrough on real \`~/.claude/projects\` data with provider filter = All:
  - By Activity: Conversation 2094t, Coding 162t, General 35t, Testing 3t, Debugging 2t, Feature 1t
  - MCP Servers: browser 547, claude-peers 94, context7 1
  - Core Tools: Bash 11526, Edit 1922, Read 1684, ... (mcp__ tools no longer present)