### PR TITLE
feat(cli-usage): global --format works everywhere + markdown renderer (SC1)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -77,7 +77,7 @@ fn cmd_show(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize config as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             let toml_str =
                 toml::to_string_pretty(&config).context("Failed to serialize config as TOML")?;
             println!("{toml_str}");
@@ -101,7 +101,7 @@ fn cmd_get(key: &str, format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize value as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             print_toml_value(value);
         }
     }
@@ -186,7 +186,7 @@ fn cmd_path(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize config paths")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             let labels = ["Project config", "User config", "System config"];
 
             println!("Configuration file locations (highest precedence first):");

--- a/ainb-tui/crates/ainb-core/src/cli/favorites.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/favorites.rs
@@ -101,7 +101,7 @@ fn cmd_list(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize favorites as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             if sorted.is_empty() {
                 println!(
                     "No favorites yet. Add one with 'ainb favorites add <source> --alias <name>'."

--- a/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
@@ -118,7 +118,7 @@ fn cmd_worktrees(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize worktree entries")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             if entries.is_empty() {
                 println!("No managed worktrees found.");
                 return Ok(());
@@ -178,7 +178,7 @@ fn cmd_cleanup(force: bool, dry_run: bool, format: OutputFormat) -> Result<()> {
     if orphans.is_empty() {
         match format {
             OutputFormat::Json => println!("[]"),
-            OutputFormat::Text | OutputFormat::Csv => {
+            OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
                 println!("No orphaned worktrees to clean up.")
             }
         }
@@ -192,7 +192,7 @@ fn cmd_cleanup(force: bool, dry_run: bool, format: OutputFormat) -> Result<()> {
                     .context("Failed to serialize orphan entries")?;
                 println!("{json}");
             }
-            OutputFormat::Text | OutputFormat::Csv => {
+            OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
                 println!(
                     "Dry run - {} orphaned worktree(s) would be removed:",
                     orphans.len()
@@ -260,7 +260,7 @@ fn cmd_status(session: &str, format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize git status report")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             let short_id = short_session_id(&report.session_id);
             println!("Session: {} ({})", report.workspace_name, short_id);
             println!("Branch:  {}", report.branch);

--- a/ainb-tui/crates/ainb-core/src/cli/init.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/init.rs
@@ -228,7 +228,7 @@ fn cmd_check(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize prerequisite report")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => print_report_text(&report),
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => print_report_text(&report),
     }
 
     if !report.all_required_present {
@@ -302,7 +302,7 @@ fn cmd_setup(format: OutputFormat) -> Result<()> {
                 serde_json::to_string_pretty(&output).context("Failed to serialize output")?
             );
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             println!("Setup complete.");
             println!("  Base dir:    {}", base_dir.display());
             println!("  Config file: {}", config_path.display());
@@ -342,7 +342,7 @@ fn cmd_status(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize status report")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             println!("Onboarding status:");
             println!("{}", "\u{2501}".repeat(60));
             let marker = if report.completed {
@@ -393,7 +393,7 @@ fn cmd_reset(force: bool, format: OutputFormat) -> Result<()> {
                 });
                 println!("{}", serde_json::to_string_pretty(&out)?);
             }
-            OutputFormat::Text | OutputFormat::Csv => {
+            OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
                 println!("Nothing to reset: {} does not exist", base_dir.display());
             }
         }
@@ -426,7 +426,7 @@ fn cmd_reset(force: bool, format: OutputFormat) -> Result<()> {
             });
             println!("{}", serde_json::to_string_pretty(&out)?);
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             println!("Factory reset complete.");
             println!("  Removed: {}", base_dir.display());
         }

--- a/ainb-tui/crates/ainb-core/src/cli/list.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/list.rs
@@ -83,7 +83,7 @@ pub async fn execute(args: ListArgs, format: OutputFormat) -> Result<()> {
 
     match format {
         OutputFormat::Json => output_json(&sessions)?,
-        OutputFormat::Text | OutputFormat::Csv => output_text(&sessions),
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => output_text(&sessions),
     }
 
     Ok(())

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -93,6 +93,7 @@ pub enum OutputFormat {
     Text,
     Json,
     Csv,
+    Markdown,
 }
 
 /// Arguments for the run command

--- a/ainb-tui/crates/ainb-core/src/cli/plugin/lint.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/plugin/lint.rs
@@ -441,7 +441,7 @@ fn emit_report(report: &LintReport, format: OutputFormat) -> Result<()> {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(report)?);
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             let label = report
                 .plugin_name
                 .as_deref()

--- a/ainb-tui/crates/ainb-core/src/cli/plugin/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/plugin/mod.rs
@@ -106,7 +106,7 @@ fn list_installed(format: OutputFormat) -> Result<()> {
             let out = serde_json::json!({ "plugins": entries });
             println!("{}", serde_json::to_string_pretty(&out)?);
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             if plugins.is_empty() {
                 println!("(no plugins registered — install via 'ainb plugin install <name>')");
             } else {

--- a/ainb-tui/crates/ainb-core/src/cli/presets.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/presets.rs
@@ -98,7 +98,7 @@ fn cmd_list(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize presets as JSON")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             println!("Available presets:");
             println!("{}", "\u{2501}".repeat(60));
             for entry in &entries {
@@ -171,7 +171,7 @@ fn cmd_show(name: &str, format: OutputFormat) -> Result<()> {
             });
             println!("{}", serde_json::to_string_pretty(&wrapper)?);
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             println!("{}", format_preset_text(&preset, builtin));
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -308,7 +308,7 @@ fn execute_list(format: OutputFormat) -> Result<()> {
                 .context("Failed to serialize orphan list")?;
             println!("{json}");
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             if orphans.is_empty() {
                 println!("No orphaned sessions found. Everything looks clean.");
                 return Ok(());

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -439,11 +439,19 @@ impl CliCommand for UsageCommand {
         // We rebuild argv from `std::env::args()` rather than `matches`
         // (clap-derive doesn't have a `to_args`); clap has already
         // validated the args before dispatch lands here.
-        let argv: Vec<String> = std::env::args()
-            .skip_while(|a| a != "usage")
-            .skip(1)
-            .collect();
+        //
+        // Pre-pend `--format <value>` so the plugin sees the host's
+        // global `--format` flag — clap-derive strips global args from
+        // the residual argv before the subcommand sees them, which is
+        // why `ainb --format json usage report` would otherwise reach
+        // the plugin as `report` (no format flag) and render text.
+        // Subcommand-position `--format` (e.g. `ainb usage report
+        // --format json`) is preserved verbatim by `std::env::args`
+        // and the plugin's `extract_format` picks the last occurrence.
         let format = ctx.format;
+        let format_token = output_format_to_token(format);
+        let mut argv: Vec<String> = vec!["--format".to_string(), format_token.to_string()];
+        argv.extend(std::env::args().skip_while(|a| a != "usage").skip(1));
         let parsed = crate::cli::usage::UsageCommands::from_arg_matches(matches);
         Box::pin(async move {
             let cmd = parsed.map_err(anyhow::Error::from)?;
@@ -465,6 +473,21 @@ impl CliCommand for UsageCommand {
 fn is_host_admin_subcommand(cmd: &crate::cli::usage::UsageCommands) -> bool {
     use crate::cli::usage::UsageCommands::*;
     matches!(cmd, Plan { .. } | Currency(_) | Cache { .. })
+}
+
+/// Mirror of clap-derive's lowercased ValueEnum form so we can pass
+/// the host's `OutputFormat` back over argv without re-parsing it
+/// inside the plugin (the plugin reads `--format <token>` via its
+/// own lightweight `extract_format`, which matches on these tokens
+/// verbatim).
+fn output_format_to_token(format: crate::cli::OutputFormat) -> &'static str {
+    use crate::cli::OutputFormat::*;
+    match format {
+        Text => "text",
+        Json => "json",
+        Csv => "csv",
+        Markdown => "markdown",
+    }
 }
 
 /// `ainb usage` shim (Phase 7c).

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -73,7 +73,7 @@ pub async fn execute(args: StatusArgs, format: OutputFormat) -> Result<()> {
                 serde_json::to_string_pretty(&output).context("Failed to serialize status")?
             );
         }
-        OutputFormat::Text | OutputFormat::Csv => {
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             let status_text = if is_running {
                 if claude_active {
                     "\x1b[32m●\x1b[0m Running (Claude active)"

--- a/ainb-tui/crates/ainb-core/tests/tripwire_usage_cli_format.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_usage_cli_format.rs
@@ -1,0 +1,221 @@
+//! Tripwire SC1: `ainb usage report --format X` produces the requested
+//! output shape in BOTH argv positions — pre-subcommand (global) and
+//! post-subcommand (positional).
+//!
+//! Catches the bug class where clap-derive consumes the host's global
+//! `--format` arg before the residual argv reaches the burndown plugin,
+//! so `ainb --format json usage report` would silently render text.
+//! Pairs with the argv injection in
+//! `crates/ainb-core/src/cli/registry.rs::dispatch_inner`.
+//!
+//! Four formats × two positions = eight invocations. Each invocation
+//! asserts on a single distinctive byte sequence that proves the
+//! requested format reached the renderer:
+//!
+//! | Format    | Distinctive marker             |
+//! |-----------|--------------------------------|
+//! | text      | "Usage Report" + no JSON brace |
+//! | json      | leading `{` + `"activities"`   |
+//! | csv       | `section,metric,value` header  |
+//! | markdown  | `# Usage Report` h1            |
+//!
+//! Skips gracefully when `dist/plugins/{burndown,session-reader}` aren't
+//! staged so fresh checkouts don't fail the suite. Requires real
+//! `~/.claude/projects` data to exist (or seeded synthetic data) — the
+//! plugin emits format-correct output even with zero data, just without
+//! populated table rows.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+/// Walk up from the ainb binary looking for the `dist/plugins/` staging
+/// dir. Mirrors `tripwire_real_data_in_tui::plugins_staged` so the test
+/// skips cleanly on fresh checkouts.
+fn plugins_staged() -> Option<PathBuf> {
+    let bin = ainb_bin();
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate
+                .join("session-reader")
+                .join("session-reader")
+                .exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).unwrap();
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).unwrap();
+
+    // Seed a synthetic claude session so session-reader publishes
+    // non-empty usage data. Empty roots are also valid (the plugin
+    // still emits a format-correct skeleton) but populated data
+    // exercises the same renderer path the user runs daily.
+    let proj_dir = home
+        .join(".claude")
+        .join("projects")
+        .join("-tripwire-fixture-project");
+    fs::create_dir_all(&proj_dir).unwrap();
+    let session_jsonl = r#"{"type":"assistant","timestamp":"2026-05-10T12:00:00.000Z","sessionId":"fixture-session-1","cwd":"/tmp/x","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#;
+    fs::write(
+        proj_dir.join("fixture-session-1.jsonl"),
+        session_jsonl,
+    )
+    .unwrap();
+}
+
+/// Invoke `ainb usage report --period today` with the requested format
+/// in either the pre- or post-subcommand position. Returns stdout as
+/// a String. Panics on non-zero exit so the caller can write tight
+/// positive assertions on the body.
+fn run_usage_report(plugin_root: &Path, home: &Path, format: &str, pre_position: bool) -> String {
+    let ainb = ainb_bin();
+    let mut cmd = Command::new(&ainb);
+    cmd.env("HOME", home)
+        .env("AINB_PLUGIN_ROOT", plugin_root);
+    if pre_position {
+        cmd.args(["--format", format, "usage", "report", "--period", "today"]);
+    } else {
+        cmd.args(["usage", "report", "--period", "today", "--format", format]);
+    }
+    let out = cmd.output().expect("ainb spawn");
+    assert!(
+        out.status.success(),
+        "ainb usage report --format {format} ({}position) failed: exit={:?}\nstderr:\n{}",
+        if pre_position { "pre-" } else { "post-" },
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn usage_report_format_text_both_positions() {
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!("SKIP: dist/plugins/{{burndown,session-reader}} not staged");
+        return;
+    };
+    let home = tempfile::tempdir().unwrap();
+    seed_isolated_home(home.path());
+
+    for pre in [true, false] {
+        let out = run_usage_report(&plugin_root, home.path(), "text", pre);
+        assert!(
+            out.contains("Usage Report"),
+            "text format ({}): missing 'Usage Report' header:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+        assert!(
+            !out.trim_start().starts_with('{'),
+            "text format ({}): leaked JSON brace:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+        assert!(
+            !out.contains("section,metric,value"),
+            "text format ({}): leaked CSV header:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+        assert!(
+            !out.contains("# Usage Report"),
+            "text format ({}): leaked markdown h1:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+    }
+}
+
+#[test]
+fn usage_report_format_json_both_positions() {
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!("SKIP: dist/plugins/{{burndown,session-reader}} not staged");
+        return;
+    };
+    let home = tempfile::tempdir().unwrap();
+    seed_isolated_home(home.path());
+
+    for pre in [true, false] {
+        let out = run_usage_report(&plugin_root, home.path(), "json", pre);
+        let trimmed = out.trim_start();
+        assert!(
+            trimmed.starts_with('{'),
+            "json format ({}): output doesn't open with '{{':\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+        // Sanity check that the body really is the JSON report (the
+        // report_json helper emits an `"activities"` array unconditionally).
+        assert!(
+            out.contains("\"activities\""),
+            "json format ({}): missing 'activities' key:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+    }
+}
+
+#[test]
+fn usage_report_format_csv_both_positions() {
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!("SKIP: dist/plugins/{{burndown,session-reader}} not staged");
+        return;
+    };
+    let home = tempfile::tempdir().unwrap();
+    seed_isolated_home(home.path());
+
+    for pre in [true, false] {
+        let out = run_usage_report(&plugin_root, home.path(), "csv", pre);
+        assert!(
+            out.starts_with("section,metric,value"),
+            "csv format ({}): missing 'section,metric,value' header:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+    }
+}
+
+#[test]
+fn usage_report_format_markdown_both_positions() {
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!("SKIP: dist/plugins/{{burndown,session-reader}} not staged");
+        return;
+    };
+    let home = tempfile::tempdir().unwrap();
+    seed_isolated_home(home.path());
+
+    for pre in [true, false] {
+        let out = run_usage_report(&plugin_root, home.path(), "markdown", pre);
+        assert!(
+            out.starts_with("# Usage Report"),
+            "markdown format ({}): missing '# Usage Report' h1:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+        assert!(
+            out.contains("## Overview"),
+            "markdown format ({}): missing '## Overview' h2:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+        assert!(
+            !out.trim_start().starts_with('{'),
+            "markdown format ({}): leaked JSON brace:\n{out}",
+            if pre { "pre" } else { "post" }
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -1074,7 +1074,7 @@ pub(crate) fn render_markdown_report(title: &str, data: &UsageData) -> String {
     for project in data.projects.iter().take(8) {
         out.push_str(&format!(
             "| {} | {} | {} | {} |\n",
-            md_escape(&project.name),
+            md_escape(&truncate_label(&project.name, 60)),
             project.bucket.call_count,
             project.bucket.total(),
             format_cost(project.bucket.cost_usd)
@@ -1114,6 +1114,22 @@ pub(crate) fn render_markdown_report(title: &str, data: &UsageData) -> String {
 /// rare in model/project/activity labels and render fine inline.
 fn md_escape(s: &str) -> String {
     s.replace('|', "\\|").replace('`', "\\`")
+}
+
+/// Char-aware truncation that keeps multi-byte chars intact and
+/// appends an ellipsis when truncated. Used to stop long
+/// directory-flattened project paths (e.g.
+/// `-Users-stevengonsalvez--agents-in-a-box-worktrees-...`) from
+/// blowing out the width of markdown tables when pasted into PR
+/// descriptions and grafana note panels.
+fn truncate_label(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let keep = max_chars.saturating_sub(1);
+    let head: String = s.chars().take(keep).collect();
+    format!("{head}…")
 }
 
 pub(crate) fn report_json(data: &UsageData) -> serde_json::Value {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -286,6 +286,9 @@ fn print_report_with_data(
         OutputFormat::Csv => {
             print!("{}", combined_csv(&view));
         }
+        OutputFormat::Markdown => {
+            print!("{}", render_markdown_report(title, &view));
+        }
         OutputFormat::Text => {
             print_text_report(title, &view);
         }
@@ -315,6 +318,9 @@ fn print_status_with_data(
             }))?
         ),
         OutputFormat::Csv => print!("{}", combined_csv(data)),
+        OutputFormat::Markdown => {
+            print!("{}", render_markdown_report("Usage Status", data));
+        }
         OutputFormat::Text => {
             print_text_report("Usage Status", data);
         }
@@ -335,6 +341,9 @@ fn export_usage_with_data(
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report_json(data))?);
+        }
+        OutputFormat::Markdown => {
+            print!("{}", render_markdown_report("Usage Export", data));
         }
         OutputFormat::Csv | OutputFormat::Text => {
             print!("{}", combined_csv(data));
@@ -578,6 +587,9 @@ fn print_report(args: &UsageReportArgs, format: OutputFormat, title: &str) -> Re
         OutputFormat::Csv => {
             print!("{}", combined_csv(&data));
         }
+        OutputFormat::Markdown => {
+            print!("{}", render_markdown_report(title, &data));
+        }
         OutputFormat::Text => {
             print_text_report(title, &data);
         }
@@ -600,6 +612,18 @@ fn print_status(args: &UsageReportArgs, format: OutputFormat) -> Result<()> {
             }))?
         ),
         OutputFormat::Csv => print!("{}", combined_csv(&data)),
+        OutputFormat::Markdown => {
+            print!("{}", render_markdown_report("Usage Status", &data));
+            if let Some(projection) = &projection {
+                println!(
+                    "\n## Plan\n\n- **Spent:** ${:.2} / ${:.2} ({:.0}%)\n- **Status:** {:?}\n",
+                    projection.spent_usd,
+                    projection.monthly_usd,
+                    projection.percent_used * 100.0,
+                    projection.status
+                );
+            }
+        }
         OutputFormat::Text => {
             print_text_report("Usage Status", &data);
             if let Some(projection) = projection {
@@ -700,6 +724,10 @@ fn export_usage(args: &UsageExportArgs, format: OutputFormat) -> Result<()> {
                 "currency": "USD",
                 "report": report_json(&data),
             }))?;
+            write_or_print(args.output.as_deref(), &text)
+        }
+        OutputFormat::Markdown => {
+            let text = render_markdown_report("Usage Export", &data);
             write_or_print(args.output.as_deref(), &text)
         }
         OutputFormat::Text => {
@@ -1019,6 +1047,73 @@ fn print_top_models(data: &UsageData) {
             format_cost(model.bucket.cost_usd)
         );
     }
+}
+
+/// Render a `UsageData` snapshot as GitHub-flavored markdown.
+///
+/// Mirrors the text renderer's structure (overview line + three "By X"
+/// sections) but uses `#`/`##` headings and pipe tables so the output
+/// pastes cleanly into READMEs, PR descriptions, and grafana note
+/// panels. Pairs with `--format markdown` (also accepts `md` as an
+/// argv alias for shell-friendliness).
+pub(crate) fn render_markdown_report(title: &str, data: &UsageData) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# {title}\n\n"));
+    out.push_str("## Overview\n\n");
+    out.push_str(&format!(
+        "- **Calls:** {}\n- **Sessions:** {}\n- **Projects:** {}\n- **Tokens:** {}\n- **Cost:** {}\n\n",
+        data.grand_total.call_count,
+        data.grand_total.session_count,
+        data.grand_total.project_count,
+        data.grand_total.total(),
+        format_cost(data.grand_total.cost_usd)
+    ));
+    out.push_str("## By Project\n\n");
+    out.push_str("| Project | Calls | Tokens | Cost |\n");
+    out.push_str("|---------|------:|-------:|-----:|\n");
+    for project in data.projects.iter().take(8) {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            md_escape(&project.name),
+            project.bucket.call_count,
+            project.bucket.total(),
+            format_cost(project.bucket.cost_usd)
+        ));
+    }
+    out.push('\n');
+    out.push_str("## By Activity\n\n");
+    out.push_str("| Activity | Turns | Retries | Tokens |\n");
+    out.push_str("|----------|------:|--------:|-------:|\n");
+    for activity in data.activities.iter().take(8) {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            md_escape(activity.category.label()),
+            activity.turns,
+            activity.retries,
+            activity.bucket.total()
+        ));
+    }
+    out.push('\n');
+    out.push_str("## By Model\n\n");
+    out.push_str("| Model | Calls | Tokens | Cost |\n");
+    out.push_str("|-------|------:|-------:|-----:|\n");
+    for model in data.models.iter().take(8) {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            md_escape(&model.model),
+            model.bucket.call_count,
+            model.bucket.total(),
+            format_cost(model.bucket.cost_usd)
+        ));
+    }
+    out
+}
+
+/// Escape characters that have semantic meaning inside a markdown
+/// table cell. Only `|` and backticks; other markdown specials are
+/// rare in model/project/activity labels and render fine inline.
+fn md_escape(s: &str) -> String {
+    s.replace('|', "\\|").replace('`', "\\`")
 }
 
 pub(crate) fn report_json(data: &UsageData) -> serde_json::Value {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/output_format.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/output_format.rs
@@ -12,4 +12,5 @@ pub enum OutputFormat {
     Text,
     Json,
     Csv,
+    Markdown,
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -700,6 +700,7 @@ fn parse_format(s: &str) -> OutputFormat {
     match s {
         "json" => OutputFormat::Json,
         "csv" => OutputFormat::Csv,
+        "markdown" | "md" => OutputFormat::Markdown,
         _ => OutputFormat::Text,
     }
 }


### PR DESCRIPTION
## Summary

Closes SC1 of the codeburn-parity goal — global \`--format\` works in both argv positions and a new \`markdown\` renderer ships for usage analytics.

- Adds \`Markdown\` variant to both the host's clap-derived \`OutputFormat\` and burndown's plugin-local mirror; \`md\` accepted as a shell-friendly argv alias.
- Plugin's \`render_markdown_report\` emits GitHub-flavored markdown — h1 title, h2 section headings, pipe tables for By-Project / By-Activity / By-Model, bold KV pairs for the overview.
- Host CLI dispatcher pre-pends \`--format <value>\` to plugin argv so the global flag survives clap-derive's residual-args strip; subcommand-position \`--format\` still wins via \`extract_format\`'s last-match semantics.
- Every non-usage \`OutputFormat::Text | Csv\` match arm picks up a Markdown branch (currently identical to text — scoped to usage analytics).
- New tripwire \`tripwire_usage_cli_format.rs\` covers 4 formats × 2 positions = 8 invocations.

Depends on #121 (Phase 7c base must merge first — the CLI dispatcher lives there).

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] All six tripwires pass (\`tripwire_burndown_keys\`, \`tripwire_burndown_pivot_badge\`, \`tripwire_real_data_in_tui\`, \`tripwire_sessions_screen\`, \`tripwire_nonblocking\`, \`tripwire_usage_cli_format\`)
- [x] \`ainb --format json usage report\` ≡ \`ainb usage report --format json\` (byte-identical body)
- [x] CSV / markdown / text formats verified manually against real 110k-call dataset