### PR TITLE
fix(ainb-tui): decouple workspace loading from Docker

### DIFF
--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -2192,96 +2192,130 @@ pub enum WorkspaceLoadResult {
 /// Load workspaces asynchronously (standalone function for use in spawned tasks)
 /// This is called from background task to avoid blocking the main thread
 async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
-    use crate::interactive::InteractiveSessionManager;
-
     info!("load_workspaces_async: Starting");
-    let mut workspaces = Vec::new();
 
-    // Load Boss mode sessions (Docker-based) if Docker is available
-    if AppState::is_docker_available_sync() {
-        info!("load_workspaces_async: Docker available, loading Boss mode sessions");
-        match SessionLoader::new().await {
-            Ok(loader) => match loader.load_active_sessions().await {
-                Ok(mut docker_workspaces) => {
-                    info!(
-                        "load_workspaces_async: Loaded {} Boss mode workspaces",
-                        docker_workspaces.len()
-                    );
-                    workspaces.append(&mut docker_workspaces);
-                }
-                Err(e) => {
-                    warn!(
-                        "load_workspaces_async: Failed to load Boss mode sessions: {}",
-                        e
-                    );
-                }
-            },
-            Err(e) => {
-                warn!(
-                    "load_workspaces_async: Failed to create session loader: {}",
-                    e
-                );
-            }
-        }
-    } else {
-        info!("load_workspaces_async: Docker not available, skipping Boss mode");
-    }
+    // Boss-mode (Docker) and Interactive-mode (tmux) sessions are fetched
+    // CONCURRENTLY with independent budgets. A slow or stuck Docker daemon
+    // must not starve Interactive loading — interactive sessions are
+    // tmux-only and have no Docker dependency. Before this split, a 9s
+    // `list_agents_containers` call would burn the outer 10s timeout
+    // before Interactive even ran, leaving the workspace tree empty even
+    // though Interactive would have returned instantly.
+    //
+    // The merge step (combining Boss and Interactive sessions into the
+    // same Workspace by canonical path) runs after both fetches return,
+    // since the workspace_map mutation is non-commutative.
+    let (boss_workspaces, interactive_sessions) =
+        tokio::join!(fetch_boss_mode_workspaces(), fetch_interactive_sessions());
 
-    // Load Interactive mode sessions (always attempt, no Docker needed)
-    info!("load_workspaces_async: Loading Interactive mode sessions");
-    match InteractiveSessionManager::new() {
-        Ok(mut manager) => {
-            match manager.list_sessions().await {
-                Ok(interactive_sessions) => {
-                    info!(
-                        "load_workspaces_async: Found {} Interactive sessions",
-                        interactive_sessions.len()
-                    );
-                    // Group sessions by workspace
-                    for interactive_session in interactive_sessions {
-                        let session = interactive_session.to_session_model();
-                        let workspace_path = interactive_session.source_repository.clone();
-                        let workspace_name = interactive_session.workspace_name.clone();
+    let mut workspaces = boss_workspaces;
+    for interactive_session in interactive_sessions {
+        let session = interactive_session.to_session_model();
+        let workspace_path = interactive_session.source_repository.clone();
+        let workspace_name = interactive_session.workspace_name.clone();
 
-                        // Find or create workspace using canonicalized path comparison
-                        // This prevents duplicates when paths differ only by normalization
-                        // (e.g., symlinks, ".." components, trailing slashes)
-                        let canonical_workspace_path = workspace_path.canonicalize().ok();
-                        if let Some(workspace) = workspaces
-                            .iter_mut()
-                            .find(|w| w.path.canonicalize().ok() == canonical_workspace_path)
-                        {
-                            workspace.add_session(session);
-                        } else {
-                            let mut workspace = Workspace::new(workspace_name, workspace_path);
-                            workspace.add_session(session);
-                            workspaces.push(workspace);
-                        }
-                    }
-                }
-                Err(e) => {
-                    warn!(
-                        "load_workspaces_async: Failed to list Interactive sessions: {}",
-                        e
-                    );
-                }
-            }
-        }
-        Err(e) => {
-            warn!(
-                "load_workspaces_async: Failed to create Interactive session manager: {}",
-                e
-            );
+        // Find or create workspace using canonicalized path comparison.
+        // This prevents duplicates when paths differ only by normalization
+        // (e.g., symlinks, ".." components, trailing slashes).
+        let canonical_workspace_path = workspace_path.canonicalize().ok();
+        if let Some(workspace) = workspaces
+            .iter_mut()
+            .find(|w| w.path.canonicalize().ok() == canonical_workspace_path)
+        {
+            workspace.add_session(session);
+        } else {
+            let mut workspace = Workspace::new(workspace_name, workspace_path);
+            workspace.add_session(session);
+            workspaces.push(workspace);
         }
     }
 
-    // Load other tmux sessions (not managed by agents-in-a-box)
-    // This is quick and doesn't involve Docker, so we include it
     info!(
         "load_workspaces_async: Complete with {} workspaces",
         workspaces.len()
     );
     Ok(workspaces)
+}
+
+/// Fetch Boss-mode (Docker container) workspaces with a strict per-mode
+/// timeout. Returns an empty `Vec` on any failure path — caller proceeds
+/// with Interactive results. The `docker info` probe runs on a blocking
+/// thread so a wedged Docker socket can't pin a tokio runtime thread.
+async fn fetch_boss_mode_workspaces() -> Vec<Workspace> {
+    const BOSS_MODE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    let docker_available =
+        tokio::task::spawn_blocking(AppState::is_docker_available_sync).await.unwrap_or(false);
+
+    if !docker_available {
+        info!("load_workspaces_async: Docker not available, skipping Boss mode");
+        return Vec::new();
+    }
+
+    info!("load_workspaces_async: Docker available, loading Boss mode sessions");
+    let load = async {
+        let loader = SessionLoader::new().await?;
+        loader.load_active_sessions().await
+    };
+
+    match tokio::time::timeout(BOSS_MODE_TIMEOUT, load).await {
+        Ok(Ok(workspaces)) => {
+            info!(
+                "load_workspaces_async: Loaded {} Boss mode workspaces",
+                workspaces.len()
+            );
+            workspaces
+        }
+        Ok(Err(e)) => {
+            warn!(
+                "load_workspaces_async: Failed to load Boss mode sessions: {}",
+                e
+            );
+            Vec::new()
+        }
+        Err(_) => {
+            warn!(
+                "load_workspaces_async: Boss mode load exceeded {}s budget — proceeding with Interactive only",
+                BOSS_MODE_TIMEOUT.as_secs()
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Fetch Interactive-mode (tmux) sessions. No Docker dependency — must
+/// not be gated on Boss-mode completing.
+async fn fetch_interactive_sessions() -> Vec<crate::interactive::InteractiveSession> {
+    use crate::interactive::InteractiveSessionManager;
+
+    info!("load_workspaces_async: Loading Interactive mode sessions");
+    let mut manager = match InteractiveSessionManager::new() {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(
+                "load_workspaces_async: Failed to create Interactive session manager: {}",
+                e
+            );
+            return Vec::new();
+        }
+    };
+
+    match manager.list_sessions().await {
+        Ok(sessions) => {
+            info!(
+                "load_workspaces_async: Found {} Interactive sessions",
+                sessions.len()
+            );
+            sessions
+        }
+        Err(e) => {
+            warn!(
+                "load_workspaces_async: Failed to list Interactive sessions: {}",
+                e
+            );
+            Vec::new()
+        }
+    }
 }
 
 /// Focus state for the combined Agent + Model selection panel

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -2208,24 +2208,32 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
     let (boss_workspaces, interactive_sessions) =
         tokio::join!(fetch_boss_mode_workspaces(), fetch_interactive_sessions());
 
+    // Index from canonicalized (or raw-fallback) workspace path to its
+    // position in `workspaces`. Computed once per workspace and once per
+    // interactive session — O(N+M) canonicalize syscalls instead of the
+    // O(N×M) "canonicalize-in-find-loop" pattern. The raw-fallback also
+    // fixes a correctness bug: two paths that both fail to canonicalize
+    // (e.g., deleted worktrees) previously matched each other via shared
+    // `None`, collapsing distinct sessions into one Workspace.
+    let canonical_key = |p: &std::path::Path| -> PathBuf {
+        p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+    };
     let mut workspaces = boss_workspaces;
+    let mut path_index: HashMap<PathBuf, usize> =
+        workspaces.iter().enumerate().map(|(i, w)| (canonical_key(&w.path), i)).collect();
+
     for interactive_session in interactive_sessions {
         let session = interactive_session.to_session_model();
         let workspace_path = interactive_session.source_repository.clone();
         let workspace_name = interactive_session.workspace_name.clone();
+        let key = canonical_key(&workspace_path);
 
-        // Find or create workspace using canonicalized path comparison.
-        // This prevents duplicates when paths differ only by normalization
-        // (e.g., symlinks, ".." components, trailing slashes).
-        let canonical_workspace_path = workspace_path.canonicalize().ok();
-        if let Some(workspace) = workspaces
-            .iter_mut()
-            .find(|w| w.path.canonicalize().ok() == canonical_workspace_path)
-        {
-            workspace.add_session(session);
+        if let Some(&idx) = path_index.get(&key) {
+            workspaces[idx].add_session(session);
         } else {
             let mut workspace = Workspace::new(workspace_name, workspace_path);
             workspace.add_session(session);
+            path_index.insert(key, workspaces.len());
             workspaces.push(workspace);
         }
     }

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -2215,12 +2215,14 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
     // fixes a correctness bug: two paths that both fail to canonicalize
     // (e.g., deleted worktrees) previously matched each other via shared
     // `None`, collapsing distinct sessions into one Workspace.
-    let canonical_key = |p: &std::path::Path| -> PathBuf {
-        p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
-    };
+    let canonical_key =
+        |p: &std::path::Path| -> PathBuf { p.canonicalize().unwrap_or_else(|_| p.to_path_buf()) };
     let mut workspaces = boss_workspaces;
-    let mut path_index: HashMap<PathBuf, usize> =
-        workspaces.iter().enumerate().map(|(i, w)| (canonical_key(&w.path), i)).collect();
+    let mut path_index: HashMap<PathBuf, usize> = workspaces
+        .iter()
+        .enumerate()
+        .map(|(i, w)| (canonical_key(&w.path), i))
+        .collect();
 
     for interactive_session in interactive_sessions {
         let session = interactive_session.to_session_model();
@@ -2252,8 +2254,9 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
 async fn fetch_boss_mode_workspaces() -> Vec<Workspace> {
     const BOSS_MODE_TIMEOUT: Duration = Duration::from_secs(5);
 
-    let docker_available =
-        tokio::task::spawn_blocking(AppState::is_docker_available_sync).await.unwrap_or(false);
+    let docker_available = tokio::task::spawn_blocking(AppState::is_docker_available_sync)
+        .await
+        .unwrap_or(false);
 
     if !docker_available {
         info!("load_workspaces_async: Docker not available, skipping Boss mode");

--- a/ainb-tui/src/app/state.rs
+++ b/ainb-tui/src/app/state.rs
@@ -3401,10 +3401,20 @@ impl AppState {
             }
         }
 
-        // Load Boss mode sessions (Docker-based) if Docker is available
+        // Load Boss mode sessions (Docker-based) if Docker is available.
+        // Capped at 5s — a slow or wedged Docker daemon must not block
+        // the workspaces panel from rendering. Interactive mode is
+        // tmux-only and runs unconditionally after this returns.
+        const BOSS_MODE_TIMEOUT: Duration = Duration::from_secs(5);
         if self.is_docker_available().await {
             info!("Docker available - loading Boss mode sessions");
-            self.load_boss_mode_sessions().await;
+            match tokio::time::timeout(BOSS_MODE_TIMEOUT, self.load_boss_mode_sessions()).await {
+                Ok(()) => {}
+                Err(_) => warn!(
+                    "load_real_workspaces: Boss mode load exceeded {}s budget — proceeding with Interactive only",
+                    BOSS_MODE_TIMEOUT.as_secs()
+                ),
+            }
         } else {
             info!("Docker not available - skipping Boss mode session loading");
         }


### PR DESCRIPTION
## Summary

- **Empty workspace tree when Docker is slow** — `load_workspaces_async` runs Docker (Boss-mode) and tmux (Interactive) sequentially under a single 10s outer timeout. A slow `list_agents_containers` (e.g. stale `Created` container) burns the full budget before Interactive even starts, leaving "Workspaces (0)" even though Interactive would have returned in <1s.
- **Manual refresh blocks ~minutes** — `load_real_workspaces` (the `f` key / auth-callback path) also calls `load_boss_mode_sessions()` with no timeout; observed ~2 minutes hold on a Docker daemon with a stale container.

## Changes

**`load_workspaces_async`** (`state.rs:2192`)
- Boss + Interactive fetched concurrently via `tokio::join!`
- `fetch_boss_mode_workspaces` capped at 5s; returns `Vec::new()` on exceed, Interactive proceeds alone
- `is_docker_available_sync()` moved to `spawn_blocking` so its 3s busy-wait poll doesn't pin a tokio runtime thread
- Merge step (workspace_map by canonical path) stays sequential after both futures resolve

**`load_real_workspaces`** (`state.rs:3404`)
- Same 5s `BOSS_MODE_TIMEOUT` wrapper around `load_boss_mode_sessions()`
- Interactive runs unconditionally afterwards

## Test plan

- [x] `cargo build` clean (no new warnings)
- [x] End-to-end verified via tmux automation: 14 Interactive sessions → 7 workspaces in 5s
- [x] Log line confirms timeout fires: `Boss mode load exceeded 5s budget — proceeding with Interactive only`
- [x] Same machine state previously produced 0 workspaces
- [x] Quit cleanly via `q` `q` after verification; other tmux sessions untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized workspace loading performance through concurrent session fetching
  * Improved timeout handling to prevent application hang when Docker is unavailable
  * Enhanced duplicate workspace prevention through path normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->