### PR TITLE
fix(reflect): claude adapter detects plugin runtime to avoid dupe-fire

### DIFF
--- a/plugins/reflect/.claude-plugin/plugin.json
+++ b/plugins/reflect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reflect",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings at SessionStart via hook. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"

--- a/plugins/reflect/adapters/claude/claude_adapter.py
+++ b/plugins/reflect/adapters/claude/claude_adapter.py
@@ -163,6 +163,32 @@ class ClaudeAdapter(AdapterBase):
         if not with_hooks:
             return [], 0
         settings_path: Path = plan.extras["settings_path"]
+
+        # Detect whether Claude Code's plugin runtime has already installed
+        # reflect via ``/plugin install reflect@agents-in-a-box``. When it
+        # has, the plugin's ``plugin.json`` autowires SessionStart →
+        # ``${CLAUDE_PLUGIN_ROOT}/skills/recall/hooks/session_start_recall.py``
+        # from the cache at every SessionStart. Adding our own entry to
+        # settings.json would point at ``~/.claude/skills/recall/hooks/``
+        # (the toolkit-deployed location) and fire a SECOND copy on every
+        # SessionStart — typically a stale version of the same script. So
+        # if the plugin runtime owns this, the adapter steps aside (and
+        # also sweeps out any legacy duplicate we wrote on a prior run).
+        plugin_runtime_owns_it = self._plugin_runtime_owns_reflect(plan.target_harness_dir)
+        if plugin_runtime_owns_it:
+            try:
+                removed = self._remove_legacy_session_start_hook(settings_path)
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                return [], 2
+            msg = (
+                f"plugin runtime owns reflect hooks; skipped settings.json merge"
+                f" ({settings_path})"
+            )
+            if removed:
+                msg += " — cleaned up legacy duplicate left by older installs"
+            return [msg], 0
+
         try:
             changed = self._merge_session_start_hook(settings_path)
         except RuntimeError as exc:
@@ -173,6 +199,68 @@ class ClaudeAdapter(AdapterBase):
         if changed:
             return [f"added SessionStart hook to {settings_path}"], 0
         return [f"SessionStart hook already present in {settings_path}"], 0
+
+    def _plugin_runtime_owns_reflect(self, claude_dir: Path) -> bool:
+        """Return True iff Claude Code's plugin runtime has installed the
+        reflect plugin (any version, any scope).
+
+        Heuristic: read ``~/.claude/plugins/installed_plugins.json`` and
+        look for any key matching ``reflect@*``. False on parse error /
+        missing file — safer to wire the hook than to skip and silently
+        leave the user with no recall.
+        """
+        installed_path = claude_dir / "plugins" / "installed_plugins.json"
+        try:
+            data = json.loads(installed_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return False
+        plugins = data.get("plugins", {})
+        if not isinstance(plugins, dict):
+            return False
+        return any(
+            isinstance(name, str) and name.split("@", 1)[0] == "reflect"
+            for name in plugins.keys()
+        )
+
+    def _remove_legacy_session_start_hook(self, settings_path: Path) -> bool:
+        """Remove any adapter-written SessionStart entry the user may have
+        from a pre-plugin-runtime install. Returns True iff anything was
+        removed. Idempotent."""
+        if not settings_path.exists():
+            return False
+        try:
+            cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            raise RuntimeError(
+                f"{settings_path} exists but is not valid JSON; refusing to overwrite"
+            )
+        wanted = _render_session_start_hook_command(settings_path.parent)
+        removable = {wanted, _LEGACY_SESSION_START_HOOK_COMMAND}
+        ss = cfg.get("hooks", {}).get("SessionStart", [])
+        new_ss: list = []
+        changed = False
+        for entry in ss:
+            kept = [h for h in entry.get("hooks", []) if h.get("command") not in removable]
+            if kept != entry.get("hooks", []):
+                changed = True
+            if kept:
+                new_entry = dict(entry)
+                new_entry["hooks"] = kept
+                new_ss.append(new_entry)
+        if not changed:
+            return False
+        hooks_block = cfg.setdefault("hooks", {})
+        if new_ss:
+            hooks_block["SessionStart"] = new_ss
+        else:
+            hooks_block.pop("SessionStart", None)
+        if not hooks_block:
+            cfg.pop("hooks", None)
+        settings_path.write_text(
+            json.dumps(cfg, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8",
+        )
+        return True
 
     def uninstall_extra(
         self, *, home: Path, with_hooks: bool = True, **kwargs: Any,

--- a/plugins/reflect/adapters/tests/test_claude_adapter.py
+++ b/plugins/reflect/adapters/tests/test_claude_adapter.py
@@ -127,6 +127,146 @@ def test_install_is_idempotent_and_preserves_existing_hooks(tmp_path):
     assert commands.count(expected) == 1
 
 
+def _seed_plugin_runtime_install(tmp_path):
+    """Create a minimal installed_plugins.json that looks like the plugin
+    runtime installed reflect via `/plugin install reflect@agents-in-a-box`."""
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    (plugins_dir / "installed_plugins.json").write_text(json.dumps({
+        "version": 2,
+        "plugins": {
+            "reflect@agents-in-a-box": [
+                {
+                    "scope": "user",
+                    "installPath": str(plugins_dir / "cache" / "agents-in-a-box" / "reflect" / "3.5.1"),
+                    "version": "3.5.1",
+                    "installedAt": "2026-05-20T00:00:00Z",
+                    "lastUpdated": "2026-05-20T00:00:00Z",
+                    "gitCommitSha": "deadbeef",
+                }
+            ]
+        }
+    }))
+
+
+def test_install_skips_settings_when_plugin_runtime_owns_it(tmp_path):
+    """When ``/plugin install reflect`` has already wired the SessionStart
+    hook via plugin.json autowire, the adapter must NOT add its own
+    duplicate entry — that creates a stale-code dupe-firing surface."""
+    _seed_plugin_runtime_install(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True, text=True,
+    )
+    assert "plugin runtime owns reflect hooks" in result.stdout
+    # Skills still installed
+    assert (tmp_path / ".claude" / "skills" / "recall" / "SKILL.md").exists()
+    # settings.json should NOT contain our SessionStart entry
+    settings_path = tmp_path / ".claude" / "settings.json"
+    if settings_path.exists():
+        cfg = json.loads(settings_path.read_text())
+        expected = claude_adapter._render_session_start_hook_command(tmp_path / ".claude")
+        commands = [
+            h["command"]
+            for entry in cfg.get("hooks", {}).get("SessionStart", [])
+            for h in entry["hooks"]
+        ]
+        assert expected not in commands
+
+
+def test_install_cleans_up_legacy_entry_when_plugin_runtime_takes_over(tmp_path):
+    """Migration scenario: user previously ran the adapter (pre-plugin),
+    then installed via the plugin runtime. Next adapter run must SWEEP
+    OUT the legacy duplicate it wrote, leaving only the plugin runtime
+    wire-up active."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    # Pre-seed settings.json with the legacy adapter-written hook.
+    legacy_cmd = claude_adapter._render_session_start_hook_command(claude_dir)
+    (claude_dir / "settings.json").write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": "echo unrelated"},
+                        {"type": "command", "command": legacy_cmd},
+                    ],
+                }
+            ]
+        }
+    }))
+    _seed_plugin_runtime_install(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True, text=True,
+    )
+    assert "cleaned up legacy duplicate" in result.stdout
+
+    cfg = json.loads((claude_dir / "settings.json").read_text())
+    commands = [
+        h["command"]
+        for entry in cfg.get("hooks", {}).get("SessionStart", [])
+        for h in entry["hooks"]
+    ]
+    assert legacy_cmd not in commands
+    assert "echo unrelated" in commands  # untouched
+
+
+def test_install_still_wires_settings_when_plugin_runtime_absent(tmp_path):
+    """If the plugin runtime is NOT used (toolkit-only / dev install),
+    the adapter still needs to write its settings.json hook so recall
+    fires on SessionStart."""
+    # No installed_plugins.json at all
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True, text=True,
+    )
+    assert "plugin runtime owns" not in result.stdout
+
+    cfg = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    commands = [
+        h["command"]
+        for entry in cfg.get("hooks", {}).get("SessionStart", [])
+        for h in entry["hooks"]
+    ]
+    expected = claude_adapter._render_session_start_hook_command(tmp_path / ".claude")
+    assert expected in commands
+
+
+def test_install_skips_settings_when_unrelated_plugin_runtime_installs_exist(tmp_path):
+    """The detection must specifically check for ``reflect`` — having
+    OTHER plugins installed shouldn't make us think reflect is also
+    plugin-runtime-managed."""
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    (plugins_dir / "installed_plugins.json").write_text(json.dumps({
+        "version": 2,
+        "plugins": {
+            "some-other-plugin@some-marketplace": [
+                {"scope": "user", "version": "1.0.0"}
+            ]
+        }
+    }))
+
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True, text=True,
+    )
+    # Should NOT detect plugin runtime — adapter writes its entry normally
+    assert "plugin runtime owns" not in result.stdout
+    cfg = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    commands = [
+        h["command"]
+        for entry in cfg.get("hooks", {}).get("SessionStart", [])
+        for h in entry["hooks"]
+    ]
+    expected = claude_adapter._render_session_start_hook_command(tmp_path / ".claude")
+    assert expected in commands
+
+
 def test_install_no_hooks_flag_leaves_settings_alone(tmp_path):
     subprocess.run(
         [sys.executable, str(ADAPTER), "install",


### PR DESCRIPTION
## Summary

Closes the SessionStart dupe-firing bug I flagged at the end of #150 / #151 verification.

When a user installs reflect via Claude Code's plugin runtime (\`/plugin install reflect@agents-in-a-box\`), the plugin's \`plugin.json\` autowires SessionStart from the cache. If the adapter ALSO writes its SessionStart entry to \`~/.claude/settings.json\` — pointing at the toolkit-deployed \`~/.claude/skills/recall/hooks/...\` location — recall fires **twice** on every SessionStart. The settings.json copy typically runs STALE code (toolkit deploy isn't refreshed on \`/plugin update\`), so the duplicate is a latent traceback surface.

I confirmed in the previous session that recall was indeed firing twice per SessionStart from a stale 23 Apr file.

## Fix

The adapter now reads \`~/.claude/plugins/installed_plugins.json\` to detect plugin-runtime installs. When \`reflect@*\` is present:

- **SKIP** the settings.json hook merge entirely (plugin runtime owns it)
- **SWEEP OUT** any legacy adapter-written entry from prior installs (catches users who installed via adapter first, then plugin runtime second)

When the plugin runtime is NOT detected (toolkit-only / dev installs), behavior is unchanged — the adapter keeps writing its settings.json entry so recall still fires.

## Detection logic

\`\`\`python
def _plugin_runtime_owns_reflect(claude_dir):
    # Reads ~/.claude/plugins/installed_plugins.json
    # Returns True if any \`reflect@<marketplace>\` key exists.
    # Fail-safe: returns False on missing file / parse error
    # (better to over-wire than to leave the user with no recall).
\`\`\`

## Test plan

- [x] 4 new tests covering: plugin-runtime-owns-it, legacy-cleanup-on-migration, plugin-runtime-absent-fallback, regression-check-only-matches-reflect-not-any-plugin
- [x] Full reflect suite: 69/69 pass
- [x] Live system: dupe entry already manually removed from \`~/.claude/settings.json\` before this PR; next \`python claude_adapter.py install\` will skip re-adding it
- [x] Version bumped 3.5.1 → 3.5.2 (patch — adapter behavior change, no hook script change)

## Why now

Per session telemetry, recall has been firing twice on every SessionStart for the past ~24h. The dupe doesn't break anything user-visible (both exit 0, both inject context), but it doubles GraphRAG query cost per session start and creates a stale-code path that crashes louder than the new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of plugin runtime ownership to prevent duplicate configuration entries.
  * Added automatic cleanup for legacy configuration when plugin runtime takes control.

* **Chores**
  * Updated reflect plugin to version 3.5.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->