### PR TITLE
fix(ainb-tui): narrow config_popup gate to text-entry variants

### DIFF
--- a/ainb-tui/src/app/events.rs
+++ b/ainb-tui/src/app/events.rs
@@ -581,14 +581,15 @@ impl EventHandler {
         // Config is multi-mode — only the states that accept free-form
         // character input count as text-entry. Plain navigation of
         // settings categories should NOT suppress global shortcuts
-        // like `H`; that would be a UX regression. AINB 2.0 also opens
-        // a modal popup via `ConfigEditSetting` whose `TextInput` /
-        // `NumberInput` variants capture characters — `show_popup` is
-        // included so `H` doesn't toggle help mid-edit there either.
+        // like `H`; that would be a UX regression. The modal popup
+        // opened via `ConfigEditSetting` is included only for its
+        // `TextInput` / `NumberInput` variants (via
+        // `ConfigPopupState::is_text_entry`); `Choice` and `Boolean`
+        // popups are navigation-only, so `H` is still allowed there.
         let config_text_active = state.current_view == View::Config
             && (state.config_screen_state.editing
                 || state.config_screen_state.api_key_input_mode
-                || state.config_popup_state.show_popup);
+                || state.config_popup_state.is_text_entry());
 
         new_session_text_active
             || matches!(
@@ -5415,15 +5416,34 @@ mod text_input_guard_tests {
             "Config + api_key_input_mode = true must be treated as text input"
         );
 
-        // Config edit popup (opened via ConfigEditSetting). Captures
-        // character input for Text/Number settings — `H` must NOT
-        // toggle help while it's open.
+        // Config edit popup (opened via ConfigEditSetting). The
+        // predicate only flips for popup variants that actually
+        // capture characters — `TextInput` and `NumberInput`. Use
+        // the public `open_text` API so the test exercises a real
+        // popup-open code path and stays valid if the popup_type
+        // representation changes.
         let mut state = AppState::default();
         state.current_view = View::Config;
-        state.config_popup_state.show_popup = true;
+        state.config_popup_state.open_text("Title", "Desc", "key", "value");
         assert!(
             EventHandler::is_text_input_context(&state),
-            "Config + config_popup_state.show_popup = true must be treated as text input"
+            "Config + config_popup TextInput must be treated as text input"
+        );
+
+        // Negative control: a Choice popup is navigation-only (arrow
+        // keys / Enter), so `H` should still toggle help.
+        let mut state = AppState::default();
+        state.current_view = View::Config;
+        state.config_popup_state.open_choice(
+            "Title",
+            "Desc",
+            "key",
+            vec!["A".into(), "B".into()],
+            0,
+        );
+        assert!(
+            !EventHandler::is_text_input_context(&state),
+            "Config + Choice popup must NOT be treated as text input"
         );
 
         // Modal flags on AppState. Each must independently flip the

--- a/ainb-tui/src/components/config_popup.rs
+++ b/ainb-tui/src/components/config_popup.rs
@@ -72,6 +72,19 @@ impl ConfigPopupState {
         Self::default()
     }
 
+    /// True when the popup is visible AND its variant captures
+    /// character input (Text/Number). Choice and Boolean popups are
+    /// navigation-only (arrow keys / Enter), so callers checking
+    /// "should bare `Char(_)` keys go to the popup" should consult
+    /// this — not `show_popup` alone.
+    pub fn is_text_entry(&self) -> bool {
+        self.show_popup
+            && matches!(
+                self.popup_type,
+                ConfigPopupType::TextInput { .. } | ConfigPopupType::NumberInput { .. }
+            )
+    }
+
     /// Open popup for a choice setting
     pub fn open_choice(
         &mut self,


### PR DESCRIPTION
## Summary
Follow-up to gemini-code-assist review on PR #138 (two MEDIUM findings).

- **Predicate too broad** — \`show_popup\` included \`Choice\` and \`Boolean\` popups too. Those are navigation-only (arrow keys / Enter); \`H\` should still toggle help while they're visible. Added \`ConfigPopupState::is_text_entry()\` returning true only for \`TextInput\` / \`NumberInput\` variants, and consulted it from the predicate.
- **Test fidelity** — the popup test set \`show_popup = true\` directly, but \`AppState::default()\` leaves \`popup_type\` as \`Choice\`. With the predicate now narrowed, that arrangement would silently exercise the wrong path. Switched to the public \`open_text(...)\` API so the test opens a real \`TextInput\` popup, and added a negative-control test that \`open_choice(...)\` does NOT flip the predicate.

## Test plan
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo build\` ✓
- Updated test asserts \`TextInput\` popup → \`is_text_input_context\` is true.
- New negative-control test asserts \`Choice\` popup → \`is_text_input_context\` is false.