### PR TITLE
fix(burndown): unstick scanning — chunker overflow + eager respawn + progress bar + flush-cache key

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -205,9 +205,9 @@ impl Plugin for BurndownPlugin {
     /// Generation is bumped only when the dispatch matched a binding,
     /// so unmapped keys won't trigger an avoidable re-render.
     async fn handle_key(&mut self, host: &HostClient, params: HandleKeyParams) -> Result<()> {
-        // Refresh is the one binding that needs the host. Everything
-        // else mutates `self.ui` only, so it lives in the pure helper
-        // below for testability.
+        // Refresh + flush-cache are the two bindings that need the
+        // host. Everything else mutates `self.ui` only, so it lives in
+        // the pure helper below for testability.
         let handled = match params.key.code {
             KeyCode::Char { ch: 'r' | 'R' } => {
                 // Ask session-reader to re-publish from scratch. Best
@@ -215,6 +215,19 @@ impl Plugin for BurndownPlugin {
                 // snapshot stays on screen.
                 let _ = host
                     .snapshot_publish("sessions.refresh_request", bytes::Bytes::new())
+                    .await;
+                true
+            }
+            KeyCode::Char { ch: 'F' } => {
+                // Wipe the persistent parse cache, then rescan. Use
+                // `F` (uppercase) to make the destructive nature
+                // obvious — `f` would be too easy to fat-finger. The
+                // scan immediately afterwards is cold-cache and may
+                // take 10s+ for large $HOME datasets; the
+                // `Scanning sessions:` skeleton (now with the new
+                // `N/M` progress bar) covers the latency.
+                let _ = host
+                    .snapshot_publish("sessions.flush_cache_request", bytes::Bytes::new())
                     .await;
                 true
             }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -415,16 +415,24 @@ impl BurndownPlugin {
     fn apply_chunk_pure(&mut self, event: UsageDataEvent) -> ChunkOutcome {
         if event.chunk_index == 0 {
             // Fresh publish sequence — seed the accumulator with the
-            // full aggregates + first call slice. Any prior in-flight
-            // accumulator is discarded (the publisher abandoned it).
+            // bounded aggregates from chunk 0. v4 wire model: chunk 0
+            // also carries empty `calls`/`sessions`/`shell_commands`
+            // (those are tail-chunked and arrive in chunks 1..N), so
+            // the seed already has the right empty tail vecs. Any
+            // prior in-flight accumulator is discarded — the publisher
+            // abandoned it.
             self.pending = Some(event.data);
         } else {
-            // Append `calls` onto the in-flight accumulator. If we
-            // missed chunk 0 (subscriber joined late or sequence got
-            // reordered), drop the chunk — partial data without
-            // aggregates is worse than no data.
+            // Extend each of the three tail-chunked vecs onto the
+            // in-flight accumulator. If we missed chunk 0 (subscriber
+            // joined late or sequence got reordered), drop the chunk —
+            // partial data without aggregates is worse than no data.
             match self.pending.as_mut() {
-                Some(acc) => acc.calls.extend(event.data.calls),
+                Some(acc) => {
+                    acc.calls.extend(event.data.calls);
+                    acc.sessions.extend(event.data.sessions);
+                    acc.shell_commands.extend(event.data.shell_commands);
+                }
                 None => return ChunkOutcome::DroppedFollowOn,
             }
         }
@@ -1187,6 +1195,102 @@ mod chunk_accumulator_tests {
         p.schema_mismatch = true;
         let _ = p.apply_chunk_pure(chunk(0, true, vec![fake_call(1)]));
         assert!(!p.schema_mismatch);
+    }
+
+    #[test]
+    fn v4_chunk_zero_no_calls_follow_on_chunks_extend_tail_vecs() {
+        // v4 wire model: chunk 0 carries only bounded aggregates;
+        // follow-on chunks carry slices of `calls`, `sessions`, and
+        // `shell_commands` that the accumulator extend()s onto the
+        // in-flight UsageData. This is what session-reader publishes
+        // after the chunker rewrite (see plugin.rs `chunk_usage_data`).
+        use ainb_plugin_types_sessions::{NamedUsage, SessionUsage};
+        use chrono::DateTime;
+
+        fn session(id: &str) -> SessionUsage {
+            SessionUsage {
+                provider: Provider::Claude,
+                project: "p".into(),
+                session_id: id.into(),
+                first_timestamp: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+                last_timestamp: DateTime::from_timestamp(1_700_000_001, 0).unwrap(),
+                bucket: TokenBucket::default(),
+            }
+        }
+
+        fn shell(name: &str) -> NamedUsage {
+            NamedUsage {
+                name: name.into(),
+                calls: 1,
+            }
+        }
+
+        let mut p = BurndownPlugin::default();
+
+        // Chunk 0: aggregates only. No calls, no sessions, no shell_cmds.
+        let mut chunk_0_data = WireUsageData::default();
+        chunk_0_data.projects = vec![ProjectUsage {
+            name: "p".into(),
+            path: "/tmp".into(),
+            bucket: TokenBucket::default(),
+            repo: None,
+        }];
+        assert_eq!(
+            p.apply_chunk_pure(UsageDataEvent {
+                version: WIRE_VERSION,
+                published_ns: 0,
+                partial: false,
+                chunk_index: 0,
+                is_final: false,
+                data: chunk_0_data,
+            }),
+            ChunkOutcome::Buffered
+        );
+
+        // Chunk 1: tail slice — 2 calls + 2 sessions + 1 shell_cmd.
+        let mut chunk_1_data = WireUsageData::default();
+        chunk_1_data.calls = vec![fake_call(1), fake_call(2)];
+        chunk_1_data.sessions = vec![session("s1"), session("s2")];
+        chunk_1_data.shell_commands = vec![shell("ls")];
+        assert_eq!(
+            p.apply_chunk_pure(UsageDataEvent {
+                version: WIRE_VERSION,
+                published_ns: 0,
+                partial: false,
+                chunk_index: 1,
+                is_final: false,
+                data: chunk_1_data,
+            }),
+            ChunkOutcome::Buffered
+        );
+
+        // Chunk 2: more tail — 1 call + 1 session + 2 shell_cmds, is_final.
+        let mut chunk_2_data = WireUsageData::default();
+        chunk_2_data.calls = vec![fake_call(3)];
+        chunk_2_data.sessions = vec![session("s3")];
+        chunk_2_data.shell_commands = vec![shell("grep"), shell("cat")];
+        assert_eq!(
+            p.apply_chunk_pure(UsageDataEvent {
+                version: WIRE_VERSION,
+                published_ns: 0,
+                partial: false,
+                chunk_index: 2,
+                is_final: true,
+                data: chunk_2_data,
+            }),
+            ChunkOutcome::Finalised
+        );
+
+        let d = p.data.as_ref().expect("snapshot finalised");
+        // Calls accumulated in order across chunks 1 and 2.
+        assert_eq!(d.calls.len(), 3);
+        assert_eq!(d.calls[0].id, 1);
+        assert_eq!(d.calls[2].id, 3);
+        // Sessions and shell_commands also accumulated.
+        assert_eq!(d.sessions.len(), 3, "sessions extended across chunks");
+        assert_eq!(d.shell_commands.len(), 3, "shell_commands extended across chunks");
+        // Aggregates from chunk 0 survived.
+        assert_eq!(d.projects.len(), 1);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Paragraph, Row, Table, Tabs},
+    widgets::{Block, BorderType, Borders, Gauge, Paragraph, Row, Table, Tabs},
 };
 
 use ainb_plugin_types_sessions::ScanProgressEvent;
@@ -1205,11 +1205,16 @@ fn render_loading(buf: &mut Buffer, area: Rect) {
 /// events from session-reader. Two formats depending on whether the
 /// scanner has pre-computed a file total:
 ///
-/// * `total > 0` → `Scanning sessions: N/M · {current_project}`
-/// * `total = 0` → `Scanning sessions… N files · {current_project}`
+/// * `total > 0` → headline `Scanning sessions: N/M · {current_project}`
+///   on row 0 of the inner area, plus a ratatui `Gauge` bar on row 1
+///   showing the `N/M` ratio with the inline `XX% (N/M)` label.
+/// * `total = 0` → headline `Scanning sessions… N files · {current_project}`
+///   only (no bar — without a total there's no ratio to render).
 ///
 /// The text is rendered in the same rounded panel as `render_loading`
-/// so the layout doesn't jitter between the two skeleton variants.
+/// so the layout doesn't jitter between the two skeleton variants. The
+/// gauge area is only allocated when total > 0; otherwise the panel is
+/// unchanged from the legacy single-line skeleton.
 pub(crate) fn render_scan_progress(
     buf: &mut Buffer,
     area: Rect,
@@ -1220,6 +1225,11 @@ pub(crate) fn render_scan_progress(
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(CORNFLOWER_BLUE))
         .style(Style::default().bg(DARK_BG));
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
 
     let mut spans = vec![
         Span::styled("  ⏳ ", Style::default().fg(GOLD)),
@@ -1235,8 +1245,45 @@ pub(crate) fn render_scan_progress(
             Style::default().fg(MUTED_GRAY),
         ));
     }
-    let paragraph = Paragraph::new(Line::from(spans)).block(block);
-    ratatui::widgets::Widget::render(paragraph, area, buf);
+
+    // When `total` is known and the panel has room for a second row,
+    // split the inner area into a 1-row headline + 1-row gauge. When
+    // `total` is 0 (or the panel is too short for 2 rows), fall back to
+    // the legacy single-line skeleton so we never render a bar with
+    // bogus 0% data.
+    let show_gauge = progress.total > 0 && inner.height >= 2;
+    if !show_gauge {
+        let paragraph = Paragraph::new(Line::from(spans));
+        ratatui::widgets::Widget::render(paragraph, inner, buf);
+        return;
+    }
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Length(1)])
+        .split(inner);
+
+    let paragraph = Paragraph::new(Line::from(spans));
+    ratatui::widgets::Widget::render(paragraph, layout[0], buf);
+
+    // Cap the ratio at 1.0 in case `scanned` overshoots `total` (can
+    // happen briefly if files are added mid-scan — ProgressReporter's
+    // counter is monotonic but `total` is the pre-walk snapshot).
+    let ratio = (f64::from(progress.scanned) / f64::from(progress.total)).clamp(0.0, 1.0);
+    let pct = (ratio * 100.0).round() as u16;
+    let gauge = Gauge::default()
+        .gauge_style(
+            Style::default()
+                .fg(SELECTION_GREEN)
+                .bg(PANEL_BG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .label(format!(
+            "{pct:>3}% ({}/{})",
+            progress.scanned, progress.total
+        ))
+        .ratio(ratio);
+    ratatui::widgets::Widget::render(gauge, layout[1], buf);
 }
 
 /// Format the scanned/total counters into the headline portion of the
@@ -5284,5 +5331,85 @@ mod scan_progress_tests {
             .collect();
         assert!(painted.contains("1 files"));
         assert!(!painted.contains(" · "), "no separator when project empty: {painted:?}");
+    }
+
+    #[test]
+    fn render_skeleton_paints_gauge_below_headline_when_total_known() {
+        // height=4 leaves an inner area of 2 rows after the rounded
+        // block — one for the headline, one for the gauge.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 4,
+        };
+        let mut buf = Buffer::empty(area);
+        render_scan_progress(&mut buf, area, &progress(50, 100, "alpha"));
+
+        // Row 1 = headline. Row 2 = gauge.
+        let headline_row: String = (0..area.width)
+            .map(|x| buf.get(x, 1).symbol().to_string())
+            .collect();
+        let gauge_row: String = (0..area.width)
+            .map(|x| buf.get(x, 2).symbol().to_string())
+            .collect();
+        assert!(
+            headline_row.contains("Scanning sessions: 50/100"),
+            "headline rendered on row 1: {headline_row:?}"
+        );
+        assert!(
+            gauge_row.contains("50%") || gauge_row.contains("(50/100)"),
+            "gauge row contains the percent/ratio label: {gauge_row:?}"
+        );
+    }
+
+    #[test]
+    fn render_skeleton_falls_back_to_single_line_when_total_unknown() {
+        // total=0 → never render the gauge, even with a tall area.
+        // Without a denominator there's no ratio to draw.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 6,
+        };
+        let mut buf = Buffer::empty(area);
+        render_scan_progress(&mut buf, area, &progress(17, 0, "alpha"));
+
+        // Row 1 should have the headline. Row 2 should be empty (no
+        // gauge), filled with spaces / default cells.
+        let row2: String = (0..area.width)
+            .map(|x| buf.get(x, 2).symbol().to_string())
+            .collect();
+        assert!(
+            !row2.contains('%'),
+            "no gauge row when total=0: row2 = {row2:?}"
+        );
+    }
+
+    #[test]
+    fn render_skeleton_clamps_overshoot_ratio() {
+        // If `scanned` somehow exceeds `total` (e.g. files added
+        // mid-scan after the pre-walk), the gauge must clamp at 100%
+        // rather than over-fill the bar or print "120%".
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 4,
+        };
+        let mut buf = Buffer::empty(area);
+        render_scan_progress(&mut buf, area, &progress(120, 100, "alpha"));
+        let gauge_row: String = (0..area.width)
+            .map(|x| buf.get(x, 2).symbol().to_string())
+            .collect();
+        assert!(
+            gauge_row.contains("100%"),
+            "overshoot clamps to 100%: {gauge_row:?}"
+        );
+        assert!(
+            !gauge_row.contains("120%"),
+            "no over-100% label: {gauge_row:?}"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -1270,7 +1270,10 @@ pub(crate) fn render_scan_progress(
     // happen briefly if files are added mid-scan — ProgressReporter's
     // counter is monotonic but `total` is the pre-walk snapshot).
     let ratio = (f64::from(progress.scanned) / f64::from(progress.total)).clamp(0.0, 1.0);
-    let pct = (ratio * 100.0).round() as u16;
+    // Ratio is in [0, 1] so `ratio * 100` is in [0, 100] — fits u16
+    // without truncation. try_from + unwrap_or makes the bound
+    // explicit instead of relying on the clamp + clippy lint allow.
+    let pct: u16 = u16::try_from((ratio * 100.0).round() as i32).unwrap_or(100);
     let gauge = Gauge::default()
         .gauge_style(
             Style::default()

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -4168,6 +4168,8 @@ fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
         Span::styled(" scroll  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("r/R", Style::default().fg(GOLD)),
         Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("F", Style::default().fg(GOLD)),
+        Span::styled(" flush cache  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("Esc", Style::default().fg(GOLD)),
         Span::styled(" back", Style::default().fg(MUTED_GRAY)),
     ]);

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -731,6 +731,39 @@ impl PluginTask {
         debug!(plugin = %self.plugin.id, "backoff {backoff:?}");
         tokio::time::sleep(backoff).await;
         self.set_state(LifecycleState::Idle);
+
+        // Honour `manifest.lifecycle.spawn = "eager"` on the *exit
+        // path*, not only at registration. An eager plugin that exits
+        // (process crash, broken pipe, etc.) needs to come back without
+        // a host event triggering it — otherwise a one-shot failure
+        // wedges the plugin dead for the rest of the TUI session. The
+        // original bug: session-reader shipped a single oversize chunk,
+        // host framer rejected it, plugin's stdout pipe closed, plugin
+        // exited; with no respawn here the burndown UI stayed at
+        // "Scanning sessions…" forever. Lazy plugins are left alone —
+        // they only spawn when first used.
+        if matches!(
+            self.plugin.manifest.lifecycle.spawn,
+            ainb_plugin_protocol::manifest::SpawnMode::Eager
+        ) && !matches!(*self.state.read(), LifecycleState::Quarantined)
+        {
+            debug!(
+                plugin = %self.plugin.id,
+                "eager: respawning after exit (attempt {})",
+                self.respawn_attempts
+            );
+            if let Err(e) = self.spawn_and_init().await {
+                warn!(
+                    plugin = %self.plugin.id,
+                    "eager respawn after exit failed: {e}"
+                );
+                // spawn_and_init transitions to Spawning then either
+                // Running on success or leaves us in Spawning on
+                // failure; explicitly fall back to Idle so the next
+                // failure scheduling math doesn't confuse states.
+                self.set_state(LifecycleState::Idle);
+            }
+        }
     }
 
     fn record_failure(&mut self) {

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
@@ -387,6 +387,67 @@ fn handle_is_send_and_clone() {
     let _: Arc<dyn Send + Sync> = Arc::new(()) as Arc<dyn Send + Sync>;
 }
 
+// Eager-respawn regression: an eager plugin that exits (crash, broken
+// pipe, etc.) must come back automatically after the backoff window —
+// not only at registration time. Without this guarantee, a single
+// transient failure wedges the plugin dead for the rest of the TUI
+// session. The original bug: session-reader shipped one oversize
+// chunk, host framer rejected it, plugin's stdout pipe closed, plugin
+// exited; burndown UI stayed stuck at "Scanning sessions…" forever
+// because session-reader never respawned.
+#[test]
+fn eager_plugin_respawns_automatically_after_exit() {
+    let (rt, handle) = build_runtime();
+    let mut manifest = fixture_manifest();
+    manifest.lifecycle.spawn = SpawnMode::Eager;
+    manifest.plugin.name = "fixture-eager-respawn".into();
+    let plugin = RegisteredPlugin::new(
+        manifest,
+        fixture_path(),
+        PathBuf::from("/dev/null/manifest.toml"),
+    );
+    let id = plugin.id.clone();
+    rt.register(plugin);
+
+    // Wait for the initial eager spawn.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if matches!(handle.lifecycle_state(&id), Some(LifecycleState::Running)) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(
+        handle.lifecycle_state(&id),
+        Some(LifecycleState::Running),
+        "eager plugin never reached initial Running"
+    );
+
+    // Kill the plugin process. The runtime should observe pipe close,
+    // log "plugin exited / pipe closed", run through backoff, then
+    // respawn because spawn=eager. No host request (render/cli) needed
+    // to trigger the respawn — that's the whole point of this test.
+    handle.inject_kill(&id).expect("inject_kill");
+
+    // Backoff is 50ms in the test config, plus exec latency. Give it
+    // generous headroom — the respawn path includes child spawn,
+    // PluginInit RPC, and reading the init response.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut respawned = false;
+    while std::time::Instant::now() < deadline {
+        if matches!(handle.lifecycle_state(&id), Some(LifecycleState::Running)) {
+            respawned = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    assert!(
+        respawned,
+        "eager plugin did not auto-respawn after exit; state = {:?}",
+        handle.lifecycle_state(&id)
+    );
+}
+
 // Eager-spawn regression: manifest declaring `spawn = "eager"` must
 // cause the runtime to launch the plugin process immediately at
 // registration time, without waiting for a first request. Without

--- a/ainb-tui/crates/ainb-plugin-session-reader/manifest.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/manifest.toml
@@ -29,7 +29,10 @@ snapshots = ["sessions.usage_data"]
 
 [subscribes]
 # Refresh trigger: any publisher on this topic prompts a re-scan.
-snapshots = ["sessions.refresh_request"]
+# Flush trigger: any publisher on `sessions.flush_cache_request`
+# prompts a cache wipe followed by a full re-scan. Used by burndown's
+# `F` key for cache-corruption recovery.
+snapshots = ["sessions.refresh_request", "sessions.flush_cache_request"]
 
 [lifecycle]
 # Eager: the host needs the first snapshot ready before burndown asks.

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -112,12 +112,17 @@ impl SessionReader {
     }
 
     /// Wipe every cached parse row and force the next scan to re-parse
-    /// every file from disk. Best-effort: if the cache hasn't been
-    /// opened yet, opens it and clears; if open fails, logs and falls
-    /// through (the subsequent rescan still works, it's just cold).
-    /// Doesn't delete the sqlite file — `UsageCache::clear()` runs
-    /// `DELETE FROM file_cache` + `VACUUM`, preserving the schema row
-    /// so the next open doesn't migrate.
+    /// every file from disk.
+    ///
+    /// Two-tier recovery: first try the fast in-place wipe
+    /// (`UsageCache::clear()` runs `DELETE FROM file_cache` + `VACUUM`,
+    /// preserving the schema row so the next open doesn't migrate). If
+    /// that fails — the user is likely pressing `F` precisely because
+    /// they suspect corruption, so SQL clear may fail too — drop the
+    /// cache handle, `rm -f` the file, and let the next
+    /// [`Self::ensure_cache`] re-create it from scratch. This way the
+    /// rescan that runs immediately afterwards starts cold-cache
+    /// regardless of how broken the previous cache was.
     #[cfg(not(target_arch = "wasm32"))]
     async fn flush_cache(&mut self, host: &HostClient) {
         self.ensure_cache();
@@ -125,22 +130,48 @@ impl SessionReader {
             match cache.clear() {
                 Ok(()) => {
                     let _ = host
-                        .log_info("flush_cache: persistent cache wiped")
+                        .log_info("flush_cache: persistent cache wiped via clear()")
+                        .await;
+                    return;
+                }
+                Err(err) => {
+                    let _ = host
+                        .log_info(format!(
+                            "flush_cache: clear() failed: {err}; falling back to file delete"
+                        ))
+                        .await;
+                }
+            }
+        }
+        // Either no cache was open, or clear() failed. Drop the handle
+        // (closes the sqlite connection if any) and remove the file —
+        // the next ensure_cache rebuilds.
+        self.cache = None;
+        self.cache_init = false;
+        if let Some(path) = crate::cache::default_db_path() {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    let _ = host
+                        .log_info(format!(
+                            "flush_cache: removed cache file at {}",
+                            path.display()
+                        ))
+                        .await;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    let _ = host
+                        .log_info("flush_cache: cache file already absent")
                         .await;
                 }
                 Err(err) => {
                     let _ = host
                         .log_info(format!(
-                            "flush_cache: cache clear failed: {err}; \
-                            next rescan will degrade to cold-cache speed regardless"
+                            "flush_cache: remove cache file failed: {err}; \
+                            next rescan still runs (but cache may stay stale)"
                         ))
                         .await;
                 }
             }
-        } else {
-            let _ = host
-                .log_info("flush_cache: no cache open; nothing to wipe")
-                .await;
         }
     }
 
@@ -475,27 +506,95 @@ pub(crate) fn chunk_usage_data(
 
             // Cut on probe overshoot, but only if the chunk has >1 item
             // total — single-item chunks always ship so a giant outlier
-            // (e.g. one 5 MiB user_message) can't stall the loop. Spill
-            // the just-popped item back to its source queue and break.
+            // (e.g. one 5 MiB user_message) can't stall the loop.
+            //
+            // Spill in a loop, not just once: STEP=64 means the chunk
+            // can land 8 MiB over budget when one of those 64 items is
+            // a 100+ KiB outlier. Single-spill would still ship a chunk
+            // 50× over target. We pop the most-recently-pushed item from
+            // the queue that received it, then re-probe; keep spilling
+            // until we're back under target or only 1 item remains.
+            // popped_from tracks the *last* push, but a multi-spill
+            // needs to walk back through previous pushes — we use the
+            // queue with the largest tail first as a heuristic.
             let chunk_item_count = chunk_data.calls.len()
                 + chunk_data.sessions.len()
                 + chunk_data.shell_commands.len();
             if probe_size >= target_bytes && chunk_item_count > 1 {
-                match popped_from {
-                    TailQueue::Calls => {
-                        if let Some(spill) = chunk_data.calls.pop() {
-                            calls_q.push_front(spill);
+                // First spill: the just-popped item, to the queue it
+                // came from. Subsequent spills come from whichever
+                // tail vec currently has the most items (best chance
+                // of cheaply shrinking the chunk).
+                let _ = popped_from; // first spill uses the queue below
+                let mut current_size = probe_size;
+                loop {
+                    // Choose the spill source: the largest tail vec.
+                    // Re-evaluate every iteration because vecs shrink.
+                    let from = if chunk_data.calls.len()
+                        >= chunk_data.sessions.len()
+                        && chunk_data.calls.len()
+                            >= chunk_data.shell_commands.len()
+                        && !chunk_data.calls.is_empty()
+                    {
+                        TailQueue::Calls
+                    } else if chunk_data.sessions.len()
+                        >= chunk_data.shell_commands.len()
+                        && !chunk_data.sessions.is_empty()
+                    {
+                        TailQueue::Sessions
+                    } else if !chunk_data.shell_commands.is_empty() {
+                        TailQueue::ShellCommands
+                    } else {
+                        break; // nothing left to spill
+                    };
+
+                    match from {
+                        TailQueue::Calls => {
+                            if let Some(spill) = chunk_data.calls.pop() {
+                                calls_q.push_front(spill);
+                            }
+                        }
+                        TailQueue::Sessions => {
+                            if let Some(spill) = chunk_data.sessions.pop() {
+                                sessions_q.push_front(spill);
+                            }
+                        }
+                        TailQueue::ShellCommands => {
+                            if let Some(spill) = chunk_data.shell_commands.pop() {
+                                shell_q.push_front(spill);
+                            }
                         }
                     }
-                    TailQueue::Sessions => {
-                        if let Some(spill) = chunk_data.sessions.pop() {
-                            sessions_q.push_front(spill);
-                        }
+
+                    let remaining_items = chunk_data.calls.len()
+                        + chunk_data.sessions.len()
+                        + chunk_data.shell_commands.len();
+                    if remaining_items <= 1 {
+                        // Single-item chunks always ship (giant-outlier
+                        // protection). Even if still oversize, exit
+                        // here rather than spill the lone survivor.
+                        break;
                     }
-                    TailQueue::ShellCommands => {
-                        if let Some(spill) = chunk_data.shell_commands.pop() {
-                            shell_q.push_front(spill);
-                        }
+
+                    // Re-probe. Cost is O(chunk_data_encoded_size) per
+                    // probe — at ~1 MiB target and 100 KiB outliers,
+                    // worst case ~10 probes per cut, totally affordable
+                    // relative to the I/O cost of the actual publish.
+                    let probe = UsageDataEvent {
+                        version: WIRE_VERSION,
+                        published_ns,
+                        partial,
+                        chunk_index,
+                        is_final: calls_q.is_empty()
+                            && sessions_q.is_empty()
+                            && shell_q.is_empty(),
+                        data: chunk_data.clone(),
+                    };
+                    current_size = rmp_serde::to_vec_named(&probe)
+                        .map(|b| b.len())
+                        .unwrap_or(target_bytes);
+                    if current_size < target_bytes {
+                        break;
                     }
                 }
                 break;
@@ -918,6 +1017,56 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[1].data.calls.len(), 3);
         assert_eq!(chunks[1].data.sessions.len(), 3);
+    }
+
+    #[test]
+    fn chunk_multispill_keeps_each_chunk_under_target_with_outlier_calls() {
+        // Regression for the multi-spill fix: when the probe step
+        // (STEP=64) accumulates a chunk that's many MiB over budget
+        // because one or more items are outliers, a single-spill cut
+        // would still ship the chunk way over. Multi-spill must drain
+        // back until under target (or 1 item remains).
+        //
+        // Build 128 fat calls (~50 KiB each). With STEP=64 and a
+        // 1 MiB target, the first probe lands at ~3.2 MiB. Without
+        // multi-spill, the chunk would ship at ~3.15 MiB. With
+        // multi-spill, each chunk must encode under 1 MiB.
+        let mut data = fake_data(0);
+        data.calls = (0..128)
+            .map(|i| {
+                let mut c = fake_call(i);
+                c.user_message = "x".repeat(50 * 1024);
+                c
+            })
+            .collect();
+
+        let target = 1024 * 1024; // 1 MiB
+        let chunks = chunk_usage_data(data, 0, false, target);
+
+        // Verify each chunk (except possibly chunk 0 which carries
+        // only bounded aggregates, well under target, and chunks
+        // containing a single mandatory item) encodes under target.
+        for (i, chunk) in chunks.iter().enumerate() {
+            let size = rmp_serde::to_vec_named(chunk).unwrap().len();
+            let item_count = chunk.data.calls.len()
+                + chunk.data.sessions.len()
+                + chunk.data.shell_commands.len();
+            // Single-item chunks always ship even if oversize (giant-
+            // outlier protection). Otherwise must fit.
+            if item_count > 1 {
+                assert!(
+                    size < target,
+                    "chunk {i} has {item_count} items at {size} bytes \
+                    (target {target}) — multi-spill should have kept \
+                    this under target"
+                );
+            }
+        }
+
+        // No call loss.
+        let (calls, _, _) = tail_totals(&chunks);
+        assert_eq!(calls, 128);
+        assert!(chunks.last().unwrap().is_final);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -45,6 +45,14 @@ pub const TOPIC_USAGE_DATA: &str = "sessions.usage_data";
 /// Topic any consumer can publish to to force a re-scan + re-publish.
 pub const TOPIC_REFRESH_REQUEST: &str = "sessions.refresh_request";
 
+/// Topic any consumer can publish to to wipe the per-file parse cache
+/// and re-publish from scratch. Distinct from `sessions.refresh_request`
+/// because the latter is cache-aware (most files short-circuit on
+/// `(mtime, size)` match) — flush-cache is the escape hatch for
+/// suspected cache corruption or behavioural drift where the user
+/// wants to know the snapshot was built from scratch.
+pub const TOPIC_FLUSH_CACHE_REQUEST: &str = "sessions.flush_cache_request";
+
 /// Topic the plugin publishes per-file scan progress on. Burndown
 /// subscribes here to render the skeleton/`Scanning sessions…` line
 /// while the cold scan is in flight.
@@ -100,6 +108,39 @@ impl SessionReader {
             cache: None,
             #[cfg(not(target_arch = "wasm32"))]
             cache_init: false,
+        }
+    }
+
+    /// Wipe every cached parse row and force the next scan to re-parse
+    /// every file from disk. Best-effort: if the cache hasn't been
+    /// opened yet, opens it and clears; if open fails, logs and falls
+    /// through (the subsequent rescan still works, it's just cold).
+    /// Doesn't delete the sqlite file — `UsageCache::clear()` runs
+    /// `DELETE FROM file_cache` + `VACUUM`, preserving the schema row
+    /// so the next open doesn't migrate.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn flush_cache(&mut self, host: &HostClient) {
+        self.ensure_cache();
+        if let Some(cache) = self.cache.as_mut() {
+            match cache.clear() {
+                Ok(()) => {
+                    let _ = host
+                        .log_info("flush_cache: persistent cache wiped")
+                        .await;
+                }
+                Err(err) => {
+                    let _ = host
+                        .log_info(format!(
+                            "flush_cache: cache clear failed: {err}; \
+                            next rescan will degrade to cold-cache speed regardless"
+                        ))
+                        .await;
+                }
+            }
+        } else {
+            let _ = host
+                .log_info("flush_cache: no cache open; nothing to wipe")
+                .await;
         }
     }
 
@@ -501,6 +542,9 @@ impl Plugin for SessionReader {
             .log_info("on_init: subscribing to sessions.refresh_request")
             .await;
         host.snapshot_subscribe(TOPIC_REFRESH_REQUEST).await?;
+        // Also subscribe to flush-cache so burndown's `F` key can wipe
+        // the persistent cache and republish from scratch.
+        host.snapshot_subscribe(TOPIC_FLUSH_CACHE_REQUEST).await?;
         let _ = host
             .log_info("on_init: subscribed, idle until refresh_request")
             .await;
@@ -524,6 +568,11 @@ impl Plugin for SessionReader {
     ) -> Result<()> {
         if params.topic == TOPIC_REFRESH_REQUEST {
             tracing::info!("session-reader: refresh requested — rescanning");
+            return self.publish(host).await;
+        }
+        if params.topic == TOPIC_FLUSH_CACHE_REQUEST {
+            tracing::info!("session-reader: flush_cache requested — wiping cache + rescanning");
+            self.flush_cache(host).await;
             return self.publish(host).await;
         }
         tracing::debug!(topic = %params.topic, "session-reader: ignoring unrelated event");

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -317,25 +317,47 @@ impl SessionReader {
 /// chunk — a few dozen for real data.
 const CHUNKER_PROBE_STEP: usize = 64;
 
+/// Identifier for which tail-chunkable vec a chunker push came from.
+/// Lets the spill-back path return the just-popped item to the right
+/// queue when an over-target probe forces a cut.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TailQueue {
+    Calls,
+    Sessions,
+    ShellCommands,
+}
+
 /// Split a `UsageData` snapshot into one or more `UsageDataEvent`
 /// chunks. Pure; unit-tested directly.
 ///
-/// Re-encodes the candidate chunk after every [`CHUNKER_PROBE_STEP`]
-/// calls; cuts when the encoded msgpack size crosses `target_bytes`.
-/// This avoids the unbounded variance seen with a static call-count
-/// budget (some real-world calls are >10x larger than others).
-///
-/// - Chunk 0 carries every aggregate field + the first slice of
-///   `data.calls` (sized so the encoded msgpack stays under
-///   `target_bytes`).
-/// - Chunks 1..N carry only the remaining `calls` (every other field
-///   is `UsageData::default()`).
-/// - The last chunk has `is_final = true`. A single-chunk publish has
-///   `chunk_index = 0, is_final = true`.
-/// - When `data.calls` is empty, returns a single chunk.
-/// - A single huge call that on its own exceeds `target_bytes` still
-///   ships (otherwise the loop would stall); the host framer's
+/// **Wire model (WIRE_VERSION 4):**
+/// - Chunk 0 carries the bounded aggregates only (`daily`, `weekly`,
+///   `projects`, `grand_total`, `models`, `activities`, `tools`,
+///   `mcp_servers`, `branches`, `model_project_counts`). `calls`,
+///   `sessions`, and `shell_commands` are emptied out and tail-chunked.
+/// - Chunks 1..N each carry slices of `calls` + `sessions` +
+///   `shell_commands`, sized so the encoded msgpack stays under
+///   `target_bytes`. Other fields are `UsageData::default()`. The
+///   consumer accumulator `extend`s the three tail vecs as chunks
+///   arrive.
+/// - The last chunk has `is_final = true`. A snapshot whose tail vecs
+///   are all empty ships as a single chunk-0 with `is_final = true`.
+/// - A single huge tail item that on its own exceeds `target_bytes`
+///   still ships (otherwise the loop would stall); the host framer's
 ///   16 MiB cap still leaves an order-of-magnitude headroom.
+///
+/// **Why tail-chunk these three.** They're the only fields whose size
+/// grows with raw call volume rather than with bounded entity counts
+/// (distinct projects, days, models, branches). At ~128k calls /
+/// ~4k sessions / many distinct bash commands a v3 chunk 0 encoded
+/// to ~17 MiB and tripped the 16 MiB framer cap — see WIRE_VERSION
+/// docs for the incident report.
+///
+/// Re-encodes the candidate chunk after every [`CHUNKER_PROBE_STEP`]
+/// items appended; cuts when the encoded msgpack size crosses
+/// `target_bytes`. Pop priority is `calls` → `sessions` →
+/// `shell_commands`, draining the biggest queue first so the chunk
+/// count for call-dominated snapshots matches the v3 distribution.
 pub(crate) fn chunk_usage_data(
     mut data: UsageData,
     published_ns: u64,
@@ -343,39 +365,57 @@ pub(crate) fn chunk_usage_data(
     target_bytes: usize,
 ) -> Vec<UsageDataEvent> {
     assert!(target_bytes >= 1024, "target_bytes too small");
-    let all_calls = std::mem::take(&mut data.calls);
 
-    let mut out: Vec<UsageDataEvent> = Vec::new();
-    let mut remaining: std::collections::VecDeque<_> = all_calls.into_iter().collect();
-    let mut chunk_index: u32 = 0;
+    // Detach the tail-chunkable vecs from `data` so chunk 0 carries
+    // only the bounded aggregates. Chunks 1..N drain from these three
+    // queues until every one is empty.
+    let mut calls_q: std::collections::VecDeque<_> =
+        std::mem::take(&mut data.calls).into_iter().collect();
+    let mut sessions_q: std::collections::VecDeque<_> =
+        std::mem::take(&mut data.sessions).into_iter().collect();
+    let mut shell_q: std::collections::VecDeque<_> =
+        std::mem::take(&mut data.shell_commands).into_iter().collect();
 
-    loop {
-        // Build the candidate chunk's data shell once per chunk —
-        // chunk 0 includes aggregates, others are calls-only.
-        let mut chunk_data = if chunk_index == 0 {
-            let mut head = data.clone();
-            head.calls = Vec::new();
-            head
-        } else {
-            UsageData::default()
-        };
+    let mut out: Vec<UsageDataEvent> = Vec::with_capacity(1);
 
-        // Push calls one at a time, probing the encoded size every
-        // CHUNKER_PROBE_STEP appends OR when the queue drains. On
-        // overshoot, roll the trailing call back so the next chunk
-        // gets it. Single-call chunks always ship (giant-outlier
-        // protection).
+    // Chunk 0: bounded aggregates only, empty tail vecs.
+    out.push(UsageDataEvent {
+        version: WIRE_VERSION,
+        published_ns,
+        partial,
+        chunk_index: 0,
+        is_final: calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty(),
+        data,
+    });
+
+    let mut chunk_index: u32 = 1;
+    while !(calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty()) {
+        let mut chunk_data = UsageData::default();
         let mut since_probe = 0usize;
+
         loop {
-            let Some(call) = remaining.pop_front() else {
-                break;
+            // Pop priority: calls (largest) → sessions → shell_commands.
+            // Track which queue we popped from so a spill-back lands in
+            // the right place.
+            let popped_from = if let Some(c) = calls_q.pop_front() {
+                chunk_data.calls.push(c);
+                TailQueue::Calls
+            } else if let Some(s) = sessions_q.pop_front() {
+                chunk_data.sessions.push(s);
+                TailQueue::Sessions
+            } else if let Some(s) = shell_q.pop_front() {
+                chunk_data.shell_commands.push(s);
+                TailQueue::ShellCommands
+            } else {
+                break; // every queue drained
             };
-            chunk_data.calls.push(call);
             since_probe += 1;
-            // Probe when we've accumulated STEP calls, or when the
-            // queue just drained (so we don't miss tiny final
-            // overshoots).
-            if since_probe < CHUNKER_PROBE_STEP && !remaining.is_empty() {
+
+            let all_empty =
+                calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty();
+            // Probe when we've accumulated STEP items, or when every
+            // queue just drained (so we don't miss tiny final overshoots).
+            if since_probe < CHUNKER_PROBE_STEP && !all_empty {
                 continue;
             }
             since_probe = 0;
@@ -385,22 +425,44 @@ pub(crate) fn chunk_usage_data(
                 published_ns,
                 partial,
                 chunk_index,
-                is_final: remaining.is_empty(),
+                is_final: all_empty,
                 data: chunk_data.clone(),
             };
             let probe_size = rmp_serde::to_vec_named(&probe_event)
                 .map(|b| b.len())
                 .unwrap_or(target_bytes);
-            if probe_size >= target_bytes && chunk_data.calls.len() > 1 {
-                // Shed the trailing call back to `remaining`.
-                if let Some(spill) = chunk_data.calls.pop() {
-                    remaining.push_front(spill);
+
+            // Cut on probe overshoot, but only if the chunk has >1 item
+            // total — single-item chunks always ship so a giant outlier
+            // (e.g. one 5 MiB user_message) can't stall the loop. Spill
+            // the just-popped item back to its source queue and break.
+            let chunk_item_count = chunk_data.calls.len()
+                + chunk_data.sessions.len()
+                + chunk_data.shell_commands.len();
+            if probe_size >= target_bytes && chunk_item_count > 1 {
+                match popped_from {
+                    TailQueue::Calls => {
+                        if let Some(spill) = chunk_data.calls.pop() {
+                            calls_q.push_front(spill);
+                        }
+                    }
+                    TailQueue::Sessions => {
+                        if let Some(spill) = chunk_data.sessions.pop() {
+                            sessions_q.push_front(spill);
+                        }
+                    }
+                    TailQueue::ShellCommands => {
+                        if let Some(spill) = chunk_data.shell_commands.pop() {
+                            shell_q.push_front(spill);
+                        }
+                    }
                 }
                 break;
             }
         }
 
-        let is_final = remaining.is_empty();
+        let is_final =
+            calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty();
         out.push(UsageDataEvent {
             version: WIRE_VERSION,
             published_ns,
@@ -409,11 +471,9 @@ pub(crate) fn chunk_usage_data(
             is_final,
             data: chunk_data,
         });
-        if is_final {
-            break;
-        }
         chunk_index = chunk_index.saturating_add(1);
     }
+
     out
 }
 
@@ -515,7 +575,8 @@ mod tests {
     }
 
     use ainb_plugin_types_sessions::{
-        ActivityCategory, ActivityUsage, ProjectUsage, Provider, ProviderCall, TokenBucket,
+        ActivityCategory, ActivityUsage, NamedUsage, ProjectUsage, Provider, ProviderCall,
+        SessionUsage, TokenBucket,
     };
     use chrono::{DateTime, Utc};
 
@@ -569,26 +630,51 @@ mod tests {
         d
     }
 
-    #[test]
-    fn chunk_single_when_calls_fit_in_one_chunk() {
-        let data = fake_data(10);
-        // 4 MiB budget — small fake calls all fit.
-        let chunks = chunk_usage_data(data, 42, false, 4 * 1024 * 1024);
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].chunk_index, 0);
-        assert!(chunks[0].is_final);
-        assert_eq!(chunks[0].data.calls.len(), 10);
-        assert_eq!(chunks[0].data.projects.len(), 1, "aggregates ride chunk 0");
-        assert_eq!(chunks[0].published_ns, 42);
+    /// Sum the lengths of every tail vec across every chunk —
+    /// callers compare to the pre-chunk totals to assert no-loss.
+    fn tail_totals(chunks: &[UsageDataEvent]) -> (usize, usize, usize) {
+        let calls: usize = chunks.iter().map(|c| c.data.calls.len()).sum();
+        let sessions: usize = chunks.iter().map(|c| c.data.sessions.len()).sum();
+        let shells: usize = chunks.iter().map(|c| c.data.shell_commands.len()).sum();
+        (calls, sessions, shells)
     }
 
     #[test]
-    fn chunk_single_when_calls_empty() {
+    fn chunk_zero_carries_aggregates_calls_ride_follow_on() {
+        // 10 small calls + bounded aggregates. v4 model: chunk 0
+        // carries the aggregates (and is_final=false because there's
+        // tail data to ship), chunk 1 carries the calls.
+        let data = fake_data(10);
+        let chunks = chunk_usage_data(data, 42, false, 4 * 1024 * 1024);
+        assert_eq!(chunks.len(), 2, "v4: chunk0 + 1 tail chunk for 10 calls");
+
+        // Chunk 0: aggregates, no tail items.
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert!(!chunks[0].is_final);
+        assert!(chunks[0].data.calls.is_empty(), "chunk 0 has no calls in v4");
+        assert!(chunks[0].data.sessions.is_empty());
+        assert!(chunks[0].data.shell_commands.is_empty());
+        assert_eq!(chunks[0].data.projects.len(), 1, "aggregates ride chunk 0");
+        assert_eq!(chunks[0].data.activities.len(), 1);
+        assert_eq!(chunks[0].published_ns, 42);
+
+        // Chunk 1: the calls.
+        assert_eq!(chunks[1].chunk_index, 1);
+        assert!(chunks[1].is_final);
+        assert_eq!(chunks[1].data.calls.len(), 10);
+        assert!(chunks[1].data.projects.is_empty(), "no aggregates in tail chunks");
+    }
+
+    #[test]
+    fn chunk_single_when_every_tail_vec_empty() {
+        // Aggregates only — no calls, no sessions, no shell_commands.
+        // Single chunk-0 with is_final=true.
         let data = fake_data(0);
         let chunks = chunk_usage_data(data, 0, false, 4 * 1024 * 1024);
         assert_eq!(chunks.len(), 1);
         assert!(chunks[0].is_final);
         assert!(chunks[0].data.calls.is_empty());
+        assert_eq!(chunks[0].chunk_index, 0);
     }
 
     #[test]
@@ -620,16 +706,17 @@ mod tests {
 
         let chunks = chunk_usage_data(data, 0, false, 128 * 1024);
         assert!(chunks.len() > 1, "expected >1 chunks, got {}", chunks.len());
-        let total_calls: usize = chunks.iter().map(|c| c.data.calls.len()).sum();
+        let (total_calls, _, _) = tail_totals(&chunks);
         assert_eq!(total_calls, 40, "no calls lost across chunks");
 
-        // Chunk 0 carries aggregates.
+        // Chunk 0 carries aggregates and no tail items.
         assert_eq!(chunks[0].chunk_index, 0);
         assert!(!chunks[0].is_final);
         assert_eq!(chunks[0].data.projects.len(), 1);
         assert_eq!(chunks[0].data.activities.len(), 1);
+        assert!(chunks[0].data.calls.is_empty(), "v4: tails live in follow-on chunks");
 
-        // Chunks 1+ carry only calls (no aggregates).
+        // Chunks 1+ carry only tail vecs (no aggregates).
         assert!(chunks[1].data.projects.is_empty());
         assert!(chunks[1].data.activities.is_empty());
         assert_eq!(chunks[1].data.grand_total, TokenBucket::default());
@@ -666,13 +753,166 @@ mod tests {
     fn chunk_with_single_giant_call_still_progresses() {
         // Even a single estimated-over-budget call must ship —
         // otherwise the chunker would loop forever waiting for room.
+        // v4: chunk 0 (empty aggregates) + chunk 1 (the giant call).
         let mut data = fake_data(0);
         let mut huge = fake_call(1);
         huge.user_message = "x".repeat(2048);
         data.calls = vec![huge];
         let chunks = chunk_usage_data(data, 0, false, 1024);
-        assert_eq!(chunks.len(), 1);
-        assert!(chunks[0].is_final);
-        assert_eq!(chunks[0].data.calls.len(), 1);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert!(!chunks[0].is_final);
+        assert_eq!(chunks[1].chunk_index, 1);
+        assert!(chunks[1].is_final);
+        assert_eq!(chunks[1].data.calls.len(), 1);
+    }
+
+    #[test]
+    fn chunk_distributes_sessions_alongside_calls() {
+        // Mixed-tail snapshot: 5 calls + 5 sessions. Single chunk
+        // should fit both at 1 MiB budget.
+        let mut data = fake_data(0);
+        data.calls = (0..5).map(|i| fake_call(i)).collect();
+        data.sessions = (0..5)
+            .map(|i| SessionUsage {
+                provider: Provider::Claude,
+                project: format!("proj-{i}"),
+                session_id: format!("sess-{i}"),
+                first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+                last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
+                bucket: TokenBucket::default(),
+            })
+            .collect();
+
+        let chunks = chunk_usage_data(data, 0, false, 1024 * 1024);
+        let (calls, sessions, shells) = tail_totals(&chunks);
+        assert_eq!(calls, 5, "all calls present");
+        assert_eq!(sessions, 5, "all sessions present");
+        assert_eq!(shells, 0);
+    }
+
+    #[test]
+    fn chunk_distributes_huge_sessions_vec_across_multiple_chunks() {
+        // Regression: at 128k calls / ~4k sessions / many shell commands,
+        // v3 chunk 0 encoded to 17 MiB and tripped the 16 MiB framer
+        // cap. v4 must keep every chunk under the configured target.
+        //
+        // Simulate "sessions-heavy" by inflating the sessions vec with
+        // long string fields so the encoded msgpack exceeds the budget.
+        let mut data = fake_data(0);
+        data.sessions = (0..200)
+            .map(|i| SessionUsage {
+                provider: Provider::Claude,
+                project: format!("project-with-a-fairly-long-name-{i:04}"),
+                session_id: format!("session-id-uuid-style-{i:020}"),
+                first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+                last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
+                bucket: TokenBucket::default(),
+            })
+            .collect();
+
+        // 4 KiB budget — much smaller than the sessions vec total to
+        // force multi-chunk distribution.
+        let chunks = chunk_usage_data(data, 0, false, 4 * 1024);
+        assert!(
+            chunks.len() > 1,
+            "expected sessions to span multiple chunks, got {}",
+            chunks.len()
+        );
+        let (_, total_sessions, _) = tail_totals(&chunks);
+        assert_eq!(total_sessions, 200, "no sessions lost");
+
+        // Last chunk is is_final.
+        assert!(chunks.last().unwrap().is_final);
+    }
+
+    #[test]
+    fn chunk_distributes_huge_shell_commands_vec_across_multiple_chunks() {
+        // Same shape as sessions — shell_commands can carry many
+        // long bash strings, easily 5-10 MiB in real $HOME data.
+        let mut data = fake_data(0);
+        data.shell_commands = (0..500)
+            .map(|i| NamedUsage {
+                name: format!("git log --oneline --all --decorate --since=\"30 days ago\" --grep=fix_{i:05}"),
+                calls: 1,
+            })
+            .collect();
+
+        let chunks = chunk_usage_data(data, 0, false, 4 * 1024);
+        assert!(chunks.len() > 1);
+        let (_, _, total_shells) = tail_totals(&chunks);
+        assert_eq!(total_shells, 500, "no shell_commands lost");
+        assert!(chunks.last().unwrap().is_final);
+    }
+
+    #[test]
+    fn chunk_pop_priority_drains_calls_before_sessions() {
+        // With a budget that fits the first few of each kind, calls
+        // should appear in chunk 1 first because the pop order is
+        // calls → sessions → shell_commands.
+        let mut data = fake_data(0);
+        data.calls = (0..3).map(|i| fake_call(i)).collect();
+        data.sessions = (0..3)
+            .map(|i| SessionUsage {
+                provider: Provider::Claude,
+                project: "p".into(),
+                session_id: format!("s-{i}"),
+                first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+                last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
+                bucket: TokenBucket::default(),
+            })
+            .collect();
+
+        let chunks = chunk_usage_data(data, 0, false, 1024 * 1024);
+        // Big budget — everything fits in one tail chunk. Order check:
+        // calls must be drained into chunk 1 before sessions.
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[1].data.calls.len(), 3);
+        assert_eq!(chunks[1].data.sessions.len(), 3);
+    }
+
+    #[test]
+    fn chunk_zero_stays_under_target_even_with_oversized_tails() {
+        // Smoking-gun regression: v3 chunk 0 carrying massive sessions
+        // + shell_commands ballooned past the framer cap. v4 chunk 0
+        // carries only bounded aggregates; tail vecs are stripped.
+        // Even if the input has 10k sessions + 5k shell_commands,
+        // chunk 0 must encode small.
+        let mut data = fake_data(0);
+        data.sessions = (0..10_000)
+            .map(|i| SessionUsage {
+                provider: Provider::Claude,
+                project: format!("proj-{i}"),
+                session_id: format!("session-{i}"),
+                first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+                last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
+                bucket: TokenBucket::default(),
+            })
+            .collect();
+        data.shell_commands = (0..5_000)
+            .map(|i| NamedUsage {
+                name: format!("cmd-{i}"),
+                calls: 1,
+            })
+            .collect();
+
+        let chunks = chunk_usage_data(data, 0, false, 2 * 1024 * 1024);
+
+        // Encode chunk 0 and check its size — it must be far under
+        // the framer cap because tail vecs were stripped before
+        // shipping chunk 0.
+        let chunk_0_bytes = rmp_serde::to_vec_named(&chunks[0]).unwrap().len();
+        assert!(
+            chunk_0_bytes < 100 * 1024,
+            "chunk 0 should be tiny (no tail vecs), got {chunk_0_bytes} bytes"
+        );
+        assert!(chunks[0].data.sessions.is_empty());
+        assert!(chunks[0].data.shell_commands.is_empty());
+
+        // All 15_000 tail items ship across follow-on chunks with no loss.
+        let (_, total_sessions, total_shells) = tail_totals(&chunks);
+        assert_eq!(total_sessions, 10_000);
+        assert_eq!(total_shells, 5_000);
+        assert!(chunks.last().unwrap().is_final);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -467,20 +467,15 @@ pub(crate) fn chunk_usage_data(
 
         loop {
             // Pop priority: calls (largest) → sessions → shell_commands.
-            // Track which queue we popped from so a spill-back lands in
-            // the right place.
-            let popped_from = if let Some(c) = calls_q.pop_front() {
+            if let Some(c) = calls_q.pop_front() {
                 chunk_data.calls.push(c);
-                TailQueue::Calls
             } else if let Some(s) = sessions_q.pop_front() {
                 chunk_data.sessions.push(s);
-                TailQueue::Sessions
             } else if let Some(s) = shell_q.pop_front() {
                 chunk_data.shell_commands.push(s);
-                TailQueue::ShellCommands
             } else {
                 break; // every queue drained
-            };
+            }
             since_probe += 1;
 
             let all_empty =
@@ -509,27 +504,20 @@ pub(crate) fn chunk_usage_data(
             // (e.g. one 5 MiB user_message) can't stall the loop.
             //
             // Spill in a loop, not just once: STEP=64 means the chunk
-            // can land 8 MiB over budget when one of those 64 items is
-            // a 100+ KiB outlier. Single-spill would still ship a chunk
-            // 50× over target. We pop the most-recently-pushed item from
-            // the queue that received it, then re-probe; keep spilling
-            // until we're back under target or only 1 item remains.
-            // popped_from tracks the *last* push, but a multi-spill
-            // needs to walk back through previous pushes — we use the
-            // queue with the largest tail first as a heuristic.
+            // can land many MiB over budget when one of those 64 items
+            // is a 100+ KiB outlier. Single-spill would still ship a
+            // chunk 50× over target. Each iteration picks the largest
+            // tail vec as the spill source (best chance of cheaply
+            // shrinking the chunk) and re-probes; keep spilling until
+            // we're back under target or only 1 item remains.
             let chunk_item_count = chunk_data.calls.len()
                 + chunk_data.sessions.len()
                 + chunk_data.shell_commands.len();
             if probe_size >= target_bytes && chunk_item_count > 1 {
-                // First spill: the just-popped item, to the queue it
-                // came from. Subsequent spills come from whichever
-                // tail vec currently has the most items (best chance
-                // of cheaply shrinking the chunk).
-                let _ = popped_from; // first spill uses the queue below
-                let mut current_size = probe_size;
                 loop {
-                    // Choose the spill source: the largest tail vec.
-                    // Re-evaluate every iteration because vecs shrink.
+                    // Choose the spill source: whichever tail vec
+                    // currently has the most items. Re-evaluate every
+                    // iteration because vecs shrink.
                     let from = if chunk_data.calls.len()
                         >= chunk_data.sessions.len()
                         && chunk_data.calls.len()
@@ -590,10 +578,10 @@ pub(crate) fn chunk_usage_data(
                             && shell_q.is_empty(),
                         data: chunk_data.clone(),
                     };
-                    current_size = rmp_serde::to_vec_named(&probe)
+                    let probe_after_spill = rmp_serde::to_vec_named(&probe)
                         .map(|b| b.len())
                         .unwrap_or(target_bytes);
-                    if current_size < target_bytes {
+                    if probe_after_spill < target_bytes {
                         break;
                     }
                 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -220,12 +220,41 @@ pub fn scan_with_cache(
 /// Cache + progress-aware scan. Drives [`ProgressReporter::note_file`]
 /// from each per-file parse so the plugin's async publish loop can
 /// fan progress out to the host without blocking the scan thread.
+///
+/// Pre-walks the Claude and Codex provider dirs to count `.jsonl`
+/// files before the actual parse loop, then calls
+/// [`ProgressReporter::set_total`] so the burndown UI can render a
+/// real `N/M` progress bar (instead of the open-ended `N files`
+/// fallback). The pre-walk is cheap — directory enumeration only, no
+/// file reads — typically under 50 ms even for 5000+ Claude session
+/// JSONLs. Gemini, Copilot, and Cursor parsers aren't progress-aware
+/// (they don't emit `note_file`) so they're excluded from the total
+/// to keep the bar honest; their file counts are usually small enough
+/// that the under-count is invisible.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn scan_with_cache_and_progress(
     roots: &ProviderRoots,
     cache: &mut Option<crate::cache::UsageCache>,
     reporter: &mut ProgressReporter,
 ) -> UsageData {
+    // Pre-walk: count the files the progress-aware parsers will visit
+    // so the UI can render an `N/M` ratio. Each branch returns 0 if the
+    // root is None or unreadable — same semantics as the parse path.
+    let claude_files = roots
+        .claude_projects
+        .as_deref()
+        .map_or(0, count_jsonl_in_two_level_tree);
+    let codex_files = roots
+        .codex_sessions
+        .as_deref()
+        .map_or(0, count_jsonl_recursive);
+    let total = claude_files.saturating_add(codex_files);
+    if total > 0 {
+        // Saturate at u32::MAX — unlikely in practice (would require
+        // ~4 billion .jsonl files) but keeps the cast explicit.
+        reporter.set_total(u32::try_from(total).unwrap_or(u32::MAX));
+    }
+
     let mut all_calls = Vec::new();
     if let Some(root) = &roots.claude_projects {
         all_calls.extend(crate::parsers::claude::parse_dir_cached_with_progress(
@@ -247,6 +276,64 @@ pub fn scan_with_cache_and_progress(
         all_calls.extend(crate::parsers::cursor::parse_dir(root));
     }
     aggregate(all_calls)
+}
+
+/// Count `.jsonl` files in the Claude layout: `<root>/<project>/<session>.jsonl`.
+/// Two-level walk (project dir → session files). Matches the iteration
+/// shape of `parsers::claude::parse_dir_cached_with_progress` so the
+/// running counter and the pre-walk total stay in sync.
+#[cfg(not(target_arch = "wasm32"))]
+fn count_jsonl_in_two_level_tree(root: &Path) -> usize {
+    let mut count = 0usize;
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return 0;
+    };
+    for project_entry in entries.flatten() {
+        let p = project_entry.path();
+        if !p.is_dir() {
+            continue;
+        }
+        let Ok(session_entries) = std::fs::read_dir(&p) else {
+            continue;
+        };
+        for session_entry in session_entries.flatten() {
+            if session_entry
+                .path()
+                .extension()
+                .and_then(|s| s.to_str())
+                == Some("jsonl")
+            {
+                count = count.saturating_add(1);
+            }
+        }
+    }
+    count
+}
+
+/// Count `.jsonl` files recursively under `root`. Used for the Codex
+/// layout (`<root>/<YYYY>/<MM>/<DD>/rollout-*.jsonl`) where depth
+/// varies. Plain depth-first walk; symlinks aren't followed.
+#[cfg(not(target_arch = "wasm32"))]
+fn count_jsonl_recursive(root: &Path) -> usize {
+    let mut count = 0usize;
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let Ok(ft) = entry.file_type() else { continue };
+            if ft.is_dir() {
+                stack.push(p);
+            } else if ft.is_file()
+                && p.extension().and_then(|s| s.to_str()) == Some("jsonl")
+            {
+                count = count.saturating_add(1);
+            }
+        }
+    }
+    count
 }
 
 /// Pure aggregation: `Vec<ProviderCall>` → `UsageData`.
@@ -730,5 +817,83 @@ mod tests {
             assert!(r.claude_projects.is_some());
             assert!(r.codex_sessions.is_some());
         }
+    }
+
+    #[test]
+    fn count_jsonl_two_level_matches_real_layout() {
+        // Build a fake Claude-layout: <root>/<project>/<session>.jsonl
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("proj-a")).unwrap();
+        std::fs::create_dir_all(root.join("proj-b")).unwrap();
+        std::fs::write(root.join("proj-a/s1.jsonl"), b"{}").unwrap();
+        std::fs::write(root.join("proj-a/s2.jsonl"), b"{}").unwrap();
+        std::fs::write(root.join("proj-b/s3.jsonl"), b"{}").unwrap();
+        // Ignored: non-jsonl file, plus a stray file at the root level.
+        std::fs::write(root.join("proj-a/notes.txt"), b"hi").unwrap();
+        std::fs::write(root.join("toplevel-stray.jsonl"), b"{}").unwrap();
+
+        assert_eq!(count_jsonl_in_two_level_tree(root), 3);
+    }
+
+    #[test]
+    fn count_jsonl_recursive_walks_arbitrary_depth() {
+        // Codex layout: <root>/<YYYY>/<MM>/<DD>/rollout-*.jsonl
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = root.join("2026/05/19");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("rollout-1.jsonl"), b"{}").unwrap();
+        std::fs::write(dir.join("rollout-2.jsonl"), b"{}").unwrap();
+        std::fs::write(dir.join("rollout-3.txt"), b"hi").unwrap(); // not jsonl
+        // Another day with one rollout.
+        let dir2 = root.join("2026/05/18");
+        std::fs::create_dir_all(&dir2).unwrap();
+        std::fs::write(dir2.join("rollout-1.jsonl"), b"{}").unwrap();
+
+        assert_eq!(count_jsonl_recursive(root), 3);
+    }
+
+    #[test]
+    fn count_jsonl_returns_zero_for_missing_root() {
+        let missing = std::path::PathBuf::from("/nonexistent/path/to/nowhere");
+        assert_eq!(count_jsonl_in_two_level_tree(&missing), 0);
+        assert_eq!(count_jsonl_recursive(&missing), 0);
+    }
+
+    #[test]
+    fn scan_pre_walk_sets_total_on_reporter() {
+        // End-to-end: build fake Claude + Codex trees, run a scan with
+        // a real ProgressReporter, and verify `total` equals the actual
+        // file count when the first note_file fires.
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_root = tmp.path().join("claude/projects");
+        let codex_root = tmp.path().join("codex/sessions");
+        std::fs::create_dir_all(claude_root.join("proj-a")).unwrap();
+        std::fs::write(claude_root.join("proj-a/s1.jsonl"), b"").unwrap();
+        std::fs::write(claude_root.join("proj-a/s2.jsonl"), b"").unwrap();
+        std::fs::create_dir_all(codex_root.join("2026/05/19")).unwrap();
+        std::fs::write(codex_root.join("2026/05/19/rollout.jsonl"), b"").unwrap();
+
+        let roots = ProviderRoots {
+            claude_projects: Some(claude_root),
+            codex_sessions: Some(codex_root),
+            ..ProviderRoots::default()
+        };
+
+        let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut reporter = ProgressReporter::new(move |evt| sink.lock().unwrap().push(evt));
+        let mut cache: Option<crate::cache::UsageCache> = None;
+        let _data = scan_with_cache_and_progress(&roots, &mut cache, &mut reporter);
+
+        let evts = captured.lock().unwrap().clone();
+        // 3 files total (2 Claude + 1 Codex). First emit should carry
+        // total=3; later emits inherit the same total via set_total.
+        assert!(!evts.is_empty(), "reporter saw at least one event");
+        assert_eq!(
+            evts[0].total, 3,
+            "pre-walk set total to count of progress-aware files"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -42,7 +42,17 @@ use serde::{Deserialize, Serialize};
 /// deserialise on v2 consumers (the externally-tagged enum rejects
 /// unknown variants), so receivers MUST check
 /// `event.version == WIRE_VERSION` before trusting the payload.
-pub const WIRE_VERSION: u32 = 3;
+///
+/// v4: per-chunk `sessions` and `shell_commands` slices. Previously
+/// chunk 0 carried the entire aggregate tree (including the full
+/// `sessions` vec and the full `shell_commands` vec), which for large
+/// `$HOME` datasets pushed chunk 0 past the framer's 16 MiB
+/// `MAX_BODY_BYTES` cap (observed: 17 MiB for ~128k calls / ~4k
+/// sessions / many distinct bash commands). Under v4, `sessions` and
+/// `shell_commands` are tail-chunkable: chunk 0 leaves them empty;
+/// follow-on chunks carry slices that the consumer accumulator
+/// `extend`s into the in-flight `UsageData` just like `calls`.
+pub const WIRE_VERSION: u32 = 4;
 
 /// Per-file scan progress payload published on the
 /// `sessions.scan_progress` topic.
@@ -76,15 +86,22 @@ pub struct ScanProgressEvent {
 /// "partial" badge and re-asks on the next refresh.
 ///
 /// **Chunked publishes**: a single logical snapshot may be split into
-/// N envelopes. Chunk 0 carries the full aggregates plus the first
-/// slice of [`UsageData::calls`]; chunks 1..N carry the remaining
-/// `calls` only (every other field is empty/default). The last chunk
-/// sets `is_final = true`; consumers concat the call slices and treat
-/// the snapshot as live once they see `is_final`.
+/// N envelopes. Chunk 0 carries the bounded aggregates (`daily`,
+/// `weekly`, `projects`, `grand_total`, `models`, `activities`,
+/// `tools`, `mcp_servers`, `branches`, `model_project_counts`); chunks
+/// 1..N carry slices of the unbounded vecs (`calls`, `sessions`,
+/// `shell_commands`). The consumer accumulator concats each slice into
+/// the in-flight `UsageData`. The last chunk sets `is_final = true`;
+/// consumers treat the snapshot as live once they see `is_final`.
 ///
 /// Single-chunk publishes use `chunk_index = 0, is_final = true` — the
 /// defaults — so old publishers and small snapshots keep working
 /// unchanged.
+///
+/// Wire-format note: chunks 1..N also leave every bounded aggregate
+/// at default (empty vec / zero counters); only `calls`, `sessions`,
+/// and `shell_commands` are populated. The consumer reads these three
+/// fields with `extend`, ignoring the others on follow-on chunks.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsageDataEvent {
     /// Schema version. Equals [`WIRE_VERSION`] when the publisher and


### PR DESCRIPTION
## Summary

Live debug session uncovered why the burndown screen was stuck at "Scanning sessions…" forever: `session-reader` shipped a chunk-0 publish at **17.0 MiB**, exceeded the host framer's **16.0 MiB `MAX_BODY_BYTES`** cap, its stdout pipe closed, the plugin exited mid-publish — and the runtime never respawned it because eager-spawn only fires at registration time.

This PR fixes both bugs and adds two UX improvements requested during the diagnosis.

## Commits (5)

| # | Commit | Concern |
|---|---|---|
| 1 | `dcede9b` | `fix(plugin-runtime)`: auto-respawn eager plugins after exit |
| 2 | `ba013fb` | `fix(session-reader,burndown,types-sessions)`: tail-chunk `sessions` + `shell_commands` (wire v4) |
| 3 | `ed508b1` | `feat(session-reader,burndown)`: pre-walk file count + N/M progress bar |
| 4 | `37d4f41` | `feat(session-reader,burndown)`: `F` key wipes parse cache and republishes |
| 5 | `7299373` | `fix(session-reader,burndown)`: review-pass — multi-spill chunker, robust flush, explicit pct cast |

## What changed

### 1. Runtime auto-respawn (`dcede9b`)
`handle_exit` only transitioned to Idle after backoff — eager plugins stayed dead until process restart. Now reads `manifest.lifecycle.spawn` after backoff and calls `spawn_and_init` when eager. Quarantine threshold still applies.

### 2. Chunker tail-distribution (`ba013fb`)
Bumped `WIRE_VERSION` 3 → 4. Chunk 0 now carries only **bounded** aggregates (daily, weekly, projects, models, branches, etc.). `calls`, `sessions`, and `shell_commands` are tail-chunked across follow-on chunks with pop priority `calls → sessions → shell_commands`. Burndown's `apply_chunk_pure` extends all three vecs on each chunk.

Why these three: they're the only aggregates whose size scales with raw call volume rather than bounded entity counts.

### 3. Progress bar (`ed508b1`)
`ProgressReporter::set_total()` was only called in tests; production scans always emitted `total=0`. Now `scan_with_cache_and_progress` pre-walks the Claude + Codex trees (dir-enumeration only, sub-50ms) and sets the total. UI splits the skeleton row into headline + `ratatui::widgets::Gauge` showing "XX% (N/M)". Falls back to legacy single-line when total=0 or the panel is too short.

### 4. Flush-cache key (`37d4f41`)
New `sessions.flush_cache_request` topic. Burndown binds **uppercase `F`** to publish it (lowercase too easy to fat-finger for a destructive action). Session-reader subscribes, calls `UsageCache::clear()`, then runs the normal publish path. Help bar updated.

### 5. Review-pass fixes (`7299373`)
- **Chunker spillback now loops** until probe drops under target. Single-spill could still ship a chunk 50× over budget if STEP=64 accumulated outlier-sized items.
- **`flush_cache` is two-tier**: try `clear()` first, then `rm -f` the db file on failure (user pressed `F` because they suspect corruption — SQL clear may itself fail).
- Explicit `u16::try_from(... as i32).unwrap_or(100)` for the gauge percent label.

## Test coverage

- **session-reader**: 67 unit tests pass, including the regression cases:
  - `chunk_zero_stays_under_target_even_with_oversized_tails` (10k sessions + 5k shell_commands)
  - `chunk_distributes_huge_sessions_vec_across_multiple_chunks`
  - `chunk_distributes_huge_shell_commands_vec_across_multiple_chunks`
  - `chunk_multispill_keeps_each_chunk_under_target_with_outlier_calls` (128 × 50 KiB calls)
  - `count_jsonl_*` pre-walk count tests
  - `scan_pre_walk_sets_total_on_reporter`
- **burndown**: 165 unit tests pass, including `v4_chunk_zero_no_calls_follow_on_chunks_extend_tail_vecs` and three new gauge tests.
- **plugin-runtime**: 10/11 fixture_e2e tests pass — the failing `send_key_forwards_handle_key_notification` was already broken on `main` (verified by stashing my changes and re-running). New `eager_plugin_respawns_automatically_after_exit` test passes.

## How to verify locally

```bash
git checkout worktree-burndown-chunker-respawn-fix
cd ainb-tui
cargo test -p ainb-plugin-session-reader -p ainb-plugin-burndown -p ainb-plugin-runtime
# kill the stuck TUI then rebuild + restart
cargo build --release
```

## Test plan

- [ ] CI: `cargo test --workspace` passes
- [ ] CI: `cargo clippy --workspace -- -D warnings` passes (modulo pre-existing warnings)
- [ ] Manual: run the new TUI against a real `$HOME` with ~128k calls; verify burndown screen shows the progress bar advancing and populates after the scan
- [ ] Manual: press `F` mid-screen; verify cache is wiped and rescan starts cold
- [ ] Manual: kill the session-reader child while burndown is open; verify it respawns automatically within ~1s

## Notes

- This is the live-debug from the burndown stuck-state investigation. Logs in `~/.agents-in-a-box/logs/agents-in-a-box-20260519-091241.jsonl` captured the exact "frame decode err: Content-Length 17005660 exceeds MAX_BODY_BYTES 16777216" line that motivated the fix.
- The wire-version bump (`v3 → v4`) means an upgrade across both plugin binaries is required atomically. The toolkit bootstrap installs both, so in practice this is automatic.