### PR TITLE
feat(plugin-burndown): flash `↻ updated` chip-strip badge on pivot recompute

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -107,12 +107,12 @@ pub struct BurndownPlugin {
     /// with `filter_cache` on each new ingest.
     indices: Option<crate::data::usage::UsageIndices>,
     /// Monotonic counter bumped every time `cached_filtered` runs an
-    /// actual recompute (cache miss). Pairs with `displayed_pivot_seq`
-    /// in the render snapshot so the chip strip can flash a brief
-    /// `↻ updated` badge on the first render frame after a pivot
-    /// lands — confirming to the user that their drill-down was
-    /// applied even when the wall-clock compute was fast enough that
-    /// the only visible change is a few panel numbers.
+    /// actual recompute (cache miss). The render path snapshots this
+    /// before/after calling `cached_filtered`; a delta means the chip
+    /// strip should flash a brief `↻ updated` badge — confirming to
+    /// the user that their drill-down was applied even when the
+    /// wall-clock compute was fast enough that the only visible
+    /// change is a few panel numbers.
     pivot_seq: u64,
 }
 
@@ -503,10 +503,11 @@ impl BurndownPlugin {
             filtered: filtered.clone(),
         });
         // Mark this render as the one that landed a fresh pivot. The
-        // render path snapshots this into the UI state and renders the
+        // render path snapshots `pivot_seq` before/after this call and
+        // sets `ui.fresh_pivot` when the seq advanced — driving the
         // `↻ updated` chip-strip badge on the first frame after a
-        // cache miss; subsequent idle frames see the same value and
-        // suppress the badge via the `displayed_pivot_seq` compare.
+        // cache miss. Idle frames hit the cache, skip this bump, and
+        // suppress the badge naturally.
         self.pivot_seq = self.pivot_seq.wrapping_add(1);
         Some(filtered)
     }
@@ -1166,6 +1167,63 @@ mod chunk_accumulator_tests {
         assert!(
             p.scan_progress.is_none(),
             "scan_progress must clear on finalise so the skeleton goes away"
+        );
+    }
+}
+
+#[cfg(test)]
+mod pivot_seq_tests {
+    //! Cover the `pivot_seq` ↔ `fresh_pivot` contract: the seq must bump
+    //! exactly once per `cached_filtered` cache miss, and not bump at
+    //! all on cache hits or no-op (every filter at default) paths. The
+    //! render path's snapshot-before/after compare relies on this to
+    //! decide when to flash the `↻ updated` chip-strip badge.
+    use super::*;
+    use crate::data::usage::{
+        BranchUsage, TokenBucket, UsageData, UsagePeriod,
+    };
+
+    fn plugin_with_one_branch() -> BurndownPlugin {
+        let mut p = BurndownPlugin::default();
+        let mut data = UsageData::default();
+        data.branches = vec![BranchUsage {
+            branch: "main".to_string(),
+            bucket: TokenBucket::default(),
+        }];
+        p.data = Some(std::sync::Arc::new(data));
+        // Period::All bypasses the period predicate so the filter
+        // pass is purely the chip dimension under test.
+        p.ui.period = UsagePeriod::All;
+        p
+    }
+
+    #[test]
+    fn cached_filtered_bumps_seq_on_cache_miss_only() {
+        let mut p = plugin_with_one_branch();
+        let g0 = p.pivot_seq;
+
+        // No active filter, period=All, provider=All → no-op fast path
+        // returns None and must NOT bump the seq.
+        assert!(p.cached_filtered().is_none());
+        assert_eq!(p.pivot_seq, g0, "no-op path must not bump pivot_seq");
+
+        // Activate a chip → cache miss → seq bumps exactly once.
+        p.ui.filters.branch.push("main".to_string());
+        let _ = p.cached_filtered();
+        assert_eq!(p.pivot_seq, g0 + 1, "cache miss must bump pivot_seq by 1");
+
+        // Repeat the same call → cache hit → seq must NOT bump.
+        let _ = p.cached_filtered();
+        assert_eq!(p.pivot_seq, g0 + 1, "cache hit must not bump pivot_seq");
+
+        // Change the filter → cache miss again → seq bumps once more.
+        p.ui.filters.branch.clear();
+        p.ui.filters.branch.push("feature".to_string());
+        let _ = p.cached_filtered();
+        assert_eq!(
+            p.pivot_seq,
+            g0 + 2,
+            "second cache miss must bump pivot_seq again"
         );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -106,6 +106,14 @@ pub struct BurndownPlugin {
     /// model / branch / activity chip is active. Cleared in lockstep
     /// with `filter_cache` on each new ingest.
     indices: Option<crate::data::usage::UsageIndices>,
+    /// Monotonic counter bumped every time `cached_filtered` runs an
+    /// actual recompute (cache miss). Pairs with `displayed_pivot_seq`
+    /// in the render snapshot so the chip strip can flash a brief
+    /// `↻ updated` badge on the first render frame after a pivot
+    /// lands — confirming to the user that their drill-down was
+    /// applied even when the wall-clock compute was fast enough that
+    /// the only visible change is a few panel numbers.
+    pivot_seq: u64,
 }
 
 /// One-deep filter-cache slot. A single entry is enough because
@@ -239,6 +247,7 @@ impl Plugin for BurndownPlugin {
             // in this order lets `cached_filtered()` mutate
             // `self.filter_cache` without colliding with the later
             // immutable read of `self.ui` and `self.data`.
+            let pivot_seq_before = self.pivot_seq;
             let cached_filtered = self.cached_filtered();
             // Snapshot the UI state so we can paint without holding a
             // mutable borrow on `self` for the whole call.
@@ -246,6 +255,11 @@ impl Plugin for BurndownPlugin {
             ui.data = self.data.clone();
             ui.scan_progress = self.scan_progress.clone();
             ui.cached_filtered = cached_filtered;
+            // True iff `cached_filtered` ran an actual recompute this
+            // frame (cache miss). The chip strip uses this to flash a
+            // brief `↻ updated` badge so the user sees confirmation
+            // their pivot landed.
+            ui.fresh_pivot = self.pivot_seq != pivot_seq_before;
             render_ui(&mut rbuf, area, &ui);
         }
         Ok(buffer_to_wire(&rbuf, area))
@@ -488,6 +502,12 @@ impl BurndownPlugin {
             inputs_hash: key.1,
             filtered: filtered.clone(),
         });
+        // Mark this render as the one that landed a fresh pivot. The
+        // render path snapshots this into the UI state and renders the
+        // `↻ updated` chip-strip badge on the first frame after a
+        // cache miss; subsequent idle frames see the same value and
+        // suppress the badge via the `displayed_pivot_seq` compare.
+        self.pivot_seq = self.pivot_seq.wrapping_add(1);
         Some(filtered)
     }
 

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -290,6 +290,12 @@ pub struct UsageViewState {
     /// `&UsageData` transparently; writes wrap in `Arc::new` or clone
     /// an existing `Arc` (refcount bump, not a deep copy).
     pub data: Option<std::sync::Arc<UsageData>>,
+    /// True for the single render frame immediately after
+    /// `cached_filtered` did a real recompute (cache miss). Set by the
+    /// plugin's render snapshot — not persisted between frames. The
+    /// chip strip renders a brief `↻ updated` badge while this is on,
+    /// giving the user a visual confirmation that their pivot landed.
+    pub fresh_pivot: bool,
     pub loading: bool,
     pub scroll_offset: usize,
     pub period: UsagePeriod,
@@ -354,6 +360,7 @@ impl Default for UsageViewState {
             provider: UsageProvider::Claude,
             active_tab: UsageTab::Burndown,
             data: None,
+            fresh_pivot: false,
             loading: false,
             scroll_offset: 0,
             period: UsagePeriod::Week,
@@ -2800,6 +2807,12 @@ fn render_period_row(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
 /// Build the chip strip line shown directly under the period+provider
 /// strip. Active chips render as `[label=value]` in GOLD; with no
 /// chips, an instruction hint is shown so users discover the pivot.
+///
+/// When `state.fresh_pivot` is true (set by the plugin's render path on
+/// the single frame after a cache miss), a brief `↻ updated` badge is
+/// appended in `SELECTION_GREEN` so the user sees confirmation their
+/// chip pivot landed even when the wall-clock compute was too fast to
+/// feel like a wait.
 pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
     let mut spans: Vec<Span<'static>> =
         vec![Span::styled("Filters: ", Style::default().fg(MUTED_GRAY))];
@@ -2808,6 +2821,9 @@ pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
             "(none)",
             Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
         ));
+        if state.fresh_pivot {
+            push_fresh_pivot_badge(&mut spans);
+        }
         return Line::from(spans);
     }
     push_chip_group(&mut spans, "project", &state.filters.project);
@@ -2834,7 +2850,23 @@ pub fn build_filter_chip_line(state: &UsageViewState) -> Line<'static> {
         Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
     ));
     spans.push(Span::styled(" clear all", Style::default().fg(MUTED_GRAY)));
+    if state.fresh_pivot {
+        push_fresh_pivot_badge(&mut spans);
+    }
     Line::from(spans)
+}
+
+/// Append the fresh-pivot badge to the chip strip. Rendered in green
+/// to visually distinguish from the gold chip group — the eye reads
+/// it as "I just did the thing" rather than another filter state.
+fn push_fresh_pivot_badge(spans: &mut Vec<Span<'static>>) {
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(
+        "↻ updated",
+        Style::default()
+            .fg(SELECTION_GREEN)
+            .add_modifier(Modifier::BOLD),
+    ));
 }
 
 fn push_chip_group(spans: &mut Vec<Span<'static>>, label: &str, values: &[String]) {
@@ -4585,6 +4617,37 @@ mod cross_filter_tests {
         ] {
             assert!(flat.contains(needle), "chip strip missing {needle}: {flat}");
         }
+    }
+
+    /// The `↻ updated` badge renders only when the plugin's render
+    /// snapshot has flagged this frame as a fresh-pivot frame.
+    #[test]
+    fn chip_strip_shows_fresh_pivot_badge_when_flag_set() {
+        let mut state = UsageViewState::default();
+        state.filters.project.push("p".into());
+
+        state.fresh_pivot = false;
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(!flat.contains("↻ updated"), "badge must hide when flag is off: {flat}");
+
+        state.fresh_pivot = true;
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("↻ updated"), "badge must show when flag is on: {flat}");
+    }
+
+    /// Same indicator visibility applies on the no-chip path so the
+    /// user gets confirmation even when they clear chips back to
+    /// `(none)` — that's still a pivot that recomputed.
+    #[test]
+    fn chip_strip_shows_fresh_pivot_badge_with_no_chips() {
+        let mut state = UsageViewState::default();
+        state.fresh_pivot = true;
+        let line = build_filter_chip_line(&state);
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("(none)"), "got {flat}");
+        assert!(flat.contains("↻ updated"), "got {flat}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a green `↻ updated` badge to the chip strip on any render frame where `cached_filtered` actually recomputed (cache miss).
- PRs E (dimension indices) + F (Arc<UsageData>) made pivots sub-millisecond — visible confirmation now matters because the wall-clock pause vanished.
- Badge clears naturally on next render (any key/event/resize) because that render hits the cache.

## Mechanism

```
plugin.rs
  pivot_seq: u64 (bumped inside cached_filtered on cache-miss path)
  render() snapshots pivot_seq before/after calling cached_filtered
  ui.fresh_pivot = (pivot_seq != pivot_seq_before)

ui.rs
  UsageViewState::fresh_pivot: bool
  build_filter_chip_line appends `↻ updated` (SELECTION_GREEN, bold) when flag set
```

No host APIs added, no plugin→host wake call needed — relies on the host's existing dirty-flag render kick.

## Test plan
- [x] `cargo test -p ainb-plugin-burndown --lib` — 152 passing, +2 new (`chip_strip_shows_fresh_pivot_badge_*`).
- [x] `cargo test -p ainb --test tripwire_burndown_keys` — existing tripwire still passes (no regressions in key handling).
- [x] Live tmux drive:
  - Press period `3` → `↻ updated` appears.
  - Press `Tab` (focus change, cache hit) → badge clears.
  - Re-press `3` (cache hit) → no badge.