### PR TITLE
fix(plugin-burndown): mid-scan banner + Esc returns to home

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -139,17 +139,27 @@ pub fn crossterm_to_protocol_key(
 /// - `?` / `H` → help toggle (already short-circuited above
 ///   `handle_key_event`'s plugin branch, but listed here for parity in
 ///   the `PluginScreen` trait impl path).
+/// - `Esc` → pop screen / return to home. The plugin/handle_key wire
+///   method is a one-way notification (no `consumed` reply), so once
+///   the host forwards a keystroke it has no way to know whether the
+///   plugin had any state to consume it. The user-visible failure is
+///   Esc-from-burndown silently disappearing into the plugin even when
+///   there's no filter chip or zoom to pop. Until the wire protocol is
+///   extended with a `consumed: bool` result for `plugin/handle_key`,
+///   Esc belongs to the host. Plugins re-bind internal pop semantics
+///   to `Backspace` (see burndown's `KeyCode::Backspace` handler).
 ///
-/// `Esc`, `q`, `a`, `Tab`, `Enter`, etc. are NOT reserved — the
-/// burndown plugin re-binds them to period switches, filter pops,
-/// panel focus, and zoom toggles. Letting the host swallow them would
-/// make the screen uninteractive.
+/// `q`, `a`, `Tab`, `Enter`, etc. remain plugin-owned — the burndown
+/// plugin re-binds them to period switches, panel focus, and zoom
+/// toggles. Letting the host swallow them would make the screen
+/// uninteractive.
 #[must_use]
 pub fn is_host_reserved_key(key: &crossterm::event::KeyEvent) -> bool {
     use crossterm::event::{KeyCode as CtKey, KeyModifiers as CtMods};
     match key.code {
         CtKey::Char('c') if key.modifiers.contains(CtMods::CONTROL) => true,
         CtKey::Char('?' | 'H') => true,
+        CtKey::Esc => true,
         _ => false,
     }
 }
@@ -695,11 +705,15 @@ mod tests {
         assert!(is_host_reserved_key(&mk(CtKey::Char('c'), KeyModifiers::CONTROL)));
         assert!(is_host_reserved_key(&mk(CtKey::Char('?'), KeyModifiers::NONE)));
         assert!(is_host_reserved_key(&mk(CtKey::Char('H'), KeyModifiers::NONE)));
+        // Esc is reserved: it must always bubble to the host so the
+        // screen pops back to home — see the doc on
+        // `is_host_reserved_key`. Plugins use `Backspace` for pop-state
+        // semantics instead.
+        assert!(is_host_reserved_key(&mk(CtKey::Esc, KeyModifiers::NONE)));
 
         // NOT reserved — these belong to the plugin on the analytics
         // screen (period switches, focus, filters, zoom).
         for k in [
-            CtKey::Esc,
             CtKey::Char('q'),
             CtKey::Char('a'),
             CtKey::Char('1'),

--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -149,6 +149,12 @@ pub fn crossterm_to_protocol_key(
 ///   Esc belongs to the host. Plugins re-bind internal pop semantics
 ///   to `Backspace` (see burndown's `KeyCode::Backspace` handler).
 ///
+///   UX note: a side-effect of routing Esc straight to the host is
+///   that Esc on a *zoomed* plugin view does NOT first un-zoom — it
+///   navigates straight to home, discarding zoom state. Users who
+///   want a one-level pop press `Backspace` (closes zoom, stays on
+///   the screen). The burndown help bar advertises both keys.
+///
 /// `q`, `a`, `Tab`, `Enter`, etc. remain plugin-owned — the burndown
 /// plugin re-binds them to period switches, panel focus, and zoom
 /// toggles. Letting the host swallow them would make the screen

--- a/ainb-tui/crates/ainb-core/tests/tripwire_burndown_esc_returns_home.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_burndown_esc_returns_home.rs
@@ -1,0 +1,257 @@
+//! Tripwire: Esc on the loaded burndown screen pops back to home.
+//!
+//! User-visible regression we're locking down: when the burndown
+//! plugin is fully rendered, pressing `Esc` MUST return the user to
+//! the home screen (sidebar + welcome panel). Before the fix in
+//! `is_host_reserved_key`, every keystroke — including `Esc` — was
+//! forwarded to the plugin via the one-way `plugin/handle_key`
+//! notification. The plugin's Esc handler popped filter chips or
+//! closed zoom, but when there was nothing to pop it silently
+//! swallowed the key, leaving the user stuck on the analytics screen.
+//!
+//! The fix: Esc is now host-reserved (see
+//! `crates/ainb-core/src/app/screens/builtin.rs::is_host_reserved_key`)
+//! so it bypasses the plugin forwarder and routes through the central
+//! key dispatch to `GoToHomeScreen`. The plugin's internal pop-state
+//! semantics moved to `Backspace` (see `tripwire_burndown_keys.rs`).
+//!
+//! Skips gracefully if `tmux` isn't on `$PATH` or `dist/plugins/` isn't
+//! staged — mirrors the gate pattern in
+//! `tripwire_burndown_keys.rs`/`tripwire_real_data_in_tui.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn plugins_staged() -> Option<PathBuf> {
+    let bin = ainb_bin();
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate
+                .join("session-reader")
+                .join("session-reader")
+                .exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("tripwire_keys")
+}
+
+fn fixture_now() -> String {
+    fs::read_to_string(fixture_root().join("FIXTURE_NOW.txt"))
+        .expect("FIXTURE_NOW.txt present")
+        .trim()
+        .to_string()
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("mkdir dst");
+    for entry in fs::read_dir(src).expect("read_dir src") {
+        let entry = entry.expect("dir entry");
+        let ty = entry.file_type().expect("file_type");
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&from, &to);
+        } else if ty.is_file() {
+            fs::copy(&from, &to).expect("copy file");
+        }
+    }
+}
+
+fn seed_fixture_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    let fixture = fixture_root();
+    let claude_src = fixture.join("claude").join("projects");
+    if claude_src.is_dir() {
+        let dst = home.join(".claude").join("projects");
+        copy_dir_all(&claude_src, &dst);
+    }
+    let codex_src = fixture.join("codex").join("sessions");
+    if codex_src.is_dir() {
+        let dst = home.join(".codex").join("sessions");
+        copy_dir_all(&codex_src, &dst);
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+fn kill_session(session: &str) {
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .status();
+}
+
+#[test]
+fn esc_on_burndown_returns_to_home() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!(
+            "SKIP: dist/plugins/{{burndown,session-reader}} not staged — \
+             run `scripts/build-plugins.sh` first"
+        );
+        return;
+    };
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_fixture_home(home_tmp.path());
+
+    let session = format!("tripwire-esc-home-{}", std::process::id());
+    let ainb = ainb_bin();
+
+    let status = Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &session,
+            "-x",
+            "200",
+            "-y",
+            "50",
+        ])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    let cmd = format!(
+        "HOME={} AINB_PLUGIN_ROOT={} AINB_NOW={} exec {} tui",
+        home_tmp.path().display(),
+        plugin_root.display(),
+        fixture_now(),
+        ainb.display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux send launch cmd");
+
+    // Wait for HomeScreen — sidebar + Stats entry visible.
+    let home_deadline = Instant::now() + Duration::from_secs(45);
+    let pre_home = poll_capture(&session, home_deadline, |c| {
+        c.contains("Stats") && c.contains("[i]")
+    });
+    if pre_home.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
+    }
+
+    // Pre-press negative assertion: we are NOT on burndown yet.
+    let pre_cap = capture_pane(&session);
+    assert!(
+        !pre_cap.contains("Usage Analytics"),
+        "before pressing `i`, burndown chrome must not be visible"
+    );
+
+    // Open burndown.
+    send_key(&session, "i");
+    let burndown_deadline = Instant::now() + Duration::from_secs(45);
+    let on_burndown = poll_capture(&session, burndown_deadline, |c| {
+        c.contains("Usage Analytics")
+            && !c.contains("Waiting for session-reader plugin")
+            && c.contains('$')
+    });
+    let Some(burndown_cap) = on_burndown else {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!(
+            "burndown never rendered real data after `i`; last:\n---\n{last}\n---"
+        );
+    };
+
+    // Sanity-check we're actually on burndown.
+    assert!(
+        burndown_cap.contains("Usage Analytics"),
+        "burndown render missing `Usage Analytics`:\n---\n{burndown_cap}\n---"
+    );
+
+    // Press Esc. Wait for home chrome to reappear. This is the
+    // assertion that locks the fix: before host-reserving Esc, the
+    // plugin silently swallowed it and the user stayed on burndown.
+    send_key(&session, "Escape");
+    let back_home_deadline = Instant::now() + Duration::from_secs(10);
+    let back_home = poll_capture(&session, back_home_deadline, |c| {
+        // Home chrome: sidebar with Stats entry visible AND the
+        // burndown's "Usage Analytics" title gone. Either alone is
+        // ambiguous (Stats[i] persists in some intermediate states);
+        // both together prove the navigation completed.
+        c.contains("Stats") && c.contains("[i]") && !c.contains("Usage Analytics")
+    });
+
+    let final_cap = capture_pane(&session);
+    kill_session(&session);
+
+    assert!(
+        back_home.is_some(),
+        "Esc on burndown did not return to home within 10s. \
+         Final capture:\n---\n{final_cap}\n---"
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_burndown_keys.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_burndown_keys.rs
@@ -361,10 +361,13 @@ fn burndown_interactive_keys_change_render() {
     // state for downstream assertions.
     let _ = send_key_and_settle(&session, "z");
 
-    // Esc must be safe when no filter chip is set — a no-op rather
-    // than crashing the plugin. We don't assert a delta; we assert
-    // the burndown screen is still rendered after Esc.
-    let cap_post_esc = send_key_and_settle(&session, "Escape");
+    // Backspace must be safe when no filter chip is set — a no-op
+    // rather than crashing the plugin. We don't assert a delta; we
+    // assert the burndown screen is still rendered after Backspace.
+    // (`Esc` is host-reserved — see `is_host_reserved_key` — so the
+    // navigation-back tripwire lives in its own test file
+    // `tripwire_burndown_esc_returns_home.rs`.)
+    let cap_post_backspace = send_key_and_settle(&session, "BSpace");
 
     kill_session(&session);
 
@@ -427,10 +430,10 @@ fn burndown_interactive_keys_change_render() {
          toggle_zoom never reached the plugin"
     );
 
-    // === Esc safety ===
+    // === Backspace safety ===
     assert!(
-        cap_post_esc.contains("Usage Analytics")
-            && !cap_post_esc.contains("Waiting for session-reader plugin"),
-        "Esc with no active filter broke the burndown render:\n---\n{cap_post_esc}\n---"
+        cap_post_backspace.contains("Usage Analytics")
+            && !cap_post_backspace.contains("Waiting for session-reader plugin"),
+        "Backspace with no active filter broke the burndown render:\n---\n{cap_post_backspace}\n---"
     );
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -187,7 +187,10 @@ impl Plugin for BurndownPlugin {
     /// were renamed during implementation to match what actually
     /// exists in `ui.rs`:
     ///
-    /// - `Esc` → `pop_filter_chip` (plan: `pop_filter`).
+    /// - `Backspace` → `pop_filter_chip` / `zoom_handle_esc` (plan:
+    ///   `pop_filter`; originally bound to `Esc` but the host now
+    ///   reserves `Esc` for navigation back to home — see
+    ///   `is_host_reserved_key` in ainb-core).
     /// - `C`   → `clear_all_filter_chips` (plan: `clear_filters`).
     /// - `d` when zoomed → `toggle_zoom_detail` (plan: `zoom_toggle_detail`).
     ///
@@ -824,7 +827,12 @@ impl BurndownPlugin {
                 let _ = self.ui.commit_focused_row_exclude();
             }
             KeyCode::Char { ch: 'C' } => self.ui.clear_all_filter_chips(),
-            KeyCode::Esc => {
+            // `Backspace` (not `Esc`) handles pop-state: close zoom if
+            // open, otherwise pop the most recent filter chip. Esc is
+            // host-reserved — it always bubbles up to navigate back to
+            // home. See the doc on `is_host_reserved_key` in
+            // ainb-core/src/app/screens/builtin.rs for the rationale.
+            KeyCode::Backspace => {
                 if self.ui.is_zoomed() {
                     let _ = self.ui.zoom_handle_esc();
                 } else {
@@ -943,18 +951,30 @@ mod handle_key_dispatch_tests {
     }
 
     #[test]
-    fn esc_pops_filter_when_not_zoomed_and_unzooms_when_zoomed() {
+    fn backspace_pops_filter_when_not_zoomed_and_unzooms_when_zoomed() {
         let mut p = BurndownPlugin::default();
-        // Not zoomed: Esc claims the key (no-op against an empty
+        // Not zoomed: Backspace claims the key (no-op against an empty
         // filter stack, but still bumps generation).
-        assert!(p.dispatch_key_pure(&KeyCode::Esc));
+        assert!(p.dispatch_key_pure(&KeyCode::Backspace));
 
-        // Zoomed: Esc should also claim, and un-zoom.
+        // Zoomed: Backspace should also claim, and un-zoom.
         let _ = p.dispatch_key_pure(&KeyCode::Tab);
         assert!(p.dispatch_key_pure(&ch('z')));
         assert!(p.ui.is_zoomed());
-        assert!(p.dispatch_key_pure(&KeyCode::Esc));
-        assert!(!p.ui.is_zoomed(), "Esc must exit zoom");
+        assert!(p.dispatch_key_pure(&KeyCode::Backspace));
+        assert!(!p.ui.is_zoomed(), "Backspace must exit zoom");
+    }
+
+    #[test]
+    fn esc_is_not_claimed_by_plugin() {
+        // Esc is host-reserved (see `is_host_reserved_key` in
+        // ainb-core/src/app/screens/builtin.rs) so the runtime should
+        // never forward it. Defensively assert dispatch returns false
+        // even if it does — the plugin must NOT claim Esc, otherwise
+        // pressing it on the analytics screen would swallow the
+        // navigation-back keystroke.
+        let mut p = BurndownPlugin::default();
+        assert!(!p.dispatch_key_pure(&KeyCode::Esc));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -904,28 +904,31 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     let show_scan_banner = state.scan_progress.is_some()
         && state.data.is_some()
         && !state.loading;
-    let constraints: Vec<Constraint> = if show_scan_banner {
-        vec![
-            Constraint::Length(3), // Summary bar
-            Constraint::Length(3), // Provider selector
-            Constraint::Length(3), // Tab bar
-            Constraint::Length(1), // Scan banner (mid-scan only)
-            Constraint::Min(0),    // Table content
-            Constraint::Length(2), // Help bar
-        ]
+    // Stack-allocated constraints — render is the hot path; avoid the Vec.
+    let layout = if show_scan_banner {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Summary bar
+                Constraint::Length(3), // Provider selector
+                Constraint::Length(3), // Tab bar
+                Constraint::Length(1), // Scan banner (mid-scan only)
+                Constraint::Min(0),    // Table content
+                Constraint::Length(2), // Help bar
+            ])
+            .split(area)
     } else {
-        vec![
-            Constraint::Length(3), // Summary bar
-            Constraint::Length(3), // Provider selector
-            Constraint::Length(3), // Tab bar
-            Constraint::Min(0),    // Table content
-            Constraint::Length(2), // Help bar
-        ]
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Summary bar
+                Constraint::Length(3), // Provider selector
+                Constraint::Length(3), // Tab bar
+                Constraint::Min(0),    // Table content
+                Constraint::Length(2), // Help bar
+            ])
+            .split(area)
     };
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(constraints)
-        .split(area);
 
     render_summary_bar(buf, layout[0], state);
     render_provider_bar(buf, layout[1], state);
@@ -1605,7 +1608,7 @@ fn render_zoom_breadcrumb(buf: &mut Buffer, area: Rect, panel: UsagePanel) {
             Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
         ),
         Span::styled("   ", Style::default()),
-        Span::styled("◀ Esc back ▶", Style::default().fg(MUTED_GRAY)),
+        Span::styled("◀ BkSp unzoom · Esc home ▶", Style::default().fg(MUTED_GRAY)),
     ]);
     ratatui::widgets::Widget::render(Paragraph::new(line), area, buf);
 }
@@ -4068,8 +4071,10 @@ fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
             Span::styled(" search  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("d", Style::default().fg(GOLD)),
             Span::styled(" detail  ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("z/Esc", Style::default().fg(GOLD)),
-            Span::styled(" back  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("z/BkSp", Style::default().fg(GOLD)),
+            Span::styled(" unzoom  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Esc", Style::default().fg(GOLD)),
+            Span::styled(" home  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("j/k", Style::default().fg(GOLD)),
             Span::styled(" row  ", Style::default().fg(MUTED_GRAY)),
         ];
@@ -4089,6 +4094,8 @@ fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     ];
     if on_burndown {
         // Burndown view: z zoom; Tab pivots panels; Enter/X commit chips; C clears.
+        // `BkSp` = Backspace (pop chip / unzoom); Esc is reserved by the host
+        // for navigation back to home, so it's listed in the trailing block.
         spans.extend_from_slice(&[
             Span::styled("z", Style::default().fg(GOLD)),
             Span::styled(" zoom  ", Style::default().fg(MUTED_GRAY)),
@@ -4098,7 +4105,7 @@ fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
             Span::styled(" add  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("X", Style::default().fg(GOLD)),
             Span::styled(" exclude  ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("Esc", Style::default().fg(GOLD)),
+            Span::styled("BkSp", Style::default().fg(GOLD)),
             Span::styled(" pop  ", Style::default().fg(MUTED_GRAY)),
             Span::styled("C", Style::default().fg(GOLD)),
             Span::styled(" clear  ", Style::default().fg(MUTED_GRAY)),

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -894,44 +894,103 @@ impl UsageViewState {
 
 /// Render the usage analytics screen
 pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
-    // Main layout: header + provider selector + tabs + content + help bar
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    // Main layout: header + provider selector + tabs + (optional scan banner) +
+    // content + help bar. The scan banner is a one-row strip that only appears
+    // while session-reader is still walking the per-provider dirs — without it,
+    // a mid-scan render shows a populated summary bar but empty panels (data
+    // streams in chunks; aggregates fill up before the panels do), which reads
+    // as a hang. The banner stays visible until the plugin clears
+    // `scan_progress` on the final `is_final` chunk.
+    let show_scan_banner = state.scan_progress.is_some()
+        && state.data.is_some()
+        && !state.loading;
+    let constraints: Vec<Constraint> = if show_scan_banner {
+        vec![
+            Constraint::Length(3), // Summary bar
+            Constraint::Length(3), // Provider selector
+            Constraint::Length(3), // Tab bar
+            Constraint::Length(1), // Scan banner (mid-scan only)
+            Constraint::Min(0),    // Table content
+            Constraint::Length(2), // Help bar
+        ]
+    } else {
+        vec![
             Constraint::Length(3), // Summary bar
             Constraint::Length(3), // Provider selector
             Constraint::Length(3), // Tab bar
             Constraint::Min(0),    // Table content
             Constraint::Length(2), // Help bar
-        ])
+        ]
+    };
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(area);
 
     render_summary_bar(buf, layout[0], state);
     render_provider_bar(buf, layout[1], state);
     render_tab_bar(buf, layout[2], state);
 
+    let (content_idx, help_idx) = if show_scan_banner {
+        render_scan_banner_inline(
+            buf,
+            layout[3],
+            state.scan_progress.as_ref().expect("guarded by show_scan_banner"),
+        );
+        (4, 5)
+    } else {
+        (3, 4)
+    };
+
     if state.loading || state.data.is_none() {
         if let Some(progress) = state.scan_progress.as_ref() {
-            render_scan_progress(buf, layout[3], progress);
+            render_scan_progress(buf, layout[content_idx], progress);
         } else {
-            render_loading(buf, layout[3]);
+            render_loading(buf, layout[content_idx]);
         }
     } else {
         let data = state.data.as_ref().unwrap();
         if data.calls.is_empty() && !state.provider.has_data() {
-            render_no_data(buf, layout[3], state);
+            render_no_data(buf, layout[content_idx], state);
         } else {
             match state.active_tab {
-                UsageTab::Daily => render_daily(buf, layout[3], data, state.scroll_offset),
-                UsageTab::Weekly => render_weekly(buf, layout[3], data, state.scroll_offset),
-                UsageTab::Projects => render_projects(buf, layout[3], data, state.scroll_offset),
-                UsageTab::Burndown => render_burndown(buf, layout[3], data, state),
-                UsageTab::Optimize => render_optimize(buf, layout[3], data),
+                UsageTab::Daily => render_daily(buf, layout[content_idx], data, state.scroll_offset),
+                UsageTab::Weekly => render_weekly(buf, layout[content_idx], data, state.scroll_offset),
+                UsageTab::Projects => render_projects(buf, layout[content_idx], data, state.scroll_offset),
+                UsageTab::Burndown => render_burndown(buf, layout[content_idx], data, state),
+                UsageTab::Optimize => render_optimize(buf, layout[content_idx], data),
             }
         }
     }
 
-    render_help_bar(buf, layout[4], state);
+    render_help_bar(buf, layout[help_idx], state);
+}
+
+/// Render a slim one-row scan-progress banner above the dashboard. Different
+/// from `render_scan_progress` (which paints the full skeleton panel when
+/// data is empty) — this is the data-present mid-scan affordance:
+///
+///   ⏳ Scanning sessions: 12/47 · my-project
+///
+/// No border, no surrounding panel — just inline text so the row above the
+/// dashboard doesn't visually compete with the panel chrome.
+fn render_scan_banner_inline(buf: &mut Buffer, area: Rect, progress: &ScanProgressEvent) {
+    let mut spans = vec![
+        Span::styled(" ⏳ ", Style::default().fg(GOLD)),
+        Span::styled(
+            scan_progress_headline(progress),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ];
+    if !progress.current_project.is_empty() {
+        spans.push(Span::styled(" · ", Style::default().fg(MUTED_GRAY)));
+        spans.push(Span::styled(
+            progress.current_project.clone(),
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+    let paragraph = Paragraph::new(Line::from(spans));
+    ratatui::widgets::Widget::render(paragraph, area, buf);
 }
 
 fn render_summary_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {


### PR DESCRIPTION
## Summary

Two user-visible regressions on the burndown analytics screen:

- **Empty panels during scan** — after pressing \`i\` from home, the summary bar populated but \`[ Daily Activity ]\`, \`[ By Project ]\`, etc. remained empty chrome for the rest of the scan. No indication anything was happening — reads as a hang.
- **Esc didn't go back to home** — once burndown finished loading, pressing \`Esc\` did nothing. The plugin silently swallowed the keystroke.

## Fixes

**Scan banner** (\`ainb-plugin-burndown/src/ui.rs\`)
Render a 1-row \`⏳ Scanning sessions: N/M · {project}\` strip above the dashboard whenever \`scan_progress.is_some() && data.is_some()\`. Existing centered-panel skeleton (\`data.is_none()\`) is unchanged.

**Esc → home** (\`ainb-core/src/app/screens/builtin.rs\` + \`ainb-plugin-burndown/src/plugin.rs\`)
Root cause: \`plugin/handle_key\` is a one-way notification — the plugin has no channel to say "ignored, fall through". So every keystroke the host forwards is treated as consumed.

Proper fix is widening \`plugin/handle_key\` to a request with \`HandleKeyResult { consumed: bool }\`, which touches the wire protocol, the SDK trait, the runtime, and every plugin (WIRE_VERSION bump). Captured as follow-up.

Interim:
- Add \`KeyCode::Esc\` to \`is_host_reserved_key\` — Esc bypasses the plugin forwarder, routes through central dispatch → \`GoToHomeScreen\`.
- Rebind burndown's pop-filter-chip / close-zoom handler from \`Esc\` to \`Backspace\`.

## Test plan

- [x] \`cargo test -p ainb-plugin-burndown --lib\` (161 tests pass, including new \`esc_is_not_claimed_by_plugin\` regression)
- [x] \`cargo test -p ainb --lib screens::builtin\` (5 tests pass, including updated reservation test)
- [x] \`cargo test --workspace --lib\` green
- [x] \`tripwire_burndown_keys\` — existing test retargeted to Backspace, passes
- [x] \`tripwire_burndown_esc_returns_home\` (new) — opens burndown, presses Esc, asserts home chrome returns. Passes against staged plugins.
- [ ] Manual: run \`./target/debug/ainb tui\` against real \`\$HOME\`, press \`i\`, observe scan banner during ingest, press \`Esc\`, return to home.