### PR TITLE
feat(reflect): codex adapter wires SessionStart + PreCompact hooks

### DIFF
--- a/docs/knowledge/hooks-and-platform.md
+++ b/docs/knowledge/hooks-and-platform.md
@@ -1,0 +1,1253 @@
+---
+title: "Hooks & Platform · how reflect captures and recalls across Claude + Codex"
+description: "Visual deep-dive into the reflect plugin's hook architecture, recall flows, capture flows, status line integration, and cross-tool drain — across Claude Code and Codex CLI."
+---
+
+> **The short version** — Two harnesses (Claude Code, Codex CLI) wire the same hook scripts
+> into different config files (`~/.claude/settings.json` vs `~/.codex/hooks.json`) and share
+> one on-disk knowledge base (`~/.reflect/` queue + `~/.learnings/` documents + GraphRAG
+> index). **SessionStart** fires the baseline recall + the bg-drainer; **UserPromptSubmit**
+> fires the intent-sharp recall with per-session dedupe; **PreCompact**, **Stop**, and
+> **PostToolUse** capture learnings into the shared store. A codex session can enqueue a
+> reflection that a later Claude session drains — and vice versa.
+
+---
+
+## Architecture at a glance
+
+Two harnesses, the same hook scripts, one shared knowledge base. Solid arrows are control
+flow; dashed clay arrows are recall (read into context); dashed olive arrows are capture
+(write to disk).
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1080 900" xmlns="http://www.w3.org/2000/svg" style="width:100%; height:auto; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;">
+        <defs>
+          <marker id="arrowhead" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <polygon points="0 0, 9 4.5, 0 9" fill="#3D3D3A"/>
+          </marker>
+          <marker id="arrowhead-clay" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <polygon points="0 0, 9 4.5, 0 9" fill="#D97757"/>
+          </marker>
+          <marker id="arrowhead-olive" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <polygon points="0 0, 9 4.5, 0 9" fill="#788C5D"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1080" height="160" fill="#FAF9F5"/>
+        <rect x="0" y="160" width="1080" height="220" fill="#FFFFFF"/>
+        <rect x="0" y="380" width="1080" height="260" fill="#FAF9F5"/>
+        <rect x="0" y="640" width="1080" height="260" fill="#FFFFFF"/>
+
+        <text x="12" y="90" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">HARNESS</text>
+        <text x="12" y="270" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">HOOK&#160;SCRIPTS</text>
+        <text x="12" y="510" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">SHARED&#160;STATE</text>
+        <text x="12" y="770" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">HEADLESS</text>
+
+        <!-- ============ HARNESS BAND ============ -->
+        <text x="290" y="22" font-size="11" font-family="ui-monospace, monospace" fill="#788C5D" text-anchor="middle">fires SessionStart · fires PreCompact</text>
+        <text x="790" y="22" font-size="11" font-family="ui-monospace, monospace" fill="#788C5D" text-anchor="middle">fires SessionStart · fires PreCompact</text>
+
+        <g>
+          <rect x="100" y="30" width="380" height="110" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="290" y="58" font-size="15" font-weight="600" fill="#141413" text-anchor="middle">Claude Code session</text>
+          <text x="290" y="80" font-size="12" fill="#3D3D3A" text-anchor="middle">reads hooks from <tspan font-family="ui-monospace, monospace" fill="#141413">~/.claude/settings.json</tspan></text>
+          <text x="290" y="100" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">wired by plugin.json autowire (CLAUDE_PLUGIN_ROOT)</text>
+          <text x="290" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">— OR — manual claude_adapter.py install</text>
+        </g>
+
+        <g>
+          <rect x="600" y="30" width="380" height="110" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="790" y="58" font-size="15" font-weight="600" fill="#141413" text-anchor="middle">Codex CLI session</text>
+          <text x="790" y="80" font-size="12" fill="#3D3D3A" text-anchor="middle">reads hooks from <tspan font-family="ui-monospace, monospace" fill="#141413">~/.codex/hooks.json</tspan></text>
+          <text x="790" y="100" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">wired by codex_adapter.py install</text>
+          <text x="790" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">(no plugin runtime — adapter autowires itself)</text>
+        </g>
+
+        <!-- ============ HOOK SCRIPTS BAND ============ -->
+        <g>
+          <rect x="70" y="200" width="280" height="130" rx="12" ry="12" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="210" y="226" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">session_start_recall.py</text>
+          <text x="210" y="244" font-size="11" fill="#3D3D3A" text-anchor="middle">fired by: SessionStart</text>
+          <text x="210" y="265" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"what learnings apply here?"</text>
+          <text x="210" y="288" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">builds query from cwd · branch</text>
+          <text x="210" y="304" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">git log · returns top-3</text>
+          <text x="210" y="320" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">via additionalContext</text>
+        </g>
+
+        <g>
+          <rect x="400" y="200" width="280" height="130" rx="12" ry="12" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="540" y="226" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">precompact_reflect.py</text>
+          <text x="540" y="244" font-size="11" fill="#3D3D3A" text-anchor="middle">fired by: PreCompact</text>
+          <text x="540" y="265" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"save this transcript for later"</text>
+          <text x="540" y="288" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">never blocks compaction</text>
+          <text x="540" y="304" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">append-only enqueue;</text>
+          <text x="540" y="320" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">reflection happens later</text>
+        </g>
+
+        <g>
+          <rect x="730" y="200" width="280" height="130" rx="12" ry="12" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="870" y="226" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">reflect-drain-bg.sh</text>
+          <text x="870" y="244" font-size="11" fill="#3D3D3A" text-anchor="middle">fired by: SessionStart</text>
+          <text x="870" y="265" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"process any queued reflections"</text>
+          <text x="870" y="288" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">detached (nohup &amp;)</text>
+          <text x="870" y="304" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">PID-locked · daily-capped</text>
+          <text x="870" y="320" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">shells out to claude -p</text>
+        </g>
+
+        <!-- ============ SHARED STATE BAND ============ -->
+        <g>
+          <rect x="100" y="420" width="280" height="190" rx="12" ry="12" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="240" y="448" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">Pending queue</text>
+          <text x="240" y="470" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">~/.reflect/pending_reflections.jsonl</text>
+          <line x1="120" y1="486" x2="360" y2="486" stroke="#3D3D3A" stroke-width="0.5" stroke-dasharray="3,3"/>
+          <text x="240" y="508" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">one line per queued transcript</text>
+          <text x="240" y="525" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">{transcript_path, session_id,</text>
+          <text x="240" y="540" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">trigger, harness, queued_at}</text>
+          <text x="240" y="572" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">harness-agnostic — any harness</text>
+          <text x="240" y="589" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">writes, any harness drains</text>
+        </g>
+
+        <g>
+          <rect x="400" y="420" width="280" height="190" rx="12" ry="12" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="540" y="448" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">Learnings store</text>
+          <text x="540" y="470" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/documents/</text>
+          <line x1="420" y1="486" x2="660" y2="486" stroke="#3D3D3A" stroke-width="0.5" stroke-dasharray="3,3"/>
+          <text x="540" y="510" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">&lt;slug&gt;.md  (the learning)</text>
+          <text x="540" y="527" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">&lt;slug&gt;.entities.yaml (sidecar</text>
+          <text x="540" y="544" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">for GraphRAG ingest)</text>
+          <text x="540" y="576" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">written by the headless</text>
+          <text x="540" y="593" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">/reflect run</text>
+        </g>
+
+        <g>
+          <rect x="700" y="420" width="280" height="190" rx="12" ry="12" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="840" y="448" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">GraphRAG + vector index</text>
+          <text x="840" y="470" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/graphrag/</text>
+          <line x1="720" y1="486" x2="960" y2="486" stroke="#3D3D3A" stroke-width="0.5" stroke-dasharray="3,3"/>
+          <text x="840" y="510" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">communities · entities · relations</text>
+          <text x="840" y="527" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">nano-vector store (hnswlib)</text>
+          <text x="840" y="559" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">queried by recall · refreshed</text>
+          <text x="840" y="576" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">by `reflect reindex` after each</text>
+          <text x="840" y="593" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">successful drain</text>
+        </g>
+
+        <!-- ============ HEADLESS BAND ============ -->
+        <g>
+          <rect x="320" y="685" width="440" height="160" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="540" y="712" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">claude -p "/reflect &lt;transcript&gt;"</text>
+          <text x="540" y="734" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">spawned by reflect-drain-bg.sh</text>
+          <text x="540" y="756" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"extract the learnings from this transcript"</text>
+          <text x="540" y="782" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">--output-format json · --max-turns 25</text>
+          <text x="540" y="799" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">--permission-mode bypassPermissions</text>
+          <text x="540" y="823" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">always claude — even when a codex session triggered the drain</text>
+        </g>
+
+        <!-- ============ ARROWS ============ -->
+
+        <!-- 1: SessionStart → recall (both harnesses) -->
+        <line x1="240" y1="140" x2="190" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <line x1="700" y1="140" x2="260" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="230" cy="170" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="230" y="174" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">1</text>
+
+        <!-- 2: recall → GraphRAG read -->
+        <path d="M 290 330 Q 360 380 730 420" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="495" cy="372" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="495" y="376" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">2</text>
+
+        <!-- 3a: GraphRAG → recall (dashed clay) -->
+        <path d="M 720 440 Q 480 350 240 330" fill="none" stroke="#D97757" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#arrowhead-clay)"/>
+        <circle cx="540" cy="358" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="540" y="362" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">3</text>
+        <text x="570" y="345" font-size="10" font-family="ui-monospace, monospace" fill="#D97757">top-3 learnings</text>
+
+        <!-- 3b: recall → session (additionalContext) -->
+        <line x1="160" y1="200" x2="220" y2="140" stroke="#D97757" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#arrowhead-clay)"/>
+        <text x="60" y="195" font-size="10" font-family="ui-monospace, monospace" fill="#D97757">additionalContext</text>
+
+        <!-- 4: PreCompact → precompact_reflect -->
+        <line x1="330" y1="140" x2="470" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <line x1="780" y1="140" x2="600" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="540" cy="170" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="540" y="174" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">4</text>
+
+        <!-- 5: precompact → queue write -->
+        <line x1="500" y1="330" x2="290" y2="420" stroke="#788C5D" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-olive)"/>
+        <circle cx="395" cy="375" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="395" y="379" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">5</text>
+        <text x="265" y="395" font-size="10" font-family="ui-monospace, monospace" fill="#788C5D">enqueue transcript_path</text>
+
+        <!-- 6: SessionStart → drain (both harnesses) -->
+        <path d="M 800 140 Q 830 165 870 200" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <path d="M 360 140 Q 620 160 830 200" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="830" cy="170" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="830" y="174" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">6</text>
+
+        <!-- 7: drain reads queue -->
+        <path d="M 740 330 Q 540 380 360 425" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="560" cy="370" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="560" y="374" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">7</text>
+
+        <!-- 8: drain spawns claude -p -->
+        <line x1="870" y1="330" x2="700" y2="685" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="800" cy="510" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="800" y="514" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">8</text>
+
+        <!-- 9: claude -p writes learnings -->
+        <line x1="450" y1="685" x2="540" y2="610" stroke="#788C5D" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-olive)"/>
+        <circle cx="495" cy="655" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="495" y="659" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">9</text>
+        <text x="555" y="650" font-size="10" font-family="ui-monospace, monospace" fill="#788C5D">.md + .entities.yaml</text>
+
+        <!-- 10: reindex updates GraphRAG -->
+        <path d="M 680 510 Q 750 540 820 610" fill="none" stroke="#788C5D" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-olive)"/>
+        <circle cx="740" cy="545" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="740" y="549" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">10</text>
+        <text x="710" y="528" font-size="10" font-family="ui-monospace, monospace" fill="#788C5D">reflect reindex</text>
+
+      </svg>
+</div>
+
+---
+
+## Session timeline · one coding session, end to end
+
+A horizontal view of what fires when. Hook events show above the spine; data I/O below.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 270" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="a-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+          <marker id="a-teal" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#9DD4C7"/>
+          </marker>
+          <marker id="a-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+        </defs>
+
+        <!-- Background bands -->
+        <rect x="0" y="0" width="1120" height="270" fill="#FAFAF8"/>
+
+        <!-- Top band: hook labels -->
+        <rect x="0" y="0" width="1120" height="54" fill="#F5F4F0"/>
+        <text x="8" y="12" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">HOOK FIRES</text>
+
+        <!-- Bottom band: data I/O -->
+        <rect x="0" y="196" width="1120" height="74" fill="#F5F4F0"/>
+        <text x="8" y="208" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">DATA READ / WRITTEN</text>
+
+        <!-- Timeline spine -->
+        <line x1="56" y1="126" x2="1082" y2="126" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a1)"/>
+
+        <!-- ---- Tick positions ---- -->
+        <!-- x positions: Install=80, SessionStart=210, Prompts=370, ToolUses=510, CtxFills=640, PreCompact=770, Compact=900, SessionEnd=1040 -->
+
+        <!-- TICK 1: Install -->
+        <line x1="80" y1="114" x2="80" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="80" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="80" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Install</text>
+        <text x="80" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">adapter / plugin</text>
+        <!-- data below -->
+        <text x="80" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">writes hooks</text>
+        <text x="80" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">to config file</text>
+
+        <!-- TICK 2: SessionStart -->
+        <line x1="210" y1="114" x2="210" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="210" cy="126" r="7" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="210" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Session starts</text>
+        <text x="210" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness boots</text>
+        <!-- hook label above -->
+        <line x1="210" y1="114" x2="210" y2="56" stroke="#9DD4C7" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#a-teal)"/>
+        <rect x="138" y="16" width="144" height="36" rx="6" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="210" y="30" font-size="10" font-weight="600" fill="#141413" text-anchor="middle">SessionStart fires</text>
+        <text x="210" y="44" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">recall + drain (bg)</text>
+        <!-- data below -->
+        <text x="210" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">reads graphrag/</text>
+        <text x="210" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">injects top-3</text>
+        <text x="210" y="246" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7" text-anchor="middle">additionalContext</text>
+
+        <!-- TICK 3: User prompts -->
+        <line x1="370" y1="114" x2="370" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="370" cy="126" r="7" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="370" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">User prompts</text>
+        <text x="370" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">conversation</text>
+        <!-- no hook -->
+        <text x="370" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="370" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">model context</text>
+        <text x="370" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">+ learnings</text>
+
+        <!-- TICK 4: Tool uses -->
+        <line x1="510" y1="114" x2="510" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="510" cy="126" r="7" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="510" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Tool uses</text>
+        <text x="510" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">edits / runs</text>
+        <text x="510" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="510" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">transcript grows;</text>
+        <text x="510" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">~/.claude/ JSONL</text>
+
+        <!-- TICK 5: Context fills -->
+        <line x1="640" y1="114" x2="640" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="640" cy="126" r="7" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="640" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Context fills</text>
+        <text x="640" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">approaching limit</text>
+        <text x="640" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="640" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness detects</text>
+        <text x="640" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">token threshold</text>
+
+        <!-- TICK 6: PreCompact -->
+        <line x1="770" y1="114" x2="770" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="770" cy="126" r="7" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="770" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">PreCompact</text>
+        <text x="770" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">hook fires</text>
+        <!-- hook label above -->
+        <line x1="770" y1="114" x2="770" y2="56" stroke="#D97757" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#a-clay)"/>
+        <rect x="694" y="16" width="152" height="36" rx="6" fill="#F4E4C1" stroke="#D97757" stroke-width="1"/>
+        <text x="770" y="30" font-size="10" font-weight="600" fill="#141413" text-anchor="middle">PreCompact fires</text>
+        <text x="770" y="44" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">precompact_reflect.py</text>
+        <!-- data below -->
+        <text x="770" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">appends to</text>
+        <text x="770" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">pending_reflections</text>
+        <text x="770" y="246" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">.jsonl (queue)</text>
+
+        <!-- TICK 7: Compaction -->
+        <line x1="900" y1="114" x2="900" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="900" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="900" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Compaction</text>
+        <text x="900" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness compresses</text>
+        <text x="900" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="900" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">transcript archived;</text>
+        <text x="900" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">context window reset</text>
+
+        <!-- TICK 8: Session ends -->
+        <line x1="1040" y1="114" x2="1040" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="1040" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="1040" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Session ends</text>
+        <text x="1040" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">process exits</text>
+        <text x="1040" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="1040" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">queue entry waits;</text>
+        <text x="1040" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">drained next start</text>
+
+        <!-- "time" label on spine -->
+        <text x="1094" y="121" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">time</text>
+      </svg>
+</div>
+
+---
+
+## Storage layers · three tiers, one knowledge base
+
+The pending queue, the learnings store, and the GraphRAG index. Append-only, grep-able,
+portable.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 310" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="b1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="b-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+          <marker id="b-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="310" fill="#FAFAF8"/>
+
+        <!-- Left labels col -->
+        <text x="14" y="78" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em" transform="rotate(-90,14,78)" text-anchor="middle">QUEUE</text>
+        <text x="14" y="170" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em" transform="rotate(-90,14,170)" text-anchor="middle">DOCS</text>
+        <text x="14" y="256" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em" transform="rotate(-90,14,256)" text-anchor="middle">INDEX</text>
+
+        <!-- ====== BAR 1: Pending queue ====== -->
+        <!-- Bar body -->
+        <rect x="32" y="20" width="780" height="74" rx="10" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <!-- Bar label inside -->
+        <text x="52" y="45" font-size="13" font-weight="600" fill="#141413">Pending queue</text>
+        <text x="52" y="62" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.reflect/pending_reflections.jsonl</text>
+        <text x="52" y="79" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">one line per queued transcript · {transcript_path, session_id, trigger, harness, queued_at}</text>
+
+        <!-- Arrow IN: precompact → bar -->
+        <line x1="32" y1="57" x2="16" y2="57" stroke="#788C5D" stroke-width="1.5" marker-end="url(#b-olive)"/>
+        <!-- Arrow IN label above bar (left) -->
+        <text x="34" y="18" font-size="10" font-family="ui-monospace,monospace" fill="#788C5D">IN: precompact_reflect.py (appends on PreCompact)</text>
+
+        <!-- Arrow OUT: bar → drain -->
+        <line x1="812" y1="57" x2="828" y2="57" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#b1)"/>
+        <text x="834" y="61" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">OUT: reflect-drain-bg.sh reads + dequeues</text>
+
+        <!-- Stats block -->
+        <rect x="862" y="20" width="242" height="74" rx="8" fill="#FAF9F5" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="876" y="40" font-size="10.5" font-weight="600" fill="#141413">append-only</text>
+        <text x="876" y="55" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">~1 line / compaction</text>
+        <text x="876" y="69" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">harness-agnostic</text>
+        <text x="876" y="83" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">any harness writes or drains</text>
+
+        <!-- ====== BAR 2: Learnings store ====== -->
+        <rect x="32" y="112" width="780" height="74" rx="10" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="52" y="137" font-size="13" font-weight="600" fill="#141413">Learnings store</text>
+        <text x="52" y="154" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.learnings/documents/  &lt;slug&gt;.md + &lt;slug&gt;.entities.yaml</text>
+        <text x="52" y="171" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">markdown document + YAML entity sidecar per learning · grep-able on disk</text>
+
+        <!-- Arrow IN -->
+        <line x1="32" y1="149" x2="16" y2="149" stroke="#788C5D" stroke-width="1.5" marker-end="url(#b-olive)"/>
+        <text x="34" y="110" font-size="10" font-family="ui-monospace,monospace" fill="#788C5D">IN: claude -p /reflect (headless · spawned by drain)</text>
+
+        <!-- Arrow OUT: to graphrag below -->
+        <line x1="420" y1="186" x2="420" y2="204" stroke="#3D3D3A" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#b1)"/>
+        <text x="428" y="200" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">reflect reindex</text>
+
+        <!-- Stats -->
+        <rect x="862" y="112" width="242" height="74" rx="8" fill="#FAF9F5" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="876" y="132" font-size="10.5" font-weight="600" fill="#141413">markdown + YAML</text>
+        <text x="876" y="147" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">one .md per learning</text>
+        <text x="876" y="161" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">entity sidecar for graph</text>
+        <text x="876" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">human-readable · git-able</text>
+
+        <!-- ====== BAR 3: GraphRAG ====== -->
+        <rect x="32" y="208" width="780" height="74" rx="10" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="52" y="233" font-size="13" font-weight="600" fill="#141413">GraphRAG + vector index</text>
+        <text x="52" y="250" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.learnings/graphrag/   communities · entities · relations · hnswlib vectors</text>
+        <text x="52" y="267" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">nano-graphrag · vector + entity graph · hybrid search · queried on SessionStart</text>
+
+        <!-- Arrow IN already shown above (reindex arrow) -->
+        <line x1="32" y1="245" x2="16" y2="245" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#b1)"/>
+        <text x="34" y="206" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">IN: reflect reindex (after each successful drain)</text>
+
+        <!-- Arrow OUT: to recall -->
+        <line x1="812" y1="245" x2="828" y2="245" stroke="#D97757" stroke-width="1.5" marker-end="url(#b-clay)"/>
+        <text x="834" y="249" font-size="10" font-family="ui-monospace,monospace" fill="#D97757">OUT: session_start_recall.py queries top-3</text>
+
+        <!-- Stats -->
+        <rect x="862" y="208" width="242" height="74" rx="8" fill="#FAF9F5" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="876" y="228" font-size="10.5" font-weight="600" fill="#141413">vector + entity graph</text>
+        <text x="876" y="243" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">queried at SessionStart</text>
+        <text x="876" y="257" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">rebuilt by reflect reindex</text>
+        <text x="876" y="271" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">dense + graph hybrid</text>
+
+        <!-- Tier connector lines left side -->
+        <line x1="26" y1="94" x2="26" y2="112" stroke="#D1CFC5" stroke-width="1.5" stroke-dasharray="3,3"/>
+        <line x1="26" y1="186" x2="26" y2="208" stroke="#D1CFC5" stroke-width="1.5" stroke-dasharray="3,3"/>
+      </svg>
+</div>
+
+---
+
+## Platform · adapter interface and shared knowledge base
+
+Each harness has its own adapter that wires hooks into its own config file. Both adapters
+point at the same hook scripts and the same shared knowledge base.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 360" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="c1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="c-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+          <marker id="c-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+          <marker id="c-gray" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#87867F"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="360" fill="#FAFAF8"/>
+
+        <!-- ===== LEFT: ADAPTERS ===== -->
+        <text x="24" y="20" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">HARNESS ADAPTERS</text>
+
+        <!-- Row 1: Claude Code -->
+        <rect x="24" y="30" width="330" height="80" rx="10" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="44" y="52" font-size="12" font-weight="600" fill="#141413">Claude Code</text>
+        <text x="44" y="68" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">.claude-plugin/plugin.json  →  ~/.claude/settings.json</text>
+        <text x="44" y="83" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">/plugin install reflect@agents-in-a-box</text>
+        <!-- autowire badge -->
+        <rect x="240" y="35" width="104" height="18" rx="4" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="292" y="48" font-size="9" font-family="ui-monospace,monospace" fill="#141413" text-anchor="middle">plugin runtime</text>
+
+        <!-- Row 2: Codex CLI -->
+        <rect x="24" y="128" width="330" height="80" rx="10" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="44" y="150" font-size="12" font-weight="600" fill="#141413">Codex CLI</text>
+        <text x="44" y="166" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">adapters/codex/codex_adapter.py  →  ~/.codex/hooks.json</text>
+        <text x="44" y="181" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">python codex_adapter.py install</text>
+        <!-- manual badge -->
+        <rect x="233" y="133" width="111" height="18" rx="4" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="288" y="146" font-size="9" font-family="ui-monospace,monospace" fill="#141413" text-anchor="middle">adapter direct</text>
+
+        <!-- Row 3: Copilot CLI (planned) -->
+        <rect x="24" y="226" width="330" height="80" rx="10" fill="#F0EEE6" stroke="#87867F" stroke-width="1.5" stroke-dasharray="6,4"/>
+        <text x="44" y="248" font-size="12" font-weight="600" fill="#87867F">Copilot CLI</text>
+        <text x="44" y="264" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">adapters/copilot/copilot_adapter.py  →  TBD</text>
+        <text x="44" y="279" font-size="10" font-family="ui-monospace,monospace" fill="#B0AFA8">python copilot_adapter.py install  (planned)</text>
+        <!-- planned badge -->
+        <rect x="256" y="231" width="88" height="18" rx="4" fill="#FAF9F5" stroke="#87867F" stroke-width="1" stroke-dasharray="4,3"/>
+        <text x="300" y="244" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">planned</text>
+
+        <!-- ===== CENTER: REFLECT CORE ===== -->
+        <text x="468" y="20" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">REFLECT CORE</text>
+
+        <rect x="396" y="30" width="328" height="276" rx="14" fill="#FFFFFF" stroke="#3D3D3A" stroke-width="2"/>
+        <!-- Core title -->
+        <text x="560" y="60" font-size="18" font-weight="700" fill="#141413" text-anchor="middle" font-family="ui-monospace,monospace">reflect</text>
+        <line x1="416" y1="70" x2="704" y2="70" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- Three inner components -->
+        <!-- Hook scripts -->
+        <rect x="414" y="82" width="292" height="58" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="104" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Hook Scripts</text>
+        <text x="560" y="120" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">session_start_recall.py · precompact_reflect.py</text>
+        <text x="560" y="133" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reflect-drain-bg.sh</text>
+
+        <!-- CLI -->
+        <rect x="414" y="156" width="292" height="58" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="178" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">CLI</text>
+        <text x="560" y="194" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reflect · recall · reindex · search</text>
+        <text x="560" y="207" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">python -m reflect_kb</text>
+
+        <!-- Headless worker -->
+        <rect x="414" y="230" width="292" height="58" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="252" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Headless Worker</text>
+        <text x="560" y="268" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">claude -p /reflect &lt;transcript&gt;</text>
+        <text x="560" y="281" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">--output-format json · --max-turns 25</text>
+
+        <!-- ===== RIGHT: KNOWLEDGE BASE ===== -->
+        <text x="786" y="20" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">SHARED KNOWLEDGE BASE</text>
+
+        <rect x="776" y="30" width="318" height="276" rx="14" fill="#FFFFFF" stroke="#3D3D3A" stroke-width="2"/>
+        <text x="935" y="60" font-size="14" font-weight="600" fill="#141413" text-anchor="middle" font-family="ui-monospace,monospace">~/.reflect/ + ~/.learnings/</text>
+        <line x1="794" y1="70" x2="1076" y2="70" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="935" y="88" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">shared by ALL harnesses — same directory</text>
+
+        <!-- KB tier 1 -->
+        <rect x="794" y="100" width="282" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="935" y="122" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">pending queue</text>
+        <text x="935" y="138" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">~/.reflect/pending_reflections.jsonl</text>
+
+        <!-- KB tier 2 -->
+        <rect x="794" y="166" width="282" height="52" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="935" y="188" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">learnings store</text>
+        <text x="935" y="204" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/documents/</text>
+
+        <!-- KB tier 3 -->
+        <rect x="794" y="232" width="282" height="52" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="935" y="254" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">GraphRAG + vector index</text>
+        <text x="935" y="270" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/graphrag/</text>
+
+        <!-- ===== ARROWS: adapters → core ===== -->
+        <!-- Claude → core -->
+        <line x1="354" y1="70" x2="396" y2="111" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#c1)"/>
+        <!-- Codex → core -->
+        <line x1="354" y1="168" x2="396" y2="168" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#c1)"/>
+        <!-- Copilot → core (dashed) -->
+        <line x1="354" y1="266" x2="396" y2="225" stroke="#87867F" stroke-width="1.5" stroke-dasharray="5,4" marker-end="url(#c-gray)"/>
+
+        <!-- Arrow label on adapter→core -->
+        <text x="360" y="155" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">wires hooks</text>
+        <text x="360" y="166" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">into harness</text>
+        <text x="360" y="177" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">config file</text>
+
+        <!-- ===== ARROWS: core → KB ===== -->
+        <!-- hooks → KB queue (write) -->
+        <line x1="724" y1="126" x2="776" y2="126" stroke="#788C5D" stroke-width="2" marker-end="url(#c-olive)"/>
+        <text x="750" y="118" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D" text-anchor="middle">enqueue</text>
+
+        <!-- worker → KB docs (write) -->
+        <line x1="724" y1="259" x2="776" y2="200" stroke="#788C5D" stroke-width="2" marker-end="url(#c-olive)"/>
+        <text x="768" y="222" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">write .md</text>
+
+        <!-- CLI → KB graphrag (reindex) -->
+        <line x1="724" y1="185" x2="776" y2="260" stroke="#3D3D3A" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#c1)"/>
+        <text x="762" y="240" font-size="9" font-family="ui-monospace,monospace" fill="#87867F">reindex</text>
+
+        <!-- KB → hooks (recall read) -->
+        <path d="M 776 255 Q 760 305 560 305 Q 450 305 430 280" fill="none" stroke="#D97757" stroke-width="2" stroke-dasharray="5,4" marker-end="url(#c-clay)"/>
+        <text x="640" y="320" font-size="9.5" font-family="ui-monospace,monospace" fill="#D97757" text-anchor="middle">recall · top-3 learnings injected into session context</text>
+
+        <!-- "one shared KB" note -->
+        <text x="935" y="326" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">ALL adapters point here — harness-agnostic</text>
+      </svg>
+</div>
+
+---
+
+## Install paths · Claude Code vs Codex CLI
+
+Claude has a plugin runtime (`/plugin install`) so installation is two slash commands.
+Codex has no plugin runtime, so the adapter does the autowire itself with one python
+command.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 380" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="d1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="380" fill="#FAFAF8"/>
+
+        <!-- Column headers -->
+        <text x="24" y="22" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">INSTALL PATH</text>
+        <text x="784" y="22" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">LEGEND</text>
+
+        <!-- ===== CLAUDE CODE ROW ===== -->
+        <text x="24" y="52" font-size="12" font-weight="600" fill="#141413" font-family="ui-monospace,monospace">Claude Code</text>
+        <!-- Complexity scale: shorter bars = fewer steps user must know -->
+
+        <!-- Step 1: marketplace command (user types 1 command) -->
+        <rect x="24" y="60" width="196" height="52" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="122" y="81" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">1. Marketplace add</text>
+        <text x="122" y="96" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">/plugin marketplace add</text>
+        <text x="122" y="108" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">stevengonsalvez/agents-in-a-box</text>
+
+        <!-- arrow -->
+        <line x1="220" y1="86" x2="238" y2="86" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 2: plugin install -->
+        <rect x="240" y="60" width="180" height="52" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="330" y="81" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">2. Plugin install</text>
+        <text x="330" y="96" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">/plugin install</text>
+        <text x="330" y="108" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reflect@agents-in-a-box</text>
+
+        <!-- arrow -->
+        <line x1="420" y1="86" x2="438" y2="86" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 3: plugin runtime (internal, automated) -->
+        <rect x="440" y="60" width="268" height="52" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="574" y="78" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">3. Plugin runtime (automated)</text>
+        <text x="574" y="93" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">extracts plugin.json · expands</text>
+        <text x="574" y="107" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">CLAUDE_PLUGIN_ROOT → ~/.claude/settings.json</text>
+
+        <!-- User-effort scale label -->
+        <text x="24" y="128" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">user effort: 2 commands · runtime handles the rest</text>
+
+        <!-- "what it writes" strip -->
+        <rect x="24" y="136" width="684" height="28" rx="6" fill="#F5F4F0" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="36" y="154" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">writes: </text>
+        <text x="82" y="154" font-size="10" font-family="ui-monospace,monospace" fill="#141413">~/.claude/settings.json  (hooks block merged)</text>
+        <text x="390" y="154" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  +  skills/ extracted to ~/.claude/plugins/reflect/</text>
+
+        <!-- ===== CODEX CLI ROW ===== -->
+        <text x="24" y="192" font-size="12" font-weight="600" fill="#141413" font-family="ui-monospace,monospace">Codex CLI</text>
+
+        <!-- Step 1: git clone / locate adapter -->
+        <rect x="24" y="200" width="142" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="95" y="218" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">1. Clone repo</text>
+        <text x="95" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">or use existing</text>
+        <text x="95" y="248" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">agents-in-a-box checkout</text>
+
+        <line x1="166" y1="226" x2="184" y2="226" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 2: run adapter -->
+        <rect x="186" y="200" width="220" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="296" y="218" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">2. Run adapter directly</text>
+        <text x="296" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">python plugins/reflect/</text>
+        <text x="296" y="248" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">adapters/codex/codex_adapter.py install</text>
+
+        <line x1="406" y1="226" x2="424" y2="226" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 3: adapter copies skills -->
+        <rect x="426" y="200" width="188" height="52" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="520" y="218" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">3. Adapter copies skills</text>
+        <text x="520" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">plugins/ → ~/.codex/skills/</text>
+        <text x="520" y="248" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">merges ~/.codex/hooks.json</text>
+
+        <line x1="614" y1="226" x2="632" y2="226" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 4: hooks wired -->
+        <rect x="634" y="200" width="74" height="52" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="671" y="221" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">4. Done</text>
+        <text x="671" y="237" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">hooks.json</text>
+        <text x="671" y="251" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">active</text>
+
+        <!-- User-effort label -->
+        <text x="24" y="268" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">user effort: 1 python command · no plugin runtime required</text>
+
+        <!-- "what it writes" strip -->
+        <rect x="24" y="276" width="684" height="28" rx="6" fill="#F5F4F0" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="36" y="294" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">writes: </text>
+        <text x="82" y="294" font-size="10" font-family="ui-monospace,monospace" fill="#141413">~/.codex/hooks.json  (SessionStart + PreCompact entries merged)</text>
+        <text x="448" y="294" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  +  skills/ copied to ~/.codex/skills/reflect/</text>
+
+        <!-- ===== LEGEND (right column) ===== -->
+        <!-- Legend box -->
+        <rect x="784" y="32" width="312" height="272" rx="12" fill="#FFFFFF" stroke="#D1CFC5" stroke-width="1.5"/>
+        <text x="800" y="54" font-size="10.5" font-weight="600" fill="#141413">Step type</text>
+        <line x1="800" y1="60" x2="1080" y2="60" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- legend item: user command -->
+        <rect x="800" y="70" width="14" height="14" rx="3" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="82" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">User command (Claude Code)</text>
+
+        <rect x="800" y="94" width="14" height="14" rx="3" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="106" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">User action (Codex)</text>
+
+        <rect x="800" y="118" width="14" height="14" rx="3" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="130" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">Automated (no user input)</text>
+
+        <rect x="800" y="142" width="14" height="14" rx="3" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="154" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">Config written / result</text>
+
+        <line x1="800" y1="168" x2="1080" y2="168" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="800" y="184" font-size="10.5" font-weight="600" fill="#141413">Config files produced</text>
+
+        <text x="800" y="202" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">Claude: ~/.claude/settings.json</text>
+        <text x="800" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">         (hooks block · plugin runtime writes)</text>
+        <text x="800" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">Codex:  ~/.codex/hooks.json</text>
+        <text x="800" y="254" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">         (hooks block · adapter writes directly)</text>
+
+        <line x1="800" y1="266" x2="1080" y2="266" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="800" y="284" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">Both point at the SAME hook scripts</text>
+        <text x="800" y="298" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">and the SAME shared knowledge base.</text>
+
+        <!-- Visual "effort" comparison bar -->
+        <text x="24" y="332" font-size="10.5" font-weight="600" fill="#141413">Relative user-facing complexity</text>
+        <!-- Claude effort bar (shorter = simpler) -->
+        <text x="24" y="352" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">Claude Code</text>
+        <rect x="130" y="340" width="180" height="16" rx="4" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="316" y="352" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  2 slash commands</text>
+        <!-- Codex effort bar (longer = more manual steps) -->
+        <text x="24" y="372" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">Codex CLI</text>
+        <rect x="130" y="360" width="308" height="16" rx="4" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="444" y="372" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  1 python command (more explicit path)</text>
+      </svg>
+</div>
+
+```bash
+# Claude Code — managed install via plugin runtime
+/plugin marketplace add stevengonsalvez/agents-in-a-box
+/plugin install reflect@agents-in-a-box
+
+# Codex CLI — adapter does the autowire
+python plugins/reflect/adapters/codex/codex_adapter.py install
+# or skip the bg drain on codex-only machines without claude on PATH:
+python plugins/reflect/adapters/codex/codex_adapter.py install --no-bg-drain
+```
+
+---
+
+## Recall · UserPromptSubmit primary, SessionStart baseline, per-session dedupe
+
+SessionStart fires *before* the user has typed anything — its recall query has to be
+inferred from cwd, branch, and recent commits. UserPromptSubmit has the actual user prompt
+to query against, which gives much sharper hits. Both fire; UserPromptSubmit dedupes against
+learnings already injected this session so the same memory doesn't re-inject on every prompt.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 340" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a5" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="a5-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="340" fill="#FAFAF8"/>
+
+        <!-- Lane labels -->
+        <text x="14" y="34" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">SESSION&#160;TIMELINE</text>
+
+        <!-- Time axis -->
+        <line x1="70" y1="80" x2="1080" y2="80" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#a5)"/>
+        <text x="60" y="86" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="end">t →</text>
+
+        <!-- Ticks: SessionStart -->
+        <line x1="120" y1="70" x2="120" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="120" cy="80" r="6" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="120" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">SessionStart</text>
+        <text x="120" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">baseline recall</text>
+        <text x="120" y="120" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">cwd · branch</text>
+
+        <!-- Ticks: User prompt 1 -->
+        <line x1="300" y1="70" x2="300" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="300" cy="80" r="6" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="300" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">UserPromptSubmit ①</text>
+        <text x="300" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"fix OAuth bug"</text>
+
+        <!-- Ticks: User prompt 2 (same topic) -->
+        <line x1="560" y1="70" x2="560" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="560" cy="80" r="6" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="560" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">UserPromptSubmit ②</text>
+        <text x="560" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"add refresh token"</text>
+
+        <!-- Ticks: User prompt 3 (topic pivot) -->
+        <line x1="820" y1="70" x2="820" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="820" cy="80" r="6" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="820" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">UserPromptSubmit ③</text>
+        <text x="820" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"now the rate-limiter"</text>
+
+        <!-- Recall actions per tick -->
+        <rect x="36" y="148" width="168" height="80" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="120" y="166" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">session_start_recall</text>
+        <text x="120" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">query: cwd + branch</text>
+        <text x="120" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">inject top-3 baseline</text>
+        <text x="120" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#D97757" text-anchor="middle">→ L₁ L₂ L₃</text>
+
+        <rect x="216" y="148" width="168" height="80" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="300" y="166" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">user_prompt_recall</text>
+        <text x="300" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">query: prompt text</text>
+        <text x="300" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">dedupe vs {L₁,L₂,L₃}</text>
+        <text x="300" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">→ L₄ (L₁ skipped)</text>
+
+        <rect x="476" y="148" width="168" height="80" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="560" y="166" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">user_prompt_recall</text>
+        <text x="560" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">query: prompt text</text>
+        <text x="560" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">dedupe vs {L₁..L₄}</text>
+        <text x="560" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">→ L₅ (L₂,L₄ skipped)</text>
+
+        <rect x="736" y="148" width="168" height="80" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="820" y="166" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">user_prompt_recall</text>
+        <text x="820" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">query: prompt text</text>
+        <text x="820" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">topic pivot → new hits</text>
+        <text x="820" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">→ L₆ L₇ L₈</text>
+
+        <!-- Dedupe state evolution -->
+        <text x="36" y="260" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">DEDUPE STATE</text>
+        <text x="36" y="276" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.reflect/session-injected/&lt;session_id&gt;.json</text>
+
+        <rect x="36" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="120" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁, L₂, L₃}</text>
+
+        <rect x="216" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="300" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁, L₂, L₃, L₄}</text>
+
+        <rect x="476" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁..L₄, L₅}</text>
+
+        <rect x="736" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁..L₅, L₆, L₇, L₈}</text>
+
+        <!-- vertical hook→state arrows -->
+        <line x1="120" y1="228" x2="120" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+        <line x1="300" y1="228" x2="300" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+        <line x1="560" y1="228" x2="560" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+        <line x1="820" y1="228" x2="820" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+
+        <!-- explainer block on the right -->
+        <rect x="940" y="148" width="160" height="174" rx="8" fill="#FFFFFF" stroke="#D1CFC5" stroke-width="1.2"/>
+        <text x="952" y="166" font-size="10" font-weight="600" fill="#141413">Why two layers?</text>
+        <text x="952" y="184" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">SessionStart fires</text>
+        <text x="952" y="196" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">BEFORE user types</text>
+        <text x="952" y="208" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">→ query is coarse</text>
+        <line x1="952" y1="218" x2="1088" y2="218" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="952" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">UserPromptSubmit has</text>
+        <text x="952" y="246" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">actual intent</text>
+        <text x="952" y="258" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">→ sharp query</text>
+        <line x1="952" y1="268" x2="1088" y2="268" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="952" y="284" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">Dedupe stops the</text>
+        <text x="952" y="296" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">same learning being</text>
+        <text x="952" y="308" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">re-injected per prompt</text>
+      </svg>
+</div>
+
+**Dedupe state** lives at `~/.reflect/session-injected/<session_id>.json` — a per-session
+set of learning IDs already injected. UserPromptSubmit recall queries the KB, intersects
+with the dedupe set, and only injects new hits as `additionalContext`.
+
+---
+
+## Capture · PostToolUse mini-learnings + Stop reflection enqueue
+
+PreCompact handles the high-cost full reflection (`claude -p /reflect`). Two more hooks
+cover gaps:
+
+- **PostToolUse** captures cheap mini-learnings inline — on tool failure, arms a watcher
+  for the next user prompt; if the prompt looks like a correction (`"try X instead"`),
+  write a low-confidence learning directly to disk. No LLM run needed.
+- **Stop** catches short sessions that end before PreCompact ever fires. Enqueues the
+  transcript on agent finish; dedupes against any PreCompact entry for the same session.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 300" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a6" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="a6-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="300" fill="#FAFAF8"/>
+
+        <!-- Two parallel sub-flows -->
+        <!-- TOP: PostToolUse mini-learning -->
+        <text x="36" y="32" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">POSTTOOLUSE · MINI-LEARNING</text>
+
+        <rect x="36" y="48" width="200" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="136" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Tool call fails</text>
+        <text x="136" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">Bash exit≠0 · Edit error</text>
+        <text x="136" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">PostToolUse hook fires</text>
+
+        <line x1="236" y1="82" x2="290" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="290" y="48" width="200" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="390" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">posttooluse_minilearning.py</text>
+        <text x="390" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">arms next-prompt watcher</text>
+        <text x="390" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">writes ~/.reflect/armed.json</text>
+
+        <line x1="490" y1="82" x2="544" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="544" y="48" width="220" height="68" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="654" y="68" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">User: "try X instead"</text>
+        <text x="654" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">UserPromptSubmit fires</text>
+        <text x="654" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">arming detected</text>
+
+        <line x1="764" y1="82" x2="818" y2="82" stroke="#788C5D" stroke-width="2" stroke-dasharray="4,2" marker-end="url(#a6-olive)"/>
+
+        <rect x="818" y="48" width="240" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="938" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.learnings/documents/</text>
+        <text x="938" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">&lt;slug&gt;.md · conf=low</text>
+        <text x="938" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">low-cost · no /reflect run</text>
+
+        <!-- Divider -->
+        <line x1="36" y1="142" x2="1080" y2="142" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- BOTTOM: Stop reflection enqueue -->
+        <text x="36" y="170" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">STOP · REFLECTION ENQUEUE (short sessions)</text>
+
+        <rect x="36" y="186" width="200" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="136" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Agent finishes</text>
+        <text x="136" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">Stop hook fires</text>
+        <text x="136" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">(context never filled)</text>
+
+        <line x1="236" y1="220" x2="290" y2="220" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="290" y="186" width="200" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="390" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">stop_reflect.py</text>
+        <text x="390" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">enqueue if not already</text>
+        <text x="390" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">dedupe by session_id</text>
+
+        <line x1="490" y1="220" x2="544" y2="220" stroke="#788C5D" stroke-width="2" stroke-dasharray="4,2" marker-end="url(#a6-olive)"/>
+
+        <rect x="544" y="186" width="240" height="68" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="664" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.reflect/pending_reflections</text>
+        <text x="664" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">.jsonl (shared queue)</text>
+        <text x="664" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">drained next SessionStart</text>
+
+        <line x1="784" y1="220" x2="818" y2="220" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="818" y="186" width="240" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="938" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">claude -p /reflect (headless)</text>
+        <text x="938" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">writes learnings + reindex</text>
+        <text x="938" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">same drain path</text>
+
+        <!-- Footer note -->
+        <text x="36" y="284" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
+          ★ Mini-learning is cheap (no LLM run); Stop-enqueue is full /reflect (same as PreCompact). Both write to the SAME learnings store.
+        </text>
+      </svg>
+</div>
+
+---
+
+## Status line · making recall + capture activity visible
+
+Both harnesses give visual feedback, but through different mechanisms.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 320" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a7" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="320" fill="#FAFAF8"/>
+
+        <!-- Claude side -->
+        <text x="36" y="32" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">CLAUDE CODE · CUSTOM SHELL STATUS LINE</text>
+
+        <rect x="36" y="48" width="240" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="156" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Any reflect hook fires</text>
+        <text x="156" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">recall · enqueue · drain</text>
+        <text x="156" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">writes ~/.reflect/last-event.json</text>
+
+        <line x1="276" y1="82" x2="330" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="330" y="48" width="200" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="430" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.reflect/last-event.json</text>
+        <text x="430" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{event, ts, detail}</text>
+        <text x="430" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">small atomic file</text>
+
+        <line x1="530" y1="82" x2="584" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="584" y="48" width="240" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="704" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.claude/statusline.sh</text>
+        <text x="704" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reads last-event.json</text>
+        <text x="704" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">renders reflect fragment</text>
+
+        <line x1="824" y1="82" x2="878" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="878" y="48" width="200" height="68" rx="8" fill="#141413" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="978" y="68" font-size="11" font-weight="600" fill="#FAF9F5" text-anchor="middle" font-family="ui-monospace,monospace">claude · main</text>
+        <text x="978" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7" text-anchor="middle">🧠 recalled 3 · queued 1</text>
+        <text x="978" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">8% ctx · 2h limit</text>
+
+        <!-- Divider -->
+        <line x1="36" y1="146" x2="1080" y2="146" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- Codex side -->
+        <text x="36" y="174" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">CODEX CLI · HOOK statusMessage FIELD (PER-CALL ONLY)</text>
+
+        <rect x="36" y="190" width="240" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="156" y="210" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Any reflect hook fires</text>
+        <text x="156" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">recall · enqueue · drain</text>
+        <text x="156" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">hook entry has statusMessage</text>
+
+        <line x1="276" y1="224" x2="330" y2="224" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="330" y="190" width="200" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="430" y="210" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">codex reads</text>
+        <text x="430" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">hooks.json entry</text>
+        <text x="430" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"statusMessage":"🧠 recalling…"</text>
+
+        <line x1="530" y1="224" x2="584" y2="224" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="584" y="190" width="240" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="704" y="210" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">codex TUI · ephemeral</text>
+        <text x="704" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">shows DURING hook only</text>
+        <text x="704" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">no persistent fragment yet</text>
+
+        <line x1="824" y1="224" x2="878" y2="224" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="878" y="190" width="200" height="68" rx="8" fill="#141413" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="978" y="210" font-size="11" font-weight="600" fill="#FAF9F5" text-anchor="middle" font-family="ui-monospace,monospace">codex · gpt-5.5</text>
+        <text x="978" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7" text-anchor="middle">🧠 recalling…</text>
+        <text x="978" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">main · ./repo · 4%</text>
+
+        <!-- Asymmetry callout -->
+        <text x="36" y="286" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
+          ★ Claude has a custom shell statusline — we get persistent counters (recalled N · queued M). Codex's status line is a fixed token list;
+        </text>
+        <text x="36" y="302" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
+          we use the per-hook statusMessage field — shows ephemerally during hook execution only. Full parity blocked on a codex custom-token API.
+        </text>
+      </svg>
+</div>
+
+- **Claude Code** — hooks write `~/.reflect/last-event.json`; the user's
+  `~/.claude/statusline.sh` reads it and renders a persistent reflect fragment
+  (`🧠 3 recalled · 1 queued`).
+- **Codex CLI** — hooks declare a `statusMessage` field in `hooks.json`. Codex shows it
+  ephemerally *during* hook execution (`🧠 recalling...`). The static `[tui] status_line`
+  config can't carry a custom token yet, so persistent codex-side counters wait on a
+  codex API extension.
+
+---
+
+## Worked example · "fix the OAuth redirect bug"
+
+A concrete walkthrough showing every hook firing in order across a morning Claude session
+and an afternoon Codex session on the same repo.
+
+<div class="svg-wrap">
+      <svg viewBox="0 0 1120 460" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a8" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="460" fill="#FAFAF8"/>
+
+        <!-- Timeline header -->
+        <text x="14" y="32" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">SCENARIO · CLAUDE CODE SESSION, MORNING</text>
+
+        <!-- Step 1: session starts -->
+        <rect x="36" y="56" width="220" height="64" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="46" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">09:14 · SESSIONSTART</text>
+        <text x="46" y="92" font-size="11" font-weight="600" fill="#141413">Session starts in ./auth-service</text>
+        <text x="46" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">recall(cwd=auth) → L₁ "OAuth state"</text>
+
+        <line x1="256" y1="88" x2="290" y2="88" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 2: User prompt -->
+        <rect x="290" y="56" width="240" height="64" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="300" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#F4E4C1">09:14 · USERPROMPTSUBMIT</text>
+        <text x="300" y="92" font-size="11" font-weight="600" fill="#FFFFFF">"fix the OAuth redirect bug"</text>
+        <text x="300" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1">recall(prompt) → L₂ L₃ (L₁ skipped)</text>
+
+        <line x1="530" y1="88" x2="564" y2="88" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 3: Tool fails -->
+        <rect x="564" y="56" width="220" height="64" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="574" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">09:18 · POSTTOOLUSE</text>
+        <text x="574" y="92" font-size="11" font-weight="600" fill="#141413">Bash exit=1 (curl 500)</text>
+        <text x="574" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">posttooluse arms watcher</text>
+
+        <line x1="784" y1="88" x2="818" y2="88" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 4: User correction -->
+        <rect x="818" y="56" width="240" height="64" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="828" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#F4E4C1">09:18 · USERPROMPTSUBMIT</text>
+        <text x="828" y="92" font-size="11" font-weight="600" fill="#FFFFFF">"use --insecure for local dev"</text>
+        <text x="828" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1">mini-learning written ✓</text>
+
+        <!-- Arrow down to next row -->
+        <line x1="938" y1="124" x2="938" y2="172" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+        <path d="M 938 172 L 938 184 L 156 184 L 156 196" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 5: Context fills -->
+        <rect x="36" y="200" width="220" height="64" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="46" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">10:42 · PRECOMPACT</text>
+        <text x="46" y="236" font-size="11" font-weight="600" fill="#141413">Context 90% full</text>
+        <text x="46" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">enqueued transcript ✓</text>
+
+        <line x1="256" y1="232" x2="290" y2="232" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 6: Session ends -->
+        <rect x="290" y="200" width="240" height="64" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="300" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">11:05 · STOP</text>
+        <text x="300" y="236" font-size="11" font-weight="600" fill="#141413">Agent finishes · session ends</text>
+        <text x="300" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">stop_reflect skips (dedupe)</text>
+
+        <line x1="530" y1="232" x2="564" y2="232" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 7: Later - codex session opens -->
+        <rect x="564" y="200" width="240" height="64" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="574" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">14:30 · CODEX · SESSIONSTART</text>
+        <text x="574" y="236" font-size="11" font-weight="600" fill="#141413">Open codex on same repo</text>
+        <text x="574" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">drain-bg picks up morning queue</text>
+
+        <line x1="804" y1="232" x2="838" y2="232" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 8: drain runs claude -p -->
+        <rect x="838" y="200" width="220" height="64" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="848" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">14:30 · BG DRAIN</text>
+        <text x="848" y="236" font-size="11" font-weight="600" fill="#141413">claude -p /reflect (headless)</text>
+        <text x="848" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">writes L₄ "OAuth state mismatch"</text>
+
+        <!-- Arrow down to next row -->
+        <line x1="938" y1="268" x2="938" y2="316" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+        <path d="M 938 316 L 938 328 L 156 328 L 156 340" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 9: codex user prompts -->
+        <rect x="36" y="344" width="240" height="64" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="46" y="362" font-size="9" font-family="ui-monospace,monospace" fill="#F4E4C1">14:31 · CODEX USERPROMPTSUBMIT</text>
+        <text x="46" y="380" font-size="11" font-weight="600" fill="#FFFFFF">"add OAuth refresh tokens"</text>
+        <text x="46" y="396" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1">recall returns L₂, L₃, L₄ ✓</text>
+
+        <!-- Outcome -->
+        <rect x="296" y="344" width="424" height="64" rx="8" fill="#FFFFFF" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="4,2"/>
+        <text x="312" y="362" font-size="10" font-family="ui-monospace,monospace" fill="#788C5D">OUTCOME</text>
+        <text x="312" y="380" font-size="11" font-weight="600" fill="#141413">Codex session benefits from this morning's Claude work</text>
+        <text x="312" y="396" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">L₄ "OAuth state mismatch (Claude AM)" is now in the index. Cross-tool.</text>
+
+        <!-- Status line strip at top right corner -->
+        <rect x="740" y="344" width="318" height="64" rx="8" fill="#141413" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="752" y="362" font-size="9" font-family="ui-monospace,monospace" fill="#9DD4C7">STATUS LINE · CODEX TUI</text>
+        <text x="752" y="380" font-size="11" font-family="ui-monospace,monospace" fill="#FAF9F5">codex · gpt-5.5  </text>
+        <text x="752" y="396" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7">🧠 3 recalled · ↗ queue empty</text>
+      </svg>
+</div>
+
+1. **09:14 · Claude SessionStart** — recall on `cwd=auth-service` returns L₁ ("OAuth state
+   handling"). Injected as baseline.
+2. **09:14 · UserPromptSubmit** — user types "fix the OAuth redirect bug". Sharp query
+   pulls L₂, L₃. L₁ skipped (already injected). Dedupe set: `{L₁, L₂, L₃}`.
+3. **09:18 · PostToolUse** — `curl` returns 500. Mini-learning watcher arms.
+4. **09:18 · UserPromptSubmit** — user types "use `--insecure` for local dev". Watcher
+   sees correction pattern, writes mini-learning directly to disk. No LLM run.
+5. **10:42 · PreCompact** — context 90% full. Transcript path enqueued to
+   `~/.reflect/pending_reflections.jsonl`.
+6. **11:05 · Stop** — agent finishes. `stop_reflect.py` checks queue, sees PreCompact
+   already enqueued this session_id → skips.
+7. **14:30 · Codex SessionStart** — different harness, same repo. `reflect-drain-bg.sh`
+   starts in background, finds the morning queue entry, spawns `claude -p /reflect`
+   headless. Writes L₄ ("OAuth state mismatch on redirect").
+8. **14:31 · Codex UserPromptSubmit** — user types "add OAuth refresh tokens". Recall pulls
+   L₂, L₃, L₄ — including the learning Claude just wrote this morning.
+
+The codex session benefits from the morning's Claude work without anyone moving files
+around. The queue and the learnings store are the only handoff.
+
+---
+
+## Files involved
+
+| File | Role |
+|---|---|
+| `plugins/reflect/skills/recall/hooks/session_start_recall.py` | SessionStart recall (baseline, cwd-based query) |
+| `plugins/reflect/skills/recall/hooks/user_prompt_submit_recall.py` | UserPromptSubmit recall (intent-sharp, with dedupe) |
+| `plugins/reflect/hooks/precompact_reflect.py` | PreCompact enqueue (full reflection deferred) |
+| `plugins/reflect/hooks/stop_reflect.py` | Stop enqueue (short-session fallback) |
+| `plugins/reflect/hooks/posttooluse_minilearning.py` | PostToolUse mini-learning capture |
+| `plugins/reflect/hooks/reflect-drain-bg.sh` | SessionStart bg-drainer (shells out to `claude -p`) |
+| `plugins/reflect/.claude-plugin/plugin.json` | Claude plugin autowire (`/plugin install`) |
+| `plugins/reflect/adapters/codex/codex_adapter.py` | Codex installer (writes `~/.codex/hooks.json`) |
+| `~/.reflect/pending_reflections.jsonl` | Shared queue (any harness writes, any drains) |
+| `~/.reflect/session-injected/<session_id>.json` | Per-session dedupe state |
+| `~/.reflect/last-event.json` | Status line fragment source |
+| `~/.learnings/documents/` | Markdown learnings + entity sidecars |
+| `~/.learnings/graphrag/` | GraphRAG + vector index |
+
+---
+
+## FAQ
+
+**Why doesn't SessionStart recall use the user's first prompt?**
+SessionStart fires *before* the user has typed anything. Its query has to be inferred from
+cwd, branch, and recent commits — coarse but immediate. UserPromptSubmit fills the
+prompt-aware recall slot.
+
+**What stops UserPromptSubmit recall from re-injecting the same learning every prompt?**
+The per-session dedupe set at `~/.reflect/session-injected/<session_id>.json`. Each hit
+becomes a `{learning_id: ts}` entry; future prompts skip already-injected learnings
+unless they'd be the top hit anyway.
+
+**Why does the drainer always shell out to `claude` instead of `codex`?**
+The `/reflect` skill is a Claude skill. Codex is the trigger (any SessionStart fires the
+bg drainer), Claude is the worker. On codex-only machines without `claude` on PATH, pass
+`--no-bg-drain` to the codex adapter to skip the drain hook.
+
+**Does Stop also fire on long sessions that hit PreCompact?**
+Yes, but `stop_reflect.py` dedupes against the queue by session_id. PreCompact gets in
+first; Stop is a fallback for sessions that never compact.
+
+**Where does `~/.reflect/` live, and is it portable?**
+Under `$HOME/.reflect/` by default; overridable via `REFLECT_STATE_DIR`. Contents are
+JSONL/Markdown/YAML — fully grep-able, version-control friendly, and portable across
+machines via filesystem sync.
+
+---
+
+> **Try it** — see the standalone visual posters with the same diagrams:
+> - Prose explainer + small SVG: <https://unfold-ledger-qjhe.here.now/>
+> - Full platform poster: <https://saffron-mesa-9nz2.here.now/>
+
+<style>
+.svg-wrap {
+  border: 1.5px solid var(--sl-color-gray-5);
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px;
+  margin: 20px 0;
+  overflow-x: auto;
+}
+.svg-wrap svg {
+  display: block;
+  width: 100%;
+  max-width: 1120px;
+  height: auto;
+  margin: 0 auto;
+}
+</style>

--- a/explainers/reflect-hooks-across-claude-codex.html
+++ b/explainers/reflect-hooks-across-claude-codex.html
@@ -1,0 +1,890 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>How reflect captures + recalls across Claude Code and Codex CLI</title>
+<style>
+  :root {
+    --ivory:   #FAF9F5;
+    --slate:   #141413;
+    --clay:    #D97757;
+    --oat:     #E3DACC;
+    --olive:   #788C5D;
+    --gray-150:#F0EEE6;
+    --gray-300:#D1CFC5;
+    --gray-500:#87867F;
+    --gray-700:#3D3D3A;
+    --serif: ui-serif, Georgia, "Times New Roman", serif;
+    --sans:  system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --mono:  ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--ivory);
+    color: var(--gray-700);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    padding: 56px 24px 120px;
+  }
+  .page {
+    max-width: 1180px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: 48px;
+  }
+  @media (max-width: 960px) { .page { grid-template-columns: 1fr; } nav { display: none; } }
+
+  nav { position: sticky; top: 32px; align-self: start; font-size: 13px; }
+  nav .label {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--gray-500);
+    margin-bottom: 12px;
+  }
+  nav a {
+    display: block;
+    padding: 5px 0 5px 12px;
+    border-left: 2px solid var(--gray-300);
+    color: var(--gray-700);
+    text-decoration: none;
+  }
+  nav a:hover { color: var(--slate); border-color: var(--slate); }
+  nav a.l2 { padding-left: 24px; font-size: 12.5px; color: var(--gray-500); }
+  nav .files {
+    margin-top: 28px;
+    border-top: 1px solid var(--gray-300);
+    padding-top: 16px;
+  }
+  nav .files code {
+    display: block;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--gray-500);
+    padding: 3px 0;
+  }
+
+  header { margin-bottom: 12px; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--gray-500);
+    margin-bottom: 10px;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 32px;
+    color: var(--slate);
+    letter-spacing: -0.01em;
+    margin-bottom: 14px;
+  }
+  .tldr {
+    border: 1.5px solid var(--gray-300);
+    border-left: 3px solid var(--clay);
+    border-radius: 10px;
+    background: #fff;
+    padding: 16px 18px;
+    margin-bottom: 8px;
+  }
+  .tldr b { color: var(--slate); }
+
+  h2 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 22px;
+    color: var(--slate);
+    margin: 40px 0 14px;
+    scroll-margin-top: 24px;
+  }
+  p { margin-bottom: 12px; max-width: 720px; }
+  code { font-family: var(--mono); font-size: 13px; }
+
+  .arch {
+    border: 1.5px solid var(--gray-300);
+    border-radius: 12px;
+    background: #fff;
+    padding: 20px;
+    margin: 18px 0 24px;
+    overflow-x: auto;
+  }
+  .arch-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 22px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--gray-500);
+    margin-top: 12px;
+    padding-top: 14px;
+    border-top: 1px dashed var(--gray-300);
+  }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .arch-legend .sw { width: 14px; height: 14px; border-radius: 3px; border: 1px solid var(--slate); }
+  .arch-legend .ln { width: 22px; height: 0; border-top: 2px solid var(--slate); }
+
+  details {
+    border: 1.5px solid var(--gray-300);
+    border-radius: 10px;
+    background: #fff;
+    margin: 14px 0;
+    overflow: hidden;
+  }
+  summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 14px 16px;
+    font-family: var(--serif);
+    font-size: 16px;
+    color: var(--slate);
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  summary::-webkit-details-marker { display: none; }
+  summary::before {
+    content: "▸";
+    color: var(--clay);
+    font-family: var(--sans);
+    font-size: 12px;
+    transition: transform 120ms;
+  }
+  details[open] summary::before { transform: rotate(90deg); }
+  summary .where {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--gray-500);
+    margin-left: auto;
+  }
+  details .body { padding: 0 16px 18px; }
+  details .body p { font-size: 14px; }
+  details .body pre {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--slate);
+    background: var(--gray-150);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin: 10px 0;
+    overflow-x: auto;
+    line-height: 1.55;
+  }
+
+  .tabs {
+    border: 1.5px solid var(--gray-300);
+    border-radius: 10px;
+    background: #fff;
+    margin: 16px 0 8px;
+    overflow: hidden;
+  }
+  .tabbar {
+    display: flex;
+    border-bottom: 1px solid var(--gray-300);
+    background: var(--gray-150);
+    overflow-x: auto;
+  }
+  .tabbar button {
+    appearance: none;
+    border: none;
+    background: none;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--gray-500);
+    padding: 10px 16px;
+    cursor: pointer;
+    border-right: 1px solid var(--gray-300);
+    white-space: nowrap;
+  }
+  .tabbar button.on {
+    background: #fff;
+    color: var(--slate);
+    border-bottom: 2px solid var(--clay);
+    margin-bottom: -1px;
+  }
+  .tabs pre {
+    display: none;
+    margin: 0;
+    padding: 16px 18px;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: var(--slate);
+    overflow-x: auto;
+  }
+  .tabs pre.on { display: block; }
+  .hl { color: var(--clay); }
+  .cm { color: var(--gray-500); }
+  .kw { color: var(--olive); }
+
+  .callout {
+    display: flex;
+    gap: 12px;
+    border: 1.5px solid var(--oat);
+    background: rgba(227,218,204,0.35);
+    border-radius: 10px;
+    padding: 14px 16px;
+    margin: 18px 0;
+    font-size: 14px;
+  }
+  .callout .ico { color: var(--clay); font-weight: 600; }
+
+  dl.faq { margin-top: 8px; }
+  dl.faq dt {
+    font-family: var(--serif);
+    font-size: 16px;
+    color: var(--slate);
+    margin-top: 18px;
+  }
+  dl.faq dd { font-size: 14px; margin: 4px 0 0; max-width: 680px; }
+</style>
+<style data-claude-theme="injected">
+/* Claude brand polish layer for explain-to-me templates.
+ * Inject as a second <style> block AFTER the template's own <style>.
+ * Templates already use Claude's palette (ivory/slate/clay/oat/olive);
+ * this layer adds:
+ *   - Söhne-like sans stack (matches claude.ai)
+ *   - Tiempos Headline–like serif fallback for headings
+ *   - Subtle paper texture on body
+ *   - Brand badge (bottom-right)
+ *   - Clay focus ring
+ * Layout-safe: only touches typography, surface, and decoration.
+ */
+
+:root {
+  /* Re-affirm tokens in case template scoped them. */
+  --ivory:    #FAF9F5;
+  --slate:    #141413;
+  --clay:     #D97757;
+  --oat:      #E3DACC;
+  --olive:    #788C5D;
+  --gray-150: #F0EEE6;
+  --gray-300: #D1CFC5;
+  --gray-500: #87867F;
+  --gray-700: #3D3D3A;
+
+  /* claude.ai font stacks. Web fonts (Söhne, Tiempos) are licensed; the
+   * stack falls back to high-quality system fonts that read as similar. */
+  --sans:  "Söhne", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --serif: "Tiempos Headline", "Tiempos Text", "Source Serif Pro", "Iowan Old Style", "Charter", Georgia, serif;
+  --mono:  "Söhne Mono", "Berkeley Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+body {
+  background-image:
+    radial-gradient(rgba(20, 20, 19, 0.018) 1px, transparent 1px);
+  background-size: 4px 4px;
+}
+
+h1, h2, h3 {
+  letter-spacing: -0.012em;
+}
+
+.eyebrow::after {
+  content: " · explained by claude";
+  color: var(--clay);
+  letter-spacing: 0.08em;
+}
+
+:focus-visible {
+  outline: 2px solid var(--clay);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+pre, code {
+  font-feature-settings: "ss01", "cv11", "calt";
+}
+pre {
+  background: var(--gray-150) !important;
+  border: 1px solid var(--gray-300);
+}
+
+body::after {
+  content: "claude · explainer";
+  position: fixed;
+  bottom: 18px;
+  right: 18px;
+  z-index: 999;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  background: rgba(250, 249, 245, 0.92);
+  border: 1px solid var(--gray-300);
+  border-left: 3px solid var(--clay);
+  padding: 6px 10px 6px 12px;
+  border-radius: 4px;
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+}
+
+@media print {
+  body::after { display: none; }
+  body { background-image: none; }
+}
+
+@media (max-width: 640px) {
+  body::after { display: none; }
+}
+
+</style>
+</head>
+<body>
+<div class="page">
+
+  <nav>
+    <div class="label">On this page</div>
+    <a href="#tldr">TL;DR</a>
+    <a href="#arch">Architecture at a glance</a>
+    <a href="#recall">Recall loop (SessionStart)</a>
+    <a href="#recall" class="l2">1. Hook fires</a>
+    <a href="#recall" class="l2">2. Query context</a>
+    <a href="#recall" class="l2">3. Rerank top-3</a>
+    <a href="#recall" class="l2">4. Inject context</a>
+    <a href="#capture">Capture loop (PreCompact)</a>
+    <a href="#capture" class="l2">1. PreCompact fires</a>
+    <a href="#capture" class="l2">2. Enqueue transcript</a>
+    <a href="#capture" class="l2">3. Drain later</a>
+    <a href="#capture" class="l2">4. Headless reflect</a>
+    <a href="#capture" class="l2">5. Reindex</a>
+    <a href="#wireup">Per-tool wireup</a>
+    <a href="#crosstool">Cross-tool drain</a>
+    <a href="#gotchas">Gotchas</a>
+    <a href="#faq">FAQ</a>
+    <div class="files">
+      <div class="label">Files involved</div>
+      <code>skills/recall/hooks/session_start_recall.py</code>
+      <code>hooks/precompact_reflect.py</code>
+      <code>hooks/reflect-drain-bg.sh</code>
+      <code>.claude-plugin/plugin.json</code>
+      <code>adapters/codex/codex_adapter.py</code>
+      <code>~/.reflect/pending_reflections.jsonl</code>
+      <code>~/.learnings/</code>
+    </div>
+  </nav>
+
+  <main>
+    <header>
+      <div class="eyebrow">Research &amp; Learning · feature summary</div>
+      <h1>How <code>reflect</code> captures + recalls across Claude Code and Codex CLI</h1>
+      <div class="tldr" id="tldr">
+        <b>TL;DR</b> — Two harnesses (Claude Code, Codex CLI) wire the same three hook scripts into different config files
+        (<code>~/.claude/settings.json</code> vs <code>~/.codex/hooks.json</code>) and share one on-disk knowledge base
+        (<code>~/.reflect/</code> queue + <code>~/.learnings/</code> documents + GraphRAG index). <b>SessionStart</b>
+        fires <em>recall</em> (inject top-3 prior learnings) and the <em>bg-drainer</em> (process any queued
+        transcripts). <b>PreCompact</b> fires <em>precompact_reflect</em> (enqueue the current transcript before
+        the harness throws it away). Because the queue is harness-agnostic, a codex session can enqueue a reflection
+        that a later Claude session drains — and vice versa.
+      </div>
+    </header>
+
+    <h2 id="arch">Architecture at a glance</h2>
+    <p>Two harnesses, three hook scripts, one shared knowledge base. Numbered circles on the diagram match the
+      steps in <a href="#recall">Recall loop</a> and <a href="#capture">Capture loop</a> below.</p>
+
+    <div class="arch">
+      <svg viewBox="0 0 1080 900" xmlns="http://www.w3.org/2000/svg" style="width:100%; height:auto; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;">
+        <defs>
+          <marker id="arrowhead" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <polygon points="0 0, 9 4.5, 0 9" fill="#3D3D3A"/>
+          </marker>
+          <marker id="arrowhead-clay" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <polygon points="0 0, 9 4.5, 0 9" fill="#D97757"/>
+          </marker>
+          <marker id="arrowhead-olive" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <polygon points="0 0, 9 4.5, 0 9" fill="#788C5D"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1080" height="160" fill="#FAF9F5"/>
+        <rect x="0" y="160" width="1080" height="220" fill="#FFFFFF"/>
+        <rect x="0" y="380" width="1080" height="260" fill="#FAF9F5"/>
+        <rect x="0" y="640" width="1080" height="260" fill="#FFFFFF"/>
+
+        <text x="12" y="90" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">HARNESS</text>
+        <text x="12" y="270" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">HOOK&#160;SCRIPTS</text>
+        <text x="12" y="510" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">SHARED&#160;STATE</text>
+        <text x="12" y="770" font-size="10" font-family="ui-monospace, monospace" fill="#87867F" letter-spacing="0.12em">HEADLESS</text>
+
+        <!-- ============ HARNESS BAND ============ -->
+        <text x="290" y="22" font-size="11" font-family="ui-monospace, monospace" fill="#788C5D" text-anchor="middle">fires SessionStart · fires PreCompact</text>
+        <text x="790" y="22" font-size="11" font-family="ui-monospace, monospace" fill="#788C5D" text-anchor="middle">fires SessionStart · fires PreCompact</text>
+
+        <g>
+          <rect x="100" y="30" width="380" height="110" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="290" y="58" font-size="15" font-weight="600" fill="#141413" text-anchor="middle">Claude Code session</text>
+          <text x="290" y="80" font-size="12" fill="#3D3D3A" text-anchor="middle">reads hooks from <tspan font-family="ui-monospace, monospace" fill="#141413">~/.claude/settings.json</tspan></text>
+          <text x="290" y="100" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">wired by plugin.json autowire (CLAUDE_PLUGIN_ROOT)</text>
+          <text x="290" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">— OR — manual claude_adapter.py install</text>
+        </g>
+
+        <g>
+          <rect x="600" y="30" width="380" height="110" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="790" y="58" font-size="15" font-weight="600" fill="#141413" text-anchor="middle">Codex CLI session</text>
+          <text x="790" y="80" font-size="12" fill="#3D3D3A" text-anchor="middle">reads hooks from <tspan font-family="ui-monospace, monospace" fill="#141413">~/.codex/hooks.json</tspan></text>
+          <text x="790" y="100" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">wired by codex_adapter.py install</text>
+          <text x="790" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">(no plugin runtime — adapter autowires itself)</text>
+        </g>
+
+        <!-- ============ HOOK SCRIPTS BAND ============ -->
+        <g>
+          <rect x="70" y="200" width="280" height="130" rx="12" ry="12" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="210" y="226" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">session_start_recall.py</text>
+          <text x="210" y="244" font-size="11" fill="#3D3D3A" text-anchor="middle">fired by: SessionStart</text>
+          <text x="210" y="265" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"what learnings apply here?"</text>
+          <text x="210" y="288" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">builds query from cwd · branch</text>
+          <text x="210" y="304" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">git log · returns top-3</text>
+          <text x="210" y="320" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">via additionalContext</text>
+        </g>
+
+        <g>
+          <rect x="400" y="200" width="280" height="130" rx="12" ry="12" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="540" y="226" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">precompact_reflect.py</text>
+          <text x="540" y="244" font-size="11" fill="#3D3D3A" text-anchor="middle">fired by: PreCompact</text>
+          <text x="540" y="265" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"save this transcript for later"</text>
+          <text x="540" y="288" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">never blocks compaction</text>
+          <text x="540" y="304" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">append-only enqueue;</text>
+          <text x="540" y="320" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">reflection happens later</text>
+        </g>
+
+        <g>
+          <rect x="730" y="200" width="280" height="130" rx="12" ry="12" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="870" y="226" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">reflect-drain-bg.sh</text>
+          <text x="870" y="244" font-size="11" fill="#3D3D3A" text-anchor="middle">fired by: SessionStart</text>
+          <text x="870" y="265" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"process any queued reflections"</text>
+          <text x="870" y="288" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">detached (nohup &amp;)</text>
+          <text x="870" y="304" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">PID-locked · daily-capped</text>
+          <text x="870" y="320" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">shells out to claude -p</text>
+        </g>
+
+        <!-- ============ SHARED STATE BAND ============ -->
+        <g>
+          <rect x="100" y="420" width="280" height="190" rx="12" ry="12" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="240" y="448" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">Pending queue</text>
+          <text x="240" y="470" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">~/.reflect/pending_reflections.jsonl</text>
+          <line x1="120" y1="486" x2="360" y2="486" stroke="#3D3D3A" stroke-width="0.5" stroke-dasharray="3,3"/>
+          <text x="240" y="508" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">one line per queued transcript</text>
+          <text x="240" y="525" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">{transcript_path, session_id,</text>
+          <text x="240" y="540" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">trigger, harness, queued_at}</text>
+          <text x="240" y="572" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">harness-agnostic — any harness</text>
+          <text x="240" y="589" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">writes, any harness drains</text>
+        </g>
+
+        <g>
+          <rect x="400" y="420" width="280" height="190" rx="12" ry="12" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="540" y="448" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">Learnings store</text>
+          <text x="540" y="470" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/documents/</text>
+          <line x1="420" y1="486" x2="660" y2="486" stroke="#3D3D3A" stroke-width="0.5" stroke-dasharray="3,3"/>
+          <text x="540" y="510" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">&lt;slug&gt;.md  (the learning)</text>
+          <text x="540" y="527" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">&lt;slug&gt;.entities.yaml (sidecar</text>
+          <text x="540" y="544" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">for GraphRAG ingest)</text>
+          <text x="540" y="576" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">written by the headless</text>
+          <text x="540" y="593" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">/reflect run</text>
+        </g>
+
+        <g>
+          <rect x="700" y="420" width="280" height="190" rx="12" ry="12" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="840" y="448" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">GraphRAG + vector index</text>
+          <text x="840" y="470" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/graphrag/</text>
+          <line x1="720" y1="486" x2="960" y2="486" stroke="#3D3D3A" stroke-width="0.5" stroke-dasharray="3,3"/>
+          <text x="840" y="510" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">communities · entities · relations</text>
+          <text x="840" y="527" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">nano-vector store (hnswlib)</text>
+          <text x="840" y="559" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">queried by recall · refreshed</text>
+          <text x="840" y="576" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">by `reflect reindex` after each</text>
+          <text x="840" y="593" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">successful drain</text>
+        </g>
+
+        <!-- ============ HEADLESS BAND ============ -->
+        <g>
+          <rect x="320" y="685" width="440" height="160" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+          <text x="540" y="712" font-size="14" font-weight="600" fill="#141413" text-anchor="middle">claude -p "/reflect &lt;transcript&gt;"</text>
+          <text x="540" y="734" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">spawned by reflect-drain-bg.sh</text>
+          <text x="540" y="756" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"extract the learnings from this transcript"</text>
+          <text x="540" y="782" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">--output-format json · --max-turns 25</text>
+          <text x="540" y="799" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">--permission-mode bypassPermissions</text>
+          <text x="540" y="823" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">always claude — even when a codex session triggered the drain</text>
+        </g>
+
+        <!-- ============ ARROWS ============ -->
+
+        <!-- 1: SessionStart → recall (both harnesses) -->
+        <line x1="240" y1="140" x2="190" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <line x1="700" y1="140" x2="260" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="230" cy="170" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="230" y="174" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">1</text>
+
+        <!-- 2: recall → GraphRAG read -->
+        <path d="M 290 330 Q 360 380 730 420" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="495" cy="372" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="495" y="376" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">2</text>
+
+        <!-- 3a: GraphRAG → recall (dashed clay) -->
+        <path d="M 720 440 Q 480 350 240 330" fill="none" stroke="#D97757" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#arrowhead-clay)"/>
+        <circle cx="540" cy="358" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="540" y="362" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">3</text>
+        <text x="570" y="345" font-size="10" font-family="ui-monospace, monospace" fill="#D97757">top-3 learnings</text>
+
+        <!-- 3b: recall → session (additionalContext) -->
+        <line x1="160" y1="200" x2="220" y2="140" stroke="#D97757" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#arrowhead-clay)"/>
+        <text x="60" y="195" font-size="10" font-family="ui-monospace, monospace" fill="#D97757">additionalContext</text>
+
+        <!-- 4: PreCompact → precompact_reflect -->
+        <line x1="330" y1="140" x2="470" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <line x1="780" y1="140" x2="600" y2="200" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="540" cy="170" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="540" y="174" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">4</text>
+
+        <!-- 5: precompact → queue write -->
+        <line x1="500" y1="330" x2="290" y2="420" stroke="#788C5D" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-olive)"/>
+        <circle cx="395" cy="375" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="395" y="379" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">5</text>
+        <text x="265" y="395" font-size="10" font-family="ui-monospace, monospace" fill="#788C5D">enqueue transcript_path</text>
+
+        <!-- 6: SessionStart → drain (both harnesses) -->
+        <path d="M 800 140 Q 830 165 870 200" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <path d="M 360 140 Q 620 160 830 200" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="830" cy="170" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="830" y="174" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">6</text>
+
+        <!-- 7: drain reads queue -->
+        <path d="M 740 330 Q 540 380 360 425" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="560" cy="370" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="560" y="374" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">7</text>
+
+        <!-- 8: drain spawns claude -p -->
+        <line x1="870" y1="330" x2="700" y2="685" stroke="#3D3D3A" stroke-width="2" marker-end="url(#arrowhead)"/>
+        <circle cx="800" cy="510" r="12" fill="#D97757" stroke="#141413" stroke-width="1"/>
+        <text x="800" y="514" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">8</text>
+
+        <!-- 9: claude -p writes learnings -->
+        <line x1="450" y1="685" x2="540" y2="610" stroke="#788C5D" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-olive)"/>
+        <circle cx="495" cy="655" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="495" y="659" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">9</text>
+        <text x="555" y="650" font-size="10" font-family="ui-monospace, monospace" fill="#788C5D">.md + .entities.yaml</text>
+
+        <!-- 10: reindex updates GraphRAG -->
+        <path d="M 680 510 Q 750 540 820 610" fill="none" stroke="#788C5D" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-olive)"/>
+        <circle cx="740" cy="545" r="12" fill="#788C5D" stroke="#141413" stroke-width="1"/>
+        <text x="740" y="549" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">10</text>
+        <text x="710" y="528" font-size="10" font-family="ui-monospace, monospace" fill="#788C5D">reflect reindex</text>
+
+      </svg>
+
+      <div class="arch-legend">
+        <span><span class="sw" style="background:#A8C5E6"></span>Harness / external process</span>
+        <span><span class="sw" style="background:#9DD4C7"></span>Hook script (process)</span>
+        <span><span class="sw" style="background:#F4E4C1"></span>Append-only queue</span>
+        <span><span class="sw" style="background:#E8E6E3"></span>Knowledge base storage</span>
+        <span><span class="ln" style="border-color:#3D3D3A"></span>Trigger / read flow</span>
+        <span><span class="ln" style="border-color:#D97757; border-style:dashed"></span>Recall (read into context)</span>
+        <span><span class="ln" style="border-color:#788C5D; border-style:dashed"></span>Capture (write to disk)</span>
+      </div>
+    </div>
+
+    <h2 id="recall">The recall loop · SessionStart → context</h2>
+    <p>Fires on every session start in both harnesses. Always exits 0 — never blocks startup even when the
+      knowledge base is empty or the reflect CLI is missing.</p>
+
+    <details open>
+      <summary>1 · Hook fires <span class="where">SessionStart</span></summary>
+      <div class="body">
+        <p>Both Claude and Codex serialize the same JSON envelope onto the hook's stdin —
+          <code>{session_id, transcript_path, cwd, hook_event_name, source, ...}</code>. The recall script
+          is the same in both cases; the only thing that differs is which config file pointed the harness at it.</p>
+        <pre><span class="cm"># the hook script reads from stdin</span>
+input = json.load(sys.stdin)
+cwd = input.get('cwd')        <span class="cm"># project being worked on</span>
+source = input.get('source')  <span class="cm"># startup | resume | clear</span></pre>
+      </div>
+    </details>
+
+    <details>
+      <summary>2 · Query context from cwd · branch · git log <span class="where">session_start_recall.py:174</span></summary>
+      <div class="body">
+        <p>The script doesn't ask the model "what do you need?" — it builds a context query <em>itself</em>
+          from cheap signals: current working directory, current git branch, recent commit messages on the
+          branch. That string becomes the GraphRAG query.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>3 · Hybrid vector + graph search; rerank to top-3 <span class="where">GraphRAG (nano-graphrag) + hnswlib</span></summary>
+      <div class="body">
+        <p>Two signals are blended: dense vector similarity over learning content, and graph proximity via
+          entity sidecars (the <code>.entities.yaml</code> files written alongside each learning). Reranking
+          weights recency, confidence tag, and tag overlap with the query. Output is capped at the top three.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>4 · Inject as additionalContext <span class="where">session_start_recall.py:158</span></summary>
+      <div class="body">
+        <p>The script emits a single JSON object on stdout containing <code>hookSpecificOutput.additionalContext</code>.
+          The harness reads that envelope and silently prepends the learnings to the session's developer-message
+          context — the user never sees the JSON, the model sees the learnings as if they were instructions.</p>
+        <pre>{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "<span class="hl">## Prior learnings relevant here</span>\n- [lrn-...] Skill X must use ..."
+  }
+}</pre>
+      </div>
+    </details>
+
+    <h2 id="capture">The capture loop · PreCompact → queue → drain</h2>
+    <p>Reflection itself is <em>not</em> done synchronously during PreCompact — the compaction can't wait for
+      a 30-second LLM run. Instead, PreCompact just enqueues the transcript path. The actual /reflect runs
+      asynchronously on the next session start (in any harness) and never blocks the user.</p>
+
+    <details open>
+      <summary>1 · PreCompact fires before compaction <span class="where">PreCompact</span></summary>
+      <div class="body">
+        <p>When the harness is about to compress history (because context is filling up), it serializes
+          <code>{session_id, transcript_path, trigger, ...}</code> to the precompact hook. <code>trigger</code>
+          is either <code>auto</code> (harness decided) or <code>manual</code> (user ran <code>/compact</code>).</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>2 · Enqueue transcript to ~/.reflect/pending_reflections.jsonl <span class="where">precompact_reflect.py:137</span></summary>
+      <div class="body">
+        <p>The script appends a single line to <code>~/.reflect/pending_reflections.jsonl</code> and returns
+          immediately. No LLM call here. The queue file is shared across all harnesses — there's nothing
+          claude-specific about it.</p>
+        <pre>{<span class="hl">"transcript_path"</span>: "...","session_id":"...","trigger":"auto","queued_at":"..."}</pre>
+      </div>
+    </details>
+
+    <details>
+      <summary>3 · Next SessionStart (any harness) fires the drainer <span class="where">SessionStart</span></summary>
+      <div class="body">
+        <p>The next session that starts on this machine — Claude or Codex — fires
+          <code>reflect-drain-bg.sh</code> as a detached background process
+          (<code>(nohup ... &amp;) &gt;/dev/null 2&gt;&amp;1</code>) with a 5-second start budget. It's PID-locked so two
+          concurrent drainers can't trample each other, and daily-capped via cost events so a runaway loop
+          can't spend unlimited tokens.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>4 · Drain shells out to a headless claude -p run <span class="where">reflect-drain-bg.sh:210</span></summary>
+      <div class="body">
+        <p>For each queue entry, the drainer spawns <code>claude -p "/reflect &lt;transcript&gt;"</code>
+          with <code>--output-format json</code>, <code>--max-turns 25</code>, and
+          <code>--permission-mode bypassPermissions</code>. The <code>/reflect</code> skill scans the
+          transcript, classifies corrections vs noteworthy patterns, and writes the resulting learning
+          documents to <code>~/.learnings/documents/</code>.</p>
+        <p><b>This subprocess is always <code>claude</code></b>, even when the queue entry was written by a
+          codex session. Codex is the trigger, Claude is the worker. (Configurable via
+          <code>REFLECT_DRAIN_CLAUDE_BIN</code> in environments where claude isn't on PATH.)</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>5 · Each successful drain triggers reflect reindex <span class="where">reflect-drain-bg.sh:end-of-main</span></summary>
+      <div class="body">
+        <p>If at least one entry processed cleanly, the drainer runs <code>reflect reindex</code> (with a
+          5-minute timeout) so the GraphRAG index picks up the new <code>.md</code> + <code>.entities.yaml</code>
+          files. Without this, learnings are still on disk — they just won't appear in future
+          <code>/recall</code> results until a manual reindex.</p>
+        <p>Successful entries are removed from the queue; transient failures stay (with a retry counter);
+          permanently broken entries (missing transcript, &gt;3 retries) are moved to
+          <code>~/.reflect/poison-reflections.jsonl</code>.</p>
+      </div>
+    </details>
+
+    <h2 id="wireup">How each harness gets wired</h2>
+    <p>The hook <em>scripts</em> are shared. The <em>config plumbing</em> is per-harness.</p>
+
+    <div class="tabs" data-tabs>
+      <div class="tabbar">
+        <button class="on" data-t="0">Claude · plugin.json (autowire)</button>
+        <button data-t="1">Claude · settings.json (effect)</button>
+        <button data-t="2">Codex · adapter command</button>
+        <button data-t="3">Codex · hooks.json (effect)</button>
+      </div>
+<pre class="on"><span class="cm">// .claude-plugin/plugin.json — wired by /plugin install reflect@agents-in-a-box</span>
+{
+  "hooks": {
+    "<span class="hl">SessionStart</span>": [{
+      "hooks": [
+        { "type":"command",
+          "command":"uv run ${CLAUDE_PLUGIN_ROOT}/skills/recall/hooks/<span class="hl">session_start_recall.py</span>" },
+        { "type":"command",
+          "command":"(nohup ${CLAUDE_PLUGIN_ROOT}/hooks/<span class="hl">reflect-drain-bg.sh</span> &amp;) ...",
+          "timeout": 5 }
+      ]
+    }],
+    "<span class="hl">PreCompact</span>": [{
+      "hooks": [{ "type":"command",
+        "command":"uv run ${CLAUDE_PLUGIN_ROOT}/hooks/<span class="hl">precompact_reflect.py</span> --auto --verbose" }]
+    }]
+  }
+}</pre>
+<pre><span class="cm">// ~/.claude/settings.json — what the plugin runtime produces</span>
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "",
+      "hooks": [
+        { "type":"command",
+          "command":"uv run /Users/&lt;you&gt;/.claude/skills/recall/hooks/session_start_recall.py" },
+        { "type":"command",
+          "command":"(nohup /Users/&lt;you&gt;/.claude/plugins/.../hooks/reflect-drain-bg.sh ...",
+          "timeout": 5 }
+      ]
+    }],
+    "PreCompact": [{ "matcher":"", "hooks":[{
+      "command":"uv run .../hooks/precompact_reflect.py --auto --verbose" }] }]
+  }
+}</pre>
+<pre><span class="cm"># codex has no plugin runtime — the adapter does the wireup itself</span>
+<span class="hl">python</span> plugins/reflect/adapters/codex/<span class="hl">codex_adapter.py</span> install
+<span class="cm"># or skip the bg drain on codex-only machines without claude on PATH:</span>
+python plugins/reflect/adapters/codex/codex_adapter.py install <span class="hl">--no-bg-drain</span>
+
+<span class="cm"># adapter physically copies plugin content into ~/.codex/skills/</span>
+<span class="cm"># and merges hook entries into ~/.codex/hooks.json</span></pre>
+<pre><span class="cm">// ~/.codex/hooks.json — what codex_adapter.py produces</span>
+{
+  "hooks": {
+    "<span class="hl">SessionStart</span>": [{
+      "matcher": "",
+      "hooks": [
+        { "type":"command",
+          "command":"uv run /Users/&lt;you&gt;/.codex/skills/recall/hooks/<span class="hl">session_start_recall.py</span>" },
+        { "type":"command",
+          "command":"(nohup /Users/&lt;you&gt;/.codex/skills/reflect/hooks/<span class="hl">reflect-drain-bg.sh</span> &amp;)...",
+          "timeout": 5 }
+      ]
+    }],
+    "<span class="hl">PreCompact</span>": [{ "matcher":"", "hooks":[{
+      "command":"uv run /Users/&lt;you&gt;/.codex/skills/reflect/hooks/<span class="hl">precompact_reflect.py</span> --auto --verbose" }] }]
+  }
+}</pre>
+    </div>
+
+    <div class="callout">
+      <span class="ico">★</span>
+      <div>The hook scripts themselves don't know which harness fired them — they just read JSON from stdin
+        and write JSON to stdout. That's the design constraint that made cross-tool reflection cheap to add.</div>
+    </div>
+
+    <h2 id="crosstool">The cross-tool case · codex queues, claude drains</h2>
+    <p>Imagine you spend the morning in Codex on a tricky migration, hit context compaction, and quit. In
+      the afternoon you open Claude on the same repo. Here's the timeline:</p>
+
+    <details open>
+      <summary>Morning · Codex compaction at 11:42 <span class="where">codex session</span></summary>
+      <div class="body">
+        <p>Codex fires <code>PreCompact</code> → <code>precompact_reflect.py</code> appends one line to
+          <code>~/.reflect/pending_reflections.jsonl</code> with the codex transcript path. No reflection
+          runs. Codex compacts and continues.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>Codex session ends · queue still has the entry <span class="where">11:55</span></summary>
+      <div class="body">
+        <p>If another SessionStart in the same codex session had fired (e.g. on resume), it would have drained.
+          But the user quit. The entry sits in the queue.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>Afternoon · Claude session starts at 14:08 <span class="where">claude session</span></summary>
+      <div class="body">
+        <p>Claude fires <code>SessionStart</code>. Two hooks run: <code>session_start_recall.py</code>
+          (injects whatever's already in the GraphRAG index — the codex morning's learnings are <em>not</em>
+          there yet because they haven't been processed) and <code>reflect-drain-bg.sh</code> as a detached
+          background process.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>Drain picks up the codex transcript · spawns claude -p <span class="where">14:08 + ~1s</span></summary>
+      <div class="body">
+        <p>The drain script reads the queue, finds the morning's codex transcript path, and spawns
+          <code>claude -p "/reflect &lt;morning-codex-transcript&gt;"</code> — note this is Claude processing
+          a transcript that was produced by Codex. The transcript format is the same JSONL the harnesses use
+          natively, so /reflect doesn't care which harness wrote it.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>Learnings land · reindex updates GraphRAG <span class="where">14:09</span></summary>
+      <div class="body">
+        <p>The headless run writes <code>.md</code> + <code>.entities.yaml</code> sidecars under
+          <code>~/.learnings/documents/</code>, then <code>reflect reindex</code> updates the GraphRAG index.
+          The queue entry is removed.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>Next session (Claude OR Codex) recalls them <span class="where">whenever</span></summary>
+      <div class="body">
+        <p>From this point forward, the next SessionStart in <em>any</em> harness — including the very same
+          Claude session that triggered the drain, on its next start — will see the morning's codex learnings
+          in the top-3 if they match the cwd context.</p>
+      </div>
+    </details>
+
+    <h2 id="gotchas">Gotchas worth knowing</h2>
+    <ul style="padding-left:20px; max-width:720px;">
+      <li style="margin-bottom:8px;"><b>The drainer ALWAYS shells out to <code>claude</code></b>. Codex is the trigger, not the worker. On a codex-only machine without <code>claude</code> on PATH, the drain logs a warning and exits 0 (no hang), but learnings never get processed. Pass <code>--no-bg-drain</code> to the codex adapter on those machines to skip the hook entirely.</li>
+      <li style="margin-bottom:8px;"><b>SessionStart never blocks startup</b>. Both hook scripts always exit 0, even on errors — a broken GraphRAG, missing reflect CLI, or unparseable queue all just result in an empty <code>additionalContext</code>.</li>
+      <li style="margin-bottom:8px;"><b>PreCompact doesn't reflect synchronously</b>. The script only enqueues. Reflection happens on the next session start so it doesn't make the user wait through compaction.</li>
+      <li style="margin-bottom:8px;"><b>Claude and Codex use the same event-name casing</b> (<code>SessionStart</code>/<code>PreCompact</code>, PascalCase). Copilot CLI uses lowercase <code>sessionStart</code>/<code>preCompact</code> — if you port the adapter, watch the casing.</li>
+      <li><b>The queue isn't transactional</b>. If a drain crashes mid-entry, the retry counter (<code>~/.reflect/retry-count.jsonl</code>) survives. Three failed retries on the same transcript and the entry is moved to <code>poison-reflections.jsonl</code> — out of the way but kept for forensics.</li>
+    </ul>
+
+    <h2 id="faq">FAQ</h2>
+    <dl class="faq">
+      <dt>Why doesn't recall just embed the user's last prompt?</dt>
+      <dd>By the time the user submits their prompt, the SessionStart hook has already run. Recall has to use
+        cheap pre-prompt signals (cwd, branch, recent commits) and inject before the conversation begins.</dd>
+
+      <dt>What stops the drain from running every session?</dt>
+      <dd>A PID lockfile (<code>~/.reflect/drain.lock</code>) — if another drain is already running, the new
+        one logs and exits. Plus daily caps via <code>REFLECT_DRAIN_DAILY_MAX</code> (default 20). And the
+        queue may simply be empty.</dd>
+
+      <dt>Can I run recall manually?</dt>
+      <dd>Yes — invoke <code>/recall</code> as a skill. The same script runs synchronously with a query you
+        provide. Useful when starting a new feature where the cwd-based query misses relevant prior work.</dd>
+
+      <dt>What happens if I install reflect on Claude AND Codex?</dt>
+      <dd>That's the supported case. The hook scripts are the same; both harnesses just point at their own
+        copies. The queue and learnings store are shared, so the cross-tool case above just works.</dd>
+
+      <dt>Where does <code>~/.reflect/</code> live, and is it portable?</dt>
+      <dd>Under <code>$HOME/.reflect/</code> by default; overridable via <code>REFLECT_STATE_DIR</code>.
+        Contents are JSONL/Markdown/YAML — fully grep-able, version-control friendly if you want, and
+        portable across machines via sync if you sync the dir.</dd>
+    </dl>
+  </main>
+
+</div>
+
+<script>
+document.querySelectorAll("[data-tabs]").forEach(box => {
+  const btns = box.querySelectorAll("button");
+  const panes = box.querySelectorAll("pre");
+  btns.forEach(b => b.addEventListener("click", () => {
+    btns.forEach(x => x.classList.remove("on"));
+    panes.forEach(x => x.classList.remove("on"));
+    b.classList.add("on");
+    panes[+b.dataset.t].classList.add("on");
+  }));
+});
+</script>
+</body>
+</html>

--- a/explainers/reflect-platform-architecture.html
+++ b/explainers/reflect-platform-architecture.html
@@ -1,0 +1,1306 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>reflect · Platform Architecture</title>
+<style>
+  :root {
+    --ivory:    #FAF9F5;
+    --slate:    #141413;
+    --clay:     #D97757;
+    --oat:      #E3DACC;
+    --olive:    #788C5D;
+    --blue:     #A8C5E6;
+    --teal:     #9DD4C7;
+    --beige:    #F4E4C1;
+    --gray-100: #F5F4F0;
+    --gray-150: #F0EEE6;
+    --gray-200: #E8E6E3;
+    --gray-300: #D1CFC5;
+    --gray-500: #87867F;
+    --gray-700: #3D3D3A;
+    --stroke:   #3D3D3A;
+    --serif: "Tiempos Headline", "Tiempos Text", "Source Serif Pro", "Iowan Old Style", Georgia, serif;
+    --sans:  "Söhne", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    --mono:  "Söhne Mono", "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--ivory);
+    background-image: radial-gradient(rgba(20,20,19,0.018) 1px, transparent 1px);
+    background-size: 4px 4px;
+    color: var(--gray-700);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    padding: 64px 32px 120px;
+  }
+  .poster {
+    max-width: 1160px;
+    margin: 0 auto;
+  }
+
+  /* Page header */
+  .page-header {
+    margin-bottom: 52px;
+    border-bottom: 1.5px solid var(--gray-300);
+    padding-bottom: 28px;
+  }
+  .page-eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--gray-500);
+    margin-bottom: 10px;
+  }
+  .page-eyebrow::after {
+    content: " · architecture poster";
+    color: var(--clay);
+  }
+  .page-title {
+    font-family: var(--serif);
+    font-size: 34px;
+    font-weight: 500;
+    color: var(--slate);
+    letter-spacing: -0.015em;
+    margin-bottom: 10px;
+  }
+  .page-sub {
+    font-size: 14px;
+    color: var(--gray-500);
+    font-family: var(--mono);
+  }
+
+  /* Section container */
+  .section {
+    margin-bottom: 44px;
+  }
+  .section-header {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    margin-bottom: 16px;
+  }
+  .section-eyebrow {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--gray-500);
+    white-space: nowrap;
+  }
+  .section-title {
+    font-family: var(--serif);
+    font-size: 22px;
+    font-weight: 500;
+    color: var(--slate);
+    letter-spacing: -0.01em;
+  }
+  .section-rule {
+    flex: 1;
+    height: 1px;
+    background: var(--gray-300);
+    margin-bottom: 3px;
+  }
+
+  /* SVG panels */
+  .panel {
+    background: #fff;
+    border: 1.5px solid var(--gray-300);
+    border-radius: 14px;
+    overflow: hidden;
+  }
+  .panel svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  /* Legend strip */
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 20px;
+    padding: 12px 20px 14px;
+    border-top: 1px dashed var(--gray-300);
+    background: var(--gray-150);
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--gray-500);
+  }
+  .legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .lsw {
+    width: 13px;
+    height: 13px;
+    border-radius: 3px;
+    border: 1px solid var(--stroke);
+    flex-shrink: 0;
+  }
+  .lln {
+    width: 22px;
+    height: 0;
+    border-top: 2px solid currentColor;
+    flex-shrink: 0;
+  }
+  .lln-dash {
+    width: 22px;
+    height: 0;
+    border-top: 2px dashed currentColor;
+    flex-shrink: 0;
+  }
+  .ldot {
+    width: 22px;
+    height: 0;
+    border-top: 2px dotted currentColor;
+    flex-shrink: 0;
+  }
+
+  /* Brand badge */
+  body::after {
+    content: "reflect · platform poster";
+    position: fixed;
+    bottom: 18px;
+    right: 18px;
+    z-index: 999;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--gray-500);
+    background: rgba(250,249,245,0.92);
+    border: 1px solid var(--gray-300);
+    border-left: 3px solid var(--clay);
+    padding: 6px 10px 6px 12px;
+    border-radius: 4px;
+    backdrop-filter: blur(6px);
+    pointer-events: none;
+  }
+
+  @media print {
+    body { background-image: none; }
+    body::after { display: none; }
+  }
+</style>
+<style data-claude-theme="injected">
+/* Claude brand polish layer for explain-to-me templates.
+ * Inject as a second <style> block AFTER the template's own <style>.
+ * Templates already use Claude's palette (ivory/slate/clay/oat/olive);
+ * this layer adds:
+ *   - Söhne-like sans stack (matches claude.ai)
+ *   - Tiempos Headline–like serif fallback for headings
+ *   - Subtle paper texture on body
+ *   - Brand badge (bottom-right)
+ *   - Clay focus ring
+ * Layout-safe: only touches typography, surface, and decoration.
+ */
+
+:root {
+  /* Re-affirm tokens in case template scoped them. */
+  --ivory:    #FAF9F5;
+  --slate:    #141413;
+  --clay:     #D97757;
+  --oat:      #E3DACC;
+  --olive:    #788C5D;
+  --gray-150: #F0EEE6;
+  --gray-300: #D1CFC5;
+  --gray-500: #87867F;
+  --gray-700: #3D3D3A;
+
+  /* claude.ai font stacks. Web fonts (Söhne, Tiempos) are licensed; the
+   * stack falls back to high-quality system fonts that read as similar. */
+  --sans:  "Söhne", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --serif: "Tiempos Headline", "Tiempos Text", "Source Serif Pro", "Iowan Old Style", "Charter", Georgia, serif;
+  --mono:  "Söhne Mono", "Berkeley Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+body {
+  background-image:
+    radial-gradient(rgba(20, 20, 19, 0.018) 1px, transparent 1px);
+  background-size: 4px 4px;
+}
+
+h1, h2, h3 {
+  letter-spacing: -0.012em;
+}
+
+.eyebrow::after {
+  content: " · explained by claude";
+  color: var(--clay);
+  letter-spacing: 0.08em;
+}
+
+:focus-visible {
+  outline: 2px solid var(--clay);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+pre, code {
+  font-feature-settings: "ss01", "cv11", "calt";
+}
+pre {
+  background: var(--gray-150) !important;
+  border: 1px solid var(--gray-300);
+}
+
+body::after {
+  content: "claude · explainer";
+  position: fixed;
+  bottom: 18px;
+  right: 18px;
+  z-index: 999;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  background: rgba(250, 249, 245, 0.92);
+  border: 1px solid var(--gray-300);
+  border-left: 3px solid var(--clay);
+  padding: 6px 10px 6px 12px;
+  border-radius: 4px;
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+}
+
+@media print {
+  body::after { display: none; }
+  body { background-image: none; }
+}
+
+@media (max-width: 640px) {
+  body::after { display: none; }
+}
+
+</style>
+</head>
+<body>
+<div class="poster">
+
+  <!-- ===== PAGE HEADER ===== -->
+  <header class="page-header">
+    <div class="page-eyebrow">reflect plugin · multi-tool platform</div>
+    <h1 class="page-title">reflect · Platform Architecture</h1>
+    <div class="page-sub">session timeline · storage layers · adapter interfaces · install paths</div>
+  </header>
+
+  <!-- ===================================================
+       SECTION 1 — SESSION TIMELINE
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 01</span>
+      <h2 class="section-title">Session timeline · one coding session, end to end</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 270" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="a-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+          <marker id="a-teal" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#9DD4C7"/>
+          </marker>
+          <marker id="a-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+        </defs>
+
+        <!-- Background bands -->
+        <rect x="0" y="0" width="1120" height="270" fill="#FAFAF8"/>
+
+        <!-- Top band: hook labels -->
+        <rect x="0" y="0" width="1120" height="54" fill="#F5F4F0"/>
+        <text x="8" y="12" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">HOOK FIRES</text>
+
+        <!-- Bottom band: data I/O -->
+        <rect x="0" y="196" width="1120" height="74" fill="#F5F4F0"/>
+        <text x="8" y="208" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">DATA READ / WRITTEN</text>
+
+        <!-- Timeline spine -->
+        <line x1="56" y1="126" x2="1082" y2="126" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a1)"/>
+
+        <!-- ---- Tick positions ---- -->
+        <!-- x positions: Install=80, SessionStart=210, Prompts=370, ToolUses=510, CtxFills=640, PreCompact=770, Compact=900, SessionEnd=1040 -->
+
+        <!-- TICK 1: Install -->
+        <line x1="80" y1="114" x2="80" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="80" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="80" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Install</text>
+        <text x="80" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">adapter / plugin</text>
+        <!-- data below -->
+        <text x="80" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">writes hooks</text>
+        <text x="80" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">to config file</text>
+
+        <!-- TICK 2: SessionStart -->
+        <line x1="210" y1="114" x2="210" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="210" cy="126" r="7" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="210" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Session starts</text>
+        <text x="210" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness boots</text>
+        <!-- hook label above -->
+        <line x1="210" y1="114" x2="210" y2="56" stroke="#9DD4C7" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#a-teal)"/>
+        <rect x="138" y="16" width="144" height="36" rx="6" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="210" y="30" font-size="10" font-weight="600" fill="#141413" text-anchor="middle">SessionStart fires</text>
+        <text x="210" y="44" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">recall + drain (bg)</text>
+        <!-- data below -->
+        <text x="210" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">reads graphrag/</text>
+        <text x="210" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">injects top-3</text>
+        <text x="210" y="246" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7" text-anchor="middle">additionalContext</text>
+
+        <!-- TICK 3: User prompts -->
+        <line x1="370" y1="114" x2="370" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="370" cy="126" r="7" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="370" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">User prompts</text>
+        <text x="370" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">conversation</text>
+        <!-- no hook -->
+        <text x="370" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="370" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">model context</text>
+        <text x="370" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">+ learnings</text>
+
+        <!-- TICK 4: Tool uses -->
+        <line x1="510" y1="114" x2="510" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="510" cy="126" r="7" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="510" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Tool uses</text>
+        <text x="510" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">edits / runs</text>
+        <text x="510" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="510" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">transcript grows;</text>
+        <text x="510" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">~/.claude/ JSONL</text>
+
+        <!-- TICK 5: Context fills -->
+        <line x1="640" y1="114" x2="640" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="640" cy="126" r="7" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="640" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Context fills</text>
+        <text x="640" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">approaching limit</text>
+        <text x="640" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="640" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness detects</text>
+        <text x="640" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">token threshold</text>
+
+        <!-- TICK 6: PreCompact -->
+        <line x1="770" y1="114" x2="770" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="770" cy="126" r="7" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="770" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">PreCompact</text>
+        <text x="770" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">hook fires</text>
+        <!-- hook label above -->
+        <line x1="770" y1="114" x2="770" y2="56" stroke="#D97757" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#a-clay)"/>
+        <rect x="694" y="16" width="152" height="36" rx="6" fill="#F4E4C1" stroke="#D97757" stroke-width="1"/>
+        <text x="770" y="30" font-size="10" font-weight="600" fill="#141413" text-anchor="middle">PreCompact fires</text>
+        <text x="770" y="44" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">precompact_reflect.py</text>
+        <!-- data below -->
+        <text x="770" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">appends to</text>
+        <text x="770" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">pending_reflections</text>
+        <text x="770" y="246" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">.jsonl (queue)</text>
+
+        <!-- TICK 7: Compaction -->
+        <line x1="900" y1="114" x2="900" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="900" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="900" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Compaction</text>
+        <text x="900" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness compresses</text>
+        <text x="900" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="900" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">transcript archived;</text>
+        <text x="900" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">context window reset</text>
+
+        <!-- TICK 8: Session ends -->
+        <line x1="1040" y1="114" x2="1040" y2="138" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="1040" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="1040" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Session ends</text>
+        <text x="1040" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">process exits</text>
+        <text x="1040" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <!-- data below -->
+        <text x="1040" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">queue entry waits;</text>
+        <text x="1040" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">drained next start</text>
+
+        <!-- "time" label on spine -->
+        <text x="1094" y="121" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">time</text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#9DD4C7"></span>SessionStart hook fires</span>
+        <span><span class="lsw" style="background:#D97757"></span>PreCompact hook fires</span>
+        <span><span class="lsw" style="background:#F4E4C1"></span>Context / queue state change</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>Harness internal event (no hook)</span>
+        <span><span class="lsw" style="background:#FAF9F5; border-color:#3D3D3A"></span>Normal conversation step</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 2 — STORAGE LAYERS
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 02</span>
+      <h2 class="section-title">Storage layers · three tiers, one knowledge base</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 310" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="b1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="b-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+          <marker id="b-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="310" fill="#FAFAF8"/>
+
+        <!-- Left labels col -->
+        <text x="14" y="78" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em" transform="rotate(-90,14,78)" text-anchor="middle">QUEUE</text>
+        <text x="14" y="170" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em" transform="rotate(-90,14,170)" text-anchor="middle">DOCS</text>
+        <text x="14" y="256" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em" transform="rotate(-90,14,256)" text-anchor="middle">INDEX</text>
+
+        <!-- ====== BAR 1: Pending queue ====== -->
+        <!-- Bar body -->
+        <rect x="32" y="20" width="780" height="74" rx="10" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <!-- Bar label inside -->
+        <text x="52" y="45" font-size="13" font-weight="600" fill="#141413">Pending queue</text>
+        <text x="52" y="62" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.reflect/pending_reflections.jsonl</text>
+        <text x="52" y="79" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">one line per queued transcript · {transcript_path, session_id, trigger, harness, queued_at}</text>
+
+        <!-- Arrow IN: precompact → bar -->
+        <line x1="32" y1="57" x2="16" y2="57" stroke="#788C5D" stroke-width="1.5" marker-end="url(#b-olive)"/>
+        <!-- Arrow IN label above bar (left) -->
+        <text x="34" y="18" font-size="10" font-family="ui-monospace,monospace" fill="#788C5D">IN: precompact_reflect.py (appends on PreCompact)</text>
+
+        <!-- Arrow OUT: bar → drain -->
+        <line x1="812" y1="57" x2="828" y2="57" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#b1)"/>
+        <text x="834" y="61" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">OUT: reflect-drain-bg.sh reads + dequeues</text>
+
+        <!-- Stats block -->
+        <rect x="862" y="20" width="242" height="74" rx="8" fill="#FAF9F5" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="876" y="40" font-size="10.5" font-weight="600" fill="#141413">append-only</text>
+        <text x="876" y="55" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">~1 line / compaction</text>
+        <text x="876" y="69" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">harness-agnostic</text>
+        <text x="876" y="83" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">any harness writes or drains</text>
+
+        <!-- ====== BAR 2: Learnings store ====== -->
+        <rect x="32" y="112" width="780" height="74" rx="10" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="52" y="137" font-size="13" font-weight="600" fill="#141413">Learnings store</text>
+        <text x="52" y="154" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.learnings/documents/  &lt;slug&gt;.md + &lt;slug&gt;.entities.yaml</text>
+        <text x="52" y="171" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">markdown document + YAML entity sidecar per learning · grep-able on disk</text>
+
+        <!-- Arrow IN -->
+        <line x1="32" y1="149" x2="16" y2="149" stroke="#788C5D" stroke-width="1.5" marker-end="url(#b-olive)"/>
+        <text x="34" y="110" font-size="10" font-family="ui-monospace,monospace" fill="#788C5D">IN: claude -p /reflect (headless · spawned by drain)</text>
+
+        <!-- Arrow OUT: to graphrag below -->
+        <line x1="420" y1="186" x2="420" y2="204" stroke="#3D3D3A" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#b1)"/>
+        <text x="428" y="200" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">reflect reindex</text>
+
+        <!-- Stats -->
+        <rect x="862" y="112" width="242" height="74" rx="8" fill="#FAF9F5" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="876" y="132" font-size="10.5" font-weight="600" fill="#141413">markdown + YAML</text>
+        <text x="876" y="147" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">one .md per learning</text>
+        <text x="876" y="161" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">entity sidecar for graph</text>
+        <text x="876" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">human-readable · git-able</text>
+
+        <!-- ====== BAR 3: GraphRAG ====== -->
+        <rect x="32" y="208" width="780" height="74" rx="10" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="52" y="233" font-size="13" font-weight="600" fill="#141413">GraphRAG + vector index</text>
+        <text x="52" y="250" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.learnings/graphrag/   communities · entities · relations · hnswlib vectors</text>
+        <text x="52" y="267" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">nano-graphrag · vector + entity graph · hybrid search · queried on SessionStart</text>
+
+        <!-- Arrow IN already shown above (reindex arrow) -->
+        <line x1="32" y1="245" x2="16" y2="245" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#b1)"/>
+        <text x="34" y="206" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">IN: reflect reindex (after each successful drain)</text>
+
+        <!-- Arrow OUT: to recall -->
+        <line x1="812" y1="245" x2="828" y2="245" stroke="#D97757" stroke-width="1.5" marker-end="url(#b-clay)"/>
+        <text x="834" y="249" font-size="10" font-family="ui-monospace,monospace" fill="#D97757">OUT: session_start_recall.py queries top-3</text>
+
+        <!-- Stats -->
+        <rect x="862" y="208" width="242" height="74" rx="8" fill="#FAF9F5" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="876" y="228" font-size="10.5" font-weight="600" fill="#141413">vector + entity graph</text>
+        <text x="876" y="243" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">queried at SessionStart</text>
+        <text x="876" y="257" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">rebuilt by reflect reindex</text>
+        <text x="876" y="271" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">dense + graph hybrid</text>
+
+        <!-- Tier connector lines left side -->
+        <line x1="26" y1="94" x2="26" y2="112" stroke="#D1CFC5" stroke-width="1.5" stroke-dasharray="3,3"/>
+        <line x1="26" y1="186" x2="26" y2="208" stroke="#D1CFC5" stroke-width="1.5" stroke-dasharray="3,3"/>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#F4E4C1"></span>Append-only queue</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>Persistent knowledge storage</span>
+        <span><span class="lln" style="color:#788C5D"></span>Write flow (capture)</span>
+        <span><span class="lln" style="color:#D97757"></span>Read flow (recall)</span>
+        <span><span class="lln-dash" style="color:#3D3D3A"></span>reindex pipeline</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 3 — PLATFORM & PLUGIN INTERFACE
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 03</span>
+      <h2 class="section-title">The platform · adapter interface and shared knowledge base</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 360" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="c1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="c-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+          <marker id="c-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+          <marker id="c-gray" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#87867F"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="360" fill="#FAFAF8"/>
+
+        <!-- ===== LEFT: ADAPTERS ===== -->
+        <text x="24" y="20" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">HARNESS ADAPTERS</text>
+
+        <!-- Row 1: Claude Code -->
+        <rect x="24" y="30" width="330" height="80" rx="10" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="44" y="52" font-size="12" font-weight="600" fill="#141413">Claude Code</text>
+        <text x="44" y="68" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">.claude-plugin/plugin.json  →  ~/.claude/settings.json</text>
+        <text x="44" y="83" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">/plugin install reflect@agents-in-a-box</text>
+        <!-- autowire badge -->
+        <rect x="240" y="35" width="104" height="18" rx="4" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="292" y="48" font-size="9" font-family="ui-monospace,monospace" fill="#141413" text-anchor="middle">plugin runtime</text>
+
+        <!-- Row 2: Codex CLI -->
+        <rect x="24" y="128" width="330" height="80" rx="10" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="44" y="150" font-size="12" font-weight="600" fill="#141413">Codex CLI</text>
+        <text x="44" y="166" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">adapters/codex/codex_adapter.py  →  ~/.codex/hooks.json</text>
+        <text x="44" y="181" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">python codex_adapter.py install</text>
+        <!-- manual badge -->
+        <rect x="233" y="133" width="111" height="18" rx="4" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="288" y="146" font-size="9" font-family="ui-monospace,monospace" fill="#141413" text-anchor="middle">adapter direct</text>
+
+        <!-- Row 3: Copilot CLI (planned) -->
+        <rect x="24" y="226" width="330" height="80" rx="10" fill="#F0EEE6" stroke="#87867F" stroke-width="1.5" stroke-dasharray="6,4"/>
+        <text x="44" y="248" font-size="12" font-weight="600" fill="#87867F">Copilot CLI</text>
+        <text x="44" y="264" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">adapters/copilot/copilot_adapter.py  →  TBD</text>
+        <text x="44" y="279" font-size="10" font-family="ui-monospace,monospace" fill="#B0AFA8">python copilot_adapter.py install  (planned)</text>
+        <!-- planned badge -->
+        <rect x="256" y="231" width="88" height="18" rx="4" fill="#FAF9F5" stroke="#87867F" stroke-width="1" stroke-dasharray="4,3"/>
+        <text x="300" y="244" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">planned</text>
+
+        <!-- ===== CENTER: REFLECT CORE ===== -->
+        <text x="468" y="20" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">REFLECT CORE</text>
+
+        <rect x="396" y="30" width="328" height="276" rx="14" fill="#FFFFFF" stroke="#3D3D3A" stroke-width="2"/>
+        <!-- Core title -->
+        <text x="560" y="60" font-size="18" font-weight="700" fill="#141413" text-anchor="middle" font-family="ui-monospace,monospace">reflect</text>
+        <line x1="416" y1="70" x2="704" y2="70" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- Three inner components -->
+        <!-- Hook scripts -->
+        <rect x="414" y="82" width="292" height="58" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="104" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Hook Scripts</text>
+        <text x="560" y="120" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">session_start_recall.py · precompact_reflect.py</text>
+        <text x="560" y="133" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reflect-drain-bg.sh</text>
+
+        <!-- CLI -->
+        <rect x="414" y="156" width="292" height="58" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="178" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">CLI</text>
+        <text x="560" y="194" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reflect · recall · reindex · search</text>
+        <text x="560" y="207" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">python -m reflect_kb</text>
+
+        <!-- Headless worker -->
+        <rect x="414" y="230" width="292" height="58" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="252" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Headless Worker</text>
+        <text x="560" y="268" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">claude -p /reflect &lt;transcript&gt;</text>
+        <text x="560" y="281" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">--output-format json · --max-turns 25</text>
+
+        <!-- ===== RIGHT: KNOWLEDGE BASE ===== -->
+        <text x="786" y="20" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">SHARED KNOWLEDGE BASE</text>
+
+        <rect x="776" y="30" width="318" height="276" rx="14" fill="#FFFFFF" stroke="#3D3D3A" stroke-width="2"/>
+        <text x="935" y="60" font-size="14" font-weight="600" fill="#141413" text-anchor="middle" font-family="ui-monospace,monospace">~/.reflect/ + ~/.learnings/</text>
+        <line x1="794" y1="70" x2="1076" y2="70" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="935" y="88" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">shared by ALL harnesses — same directory</text>
+
+        <!-- KB tier 1 -->
+        <rect x="794" y="100" width="282" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="935" y="122" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">pending queue</text>
+        <text x="935" y="138" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">~/.reflect/pending_reflections.jsonl</text>
+
+        <!-- KB tier 2 -->
+        <rect x="794" y="166" width="282" height="52" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="935" y="188" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">learnings store</text>
+        <text x="935" y="204" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/documents/</text>
+
+        <!-- KB tier 3 -->
+        <rect x="794" y="232" width="282" height="52" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="935" y="254" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">GraphRAG + vector index</text>
+        <text x="935" y="270" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">~/.learnings/graphrag/</text>
+
+        <!-- ===== ARROWS: adapters → core ===== -->
+        <!-- Claude → core -->
+        <line x1="354" y1="70" x2="396" y2="111" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#c1)"/>
+        <!-- Codex → core -->
+        <line x1="354" y1="168" x2="396" y2="168" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#c1)"/>
+        <!-- Copilot → core (dashed) -->
+        <line x1="354" y1="266" x2="396" y2="225" stroke="#87867F" stroke-width="1.5" stroke-dasharray="5,4" marker-end="url(#c-gray)"/>
+
+        <!-- Arrow label on adapter→core -->
+        <text x="360" y="155" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">wires hooks</text>
+        <text x="360" y="166" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">into harness</text>
+        <text x="360" y="177" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">config file</text>
+
+        <!-- ===== ARROWS: core → KB ===== -->
+        <!-- hooks → KB queue (write) -->
+        <line x1="724" y1="126" x2="776" y2="126" stroke="#788C5D" stroke-width="2" marker-end="url(#c-olive)"/>
+        <text x="750" y="118" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D" text-anchor="middle">enqueue</text>
+
+        <!-- worker → KB docs (write) -->
+        <line x1="724" y1="259" x2="776" y2="200" stroke="#788C5D" stroke-width="2" marker-end="url(#c-olive)"/>
+        <text x="768" y="222" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">write .md</text>
+
+        <!-- CLI → KB graphrag (reindex) -->
+        <line x1="724" y1="185" x2="776" y2="260" stroke="#3D3D3A" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#c1)"/>
+        <text x="762" y="240" font-size="9" font-family="ui-monospace,monospace" fill="#87867F">reindex</text>
+
+        <!-- KB → hooks (recall read) -->
+        <path d="M 776 255 Q 760 305 560 305 Q 450 305 430 280" fill="none" stroke="#D97757" stroke-width="2" stroke-dasharray="5,4" marker-end="url(#c-clay)"/>
+        <text x="640" y="320" font-size="9.5" font-family="ui-monospace,monospace" fill="#D97757" text-anchor="middle">recall · top-3 learnings injected into session context</text>
+
+        <!-- "one shared KB" note -->
+        <text x="935" y="326" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">ALL adapters point here — harness-agnostic</text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#A8C5E6"></span>Harness adapter (live)</span>
+        <span><span class="lsw" style="background:#F0EEE6; border-color:#87867F"></span>Harness adapter (planned)</span>
+        <span><span class="lsw" style="background:#9DD4C7"></span>Hook scripts</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>CLI / storage</span>
+        <span><span class="lln" style="color:#3D3D3A"></span>Wires / trigger</span>
+        <span><span class="lln" style="color:#788C5D"></span>Write (capture)</span>
+        <span><span class="lln-dash" style="color:#D97757"></span>Read (recall)</span>
+        <span><span class="ldot" style="color:#87867F"></span>Planned path</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 4 — INSTALL PATHS COMPARISON
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 04</span>
+      <h2 class="section-title">Install paths · Claude Code vs Codex CLI</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 380" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="d1" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="380" fill="#FAFAF8"/>
+
+        <!-- Column headers -->
+        <text x="24" y="22" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">INSTALL PATH</text>
+        <text x="784" y="22" font-size="9" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">LEGEND</text>
+
+        <!-- ===== CLAUDE CODE ROW ===== -->
+        <text x="24" y="52" font-size="12" font-weight="600" fill="#141413" font-family="ui-monospace,monospace">Claude Code</text>
+        <!-- Complexity scale: shorter bars = fewer steps user must know -->
+
+        <!-- Step 1: marketplace command (user types 1 command) -->
+        <rect x="24" y="60" width="196" height="52" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="122" y="81" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">1. Marketplace add</text>
+        <text x="122" y="96" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">/plugin marketplace add</text>
+        <text x="122" y="108" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">stevengonsalvez/agents-in-a-box</text>
+
+        <!-- arrow -->
+        <line x1="220" y1="86" x2="238" y2="86" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 2: plugin install -->
+        <rect x="240" y="60" width="180" height="52" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="330" y="81" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">2. Plugin install</text>
+        <text x="330" y="96" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">/plugin install</text>
+        <text x="330" y="108" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reflect@agents-in-a-box</text>
+
+        <!-- arrow -->
+        <line x1="420" y1="86" x2="438" y2="86" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 3: plugin runtime (internal, automated) -->
+        <rect x="440" y="60" width="268" height="52" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="574" y="78" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">3. Plugin runtime (automated)</text>
+        <text x="574" y="93" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">extracts plugin.json · expands</text>
+        <text x="574" y="107" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">CLAUDE_PLUGIN_ROOT → ~/.claude/settings.json</text>
+
+        <!-- User-effort scale label -->
+        <text x="24" y="128" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">user effort: 2 commands · runtime handles the rest</text>
+
+        <!-- "what it writes" strip -->
+        <rect x="24" y="136" width="684" height="28" rx="6" fill="#F5F4F0" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="36" y="154" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">writes: </text>
+        <text x="82" y="154" font-size="10" font-family="ui-monospace,monospace" fill="#141413">~/.claude/settings.json  (hooks block merged)</text>
+        <text x="390" y="154" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  +  skills/ extracted to ~/.claude/plugins/reflect/</text>
+
+        <!-- ===== CODEX CLI ROW ===== -->
+        <text x="24" y="192" font-size="12" font-weight="600" fill="#141413" font-family="ui-monospace,monospace">Codex CLI</text>
+
+        <!-- Step 1: git clone / locate adapter -->
+        <rect x="24" y="200" width="142" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="95" y="218" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">1. Clone repo</text>
+        <text x="95" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">or use existing</text>
+        <text x="95" y="248" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">agents-in-a-box checkout</text>
+
+        <line x1="166" y1="226" x2="184" y2="226" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 2: run adapter -->
+        <rect x="186" y="200" width="220" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="296" y="218" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">2. Run adapter directly</text>
+        <text x="296" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">python plugins/reflect/</text>
+        <text x="296" y="248" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">adapters/codex/codex_adapter.py install</text>
+
+        <line x1="406" y1="226" x2="424" y2="226" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 3: adapter copies skills -->
+        <rect x="426" y="200" width="188" height="52" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="520" y="218" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">3. Adapter copies skills</text>
+        <text x="520" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">plugins/ → ~/.codex/skills/</text>
+        <text x="520" y="248" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">merges ~/.codex/hooks.json</text>
+
+        <line x1="614" y1="226" x2="632" y2="226" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#d1)"/>
+
+        <!-- Step 4: hooks wired -->
+        <rect x="634" y="200" width="74" height="52" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="671" y="221" font-size="10.5" font-weight="600" fill="#141413" text-anchor="middle">4. Done</text>
+        <text x="671" y="237" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">hooks.json</text>
+        <text x="671" y="251" font-size="9.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">active</text>
+
+        <!-- User-effort label -->
+        <text x="24" y="268" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">user effort: 1 python command · no plugin runtime required</text>
+
+        <!-- "what it writes" strip -->
+        <rect x="24" y="276" width="684" height="28" rx="6" fill="#F5F4F0" stroke="#D1CFC5" stroke-width="1"/>
+        <text x="36" y="294" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">writes: </text>
+        <text x="82" y="294" font-size="10" font-family="ui-monospace,monospace" fill="#141413">~/.codex/hooks.json  (SessionStart + PreCompact entries merged)</text>
+        <text x="448" y="294" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  +  skills/ copied to ~/.codex/skills/reflect/</text>
+
+        <!-- ===== LEGEND (right column) ===== -->
+        <!-- Legend box -->
+        <rect x="784" y="32" width="312" height="272" rx="12" fill="#FFFFFF" stroke="#D1CFC5" stroke-width="1.5"/>
+        <text x="800" y="54" font-size="10.5" font-weight="600" fill="#141413">Step type</text>
+        <line x1="800" y1="60" x2="1080" y2="60" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- legend item: user command -->
+        <rect x="800" y="70" width="14" height="14" rx="3" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="82" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">User command (Claude Code)</text>
+
+        <rect x="800" y="94" width="14" height="14" rx="3" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="106" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">User action (Codex)</text>
+
+        <rect x="800" y="118" width="14" height="14" rx="3" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="130" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">Automated (no user input)</text>
+
+        <rect x="800" y="142" width="14" height="14" rx="3" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="154" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">Config written / result</text>
+
+        <line x1="800" y1="168" x2="1080" y2="168" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="800" y="184" font-size="10.5" font-weight="600" fill="#141413">Config files produced</text>
+
+        <text x="800" y="202" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">Claude: ~/.claude/settings.json</text>
+        <text x="800" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">         (hooks block · plugin runtime writes)</text>
+        <text x="800" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">Codex:  ~/.codex/hooks.json</text>
+        <text x="800" y="254" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">         (hooks block · adapter writes directly)</text>
+
+        <line x1="800" y1="266" x2="1080" y2="266" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="800" y="284" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">Both point at the SAME hook scripts</text>
+        <text x="800" y="298" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">and the SAME shared knowledge base.</text>
+
+        <!-- Visual "effort" comparison bar -->
+        <text x="24" y="332" font-size="10.5" font-weight="600" fill="#141413">Relative user-facing complexity</text>
+        <!-- Claude effort bar (shorter = simpler) -->
+        <text x="24" y="352" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">Claude Code</text>
+        <rect x="130" y="340" width="180" height="16" rx="4" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="316" y="352" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  2 slash commands</text>
+        <!-- Codex effort bar (longer = more manual steps) -->
+        <text x="24" y="372" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">Codex CLI</text>
+        <rect x="130" y="360" width="308" height="16" rx="4" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="444" y="372" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">  1 python command (more explicit path)</text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#A8C5E6"></span>Claude Code user step</span>
+        <span><span class="lsw" style="background:#F4E4C1"></span>Codex CLI user step</span>
+        <span><span class="lsw" style="background:#9DD4C7"></span>Automated / runtime-handled</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>Config file written / result state</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 5 — UPDATED RECALL · UserPromptSubmit + dedupe
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 05 · update</span>
+      <h2 class="section-title">Updated recall · UserPromptSubmit primary, SessionStart baseline, per-session dedupe</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 340" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a5" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="a5-clay" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#D97757"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="340" fill="#FAFAF8"/>
+
+        <!-- Lane labels -->
+        <text x="14" y="34" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">SESSION&#160;TIMELINE</text>
+
+        <!-- Time axis -->
+        <line x1="70" y1="80" x2="1080" y2="80" stroke="#3D3D3A" stroke-width="1.5" marker-end="url(#a5)"/>
+        <text x="60" y="86" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="end">t →</text>
+
+        <!-- Ticks: SessionStart -->
+        <line x1="120" y1="70" x2="120" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="120" cy="80" r="6" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="120" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">SessionStart</text>
+        <text x="120" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">baseline recall</text>
+        <text x="120" y="120" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">cwd · branch</text>
+
+        <!-- Ticks: User prompt 1 -->
+        <line x1="300" y1="70" x2="300" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="300" cy="80" r="6" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="300" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">UserPromptSubmit ①</text>
+        <text x="300" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"fix OAuth bug"</text>
+
+        <!-- Ticks: User prompt 2 (same topic) -->
+        <line x1="560" y1="70" x2="560" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="560" cy="80" r="6" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="560" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">UserPromptSubmit ②</text>
+        <text x="560" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"add refresh token"</text>
+
+        <!-- Ticks: User prompt 3 (topic pivot) -->
+        <line x1="820" y1="70" x2="820" y2="90" stroke="#3D3D3A" stroke-width="2"/>
+        <circle cx="820" cy="80" r="6" fill="#D97757" stroke="#3D3D3A" stroke-width="1.5"/>
+        <text x="820" y="60" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">UserPromptSubmit ③</text>
+        <text x="820" y="106" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"now the rate-limiter"</text>
+
+        <!-- Recall actions per tick -->
+        <rect x="36" y="148" width="168" height="80" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="120" y="166" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">session_start_recall</text>
+        <text x="120" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">query: cwd + branch</text>
+        <text x="120" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">inject top-3 baseline</text>
+        <text x="120" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#D97757" text-anchor="middle">→ L₁ L₂ L₃</text>
+
+        <rect x="216" y="148" width="168" height="80" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="300" y="166" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">user_prompt_recall</text>
+        <text x="300" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">query: prompt text</text>
+        <text x="300" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">dedupe vs {L₁,L₂,L₃}</text>
+        <text x="300" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">→ L₄ (L₁ skipped)</text>
+
+        <rect x="476" y="148" width="168" height="80" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="560" y="166" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">user_prompt_recall</text>
+        <text x="560" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">query: prompt text</text>
+        <text x="560" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">dedupe vs {L₁..L₄}</text>
+        <text x="560" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">→ L₅ (L₂,L₄ skipped)</text>
+
+        <rect x="736" y="148" width="168" height="80" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="820" y="166" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">user_prompt_recall</text>
+        <text x="820" y="184" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">query: prompt text</text>
+        <text x="820" y="200" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">topic pivot → new hits</text>
+        <text x="820" y="218" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">→ L₆ L₇ L₈</text>
+
+        <!-- Dedupe state evolution -->
+        <text x="36" y="260" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">DEDUPE STATE</text>
+        <text x="36" y="276" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A">~/.reflect/session-injected/&lt;session_id&gt;.json</text>
+
+        <rect x="36" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="120" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁, L₂, L₃}</text>
+
+        <rect x="216" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="300" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁, L₂, L₃, L₄}</text>
+
+        <rect x="476" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="560" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁..L₄, L₅}</text>
+
+        <rect x="736" y="292" width="168" height="30" rx="6" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1"/>
+        <text x="820" y="312" font-size="10.5" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{L₁..L₅, L₆, L₇, L₈}</text>
+
+        <!-- vertical hook→state arrows -->
+        <line x1="120" y1="228" x2="120" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+        <line x1="300" y1="228" x2="300" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+        <line x1="560" y1="228" x2="560" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+        <line x1="820" y1="228" x2="820" y2="292" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="3,2"/>
+
+        <!-- explainer block on the right -->
+        <rect x="940" y="148" width="160" height="174" rx="8" fill="#FFFFFF" stroke="#D1CFC5" stroke-width="1.2"/>
+        <text x="952" y="166" font-size="10" font-weight="600" fill="#141413">Why two layers?</text>
+        <text x="952" y="184" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">SessionStart fires</text>
+        <text x="952" y="196" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">BEFORE user types</text>
+        <text x="952" y="208" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">→ query is coarse</text>
+        <line x1="952" y1="218" x2="1088" y2="218" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="952" y="234" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">UserPromptSubmit has</text>
+        <text x="952" y="246" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">actual intent</text>
+        <text x="952" y="258" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">→ sharp query</text>
+        <line x1="952" y1="268" x2="1088" y2="268" stroke="#E8E6E3" stroke-width="1"/>
+        <text x="952" y="284" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">Dedupe stops the</text>
+        <text x="952" y="296" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">same learning being</text>
+        <text x="952" y="308" font-size="9.5" font-family="ui-monospace,monospace" fill="#87867F">re-injected per prompt</text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#9DD4C7"></span>SessionStart recall (baseline · cwd+branch query)</span>
+        <span><span class="lsw" style="background:#D97757"></span>UserPromptSubmit recall (intent-sharp · prompt query)</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>Per-session dedupe state (filesystem JSON)</span>
+        <span><span class="ln" style="border-color:#788C5D; border-style:dashed"></span>Hook writes to dedupe state</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 6 — EXTRA CAPTURE HOOKS
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 06 · new</span>
+      <h2 class="section-title">Extra capture hooks · PostToolUse mini-learning + Stop reflection enqueue</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 300" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a6" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+          <marker id="a6-olive" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#788C5D"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="300" fill="#FAFAF8"/>
+
+        <!-- Two parallel sub-flows -->
+        <!-- TOP: PostToolUse mini-learning -->
+        <text x="36" y="32" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">POSTTOOLUSE · MINI-LEARNING</text>
+
+        <rect x="36" y="48" width="200" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="136" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Tool call fails</text>
+        <text x="136" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">Bash exit≠0 · Edit error</text>
+        <text x="136" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">PostToolUse hook fires</text>
+
+        <line x1="236" y1="82" x2="290" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="290" y="48" width="200" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="390" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">posttooluse_minilearning.py</text>
+        <text x="390" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">arms next-prompt watcher</text>
+        <text x="390" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">writes ~/.reflect/armed.json</text>
+
+        <line x1="490" y1="82" x2="544" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="544" y="48" width="220" height="68" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="654" y="68" font-size="11" font-weight="600" fill="#FFFFFF" text-anchor="middle">User: "try X instead"</text>
+        <text x="654" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#FFFFFF" text-anchor="middle">UserPromptSubmit fires</text>
+        <text x="654" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1" text-anchor="middle">arming detected</text>
+
+        <line x1="764" y1="82" x2="818" y2="82" stroke="#788C5D" stroke-width="2" stroke-dasharray="4,2" marker-end="url(#a6-olive)"/>
+
+        <rect x="818" y="48" width="240" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="938" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.learnings/documents/</text>
+        <text x="938" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">&lt;slug&gt;.md · conf=low</text>
+        <text x="938" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">low-cost · no /reflect run</text>
+
+        <!-- Divider -->
+        <line x1="36" y1="142" x2="1080" y2="142" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- BOTTOM: Stop reflection enqueue -->
+        <text x="36" y="170" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">STOP · REFLECTION ENQUEUE (short sessions)</text>
+
+        <rect x="36" y="186" width="200" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="136" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Agent finishes</text>
+        <text x="136" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">Stop hook fires</text>
+        <text x="136" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">(context never filled)</text>
+
+        <line x1="236" y1="220" x2="290" y2="220" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="290" y="186" width="200" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="390" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">stop_reflect.py</text>
+        <text x="390" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">enqueue if not already</text>
+        <text x="390" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">dedupe by session_id</text>
+
+        <line x1="490" y1="220" x2="544" y2="220" stroke="#788C5D" stroke-width="2" stroke-dasharray="4,2" marker-end="url(#a6-olive)"/>
+
+        <rect x="544" y="186" width="240" height="68" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="664" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.reflect/pending_reflections</text>
+        <text x="664" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">.jsonl (shared queue)</text>
+        <text x="664" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">drained next SessionStart</text>
+
+        <line x1="784" y1="220" x2="818" y2="220" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a6)"/>
+
+        <rect x="818" y="186" width="240" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="938" y="206" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">claude -p /reflect (headless)</text>
+        <text x="938" y="222" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">writes learnings + reindex</text>
+        <text x="938" y="238" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">same drain path</text>
+
+        <!-- Footer note -->
+        <text x="36" y="284" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
+          ★ Mini-learning is cheap (no LLM run); Stop-enqueue is full /reflect (same as PreCompact). Both write to the SAME learnings store.
+        </text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#A8C5E6"></span>Lifecycle event (harness fires)</span>
+        <span><span class="lsw" style="background:#9DD4C7"></span>Hook script</span>
+        <span><span class="lsw" style="background:#F4E4C1"></span>Shared queue</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>Storage write</span>
+        <span><span class="ln" style="border-color:#788C5D; border-style:dashed"></span>Capture (write to disk)</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 7 — STATUS LINE INTEGRATION
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 07 · new</span>
+      <h2 class="section-title">Status line · making recall + capture activity visible</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 320" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a7" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="320" fill="#FAFAF8"/>
+
+        <!-- Claude side -->
+        <text x="36" y="32" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">CLAUDE CODE · CUSTOM SHELL STATUS LINE</text>
+
+        <rect x="36" y="48" width="240" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="156" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Any reflect hook fires</text>
+        <text x="156" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">recall · enqueue · drain</text>
+        <text x="156" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">writes ~/.reflect/last-event.json</text>
+
+        <line x1="276" y1="82" x2="330" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="330" y="48" width="200" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="430" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.reflect/last-event.json</text>
+        <text x="430" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">{event, ts, detail}</text>
+        <text x="430" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">small atomic file</text>
+
+        <line x1="530" y1="82" x2="584" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="584" y="48" width="240" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="704" y="68" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">~/.claude/statusline.sh</text>
+        <text x="704" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">reads last-event.json</text>
+        <text x="704" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">renders reflect fragment</text>
+
+        <line x1="824" y1="82" x2="878" y2="82" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="878" y="48" width="200" height="68" rx="8" fill="#141413" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="978" y="68" font-size="11" font-weight="600" fill="#FAF9F5" text-anchor="middle" font-family="ui-monospace,monospace">claude · main</text>
+        <text x="978" y="84" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7" text-anchor="middle">🧠 recalled 3 · queued 1</text>
+        <text x="978" y="100" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">8% ctx · 2h limit</text>
+
+        <!-- Divider -->
+        <line x1="36" y1="146" x2="1080" y2="146" stroke="#E8E6E3" stroke-width="1"/>
+
+        <!-- Codex side -->
+        <text x="36" y="174" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">CODEX CLI · HOOK statusMessage FIELD (PER-CALL ONLY)</text>
+
+        <rect x="36" y="190" width="240" height="68" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="156" y="210" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">Any reflect hook fires</text>
+        <text x="156" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">recall · enqueue · drain</text>
+        <text x="156" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">hook entry has statusMessage</text>
+
+        <line x1="276" y1="224" x2="330" y2="224" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="330" y="190" width="200" height="68" rx="8" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="430" y="210" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">codex reads</text>
+        <text x="430" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">hooks.json entry</text>
+        <text x="430" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">"statusMessage":"🧠 recalling…"</text>
+
+        <line x1="530" y1="224" x2="584" y2="224" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="584" y="190" width="240" height="68" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="704" y="210" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">codex TUI · ephemeral</text>
+        <text x="704" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle">shows DURING hook only</text>
+        <text x="704" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">no persistent fragment yet</text>
+
+        <line x1="824" y1="224" x2="878" y2="224" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a7)"/>
+
+        <rect x="878" y="190" width="200" height="68" rx="8" fill="#141413" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="978" y="210" font-size="11" font-weight="600" fill="#FAF9F5" text-anchor="middle" font-family="ui-monospace,monospace">codex · gpt-5.5</text>
+        <text x="978" y="226" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7" text-anchor="middle">🧠 recalling…</text>
+        <text x="978" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">main · ./repo · 4%</text>
+
+        <!-- Asymmetry callout -->
+        <text x="36" y="286" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
+          ★ Claude has a custom shell statusline — we get persistent counters (recalled N · queued M). Codex's status line is a fixed token list;
+        </text>
+        <text x="36" y="302" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
+          we use the per-hook statusMessage field — shows ephemerally during hook execution only. Full parity blocked on a codex custom-token API.
+        </text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#9DD4C7"></span>Hook (writes event)</span>
+        <span><span class="lsw" style="background:#E8E6E3"></span>Intermediate state file / config</span>
+        <span><span class="lsw" style="background:#A8C5E6"></span>Harness UI consumer</span>
+        <span><span class="lsw" style="background:#141413"></span>Status line output</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================================================
+       SECTION 8 — WORKED EXAMPLE
+       =================================================== -->
+  <section class="section">
+    <div class="section-header">
+      <span class="section-eyebrow">Section 08 · worked example</span>
+      <h2 class="section-title">End to end · "fix the OAuth bug" through both flows</h2>
+      <div class="section-rule"></div>
+    </div>
+    <div class="panel">
+      <svg viewBox="0 0 1120 460" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="a8" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <polygon points="0 0,8 4,0 8" fill="#3D3D3A"/>
+          </marker>
+        </defs>
+
+        <rect x="0" y="0" width="1120" height="460" fill="#FAFAF8"/>
+
+        <!-- Timeline header -->
+        <text x="14" y="32" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" letter-spacing="0.1em">SCENARIO · CLAUDE CODE SESSION, MORNING</text>
+
+        <!-- Step 1: session starts -->
+        <rect x="36" y="56" width="220" height="64" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="46" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">09:14 · SESSIONSTART</text>
+        <text x="46" y="92" font-size="11" font-weight="600" fill="#141413">Session starts in ./auth-service</text>
+        <text x="46" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">recall(cwd=auth) → L₁ "OAuth state"</text>
+
+        <line x1="256" y1="88" x2="290" y2="88" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 2: User prompt -->
+        <rect x="290" y="56" width="240" height="64" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="300" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#F4E4C1">09:14 · USERPROMPTSUBMIT</text>
+        <text x="300" y="92" font-size="11" font-weight="600" fill="#FFFFFF">"fix the OAuth redirect bug"</text>
+        <text x="300" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1">recall(prompt) → L₂ L₃ (L₁ skipped)</text>
+
+        <line x1="530" y1="88" x2="564" y2="88" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 3: Tool fails -->
+        <rect x="564" y="56" width="220" height="64" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="574" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">09:18 · POSTTOOLUSE</text>
+        <text x="574" y="92" font-size="11" font-weight="600" fill="#141413">Bash exit=1 (curl 500)</text>
+        <text x="574" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">posttooluse arms watcher</text>
+
+        <line x1="784" y1="88" x2="818" y2="88" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 4: User correction -->
+        <rect x="818" y="56" width="240" height="64" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="828" y="74" font-size="9" font-family="ui-monospace,monospace" fill="#F4E4C1">09:18 · USERPROMPTSUBMIT</text>
+        <text x="828" y="92" font-size="11" font-weight="600" fill="#FFFFFF">"use --insecure for local dev"</text>
+        <text x="828" y="108" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1">mini-learning written ✓</text>
+
+        <!-- Arrow down to next row -->
+        <line x1="938" y1="124" x2="938" y2="172" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+        <path d="M 938 172 L 938 184 L 156 184 L 156 196" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 5: Context fills -->
+        <rect x="36" y="200" width="220" height="64" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="46" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">10:42 · PRECOMPACT</text>
+        <text x="46" y="236" font-size="11" font-weight="600" fill="#141413">Context 90% full</text>
+        <text x="46" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">enqueued transcript ✓</text>
+
+        <line x1="256" y1="232" x2="290" y2="232" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 6: Session ends -->
+        <rect x="290" y="200" width="240" height="64" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="300" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">11:05 · STOP</text>
+        <text x="300" y="236" font-size="11" font-weight="600" fill="#141413">Agent finishes · session ends</text>
+        <text x="300" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">stop_reflect skips (dedupe)</text>
+
+        <line x1="530" y1="232" x2="564" y2="232" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 7: Later - codex session opens -->
+        <rect x="564" y="200" width="240" height="64" rx="8" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="574" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">14:30 · CODEX · SESSIONSTART</text>
+        <text x="574" y="236" font-size="11" font-weight="600" fill="#141413">Open codex on same repo</text>
+        <text x="574" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">drain-bg picks up morning queue</text>
+
+        <line x1="804" y1="232" x2="838" y2="232" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 8: drain runs claude -p -->
+        <rect x="838" y="200" width="220" height="64" rx="8" fill="#9DD4C7" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="848" y="218" font-size="9" font-family="ui-monospace,monospace" fill="#788C5D">14:30 · BG DRAIN</text>
+        <text x="848" y="236" font-size="11" font-weight="600" fill="#141413">claude -p /reflect (headless)</text>
+        <text x="848" y="252" font-size="10" font-family="ui-monospace,monospace" fill="#3D3D3A">writes L₄ "OAuth state mismatch"</text>
+
+        <!-- Arrow down to next row -->
+        <line x1="938" y1="268" x2="938" y2="316" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+        <path d="M 938 316 L 938 328 L 156 328 L 156 340" fill="none" stroke="#3D3D3A" stroke-width="2" marker-end="url(#a8)"/>
+
+        <!-- Step 9: codex user prompts -->
+        <rect x="36" y="344" width="240" height="64" rx="8" fill="#D97757" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="46" y="362" font-size="9" font-family="ui-monospace,monospace" fill="#F4E4C1">14:31 · CODEX USERPROMPTSUBMIT</text>
+        <text x="46" y="380" font-size="11" font-weight="600" fill="#FFFFFF">"add OAuth refresh tokens"</text>
+        <text x="46" y="396" font-size="10" font-family="ui-monospace,monospace" fill="#F4E4C1">recall returns L₂, L₃, L₄ ✓</text>
+
+        <!-- Outcome -->
+        <rect x="296" y="344" width="424" height="64" rx="8" fill="#FFFFFF" stroke="#788C5D" stroke-width="1.5" stroke-dasharray="4,2"/>
+        <text x="312" y="362" font-size="10" font-family="ui-monospace,monospace" fill="#788C5D">OUTCOME</text>
+        <text x="312" y="380" font-size="11" font-weight="600" fill="#141413">Codex session benefits from this morning's Claude work</text>
+        <text x="312" y="396" font-size="10" font-family="ui-monospace,monospace" fill="#87867F">L₄ "OAuth state mismatch (Claude AM)" is now in the index. Cross-tool.</text>
+
+        <!-- Status line strip at top right corner -->
+        <rect x="740" y="344" width="318" height="64" rx="8" fill="#141413" stroke="#3D3D3A" stroke-width="1.2"/>
+        <text x="752" y="362" font-size="9" font-family="ui-monospace,monospace" fill="#9DD4C7">STATUS LINE · CODEX TUI</text>
+        <text x="752" y="380" font-size="11" font-family="ui-monospace,monospace" fill="#FAF9F5">codex · gpt-5.5  </text>
+        <text x="752" y="396" font-size="10" font-family="ui-monospace,monospace" fill="#9DD4C7">🧠 3 recalled · ↗ queue empty</text>
+      </svg>
+
+      <div class="legend">
+        <span><span class="lsw" style="background:#9DD4C7"></span>SessionStart · Stop · drain hooks</span>
+        <span><span class="lsw" style="background:#D97757"></span>UserPromptSubmit recall</span>
+        <span><span class="lsw" style="background:#A8C5E6"></span>PostToolUse / harness event</span>
+        <span><span class="lsw" style="background:#F4E4C1"></span>PreCompact · queue</span>
+        <span><span class="ln" style="border-color:#788C5D; border-style:dashed"></span>Cross-tool outcome</span>
+      </div>
+    </div>
+  </section>
+
+</div>
+</body>
+</html>

--- a/plugins/reflect/adapters/base.py
+++ b/plugins/reflect/adapters/base.py
@@ -30,7 +30,9 @@ CLI capable of driving any subclass without per-harness boilerplate.
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -101,6 +103,138 @@ def find_plugin_root(script_path: Path | None = None) -> Path:
         f"could not find reflect plugin root walking up from {here!r}; "
         "expected a parent containing both skills/ and adapters/"
     )
+
+
+def inject_managed_by(text: str, sentinel: str) -> str:
+    """Ensure ``text``'s YAML frontmatter contains ``managed_by: <sentinel>``.
+
+    Used by adapters that copy full SKILL.md content (Claude, Codex) to
+    mark adapter-installed files for later uninstall while preserving the
+    rest of the file byte-for-byte. Three cases:
+
+      * No frontmatter at all → wrap with minimal ``---\\nmanaged_by:...\\n---``.
+      * Frontmatter present, no ``managed_by`` key → append the line before
+        the closing ``---``.
+      * Frontmatter present with ``managed_by`` already → replace that line.
+
+    Body content (including stray ``---`` rules used as horizontal dividers)
+    is left untouched.
+    """
+    if not text.startswith("---"):
+        return f"---\nmanaged_by: {sentinel}\n---\n\n{text}"
+
+    body = text[3:]
+    m = re.search(r"(^|\n)---(\n|$)", body)
+    if not m:
+        return f"---\nmanaged_by: {sentinel}\n---\n\n{text}"
+
+    fm_block = body[: m.start()]
+    rest = body[m.end():]
+    trailing = m.group(2)
+
+    managed_re = re.compile(r"^managed_by:.*$", re.MULTILINE)
+    if managed_re.search(fm_block):
+        new_fm = managed_re.sub(f"managed_by: {sentinel}", fm_block)
+    else:
+        new_fm = fm_block.rstrip("\n") + f"\nmanaged_by: {sentinel}\n"
+
+    return f"---{new_fm}---{trailing}{rest}"
+
+
+def merge_hook_commands(
+    config: dict,
+    *,
+    event: str,
+    commands: Sequence[dict],
+    legacy_commands: Sequence[str] = (),
+) -> bool:
+    """Add hook command entries under ``config['hooks'][event]``.
+
+    Each item in ``commands`` is a dict shaped like
+    ``{"type": "command", "command": "...", ...}`` (optionally with
+    ``timeout`` / ``statusMessage`` etc — the shape both Claude and Codex
+    accept verbatim).
+
+    ``legacy_commands`` contains literal command strings produced by
+    earlier buggy adapter versions; any matching entry is stripped so
+    re-installs heal the file. Returns ``True`` iff the config was
+    mutated.
+
+    The function does **not** persist the change — callers serialise the
+    mutated ``config`` themselves so this helper stays harness-agnostic
+    (settings.json vs hooks.json).
+    """
+    changed = False
+    hooks = config.setdefault("hooks", {})
+    entries = hooks.setdefault(event, [])
+
+    legacy_set = set(legacy_commands)
+    if legacy_set:
+        for entry in entries:
+            original_hooks = entry.get("hooks", [])
+            kept = [
+                hook for hook in original_hooks
+                if hook.get("command") not in legacy_set
+            ]
+            if kept != original_hooks:
+                entry["hooks"] = kept
+                changed = True
+        entries[:] = [e for e in entries if e.get("hooks")]
+
+    already_present_cmds = {
+        hook.get("command")
+        for entry in entries
+        for hook in entry.get("hooks", [])
+    }
+    to_add = [entry for entry in commands if entry["command"] not in already_present_cmds]
+
+    if to_add:
+        entries.append({"matcher": "", "hooks": list(to_add)})
+        changed = True
+
+    return changed
+
+
+def remove_hook_commands(
+    config: dict,
+    *,
+    event: str,
+    commands: Sequence[str],
+) -> bool:
+    """Remove any hook entry under ``config['hooks'][event]`` whose
+    ``command`` matches one of ``commands``. Returns ``True`` iff the
+    config was mutated. Empty hook groups are dropped; empty events are
+    pruned; empty ``hooks`` block is removed entirely.
+    """
+    hooks = config.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    entries = hooks.get(event)
+    if not isinstance(entries, list):
+        return False
+    removable = set(commands)
+    changed = False
+    filtered: list = []
+    for entry in entries:
+        kept = [
+            hook for hook in entry.get("hooks", [])
+            if hook.get("command") not in removable
+        ]
+        if kept != entry.get("hooks", []):
+            changed = True
+        if kept:
+            new_entry = dict(entry)
+            new_entry["hooks"] = kept
+            filtered.append(new_entry)
+    if not changed:
+        return False
+    if filtered:
+        hooks[event] = filtered
+    else:
+        hooks.pop(event, None)
+    if not hooks:
+        config.pop("hooks", None)
+    return True
 
 
 def parse_skill_frontmatter(text: str) -> dict[str, Any]:

--- a/plugins/reflect/adapters/claude/claude_adapter.py
+++ b/plugins/reflect/adapters/claude/claude_adapter.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -55,6 +54,7 @@ from base import (  # noqa: E402
     PLUGIN_SKILLS,  # re-exported for backwards-compat with tests
     _resolve_home,
     find_plugin_root as _shared_find_plugin_root,
+    inject_managed_by as _inject_managed_by,
     parse_skill_frontmatter,
     run_cli,
 )
@@ -83,46 +83,6 @@ def _render_session_start_hook_command(claude_dir: Path) -> str:
 _LEGACY_SESSION_START_HOOK_COMMAND = SESSION_START_HOOK_COMMAND_TEMPLATE.replace(
     "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
 )
-
-
-def _inject_managed_by(text: str, sentinel: str) -> str:
-    """Ensure ``text``'s YAML frontmatter contains ``managed_by: <sentinel>``.
-
-    Used by :class:`ClaudeAdapter` to mark adapter-installed skill files for
-    later uninstall while preserving the rest of the plugin SKILL.md byte
-    for byte. Three cases:
-
-      * No frontmatter at all → wrap with minimal ``---\\nmanaged_by:...\\n---``.
-      * Frontmatter present, no ``managed_by`` key → append the line before
-        the closing ``---``.
-      * Frontmatter present with ``managed_by`` already → replace that line.
-
-    Body content (including stray ``---`` rules used as horizontal dividers)
-    is left untouched.
-    """
-    if not text.startswith("---"):
-        return f"---\nmanaged_by: {sentinel}\n---\n\n{text}"
-
-    # Locate the closing ``---`` of the first frontmatter block. Search
-    # starts after the opening ``---`` (position 3) and matches a ``---``
-    # that's the entire content of its own line.
-    body = text[3:]
-    m = re.search(r"(^|\n)---(\n|$)", body)
-    if not m:
-        # Malformed frontmatter (no closing) — treat as no frontmatter.
-        return f"---\nmanaged_by: {sentinel}\n---\n\n{text}"
-
-    fm_block = body[: m.start()]
-    rest = body[m.end():]
-    trailing = m.group(2)  # "\n" or "" (end-of-file)
-
-    managed_re = re.compile(r"^managed_by:.*$", re.MULTILINE)
-    if managed_re.search(fm_block):
-        new_fm = managed_re.sub(f"managed_by: {sentinel}", fm_block)
-    else:
-        new_fm = fm_block.rstrip("\n") + f"\nmanaged_by: {sentinel}\n"
-
-    return f"---{new_fm}---{trailing}{rest}"
 
 
 class ClaudeAdapter(AdapterBase):

--- a/plugins/reflect/adapters/codex/README.md
+++ b/plugins/reflect/adapters/codex/README.md
@@ -1,19 +1,84 @@
 # Codex CLI adapter for reflect-kb
 
-Thin installer that plugs the reflect plugin's skills into Codex CLI's
-`~/.codex/` layout. Sister to the Claude adapter, but invocation-only:
-Codex has no SessionStart hook parity, so the adapter only writes pointer
-skill files — users invoke `/recall`, `/reflect` etc. manually (per v4
-spec §"Invocation Per Harness").
+Installs the reflect plugin into Codex CLI's `~/.codex/` layout, mirroring
+what `/plugin install reflect@agents-in-a-box` does for Claude Code.
+
+Codex 0.129+ grew first-class hook parity with Claude (SessionStart,
+PreCompact, PostCompact, PreToolUse, PostToolUse, PermissionRequest,
+UserPromptSubmit, Stop). The adapter wires both default reflect hooks:
+
+| Event | Hook | Effect |
+|-------|------|--------|
+| `SessionStart` | `recall/hooks/session_start_recall.py` | Inject top-3 relevant learnings into context |
+| `SessionStart` | `reflect/hooks/reflect-drain-bg.sh` | Background-drain queued reflections (shells out to `claude -p`) |
+| `PreCompact`   | `reflect/hooks/precompact_reflect.py --auto --verbose` | Capture learnings before context compaction |
+
+Hooks land in `~/.codex/hooks.json` (codex's analogue of Claude's
+`~/.claude/settings.json` hooks block — same nested matcher/hooks/command
+structure).
 
 ## Usage
 
 ```bash
 python codex_adapter.py install --dry-run    # preview
-python codex_adapter.py install              # write ~/.codex/skills/*/SKILL.md
-python codex_adapter.py uninstall            # remove only adapter-managed files
+python codex_adapter.py install              # full install: skills + hooks
+python codex_adapter.py install --no-hooks   # skill content only, skip hooks.json
+python codex_adapter.py install --no-bg-drain  # SessionStart-recall only (no drain script)
+python codex_adapter.py install --force      # replace hand-written sibling SKILL.md files
+python codex_adapter.py uninstall            # remove only adapter-managed entries
 ```
 
-The pointer carries a `managed_by: reflect-kb/adapters/codex` sentinel so
-`uninstall` never touches hand-written sibling files in the same skill
-directory.
+## What gets deployed
+
+```
+~/.codex/
+├── hooks.json                       # SessionStart + PreCompact entries (merged)
+└── skills/
+    ├── reflect/
+    │   ├── SKILL.md                 # full plugin content + managed_by sentinel
+    │   ├── hooks/                   # plugin-level hooks (drain, precompact)
+    │   ├── scripts/                 # plugin-level scripts
+    │   ├── assets/
+    │   ├── references/
+    │   └── reflect.toml
+    ├── recall/
+    │   ├── SKILL.md
+    │   ├── hooks/                   # session_start_recall.py
+    │   └── scripts/
+    ├── reflect-status/SKILL.md
+    ├── consolidate/SKILL.md
+    └── ingest/SKILL.md
+```
+
+Plugin-level shared content (the top-level `hooks/`, `scripts/`,
+`assets/`, `references/` and `reflect.toml`) lands under the `reflect`
+umbrella skill, matching the layout the hook commands in `hooks.json`
+expect.
+
+## Safety
+
+* Each adapter-installed SKILL.md carries
+  `managed_by: reflect-kb/adapters/codex` in its frontmatter. Uninstall
+  refuses to touch any SKILL.md missing that sentinel.
+* `install` refuses to overwrite an existing hand-written SKILL.md
+  unless `--force` is passed.
+* `install` refuses to overwrite a corrupt `hooks.json` (exit 2 with
+  the path in stderr) rather than silently rewriting it.
+* Legacy `{{HOME_TOOL_DIR}}` literal entries from older buggy installs
+  are swept out on the next install.
+
+## Why this differs from the Claude adapter
+
+Claude Code has a plugin runtime (`/plugin install`) that extracts the
+whole plugin tree under `~/.claude/plugins/<name>/` and auto-wires hooks
+via the plugin's `plugin.json`. Codex has no plugin runtime equivalent,
+so this adapter physically copies the skill content into
+`~/.codex/skills/` and merges hook entries into `hooks.json` itself.
+
+## Caveat: drain script still needs `claude`
+
+`reflect-drain-bg.sh` shells out to `claude -p /reflect <transcript>` to
+turn queued transcripts into learning documents. On a codex-only machine
+without `claude` on PATH, the drain logs a warning and exits 0 (so the
+SessionStart hook never blocks codex startup). Pass `--no-bg-drain` to
+omit the drain hook entirely in that case.

--- a/plugins/reflect/adapters/codex/codex_adapter.py
+++ b/plugins/reflect/adapters/codex/codex_adapter.py
@@ -1,43 +1,54 @@
 #!/usr/bin/env python3
-"""Codex CLI adapter for the reflect-kb plugin (v4 §Phase 2 adapter work).
+"""Codex CLI adapter for the reflect-kb plugin.
 
-Per the v4 spec, Codex gets first-class skill *invocation* but NOT
-auto-recall on session start: the harness has no hook system parity with
-Claude Code, and a shell-wrapper imitation would be fragile. So this
-adapter only writes pointer skill files into ``~/.codex/skills/<name>/``;
-users invoke ``/recall`` and friends manually.
+Codex 0.129+ grew first-class hook parity with Claude Code (SessionStart,
+PreCompact, PostCompact, PreToolUse, PostToolUse, PermissionRequest,
+UserPromptSubmit, Stop), so this adapter now wires both:
+
+  1. ``SessionStart`` → ``session_start_recall.py`` (inject top-3
+     learnings) + ``reflect-drain-bg.sh`` (drain queued reflections in
+     the background; the drain script itself still shells out to
+     ``claude -p`` for reflection capture — codex sessions trigger the
+     drain, claude does the heavy lifting).
+  2. ``PreCompact`` → ``precompact_reflect.py --auto --verbose``
+     (capture learnings before context compaction).
+
+Because codex has no plugin runtime that extracts the whole plugin tree
+the way Claude's ``/plugin install`` does, this adapter physically
+deploys the plugin content into ``~/.codex/skills/`` so the hook commands
+in ``~/.codex/hooks.json`` point at real on-disk paths:
+
+  * ``plugins/reflect/skills/<name>/`` → ``~/.codex/skills/<name>/``
+    (recursive: SKILL.md + hooks/ + scripts/).
+  * ``plugins/reflect/{hooks,scripts,assets,references}/`` →
+    ``~/.codex/skills/reflect/{hooks,scripts,assets,references}/``
+    (shared plugin resources land under the ``reflect`` umbrella skill,
+    matching the layout produced by older bootstraps).
+
+A ``managed_by: reflect-kb/adapters/codex`` sentinel injected into each
+copied SKILL.md keeps uninstall safe against hand-written sibling files.
 
 Usage::
 
     python codex_adapter.py install --dry-run
     python codex_adapter.py install
+    python codex_adapter.py install --force        # overwrite hand-written siblings
+    python codex_adapter.py install --no-hooks     # skip hooks.json merge
+    python codex_adapter.py install --no-bg-drain  # SessionStart-recall only
     python codex_adapter.py uninstall
 
-The pointer files reference the canonical ``SKILL.md`` under the reflect
-plugin source so upstream edits propagate without reinstalling. A
-``managed_by: reflect-kb/adapters/codex`` sentinel keeps uninstall safe
-against hand-written sibling files.
-
-Most of the install/uninstall mechanics live on :class:`AdapterBase` —
-this module just supplies the harness-specific constants and pointer
-body. Compare with ``claude_adapter.py`` which adds a SessionStart hook
-merge step on top of the same base.
-
-TODO(closed-loop): also wire ``~/.claude/scripts/reflect-drain-bg.sh``
-into a Codex session-init hook once Codex grows hook parity. The drain
-script is harness-agnostic — it reads the shared
-``~/.reflect/pending_reflections.jsonl`` queue and shells out to
-``claude -p /reflect <transcript>`` to capture learnings. Until Codex
-gets a session-start hook (or we add a wrapper that runs the drain on
-``codex`` invocation), Codex sessions piggy-back on Claude Code sessions
-opening to drain the queue.
+Sister to :mod:`claude_adapter`; the install/uninstall mechanics live on
+:class:`AdapterBase` and the JSON hook merge helpers in :mod:`base`.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
+import shutil
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 # Make the shared base importable whether the script is invoked directly
 # or through pytest. See claude_adapter.py for the same pattern.
@@ -47,20 +58,103 @@ from base import (  # noqa: E402
     InstallPlan,
     PLUGIN_SKILLS,  # re-exported for backwards-compat with tests
     find_plugin_root as _shared_find_plugin_root,
+    inject_managed_by as _inject_managed_by,
+    merge_hook_commands,
+    remove_hook_commands,
     run_cli,
 )
 
 POINTER_MANAGED_BY = "reflect-kb/adapters/codex"
 HARNESS_DIR = ".codex"
+HOOKS_FILE = "hooks.json"  # codex hooks live in ~/.codex/hooks.json, not settings.json
+
+# Skill subdirectories we sync verbatim alongside SKILL.md. Each per-skill
+# install copies these from ``plugins/reflect/skills/<name>/<subdir>/`` →
+# ``~/.codex/skills/<name>/<subdir>/`` when they exist upstream.
+SKILL_SUBDIRS: tuple[str, ...] = ("hooks", "scripts", "assets", "references")
+
+# Plugin-level resources that aren't tied to any single skill. They land
+# under the ``reflect`` umbrella skill so the deployed layout mirrors what
+# older bootstraps produced (and what the hook commands in this module
+# expect at runtime).
+PLUGIN_ROOT_RESOURCES: tuple[str, ...] = (
+    "hooks",
+    "scripts",
+    "assets",
+    "references",
+)
+
+# Single-file plugin-root resources copied next to the reflect skill (eg.
+# ``reflect.toml`` carries plugin defaults read by reflect-kb).
+PLUGIN_ROOT_FILES: tuple[str, ...] = ("reflect.toml",)
+
+
+# --- Hook command templates --------------------------------------------------
+#
+# All three render with ``home_tool_dir`` = resolved ``~/.codex`` path at
+# install time. The template form lets us:
+#   * substitute eagerly (so hooks.json never carries literal ``{{...}}``)
+#   * still match legacy entries on uninstall via the literal form
+#
+# Why three? The plugin's Claude-side autowire (plugin.json) wires three
+# parallel hooks: SessionStart-recall, SessionStart-drain-bg, and PreCompact-
+# reflect. Codex needs the same set since there's no plugin runtime to do
+# the autowire for us.
+
+_RECALL_HOOK_TEMPLATE = (
+    "uv run {home_tool_dir}/skills/recall/hooks/session_start_recall.py"
+)
+_PRECOMPACT_HOOK_TEMPLATE = (
+    "uv run {home_tool_dir}/skills/reflect/hooks/"
+    "precompact_reflect.py --auto --verbose"
+)
+# Detached background drain — same pattern as the plugin.json wires for
+# Claude. Wrapping in ``(nohup ... &)`` makes the parent exit immediately
+# while the drain keeps running; codex doesn't block on the hook.
+_DRAIN_HOOK_TEMPLATE = (
+    "(nohup {home_tool_dir}/skills/reflect/hooks/"
+    "reflect-drain-bg.sh >/dev/null 2>&1 &) >/dev/null 2>&1"
+)
+
+
+def _render(template: str, codex_dir: Path) -> str:
+    return template.format(home_tool_dir=str(codex_dir))
+
+
+def _render_recall_hook_command(codex_dir: Path) -> str:
+    return _render(_RECALL_HOOK_TEMPLATE, codex_dir)
+
+
+def _render_precompact_hook_command(codex_dir: Path) -> str:
+    return _render(_PRECOMPACT_HOOK_TEMPLATE, codex_dir)
+
+
+def _render_drain_hook_command(codex_dir: Path) -> str:
+    return _render(_DRAIN_HOOK_TEMPLATE, codex_dir)
+
+
+# Legacy literals that older buggy installs may have persisted (template
+# placeholder never substituted). Match them on re-install / uninstall so
+# we self-heal.
+_LEGACY_RECALL_HOOK_COMMAND = _RECALL_HOOK_TEMPLATE.replace(
+    "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
+)
+_LEGACY_PRECOMPACT_HOOK_COMMAND = _PRECOMPACT_HOOK_TEMPLATE.replace(
+    "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
+)
+_LEGACY_DRAIN_HOOK_COMMAND = _DRAIN_HOOK_TEMPLATE.replace(
+    "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
+)
 
 
 class CodexAdapter(AdapterBase):
-    """Codex harness: pointer install only (no hook system to wire into)."""
+    """Codex harness: full-content skill install + hooks.json hook merge."""
 
     POINTER_MANAGED_BY = POINTER_MANAGED_BY
     HARNESS_DIR = HARNESS_DIR
     HARNESS_LABEL = "Codex"
 
+    # Fallback only — _pointer_body overrides to write full SKILL.md content.
     POINTER_BODY_TEMPLATE = (
         "---\n"
         "name: {name}\n"
@@ -68,11 +162,298 @@ class CodexAdapter(AdapterBase):
         "managed_by: {managed_by}\n"
         "source: {source}\n"
         "---\n\n"
-        "Pointer skill installed by the reflect-kb {harness_label} adapter.\n\n"
-        "Codex has no SessionStart hook parity with Claude Code, so this\n"
-        "skill is invocation-only — call `/recall`, `/reflect`, etc.\n"
-        "manually. The canonical definition lives at `{source}`.\n"
+        "Adapter could not read the upstream SKILL.md at `{source}` —\n"
+        "re-run the install once the source path is accessible.\n"
     )
+
+    def _pointer_body(self, source_skill: Path) -> str:
+        """Return the full plugin SKILL.md content with ``managed_by:`` injected.
+
+        Codex's skill loader reads file content directly (no ``source:``
+        dereference). Mirrors :meth:`ClaudeAdapter._pointer_body`.
+        """
+        try:
+            text = source_skill.read_text(encoding="utf-8")
+        except OSError:
+            return super()._pointer_body(source_skill)
+        return _inject_managed_by(text, self.POINTER_MANAGED_BY)
+
+    # --- CLI flags -------------------------------------------------------
+
+    def configure_install_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--no-hooks", action="store_true",
+            help="Skip merging SessionStart/PreCompact entries into hooks.json.",
+        )
+        parser.add_argument(
+            "--no-bg-drain", action="store_true",
+            help="Skip the SessionStart bg-drain hook (only wire the recall "
+                 "and PreCompact hooks). The drain script shells out to "
+                 "`claude -p` for reflection capture; disable on codex-only "
+                 "machines.",
+        )
+
+    def configure_uninstall_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--no-hooks", action="store_true",
+            help="Leave hooks.json untouched; only remove skill content.",
+        )
+
+    def install_kwargs_from_args(self, args: argparse.Namespace) -> dict[str, Any]:
+        return {
+            "with_hooks": not getattr(args, "no_hooks", False),
+            "with_bg_drain": not getattr(args, "no_bg_drain", False),
+        }
+
+    def uninstall_kwargs_from_args(self, args: argparse.Namespace) -> dict[str, Any]:
+        return {"with_hooks": not getattr(args, "no_hooks", False)}
+
+    # --- plan augmentation + extras --------------------------------------
+
+    def augment_plan(
+        self,
+        plan: InstallPlan,
+        *,
+        home: Path,
+        with_hooks: bool = True,
+        with_bg_drain: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        plan.extras["with_hooks"] = with_hooks
+        plan.extras["with_bg_drain"] = with_bg_drain
+        plan.extras["hooks_path"] = plan.target_harness_dir / HOOKS_FILE
+
+        # Per-skill subdir syncs. Each entry is (src_dir, dst_dir).
+        plugin_root = self.find_plugin_root()
+        subdir_syncs: list[tuple[Path, Path]] = []
+        for name in PLUGIN_SKILLS:
+            src_skill_dir = plugin_root / "skills" / name
+            if not src_skill_dir.is_dir():
+                continue
+            dst_skill_dir = plan.target_harness_dir / "skills" / name
+            for subdir in SKILL_SUBDIRS:
+                src_sub = src_skill_dir / subdir
+                if src_sub.is_dir():
+                    subdir_syncs.append((src_sub, dst_skill_dir / subdir))
+
+        # Plugin-level shared resources (hooks/scripts/assets/references)
+        # land under the reflect umbrella skill so the hook commands above
+        # resolve correctly.
+        reflect_umbrella = plan.target_harness_dir / "skills" / "reflect"
+        root_resource_syncs: list[tuple[Path, Path]] = []
+        for resource in PLUGIN_ROOT_RESOURCES:
+            src_dir = plugin_root / resource
+            if src_dir.is_dir():
+                root_resource_syncs.append((src_dir, reflect_umbrella / resource))
+        root_file_copies: list[tuple[Path, Path]] = []
+        for filename in PLUGIN_ROOT_FILES:
+            src_file = plugin_root / filename
+            if src_file.is_file():
+                root_file_copies.append((src_file, reflect_umbrella / filename))
+
+        plan.extras["subdir_syncs"] = subdir_syncs
+        plan.extras["root_resource_syncs"] = root_resource_syncs
+        plan.extras["root_file_copies"] = root_file_copies
+
+        describe_extra: list[str] = []
+        for src, dst in subdir_syncs:
+            describe_extra.append(f"sync dir: {src} → {dst}")
+        for src, dst in root_resource_syncs:
+            describe_extra.append(f"sync dir: {src} → {dst}")
+        for src, dst in root_file_copies:
+            describe_extra.append(f"copy file: {src} → {dst}")
+        if with_hooks:
+            hooks_path = plan.extras["hooks_path"]
+            describe_extra.append(
+                f"hook: add SessionStart recall entry to {hooks_path}"
+            )
+            if with_bg_drain:
+                describe_extra.append(
+                    f"hook: add SessionStart bg-drain entry to {hooks_path}"
+                )
+            describe_extra.append(
+                f"hook: add PreCompact reflect entry to {hooks_path}"
+            )
+        plan.extras["describe_extra"] = describe_extra
+
+    def execute_extra(
+        self,
+        plan: InstallPlan,
+        *,
+        with_hooks: bool = True,
+        with_bg_drain: bool = True,
+        **kwargs: Any,
+    ) -> tuple[list[str], int]:
+        actions: list[str] = []
+
+        # 1. Sync per-skill subdirs. We do a "merge" copy: each file under
+        # ``src_dir`` overwrites the corresponding file under ``dst_dir``
+        # without deleting unrelated files (so user-dropped siblings
+        # under e.g. ``recall/scripts/`` survive). Adapter-uninstall only
+        # removes files we actually wrote, tracked via sentinel files —
+        # but since per-file sentinels would be invasive, we accept that
+        # uninstall leaves these dirs in place if they still contain user
+        # content (the SKILL.md sentinel is the authoritative marker).
+        for src, dst in plan.extras.get("subdir_syncs", []):
+            self._sync_dir(src, dst)
+            actions.append(f"synced {dst}")
+
+        # 2. Sync plugin-level shared dirs into the reflect umbrella.
+        for src, dst in plan.extras.get("root_resource_syncs", []):
+            self._sync_dir(src, dst)
+            actions.append(f"synced {dst}")
+
+        # 3. Copy plugin-level single files.
+        for src, dst in plan.extras.get("root_file_copies", []):
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            actions.append(f"copied {dst}")
+
+        # 4. Merge hook entries into hooks.json.
+        if with_hooks:
+            try:
+                hook_actions = self._merge_hooks(
+                    plan.extras["hooks_path"], with_bg_drain=with_bg_drain,
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                return actions, 2
+            actions.extend(hook_actions)
+
+        return actions, 0
+
+    def uninstall_extra(
+        self, *, home: Path, with_hooks: bool = True, **kwargs: Any,
+    ) -> list[str]:
+        if not with_hooks:
+            return []
+        hooks_path = home / self.HARNESS_DIR / HOOKS_FILE
+        if not hooks_path.exists():
+            return []
+        try:
+            cfg = json.loads(hooks_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return [
+                f"hooks.json is not valid JSON; "
+                f"skipped hook removal: {hooks_path}"
+            ]
+
+        codex_dir = hooks_path.parent
+        removals = {
+            "SessionStart": [
+                _render_recall_hook_command(codex_dir),
+                _render_drain_hook_command(codex_dir),
+                _LEGACY_RECALL_HOOK_COMMAND,
+                _LEGACY_DRAIN_HOOK_COMMAND,
+            ],
+            "PreCompact": [
+                _render_precompact_hook_command(codex_dir),
+                _LEGACY_PRECOMPACT_HOOK_COMMAND,
+            ],
+        }
+        changed = False
+        for event, cmds in removals.items():
+            if remove_hook_commands(cfg, event=event, commands=cmds):
+                changed = True
+        if not changed:
+            return []
+        hooks_path.write_text(
+            json.dumps(cfg, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8",
+        )
+        return [f"removed reflect hook entries from {hooks_path}"]
+
+    # --- helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _sync_dir(src: Path, dst: Path) -> None:
+        """Mirror ``src`` into ``dst``, overwriting same-named files.
+
+        Does NOT delete files under ``dst`` that aren't in ``src`` so any
+        user-dropped siblings survive. ``__pycache__`` and ``.DS_Store``
+        are skipped because they're build/IDE noise that would otherwise
+        ride along on every install.
+        """
+        dst.mkdir(parents=True, exist_ok=True)
+        for entry in src.iterdir():
+            if entry.name in ("__pycache__", ".DS_Store"):
+                continue
+            target = dst / entry.name
+            if entry.is_dir():
+                CodexAdapter._sync_dir(entry, target)
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(entry, target)
+
+    def _merge_hooks(
+        self, hooks_path: Path, *, with_bg_drain: bool,
+    ) -> list[str]:
+        """Merge SessionStart + PreCompact entries into ``hooks_path``.
+
+        Re-reads any existing ``hooks.json`` content, preserves unrelated
+        hook entries, sweeps out legacy unsubstituted commands, then adds
+        the reflect-managed entries idempotently.
+        """
+        current: dict = {}
+        if hooks_path.exists():
+            try:
+                current = json.loads(hooks_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                raise RuntimeError(
+                    f"{hooks_path} exists but is not valid JSON; "
+                    f"refusing to overwrite"
+                )
+        if not isinstance(current, dict):
+            raise RuntimeError(
+                f"{hooks_path} top-level must be a JSON object; "
+                f"found {type(current).__name__}"
+            )
+
+        codex_dir = hooks_path.parent
+        actions: list[str] = []
+
+        session_start_cmds: list[dict] = [
+            {"type": "command", "command": _render_recall_hook_command(codex_dir)},
+        ]
+        if with_bg_drain:
+            session_start_cmds.append({
+                "type": "command",
+                "command": _render_drain_hook_command(codex_dir),
+                "timeout": 5,
+            })
+
+        changed_ss = merge_hook_commands(
+            current,
+            event="SessionStart",
+            commands=session_start_cmds,
+            legacy_commands=[
+                _LEGACY_RECALL_HOOK_COMMAND,
+                _LEGACY_DRAIN_HOOK_COMMAND,
+            ],
+        )
+        changed_pc = merge_hook_commands(
+            current,
+            event="PreCompact",
+            commands=[{
+                "type": "command",
+                "command": _render_precompact_hook_command(codex_dir),
+            }],
+            legacy_commands=[_LEGACY_PRECOMPACT_HOOK_COMMAND],
+        )
+
+        if changed_ss or changed_pc:
+            hooks_path.parent.mkdir(parents=True, exist_ok=True)
+            hooks_path.write_text(
+                json.dumps(current, indent=2, sort_keys=False) + "\n",
+                encoding="utf-8",
+            )
+            if changed_ss:
+                actions.append(f"merged SessionStart reflect hooks into {hooks_path}")
+            if changed_pc:
+                actions.append(f"merged PreCompact reflect hook into {hooks_path}")
+        else:
+            actions.append(f"reflect hooks already present in {hooks_path}")
+        return actions
 
 
 # --- backwards-compatible module-level API ------------------------------
@@ -85,18 +466,34 @@ def find_plugin_root(script_path: Path | None = None) -> Path:
 
 
 def build_plan(
-    *, home: Optional[Path] = None, plugin_root: Optional[Path] = None,
+    *,
+    home: Optional[Path] = None,
+    plugin_root: Optional[Path] = None,
+    with_hooks: bool = True,
+    with_bg_drain: bool = True,
 ) -> InstallPlan:
-    return _DEFAULT_ADAPTER.build_plan(home=home, plugin_root=plugin_root)
+    return _DEFAULT_ADAPTER.build_plan(
+        home=home,
+        plugin_root=plugin_root,
+        with_hooks=with_hooks,
+        with_bg_drain=with_bg_drain,
+    )
 
 
 def execute(plan: InstallPlan, *, force: bool = False) -> list[str]:
-    actions, _ = _DEFAULT_ADAPTER.execute(plan, force=force)
+    actions, _ = _DEFAULT_ADAPTER.execute(
+        plan,
+        force=force,
+        with_hooks=plan.extras.get("with_hooks", True),
+        with_bg_drain=plan.extras.get("with_bg_drain", True),
+    )
     return actions
 
 
-def uninstall(*, home: Optional[Path] = None) -> list[str]:
-    return _DEFAULT_ADAPTER.uninstall(home=home)
+def uninstall(
+    *, home: Optional[Path] = None, with_hooks: bool = True,
+) -> list[str]:
+    return _DEFAULT_ADAPTER.uninstall(home=home, with_hooks=with_hooks)
 
 
 def _cli() -> int:

--- a/plugins/reflect/adapters/tests/test_claude_adapter.py
+++ b/plugins/reflect/adapters/tests/test_claude_adapter.py
@@ -66,7 +66,6 @@ def test_install_writes_pointer_files_and_hook(tmp_path):
 
     recall_body = recall.read_text(encoding="utf-8")
     assert claude_adapter.POINTER_MANAGED_BY in recall_body
-    assert "source:" in recall_body
     # Name preserved from upstream frontmatter (reflect:recall).
     assert "name: reflect:recall" in recall_body
 

--- a/plugins/reflect/adapters/tests/test_codex_adapter.py
+++ b/plugins/reflect/adapters/tests/test_codex_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -59,10 +60,242 @@ def test_install_writes_pointer_files_under_dot_codex(tmp_path):
     body = recall.read_text(encoding="utf-8")
     assert codex_adapter.POINTER_MANAGED_BY in body
     assert "name: reflect:recall" in body
-    # Codex adapter never touches settings.json (no hook system parity)
+    # Codex uses hooks.json, not settings.json
     assert not (tmp_path / ".codex" / "settings.json").exists()
     # And it must not have leaked into a Claude dir.
     assert not (tmp_path / ".claude").exists()
+
+
+def test_install_syncs_recall_hooks_and_scripts(tmp_path):
+    """Codex needs the hook script files physically present so the hook
+    command in hooks.json resolves at runtime. Validate the recall hook
+    and the plugin-level reflect hook both land under ~/.codex/skills/."""
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+    recall_hook = (
+        tmp_path / ".codex" / "skills" / "recall" / "hooks"
+        / "session_start_recall.py"
+    )
+    assert recall_hook.exists()
+    assert recall_hook.read_text().startswith("#!/usr/bin/env -S uv run")
+
+    precompact = (
+        tmp_path / ".codex" / "skills" / "reflect" / "hooks"
+        / "precompact_reflect.py"
+    )
+    assert precompact.exists()
+
+    drain = (
+        tmp_path / ".codex" / "skills" / "reflect" / "hooks"
+        / "reflect-drain-bg.sh"
+    )
+    assert drain.exists()
+
+
+def test_install_writes_hooks_json_with_all_three_entries(tmp_path):
+    """Default install wires SessionStart-recall, SessionStart-drain, and
+    PreCompact-reflect into ~/.codex/hooks.json."""
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+
+    hooks_path = tmp_path / ".codex" / "hooks.json"
+    assert hooks_path.exists()
+    cfg = json.loads(hooks_path.read_text())
+    ss_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["SessionStart"]
+        for h in entry["hooks"]
+    ]
+    pc_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["PreCompact"]
+        for h in entry["hooks"]
+    ]
+    codex_dir = tmp_path / ".codex"
+    assert codex_adapter._render_recall_hook_command(codex_dir) in ss_cmds
+    assert codex_adapter._render_drain_hook_command(codex_dir) in ss_cmds
+    assert codex_adapter._render_precompact_hook_command(codex_dir) in pc_cmds
+
+    # No surviving template placeholders in the persisted file.
+    text = hooks_path.read_text()
+    assert "{{" not in text
+    assert "{home_tool_dir}" not in text
+
+
+def test_install_no_hooks_flag_skips_hooks_json(tmp_path):
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install",
+         "--home", str(tmp_path), "--no-hooks"],
+        check=True, capture_output=True,
+    )
+    assert (tmp_path / ".codex" / "skills" / "recall" / "SKILL.md").exists()
+    assert not (tmp_path / ".codex" / "hooks.json").exists()
+
+
+def test_install_no_bg_drain_omits_drain_hook(tmp_path):
+    """--no-bg-drain wires only SessionStart-recall + PreCompact, not the
+    drain shell script (useful on codex-only machines without claude)."""
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install",
+         "--home", str(tmp_path), "--no-bg-drain"],
+        check=True, capture_output=True,
+    )
+    cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    ss_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["SessionStart"]
+        for h in entry["hooks"]
+    ]
+    codex_dir = tmp_path / ".codex"
+    assert codex_adapter._render_recall_hook_command(codex_dir) in ss_cmds
+    assert codex_adapter._render_drain_hook_command(codex_dir) not in ss_cmds
+    # PreCompact still wired
+    pc_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["PreCompact"]
+        for h in entry["hooks"]
+    ]
+    assert codex_adapter._render_precompact_hook_command(codex_dir) in pc_cmds
+
+
+def test_install_preserves_existing_unrelated_hooks_json(tmp_path):
+    """Adapter must merge into an existing hooks.json without nuking
+    unrelated entries already wired by other tools (eg. superset)."""
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    existing = {
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": "echo superset-ss"}]}
+            ],
+            "Stop": [
+                {"hooks": [{"type": "command", "command": "echo superset-stop"}]}
+            ],
+        }
+    }
+    (codex_dir / "hooks.json").write_text(json.dumps(existing))
+
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+
+    cfg = json.loads((codex_dir / "hooks.json").read_text())
+    all_ss_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["SessionStart"]
+        for h in entry["hooks"]
+    ]
+    all_stop_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["Stop"]
+        for h in entry["hooks"]
+    ]
+    # Pre-existing unrelated entries survived
+    assert "echo superset-ss" in all_ss_cmds
+    assert "echo superset-stop" in all_stop_cmds
+    # And our reflect entries landed
+    assert codex_adapter._render_recall_hook_command(codex_dir) in all_ss_cmds
+
+
+def test_install_idempotent_hooks_json(tmp_path):
+    """Two installs in a row: hook entries should appear exactly once."""
+    for _ in range(2):
+        subprocess.run(
+            [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+            check=True, capture_output=True,
+        )
+    cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    codex_dir = tmp_path / ".codex"
+    ss_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["SessionStart"]
+        for h in entry["hooks"]
+    ]
+    assert ss_cmds.count(codex_adapter._render_recall_hook_command(codex_dir)) == 1
+    assert ss_cmds.count(codex_adapter._render_drain_hook_command(codex_dir)) == 1
+
+
+def test_install_cleans_up_legacy_unsubstituted_hook(tmp_path):
+    """Legacy {{HOME_TOOL_DIR}} hooks from earlier installs should be
+    swept out and replaced with the correctly-rendered command."""
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    legacy = (
+        "uv run {{HOME_TOOL_DIR}}/skills/recall/hooks/session_start_recall.py"
+    )
+    (codex_dir / "hooks.json").write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"matcher": "", "hooks": [{"type": "command", "command": legacy}]}
+            ]
+        }
+    }))
+
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+
+    cfg_text = (codex_dir / "hooks.json").read_text()
+    assert "{{HOME_TOOL_DIR}}" not in cfg_text
+    cfg = json.loads(cfg_text)
+    ss_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["SessionStart"]
+        for h in entry["hooks"]
+    ]
+    assert legacy not in ss_cmds
+    assert ss_cmds.count(codex_adapter._render_recall_hook_command(codex_dir)) == 1
+
+
+def test_install_errors_on_corrupt_hooks_json(tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "hooks.json").write_text("{ not valid json")
+
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "hooks.json" in result.stderr.lower()
+
+
+def test_uninstall_removes_hook_entries(tmp_path):
+    """Uninstall strips reflect hook entries but leaves unrelated ones."""
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "hooks.json").write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": "echo unrelated"}]}
+            ]
+        }
+    }))
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "uninstall", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+
+    cfg = json.loads((codex_dir / "hooks.json").read_text())
+    ss_cmds = [
+        h["command"]
+        for entry in cfg.get("hooks", {}).get("SessionStart", [])
+        for h in entry["hooks"]
+    ]
+    assert "echo unrelated" in ss_cmds
+    assert codex_adapter._render_recall_hook_command(codex_dir) not in ss_cmds
+    # PreCompact had only our entries → block dropped entirely
+    assert "PreCompact" not in cfg.get("hooks", {})
 
 
 def test_install_is_idempotent(tmp_path):

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
           label: 'Knowledge',
           items: [
             { label: 'How reflection works', slug: 'knowledge/overview' },
+            { label: 'Hooks & platform (Claude + Codex)', slug: 'knowledge/hooks-and-platform' },
             { label: 'reflect CLI', slug: 'knowledge/reflect-cli' },
           ],
         },


### PR DESCRIPTION
## Summary

Brings the reflect plugin's codex adapter to hook parity with Claude. Codex 0.129+ grew first-class hook support (`~/.codex/hooks.json` with the same nested matcher/hooks/command shape as Claude's `settings.json`), so the adapter no longer ships as invocation-only.

- **`SessionStart` → recall** — inject top-3 relevant learnings into context on every session start
- **`SessionStart` → `reflect-drain-bg.sh`** — drain queued reflections in the background (shells out to `claude -p`; `--no-bg-drain` skips on codex-only machines)
- **`PreCompact` → `precompact_reflect.py --auto --verbose`** — capture learnings before context compaction

Because codex has no plugin runtime to extract the plugin tree (the way Claude's `/plugin install` does via `plugin.json` autowire), the adapter physically deploys skill content (SKILL.md + hooks/ + scripts/ + plugin-level shared dirs) into `~/.codex/skills/` so the hook commands resolve at runtime.

### What's in each commit

1. **`refactor(reflect)`** — extract `inject_managed_by`, `merge_hook_commands`, `remove_hook_commands` from `claude_adapter.py` into `adapters/base.py` so both adapters share JSON-hook-merge mechanics. Claude install output is byte-identical to before (verified end-to-end against a temp HOME).
2. **`feat(reflect)`** — full codex adapter rewrite + 7 new tests on top of the 10 existing ones (46/46 adapter tests pass).

### Safety

- `managed_by: reflect-kb/adapters/codex` sentinel in every adapter-written SKILL.md; uninstall ignores foreign files
- Refuses to overwrite hand-written sibling SKILL.md unless `--force`
- Refuses to overwrite corrupt `hooks.json` (exit 2)
- Self-heals legacy `{{HOME_TOOL_DIR}}` literal entries from older buggy installs
- Merge preserves unrelated hooks (e.g. superset's SessionStart entries)

### New flags

```
--no-hooks      skip hooks.json merge (skill content only)
--no-bg-drain   omit drain hook (codex-only machines without `claude`)
--force         replace hand-written sibling SKILL.md files
--dry-run       preview without changes
```

## Test plan

- [x] `pytest plugins/reflect/adapters/tests/` — 46/46 pass
- [x] Verified Claude install output byte-identical pre/post refactor (zero diff in `settings.json` + SKILL.md against `/tmp` temp HOMEs)
- [x] Verified codex install against `/tmp/codex-test-home`: skills + hooks.json correct, idempotent on re-run
- [x] Verified merge preserves unrelated pre-existing `hooks.json` entries
- [x] Verified uninstall strips only reflect entries
- [ ] **Manual smoke test on real `~/.codex/`** — please run `python plugins/reflect/adapters/codex/codex_adapter.py install --dry-run` first to inspect, then install for real

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex adapter now manages hook commands in `hooks.json`, with support for SessionStart and PreCompact events.
  * Added configurable flags to control hook installation and background drain behavior during installation.
  * Hook uninstall now removes only reflect-managed entries while preserving unrelated hooks.

* **Documentation**
  * Updated Codex adapter documentation with comprehensive hook parity details and deployment guidelines.

* **Tests**
  * Added extensive test coverage for hook installation, merge, and uninstall scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->