### PR TITLE
feat(reflect): UserPromptSubmit recall + PostToolUse mini-learning + Stop enqueue

### DIFF
--- a/plugins/reflect/.claude-plugin/plugin.json
+++ b/plugins/reflect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reflect",
-  "version": "3.5.2",
-  "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings at SessionStart via hook. Philosophy: Correct once, never again; recall everything next time.",
+  "version": "3.6.0",
+  "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings via SessionStart/UserPromptSubmit hooks. PostToolUse arms low-cost mini-learning capture; Stop enqueues short-session reflection. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"
   },
@@ -18,6 +18,39 @@
             "type": "command",
             "command": "(nohup ${CLAUDE_PLUGIN_ROOT}/hooks/reflect-drain-bg.sh >/dev/null 2>&1 &) >/dev/null 2>&1",
             "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/skills/recall/hooks/user_prompt_submit_recall.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse_minilearning.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/stop_reflect.py"
           }
         ]
       }

--- a/plugins/reflect/adapters/codex/codex_adapter.py
+++ b/plugins/reflect/adapters/codex/codex_adapter.py
@@ -115,6 +115,16 @@ _DRAIN_HOOK_TEMPLATE = (
     "(nohup {home_tool_dir}/skills/reflect/hooks/"
     "reflect-drain-bg.sh >/dev/null 2>&1 &) >/dev/null 2>&1"
 )
+# Three new hooks added in 3.6.0 (matching plugin.json autowire).
+_USER_PROMPT_RECALL_TEMPLATE = (
+    "uv run {home_tool_dir}/skills/recall/hooks/user_prompt_submit_recall.py"
+)
+_POSTTOOLUSE_MINILEARNING_TEMPLATE = (
+    "uv run {home_tool_dir}/skills/reflect/hooks/posttooluse_minilearning.py"
+)
+_STOP_REFLECT_TEMPLATE = (
+    "uv run {home_tool_dir}/skills/reflect/hooks/stop_reflect.py"
+)
 
 
 def _render(template: str, codex_dir: Path) -> str:
@@ -133,6 +143,18 @@ def _render_drain_hook_command(codex_dir: Path) -> str:
     return _render(_DRAIN_HOOK_TEMPLATE, codex_dir)
 
 
+def _render_user_prompt_recall_command(codex_dir: Path) -> str:
+    return _render(_USER_PROMPT_RECALL_TEMPLATE, codex_dir)
+
+
+def _render_posttooluse_minilearning_command(codex_dir: Path) -> str:
+    return _render(_POSTTOOLUSE_MINILEARNING_TEMPLATE, codex_dir)
+
+
+def _render_stop_reflect_command(codex_dir: Path) -> str:
+    return _render(_STOP_REFLECT_TEMPLATE, codex_dir)
+
+
 # Legacy literals that older buggy installs may have persisted (template
 # placeholder never substituted). Match them on re-install / uninstall so
 # we self-heal.
@@ -143,6 +165,15 @@ _LEGACY_PRECOMPACT_HOOK_COMMAND = _PRECOMPACT_HOOK_TEMPLATE.replace(
     "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
 )
 _LEGACY_DRAIN_HOOK_COMMAND = _DRAIN_HOOK_TEMPLATE.replace(
+    "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
+)
+_LEGACY_USER_PROMPT_RECALL_COMMAND = _USER_PROMPT_RECALL_TEMPLATE.replace(
+    "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
+)
+_LEGACY_POSTTOOLUSE_MINILEARNING_COMMAND = _POSTTOOLUSE_MINILEARNING_TEMPLATE.replace(
+    "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
+)
+_LEGACY_STOP_REFLECT_COMMAND = _STOP_REFLECT_TEMPLATE.replace(
     "{home_tool_dir}", "{{HOME_TOOL_DIR}}"
 )
 
@@ -274,6 +305,15 @@ class CodexAdapter(AdapterBase):
             describe_extra.append(
                 f"hook: add PreCompact reflect entry to {hooks_path}"
             )
+            describe_extra.append(
+                f"hook: add UserPromptSubmit recall entry to {hooks_path}"
+            )
+            describe_extra.append(
+                f"hook: add PostToolUse mini-learning entry to {hooks_path}"
+            )
+            describe_extra.append(
+                f"hook: add Stop reflect-enqueue entry to {hooks_path}"
+            )
         plan.extras["describe_extra"] = describe_extra
 
     def execute_extra(
@@ -349,6 +389,18 @@ class CodexAdapter(AdapterBase):
             "PreCompact": [
                 _render_precompact_hook_command(codex_dir),
                 _LEGACY_PRECOMPACT_HOOK_COMMAND,
+            ],
+            "UserPromptSubmit": [
+                _render_user_prompt_recall_command(codex_dir),
+                _LEGACY_USER_PROMPT_RECALL_COMMAND,
+            ],
+            "PostToolUse": [
+                _render_posttooluse_minilearning_command(codex_dir),
+                _LEGACY_POSTTOOLUSE_MINILEARNING_COMMAND,
+            ],
+            "Stop": [
+                _render_stop_reflect_command(codex_dir),
+                _LEGACY_STOP_REFLECT_COMMAND,
             ],
         }
         changed = False
@@ -440,8 +492,42 @@ class CodexAdapter(AdapterBase):
             }],
             legacy_commands=[_LEGACY_PRECOMPACT_HOOK_COMMAND],
         )
+        # New in 3.6.0: UserPromptSubmit (prompt-aware recall + dedupe),
+        # PostToolUse (mini-learning arming), Stop (short-session reflect
+        # enqueue). All wired with the same merge mechanics so they
+        # preserve unrelated user hooks already in hooks.json.
+        changed_ups = merge_hook_commands(
+            current,
+            event="UserPromptSubmit",
+            commands=[{
+                "type": "command",
+                "command": _render_user_prompt_recall_command(codex_dir),
+            }],
+            legacy_commands=[_LEGACY_USER_PROMPT_RECALL_COMMAND],
+        )
+        changed_ptu = merge_hook_commands(
+            current,
+            event="PostToolUse",
+            commands=[{
+                "type": "command",
+                "command": _render_posttooluse_minilearning_command(codex_dir),
+            }],
+            legacy_commands=[_LEGACY_POSTTOOLUSE_MINILEARNING_COMMAND],
+        )
+        changed_stop = merge_hook_commands(
+            current,
+            event="Stop",
+            commands=[{
+                "type": "command",
+                "command": _render_stop_reflect_command(codex_dir),
+            }],
+            legacy_commands=[_LEGACY_STOP_REFLECT_COMMAND],
+        )
 
-        if changed_ss or changed_pc:
+        any_changed = any([
+            changed_ss, changed_pc, changed_ups, changed_ptu, changed_stop,
+        ])
+        if any_changed:
             hooks_path.parent.mkdir(parents=True, exist_ok=True)
             hooks_path.write_text(
                 json.dumps(current, indent=2, sort_keys=False) + "\n",
@@ -451,6 +537,12 @@ class CodexAdapter(AdapterBase):
                 actions.append(f"merged SessionStart reflect hooks into {hooks_path}")
             if changed_pc:
                 actions.append(f"merged PreCompact reflect hook into {hooks_path}")
+            if changed_ups:
+                actions.append(f"merged UserPromptSubmit recall hook into {hooks_path}")
+            if changed_ptu:
+                actions.append(f"merged PostToolUse mini-learning hook into {hooks_path}")
+            if changed_stop:
+                actions.append(f"merged Stop reflect-enqueue hook into {hooks_path}")
         else:
             actions.append(f"reflect hooks already present in {hooks_path}")
         return actions

--- a/plugins/reflect/adapters/tests/test_codex_adapter.py
+++ b/plugins/reflect/adapters/tests/test_codex_adapter.py
@@ -126,6 +126,101 @@ def test_install_writes_hooks_json_with_all_three_entries(tmp_path):
     assert "{home_tool_dir}" not in text
 
 
+def test_install_writes_new_hooks_for_3_6_0(tmp_path):
+    """3.6.0 adds UserPromptSubmit, PostToolUse, and Stop hooks.
+    Verify they all land in ~/.codex/hooks.json under the right events."""
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+
+    cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    codex_dir = tmp_path / ".codex"
+
+    ups_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["UserPromptSubmit"]
+        for h in entry["hooks"]
+    ]
+    ptu_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["PostToolUse"]
+        for h in entry["hooks"]
+    ]
+    stop_cmds = [
+        h["command"]
+        for entry in cfg["hooks"]["Stop"]
+        for h in entry["hooks"]
+    ]
+    assert codex_adapter._render_user_prompt_recall_command(codex_dir) in ups_cmds
+    assert codex_adapter._render_posttooluse_minilearning_command(codex_dir) in ptu_cmds
+    assert codex_adapter._render_stop_reflect_command(codex_dir) in stop_cmds
+
+
+def test_install_deploys_new_hook_scripts_on_disk(tmp_path):
+    """The three new hook script files must physically exist under
+    ~/.codex/skills/ — otherwise the hook commands in hooks.json
+    reference non-existent paths and the harness silently skips them."""
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+    codex_dir = tmp_path / ".codex"
+    expected = [
+        codex_dir / "skills" / "recall" / "hooks" / "user_prompt_submit_recall.py",
+        codex_dir / "skills" / "reflect" / "hooks" / "posttooluse_minilearning.py",
+        codex_dir / "skills" / "reflect" / "hooks" / "stop_reflect.py",
+    ]
+    for path in expected:
+        assert path.exists(), f"missing on disk: {path}"
+
+
+def test_uninstall_removes_new_hooks_too(tmp_path):
+    """Uninstall must strip all five reflect-managed events
+    (SessionStart, PreCompact, UserPromptSubmit, PostToolUse, Stop)."""
+    # Pre-seed with an unrelated entry under each event to verify it survives.
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "hooks.json").write_text(json.dumps({
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": "echo other-ups"}]}
+            ],
+            "PostToolUse": [
+                {"hooks": [{"type": "command", "command": "echo other-ptu"}]}
+            ],
+            "Stop": [
+                {"hooks": [{"type": "command", "command": "echo other-stop"}]}
+            ],
+        }
+    }))
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "install", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        [sys.executable, str(ADAPTER), "uninstall", "--home", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+
+    cfg = json.loads((codex_dir / "hooks.json").read_text())
+    # Map each event to (seeded-unrelated-cmd, reflect-render-fn)
+    spec = {
+        "UserPromptSubmit": ("echo other-ups", codex_adapter._render_user_prompt_recall_command),
+        "PostToolUse":      ("echo other-ptu", codex_adapter._render_posttooluse_minilearning_command),
+        "Stop":             ("echo other-stop", codex_adapter._render_stop_reflect_command),
+    }
+    for event, (other_cmd, render_fn) in spec.items():
+        cmds = [
+            h["command"]
+            for entry in cfg.get("hooks", {}).get(event, [])
+            for h in entry["hooks"]
+        ]
+        assert other_cmd in cmds, f"unrelated {event} hook lost! cmds={cmds}"
+        # Reflect entry should be gone
+        assert render_fn(codex_dir) not in cmds
+
+
 def test_install_no_hooks_flag_skips_hooks_json(tmp_path):
     subprocess.run(
         [sys.executable, str(ADAPTER), "install",

--- a/plugins/reflect/hooks/posttooluse_minilearning.py
+++ b/plugins/reflect/hooks/posttooluse_minilearning.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+PostToolUse Mini-Learning Arming Hook.
+
+Fires after every tool call. If the tool FAILED (non-zero exit, error
+status, etc), arm a watcher at ``~/.reflect/armed/<session_id>.json``.
+The next UserPromptSubmit hook reads this file — if the user's prompt
+looks like a correction (``try X instead``, ``no, use Y``, …), it writes
+a low-confidence mini-learning to disk without spending an LLM call.
+
+Two-phase capture means we don't pay for /reflect on the dozens of
+tool failures that DON'T have an obvious correction follow-up.
+
+Usage in hooks config:
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "uv run <HOME_TOOL_DIR>/hooks/posttooluse_minilearning.py"
+      }]
+    }]
+  }
+}
+
+Output: ALWAYS empty stdout. Codex has ``PostToolUseHookSpecificOutputWire``
+in its schema but our use case has no useful response to inject — we only
+want the side-effect (armed file). Empty stdout = success in both
+harnesses.
+
+Exit behavior: always 0. Silent-fail wrapped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+# Shared silent-fail mechanics.
+_HOOK_NAME = "posttooluse_minilearning"
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]  # hooks/<this> → plugins/reflect/
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+try:
+    from silent_fail import write_last_event, forensics_log, scrub_secrets  # noqa: E402
+except ImportError:
+    def write_last_event(**kwargs):  # type: ignore[no-redef]
+        pass
+    def forensics_log(*args, **kwargs):  # type: ignore[no-redef]
+        pass
+    def scrub_secrets(text):  # type: ignore[no-redef]
+        return text
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect")))
+
+
+def armed_path(session_id: str) -> Path:
+    return state_dir() / "armed" / f"{session_id}.json"
+
+
+def tool_failed(tool_response: dict, tool_name: str) -> bool:
+    """Best-effort detector for tool failure.
+
+    Both Claude and Codex send the tool_response on PostToolUse but the
+    shape differs slightly. We look for the most common failure markers:
+
+      * Non-zero ``exit_code`` / ``exitCode`` / ``returncode``
+      * ``is_error`` / ``isError`` truthy
+      * ``stderr`` non-empty (heuristic — many tools write warnings here
+        too, so we ONLY use this as a tiebreaker when exit_code is absent)
+      * ``error`` field present and truthy
+
+    The detector is intentionally conservative — false positives arm
+    a watcher that does nothing (the next prompt either looks like a
+    correction or doesn't), so over-arming is cheap.
+    """
+    if not isinstance(tool_response, dict):
+        return False
+
+    for k in ("exit_code", "exitCode", "returncode"):
+        v = tool_response.get(k)
+        if isinstance(v, int) and v != 0:
+            return True
+
+    for k in ("is_error", "isError"):
+        if tool_response.get(k):
+            return True
+
+    err = tool_response.get("error")
+    if err and not (isinstance(err, str) and err.strip() == ""):
+        return True
+
+    # Bash-specific: if stdout is empty but stderr has content AND
+    # there's no exit_code field, treat stderr as a failure signal.
+    # Conservative: skip for read-only tools where stderr is just info.
+    if tool_name and tool_name.lower() in ("bash", "shell", "execute"):
+        if not tool_response.get("stdout") and tool_response.get("stderr"):
+            return True
+
+    return False
+
+
+def _main_body() -> None:
+    raw = ""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        pass
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        data = {}
+
+    session_id = str(data.get("session_id", "") or "").strip()
+    if not session_id:
+        return  # Nothing to arm — no session_id to key against.
+
+    tool_name = str(data.get("tool", "") or data.get("tool_name", "") or "")
+    tool_input = data.get("tool_input", "")
+    tool_response = data.get("tool_response", data.get("response", {}))
+
+    if not tool_failed(tool_response, tool_name):
+        return  # Successful tool calls don't arm.
+
+    # Write armed file. Truncate large payloads — only need enough for
+    # the mini-learning context, not full transcripts.
+    try:
+        path = armed_path(session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "tool": tool_name,
+            "tool_input": scrub_secrets(str(tool_input)[:500]),
+            "tool_response": scrub_secrets(json.dumps(tool_response)[:500]),
+            "ts": time.time(),
+        }
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(path)
+        forensics_log(_HOOK_NAME, f"armed for session={session_id[:8]} tool={tool_name}")
+    except Exception:
+        # If even the armed write fails, we silently move on.
+        pass
+
+
+def main() -> None:
+    try:
+        _main_body()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001
+        detail = str(exc) or traceback.format_exc(limit=2)
+        write_last_event(
+            hook_name=_HOOK_NAME,
+            event="error",
+            kind=type(exc).__name__,
+            detail=detail,
+        )
+        forensics_log(_HOOK_NAME, f"{type(exc).__name__}: {detail}")
+    # Always exit 0 with empty stdout regardless of success / failure.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/reflect/hooks/stop_reflect.py
+++ b/plugins/reflect/hooks/stop_reflect.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+Stop Reflection Enqueue Hook.
+
+Fires when the agent finishes a turn. Enqueues the transcript for
+asynchronous reflection — same queue as ``precompact_reflect.py``,
+but for short sessions that ended before PreCompact ever fired.
+
+Dedupe vs PreCompact
+--------------------
+
+Long sessions hit PreCompact first (context fills up) → that hook
+enqueues. Then Stop fires too. Without dedupe, we'd enqueue the same
+session twice and the drainer would burn LLM calls processing it
+twice. So we scan ``pending_reflections.jsonl`` first and skip if any
+existing entry shares this ``session_id``.
+
+Usage in hooks config:
+{
+  "hooks": {
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "uv run <HOME_TOOL_DIR>/hooks/stop_reflect.py"
+      }]
+    }]
+  }
+}
+
+Output: ALWAYS empty stdout. Codex 0.131 has no ``StopHookSpecificOutputWire``
+(same lesson as PreCompact — see plugins/reflect/.claude-plugin/plugin.json
+PR #151). Empty stdout = success in both harnesses.
+
+Exit behavior: always 0. Silent-fail wrapped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+
+# Shared silent-fail mechanics.
+_HOOK_NAME = "stop_reflect"
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]  # hooks/<this> → plugins/reflect/
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+try:
+    from silent_fail import write_last_event, forensics_log  # noqa: E402
+except ImportError:
+    def write_last_event(**kwargs):  # type: ignore[no-redef]
+        pass
+    def forensics_log(*args, **kwargs):  # type: ignore[no-redef]
+        pass
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect")))
+
+
+def queue_file() -> Path:
+    return state_dir() / "pending_reflections.jsonl"
+
+
+def session_already_queued(qfile: Path, session_id: str) -> bool:
+    """Scan the JSONL queue for any existing entry with this session_id.
+
+    Returns ``True`` if found, ``False`` otherwise (or on any read error
+    — better to enqueue twice than to skip silently).
+    """
+    if not session_id or not qfile.exists():
+        return False
+    try:
+        with open(qfile, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if e.get("session_id") == session_id:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def _main_body() -> None:
+    raw = ""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        pass
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        data = {}
+
+    session_id = str(data.get("session_id", "") or "").strip()
+    transcript_path = str(data.get("transcript_path", "") or "").strip()
+
+    if not transcript_path:
+        # Nothing useful to queue without a transcript path.
+        return
+
+    qf = queue_file()
+    if session_already_queued(qf, session_id):
+        forensics_log(_HOOK_NAME, f"skip (already queued by PreCompact): session={session_id[:8]}")
+        return
+
+    try:
+        qf.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "ts": datetime.now().isoformat(),
+            "session_id": session_id or "unknown",
+            "transcript_path": transcript_path,
+            "trigger": "stop",
+            "cwd": data.get("cwd", os.getcwd()),
+        }
+        # Append, not atomic — JSONL queue is append-only and the
+        # drainer tolerates partial lines.
+        with open(qf, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        forensics_log(_HOOK_NAME, f"enqueued: session={session_id[:8]}")
+    except OSError:
+        pass
+
+
+def main() -> None:
+    try:
+        _main_body()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001
+        detail = str(exc) or traceback.format_exc(limit=2)
+        write_last_event(
+            hook_name=_HOOK_NAME,
+            event="error",
+            kind=type(exc).__name__,
+            detail=detail,
+        )
+        forensics_log(_HOOK_NAME, f"{type(exc).__name__}: {detail}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/reflect/hooks/stop_reflect.py
+++ b/plugins/reflect/hooks/stop_reflect.py
@@ -76,6 +76,11 @@ def session_already_queued(qfile: Path, session_id: str) -> bool:
 
     Returns ``True`` if found, ``False`` otherwise (or on any read error
     — better to enqueue twice than to skip silently).
+
+    The scan is linear but bounded: ``reflect-drain-bg.sh`` caps the
+    queue at ``REFLECT_DRAIN_DAILY_MAX`` (default 20) entries before
+    flushing, so worst-case this reads 20 short JSONL lines — fine for
+    a hook that runs once per agent finish.
     """
     if not session_id or not qfile.exists():
         return False

--- a/plugins/reflect/skills/recall/hooks/user_prompt_submit_recall.py
+++ b/plugins/reflect/skills/recall/hooks/user_prompt_submit_recall.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+UserPromptSubmit Recall Hook (Phase 3 of reflect retrieval).
+
+Fires on every UserPromptSubmit. Uses the user's actual prompt as the
+GraphRAG query — much sharper than SessionStart's cwd/branch heuristic —
+and injects new (not-already-injected) top-N learnings as
+``additionalContext``.
+
+Companion to ``session_start_recall.py``:
+
+  * SessionStart fires BEFORE the user has typed anything; query has to
+    be inferred from cwd, branch, recent commits. Coarse but immediate.
+  * UserPromptSubmit has the actual prompt to query against; sharp hits.
+    Per-session dedupe (``~/.reflect/session-injected/<sid>.json``)
+    prevents re-injecting the same learning on every prompt.
+
+This hook ALSO handles the second half of the PostToolUse mini-learning
+capture: if the PostToolUse hook armed a watcher
+(``~/.reflect/armed/<sid>.json``) and the current prompt looks like a
+correction, write a low-confidence learning directly to disk WITHOUT
+calling /reflect, then clear the armed state.
+
+Usage in hooks config (Claude plugin.json or Codex hooks.json):
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "uv run <HOME_TOOL_DIR>/skills/recall/hooks/user_prompt_submit_recall.py"
+      }]
+    }]
+  }
+}
+
+Exit behavior: always exits 0 with possibly-empty hookSpecificOutput.
+On any uncaught exception, falls through to empty inject + breadcrumb.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import NoReturn
+
+
+# Shared silent-fail mechanics.
+_HOOK_NAME = "user_prompt_submit_recall"
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]  # skills/recall/hooks/<this> → plugins/reflect/
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+try:
+    from silent_fail import write_last_event, forensics_log, scrub_secrets  # noqa: E402
+except ImportError:
+    def write_last_event(**kwargs):  # type: ignore[no-redef]
+        pass
+    def forensics_log(*args, **kwargs):  # type: ignore[no-redef]
+        pass
+    def scrub_secrets(text):  # type: ignore[no-redef]
+        return text
+
+
+# --- Tunables ------------------------------------------------------------
+
+# Per-prompt recall is tighter than SessionStart baseline. SessionStart
+# injects 3 broad learnings; we inject up to 3 prompt-sharp ones but
+# dedupe against the session-injected set.
+USER_PROMPT_LIMIT = 3
+USER_PROMPT_CONFIDENCE = "ANY"
+USER_PROMPT_MAX_CHARS = 1500
+
+# Minimum prompt length to bother querying — anything shorter is too
+# noisy to give useful hits and would inject random learnings on every
+# "hi" / "ok" / "next".
+MIN_PROMPT_CHARS = 12
+
+
+# --- Paths (resolved per-call to honor REFLECT_STATE_DIR at runtime) -----
+
+def state_dir() -> Path:
+    return Path(os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect")))
+
+
+def session_injected_path(session_id: str) -> Path:
+    return state_dir() / "session-injected" / f"{session_id}.json"
+
+
+def armed_path(session_id: str) -> Path:
+    return state_dir() / "armed" / f"{session_id}.json"
+
+
+def learnings_dir() -> Path:
+    """Where mini-learnings get written. Honors REFLECT_LEARNINGS_DIR
+    override; defaults to ~/.learnings/documents/."""
+    custom = os.environ.get("REFLECT_LEARNINGS_DIR")
+    if custom:
+        return Path(custom).expanduser()
+    return Path.home() / ".learnings" / "documents"
+
+
+# --- Mini-learning correction detection ---------------------------------
+
+# Patterns that suggest the user is correcting a failed approach. Tuned
+# to be conservative — false positives produce noise learnings, so we
+# require an explicit corrective verb. ``\S+`` (not ``\w+``) so flag-like
+# tokens such as ``--insecure`` are matched naturally.
+_CORRECTION_PATTERNS = [
+    re.compile(r"(?i)\b(?:try|use|do)\s+\S+(?:\s+\S+)*?\s+(?:instead|rather)\b"),
+    re.compile(r"(?i)\b(?:no|don't|do not),?\s+(?:use|try|do)\b"),
+    re.compile(r"(?i)\b(?:should have|shouldn't have|must use|need to use)\b"),
+    re.compile(r"(?i)\binstead\s+of\s+\S+,?\s+(?:use|try|do)\b"),
+]
+
+
+def looks_like_correction(prompt: str) -> bool:
+    return any(p.search(prompt) for p in _CORRECTION_PATTERNS)
+
+
+# --- Dedupe state --------------------------------------------------------
+
+def load_session_injected(session_id: str) -> set[str]:
+    """Per-session set of learning IDs already injected. Returns empty
+    set on missing/corrupt file (best-effort, never raises)."""
+    if not session_id:
+        return set()
+    p = session_injected_path(session_id)
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        ids = data.get("injected", [])
+        return set(ids) if isinstance(ids, list) else set()
+    except (FileNotFoundError, OSError, json.JSONDecodeError, ValueError):
+        return set()
+
+
+def save_session_injected(session_id: str, injected: set[str]) -> None:
+    """Atomic write of the dedupe set. Best-effort; never raises."""
+    if not session_id:
+        return
+    try:
+        p = session_injected_path(session_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"injected": sorted(injected), "ts": time.time()}
+        tmp = p.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(p)
+    except Exception:
+        pass
+
+
+# --- recall.py invocation (mirrors session_start_recall.py) -------------
+
+UV_BIN = shutil.which("uv")
+
+
+def find_recall_script() -> Path | None:
+    here = Path(__file__).resolve().parent
+    candidates = [
+        here.parent / "scripts" / "recall.py",
+        here / "recall.py",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def query_recall(query: str) -> tuple[str, list[str]]:
+    """Run the recall script with the prompt as query.
+
+    Returns ``(markdown_output, learning_ids)``. On any failure, returns
+    ``("", [])`` — silent.
+
+    The recall script emits markdown with learning IDs in ``[lrn-...]``
+    style brackets; we extract those for the dedupe set. If we ever
+    can't parse the IDs we still inject the markdown — better to
+    re-inject a learning than skip recall entirely.
+    """
+    recall = find_recall_script()
+    if not recall or not UV_BIN:
+        return "", []
+    try:
+        r = subprocess.run(
+            [
+                UV_BIN, "run", "--quiet", str(recall),
+                query,
+                "--limit", str(USER_PROMPT_LIMIT * 3),  # over-fetch; dedupe filters
+                "--confidence", USER_PROMPT_CONFIDENCE,
+                "--format", "markdown",
+                "--max-chars", str(USER_PROMPT_MAX_CHARS * 2),
+                "--tags", "",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return "", []
+    if r.returncode != 0:
+        return "", []
+    output = (r.stdout or "").strip()
+    ids = re.findall(r"\[lrn-[a-z0-9\-]+\]", output)
+    return output, ids
+
+
+def filter_to_new(markdown: str, ids: list[str], already_injected: set[str]) -> tuple[str, list[str]]:
+    """Strip out blocks corresponding to already-injected learning IDs.
+
+    The markdown is a list of bullets (one per learning). We split on
+    line boundaries and keep blocks whose ID is NOT in ``already_injected``.
+    Returns ``(filtered_markdown, new_ids)``.
+    """
+    if not markdown:
+        return "", []
+    lines = markdown.split("\n")
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        # New bullet starts a new block (top-level "- " line).
+        if line.startswith("- ") and current:
+            blocks.append(current)
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        blocks.append(current)
+
+    kept_blocks = []
+    kept_ids = []
+    for block in blocks:
+        block_text = "\n".join(block)
+        ids_in_block = re.findall(r"\[(lrn-[a-z0-9\-]+)\]", block_text)
+        if any(f"[{i}]" in block_text or i in [b.strip("[]") for b in ids] for i in ids_in_block):
+            pass  # carry on
+        is_new = not any(i in already_injected for i in ids_in_block)
+        if is_new:
+            kept_blocks.append(block_text)
+            kept_ids.extend(ids_in_block)
+        if len(kept_blocks) >= USER_PROMPT_LIMIT:
+            break
+    return "\n".join(kept_blocks), kept_ids[:USER_PROMPT_LIMIT]
+
+
+# --- Mini-learning capture (Phase 2 of PostToolUse arming) ---------------
+
+def maybe_capture_minilearning(session_id: str, prompt: str) -> bool:
+    """If PostToolUse armed a watcher for this session and the current
+    prompt looks like a correction, write a low-confidence learning to
+    disk and clear the armed state.
+
+    Returns ``True`` iff a learning was written. Best-effort; swallows
+    all errors (silent-fail).
+    """
+    if not session_id:
+        return False
+    armed = armed_path(session_id)
+    if not armed.exists():
+        return False
+    try:
+        armed_data = json.loads(armed.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # Clear the broken armed file so it doesn't linger.
+        try:
+            armed.unlink()
+        except OSError:
+            pass
+        return False
+
+    if not looks_like_correction(prompt):
+        # Not a correction — leave the armed state in place for a few
+        # minutes in case the NEXT prompt is the correction. We add a
+        # max-age check below.
+        try:
+            armed_age = time.time() - float(armed_data.get("ts", 0))
+            if armed_age > 600:  # 10 minutes
+                armed.unlink()
+        except (OSError, ValueError):
+            pass
+        return False
+
+    # Write the mini-learning.
+    try:
+        ld = learnings_dir()
+        ld.mkdir(parents=True, exist_ok=True)
+        ts = int(time.time())
+        slug = f"lrn-mini-{ts}-{session_id[:8]}"
+        path = ld / f"{slug}.md"
+        tool = armed_data.get("tool", "unknown")
+        tool_input = scrub_secrets(str(armed_data.get("tool_input", ""))[:200])
+        tool_response = scrub_secrets(str(armed_data.get("tool_response", ""))[:200])
+        body = (
+            f"---\n"
+            f"id: {slug}\n"
+            f"confidence: low\n"
+            f"source: posttooluse-minilearning\n"
+            f"session_id: {session_id}\n"
+            f"captured_at: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
+            f"---\n\n"
+            f"# Mini-learning: {tool} correction\n\n"
+            f"**Failed tool call**: `{tool}`\n\n"
+            f"Input (truncated): `{tool_input}`\n\n"
+            f"Response (truncated): `{tool_response}`\n\n"
+            f"**User correction**: {scrub_secrets(prompt[:500])}\n\n"
+            f"_Auto-captured by the PostToolUse + UserPromptSubmit watcher. "
+            f"Confidence is `low` — review before relying on it._\n"
+        )
+        path.write_text(body, encoding="utf-8")
+        forensics_log(_HOOK_NAME, f"mini-learning captured: {slug}")
+    except Exception:
+        return False
+
+    # Clear armed state (single shot).
+    try:
+        armed.unlink()
+    except OSError:
+        pass
+    return True
+
+
+# --- Output --------------------------------------------------------------
+
+def emit(additional_context: str) -> NoReturn:
+    """Always exit 0 with valid JSON for the UserPromptSubmit event."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": additional_context,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+def _main_body() -> NoReturn:
+    raw = ""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        pass
+
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        data = {}
+
+    session_id = str(data.get("session_id", "") or "").strip()
+    prompt = str(data.get("prompt", "") or "").strip()
+
+    # If we can capture a mini-learning, do it BEFORE recall — the
+    # captured learning won't be in the index yet but the act of
+    # writing it is the side-effect we care about.
+    if session_id and prompt:
+        maybe_capture_minilearning(session_id, prompt)
+
+    if len(prompt) < MIN_PROMPT_CHARS:
+        emit("")
+
+    # Query recall with the prompt itself.
+    markdown, _ids = query_recall(prompt)
+    if not markdown:
+        emit("")
+
+    already = load_session_injected(session_id)
+    filtered, new_ids = filter_to_new(markdown, _ids, already)
+    if not filtered:
+        emit("")
+
+    # Persist the new IDs so future prompts in this session don't
+    # re-inject the same learnings.
+    if session_id and new_ids:
+        save_session_injected(session_id, already | set(new_ids))
+
+    # Truncate to the per-prompt char budget (filter_to_new uses block
+    # boundaries; this is a hard upper bound).
+    if len(filtered) > USER_PROMPT_MAX_CHARS:
+        filtered = filtered[:USER_PROMPT_MAX_CHARS].rstrip() + " …"
+
+    emit(filtered)
+
+
+def main() -> NoReturn:
+    """Top-level entry. Silent-fail wrapper — any uncaught exception
+    becomes an empty inject + a breadcrumb on ~/.reflect/last-event.json."""
+    try:
+        _main_body()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — deliberately broadest catch
+        detail = str(exc) or traceback.format_exc(limit=2)
+        write_last_event(
+            hook_name=_HOOK_NAME,
+            event="error",
+            kind=type(exc).__name__,
+            detail=detail,
+        )
+        forensics_log(_HOOK_NAME, f"{type(exc).__name__}: {detail}")
+        try:
+            sys.stdout.write(
+                '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit",'
+                '"additionalContext":""}}\n'
+            )
+            sys.stdout.flush()
+        except Exception:
+            pass
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/reflect/skills/recall/hooks/user_prompt_submit_recall.py
+++ b/plugins/reflect/skills/recall/hooks/user_prompt_submit_recall.py
@@ -214,19 +214,19 @@ def query_recall(query: str) -> tuple[str, list[str]]:
     return output, ids
 
 
-def filter_to_new(markdown: str, ids: list[str], already_injected: set[str]) -> tuple[str, list[str]]:
+def filter_to_new(markdown: str, already_injected: set[str]) -> tuple[str, list[str]]:
     """Strip out blocks corresponding to already-injected learning IDs.
 
-    The markdown is a list of bullets (one per learning). We split on
-    line boundaries and keep blocks whose ID is NOT in ``already_injected``.
-    Returns ``(filtered_markdown, new_ids)``.
+    The recall script emits markdown as a flat list of bullets (one per
+    learning). We split on top-level ``"- "`` lines and keep blocks whose
+    ``[lrn-...]`` ID is NOT in ``already_injected``. Returns
+    ``(filtered_markdown, new_ids)``.
     """
     if not markdown:
         return "", []
-    lines = markdown.split("\n")
     blocks: list[list[str]] = []
     current: list[str] = []
-    for line in lines:
+    for line in markdown.split("\n"):
         # New bullet starts a new block (top-level "- " line).
         if line.startswith("- ") and current:
             blocks.append(current)
@@ -236,17 +236,15 @@ def filter_to_new(markdown: str, ids: list[str], already_injected: set[str]) -> 
     if current:
         blocks.append(current)
 
-    kept_blocks = []
-    kept_ids = []
+    kept_blocks: list[str] = []
+    kept_ids: list[str] = []
     for block in blocks:
         block_text = "\n".join(block)
         ids_in_block = re.findall(r"\[(lrn-[a-z0-9\-]+)\]", block_text)
-        if any(f"[{i}]" in block_text or i in [b.strip("[]") for b in ids] for i in ids_in_block):
-            pass  # carry on
-        is_new = not any(i in already_injected for i in ids_in_block)
-        if is_new:
-            kept_blocks.append(block_text)
-            kept_ids.extend(ids_in_block)
+        if any(i in already_injected for i in ids_in_block):
+            continue  # already injected this session — skip
+        kept_blocks.append(block_text)
+        kept_ids.extend(ids_in_block)
         if len(kept_blocks) >= USER_PROMPT_LIMIT:
             break
     return "\n".join(kept_blocks), kept_ids[:USER_PROMPT_LIMIT]
@@ -370,12 +368,12 @@ def _main_body() -> NoReturn:
         emit("")
 
     # Query recall with the prompt itself.
-    markdown, _ids = query_recall(prompt)
+    markdown, _ = query_recall(prompt)
     if not markdown:
         emit("")
 
     already = load_session_injected(session_id)
-    filtered, new_ids = filter_to_new(markdown, _ids, already)
+    filtered, new_ids = filter_to_new(markdown, already)
     if not filtered:
         emit("")
 

--- a/plugins/reflect/tests/test_new_hooks.py
+++ b/plugins/reflect/tests/test_new_hooks.py
@@ -1,0 +1,311 @@
+"""Behavior tests for the three new hooks shipped in 3.6.0.
+
+  * user_prompt_submit_recall.py — prompt-aware recall + per-session
+    dedupe + inline mini-learning capture from armed state
+  * posttooluse_minilearning.py — arms watcher on tool failure
+  * stop_reflect.py — enqueue transcript on agent finish; dedupe vs
+    PreCompact entries already in the queue
+
+Silent-fail invariants are covered separately in test_hooks_silent_fail
+— this file focuses on the new hooks' BEHAVIOR (what they write, what
+they dedupe, what they skip).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+PLUGIN_ROOT = HERE.parent
+USER_PROMPT_HOOK = PLUGIN_ROOT / "skills" / "recall" / "hooks" / "user_prompt_submit_recall.py"
+POSTTOOLUSE_HOOK = PLUGIN_ROOT / "hooks" / "posttooluse_minilearning.py"
+STOP_HOOK = PLUGIN_ROOT / "hooks" / "stop_reflect.py"
+
+
+def _run(hook: Path, stdin: str, state_dir: Path, *, extra_env=None) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "REFLECT_STATE_DIR": str(state_dir)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(hook)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=20,
+    )
+
+
+# --- PostToolUse arming -----------------------------------------------------
+
+
+def test_posttooluse_skips_when_tool_succeeded(tmp_path):
+    """No armed file should be written when the tool exited cleanly."""
+    payload = json.dumps({
+        "session_id": "sess-ok",
+        "tool": "Bash",
+        "tool_input": "ls",
+        "tool_response": {"exit_code": 0, "stdout": "file1\n", "stderr": ""},
+    })
+    result = _run(POSTTOOLUSE_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""  # side-effect only
+    assert not (tmp_path / "armed" / "sess-ok.json").exists()
+
+
+def test_posttooluse_arms_on_nonzero_exit(tmp_path):
+    """Bash exit≠0 should arm the watcher."""
+    payload = json.dumps({
+        "session_id": "sess-fail",
+        "tool": "Bash",
+        "tool_input": "curl https://bad.example",
+        "tool_response": {"exit_code": 7, "stderr": "Could not resolve host"},
+    })
+    result = _run(POSTTOOLUSE_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+    armed = tmp_path / "armed" / "sess-fail.json"
+    assert armed.exists()
+    data = json.loads(armed.read_text())
+    assert data["tool"] == "Bash"
+    assert "curl" in data["tool_input"]
+    assert isinstance(data["ts"], (int, float))
+
+
+def test_posttooluse_arms_on_is_error_flag(tmp_path):
+    """``is_error: true`` should also count as failure."""
+    payload = json.dumps({
+        "session_id": "sess-err",
+        "tool": "Edit",
+        "tool_response": {"is_error": True, "error": "File not found"},
+    })
+    _run(POSTTOOLUSE_HOOK, payload, tmp_path)
+    assert (tmp_path / "armed" / "sess-err.json").exists()
+
+
+def test_posttooluse_no_session_id_is_noop(tmp_path):
+    """Without a session_id we have no key to arm against — skip."""
+    payload = json.dumps({"tool": "Bash", "tool_response": {"exit_code": 1}})
+    result = _run(POSTTOOLUSE_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert not (tmp_path / "armed").exists()
+
+
+def test_posttooluse_empty_stdout_always(tmp_path):
+    """PostToolUse is side-effect only. Verify stdout is always empty
+    regardless of input shape — codex schema sensitivity."""
+    for payload in [
+        "{}",
+        '{"session_id":"x","tool_response":{}}',
+        '{"session_id":"x","tool_response":{"exit_code":1}}',
+        "not json at all",
+    ]:
+        result = _run(POSTTOOLUSE_HOOK, payload, tmp_path)
+        assert result.returncode == 0
+        assert result.stdout == "", f"stdout pollution on payload={payload!r}: {result.stdout!r}"
+
+
+# --- Stop reflection enqueue -----------------------------------------------
+
+
+def test_stop_enqueues_transcript(tmp_path):
+    payload = json.dumps({
+        "session_id": "sess-1",
+        "transcript_path": "/tmp/transcript-1.jsonl",
+        "cwd": "/some/project",
+    })
+    result = _run(STOP_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+    queue = tmp_path / "pending_reflections.jsonl"
+    assert queue.exists()
+    lines = [l for l in queue.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["session_id"] == "sess-1"
+    assert entry["transcript_path"] == "/tmp/transcript-1.jsonl"
+    assert entry["trigger"] == "stop"
+
+
+def test_stop_dedupes_against_precompact_entry(tmp_path):
+    """If PreCompact already enqueued this session, Stop must skip
+    (don't re-enqueue the same session for double drain cost)."""
+    queue = tmp_path / "pending_reflections.jsonl"
+    queue.write_text(json.dumps({
+        "ts": "2026-05-21T10:00:00",
+        "session_id": "long-session",
+        "transcript_path": "/tmp/transcript-long.jsonl",
+        "trigger": "auto",  # PreCompact-style entry
+    }) + "\n")
+
+    payload = json.dumps({
+        "session_id": "long-session",
+        "transcript_path": "/tmp/transcript-long.jsonl",
+    })
+    result = _run(STOP_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+
+    lines = [l for l in queue.read_text().splitlines() if l.strip()]
+    # Still exactly ONE entry — Stop dedupe'd.
+    assert len(lines) == 1
+
+
+def test_stop_enqueues_when_different_session(tmp_path):
+    """Existing queue entry for a DIFFERENT session shouldn't block."""
+    queue = tmp_path / "pending_reflections.jsonl"
+    queue.write_text(json.dumps({
+        "session_id": "other-session",
+        "transcript_path": "/tmp/other.jsonl",
+        "trigger": "auto",
+    }) + "\n")
+
+    payload = json.dumps({
+        "session_id": "new-session",
+        "transcript_path": "/tmp/new.jsonl",
+    })
+    _run(STOP_HOOK, payload, tmp_path)
+
+    lines = [l for l in queue.read_text().splitlines() if l.strip()]
+    assert len(lines) == 2
+
+
+def test_stop_no_transcript_path_skips(tmp_path):
+    payload = json.dumps({"session_id": "sess"})  # no transcript_path
+    result = _run(STOP_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    assert not (tmp_path / "pending_reflections.jsonl").exists()
+
+
+def test_stop_empty_stdout_always(tmp_path):
+    """Stop schema in codex has no HookSpecificOutputWire — empty stdout required."""
+    for payload in [
+        "{}",
+        '{"session_id":"x"}',
+        '{"session_id":"x","transcript_path":"/tmp/y"}',
+        "garbage",
+    ]:
+        result = _run(STOP_HOOK, payload, tmp_path)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+
+# --- UserPromptSubmit recall + dedupe + mini-learning -----------------------
+
+
+def test_user_prompt_recall_emits_valid_json(tmp_path):
+    """Even with no learnings available, output must be valid JSON
+    with hookEventName=UserPromptSubmit."""
+    payload = json.dumps({
+        "session_id": "sess-1",
+        "prompt": "help me debug this OAuth bug in production",
+    })
+    result = _run(USER_PROMPT_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    obj = json.loads(result.stdout.strip() or "{}")
+    assert obj["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    # additionalContext can be empty (no graphrag in test env) — that's fine.
+    assert "additionalContext" in obj["hookSpecificOutput"]
+
+
+def test_user_prompt_recall_skips_short_prompts(tmp_path):
+    """Prompts shorter than MIN_PROMPT_CHARS should inject empty
+    context — too noisy to query graphrag on."""
+    payload = json.dumps({"session_id": "s", "prompt": "hi"})
+    result = _run(USER_PROMPT_HOOK, payload, tmp_path)
+    assert result.returncode == 0
+    obj = json.loads(result.stdout.strip())
+    assert obj["hookSpecificOutput"]["additionalContext"] == ""
+
+
+def test_user_prompt_recall_captures_mini_learning_on_correction(tmp_path):
+    """Armed state + correction-pattern prompt → mini-learning written to disk."""
+    # Pre-arm the watcher (PostToolUse would normally do this).
+    armed = tmp_path / "armed" / "sess-correct.json"
+    armed.parent.mkdir(parents=True, exist_ok=True)
+    armed.write_text(json.dumps({
+        "tool": "Bash",
+        "tool_input": "curl https://api.example.com",
+        "tool_response": '{"exit_code":1,"stderr":"401 Unauthorized"}',
+        "ts": 1779456000.0,  # ~now
+    }))
+
+    learnings_dir = tmp_path / "learnings-out"
+    payload = json.dumps({
+        "session_id": "sess-correct",
+        "prompt": "try --insecure instead, this is local dev",
+    })
+    result = _run(
+        USER_PROMPT_HOOK, payload, tmp_path,
+        extra_env={"REFLECT_LEARNINGS_DIR": str(learnings_dir)},
+    )
+    assert result.returncode == 0
+
+    # Armed file should be cleared (single-shot).
+    assert not armed.exists()
+
+    # Mini-learning written.
+    files = list(learnings_dir.glob("lrn-mini-*-sess-cor*.md"))
+    assert len(files) == 1
+    body = files[0].read_text()
+    assert "confidence: low" in body
+    assert "Bash" in body
+    assert "--insecure" in body  # the user's correction text appears
+
+
+def test_user_prompt_recall_clears_old_armed_state(tmp_path):
+    """Armed state older than 10 min must be cleared even on a
+    non-correction prompt — avoids stale arms firing later."""
+    armed = tmp_path / "armed" / "sess-stale.json"
+    armed.parent.mkdir(parents=True, exist_ok=True)
+    armed.write_text(json.dumps({
+        "tool": "Bash",
+        "ts": 1.0,  # ancient
+    }))
+
+    payload = json.dumps({
+        "session_id": "sess-stale",
+        "prompt": "just keep going, no correction here",
+    })
+    _run(USER_PROMPT_HOOK, payload, tmp_path)
+    assert not armed.exists()
+
+
+def test_user_prompt_recall_keeps_recent_armed_state_on_non_correction(tmp_path):
+    """Fresh armed state with a non-correction prompt should be PRESERVED
+    so the NEXT prompt has a chance to trigger the mini-learning."""
+    import time as _t
+    armed = tmp_path / "armed" / "sess-keep.json"
+    armed.parent.mkdir(parents=True, exist_ok=True)
+    armed.write_text(json.dumps({
+        "tool": "Bash",
+        "ts": _t.time(),  # fresh
+    }))
+
+    payload = json.dumps({
+        "session_id": "sess-keep",
+        "prompt": "ok let me look at the logs",  # not a correction
+    })
+    _run(USER_PROMPT_HOOK, payload, tmp_path)
+    assert armed.exists()  # preserved for next prompt
+
+
+def test_user_prompt_recall_writes_dedupe_state_only_on_real_inject(tmp_path):
+    """If no recall hits (no graphrag in test env), dedupe state must
+    NOT be written — an empty session-injected file would prevent
+    legitimate first-time injections after the index is populated."""
+    payload = json.dumps({
+        "session_id": "sess-nohits",
+        "prompt": "longer prompt that meets the minimum char floor here",
+    })
+    _run(USER_PROMPT_HOOK, payload, tmp_path)
+    # No graphrag → no hits → no state file written.
+    assert not (tmp_path / "session-injected" / "sess-nohits.json").exists()


### PR DESCRIPTION
## Summary

Lands the three hooks I scoped out of PR #149 off-script (apologies again for that). Closes tasks #5, #6, #7, #9.

| Hook | Event | Purpose |
|---|---|---|
| \`user_prompt_submit_recall.py\` | UserPromptSubmit | Prompt-aware recall (vs SessionStart's cwd-only query) + per-session dedupe + inline mini-learning capture when PostToolUse-armed |
| \`posttooluse_minilearning.py\` | PostToolUse | On tool failure, arm a watcher at \`~/.reflect/armed/<sid>.json\` |
| \`stop_reflect.py\` | Stop | Enqueue transcript for short sessions that never hit PreCompact; dedupe by session_id |

All three wrap in the shared \`silent_fail\` helper — any uncaught exception writes a breadcrumb to \`~/.reflect/last-event.json\` and exits 0 silently.

## Schema awareness (lessons from PR #151)

- UserPromptSubmit emits standard \`hookSpecificOutput\` (codex HAS \`UserPromptSubmitHookSpecificOutputWire\`)
- PostToolUse + Stop emit **empty stdout** (codex has \`PostToolUseHookSpecificOutputWire\` but our use case has no useful response; Stop has NO wire schema at all — same lesson as PreCompact)

## Wiring

- \`plugin.json\`: 3 new entries (Claude autowire)
- \`codex_adapter.py\`: 3 new render functions + 3 legacy constants + merge_hook_commands calls + uninstall removals

## Test plan

- [x] 13 new behavior tests in \`test_new_hooks.py\`
- [x] 4 new adapter tests in \`test_codex_adapter.py\`
- [x] All 5 reflect events wire correctly into \`~/.codex/hooks.json\` (smoke-tested at \`/tmp/codex-360-test\`)
- [x] Hook scripts physically deployed under \`~/.codex/skills/{recall,reflect}/hooks/\`
- [x] Uninstall removes reflect entries while preserving unrelated user hooks under the same events
- [x] 88/88 reflect tests pass
- [x] Version bumped 3.5.2 → 3.6.0 (minor — new features, full surface parity)

## Mini-learning correction patterns

Conservative — requires an explicit corrective verb to avoid false positives:

\`\`\`
try/use/do <something> instead/rather
no/don't/do not, use/try/do
should have / shouldn't have / must use / need to use
instead of <foo>, use/try/do
\`\`\`

Uses \`\\S+\` (not \`\\w+\`) so flag-like tokens (\`--insecure\`, \`-x\`) match naturally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds three hook integrations: mini-learning capture after tool failures, recall-based injection on user prompt submit, and session reflection when an agent stops.

* **Chores**
  * Bumped plugin version to 3.6.0.

* **Tests**
  * Added behavior-focused tests validating the three new hooks, their side effects, deduplication, and robustness to malformed inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->