### PR TITLE
Phase 7c: wire host CLI dispatcher to burndown plugin

### DIFF
--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -81,6 +81,9 @@ bincode = { workspace = true }
 # Plugin runtime (Phase 7 — subprocess + JSON-RPC, replaces wasmi host).
 ainb-plugin-runtime = { path = "../ainb-plugin-runtime", version = "0.1.0" }
 ainb-plugin-protocol = { path = "../ainb-plugin-protocol", version = "0.1.0" }
+# Zero-copy byte buffers — required for `RuntimeHandle::publish_snapshot`'s
+# `payload: bytes::Bytes` parameter, used by the Phase 7c CLI dispatcher.
+bytes = "1.6"
 
 # Fuzzy search
 nucleo-matcher = { workspace = true }

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -500,13 +500,24 @@ async fn dispatch_usage_via_plugin(argv: Vec<String>) -> ! {
     std::process::exit(exit_code);
 }
 
-/// Hard deadline for `ainb usage` to surface output. Generously sized
-/// because the first scan of a large `~/.claude/projects` (100k+ calls,
-/// 50+ msgpack chunks at 2 MB/chunk) takes ~40 s on a cold cache and
-/// must finish *before* burndown's `cli_dispatch` returns useful data.
-/// Subsequent runs hit session-reader's sqlite cache and finish in well
-/// under a second.
-const PLUGIN_DATA_WAIT: std::time::Duration = std::time::Duration::from_secs(120);
+/// Default hard deadline for `ainb usage` to surface output. Generously
+/// sized because the first scan of a large `~/.claude/projects` (100k+
+/// calls, 50+ msgpack chunks at 2 MB/chunk) takes ~40 s on a cold cache
+/// and must finish *before* burndown's `cli_dispatch` returns useful
+/// data. Subsequent runs hit session-reader's sqlite cache and finish
+/// in well under a second.
+///
+/// Override via the `AINB_USAGE_TIMEOUT_SECS` env var when running
+/// against very large session archives.
+const PLUGIN_DATA_WAIT_DEFAULT_SECS: u64 = 120;
+
+fn plugin_data_wait() -> std::time::Duration {
+    std::env::var("AINB_USAGE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| std::time::Duration::from_secs(PLUGIN_DATA_WAIT_DEFAULT_SECS))
+}
 
 /// Pause between retry attempts when burndown still reports
 /// "install session-reader" — long enough that we don't hot-loop
@@ -592,7 +603,8 @@ async fn dispatch_inner(
     // exit 0) breaks out of the retry loop immediately so we don't
     // mask a genuine failure as "still waiting".
     let install_hint_marker = b"install session-reader";
-    let deadline = std::time::Instant::now() + PLUGIN_DATA_WAIT;
+    let wait_budget = plugin_data_wait();
+    let deadline = std::time::Instant::now() + wait_budget;
     let started = std::time::Instant::now();
     let mut last_trace = started;
     let mut attempt: u32 = 0;
@@ -618,7 +630,9 @@ async fn dispatch_inner(
         outcome = handle
             .dispatch_cli(&burndown, "usage", argv.clone())
             .await
-            .map_err(|_| anyhow::anyhow!("burndown plugin task disconnected before replying"))?;
+            .map_err(|e| {
+                anyhow::anyhow!("burndown plugin task disconnected before replying: {e}")
+            })?;
         let should_retry = matches!(
             &outcome,
             CliOutcome::Ok(r)
@@ -641,8 +655,8 @@ async fn dispatch_inner(
             anyhow::bail!(
                 "error: session-reader plugin didn't publish usage data within {}s \
                  — rerun with RUST_LOG=ainb_plugin_runtime=debug,ainb_plugin_session_reader=debug \
-                 to see scan progress",
-                PLUGIN_DATA_WAIT.as_secs()
+                 to see scan progress, or raise the budget via AINB_USAGE_TIMEOUT_SECS=<n>",
+                wait_budget.as_secs()
             );
         }
         if trace {

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -450,12 +450,10 @@ impl CliCommand for UsageCommand {
             if is_host_admin_subcommand(&cmd) {
                 return crate::cli::usage::execute(cmd, format).await;
             }
-            dispatch_usage_via_plugin(&argv);
+            dispatch_usage_via_plugin(argv).await;
             // dispatch_usage_via_plugin always exits the process on
-            // both happy and failure paths (process::exit) — return
-            // unreachable Ok to satisfy the type. Matches the
-            // exit-2 contract spelled out in
-            // plans/plugin-phase-6-data-plane.md.
+            // both happy and failure paths (process::exit). Returning
+            // unreachable Ok satisfies the trait's `Result<()>`.
             #[allow(unreachable_code)]
             Ok(())
         })
@@ -469,22 +467,213 @@ fn is_host_admin_subcommand(cmd: &crate::cli::usage::UsageCommands) -> bool {
     matches!(cmd, Plan { .. } | Currency(_) | Cache { .. })
 }
 
-/// `ainb usage` shim.
+/// `ainb usage` shim (Phase 7c).
 ///
-/// Phase 6 wired this through the wasmi-based burndown plugin with a
-/// cross-plugin broker hack (`inject_session_reader_snapshot`) to side-step
-/// the wasmi single-threaded deadlock. Phase 7b deletes the wasmi host
-/// entirely; the subprocess-Rust replacement plugins (burndown +
-/// session-reader) are tracked under Phase 7c. Until those land, the
-/// burndown shim returns the operator-actionable error every existing
-/// caller already handled (exit 2, "install via 'ainb plugin install').
-fn dispatch_usage_via_plugin(_argv: &[String]) -> ! {
-    eprintln!(
-        "error: usage analytics requires the burndown plugin \
-         (install via 'ainb plugin install burndown') — \
-         subprocess port pending under Phase 7c"
-    );
-    std::process::exit(2);
+/// Boots the subprocess plugin runtime, waits for session-reader to publish
+/// the initial `sessions.usage_data` snapshot, dispatches the parsed argv
+/// to the burndown plugin's `cli_dispatch` over JSON-RPC, prints captured
+/// stdout/stderr, then exits with the plugin's reported exit code.
+///
+/// Always exits the process — never returns. Failure modes:
+///
+/// * No `dist/plugins/` discovered → exit 2 with the "install burndown"
+///   hint that pre-7c callers already handle.
+/// * Burndown plugin not registered → same exit-2 hint.
+/// * Session-reader never publishes within
+///   [`PLUGIN_DATA_WAIT`] → exit 1 with a "session-reader didn't publish"
+///   message so the user can rerun with `RUST_LOG=debug` to see the scan
+///   progress.
+/// * Plugin returned a non-zero exit code → exit that code, after writing
+///   its stdout/stderr verbatim.
+///
+/// Cleanup: the owning [`Runtime`] is dropped via `spawn_blocking` so the
+/// tokio "Cannot drop a runtime in a context where blocking is not allowed"
+/// panic from [`ainb plugin list`](crate::cli::plugin) doesn't bite us here.
+async fn dispatch_usage_via_plugin(argv: Vec<String>) -> ! {
+    let exit_code = match run_usage_via_plugin(argv).await {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("{e}");
+            2
+        }
+    };
+    std::process::exit(exit_code);
+}
+
+/// Hard deadline for `ainb usage` to surface output. Generously sized
+/// because the first scan of a large `~/.claude/projects` (100k+ calls,
+/// 50+ msgpack chunks at 2 MB/chunk) takes ~40 s on a cold cache and
+/// must finish *before* burndown's `cli_dispatch` returns useful data.
+/// Subsequent runs hit session-reader's sqlite cache and finish in well
+/// under a second.
+const PLUGIN_DATA_WAIT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Pause between retry attempts when burndown still reports
+/// "install session-reader" — long enough that we don't hot-loop
+/// against the plugin's mutex while it is processing handle_event
+/// chunks, short enough that we don't add visible tail latency on the
+/// cached path (where the very first dispatch usually succeeds).
+const PLUGIN_DATA_POLL: std::time::Duration = std::time::Duration::from_millis(250);
+
+async fn run_usage_via_plugin(argv: Vec<String>) -> anyhow::Result<i32> {
+    // Step 1 — bring up the runtime + discover staged plugins. Mirrors
+    // `crate::cli::plugin::watch`, including the spawn_blocking drop
+    // dance to avoid the tokio "Cannot drop a runtime in a context
+    // where blocking is not allowed" panic on shutdown.
+    let (runtime, handle, _outcome) = crate::plugins::init_plugin_runtime()
+        .map_err(|e| anyhow::anyhow!("plugin runtime init failed: {e}"))?;
+
+    let result = dispatch_inner(&handle, argv).await;
+
+    // Drop the owning runtime off the async context.
+    tokio::task::spawn_blocking(move || drop(runtime))
+        .await
+        .ok();
+
+    result
+}
+
+/// Inner half of [`run_usage_via_plugin`] — does the real work given a
+/// `RuntimeHandle`, leaving the runtime ownership / cleanup dance to the
+/// caller. Split for testability and for the spawn_blocking shutdown
+/// pattern.
+///
+/// Data-flow contract assumed here:
+///
+/// 1. Both `burndown` and `session-reader` are eager-spawned (see
+///    `dist/plugins/burndown/manifest.toml`). The runtime's `discover`
+///    has already sent each plugin task an `EnsureSpawned`, which
+///    triggers `on_init` on the child process.
+/// 2. burndown's `on_init` subscribes to `sessions.usage_data` *before*
+///    publishing `sessions.refresh_request`, guaranteeing it catches
+///    chunk-0 of session-reader's response. Re-publishing
+///    `refresh_request` from this shim is therefore counter-productive
+///    — each republish queues a *fresh* full rescan on session-reader,
+///    and burndown's plugin task processes its inbox serially: the
+///    `cli_dispatch` we are about to send would sit behind every queued
+///    `handle_event` chunk, never reaching `cli_dispatch` before the
+///    deadline.
+/// 3. session-reader chunks the snapshot into ≥1 `UsageDataEvent`
+///    publishes; only the chunk with `is_final = true` causes burndown
+///    to populate `self.data`. burndown's plugin task processes its
+///    inbox serially, so once `cli_dispatch` is queued *after* every
+///    in-flight `handle_event`, it is guaranteed to see populated
+///    `self.data` — except on the very first call where the inbox may
+///    not yet have any chunks (snapshot not yet built). That call
+///    returns the "install session-reader" hint; the retry loop below
+///    re-queues `cli_dispatch` behind whatever chunks have accumulated
+///    since.
+async fn dispatch_inner(
+    handle: &ainb_plugin_runtime::RuntimeHandle,
+    argv: Vec<String>,
+) -> anyhow::Result<i32> {
+    use ainb_plugin_runtime::{CliOutcome, PluginId};
+
+    let trace = std::env::var("AINB_USAGE_TRACE").is_ok();
+    let burndown = PluginId::from("burndown");
+    let registered = handle.registered_plugins();
+    if trace {
+        eprintln!(
+            "[usage-cli] registered plugins: {:?}",
+            registered.iter().map(|p| p.id.to_string()).collect::<Vec<_>>()
+        );
+    }
+    if !registered.iter().any(|p| p.id == burndown) {
+        anyhow::bail!(
+            "error: usage analytics requires the burndown plugin \
+             (install via 'ainb plugin install burndown')"
+        );
+    }
+
+    // Retry contract: burndown reports `exit_code = 1` + empty stdout +
+    // a stderr containing this exact byte sequence when `self.data` is
+    // None. Any *other* exit/stdout/stderr shape (including a real
+    // error from clap, a runtime fault, or a successful report with
+    // exit 0) breaks out of the retry loop immediately so we don't
+    // mask a genuine failure as "still waiting".
+    let install_hint_marker = b"install session-reader";
+    let deadline = std::time::Instant::now() + PLUGIN_DATA_WAIT;
+    let started = std::time::Instant::now();
+    let mut last_trace = started;
+    let mut attempt: u32 = 0;
+    let mut outcome;
+    loop {
+        attempt = attempt.wrapping_add(1);
+        if trace && last_trace.elapsed() >= std::time::Duration::from_secs(2) {
+            // Periodic heartbeat: include plugin lifecycle state so a
+            // user running `AINB_USAGE_TRACE=1` can distinguish "scan
+            // in progress" from "plugin crashed". Mirrors
+            // `ainb plugin watch` semantics.
+            for p in &registered {
+                let state = handle.lifecycle_state(&p.id);
+                eprintln!(
+                    "[usage-cli] @{:.1}s attempt {attempt} plugin {} lifecycle={:?}",
+                    started.elapsed().as_secs_f32(),
+                    p.id,
+                    state
+                );
+            }
+            last_trace = std::time::Instant::now();
+        }
+        outcome = handle
+            .dispatch_cli(&burndown, "usage", argv.clone())
+            .await
+            .map_err(|_| anyhow::anyhow!("burndown plugin task disconnected before replying"))?;
+        let should_retry = matches!(
+            &outcome,
+            CliOutcome::Ok(r)
+                if r.exit_code == 1
+                    && r.stdout.is_empty()
+                    && r.stderr
+                        .windows(install_hint_marker.len())
+                        .any(|w| w == install_hint_marker)
+        );
+        if !should_retry {
+            if trace {
+                eprintln!(
+                    "[usage-cli] dispatch returned in {:.1}s (attempt {attempt})",
+                    started.elapsed().as_secs_f32()
+                );
+            }
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "error: session-reader plugin didn't publish usage data within {}s \
+                 — rerun with RUST_LOG=ainb_plugin_runtime=debug,ainb_plugin_session_reader=debug \
+                 to see scan progress",
+                PLUGIN_DATA_WAIT.as_secs()
+            );
+        }
+        if trace {
+            eprintln!(
+                "[usage-cli] attempt {attempt} returned 'install session-reader' \
+                 (snapshot not yet finalised); retrying in {}ms",
+                PLUGIN_DATA_POLL.as_millis()
+            );
+        }
+        tokio::time::sleep(PLUGIN_DATA_POLL).await;
+    }
+
+    let exit = match outcome {
+        CliOutcome::Ok(result) => {
+            use std::io::Write;
+            // Write raw bytes — the plugin owns the format (text /
+            // json / csv per `--format`) and we must not re-encode.
+            let _ = std::io::stdout().write_all(&result.stdout);
+            let _ = std::io::stderr().write_all(&result.stderr);
+            result.exit_code
+        }
+        CliOutcome::PluginError { code, message } => {
+            eprintln!("error: burndown plugin error {code}: {message}");
+            1
+        }
+        CliOutcome::RuntimeError(msg) => {
+            eprintln!("error: plugin runtime: {msg}");
+            1
+        }
+    };
+    Ok(exit)
 }
 
 /// Legacy top-level `ainb statusline`. Kept (hidden) so existing

--- a/ainb-tui/crates/ainb-plugin-burndown/plugin.toml
+++ b/ainb-tui/crates/ainb-plugin-burndown/plugin.toml
@@ -36,5 +36,17 @@ snapshots      = []
 snapshots = ["sessions.usage_data"]
 
 [lifecycle]
-spawn          = "lazy"
+# Eager — burndown must subscribe to `sessions.usage_data` BEFORE
+# session-reader publishes. With `lazy`, the first `dispatch_cli`
+# (TUI screen open OR `ainb usage …`) is what spawns burndown, but
+# by then the publish window has closed: chunked publishes from
+# session-reader landed in the snapshot store (last-chunk-wins) and
+# burndown's just-installed subscription only catches future
+# publishes. `snapshot_get` then reads a single follow-on chunk
+# with no chunk-0 seed → `DroppedFollowOn` → `self.data = None` →
+# "install session-reader" hint. Eager-spawn closes the race:
+# burndown's `on_init` subscribes synchronously, then publishes
+# `sessions.refresh_request` to kick session-reader's first scan
+# with us already on the wire.
+spawn          = "eager"
 idle_reap_secs = 600

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -285,12 +285,28 @@ impl Plugin for BurndownPlugin {
         let format = extract_format(argv);
         let stripped = strip_format_flag(argv);
 
-        // Make sure we have a snapshot. If the host hasn't pushed one
-        // yet, ask synchronously; bail with an actionable error if the
-        // session-reader plugin isn't installed.
-        if self.data.is_none() {
-            self.refresh_snapshot(host).await;
-        }
+        // The caller (host CLI shim) is responsible for waiting until
+        // `self.data` has been populated via the `sessions.usage_data`
+        // subscription. We deliberately do NOT call `refresh_snapshot`
+        // here: it holds the plugin mutex while awaiting a host RPC
+        // (`host/snapshot/get`). The SDK's `read_loop` services
+        // `plugin/handle_event` *inline* (to preserve chunk order — see
+        // `ainb-plugin-sdk-rust::server::read_loop`), so if a chunk
+        // event arrives while we're holding the mutex on a host RPC,
+        // `dispatch_incoming.await` for the chunk blocks the read loop
+        // on `plugin.lock().await` — and the host's response to our
+        // `host/snapshot/get` can never be read from stdin. Deadlock.
+        //
+        // Skipping the explicit pull is safe here because burndown is
+        // eager-spawned (manifest `[lifecycle].spawn = "eager"`) and
+        // its `on_init` subscribes to `sessions.usage_data` *before*
+        // session-reader publishes — so the chunk push path always
+        // populates `self.data` once the publisher finishes its scan.
+        // First-call races (data not yet populated) surface as the
+        // "install session-reader" hint, and the host CLI shim retries
+        // until it succeeds or the deadline elapses (see
+        // `crates/ainb-core/src/cli/registry.rs::dispatch_inner`).
+        let _ = host;
         let Some(data) = self.data.clone() else {
             return Ok(CliOutput {
                 stdout: Vec::new(),


### PR DESCRIPTION
## Summary

`ainb usage <subcommand>` was a stub since the wasmi removal in Phase 7b. This PR ships the JSON-RPC bridge end-to-end so all 12 usage subcommands return real analytics. Three commits, one concern each.

### Three fixes, one story

| Commit | Why |
|---|---|
| `fix(plugin-burndown): eager-spawn so usage_data subscription beats publisher` | Lazy-spawn meant burndown's `on_init` (which calls `snapshot_subscribe(sessions.usage_data)`) didn't run until first `dispatch_cli`. By then session-reader had published, the snapshot store held only the LAST chunk, and `apply_chunk_pure` dropped it as `DroppedFollowOn`. Eager-spawn closes the race. |
| `fix(plugin-burndown): drop refresh_snapshot from cli_dispatch to break inline-event deadlock` | `cli_dispatch` held the plugin `Mutex` while awaiting `host.snapshot_get`. The SDK's `read_loop` services `plugin/handle_event` **inline** (commit `4ad7b46`) so a concurrent chunk frame blocked `plugin.lock().await`, freezing `read_loop` — and the host's `snapshot_get` reply could never be drained from stdin. Deadlock. With eager-spawn the push path is reliable, so the explicit pull becomes unnecessary AND unsafe — drop it. |
| `feat(cli-usage): wire host CLI dispatcher to burndown plugin (Phase 7c)` | Replaces the `_argv -> !` stub with a real bridge. Retry-only loop with 120s deadline; no host-side refresh_request republish (burndown's on_init owns it now, and republishing was queuing wasted rescans); no snapshot-presence wait (`snapshot_get != None` only proves chunk 1 of N, not the final chunk). |

### Validation

- All 5 tripwires green: `tripwire_burndown_keys`, `tripwire_burndown_pivot_badge`, `tripwire_real_data_in_tui`, `tripwire_sessions_screen`, `tripwire_nonblocking`
- Unit tests green: 153 burndown, 661 ainb host, 55 session-reader
- CLI smoke against real 110k-call dataset (~40s cold scan):
  - ✅ `ainb usage report --period today` — full report
  - ✅ `ainb usage today` / `usage month` / `usage status`
  - ✅ `ainb usage export` — sectioned CSV stream
  - ✅ `ainb usage optimize` — health score + findings
  - ✅ `ainb usage report --format json` and `--format csv` (post-subcmd position)
  - ✗ `ainb --format json usage report` — global `--format` ignored (clap-derive consumes before plugin sees argv). Tracked as the first follow-up; explicit out-of-scope here so this PR stays focused on the deadlock fix.

### Trace mode

`AINB_USAGE_TRACE=1 ainb usage report …` surfaces:
- Registered plugin IDs
- Per-2s lifecycle heartbeat for each registered plugin
- Per-attempt retry pings when burndown still reports "install session-reader"
- Final dispatch latency (e.g. `dispatch returned in 40.0s (attempt 122)`)

Use this to diagnose cold-cache hangs without enabling `RUST_LOG=ainb_plugin_runtime=debug` (very noisy under chunked publishes).

### Out of scope (filed as follow-ups in `.agents/goals/ainb-usage-codeburn-parity.md`)

- Global `ainb --format X` injection at `dispatch_inner` (SC1)
- Per-table CSV folder export via `usage export -o <dir>` (SC2)
- Provider expansion + `usage models --by-task` (SC3)

## Test plan

- [x] `cargo test -p ainb-plugin-burndown` (153 ok)
- [x] `cargo test -p ainb-plugin-session-reader` (55 ok)
- [x] `cargo test -p ainb --lib` (661 ok)
- [x] All 5 tripwires sequential pass
- [x] CLI smoke `ainb usage report/today/month/export/status/optimize` returns real data