### PR TITLE
perf(plugin-burndown): Arc<UsageData> shared between plugin + ui

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -56,8 +56,12 @@ pub struct BurndownPlugin {
     /// CLI/event-driven tab switches.
     ui: UsageViewState,
     /// Most recent fully-assembled `UsageData` snapshot decoded from
-    /// `sessions.usage_data`.
-    data: Option<UsageData>,
+    /// `sessions.usage_data`. Stored as `Arc` so the per-Enter sync
+    /// into `ui.data` and the per-render snapshot copy are reference-
+    /// count bumps (`O(1)`) instead of full 30K-call deep clones. The
+    /// filter cache holds its own derived `Arc<UsageData>` keyed on
+    /// `(data_generation, inputs_hash)`.
+    data: Option<std::sync::Arc<UsageData>>,
     /// Accumulator for the in-flight chunked publish (if any). Reset
     /// on `chunk_index == 0`, appended-to on follow-on chunks,
     /// finalised + moved into `self.data` on `is_final = true`. See
@@ -394,7 +398,7 @@ impl BurndownPlugin {
 
         if event.is_final {
             if let Some(assembled) = self.pending.take() {
-                self.data = Some(wire_to_local(assembled));
+                self.data = Some(std::sync::Arc::new(wire_to_local(assembled)));
                 self.schema_mismatch = false;
                 // Real data has landed — the scan is done. Drop any
                 // lingering progress event so the UI flips from
@@ -772,6 +776,8 @@ impl BurndownPlugin {
                 // (the render path copies it into `ui.data` only at
                 // render time), so without this sync the commit
                 // would silently return false — drill-down dead.
+                // Now that `self.data` is `Arc<UsageData>`, the sync
+                // is an `Arc::clone` (refcount bump), not a deep copy.
                 self.ui.data = self.data.clone();
                 let _ = self.ui.commit_focused_row();
             }
@@ -945,7 +951,7 @@ mod handle_key_dispatch_tests {
         }];
         // Plugin-level snapshot ONLY — leave self.ui.data as None to
         // mirror the production state right after `apply_chunk_pure`.
-        p.data = Some(data);
+        p.data = Some(std::sync::Arc::new(data));
         p.ui.data = None;
         p.ui.focused_panel = Some(UsagePanel::ByBranch);
         p.ui.focus_row = 0;

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -283,7 +283,13 @@ pub enum UsageFilterTarget {
 pub struct UsageViewState {
     pub provider: UsageProvider,
     pub active_tab: UsageTab,
-    pub data: Option<UsageData>,
+    /// Most-recent parsed usage snapshot. Held as `Arc` so the plugin
+    /// can share the same instance across `ui.data` and the cached
+    /// filter results without paying a 30K-call clone on every Enter
+    /// keypress (drill-down) or render-snapshot copy. Reads deref to
+    /// `&UsageData` transparently; writes wrap in `Arc::new` or clone
+    /// an existing `Arc` (refcount bump, not a deep copy).
+    pub data: Option<std::sync::Arc<UsageData>>,
     pub loading: bool,
     pub scroll_offset: usize,
     pub period: UsagePeriod,
@@ -4301,7 +4307,7 @@ mod cross_filter_tests {
     #[test]
     fn enter_on_by_project_row_sets_project_filter() {
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         // Fixture uses pre-aggregated projects/sessions with `calls: vec![]`,
         // so re-aggregation via the period filter would zero out the rows.
         // Bypass period filtering — this test is about Enter→chip dispatch.
@@ -4315,7 +4321,7 @@ mod cross_filter_tests {
     #[test]
     fn enter_on_top_session_row_sets_session_filter() {
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::TopSessions);
         state.focus_row = 0;
@@ -4351,7 +4357,7 @@ mod cross_filter_tests {
         data.sessions = vec![session_alpha, session_beta];
 
         let mut state = UsageViewState::default();
-        state.data = Some(data);
+        state.data = Some(std::sync::Arc::new(data));
         state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::TopSessions);
         state.focus_row = 0;
@@ -4370,7 +4376,7 @@ mod cross_filter_tests {
     #[test]
     fn enter_on_by_model_row_sets_model_filter() {
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByModel);
         state.focus_row = 0;
@@ -4381,7 +4387,7 @@ mod cross_filter_tests {
     #[test]
     fn enter_on_by_activity_row_sets_activity_filter() {
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByActivity);
         state.focus_row = 1; // Conversation
@@ -4393,7 +4399,7 @@ mod cross_filter_tests {
     fn enter_on_daily_activity_row_is_noop() {
         // Brief: read-only panels — Enter is a no-op.
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         state.focused_panel = Some(UsagePanel::DailyActivity);
         state.focus_row = 0;
         assert!(!state.commit_focused_row());
@@ -4441,7 +4447,7 @@ mod cross_filter_tests {
             },
         ];
         let mut state = UsageViewState::default();
-        state.data = Some(data);
+        state.data = Some(std::sync::Arc::new(data));
         state.focused_panel = Some(UsagePanel::ByBranch);
         state.focus_row = 0;
         // Bypass period filtering — this test is about Enter→chip dispatch.
@@ -4460,7 +4466,7 @@ mod cross_filter_tests {
             bucket: bucket(3),
         }];
         let mut state = UsageViewState::default();
-        state.data = Some(data);
+        state.data = Some(std::sync::Arc::new(data));
         state.focused_panel = Some(UsagePanel::ByBranch);
         state.focus_row = 0;
         state.period = UsagePeriod::All;
@@ -4507,7 +4513,7 @@ mod cross_filter_tests {
     #[test]
     fn enter_on_leaderboard_maps_to_project_filter() {
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::Leaderboard);
         state.focus_row = 0; // alpha (rendered from filtered_data.projects)
@@ -4588,7 +4594,7 @@ mod cross_filter_tests {
         use std::collections::HashMap;
 
         let mut state = UsageViewState::default();
-        state.data = Some(fixture());
+        state.data = Some(std::sync::Arc::new(fixture()));
         state.period = UsagePeriod::All;
         state.focused_panel = Some(UsagePanel::ByProject);
         state.focus_row = 1; // beta


### PR DESCRIPTION
## Summary

Eliminates the 30K-call deep clone on every drill-down keypress and every render snapshot copy.

\`BurndownPlugin.data\` and \`UsageViewState.data\` were both \`Option<UsageData>\`, so the Enter handler's \`self.ui.data = self.data.clone()\` (added in PR C to fix the silent no-op drill-down) was paying a full deep-clone of every \`ProviderCall\`. Wrap both in \`Arc<UsageData>\` — clone is a refcount bump now.

## Changes

- \`BurndownPlugin.data\`: \`Option<UsageData>\` → \`Option<Arc<UsageData>>\`
- \`UsageViewState.data\`: same
- \`apply_chunk_pure\` wraps the freshly-built local snapshot in \`Arc::new\` before assigning
- Read sites unchanged — \`Arc<T>: Deref<Target = T>\` carries \`&UsageData\` through transparently
- Tests that assigned \`state.data = Some(fixture())\` now wrap in \`Arc::new\`

## Test plan

- [x] 150 / 150 unit tests
- [x] tmux walkthrough — drill into shotclubhouse still rebuckets correctly (\$14170 → \$5392, 24849 → 9490 calls / 1 project)