### PR TITLE
feat(plugins): per-plugin enable/disable via env + config.toml

### DIFF
--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -242,6 +242,40 @@ pub struct AppConfig {
     /// Usage analytics configuration.
     #[serde(default)]
     pub usage: UsageConfig,
+
+    /// Plugin enable/disable lists. See [`PluginsConfig`].
+    #[serde(default)]
+    pub plugins: PluginsConfig,
+}
+
+/// Per-plugin filter persisted in `config.toml`.
+///
+/// Either list is empty by default — meaning "no filter from config".
+/// Env vars (`AINB_DISABLE_PLUGINS`, `AINB_DISABLE_PLUGIN`,
+/// `AINB_ONLY_PLUGINS`) override these at runtime; see
+/// `crates/ainb-core/src/plugins.rs::resolve_plugin_filter` for the
+/// precedence ladder.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [plugins]
+/// disabled = ["burndown"]              # everything except burndown loads
+///
+/// # OR — allowlist (denylist becomes a no-op when `enabled` is non-empty):
+/// [plugins]
+/// enabled = ["session-reader"]         # only session-reader loads
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct PluginsConfig {
+    /// Allowlist — when non-empty, ONLY plugins whose `id` appears here
+    /// are loaded. Takes precedence over `disabled` when both are set.
+    #[serde(default)]
+    pub enabled: Vec<String>,
+
+    /// Denylist — plugins whose `id` appears here are skipped during
+    /// discovery. Ignored entirely when `enabled` is non-empty.
+    #[serde(default)]
+    pub disabled: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -710,6 +744,7 @@ impl Default for AppConfig {
             ui_preferences: UiPreferences::default(),
             docker: DockerConfig::default(),
             usage: UsageConfig::default(),
+            plugins: PluginsConfig::default(),
         };
 
         // Load built-in templates

--- a/ainb-tui/crates/ainb-core/src/plugins.rs
+++ b/ainb-tui/crates/ainb-core/src/plugins.rs
@@ -79,16 +79,17 @@ pub fn init_plugin_runtime() -> Result<(Runtime, RuntimeHandle, LoadOutcome), Ru
     Ok((runtime, handle, outcome))
 }
 
-/// Resolved per-plugin filter. Encodes the four states the plugin
+/// Resolved per-plugin filter. Encodes the three states the plugin
 /// admission decision can land in after merging env vars + config.toml.
 ///
 /// **Precedence** (most specific wins):
-/// 1. `AINB_DISABLE_PLUGINS=1` → [`AllOff`](PluginFilter::AllOff) — handled
-///    upstream in [`init_plugin_runtime`], never reaches this enum.
-/// 2. `AINB_ONLY_PLUGINS=a,b` → [`Allow`](PluginFilter::Allow) — env allowlist
-///    overrides config entirely.
-/// 3. `AINB_DISABLE_PLUGIN=a,b` → [`Deny`](PluginFilter::Deny) — env denylist
-///    when no env allowlist is set.
+/// 1. `AINB_DISABLE_PLUGINS=1` → discovery skipped entirely. Handled
+///    upstream in [`init_plugin_runtime`] before this enum is built,
+///    so it never appears as a `PluginFilter` variant.
+/// 2. `AINB_ONLY_PLUGINS=a,b` → [`Allow`](PluginFilter::Allow) — env
+///    allowlist overrides config entirely.
+/// 3. `AINB_DISABLE_PLUGIN=a,b` → [`Deny`](PluginFilter::Deny) — env
+///    denylist when no env allowlist is set.
 /// 4. `config.toml [plugins].enabled = [...]` → [`Allow`](PluginFilter::Allow)
 ///    when env didn't decide.
 /// 5. `config.toml [plugins].disabled = [...]` → [`Deny`](PluginFilter::Deny)
@@ -151,10 +152,22 @@ impl PluginFilter {
 fn resolve_plugin_filter_from_env_and_config() -> PluginFilter {
     let env_only = std::env::var("AINB_ONLY_PLUGINS").ok();
     let env_disable = std::env::var("AINB_DISABLE_PLUGIN").ok();
-    let cfg = crate::config::AppConfig::load()
-        .ok()
-        .map(|c| c.plugins)
-        .unwrap_or_default();
+    // Load config.toml; surface load failures so a corrupt config
+    // doesn't silently disable the user's plugin filter intent. Falling
+    // back to `Default` is still the right behaviour — booting plugin-
+    // free isn't what the user wanted — but the warn line gives them a
+    // breadcrumb in `~/.agents-in-a-box/logs/`.
+    let cfg = match crate::config::AppConfig::load() {
+        Ok(c) => c.plugins,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "config.toml failed to load — falling back to default plugin filter (all plugins enabled). \
+                 [plugins].enabled / .disabled will not apply this session."
+            );
+            PluginsConfig::default()
+        }
+    };
     resolve_plugin_filter(env_only.as_deref(), env_disable.as_deref(), &cfg)
 }
 

--- a/ainb-tui/crates/ainb-core/src/plugins.rs
+++ b/ainb-tui/crates/ainb-core/src/plugins.rs
@@ -13,10 +13,13 @@
 //! same way it did when discovery returned no `dist/plugins/` directory under
 //! the old host.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use ainb_plugin_runtime::{Runtime, RuntimeError, RuntimeHandle};
 use tracing::{debug, info, warn};
+
+use crate::config::PluginsConfig;
 
 /// Outcome of [`init_plugin_runtime`] — kept for parity with the previous
 /// `LoadOutcome` type so callers (CLI, smoke tests) can log discovery results
@@ -51,8 +54,16 @@ pub fn init_plugin_runtime() -> Result<(Runtime, RuntimeHandle, LoadOutcome), Ru
         return Ok((runtime, handle, outcome));
     };
 
+    // Per-plugin enable/disable filter, resolved from env + config.toml
+    // with documented precedence. See `resolve_plugin_filter` doc.
+    let filter = resolve_plugin_filter_from_env_and_config();
+    if let Some(reason) = filter.describe() {
+        info!(filter = %reason, "applying plugin filter");
+    }
+
     info!(plugin_root = %root.display(), "discovering subprocess plugins");
-    match handle.discover(&root) {
+    let result = handle.discover_filtered(&root, |p| filter.allows(p.id.as_str()));
+    match result {
         Ok(plugins) => {
             for p in plugins {
                 info!(plugin = %p.id, "registered plugin");
@@ -66,6 +77,143 @@ pub fn init_plugin_runtime() -> Result<(Runtime, RuntimeHandle, LoadOutcome), Ru
     }
 
     Ok((runtime, handle, outcome))
+}
+
+/// Resolved per-plugin filter. Encodes the four states the plugin
+/// admission decision can land in after merging env vars + config.toml.
+///
+/// **Precedence** (most specific wins):
+/// 1. `AINB_DISABLE_PLUGINS=1` → [`AllOff`](PluginFilter::AllOff) — handled
+///    upstream in [`init_plugin_runtime`], never reaches this enum.
+/// 2. `AINB_ONLY_PLUGINS=a,b` → [`Allow`](PluginFilter::Allow) — env allowlist
+///    overrides config entirely.
+/// 3. `AINB_DISABLE_PLUGIN=a,b` → [`Deny`](PluginFilter::Deny) — env denylist
+///    when no env allowlist is set.
+/// 4. `config.toml [plugins].enabled = [...]` → [`Allow`](PluginFilter::Allow)
+///    when env didn't decide.
+/// 5. `config.toml [plugins].disabled = [...]` → [`Deny`](PluginFilter::Deny)
+///    when env didn't decide and config has no allowlist.
+/// 6. Default → [`AllOn`](PluginFilter::AllOn).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum PluginFilter {
+    /// Load every discovered plugin.
+    AllOn,
+    /// Load only plugins whose `id` appears in this set.
+    Allow {
+        allowed: HashSet<String>,
+        source: &'static str,
+    },
+    /// Load every plugin except those whose `id` appears in this set.
+    Deny {
+        denied: HashSet<String>,
+        source: &'static str,
+    },
+}
+
+impl PluginFilter {
+    /// Return `true` iff this filter would load a plugin with the
+    /// given id. `id` is a string slice (not a `PluginId`) so this
+    /// stays free of a runtime-crate-type dependency and unit-tests
+    /// cheaply.
+    pub(crate) fn allows(&self, id: &str) -> bool {
+        match self {
+            Self::AllOn => true,
+            Self::Allow { allowed, .. } => allowed.contains(id),
+            Self::Deny { denied, .. } => !denied.contains(id),
+        }
+    }
+
+    /// Human-readable summary for the startup log line. `None` when
+    /// the filter is the default no-op so we don't log "filter: none"
+    /// noise on every cold start.
+    pub(crate) fn describe(&self) -> Option<String> {
+        match self {
+            Self::AllOn => None,
+            Self::Allow { allowed, source } => {
+                let mut names: Vec<&str> = allowed.iter().map(String::as_str).collect();
+                names.sort_unstable();
+                Some(format!("allow={names:?} via {source}"))
+            }
+            Self::Deny { denied, source } => {
+                let mut names: Vec<&str> = denied.iter().map(String::as_str).collect();
+                names.sort_unstable();
+                Some(format!("deny={names:?} via {source}"))
+            }
+        }
+    }
+}
+
+/// Build a [`PluginFilter`] from env vars + the loaded `config.toml`.
+///
+/// Wrapper that gathers the inputs from process state. The pure
+/// resolution logic lives in [`resolve_plugin_filter`] so it's
+/// testable without poking `std::env`.
+fn resolve_plugin_filter_from_env_and_config() -> PluginFilter {
+    let env_only = std::env::var("AINB_ONLY_PLUGINS").ok();
+    let env_disable = std::env::var("AINB_DISABLE_PLUGIN").ok();
+    let cfg = crate::config::AppConfig::load()
+        .ok()
+        .map(|c| c.plugins)
+        .unwrap_or_default();
+    resolve_plugin_filter(env_only.as_deref(), env_disable.as_deref(), &cfg)
+}
+
+/// Pure filter resolution. Inputs are the two env-var values (already
+/// fetched) and the loaded [`PluginsConfig`]; output is the merged
+/// [`PluginFilter`]. Split from the env-poking wrapper so unit tests
+/// don't touch process state.
+pub(crate) fn resolve_plugin_filter(
+    env_only: Option<&str>,
+    env_disable: Option<&str>,
+    config: &PluginsConfig,
+) -> PluginFilter {
+    // 1. Env allowlist beats everything else.
+    if let Some(raw) = env_only {
+        let set = parse_csv(raw);
+        if !set.is_empty() {
+            return PluginFilter::Allow {
+                allowed: set,
+                source: "AINB_ONLY_PLUGINS",
+            };
+        }
+    }
+    // 2. Env denylist beats config.
+    if let Some(raw) = env_disable {
+        let set = parse_csv(raw);
+        if !set.is_empty() {
+            return PluginFilter::Deny {
+                denied: set,
+                source: "AINB_DISABLE_PLUGIN",
+            };
+        }
+    }
+    // 3. Config allowlist beats config denylist.
+    if !config.enabled.is_empty() {
+        return PluginFilter::Allow {
+            allowed: config.enabled.iter().cloned().collect(),
+            source: "config.toml [plugins].enabled",
+        };
+    }
+    // 4. Config denylist.
+    if !config.disabled.is_empty() {
+        return PluginFilter::Deny {
+            denied: config.disabled.iter().cloned().collect(),
+            source: "config.toml [plugins].disabled",
+        };
+    }
+    // 5. Default — load everything.
+    PluginFilter::AllOn
+}
+
+/// Comma-separated list parser. Empty entries (e.g. trailing comma) are
+/// dropped silently; surrounding whitespace is trimmed. Returns an
+/// empty set when the input is just commas/whitespace.
+fn parse_csv(raw: &str) -> HashSet<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
 }
 
 /// Operator-controlled kill switch. Recognises `1`, `true`, `yes`, `on`
@@ -163,5 +311,153 @@ mod tests {
         }
         std::env::remove_var("AINB_DISABLE_PLUGINS");
         assert!(!plugins_disabled(), "unset must leave plugins enabled");
+    }
+}
+
+#[cfg(test)]
+mod plugin_filter_tests {
+    //! Pure unit tests for the per-plugin allow/deny filter. Touch
+    //! `resolve_plugin_filter` directly so we don't pollute process
+    //! env state — the env-poking wrapper
+    //! `resolve_plugin_filter_from_env_and_config` is exercised
+    //! end-to-end by the existing tripwires that boot ainb under
+    //! various env combinations.
+    use super::*;
+    use crate::config::PluginsConfig;
+
+    fn cfg(enabled: &[&str], disabled: &[&str]) -> PluginsConfig {
+        PluginsConfig {
+            enabled: enabled.iter().map(|s| s.to_string()).collect(),
+            disabled: disabled.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn no_inputs_yields_all_on() {
+        let f = resolve_plugin_filter(None, None, &PluginsConfig::default());
+        assert_eq!(f, PluginFilter::AllOn);
+        assert!(f.allows("burndown"));
+        assert!(f.allows("any-other-name"));
+        assert!(f.describe().is_none(), "AllOn must not log noise");
+    }
+
+    #[test]
+    fn env_only_plugins_creates_allowlist() {
+        let f = resolve_plugin_filter(Some("burndown"), None, &PluginsConfig::default());
+        assert!(f.allows("burndown"));
+        assert!(!f.allows("session-reader"));
+        assert!(matches!(
+            f,
+            PluginFilter::Allow { source, .. } if source == "AINB_ONLY_PLUGINS"
+        ));
+    }
+
+    #[test]
+    fn env_disable_plugin_creates_denylist() {
+        let f = resolve_plugin_filter(None, Some("burndown"), &PluginsConfig::default());
+        assert!(!f.allows("burndown"));
+        assert!(f.allows("session-reader"));
+        assert!(matches!(
+            f,
+            PluginFilter::Deny { source, .. } if source == "AINB_DISABLE_PLUGIN"
+        ));
+    }
+
+    #[test]
+    fn env_only_overrides_env_disable() {
+        // Both env vars present — allowlist wins per precedence rule.
+        let f = resolve_plugin_filter(
+            Some("burndown"),
+            Some("burndown,session-reader"),
+            &PluginsConfig::default(),
+        );
+        assert!(f.allows("burndown"));
+        assert!(!f.allows("session-reader"));
+        assert!(matches!(
+            f,
+            PluginFilter::Allow { source, .. } if source == "AINB_ONLY_PLUGINS"
+        ));
+    }
+
+    #[test]
+    fn env_only_overrides_config_disabled() {
+        let f = resolve_plugin_filter(
+            Some("burndown"),
+            None,
+            &cfg(&[], &["burndown", "session-reader"]),
+        );
+        assert!(f.allows("burndown"));
+        assert!(!f.allows("session-reader"));
+    }
+
+    #[test]
+    fn env_disable_overrides_config_enabled() {
+        let f = resolve_plugin_filter(None, Some("burndown"), &cfg(&["burndown"], &[]));
+        // Config wanted only burndown; env explicitly disables burndown.
+        // Env denylist takes precedence over config allowlist.
+        assert!(!f.allows("burndown"));
+        assert!(f.allows("session-reader"));
+    }
+
+    #[test]
+    fn config_enabled_when_no_env() {
+        let f = resolve_plugin_filter(None, None, &cfg(&["session-reader"], &[]));
+        assert!(!f.allows("burndown"));
+        assert!(f.allows("session-reader"));
+        assert!(matches!(
+            f,
+            PluginFilter::Allow { source, .. } if source == "config.toml [plugins].enabled"
+        ));
+    }
+
+    #[test]
+    fn config_disabled_when_no_env_no_enabled() {
+        let f = resolve_plugin_filter(None, None, &cfg(&[], &["burndown"]));
+        assert!(!f.allows("burndown"));
+        assert!(f.allows("session-reader"));
+        assert!(matches!(
+            f,
+            PluginFilter::Deny { source, .. } if source == "config.toml [plugins].disabled"
+        ));
+    }
+
+    #[test]
+    fn config_enabled_beats_config_disabled() {
+        // Both lists in config — allowlist wins (don't make the user
+        // reason about union/intersection of two lists).
+        let f = resolve_plugin_filter(None, None, &cfg(&["burndown"], &["burndown"]));
+        assert!(f.allows("burndown"));
+        assert!(!f.allows("session-reader"));
+    }
+
+    #[test]
+    fn empty_env_strings_fall_through_to_config() {
+        // Empty/whitespace-only env values must NOT lock the filter
+        // into an empty allowlist (which would disable every plugin).
+        let f = resolve_plugin_filter(Some(""), Some(",,, , "), &cfg(&[], &["burndown"]));
+        // Env contributed nothing → config denylist took effect.
+        assert!(!f.allows("burndown"));
+        assert!(f.allows("session-reader"));
+    }
+
+    #[test]
+    fn csv_parser_handles_whitespace_and_empty_entries() {
+        let parsed = parse_csv("  burndown , , session-reader,  ");
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains("burndown"));
+        assert!(parsed.contains("session-reader"));
+    }
+
+    #[test]
+    fn describe_renders_sorted_names_for_logs() {
+        // Log line stability — sorting prevents iteration-order churn
+        // between processes (HashSet has no order guarantee).
+        let f = resolve_plugin_filter(
+            Some("zebra,alpha,middle"),
+            None,
+            &PluginsConfig::default(),
+        );
+        let desc = f.describe().expect("Allow filter must describe");
+        assert!(desc.contains(r#"["alpha", "middle", "zebra"]"#), "got: {desc}");
     }
 }

--- a/ainb-tui/crates/ainb-core/tests/plugin_runtime_smoke.rs
+++ b/ainb-tui/crates/ainb-core/tests/plugin_runtime_smoke.rs
@@ -5,16 +5,26 @@
 //! (`AINB_DISABLE_PLUGINS`) still short-circuits.
 
 use ainb::plugins::{init_plugin_runtime, LoadOutcome};
+use std::sync::Mutex;
+
+/// Serialises process-env mutations across this file's tests so the
+/// parallel cargo-test runner doesn't race one test's `AINB_PLUGIN_ROOT`
+/// into another's `init_plugin_runtime` call. Pattern documented in
+/// the project memory under `reference_env_lock_for_parallel_tests`.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// Fresh runtime with no plugin root in scope: should succeed, return
 /// an empty `LoadOutcome`, and have zero registered plugins on the
 /// handle.
 #[test]
 fn empty_root_brings_runtime_up_cleanly() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     // Force discovery to a path that doesn't exist so every fallback
     // (exe-dir, cwd, ~/.agents-in-a-box) gets skipped.
     std::env::set_var("AINB_PLUGIN_ROOT", "/definitely/not/a/real/plugin/root");
     std::env::remove_var("AINB_DISABLE_PLUGINS");
+    std::env::remove_var("AINB_DISABLE_PLUGIN");
+    std::env::remove_var("AINB_ONLY_PLUGINS");
 
     let (runtime, handle, outcome): (_, _, LoadOutcome) =
         init_plugin_runtime().expect("runtime startup must succeed");
@@ -48,7 +58,10 @@ fn empty_root_brings_runtime_up_cleanly() {
 /// keeps working when plugins are deliberately disabled.
 #[test]
 fn disable_env_skips_discovery() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     std::env::set_var("AINB_DISABLE_PLUGINS", "1");
+    std::env::remove_var("AINB_DISABLE_PLUGIN");
+    std::env::remove_var("AINB_ONLY_PLUGINS");
     // Even with a "real" looking root, the env var must take
     // precedence — set it to a path that *would* error if scanned.
     std::env::set_var("AINB_PLUGIN_ROOT", "/this/should/never/be/read");
@@ -64,4 +77,106 @@ fn disable_env_skips_discovery() {
     drop(runtime);
     std::env::remove_var("AINB_DISABLE_PLUGINS");
     std::env::remove_var("AINB_PLUGIN_ROOT");
+}
+
+/// `AINB_DISABLE_PLUGIN=burndown` runs discovery normally but skips
+/// the named plugin. Verifies the env-var deny path lands end-to-end
+/// against the real staged `dist/plugins/` layout — unit tests cover
+/// the filter math, this one proves the wiring.
+///
+/// Skips when `dist/plugins/` isn't staged (fresh checkout, no `just
+/// stage-plugins` run yet) so CI runs that don't build plugins don't
+/// fail this test.
+#[test]
+fn disable_plugin_env_skips_named_plugin() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let plugin_root = locate_dist_plugins();
+    let Some(root) = plugin_root else {
+        eprintln!("SKIP: dist/plugins not staged — run `scripts/build-plugins.sh`");
+        return;
+    };
+
+    // Pin discovery to the staged layout, deny burndown by name.
+    std::env::set_var("AINB_PLUGIN_ROOT", &root);
+    std::env::set_var("AINB_DISABLE_PLUGIN", "burndown");
+    std::env::remove_var("AINB_DISABLE_PLUGINS");
+    std::env::remove_var("AINB_ONLY_PLUGINS");
+
+    let (runtime, handle, outcome) =
+        init_plugin_runtime().expect("runtime startup with plugin denylist must succeed");
+
+    assert!(
+        !outcome.loaded.iter().any(|id| id == "burndown"),
+        "AINB_DISABLE_PLUGIN=burndown must skip burndown; loaded={:?}",
+        outcome.loaded
+    );
+    // session-reader should still load (it's the other in-tree plugin
+    // and isn't in the denylist).
+    assert!(
+        outcome.loaded.iter().any(|id| id == "session-reader"),
+        "denying burndown must not also drop session-reader; loaded={:?}",
+        outcome.loaded
+    );
+
+    drop(handle);
+    drop(runtime);
+    std::env::remove_var("AINB_DISABLE_PLUGIN");
+    std::env::remove_var("AINB_PLUGIN_ROOT");
+}
+
+/// `AINB_ONLY_PLUGINS=session-reader` is the inverse — only the named
+/// plugin loads; burndown must be skipped. Same skip-on-no-dist gate
+/// as the deny test.
+#[test]
+fn only_plugins_env_creates_exact_allowlist() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let plugin_root = locate_dist_plugins();
+    let Some(root) = plugin_root else {
+        eprintln!("SKIP: dist/plugins not staged — run `scripts/build-plugins.sh`");
+        return;
+    };
+
+    std::env::set_var("AINB_PLUGIN_ROOT", &root);
+    std::env::set_var("AINB_ONLY_PLUGINS", "session-reader");
+    std::env::remove_var("AINB_DISABLE_PLUGINS");
+    std::env::remove_var("AINB_DISABLE_PLUGIN");
+
+    let (runtime, handle, outcome) =
+        init_plugin_runtime().expect("runtime startup with plugin allowlist must succeed");
+
+    assert_eq!(
+        outcome.loaded,
+        vec!["session-reader".to_string()],
+        "AINB_ONLY_PLUGINS=session-reader must load exactly session-reader; got {:?}",
+        outcome.loaded
+    );
+
+    drop(handle);
+    drop(runtime);
+    std::env::remove_var("AINB_ONLY_PLUGINS");
+    std::env::remove_var("AINB_PLUGIN_ROOT");
+}
+
+/// Walk up from the test binary looking for `dist/plugins/` with both
+/// in-tree plugin binaries staged. Returns `None` if not present — the
+/// test then skips rather than failing.
+fn locate_dist_plugins() -> Option<std::path::PathBuf> {
+    use std::path::PathBuf;
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_ainb"));
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate
+                .join("session-reader")
+                .join("session-reader")
+                .exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
 }

--- a/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/handle.rs
@@ -318,8 +318,29 @@ impl RuntimeHandle {
     /// launched immediately — required for pure-publisher plugins
     /// (e.g. session-reader) that no caller drives directly.
     pub fn discover(&self, root: &Path) -> Result<Vec<RegisteredPlugin>, RuntimeError> {
-        let plugins = crate::registry::discover(root)?;
-        for p in &plugins {
+        self.discover_filtered(root, |_| true)
+    }
+
+    /// Discover plugins under `root` and register only those for which
+    /// `filter` returns `true`. The returned `Vec` reflects the
+    /// *registered* subset, not the on-disk superset — callers logging
+    /// "loaded plugins" want this, not the pre-filter list.
+    ///
+    /// Used by the host's `init_plugin_runtime` to apply env-var /
+    /// config.toml allowlist/denylist before any plugin task is
+    /// spawned. Filtering at discovery time (vs. spawn time) avoids
+    /// allocating per-plugin channels for skipped plugins.
+    pub fn discover_filtered<F>(
+        &self,
+        root: &Path,
+        filter: F,
+    ) -> Result<Vec<RegisteredPlugin>, RuntimeError>
+    where
+        F: Fn(&RegisteredPlugin) -> bool,
+    {
+        let discovered = crate::registry::discover(root)?;
+        let kept: Vec<RegisteredPlugin> = discovered.into_iter().filter(&filter).collect();
+        for p in &kept {
             self.inner.channels.register(p.clone());
             let arc = Arc::new(p.clone());
             let eager = matches!(
@@ -359,7 +380,7 @@ impl RuntimeHandle {
                 }),
             );
         }
-        Ok(plugins)
+        Ok(kept)
     }
 
     /// Reload (clear quarantine + failure history).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -119,13 +119,44 @@ See [docs/plugin-spec/v2.md §1](./plugin-spec/v2.md#1-manifest) for full semant
 
 ## Configuration
 
-### Disable plugins
+### Enable/disable plugins
+
+The host supports four knobs for selecting which plugins load, evaluated in this precedence order (most specific wins):
+
+| Knob | Where | Behavior |
+|---|---|---|
+| `AINB_DISABLE_PLUGINS=1` | env | Kill switch — skip discovery entirely. Runtime comes up plugin-free. |
+| `AINB_ONLY_PLUGINS=a,b` | env | Allowlist — load ONLY the named plugins; everything else skipped. |
+| `AINB_DISABLE_PLUGIN=a,b` | env | Denylist — load everything EXCEPT the named plugins. Ignored when `AINB_ONLY_PLUGINS` is set. |
+| `[plugins].enabled = [...]` | `config.toml` | Persistent allowlist. Same shape as `AINB_ONLY_PLUGINS` but survives across runs. Env vars override config. |
+| `[plugins].disabled = [...]` | `config.toml` | Persistent denylist. Ignored when `[plugins].enabled` is non-empty. |
+
+Examples:
 
 ```bash
+# All-or-nothing kill switch (existing behavior).
 AINB_DISABLE_PLUGINS=1 ainb tui
+
+# Skip burndown but keep session-reader running.
+AINB_DISABLE_PLUGIN=burndown ainb tui
+
+# Load only session-reader (useful for a headless data pipeline).
+AINB_ONLY_PLUGINS=session-reader ainb tui
+
+# Multiple names — comma-separated, whitespace tolerated.
+AINB_ONLY_PLUGINS="burndown, session-reader" ainb tui
 ```
 
-Boots the host with the plugin runtime disabled — no discovery, no spawn. The Analytics screen falls back to a "plugin: rendering…" placeholder when its owner plugin isn't loaded.
+Persistent config (`~/.agents-in-a-box/config/config.toml`):
+
+```toml
+[plugins]
+# Either list (or neither) — when both are set, `enabled` wins.
+enabled = ["session-reader"]
+# disabled = ["burndown"]
+```
+
+When `AINB_DISABLE_PLUGINS=1`, the Analytics screen falls back to a "plugin: rendering…" placeholder. When only specific plugins are disabled via allow/deny, screens owned by disabled plugins show the same placeholder; other screens are unaffected.
 
 ### Override the plugin search root
 


### PR DESCRIPTION
## Summary

Adds three new knobs for selecting which plugins load, alongside the existing all-or-nothing \`AINB_DISABLE_PLUGINS=1\` kill switch.

| Knob | Where | Behavior |
|---|---|---|
| \`AINB_ONLY_PLUGINS=a,b\` | env | Allowlist — load ONLY these |
| \`AINB_DISABLE_PLUGIN=a,b\` | env | Denylist — load everything EXCEPT these |
| \`[plugins].enabled = [...]\` | config.toml | Persistent allowlist |
| \`[plugins].disabled = [...]\` | config.toml | Persistent denylist |

**Precedence** (most specific wins): \`AINB_DISABLE_PLUGINS\` > env allow > env deny > config allow > config deny > default.

## Why

Until now, the only knob was binary: all plugins on, or all plugins off via \`AINB_DISABLE_PLUGINS=1\`. With burndown + session-reader (and more plugins coming), users want surgical control — "boot ainb but skip burndown" while keeping session-reader feeding the data pipeline.

## Files

| File | What |
|---|---|
| \`crates/ainb-plugin-runtime/src/handle.rs\` | New \`discover_filtered(root, filter)\` helper; existing \`discover\` is a thin wrapper over it |
| \`crates/ainb-core/src/config/mod.rs\` | New \`PluginsConfig\` struct on \`AppConfig\` with \`enabled\`/\`disabled\` lists |
| \`crates/ainb-core/src/plugins.rs\` | \`PluginFilter\` enum + pure \`resolve_plugin_filter()\` function wired into \`init_plugin_runtime\` |
| \`crates/ainb-core/tests/plugin_runtime_smoke.rs\` | 2 new integration tests against real staged \`dist/plugins/\` + ENV_LOCK to prevent parallel-test env-var race |
| \`docs/plugins.md\` | Precedence table + bash/TOML examples in Configuration section |

## Test plan

- [x] \`cargo test -p ainb --lib plugin_filter_tests\` — 12 new unit tests covering precedence + edge cases, all pass
- [x] \`cargo test -p ainb --test plugin_runtime_smoke\` — 4 tests (2 existing + 2 new env allow/deny against staged plugins), all pass
- [x] \`cargo test -p ainb --lib\` — 673 unit tests green (no regressions)
- [x] \`cargo test -p ainb-plugin-runtime --lib\` — 20 tests green (\`discover_filtered\` refactor compatible)
- [ ] Manual: \`AINB_DISABLE_PLUGIN=burndown ./target/debug/ainb tui\` → home screen renders, analytics shows placeholder
- [ ] Manual: \`AINB_ONLY_PLUGINS=session-reader ./target/debug/ainb tui\` → only session-reader spawns