### PR TITLE
style(ainb-tui): rustfmt drift fix in state.rs

### DIFF
--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -30,10 +30,19 @@ use uuid::Uuid;
 /// row's current visible position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttachableRef {
-    WorkspaceSession { workspace_idx: usize, session_idx: usize },
-    WorkspaceShell { workspace_idx: usize },
-    SshSession { ssh_idx: usize },
-    OtherTmux { other_idx: usize },
+    WorkspaceSession {
+        workspace_idx: usize,
+        session_idx: usize,
+    },
+    WorkspaceShell {
+        workspace_idx: usize,
+    },
+    SshSession {
+        ssh_idx: usize,
+    },
+    OtherTmux {
+        other_idx: usize,
+    },
 }
 
 /// Text editor with cursor support for boss mode prompts
@@ -2715,8 +2724,7 @@ impl Default for AppState {
 
             statusline_status_cache: None,
 
-            live_window_watcher:
-                crate::models::live_window_watcher::LiveWindowWatcher::default(),
+            live_window_watcher: crate::models::live_window_watcher::LiveWindowWatcher::default(),
 
             // Usage analytics state
             usage_state: crate::components::usage::UsageViewState::default(),


### PR DESCRIPTION
## Summary
- Two pre-existing rustfmt-on-stable diffs in `ainb-tui/src/app/state.rs` have been failing CI on `main` since at least 2026-05-10 (3+ failed runs). Flagged as a follow-up in #130.
- Reformat to satisfy stable rustfmt. No semantic change.

## What changed
- `AttachableRef` enum: variants reformatted from single-line struct form to multi-line (stable rustfmt's default layout).
- `live_window_watcher` field init: expression moved onto the same line as the field key.

## Test plan
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo build\` ✓
- [x] No semantic change — only whitespace/line-break formatting.