### PR TITLE
fix(plugin-burndown): drill-down on Enter works for every panel (incl. By Branch)

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -905,6 +905,45 @@ mod handle_key_dispatch_tests {
         assert!(p.dispatch_key_pure(&ch('k')));
     }
 
+    /// Regression: `commit_focused_row` reads `self.ui.data`, but the
+    /// plugin parks the parsed snapshot on `self.data`. Before the
+    /// dispatcher started syncing data into `ui` ahead of the commit,
+    /// Enter was a silent no-op — no chip, no error, no log line. This
+    /// test lifts the contract into the dispatcher's surface so the
+    /// sync can't regress without a CI signal.
+    #[test]
+    fn enter_commits_branch_chip_when_only_plugin_data_is_set() {
+        use crate::data::usage::{BranchUsage, TokenBucket, UsageData, UsagePeriod};
+        use crate::ui::UsagePanel;
+
+        let mut p = BurndownPlugin::default();
+        let mut data = UsageData::default();
+        data.branches = vec![BranchUsage {
+            branch: "main".to_string(),
+            bucket: TokenBucket {
+                input_tokens: 100,
+                output_tokens: 100,
+                ..Default::default()
+            },
+        }];
+        // Plugin-level snapshot ONLY — leave self.ui.data as None to
+        // mirror the production state right after `apply_chunk_pure`.
+        p.data = Some(data);
+        p.ui.data = None;
+        p.ui.focused_panel = Some(UsagePanel::ByBranch);
+        p.ui.focus_row = 0;
+        // Bypass period filtering so the synthetic call survives the
+        // re-aggregate in `filter_usage_data_full`.
+        p.ui.period = UsagePeriod::All;
+
+        assert!(p.dispatch_key_pure(&KeyCode::Enter));
+        assert_eq!(
+            p.ui.filters.branch,
+            vec!["main".to_string()],
+            "Enter must commit a chip even when only self.data (not self.ui.data) is set"
+        );
+    }
+
     #[test]
     fn unmapped_keys_are_not_claimed() {
         let mut p = BurndownPlugin::default();

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -749,9 +749,17 @@ impl BurndownPlugin {
             KeyCode::Char { ch: '/' } if self.ui.is_zoomed() => self.ui.zoom_begin_search(),
             KeyCode::Char { ch: 'd' } if self.ui.is_zoomed() => self.ui.toggle_zoom_detail(),
             KeyCode::Enter => {
+                // `commit_focused_row` resolves the row through
+                // `filtered_data()` which reads `self.ui.data`. The
+                // plugin keeps the parsed snapshot on `self.data`
+                // (the render path copies it into `ui.data` only at
+                // render time), so without this sync the commit
+                // would silently return false — drill-down dead.
+                self.ui.data = self.data.clone();
                 let _ = self.ui.commit_focused_row();
             }
             KeyCode::Char { ch: 'X' } => {
+                self.ui.data = self.data.clone();
                 let _ = self.ui.commit_focused_row_exclude();
             }
             KeyCode::Char { ch: 'C' } => self.ui.clear_all_filter_chips(),

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -243,12 +243,16 @@ impl UsagePanel {
     /// Whether `Enter` on this panel maps a row onto a cross-filter.
     /// Daily Activity, Optimize, and Budget are read-only — Enter is a
     /// no-op there. Leaderboard maps the focused row onto the Project
-    /// filter (rows are projects).
+    /// filter (rows are projects). Core Tools, Shell Commands, and
+    /// MCP Servers are read-only too: a single call uses many tools,
+    /// so "filter calls where tool = X" doesn't map cleanly onto the
+    /// per-call filter contract.
     pub fn enter_target(self) -> Option<UsageFilterTarget> {
         match self {
             UsagePanel::ByProject | UsagePanel::Leaderboard => Some(UsageFilterTarget::Project),
             UsagePanel::ByActivity => Some(UsageFilterTarget::Activity),
             UsagePanel::ByModel => Some(UsageFilterTarget::Model),
+            UsagePanel::ByBranch => Some(UsageFilterTarget::Branch),
             UsagePanel::TopSessions | UsagePanel::Live => Some(UsageFilterTarget::Session),
             _ => None,
         }
@@ -262,6 +266,7 @@ pub enum UsageFilterTarget {
     Model,
     Activity,
     Session,
+    Branch,
 }
 
 /// View state for the usage analytics screen.
@@ -671,6 +676,9 @@ impl UsageViewState {
                 .sessions
                 .get(row_idx)
                 .map(|s| (target, s.session_id.clone(), Some(s.project.clone()))),
+            (UsageFilterTarget::Branch, _) => {
+                filtered.branches.get(row_idx).map(|b| (target, b.branch.clone(), None))
+            }
             _ => None,
         }
     }
@@ -711,6 +719,11 @@ impl UsageViewState {
                     }
                 }
             }
+            UsageFilterTarget::Branch => {
+                if !self.filters.branch.contains(&value) {
+                    self.filters.branch.push(value);
+                }
+            }
         }
         true
     }
@@ -743,6 +756,11 @@ impl UsageViewState {
             UsageFilterTarget::Session => {
                 if !self.filters.exclude_session.contains(&value) {
                     self.filters.exclude_session.push(value);
+                }
+            }
+            UsageFilterTarget::Branch => {
+                if !self.filters.exclude_branch.contains(&value) {
+                    self.filters.exclude_branch.push(value);
                 }
             }
         }
@@ -4407,15 +4425,47 @@ mod cross_filter_tests {
         assert_eq!(state.focused_panel, Some(UsagePanel::ByBranch));
     }
 
-    /// Brief: branches are display-only for this PR — no chip pivot.
+    /// Grafana-style cross-filter: Enter on a By Branch row commits the
+    /// branch as a chip and propagates the filter to every other widget.
     #[test]
-    fn enter_on_by_branch_row_is_noop() {
+    fn enter_on_by_branch_row_sets_branch_filter() {
+        let mut data = fixture();
+        data.branches = vec![
+            BranchUsage {
+                branch: "main".to_string(),
+                bucket: bucket(3),
+            },
+            BranchUsage {
+                branch: "feat/burndown".to_string(),
+                bucket: bucket(1),
+            },
+        ];
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(data);
         state.focused_panel = Some(UsagePanel::ByBranch);
         state.focus_row = 0;
-        assert!(!state.commit_focused_row());
-        assert!(state.filters.is_empty());
+        // Bypass period filtering — this test is about Enter→chip dispatch.
+        state.period = UsagePeriod::All;
+        assert!(state.commit_focused_row(), "Enter on a branch row must commit a chip");
+        assert_eq!(state.filters.branch, vec!["main".to_string()]);
+    }
+
+    /// Mirror of the include path: X on a By Branch row commits the
+    /// branch into the exclude_branch list.
+    #[test]
+    fn exclude_on_by_branch_row_sets_exclude_branch_filter() {
+        let mut data = fixture();
+        data.branches = vec![BranchUsage {
+            branch: "main".to_string(),
+            bucket: bucket(3),
+        }];
+        let mut state = UsageViewState::default();
+        state.data = Some(data);
+        state.focused_panel = Some(UsagePanel::ByBranch);
+        state.focus_row = 0;
+        state.period = UsagePeriod::All;
+        assert!(state.commit_focused_row_exclude(), "X on a branch row must commit an exclude chip");
+        assert_eq!(state.filters.exclude_branch, vec!["main".to_string()]);
     }
 
     /// Smoke test: render_branch_panel must not panic on a small frame


### PR DESCRIPTION
## Summary

Fixes defect 3 of the burndown plugin extraction (\"Enter doesn't drill-down to filter all other widgets\") and extends drill-down coverage to the By Branch panel.

Two layered bugs:

1. **The bigger one**: \`commit_focused_row\` reads \`self.ui.data\` to resolve the focused row, but the plugin keeps the parsed snapshot on \`self.data\` and only copies it into \`ui.data\` at render time. So every Enter / X press on the burndown screen silently no-op'd — the dispatch routed, the commit function ran, it called \`filtered_data()?\` which returned \`None\`, and the early-return ate the keystroke without telling anyone. Unit tests never caught it because they set \`state.data\` directly before calling commit.

2. **The smaller one**: \`UsagePanel::ByBranch\` had no \`enter_target\` mapping. The prior PR shipped a deliberate \`enter_on_by_branch_row_is_noop\` test claiming branches were display-only — but grafana-style cross-filtering wants every aggregated row to be a click-to-pivot target. \`UsageFilters\` already had \`branch + exclude_branch\` slots, so this is a wiring change.

## Changes

- \`plugin.rs::dispatch_key_pure\`: sync \`self.ui.data = self.data.clone()\` immediately before \`Enter\` → \`commit_focused_row()\` and \`X\` → \`commit_focused_row_exclude()\`. One-line fix, fixes every drill-down across the dashboard.
- \`ui.rs::UsageFilterTarget\`: new \`Branch\` variant.
- \`ui.rs::UsagePanel::enter_target\`: \`ByBranch → UsageFilterTarget::Branch\`. Inline docstring updated to explain why Core Tools / Shell Commands / MCP Servers stay read-only (per-call matching contract doesn't map onto multi-tool calls).
- \`ui.rs::resolve_focused_row\`: new match arm for Branch.
- \`ui.rs::commit_focused_row\` + \`_exclude\`: push into \`filters.branch\` and \`filters.exclude_branch\` respectively.
- Tests: replaced \`enter_on_by_branch_row_is_noop\` with the positive \`enter_on_by_branch_row_sets_branch_filter\`; added \`exclude_on_by_branch_row_sets_exclude_branch_filter\`.

## Test plan

- [x] Replaced test + new exclude test green
- [x] Full crate: \`cargo test -p ainb-plugin-burndown --lib\` → 140 / 140
- [x] tmux walkthrough on real \`~/.claude/projects\` data:
  - Tab to ByBranch, Enter on \`HEAD\` row → \`Filters: branch=HEAD\` chip lights up, dashboard rebuckets ($17021 → $3209 cost, calls 30938 → 7174)
  - Tab to ByActivity, Enter on \`Conversation\` row → \`Filters: activity=Conversation\` chip
  - Tab to ByModel, Enter on \`claude-opus-4-7\` row → \`Filters: model=claude-opus-4-7\` chip