### PR TITLE
feat(reflect): hash-based dedup helpers on memory_discovery.py

### DIFF
--- a/toolkit/packages/plugins/reflect/scripts/memory_discovery.py
+++ b/toolkit/packages/plugins/reflect/scripts/memory_discovery.py
@@ -13,14 +13,23 @@ Usage:
     python memory_discovery.py discover              List all memories
     python memory_discovery.py discover --json       JSON output
     python memory_discovery.py discover --provider claude
+    python memory_discovery.py discover --new-only   Filter to unindexed (hash dedup)
     python memory_discovery.py stats                 Counts and line totals
+    python memory_discovery.py ingested? <file>      Exit 0 if file already indexed
     python memory_discovery.py cleanup <file>        Delete listed paths
     python memory_discovery.py cleanup <file> --execute   Actually delete (default is dry-run)
     python memory_discovery.py project-id            Git repo name
+
+Dedup vs the ingest log (`~/.learnings/.memory-ingest-log.yaml`) is BY
+CONTENT HASH, not by path — path-based dedup misses files that moved
+or were re-archived. Use `--new-only` or `ingested?` to get the right
+answer in one call instead of agents reinventing the hash check.
 """
 
 import argparse
+import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -36,6 +45,59 @@ from providers.claude import ClaudeProvider
 from providers.codex import CodexProvider
 from providers.copilot import CopilotProvider
 from providers.gemini import GeminiProvider
+
+# ---------------------------------------------------------------------------
+# Ingest-log dedup helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_ingest_log_path() -> Path:
+    """Return the default ingest log path (env override honoured)."""
+    learnings_home = Path(os.environ.get("LEARNINGS_HOME", Path.home() / ".learnings"))
+    return learnings_home / ".memory-ingest-log.yaml"
+
+
+def _load_ingested_hashes(log_path: Path | None = None) -> set[str]:
+    """Parse the ingest log and return every `content_hash` value already indexed.
+
+    Hand-rolled line scanner (no yaml dep) to keep this script standalone per
+    the `# dependencies = []` shebang. The log's flat shape — repeating
+    `- file:` / `  content_hash:` / `  ingested_at:` / … blocks — makes this
+    safe; we extract every line that starts with `content_hash:` regardless
+    of nesting.
+
+    Quoted or unquoted hash values both work; we strip surrounding quotes.
+    Hashes are 16 hex chars (sha256 prefix) but we don't validate length
+    here — any non-empty string is treated as a fingerprint.
+    """
+    if log_path is None:
+        log_path = _default_ingest_log_path()
+    if not log_path.is_file():
+        return set()
+    hashes: set[str] = set()
+    for raw in log_path.read_text().splitlines():
+        stripped = raw.strip()
+        if not stripped.startswith("content_hash:"):
+            continue
+        value = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+        if value:
+            hashes.add(value)
+    return hashes
+
+
+def _hash_file(path: Path, hash_len: int = 16) -> str:
+    """Return the sha256 prefix used as content fingerprint elsewhere in reflect.
+
+    Matches the convention used by `providers/*.py` when stamping
+    `DiscoveredMemory.content_hash`. Default length 16 hex chars keeps logs
+    compact while collision-safe at this corpus size.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()[:hash_len]
+
 
 # ---------------------------------------------------------------------------
 # Provider registry
@@ -98,6 +160,15 @@ def action_discover(args: argparse.Namespace) -> None:
     """List discovered memories."""
     memories = _discover_all(args.provider)
 
+    # --new-only: filter against the ingest log by content_hash. Per the
+    # SKILL.md dedup rule, hashes are the canonical key — paths can shift
+    # across runs (worktree paths, archive relocations) but a content
+    # fingerprint doesn't, so this is the agent-safe answer to "has this
+    # file been ingested already?".
+    if getattr(args, "new_only", False):
+        ingested = _load_ingested_hashes()
+        memories = [m for m in memories if m.content_hash not in ingested]
+
     if not memories:
         if args.json:
             print("[]")
@@ -125,6 +196,40 @@ def action_discover(args: argparse.Namespace) -> None:
             lines = m.content.count("\n") + 1
             print(f"  [{m.source_tool}] {m.source_path}  "
                   f"({lines} lines, project={m.project_name})")
+
+
+def action_ingested(args: argparse.Namespace) -> None:
+    """Check whether a file's content is already in the ingest log.
+
+    Exits 0 if the file's sha256 prefix matches an entry in the log,
+    1 if it's new (not yet indexed). Designed for shell/agent integration:
+
+        if memory_discovery.py "ingested?" "$f" >/dev/null; then
+            echo "skip — already indexed"
+        else
+            # process $f
+        fi
+
+    Use `--print-hash` to also emit the computed fingerprint for logs.
+    """
+    path = Path(args.file)
+    if not path.is_file():
+        print(f"ERROR: File not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    file_hash = _hash_file(path)
+    ingested = _load_ingested_hashes()
+    is_ingested = file_hash in ingested
+    if args.print_hash:
+        print(file_hash)
+    if args.json:
+        print(json.dumps({
+            "path": str(path),
+            "content_hash": file_hash,
+            "ingested": is_ingested,
+        }))
+    elif not args.print_hash:
+        print("ingested" if is_ingested else "new")
+    sys.exit(0 if is_ingested else 1)
 
 
 def action_stats(args: argparse.Namespace) -> None:
@@ -220,12 +325,28 @@ def main() -> None:
     p_discover.add_argument("--json", action="store_true", help="JSON output")
     p_discover.add_argument("--provider", type=str, default=None,
                             help="Filter to a single provider")
+    p_discover.add_argument(
+        "--new-only", action="store_true",
+        help="Only emit memories whose content_hash is NOT in the ingest log",
+    )
     p_discover.set_defaults(func=action_discover)
 
     # stats
     p_stats = sub.add_parser("stats", help="Show counts and line totals")
     p_stats.add_argument("--provider", type=str, default=None)
     p_stats.set_defaults(func=action_stats)
+
+    # ingested?  (exit code = was this file already indexed by reflect:ingest?)
+    p_ingested = sub.add_parser(
+        "ingested?",
+        help="Check if a file's content_hash appears in the ingest log",
+    )
+    p_ingested.add_argument("file", help="Path to a memory file")
+    p_ingested.add_argument("--json", action="store_true",
+                            help="JSON output with hash + ingested flag")
+    p_ingested.add_argument("--print-hash", action="store_true",
+                            help="Print the computed sha256 prefix")
+    p_ingested.set_defaults(func=action_ingested)
 
     # cleanup
     p_cleanup = sub.add_parser("cleanup", help="Delete paths listed in a file")


### PR DESCRIPTION
## Summary

Adds two helpers to `memory_discovery.py` so agents stop reinventing the ingest-log dedup check:

- `discover --new-only` — filters output to memories whose `content_hash` is NOT in `~/.learnings/.memory-ingest-log.yaml`
- `ingested? <file>` — exit 0 if a file's sha256 prefix is already indexed, 1 if new. Designed for shell guards:
  ```bash
  if memory_discovery.py "ingested?" "$f" >/dev/null; then continue; fi
  ```

## Why

Agents running `reflect:ingest` kept dedup-by-path, which gives wrong answers. Files move across worktree paths and archive runs, but their content hash doesn't. Latest example: a 62-truly-new shotclubhouse batch read as 355 "new" — would have wasted ~30 min ingesting 290 duplicates.

The SKILL.md spec (line 142-144) already says "check by `content_hash`", but it's enforced by convention only. This bakes the canonical answer into the tool.

## Implementation notes

- Line-based YAML parse (no `yaml` dep) preserves the script's `# dependencies = []` shebang
- `LEARNINGS_HOME` env override honoured for test/parallel runs
- 16-char sha256 prefix matches `providers/*.py` stamping convention

## Test plan

- [x] `discover --new-only --json` returns 88 items (matches independent hand-count: 82 atomic + 3 MEMORY.md + 3 codex)
- [x] `ingested? <known-indexed-file>` exits 0
- [x] `ingested? <known-new-file>` exits 1
- [x] `--json` + `--print-hash` flags work
- [ ] Update SKILL.md to reference these helpers (follow-up — out of scope for this PR)