### PR TITLE
fix(ainb-tui): include config_popup_state in text-input predicate

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -578,12 +578,17 @@ impl EventHandler {
         let git_view_text_active = state.current_view == View::GitView
             && state.git_view_state.as_ref().map(|gv| gv.is_in_commit_mode()).unwrap_or(false);
 
-        // Config is multi-mode — `editing` and `api_key_input_mode`
-        // are the only states that accept free-form character input.
-        // Plain navigation of settings categories should NOT suppress
-        // global shortcuts like `H`; that would be a UX regression.
+        // Config is multi-mode — only the states that accept free-form
+        // character input count as text-entry. Plain navigation of
+        // settings categories should NOT suppress global shortcuts
+        // like `H`; that would be a UX regression. AINB 2.0 also opens
+        // a modal popup via `ConfigEditSetting` whose `TextInput` /
+        // `NumberInput` variants capture characters — `show_popup` is
+        // included so `H` doesn't toggle help mid-edit there either.
         let config_text_active = state.current_view == View::Config
-            && (state.config_screen_state.editing || state.config_screen_state.api_key_input_mode);
+            && (state.config_screen_state.editing
+                || state.config_screen_state.api_key_input_mode
+                || state.config_popup_state.show_popup);
 
         new_session_text_active
             || matches!(
@@ -5408,6 +5413,17 @@ mod text_input_guard_tests {
         assert!(
             EventHandler::is_text_input_context(&state),
             "Config + api_key_input_mode = true must be treated as text input"
+        );
+
+        // Config edit popup (opened via ConfigEditSetting). Captures
+        // character input for Text/Number settings — `H` must NOT
+        // toggle help while it's open.
+        let mut state = AppState::default();
+        state.current_view = View::Config;
+        state.config_popup_state.show_popup = true;
+        assert!(
+            EventHandler::is_text_input_context(&state),
+            "Config + config_popup_state.show_popup = true must be treated as text input"
         );
 
         // Modal flags on AppState. Each must independently flip the


### PR DESCRIPTION
## Summary
Follow-up to gemini-code-assist review on PR #133.

- **HIGH** — \`config_text_active\` only checked \`config_screen_state.{editing,api_key_input_mode}\`. AINB 2.0 opens a modal popup via \`ConfigEditSetting\` whose Text/Number variants capture character input — without this, pressing \`H\` while editing a setting in the popup toggled the help overlay mid-edit.
- **MEDIUM** — add a test case pinning that \`config_popup_state.show_popup = true\` flips \`is_text_input_context\` to true.

## Change
\`\`\`rust
let config_text_active = state.current_view == View::Config
    && (state.config_screen_state.editing
        || state.config_screen_state.api_key_input_mode
        || state.config_popup_state.show_popup);
\`\`\`

## Test plan
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo build\` ✓
- New test \`Config + config_popup_state.show_popup = true\` added to \`is_text_input_context_covers_every_other_branch\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed global keyboard shortcuts accidentally triggering while editing configuration settings in popup windows. Single-character shortcuts are now properly suppressed during config value entry to prevent unintended actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->