### PR TITLE
fix(reflect): precompact emits empty stdout — codex schema compat

### DIFF
--- a/plugins/reflect/.claude-plugin/plugin.json
+++ b/plugins/reflect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reflect",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings at SessionStart via hook. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"

--- a/plugins/reflect/hooks/precompact_reflect.py
+++ b/plugins/reflect/hooks/precompact_reflect.py
@@ -206,31 +206,35 @@ def _main_body():
     # Log the event
     log_precompact_event(input_data, mode)
 
-    # Handle based on mode
+    # ── stdout protocol ───────────────────────────────────────────────────
+    # PreCompact is a pure side-effect hook in both harnesses:
+    #   * The transcript is about to be compacted — anything we inject as
+    #     additionalContext gets compacted immediately, so it's pointless.
+    #   * Codex 0.131 does NOT define ``PreCompactHookSpecificOutputWire``
+    #     in its schema. Emitting ``{"hookSpecificOutput":{...}}`` for
+    #     PreCompact triggers an "invalid PreCompact hook JSON output"
+    #     error in codex (Claude tolerates it, but it's noise).
+    #
+    # So: regardless of mode, we just enqueue (run_reflection_analysis does
+    # the file I/O for its side-effect) and exit 0 with NO stdout output.
+    # Verbose chatter goes to stderr only — never pollute the protocol
+    # channel.
+    if args.verbose:
+        print(f"[precompact_reflect] mode={mode} trigger={trigger}", file=sys.stderr)
+
     if mode == 'log-only':
-        if args.verbose:
-            print(f"Logged PreCompact event (trigger={trigger})")
         sys.exit(0)
 
-    elif mode == 'auto' and is_auto_reflect_enabled():
-        # Run automatic reflection
-        output = run_reflection_analysis(input_data)
-        print(json.dumps(output))
-        sys.exit(0)
+    # 'auto' or 'remind' — both enqueue for the next-session drainer.
+    # We deliberately ignore the dict return value: the queue is the
+    # canonical side-effect; the dict was only useful when we were
+    # injecting additionalContext (which we no longer do).
+    if mode == 'auto' and is_auto_reflect_enabled():
+        run_reflection_analysis(input_data)
+    # 'remind' mode and the "auto but disabled" fallback are no-ops on
+    # disk now — the drainer surfaces queued entries on its own.
 
-    elif mode == 'remind':
-        # Just add a reminder
-        output = generate_reminder_context(trigger)
-        print(json.dumps(output))
-        sys.exit(0)
-
-    else:
-        # Auto mode but not enabled, just remind
-        if args.verbose:
-            print("Auto-reflect not enabled, adding reminder")
-        output = generate_reminder_context(trigger)
-        print(json.dumps(output))
-        sys.exit(0)
+    sys.exit(0)
 
 
 def main():

--- a/plugins/reflect/tests/test_hooks_silent_fail.py
+++ b/plugins/reflect/tests/test_hooks_silent_fail.py
@@ -331,6 +331,44 @@ def test_forensics_log_scrubs_secrets(tmp_path, monkeypatch):
     assert "***REDACTED***" in contents
 
 
+def test_precompact_emits_no_stdout_protocol_pollution(tmp_path):
+    """Regression for codex 'invalid PreCompact hook JSON output' error.
+
+    Codex 0.131 doesn't define PreCompactHookSpecificOutputWire in its
+    schema — any ``hookSpecificOutput`` envelope emitted from PreCompact
+    triggers an "invalid JSON output" rejection. PreCompact is now a pure
+    side-effect hook (enqueue only); stdout MUST be empty regardless of
+    mode/verbose/env flags.
+
+    Also covers the earlier bug where ``--verbose`` printed plaintext
+    chatter to stdout BEFORE the JSON, producing two-line output that
+    codex couldn't parse as a single JSON object.
+    """
+    test_cases = [
+        # (env, args, stdin, label)
+        ({}, ["--auto", "--verbose"], '{"trigger":"auto","transcript_path":"/tmp/x"}', "auto+verbose+enabled"),
+        ({"REFLECT_AUTO_REFLECT": "0"}, ["--auto", "--verbose"], '{"trigger":"auto","transcript_path":"/tmp/x"}', "auto+verbose+disabled"),
+        ({}, ["--auto"], '{"trigger":"auto","transcript_path":"/tmp/x"}', "auto only"),
+        ({}, ["--remind", "--verbose"], '{"trigger":"manual"}', "remind+verbose"),
+        ({}, ["--log-only", "--verbose"], '{"trigger":"auto"}', "log-only+verbose"),
+    ]
+    for env_extra, args, stdin, label in test_cases:
+        result = subprocess.run(
+            [sys.executable, str(PRECOMPACT_HOOK), *args],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "REFLECT_STATE_DIR": str(tmp_path), **env_extra},
+            timeout=20,
+        )
+        assert result.returncode == 0, f"[{label}] exit={result.returncode}"
+        assert result.stdout == "", (
+            f"[{label}] PreCompact must emit NO stdout (would break codex "
+            f"schema validation). Got: {result.stdout!r}"
+        )
+        # Verbose chatter, if any, lives on stderr — that's allowed.
+
+
 def test_precompact_log_path_is_harness_neutral(tmp_path):
     """End-to-end: run precompact_reflect.py with --log-only and confirm
     the log lands under $REFLECT_STATE_DIR/logs/, NOT ~/.claude/logs/.


### PR DESCRIPTION
## Summary

Fixes the `PreCompact hook (failed) — error: hook returned invalid PreCompact hook JSON output` error Stevie hit in codex sessions.

### Root cause

Codex 0.131's hook protocol schema defines `HookSpecificOutputWire` for SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, and PermissionRequest — but **not** PreCompact. Any `{"hookSpecificOutput": {"hookEventName": "PreCompact", ...}}` envelope we emit fails schema validation. Claude tolerated it; codex doesn't.

Verified by searching the codex binary's embedded JSON schema:

```
SessionStartHookSpecificOutputWire     ✓
UserPromptSubmitHookSpecificOutputWire ✓
PreToolUseHookSpecificOutputWire       ✓
PostToolUseHookSpecificOutputWire      ✓
PermissionRequestHookSpecificOutputWire ✓
PreCompactHookSpecificOutputWire       ✗ (not defined)
```

Second bug found along the way: `--verbose` mode printed plaintext chatter to stdout **before** the JSON in the `REFLECT_AUTO_REFLECT=0` fallback path. That produced two-line output (plaintext + JSON) — broken even before codex's stricter validation.

### Fix

PreCompact is a pure side-effect hook in both harnesses (the queued transcript is the only thing that matters; injected context gets compacted seconds later anyway). Strip the stdout protocol entirely:

- Every code path now exits 0 with **empty stdout** regardless of mode/verbose/env.
- `--verbose` chatter routes to stderr (still debuggable for manual runs).
- `run_reflection_analysis()` still runs the queue enqueue on the auto+enabled path; the returned dict is discarded.

### Version bump

`3.5.0 → 3.5.1` (patch — pure compat fix, no API surface change).

## Test plan

- [x] New test `test_precompact_emits_no_stdout_protocol_pollution` covers 5 permutations:
  - `--auto --verbose` with auto enabled
  - `--auto --verbose` with `REFLECT_AUTO_REFLECT=0` (was the broken case)
  - `--auto` alone
  - `--remind --verbose`
  - `--log-only --verbose`
  All assert `stdout == ""` and `exit==0`.
- [x] All 18 silent-fail tests still pass
- [x] All 46 adapter tests still pass (65/65 total)
- [ ] **Manual** — after merge, re-run `claude plugin install reflect@agents-in-a-box` and `python codex_adapter.py install --force` to pick up the new hook on disk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the Reflect plugin to prevent unwanted output that could interfere with normal operation.

* **Tests**
  * Added regression test to verify proper output behavior.

* **Chores**
  * Bumped Reflect plugin version to 3.5.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->