### PR TITLE
fix(reflect): hooks silent-fail on uncaught exception + breadcrumb

### DIFF
--- a/plugins/reflect/.claude-plugin/plugin.json
+++ b/plugins/reflect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reflect",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings at SessionStart via hook. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"

--- a/plugins/reflect/hooks/precompact_reflect.py
+++ b/plugins/reflect/hooks/precompact_reflect.py
@@ -37,7 +37,6 @@ import argparse
 import json
 import os
 import sys
-import time
 import traceback
 from datetime import datetime
 from pathlib import Path
@@ -48,33 +47,17 @@ except ImportError:
     yaml = None
 
 
-# --- Silent-fail event sink ----------------------------------------------
-#
-# PreCompact must never raise into the user's session. On any uncaught
-# exception we still exit 0 (silently), but we leave a breadcrumb at
-# ~/.reflect/last-event.json so the status line can render a "⚠ reflect
-# failed" fragment without polluting stderr.
-
-LAST_EVENT_PATH = Path(
-    os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect"))
-) / "last-event.json"
-
-
-def _write_last_event(event: str, kind: str, detail: str) -> None:
-    """Best-effort error breadcrumb for the status line. Never raises."""
-    try:
-        LAST_EVENT_PATH.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "event": event,
-            "hook": "precompact_reflect",
-            "kind": kind,
-            "detail": detail[:500],
-            "ts": time.time(),
-        }
-        tmp = LAST_EVENT_PATH.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(payload), encoding="utf-8")
-        tmp.replace(LAST_EVENT_PATH)
-    except Exception:
+# Shared silent-fail mechanics — breadcrumb writer, secret scrubber,
+# forensics log. See plugins/reflect/scripts/silent_fail.py.
+_HOOK_NAME = "precompact_reflect"
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]  # hooks/<this> → plugins/reflect/
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+try:
+    from silent_fail import write_last_event, forensics_log  # noqa: E402
+except ImportError:
+    def write_last_event(**kwargs):  # type: ignore[no-redef]
+        pass
+    def forensics_log(*args, **kwargs):  # type: ignore[no-redef]
         pass
 
 
@@ -103,20 +86,17 @@ def is_auto_reflect_enabled() -> bool:
 
 
 def log_precompact_event(input_data: dict, mode: str):
-    """Log the PreCompact event for debugging."""
-    log_dir = Path.home() / '.claude' / 'logs'
-    log_dir.mkdir(parents=True, exist_ok=True)
+    """Log the PreCompact event for debugging.
 
-    log_file = log_dir / 'reflect_precompact.log'
-
-    timestamp = datetime.now().isoformat()
-    session_id = input_data.get('session_id', 'unknown')[:8]
+    Lands at ``$REFLECT_STATE_DIR/logs/reflect_precompact.log`` (defaults
+    to ``~/.reflect/logs/``) — harness-agnostic, so codex-fired
+    invocations log to the same place as claude-fired ones. Previously
+    this hardcoded ``~/.claude/logs/`` which dropped codex logs into a
+    Claude-flavoured directory the user wouldn't think to look in.
+    """
+    session_id = str(input_data.get('session_id', 'unknown'))[:8]
     trigger = input_data.get('trigger', 'unknown')
-
-    log_entry = f"[{timestamp}] session={session_id} trigger={trigger} mode={mode}\n"
-
-    with open(log_file, 'a') as f:
-        f.write(log_entry)
+    forensics_log(_HOOK_NAME, f"session={session_id} trigger={trigger} mode={mode}")
 
 
 def generate_reminder_context(trigger: str) -> dict:
@@ -267,11 +247,14 @@ def main():
     except SystemExit:
         raise
     except BaseException as exc:  # noqa: BLE001 — deliberately broadest catch
-        _write_last_event(
+        detail = str(exc) or traceback.format_exc(limit=2)
+        write_last_event(
+            hook_name=_HOOK_NAME,
             event="error",
             kind=type(exc).__name__,
-            detail=str(exc) or traceback.format_exc(limit=2),
+            detail=detail,
         )
+        forensics_log(_HOOK_NAME, f"{type(exc).__name__}: {detail}")
         sys.exit(0)
 
 

--- a/plugins/reflect/hooks/precompact_reflect.py
+++ b/plugins/reflect/hooks/precompact_reflect.py
@@ -37,6 +37,8 @@ import argparse
 import json
 import os
 import sys
+import time
+import traceback
 from datetime import datetime
 from pathlib import Path
 
@@ -44,6 +46,36 @@ try:
     import yaml
 except ImportError:
     yaml = None
+
+
+# --- Silent-fail event sink ----------------------------------------------
+#
+# PreCompact must never raise into the user's session. On any uncaught
+# exception we still exit 0 (silently), but we leave a breadcrumb at
+# ~/.reflect/last-event.json so the status line can render a "⚠ reflect
+# failed" fragment without polluting stderr.
+
+LAST_EVENT_PATH = Path(
+    os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect"))
+) / "last-event.json"
+
+
+def _write_last_event(event: str, kind: str, detail: str) -> None:
+    """Best-effort error breadcrumb for the status line. Never raises."""
+    try:
+        LAST_EVENT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "event": event,
+            "hook": "precompact_reflect",
+            "kind": kind,
+            "detail": detail[:500],
+            "ts": time.time(),
+        }
+        tmp = LAST_EVENT_PATH.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(LAST_EVENT_PATH)
+    except Exception:
+        pass
 
 
 def get_state_dir() -> Path:
@@ -162,7 +194,7 @@ def run_reflection_analysis(input_data: dict) -> dict:
     }
 
 
-def main():
+def _main_body():
     parser = argparse.ArgumentParser(description='PreCompact Reflect Hook')
     parser.add_argument('--remind', action='store_true',
                        help='Add reminder to run /reflect')
@@ -218,6 +250,28 @@ def main():
             print("Auto-reflect not enabled, adding reminder")
         output = generate_reminder_context(trigger)
         print(json.dumps(output))
+        sys.exit(0)
+
+
+def main():
+    """Top-level entry. Any uncaught exception writes a breadcrumb to
+    ~/.reflect/last-event.json and exits 0 silently so PreCompact never
+    surfaces a traceback into the user's session.
+
+    SystemExit is re-raised so intentional clean exits (sys.exit(0) from
+    the body) propagate unchanged. We don't catch argparse's SystemExit(2)
+    on bad args either — that's a config bug worth surfacing.
+    """
+    try:
+        _main_body()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — deliberately broadest catch
+        _write_last_event(
+            event="error",
+            kind=type(exc).__name__,
+            detail=str(exc) or traceback.format_exc(limit=2),
+        )
         sys.exit(0)
 
 

--- a/plugins/reflect/hooks/sessionstart_drain_reflections.py
+++ b/plugins/reflect/hooks/sessionstart_drain_reflections.py
@@ -20,23 +20,42 @@ Output goes to additionalContext so the new agent sees it as part of its
 initial context. The agent is responsible for archiving the queue once
 processed (instructions included in the surfaced text).
 
-Wire up in ~/.claude/settings.json:
+Wire up in the harness's hooks config:
+- Claude: ~/.claude/settings.json (hooks.SessionStart)
+- Codex:  ~/.codex/hooks.json    (hooks.SessionStart)
+
+Same JSON shape in both:
 {
   "hooks": {
     "SessionStart": [
       { "hooks": [
         { "type": "command",
-          "command": "uv run ~/.claude/skills/reflect/hooks/sessionstart_drain_reflections.py" }
+          "command": "uv run <HOME_TOOL_DIR>/skills/reflect/hooks/sessionstart_drain_reflections.py" }
       ] }
     ]
   }
 }
+where <HOME_TOOL_DIR> is ~/.claude or ~/.codex.
 """
 
 import json
 import os
 import sys
+import traceback
 from pathlib import Path
+
+
+# Shared silent-fail mechanics.
+_HOOK_NAME = "sessionstart_drain_reflections"
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]  # hooks/<this> → plugins/reflect/
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+try:
+    from silent_fail import write_last_event, forensics_log  # noqa: E402
+except ImportError:
+    def write_last_event(**kwargs):  # type: ignore[no-redef]
+        pass
+    def forensics_log(*args, **kwargs):  # type: ignore[no-redef]
+        pass
 
 
 def get_state_dir() -> Path:
@@ -44,7 +63,7 @@ def get_state_dir() -> Path:
     return Path(custom).expanduser() if custom else Path.home() / '.reflect'
 
 
-def main():
+def _main_body():
     queue_file = get_state_dir() / 'pending_reflections.jsonl'
 
     # No queue, no work — exit silently so SessionStart isn't noisy.
@@ -69,9 +88,10 @@ def main():
     lines = [
         f"## Pending auto-reflections ({len(entries)})",
         "",
-        "Previous Claude session(s) ended with a context compaction. Their transcripts "
-        "were queued for reflection but the actual learning capture didn't run yet "
-        "(hook scripts can't invoke an LLM).",
+        "Previous session(s) (Claude and/or Codex) ended with a context "
+        "compaction. Their transcripts were queued for reflection but the "
+        "actual learning capture didn't run yet (hook scripts can't "
+        "invoke an LLM).",
         "",
         "**Action:** For each transcript below, invoke the `/reflect` skill with the "
         "transcript path. Process them in order, then archive the queue.",
@@ -102,6 +122,36 @@ def main():
     }
     print(json.dumps(output))
     sys.exit(0)
+
+
+def main():
+    """Top-level entry. Any uncaught exception writes a breadcrumb to
+    ~/.reflect/last-event.json and exits 0 silently so SessionStart never
+    surfaces a traceback into the user's session.
+    """
+    try:
+        _main_body()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — deliberately broadest catch
+        detail = str(exc) or traceback.format_exc(limit=2)
+        write_last_event(
+            hook_name=_HOOK_NAME,
+            event="error",
+            kind=type(exc).__name__,
+            detail=detail,
+        )
+        forensics_log(_HOOK_NAME, f"{type(exc).__name__}: {detail}")
+        # SessionStart must produce valid JSON or nothing; emit empty.
+        try:
+            sys.stdout.write(
+                '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
+                '"additionalContext":""}}\n'
+            )
+            sys.stdout.flush()
+        except Exception:
+            pass
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/plugins/reflect/scripts/silent_fail.py
+++ b/plugins/reflect/scripts/silent_fail.py
@@ -1,0 +1,165 @@
+"""Shared silent-fail mechanics for reflect hooks.
+
+All reflect hooks (recall, reflect, drain, mini-learning) MUST exit 0
+cleanly on any uncaught exception — see ``feedback_reflect_hooks_silent_fail``
+in MEMORY.md. This module centralises the breadcrumb writer, credential
+scrubber, and forensics log so hooks don't duplicate the same 30 lines.
+
+Three primitives:
+
+  * :func:`write_last_event` — atomic breadcrumb at
+    ``$REFLECT_STATE_DIR/last-event.json`` (default ``~/.reflect/``). The
+    status line reads this to render ⚠ recall failed fragments. Always
+    safe to call; swallows its own errors.
+
+  * :func:`forensics_log` — append-only developer log at
+    ``$REFLECT_STATE_DIR/logs/reflect_<hook>.log``. NOT user-visible —
+    debuggability for incident review only.
+
+  * :func:`scrub_secrets` — best-effort credential masking applied to any
+    text persisted via the above two. Not a security boundary; just
+    keeps casual exception messages from leaking obvious tokens.
+
+All three resolve ``REFLECT_STATE_DIR`` at call time (not import time) so
+tests and runtime callers can change the env mid-process without
+restarting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Literal
+
+
+# --- Paths (resolved at call-time, NOT import-time) -----------------------
+
+def state_dir() -> Path:
+    """Resolve ``REFLECT_STATE_DIR`` (or ``~/.reflect``) at call time.
+
+    Per-call resolution lets test code or runtime callers change the env
+    after this module has been imported — previously the path was bound
+    at import time and was effectively immutable in-process.
+    """
+    return Path(os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect")))
+
+
+def last_event_path() -> Path:
+    return state_dir() / "last-event.json"
+
+
+def logs_dir() -> Path:
+    return state_dir() / "logs"
+
+
+# --- Secret scrubbing ----------------------------------------------------
+
+# Order matters: more specific patterns first so we don't double-mask.
+# Each entry is (regex, group_index_to_mask). group_index=0 masks the whole
+# match; >0 masks only the captured credential while preserving the prefix.
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], int]] = [
+    # "Authorization: Bearer <token>" / "Authorization: <token>"
+    (re.compile(r"(?i)Authorization\s*:\s*(?:Bearer\s+)?([A-Za-z0-9._\-/+]{8,})"), 1),
+    # "X-Api-Key: <token>" / "X-Auth-Token: <token>" / similar headers
+    (re.compile(r"(?i)X-(?:Api-)?(?:Key|Auth|Token)[^:]*:\s*([A-Za-z0-9._\-/+]{8,})"), 1),
+    # "Bearer <token>" anywhere in text (e.g. exception "401 Bearer xxx").
+    (re.compile(r"(?i)\bBearer\s+([A-Za-z0-9._\-/+]{8,})"), 1),
+    # key=value style in URLs / config / env: "token=...", "api_key=...", "password=..."
+    (re.compile(r"(?i)\b(?:token|api[_-]?key|password|passwd|secret|auth)\s*[:=]\s*['\"]?([A-Za-z0-9._\-/+]{8,})"), 1),
+    # Provider-specific key shapes (whole match masked).
+    (re.compile(r"sk-[A-Za-z0-9_\-]{20,}"), 0),    # OpenAI-style
+    (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), 0),  # Anthropic-style
+    (re.compile(r"ghp_[A-Za-z0-9]{20,}"), 0),       # GitHub PAT
+    (re.compile(r"ghs_[A-Za-z0-9]{20,}"), 0),       # GitHub app-token
+    (re.compile(r"xox[abp]-[A-Za-z0-9\-]{20,}"), 0),  # Slack
+    (re.compile(r"AKIA[0-9A-Z]{16}"), 0),           # AWS access key ID
+]
+
+
+def scrub_secrets(text: str) -> str:
+    """Mask common credential patterns. Best-effort; not a security boundary.
+
+    Returns ``text`` with any matched credentials replaced by
+    ``***REDACTED***``. Patterns covered: Authorization/X-API headers,
+    ``token=``/``api_key=``/``password=``/``secret=`` style values,
+    and well-known provider key prefixes (sk-, ghp_, xox*, AKIA*).
+    """
+    if not text:
+        return text
+    result = text
+    for pattern, group in _SECRET_PATTERNS:
+        if group == 0:
+            result = pattern.sub("***REDACTED***", result)
+        else:
+            def _mask(m: re.Match[str]) -> str:
+                whole = m.group(0)
+                secret = m.group(group)
+                return whole.replace(secret, "***REDACTED***")
+            result = pattern.sub(_mask, result)
+    return result
+
+
+# --- Atomic breadcrumb writer --------------------------------------------
+
+def write_last_event(
+    *,
+    hook_name: str,
+    event: Literal["ok", "error"],
+    kind: str,
+    detail: str,
+) -> None:
+    """Best-effort breadcrumb for the status line. Never raises.
+
+    Writes ``last-event.json`` atomically (write to ``.tmp`` then
+    ``replace``) so a concurrent status-line reader never sees a
+    half-written file.
+
+    ``event="ok"`` is reserved for the upcoming status-line counter view
+    (status line shows "🧠 N recalled · M queued"). The silent-fail
+    wrapper itself only ever writes ``event="error"``.
+    """
+    try:
+        path = last_event_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "event": event,
+            "hook": hook_name,
+            "kind": kind,
+            "detail": scrub_secrets(detail)[:500],
+            "ts": time.time(),
+        }
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(path)
+    except Exception:
+        # If even the breadcrumb fails, we still MUST NOT surface
+        # anything. Status line goes without a fresh event; that's fine.
+        pass
+
+
+# --- Forensics log -------------------------------------------------------
+
+def forensics_log(hook_name: str, message: str) -> None:
+    """Append ``message`` to ``$REFLECT_STATE_DIR/logs/<hook_name>.log``.
+
+    Harness-agnostic — previously `precompact_reflect.py` hardcoded
+    ``~/.claude/logs/reflect_precompact.log`` which sent codex-fired log
+    lines into a Claude-flavoured directory. This helper picks the
+    unified reflect state dir so logs from both harnesses land in the
+    same place. The ``reflect_`` prefix is dropped (logs already live
+    under ``~/.reflect/logs/`` — the prefix was doubly redundant).
+
+    Never raises. Not user-visible — developer debugging only.
+    """
+    try:
+        logs = logs_dir()
+        logs.mkdir(parents=True, exist_ok=True)
+        log_path = logs / f"{hook_name}.log"
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] {scrub_secrets(message)}\n")
+    except Exception:
+        pass

--- a/plugins/reflect/skills/recall/hooks/session_start_recall.py
+++ b/plugins/reflect/skills/recall/hooks/session_start_recall.py
@@ -35,7 +35,6 @@ import re
 import shutil
 import subprocess
 import sys
-import time
 import traceback
 from pathlib import Path
 from typing import NoReturn
@@ -44,35 +43,24 @@ from typing import NoReturn
 # --- Silent-fail event sink ----------------------------------------------
 #
 # Hooks MUST NOT raise into the user's session — a recall failure (graphrag
-# down, broken cwd, missing dep) is not the user's problem. On any uncaught
-# exception we still exit 0 with an empty additionalContext, but we leave a
-# breadcrumb at ~/.reflect/last-event.json so the harness's status line can
-# render a "⚠ recall failed" fragment without flooding stderr.
-#
-# Atomic write (tmp + rename) so a concurrent status-line reader never sees
-# a half-written file.
+# down, broken cwd, missing dep) is not the user's problem. The shared
+# helper in ``plugins/reflect/scripts/silent_fail.py`` handles the
+# breadcrumb writer + credential scrubber + forensics log; we just import
+# it. sys.path manipulation needed because uv-script mode doesn't see
+# sibling packages by default.
 
-LAST_EVENT_PATH = Path(
-    os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect"))
-) / "last-event.json"
-
-
-def _write_last_event(event: str, kind: str, detail: str) -> None:
-    """Best-effort error breadcrumb for the status line. Never raises."""
-    try:
-        LAST_EVENT_PATH.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "event": event,            # "ok" | "error"
-            "hook": "session_start_recall",
-            "kind": kind,              # short error class, e.g. "OSError"
-            "detail": detail[:500],    # truncated message
-            "ts": time.time(),
-        }
-        tmp = LAST_EVENT_PATH.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(payload), encoding="utf-8")
-        tmp.replace(LAST_EVENT_PATH)
-    except Exception:
-        # If even the breadcrumb fails, we still must not surface anything.
+_HOOK_NAME = "session_start_recall"
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]  # skills/recall/hooks/<this> → plugins/reflect/
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+try:
+    from silent_fail import write_last_event, forensics_log  # noqa: E402
+except ImportError:
+    # Defensive fallback: if the shared helper is missing (broken install)
+    # we still must silent-fail. Define no-ops so the wrapper at the bottom
+    # of this file can't itself blow up.
+    def write_last_event(**kwargs):  # type: ignore[no-redef]
+        pass
+    def forensics_log(*args, **kwargs):  # type: ignore[no-redef]
         pass
 
 
@@ -271,11 +259,14 @@ def main() -> NoReturn:
         # let those through unchanged.
         raise
     except BaseException as exc:  # noqa: BLE001 — deliberately broadest catch
-        _write_last_event(
+        detail = str(exc) or traceback.format_exc(limit=2)
+        write_last_event(
+            hook_name=_HOOK_NAME,
             event="error",
             kind=type(exc).__name__,
-            detail=str(exc) or traceback.format_exc(limit=2),
+            detail=detail,
         )
+        forensics_log(_HOOK_NAME, f"{type(exc).__name__}: {detail}")
         # MUST exit 0 with valid JSON. Don't even let json.dumps raise —
         # use a literal so this last branch can never throw.
         try:

--- a/plugins/reflect/skills/recall/hooks/session_start_recall.py
+++ b/plugins/reflect/skills/recall/hooks/session_start_recall.py
@@ -35,8 +35,45 @@ import re
 import shutil
 import subprocess
 import sys
+import time
+import traceback
 from pathlib import Path
 from typing import NoReturn
+
+
+# --- Silent-fail event sink ----------------------------------------------
+#
+# Hooks MUST NOT raise into the user's session — a recall failure (graphrag
+# down, broken cwd, missing dep) is not the user's problem. On any uncaught
+# exception we still exit 0 with an empty additionalContext, but we leave a
+# breadcrumb at ~/.reflect/last-event.json so the harness's status line can
+# render a "⚠ recall failed" fragment without flooding stderr.
+#
+# Atomic write (tmp + rename) so a concurrent status-line reader never sees
+# a half-written file.
+
+LAST_EVENT_PATH = Path(
+    os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect"))
+) / "last-event.json"
+
+
+def _write_last_event(event: str, kind: str, detail: str) -> None:
+    """Best-effort error breadcrumb for the status line. Never raises."""
+    try:
+        LAST_EVENT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "event": event,            # "ok" | "error"
+            "hook": "session_start_recall",
+            "kind": kind,              # short error class, e.g. "OSError"
+            "detail": detail[:500],    # truncated message
+            "ts": time.time(),
+        }
+        tmp = LAST_EVENT_PATH.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(LAST_EVENT_PATH)
+    except Exception:
+        # If even the breadcrumb fails, we still must not surface anything.
+        pass
 
 
 # D2: conservative caps for auto-inject
@@ -171,7 +208,9 @@ def emit(additional_context: str) -> NoReturn:
 UV_BIN = shutil.which("uv")
 
 
-def main() -> NoReturn:
+def _main_body() -> NoReturn:
+    """The real work. Wrapped by ``main()`` in a top-level catch so any
+    uncaught exception silent-fails to an empty inject + last-event log."""
     # Hooks receive JSON on stdin but we don't need it for cwd derivation
     try:
         _ = sys.stdin.read()
@@ -219,6 +258,35 @@ def main() -> NoReturn:
         emit("")
 
     emit((r.stdout or "").strip())
+
+
+def main() -> NoReturn:
+    """Top-level entry. Any uncaught exception falls through to an empty
+    inject + a breadcrumb on ~/.reflect/last-event.json so the status line
+    can show ⚠ without anything reaching the user's session."""
+    try:
+        _main_body()
+    except SystemExit:
+        # ``emit()`` and the inner code use sys.exit(0) for clean exits —
+        # let those through unchanged.
+        raise
+    except BaseException as exc:  # noqa: BLE001 — deliberately broadest catch
+        _write_last_event(
+            event="error",
+            kind=type(exc).__name__,
+            detail=str(exc) or traceback.format_exc(limit=2),
+        )
+        # MUST exit 0 with valid JSON. Don't even let json.dumps raise —
+        # use a literal so this last branch can never throw.
+        try:
+            sys.stdout.write(
+                '{"hookSpecificOutput":{"hookEventName":"SessionStart",'
+                '"additionalContext":""}}\n'
+            )
+            sys.stdout.flush()
+        except Exception:
+            pass
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/plugins/reflect/tests/test_hooks_silent_fail.py
+++ b/plugins/reflect/tests/test_hooks_silent_fail.py
@@ -205,3 +205,202 @@ def test_precompact_survives_corrupt_stdin(tmp_path):
         timeout=20,
     )
     assert result.returncode == 0
+
+
+# --- shared silent_fail helper ----------------------------------------------
+
+# Imported lazily to exercise the real module under test.
+def _import_silent_fail():
+    sf_path = PLUGIN_ROOT / "scripts"
+    sys.path.insert(0, str(sf_path))
+    if "silent_fail" in sys.modules:
+        del sys.modules["silent_fail"]
+    import silent_fail
+    return silent_fail
+
+
+def test_scrub_secrets_masks_bearer_token():
+    sf = _import_silent_fail()
+    text = "OSError: 401 Unauthorized — Authorization: Bearer abc123xyz789TOKEN"
+    out = sf.scrub_secrets(text)
+    assert "abc123xyz789TOKEN" not in out
+    assert "***REDACTED***" in out
+    # Prefix preserved so the operator still sees WHERE the credential came from
+    assert "Authorization" in out
+
+
+def test_scrub_secrets_masks_api_key_assignments():
+    sf = _import_silent_fail()
+    for raw in (
+        'api_key="sk-proj-zZ1234567890ABCdefgh"',
+        "token=ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+        "password = SuperSecretPassword123",
+        "X-Api-Key: my_secret_api_key_value_999",
+    ):
+        out = sf.scrub_secrets(raw)
+        assert "***REDACTED***" in out, f"failed to mask: {raw!r} → {out!r}"
+
+
+def test_scrub_secrets_masks_provider_key_shapes():
+    sf = _import_silent_fail()
+    text = (
+        "Failed with key sk-proj-1234567890abcdefghij in path "
+        "and ghp_abc123def456ghi789jkl012mno345pqr678"
+    )
+    out = sf.scrub_secrets(text)
+    assert "sk-proj-1234567890abcdefghij" not in out
+    assert "ghp_abc123def456ghi789jkl012mno345pqr678" not in out
+    assert out.count("***REDACTED***") == 2
+
+
+def test_scrub_secrets_idempotent_on_clean_text():
+    sf = _import_silent_fail()
+    text = "OSError: file not found at /tmp/x.json"
+    assert sf.scrub_secrets(text) == text
+
+
+def test_write_last_event_supports_ok_event(tmp_path, monkeypatch):
+    """The breadcrumb writer must also support event='ok' for the
+    upcoming status-line counter view (not just 'error')."""
+    sf = _import_silent_fail()
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    sf.write_last_event(
+        hook_name="user_prompt_submit_recall",
+        event="ok",
+        kind="recall",
+        detail="injected 3 learnings",
+    )
+    payload = json.loads((tmp_path / "last-event.json").read_text())
+    assert payload["event"] == "ok"
+    assert payload["hook"] == "user_prompt_submit_recall"
+
+
+def test_write_last_event_resolves_env_per_call(tmp_path, monkeypatch):
+    """Regression: previously LAST_EVENT_PATH was bound at import time,
+    so changing REFLECT_STATE_DIR mid-process had no effect. The shared
+    helper must resolve the env every call."""
+    sf = _import_silent_fail()
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(first))
+    sf.write_last_event(hook_name="h", event="error", kind="X", detail="d1")
+    assert (first / "last-event.json").exists()
+
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(second))
+    sf.write_last_event(hook_name="h", event="error", kind="X", detail="d2")
+    assert (second / "last-event.json").exists()
+
+
+def test_write_last_event_scrubs_secrets_in_detail(tmp_path, monkeypatch):
+    """Detail field gets scrubbed before persisting so we don't write
+    tokens to disk even via the breadcrumb."""
+    sf = _import_silent_fail()
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    sf.write_last_event(
+        hook_name="h",
+        event="error",
+        kind="RuntimeError",
+        detail="Failed with Bearer abc123xyz789TOKEN_VALUE",
+    )
+    payload = json.loads((tmp_path / "last-event.json").read_text())
+    assert "abc123xyz789TOKEN_VALUE" not in payload["detail"]
+    assert "***REDACTED***" in payload["detail"]
+
+
+def test_forensics_log_goes_to_reflect_state_dir_not_claude(tmp_path, monkeypatch):
+    """The fix for the codex bug: forensics_log MUST write to
+    $REFLECT_STATE_DIR/logs/, NOT ~/.claude/logs/. Otherwise codex-fired
+    precompact hooks write logs into a Claude-flavoured directory."""
+    sf = _import_silent_fail()
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    sf.forensics_log("precompact_reflect", "session=abc trigger=auto mode=remind")
+
+    expected = tmp_path / "logs" / "precompact_reflect.log"
+    assert expected.exists(), f"expected log at {expected}"
+    contents = expected.read_text()
+    assert "trigger=auto" in contents
+
+
+def test_forensics_log_scrubs_secrets(tmp_path, monkeypatch):
+    sf = _import_silent_fail()
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    sf.forensics_log("h", "Calling api with token=ghp_abcdef1234567890ABCDEFGHIJ")
+    contents = (tmp_path / "logs" / "h.log").read_text()
+    assert "ghp_abcdef" not in contents
+    assert "***REDACTED***" in contents
+
+
+def test_precompact_log_path_is_harness_neutral(tmp_path):
+    """End-to-end: run precompact_reflect.py with --log-only and confirm
+    the log lands under $REFLECT_STATE_DIR/logs/, NOT ~/.claude/logs/.
+    This is the regression test for the codex bug Stevie flagged."""
+    result = subprocess.run(
+        [sys.executable, str(PRECOMPACT_HOOK), "--log-only"],
+        input='{"trigger":"auto","session_id":"deadbeef"}',
+        capture_output=True,
+        text=True,
+        env={**os.environ, "REFLECT_STATE_DIR": str(tmp_path)},
+        timeout=20,
+    )
+    assert result.returncode == 0
+    expected = tmp_path / "logs" / "precompact_reflect.log"
+    assert expected.exists(), (
+        f"expected log at {expected}, contents of {tmp_path}: "
+        f"{list(tmp_path.rglob('*'))}"
+    )
+    contents = expected.read_text()
+    assert "trigger=auto" in contents
+    assert "session=deadbeef" in contents
+
+
+def test_drain_reflections_silent_fail_on_corrupt_queue(tmp_path):
+    """sessionstart_drain_reflections.py must also silent-fail. Feed it
+    a queue file whose parent directory is unreadable (simulated via
+    REFLECT_STATE_DIR pointing at a file, not a dir) → exit 0, breadcrumb."""
+    # Pre-create a regular file at the state dir path so get_state_dir
+    # returns a path that can't be used as a directory.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("blocker", encoding="utf-8")
+
+    drain_hook = PLUGIN_ROOT / "hooks" / "sessionstart_drain_reflections.py"
+    result = subprocess.run(
+        [sys.executable, str(drain_hook)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env={**os.environ, "REFLECT_STATE_DIR": str(blocker)},
+        timeout=20,
+    )
+    assert result.returncode == 0, (
+        f"drain hook exited non-zero on broken state dir:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+
+
+def test_recall_via_uv_run_script_silent_fail(tmp_path):
+    """The recall hook runs in production via ``uv run --script`` (per
+    its shebang). Verify the silent-fail wrapper still catches via the
+    real invocation path, not just bare python3."""
+    uv = subprocess.run(["uv", "--version"], capture_output=True, text=True)
+    if uv.returncode != 0:
+        pytest.skip("uv not available")
+
+    result = subprocess.run(
+        ["uv", "run", "--script", str(RECALL_HOOK)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "REFLECT_STATE_DIR": str(tmp_path),
+            "HOME": str(tmp_path),
+            "CLAUDE_PROJECT_DIR": str(tmp_path),  # cwd=$HOME early-exit
+        },
+        timeout=30,
+    )
+    # Even via uv invocation path, hook exits 0.
+    assert result.returncode == 0, (
+        f"uv-run recall hook exited non-zero:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )

--- a/plugins/reflect/tests/test_hooks_silent_fail.py
+++ b/plugins/reflect/tests/test_hooks_silent_fail.py
@@ -1,0 +1,207 @@
+"""Tests for the silent-fail invariant on reflect hooks.
+
+The recall + reflect hooks MUST NOT surface tracebacks into the user's
+session even when downstream dependencies blow up (graphrag down, broken
+cwd, missing libs). On any uncaught exception they should:
+
+  * exit 0
+  * emit valid empty JSON on stdout (or nothing for precompact)
+  * leave a breadcrumb at ~/.reflect/last-event.json so the harness's
+    status line can render ⚠ recall failed / ⚠ reflect failed
+
+These tests force a raise by injecting a monkey-patched function that
+throws, then assert the three invariants above.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+PLUGIN_ROOT = HERE.parent
+RECALL_HOOK = PLUGIN_ROOT / "skills" / "recall" / "hooks" / "session_start_recall.py"
+PRECOMPACT_HOOK = PLUGIN_ROOT / "hooks" / "precompact_reflect.py"
+
+
+# Tests run the hook *script* in a subprocess so we exercise the same code
+# path the harness does — including the top-level ``main()`` guard. Each
+# subprocess is launched with REFLECT_STATE_DIR pointing at a tmp_path so
+# the last-event.json breadcrumb lands in an isolated dir.
+
+
+def _run_hook_forcing_raise(
+    hook_path: Path,
+    state_dir: Path,
+    raise_in: str,
+    stdin_payload: str = "{}",
+) -> subprocess.CompletedProcess[str]:
+    """Run ``hook_path`` after monkey-patching ``raise_in`` to throw.
+
+    Gotcha: ``runpy.run_path`` returns a dict that is NOT the same dict
+    used as the loaded functions' ``__globals__`` — so patching
+    ``mod_globals[name]`` has no effect on subsequent function calls
+    inside the module. We patch via ``main.__globals__`` instead, which
+    IS the actual lookup dict for every function defined in the script.
+    """
+    shim = textwrap.dedent(f"""
+        import os, runpy, sys
+        os.environ["REFLECT_STATE_DIR"] = {str(state_dir)!r}
+
+        target = {str(hook_path)!r}
+        mod_globals = runpy.run_path(target, run_name="__pre_main__")
+
+        # Patch the function's REAL globals (the dict its name lookups go
+        # through), not the dict runpy hands back.
+        real_globals = mod_globals["main"].__globals__
+
+        def _boom(*a, **kw):
+            raise RuntimeError("forced failure for silent-fail test")
+        real_globals[{raise_in!r}] = _boom
+
+        mod_globals["main"]()
+    """)
+    return subprocess.run(
+        [sys.executable, "-c", shim],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "REFLECT_STATE_DIR": str(state_dir)},
+        timeout=20,
+    )
+
+
+# --- session_start_recall ----------------------------------------------------
+
+
+def test_recall_silent_on_build_query_raise(tmp_path):
+    """Force build_query() to raise → hook must exit 0, emit empty
+    additionalContext, write last-event.json with event=error."""
+    result = _run_hook_forcing_raise(
+        RECALL_HOOK, tmp_path, raise_in="build_query"
+    )
+    assert result.returncode == 0, (
+        f"recall hook exited non-zero on raised exception:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    # Output must be parseable JSON with empty additionalContext.
+    # (Some shim noise can land on stderr from runpy itself; we don't
+    # police stderr in this test — we police what reaches the harness
+    # via stdout, which is what gets fed back as hookSpecificOutput.)
+    body = (result.stdout or "").strip()
+    if body:
+        parsed = json.loads(body)
+        assert parsed["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+        assert parsed["hookSpecificOutput"]["additionalContext"] == ""
+
+    # Breadcrumb written.
+    breadcrumb = tmp_path / "last-event.json"
+    assert breadcrumb.exists(), (
+        f"expected breadcrumb at {breadcrumb}; tmp_path contents: "
+        f"{list(tmp_path.iterdir())}"
+    )
+    event = json.loads(breadcrumb.read_text())
+    assert event["event"] == "error"
+    assert event["hook"] == "session_start_recall"
+    assert event["kind"] == "RuntimeError"
+    assert "forced failure" in event["detail"]
+    assert isinstance(event["ts"], (int, float))
+
+
+def test_recall_no_breadcrumb_on_happy_path(tmp_path):
+    """Happy path (cwd=$HOME → emit("")) must NOT write an error
+    breadcrumb. Asserts the silent-fail wrapper isn't firing spuriously."""
+    result = subprocess.run(
+        [sys.executable, str(RECALL_HOOK)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "REFLECT_STATE_DIR": str(tmp_path),
+            "HOME": str(tmp_path),       # cwd=$HOME branch
+            "CLAUDE_PROJECT_DIR": str(tmp_path),
+        },
+        timeout=20,
+    )
+    assert result.returncode == 0
+    assert not (tmp_path / "last-event.json").exists()
+
+
+# --- precompact_reflect ------------------------------------------------------
+
+
+def test_precompact_silent_on_runtime_raise(tmp_path):
+    """Force log_precompact_event() to raise → hook must exit 0 and
+    write last-event.json with event=error."""
+    result = _run_hook_forcing_raise(
+        PRECOMPACT_HOOK, tmp_path,
+        raise_in="log_precompact_event",
+        stdin_payload='{"trigger":"auto"}',
+    )
+    assert result.returncode == 0, (
+        f"precompact hook exited non-zero on raised exception:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    breadcrumb = tmp_path / "last-event.json"
+    assert breadcrumb.exists()
+    event = json.loads(breadcrumb.read_text())
+    assert event["event"] == "error"
+    assert event["hook"] == "precompact_reflect"
+    assert event["kind"] == "RuntimeError"
+
+
+def test_precompact_breadcrumb_is_atomic(tmp_path):
+    """Run twice in quick succession; the breadcrumb file must always
+    be a complete valid JSON object (no half-written reads). We can't
+    easily race here in a unit test, but we can at least assert the
+    file persists as valid JSON after multiple writes."""
+    for _ in range(3):
+        _run_hook_forcing_raise(
+            PRECOMPACT_HOOK, tmp_path,
+            raise_in="log_precompact_event",
+            stdin_payload='{"trigger":"auto"}',
+        )
+        # Each write must leave behind a valid JSON object.
+        json.loads((tmp_path / "last-event.json").read_text())
+
+
+# --- defense in depth -------------------------------------------------------
+
+
+def test_recall_survives_corrupt_stdin(tmp_path):
+    """A malformed stdin payload (not JSON) must not crash the hook."""
+    result = subprocess.run(
+        [sys.executable, str(RECALL_HOOK)],
+        input="this is not valid json at all{{{",
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "REFLECT_STATE_DIR": str(tmp_path),
+            "HOME": str(tmp_path),
+            "CLAUDE_PROJECT_DIR": str(tmp_path),
+        },
+        timeout=20,
+    )
+    assert result.returncode == 0
+
+
+def test_precompact_survives_corrupt_stdin(tmp_path):
+    """precompact_reflect already catches JSONDecodeError explicitly,
+    but we keep this test as a regression guard."""
+    result = subprocess.run(
+        [sys.executable, str(PRECOMPACT_HOOK), "--log-only"],
+        input="not json",
+        capture_output=True,
+        text=True,
+        env={**os.environ, "REFLECT_STATE_DIR": str(tmp_path)},
+        timeout=20,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Reflect hooks must never throw a traceback into the user's Claude session — recall and reflect are passive layers, and a failed lookup (graphrag down, broken cwd, missing dep) is not the user's problem.

The current code handles **known** failure modes (timeouts, missing uv, subprocess errors, JSONDecodeError on stdin) cleanly with `sys.exit(0)`. But anything unexpected raised from `build_query()` / `find_recall_script()` / `log_precompact_event()` would escape as a traceback to stderr and land in the Claude session.

This PR wraps `main()` in both Python hooks with a top-level `except BaseException` that:

1. Writes `~/.reflect/last-event.json` with `{event, hook, kind, detail, ts}` atomically (tmp + rename) so a status-line reader never sees a half-written file.
2. Emits valid empty `hookSpecificOutput` JSON (recall) or just `sys.exit(0)` (precompact).
3. Swallows the exception — nothing reaches stderr.

`SystemExit` is re-raised so intentional `sys.exit(0)` calls and argparse-on-bad-args still behave normally (config bugs should be visible).

## Why now

Sets up the upcoming status-line integration (task #8 in the follow-up): `~/.claude/statusline.sh` will read `last-event.json` and render a `⚠ recall failed` fragment when the most recent event has `event=error` within the last N seconds. Codex side will use the per-hook `statusMessage` field (ephemeral, fixed token list — best we can do until codex grows a custom status token).

## Test plan

- [x] 6 new tests in `plugins/reflect/tests/test_hooks_silent_fail.py`:
  - forced raise in `build_query` → exit 0, breadcrumb written with `event=error`, `kind=RuntimeError`
  - forced raise in `log_precompact_event` → exit 0, breadcrumb written
  - happy path (cwd=$HOME) → NO breadcrumb (silent-fail wrapper not spuriously firing)
  - 3 consecutive raises → breadcrumb always valid JSON (atomic write check)
  - corrupt stdin survives in both hooks
- [x] All 46 existing adapter tests still pass (52/52 total)
- [x] Drain script (`reflect-drain-bg.sh`) was already silent-fail-correct — no changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized silent-fail support with secure secret-scrubbing and stable breadcrumb/logging for reflect hooks.
* **Bug Fixes**
  * PreCompact, SessionStart Recall, and session-start drain hooks now catch unexpected errors, exit cleanly (no tracebacks), and preserve user-facing stability.
* **Tests**
  * Added comprehensive tests covering silent-fail behavior, secret scrubbing, and robustness to malformed input.
* **Documentation**
  * Hook messaging broadened to reference both Claude and Codex where applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->