### PR TITLE
feat(session-list): spinner while workspaces are still scanning

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -696,13 +696,39 @@ impl SessionListComponent {
         }
 
         if items.is_empty() {
-            let empty_line = Line::from(vec![
-                Span::styled("✨ ", Style::default().fg(MUTED_GRAY)),
-                Span::styled(
-                    "No workspaces found",
-                    Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
-                ),
-            ]);
+            // Distinguish "still loading" from "loaded but empty" — the
+            // background workspace scan can take a few seconds on cold
+            // launch and a bare "No workspaces found" line during that
+            // window reads as "you have nothing here" when the truth is
+            // "we haven't looked yet". Spinner matches the one used in
+            // the home screen's recent-activity strip so the two
+            // surfaces share a vocabulary.
+            let empty_line = if state.is_loading_workspaces {
+                let spinner_frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+                let frame_idx = (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() / 100)
+                    .unwrap_or(0)
+                    % spinner_frames.len() as u128) as usize;
+                Line::from(vec![
+                    Span::styled(
+                        format!("{} ", spinner_frames[frame_idx]),
+                        Style::default().fg(GOLD),
+                    ),
+                    Span::styled(
+                        "Loading workspaces…",
+                        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                    ),
+                ])
+            } else {
+                Line::from(vec![
+                    Span::styled("✨ ", Style::default().fg(MUTED_GRAY)),
+                    Span::styled(
+                        "No workspaces found",
+                        Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+                    ),
+                ])
+            };
             items.push(ListItem::new(empty_line));
         }
 


### PR DESCRIPTION
## Summary

On cold launch the session-list panel showed \`✨ No workspaces found\` during the background workspace scan — indistinguishable from a truly empty install. Users inferred "nothing here", switched away, and came back confused when sessions appeared.

**Before**:
\`\`\`
✨ No workspaces found
\`\`\`

**After** (during the cold-scan window):
\`\`\`
⠧ Loading workspaces…
\`\`\`

After the scan completes, the same panel populates with the workspace tree as before. If the scan finishes with zero workspaces, the original "No workspaces found" message renders — preserved for the genuinely-empty case.

## Implementation

Single render-site branch in \`session_list.rs::build_list_items_static\` on the existing \`state.is_loading_workspaces\` flag. Spinner uses the same 10-frame braille pattern + GOLD colour as \`HomeScreenV2Component::render_loading_indicator\` so the home-screen recent-activity strip and the session-list panel share a vocabulary during the same cold-load window.

No new state, no new event, no plumbing changes.

## Test plan

- [x] \`cargo check -p ainb\` clean
- [ ] Manual: \`./target/debug/ainb tui\` cold launch → press \`s\` → spinner during scan → workspace tree replaces it once scan completes
- [ ] Manual: launch with empty \`~/.agents-in-a-box/repos/\` → genuinely-empty case still shows \`✨ No workspaces found\`