### PR TITLE
fix(tui): prevent git auth hang and add inline auth pre-check

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -407,7 +407,7 @@ fn source_provenance(
 /// Compute a stable display label for a `RepoSource` — drives the Configure
 /// screen's title bar and the persistence key in `session-defaults.yaml`.
 /// Phase 5 (new-session redesign).
-fn derive_repo_label(source: &crate::git::repo_source::RepoSource) -> String {
+pub fn derive_repo_label(source: &crate::git::repo_source::RepoSource) -> String {
     use crate::git::repo_source::RepoSource;
     match source {
         RepoSource::LocalPath(p) => p
@@ -1406,7 +1406,21 @@ impl EventHandler {
                 .unwrap_or(PickRepoOutcome::Stay);
 
             return match outcome {
-                PickRepoOutcome::Stay => None,
+                PickRepoOutcome::Stay => {
+                    // Check if the key handler set git_auth_status to
+                    // Checking (user pressed Enter to retry auth).
+                    use crate::components::new_session::pick_repo::GitAuthStatus;
+                    let needs_recheck = state
+                        .new_session_state
+                        .as_ref()
+                        .and_then(|ns| ns.pick_repo_state.as_ref())
+                        .and_then(|p| p.git_auth_status.as_ref())
+                        == Some(&GitAuthStatus::Checking);
+                    if needs_recheck {
+                        state.pending_async_action = Some(AsyncAction::CheckGitAuth);
+                    }
+                    None
+                }
                 PickRepoOutcome::Notice { message, is_error } => {
                     // Favorite added/removed or a refusal (e.g. starring a repo
                     // with no remote). Surface it and stay on the picker.
@@ -1464,77 +1478,39 @@ impl EventHandler {
                     state.current_screen = prev;
                     None
                 }
-                PickRepoOutcome::AdvanceTo(source) | PickRepoOutcome::StartClone(source) => {
-                    // Phase 5: transition into Configure. StartClone for now
-                    // skips the real async clone (Phase 6+ wires it) and
-                    // advances straight in — the tripwires don't depend on
-                    // network I/O. Build `configure_state` from `source` +
-                    // session-defaults, set step = Configure.
-                    //
-                    // The dispatcher (not the UI layer) computes:
-                    //   - the HEAD branch via `git::repo_source::head_branch`
-                    //     (finding #9 — keeps git2 out of components/);
-                    //   - the configured `branch_prefix` (finding #5);
-                    //   - the existing-branch list for collision-disamb
-                    //     (finding #16).
-                    // PickRepo persistence (finding #3): write
-                    // session-defaults ONCE here, not on every arrow keypress.
-                    use crate::components::new_session::configure::ConfigureState;
-                    use crate::config::session_defaults::SessionDefaults;
-                    use crate::git::repo_source::head_branch;
-                    if let Some(pick) =
-                        state.new_session_state.as_ref().and_then(|ns| ns.pick_repo_state.as_ref())
-                    {
-                        let path = SessionDefaults::default_path();
-                        if let Err(err) = pick.defaults.save_to(&path) {
-                            tracing::warn!(error = %err, "PickRepo advance: persist session-defaults failed");
+                PickRepoOutcome::AdvanceTo(source) => {
+                    state.advance_pick_repo_to_configure(source);
+                    None
+                }
+                PickRepoOutcome::StartClone(source) => {
+                    // For GitHub HTTPS / shorthand sources, pre-check auth
+                    // before advancing — git credential prompts hang the TUI.
+                    // Non-GitHub HTTPS (GitLab, self-hosted) is left alone: the
+                    // `gh auth status` probe is GitHub-specific and would put an
+                    // irrelevant failure screen in front of those clones.
+                    use crate::components::new_session::pick_repo::GitAuthStatus;
+                    let needs_auth_check = match &source {
+                        crate::git::repo_source::RepoSource::GithubShorthand { .. } => true,
+                        crate::git::repo_source::RepoSource::HttpsUrl(url) => {
+                            crate::git::repo_source::is_github_host(url)
                         }
-                    }
-                    let defaults = SessionDefaults::load_from(&SessionDefaults::default_path());
-                    let label = derive_repo_label(&source);
-                    let branch_source = match &source {
-                        crate::git::repo_source::RepoSource::LocalPath(p) => head_branch(p),
-                        _ => None,
+                        _ => false,
                     };
-                    let branch_prefix = state.app_config.workspace_defaults.branch_prefix.clone();
-                    // Every branch already checked out in any worktree (ainb's
-                    // by-session worktrees + the repo's own checkout + manual
-                    // worktrees). Single source of truth so the collision guard
-                    // matches what `git worktree add` will accept — the legacy
-                    // `list_worktrees()` alone missed by-name worktrees
-                    // (Stevie 2026-05-27: feat/blog re-launch slipped through;
-                    // review P1, PR #211 added the repo's own checkout).
-                    let repo_path = match &source {
-                        crate::git::repo_source::RepoSource::LocalPath(p) => Some(p.as_path()),
-                        _ => None,
-                    };
-                    let existing_branches = crate::git::branch_list::in_use_branch_names(repo_path);
-                    // All existing branch names (local heads + remote-tracking)
-                    // for the base-off "⚠ exists" guard. Cheap for a local repo;
-                    // a remote pick fills this in later when the base picker
-                    // lists/fetches branches.
-                    let repo_branch_names = repo_path
-                        .map(|p| {
-                            crate::git::branch_list::list_repo_branches(p)
-                                .into_iter()
-                                .map(|e| e.short_name)
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    let cfg = ConfigureState::from_pick_repo(
-                        source.clone(),
-                        label,
-                        &defaults,
-                        branch_source,
-                        &branch_prefix,
-                        existing_branches,
-                        repo_branch_names,
-                    );
-                    if let Some(ns) = state.new_session_state.as_mut() {
-                        ns.configure_state = Some(cfg);
-                        ns.step = NewSessionStep::Configure;
+                    if needs_auth_check {
+                        if let Some(pick) = state
+                            .new_session_state
+                            .as_mut()
+                            .and_then(|ns| ns.pick_repo_state.as_mut())
+                        {
+                            pick.git_auth_status = Some(GitAuthStatus::Checking);
+                            pick.pending_clone_source = Some(source);
+                        }
+                        state.pending_async_action = Some(AsyncAction::CheckGitAuth);
+                    } else {
+                        // SSH (key-based auth), local paths, and non-GitHub
+                        // HTTPS remotes skip the GitHub pre-check.
+                        state.advance_pick_repo_to_configure(source);
                     }
-                    tracing::debug!(?source, "PickRepo advance → Configure");
                     None
                 }
             };

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2720,6 +2720,8 @@ pub enum AsyncAction {
     /// the dispatcher so the async path doesn't re-derive it from
     /// `configure_state` (finding #7).
     CreateSessionFromConfigure(crate::components::new_session::configure::LaunchSpec),
+    /// Pre-check GitHub auth via `gh auth status` before allowing remote clone.
+    CheckGitAuth,
     DeleteSession(Uuid),         // New - delete session with container cleanup
     StopSession(Uuid),           // Soft-stop interactive session (kill tmux only)
     ResumeSession(Uuid, String), // Recreate tmux for a Stopped interactive session; String is the trigger key for audit
@@ -6268,6 +6270,114 @@ impl AppState {
     /// terminal errors. On failure: notifies the user, calls
     /// `cancel_new_session()` so the picker reopens, returns `Err(())`.
     ///
+    /// Transition from PickRepo → Configure for a given source. Extracted so
+    /// both the events.rs dispatcher and the async auth-check handler can call it.
+    pub fn advance_pick_repo_to_configure(
+        &mut self,
+        source: crate::git::repo_source::RepoSource,
+    ) {
+        use crate::components::new_session::configure::ConfigureState;
+        use crate::config::session_defaults::SessionDefaults;
+        use crate::git::repo_source::head_branch;
+
+        if let Some(pick) = self
+            .new_session_state
+            .as_ref()
+            .and_then(|ns| ns.pick_repo_state.as_ref())
+        {
+            let path = SessionDefaults::default_path();
+            if let Err(err) = pick.defaults.save_to(&path) {
+                tracing::warn!(error = %err, "advance_pick_repo_to_configure: persist session-defaults failed");
+            }
+        }
+        let defaults = SessionDefaults::load_from(&SessionDefaults::default_path());
+        let label = crate::app::events::derive_repo_label(&source);
+        let branch_source = match &source {
+            crate::git::repo_source::RepoSource::LocalPath(p) => head_branch(p),
+            _ => None,
+        };
+        let branch_prefix = self.app_config.workspace_defaults.branch_prefix.clone();
+        // Every branch already checked out in any worktree (ainb's by-session
+        // worktrees + the repo's own checkout + manual worktrees). Single
+        // source of truth so the collision guard matches what `git worktree
+        // add` will accept — the legacy `list_worktrees()` alone missed by-name
+        // worktrees (Stevie 2026-05-27: feat/blog re-launch slipped through;
+        // review P1, PR #211 added the repo's own checkout; deduped in #232).
+        let repo_path = match &source {
+            crate::git::repo_source::RepoSource::LocalPath(p) => Some(p.as_path()),
+            _ => None,
+        };
+        let existing_branches = crate::git::branch_list::in_use_branch_names(repo_path);
+        // All existing branch names (local heads + remote-tracking) for the
+        // base-off "⚠ exists" guard. Cheap for a local repo; a remote pick
+        // fills this in later when the base picker lists/fetches branches.
+        let repo_branch_names: Vec<String> = repo_path
+            .map(|p| {
+                crate::git::branch_list::list_repo_branches(p)
+                    .into_iter()
+                    .map(|e| e.short_name)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let cfg = ConfigureState::from_pick_repo(
+            source.clone(),
+            label,
+            &defaults,
+            branch_source,
+            &branch_prefix,
+            existing_branches,
+            repo_branch_names,
+        );
+        if let Some(ns) = self.new_session_state.as_mut() {
+            ns.configure_state = Some(cfg);
+            ns.step = NewSessionStep::Configure;
+        }
+        tracing::debug!(?source, "advance_pick_repo_to_configure → Configure");
+        self.ui_needs_refresh = true;
+    }
+
+    /// Pre-check GitHub authentication via `gh auth status`. Updates the
+    /// `git_auth_status` field on PickRepoState. If authenticated and a
+    /// `pending_clone_source` is waiting, automatically advances to Configure.
+    async fn check_git_auth(&mut self) {
+        use crate::components::new_session::pick_repo::GitAuthStatus;
+
+        let auth_ok = tokio::task::spawn_blocking(|| {
+            std::process::Command::new("gh")
+                .args(["auth", "status", "--hostname", "github.com"])
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        })
+        .await
+        .unwrap_or(false);
+
+        if let Some(pick) = self
+            .new_session_state
+            .as_mut()
+            .and_then(|ns| ns.pick_repo_state.as_mut())
+        {
+            if auth_ok {
+                tracing::info!("GitHub auth check passed");
+                pick.git_auth_status = Some(GitAuthStatus::Authenticated);
+                // Auto-advance: take the pending source and emit StartClone
+                // via the advance-to-configure path. We replicate the
+                // AdvanceTo → Configure transition inline here.
+                if let Some(source) = pick.pending_clone_source.take() {
+                    pick.git_auth_status = None;
+                    self.advance_pick_repo_to_configure(source);
+                }
+            } else {
+                tracing::warn!("GitHub auth check failed");
+                pick.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+            }
+        }
+        self.ui_needs_refresh = true;
+    }
+
     /// The clone itself runs on `spawn_blocking` because `git2` / `git` CLI
     /// are synchronous and would otherwise block the async runtime.
     async fn clone_remote_for_configure(
@@ -7644,6 +7754,9 @@ impl AppState {
             match action {
                 AsyncAction::CreateSessionFromConfigure(spec) => {
                     self.create_session_from_configure(spec).await;
+                }
+                AsyncAction::CheckGitAuth => {
+                    self.check_git_auth().await;
                 }
                 AsyncAction::DeleteSession(session_id) => {
                     if let Err(e) = self.delete_session(session_id).await {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -6272,18 +6272,13 @@ impl AppState {
     ///
     /// Transition from PickRepo → Configure for a given source. Extracted so
     /// both the events.rs dispatcher and the async auth-check handler can call it.
-    pub fn advance_pick_repo_to_configure(
-        &mut self,
-        source: crate::git::repo_source::RepoSource,
-    ) {
+    pub fn advance_pick_repo_to_configure(&mut self, source: crate::git::repo_source::RepoSource) {
         use crate::components::new_session::configure::ConfigureState;
         use crate::config::session_defaults::SessionDefaults;
         use crate::git::repo_source::head_branch;
 
-        if let Some(pick) = self
-            .new_session_state
-            .as_ref()
-            .and_then(|ns| ns.pick_repo_state.as_ref())
+        if let Some(pick) =
+            self.new_session_state.as_ref().and_then(|ns| ns.pick_repo_state.as_ref())
         {
             let path = SessionDefaults::default_path();
             if let Err(err) = pick.defaults.save_to(&path) {
@@ -6342,7 +6337,11 @@ impl AppState {
     async fn check_git_auth(&mut self) {
         use crate::components::new_session::pick_repo::GitAuthStatus;
 
-        let auth_ok = tokio::task::spawn_blocking(|| {
+        // Bound the probe: a hung `gh` (network stall, credential helper
+        // wedged) must not leave the picker stuck in `Checking` forever.
+        // Timeout and task-panic both fail closed → NotAuthenticated, with a
+        // warning so the cause is visible in the logs.
+        let auth_check = tokio::task::spawn_blocking(|| {
             std::process::Command::new("gh")
                 .args(["auth", "status", "--hostname", "github.com"])
                 .env("GIT_TERMINAL_PROMPT", "0")
@@ -6351,14 +6350,21 @@ impl AppState {
                 .status()
                 .map(|s| s.success())
                 .unwrap_or(false)
-        })
-        .await
-        .unwrap_or(false);
+        });
+        let auth_ok = match tokio::time::timeout(Duration::from_secs(5), auth_check).await {
+            Ok(Ok(ok)) => ok,
+            Ok(Err(join_err)) => {
+                tracing::warn!(error = %join_err, "GitHub auth check task panicked");
+                false
+            }
+            Err(_) => {
+                tracing::warn!("GitHub auth check timed out after 5s");
+                false
+            }
+        };
 
-        if let Some(pick) = self
-            .new_session_state
-            .as_mut()
-            .and_then(|ns| ns.pick_repo_state.as_mut())
+        if let Some(pick) =
+            self.new_session_state.as_mut().and_then(|ns| ns.pick_repo_state.as_mut())
         {
             if auth_ok {
                 tracing::info!("GitHub auth check passed");

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -79,6 +79,19 @@ pub struct CloneProgress {
     pub error: Option<String>,
 }
 
+/// GitHub auth pre-check status shown inline on the picker when a remote
+/// URL requires authentication. The dispatcher runs `gh auth status` before
+/// advancing to Configure for HTTPS/GitHub sources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitAuthStatus {
+    /// Async check in flight.
+    Checking,
+    /// `gh auth status` succeeded — the dispatcher auto-advances.
+    Authenticated,
+    /// Not authenticated — show inline instructions.
+    NotAuthenticated,
+}
+
 /// Outcome of a single key press on the picker. The caller (events.rs)
 /// translates this into the appropriate `AppEvent` / async action.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -128,6 +141,11 @@ pub struct PickRepoState {
     pub selected: usize,
     /// Inline clone progress for the highlighted row (None when idle).
     pub clone_progress: Option<CloneProgress>,
+    /// GitHub auth pre-check status. Set by the dispatcher before allowing
+    /// HTTPS/GitHub clones. `None` = no check in progress or needed.
+    pub git_auth_status: Option<GitAuthStatus>,
+    /// Source that triggered the auth check, held until auth passes or user skips.
+    pub pending_clone_source: Option<RepoSource>,
     /// Snapshot of session-defaults — read on open, updated on `^R`.
     pub defaults: SessionDefaults,
     /// Snapshot of favorites — read on open, updated on `^F`.
@@ -150,6 +168,8 @@ impl PickRepoState {
             filtered_indices,
             selected,
             clone_progress: None,
+            git_auth_status: None,
+            pending_clone_source: None,
             defaults,
             favorites,
         }
@@ -477,12 +497,60 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
                 spans.push(Span::styled(detail, Style::default().fg(MUTED_GRAY)));
             }
 
-            // Inline clone progress shown directly under the highlighted row
-            // by appending a second visual span. Simpler than a sub-list:
-            // works inside ListItem::new(vec![Line, Line]).
+            // Inline status shown directly under the highlighted row
+            // by appending extra lines. Works inside ListItem::new(vec![…]).
             let mut lines = vec![Line::from(spans)];
             if is_selected {
-                if let Some(progress) = &state.clone_progress {
+                if let Some(auth) = &state.git_auth_status {
+                    match auth {
+                        GitAuthStatus::Checking => {
+                            lines.push(Line::from(vec![
+                                Span::raw("    "),
+                                Span::styled(
+                                    "\u{1f504} Checking GitHub auth...",
+                                    Style::default().fg(Color::Rgb(100, 200, 230)),
+                                ),
+                            ]));
+                        }
+                        GitAuthStatus::NotAuthenticated => {
+                            let amber = Color::Rgb(255, 191, 0);
+                            lines.push(Line::from(vec![
+                                Span::raw("    "),
+                                Span::styled(
+                                    "\u{1f511} GitHub auth required. In another terminal run:",
+                                    Style::default().fg(amber),
+                                ),
+                            ]));
+                            lines.push(Line::from(vec![
+                                Span::raw("      "),
+                                Span::styled(
+                                    "gh auth login && gh auth setup-git",
+                                    Style::default()
+                                        .fg(SELECTION_GREEN)
+                                        .add_modifier(Modifier::BOLD),
+                                ),
+                            ]));
+                            lines.push(Line::from(vec![
+                                Span::raw("    "),
+                                Span::styled("Enter", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                                Span::styled("=Retry  ", Style::default().fg(MUTED_GRAY)),
+                                Span::styled("s", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                                Span::styled("=Skip auth  ", Style::default().fg(MUTED_GRAY)),
+                                Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                                Span::styled("=Back", Style::default().fg(MUTED_GRAY)),
+                            ]));
+                        }
+                        GitAuthStatus::Authenticated => {
+                            lines.push(Line::from(vec![
+                                Span::raw("    "),
+                                Span::styled(
+                                    "\u{2705} Authenticated",
+                                    Style::default().fg(SELECTION_GREEN),
+                                ),
+                            ]));
+                        }
+                    }
+                } else if let Some(progress) = &state.clone_progress {
                     if let Some(err) = &progress.error {
                         lines.push(Line::from(vec![
                             Span::raw("    "),
@@ -558,6 +626,47 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
 ///   2. `^F` (favorite toggle) — already writes `favorites.yaml`
 ///      synchronously inside `toggle_favorite`.
 pub fn handle_key(state: &mut PickRepoState, key: KeyEvent) -> PickRepoOutcome {
+    // When an auth check is in flight or failed, intercept keys before
+    // normal picker handling. Checking → only Esc; NotAuthenticated →
+    // Enter retries, s skips, Esc clears.
+    if let Some(ref auth) = state.git_auth_status {
+        match auth {
+            GitAuthStatus::Checking => {
+                if matches!(key.code, KeyCode::Esc) {
+                    state.git_auth_status = None;
+                    state.pending_clone_source = None;
+                }
+                return PickRepoOutcome::Stay;
+            }
+            GitAuthStatus::NotAuthenticated => {
+                match key.code {
+                    KeyCode::Enter => {
+                        state.git_auth_status = Some(GitAuthStatus::Checking);
+                        return PickRepoOutcome::Stay; // dispatcher sees Checking → re-runs check
+                    }
+                    KeyCode::Char('s' | 'S') => {
+                        let source = state.pending_clone_source.take();
+                        state.git_auth_status = None;
+                        if let Some(src) = source {
+                            return PickRepoOutcome::StartClone(src);
+                        }
+                        return PickRepoOutcome::Stay;
+                    }
+                    KeyCode::Esc => {
+                        state.git_auth_status = None;
+                        state.pending_clone_source = None;
+                        return PickRepoOutcome::Stay;
+                    }
+                    _ => return PickRepoOutcome::Stay,
+                }
+            }
+            GitAuthStatus::Authenticated => {
+                // Auto-advance handled by dispatcher; shouldn't linger here
+                state.git_auth_status = None;
+            }
+        }
+    }
+
     let defaults_path = SessionDefaults::default_path();
     // Ctrl-modified keys take precedence over plain chars so `^R` / `^F`
     // never get swallowed by the filter-input branch below.

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -513,6 +513,11 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
                             ]));
                         }
                         GitAuthStatus::NotAuthenticated => {
+                            // The `gh`-specific copy is intentional: the auth
+                            // pre-check only fires for GitHub sources (see
+                            // `is_github_host` gating in events.rs StartClone),
+                            // so this branch never renders for GitLab /
+                            // self-hosted HTTPS remotes.
                             let amber = Color::Rgb(255, 191, 0);
                             lines.push(Line::from(vec![
                                 Span::raw("    "),
@@ -532,11 +537,20 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
                             ]));
                             lines.push(Line::from(vec![
                                 Span::raw("    "),
-                                Span::styled("Enter", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                                Span::styled(
+                                    "Enter",
+                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                                ),
                                 Span::styled("=Retry  ", Style::default().fg(MUTED_GRAY)),
-                                Span::styled("s", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                                Span::styled(
+                                    "s",
+                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                                ),
                                 Span::styled("=Skip auth  ", Style::default().fg(MUTED_GRAY)),
-                                Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                                Span::styled(
+                                    "Esc",
+                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                                ),
                                 Span::styled("=Back", Style::default().fg(MUTED_GRAY)),
                             ]));
                         }
@@ -898,6 +912,8 @@ mod tests {
             filtered_indices,
             selected: 0,
             clone_progress: None,
+            git_auth_status: None,
+            pending_clone_source: None,
             defaults: SessionDefaults::default(),
             favorites: FavoritesStore::default(),
         }
@@ -1105,5 +1121,143 @@ mod tests {
         s.append_filter("zzz");
         assert_eq!(s.filter, "shotclubzzz");
         assert_eq!(s.filtered_indices.len(), 0);
+    }
+
+    // ── GitHub auth pre-check: prompt UI + key FSM ──────────────────────────
+    //
+    // These exercise the inline "auth required" prompt entirely from in-memory
+    // state — no `gh`, no network, no real GitHub credentials. That's the
+    // sandbox harness for verifying the prompt renders and reacts correctly
+    // when `gh auth status` would have failed (the dispatcher sets
+    // `NotAuthenticated`; here we set it directly and assert behaviour).
+
+    fn github_source() -> RepoSource {
+        RepoSource::GithubShorthand {
+            owner: "stevengonsalvez".into(),
+            repo: "agents-in-a-box".into(),
+        }
+    }
+
+    /// Render the picker and flatten the terminal buffer to a single string so
+    /// tests can assert on visible copy without a real terminal.
+    fn render_to_string(state: &PickRepoState, w: u16, h: u16) -> String {
+        let backend = ratatui::backend::TestBackend::new(w, h);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.size();
+                render(f, state, area);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer.get(x, y).symbol().chars().next().unwrap_or(' '))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn auth_prompt_renders_instructions_without_invoking_gh() {
+        let mut s = mk_state_with_rows(one_row());
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        s.pending_clone_source = Some(github_source());
+
+        let text = render_to_string(&s, 100, 24);
+
+        // The amber instruction line + the exact remediation command.
+        assert!(
+            text.contains("auth required"),
+            "missing auth prompt in:\n{text}"
+        );
+        assert!(
+            text.contains("gh auth login"),
+            "missing gh remediation command in:\n{text}"
+        );
+        // The three key hints the user can act on.
+        assert!(text.contains("Retry"), "missing Retry hint in:\n{text}");
+        assert!(text.contains("Skip"), "missing Skip hint in:\n{text}");
+        assert!(text.contains("Back"), "missing Back hint in:\n{text}");
+    }
+
+    #[test]
+    fn checking_state_renders_spinner_line() {
+        let mut s = mk_state_with_rows(one_row());
+        s.git_auth_status = Some(GitAuthStatus::Checking);
+        let text = render_to_string(&s, 100, 24);
+        assert!(
+            text.contains("Checking GitHub auth"),
+            "missing checking spinner in:\n{text}"
+        );
+    }
+
+    #[test]
+    fn not_authenticated_enter_retries_the_check() {
+        let mut s = mk_state_with_rows(one_row());
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        s.pending_clone_source = Some(github_source());
+
+        let out = handle_key(&mut s, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        // Enter flips back to Checking so the dispatcher re-runs `gh auth status`.
+        assert_eq!(out, PickRepoOutcome::Stay);
+        assert_eq!(s.git_auth_status, Some(GitAuthStatus::Checking));
+        // The source is preserved across the retry.
+        assert_eq!(s.pending_clone_source, Some(github_source()));
+    }
+
+    #[test]
+    fn not_authenticated_skip_starts_the_clone_anyway() {
+        let mut s = mk_state_with_rows(one_row());
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        s.pending_clone_source = Some(github_source());
+
+        let out = handle_key(
+            &mut s,
+            KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+        );
+
+        // `s` bypasses the gate and proceeds to clone with the pending source.
+        assert_eq!(out, PickRepoOutcome::StartClone(github_source()));
+        assert_eq!(s.git_auth_status, None);
+        assert_eq!(s.pending_clone_source, None);
+    }
+
+    #[test]
+    fn not_authenticated_esc_cancels_the_prompt() {
+        let mut s = mk_state_with_rows(one_row());
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        s.pending_clone_source = Some(github_source());
+
+        let out = handle_key(&mut s, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        // Esc dismisses the prompt and clears the pending source.
+        assert_eq!(out, PickRepoOutcome::Stay);
+        assert_eq!(s.git_auth_status, None);
+        assert_eq!(s.pending_clone_source, None);
+    }
+
+    #[test]
+    fn checking_state_swallows_keys_except_esc() {
+        let mut s = mk_state_with_rows(one_row());
+        s.git_auth_status = Some(GitAuthStatus::Checking);
+        s.pending_clone_source = Some(github_source());
+
+        // A stray keypress while the check is in flight is ignored, state holds.
+        let out = handle_key(
+            &mut s,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
+        assert_eq!(out, PickRepoOutcome::Stay);
+        assert_eq!(s.git_auth_status, Some(GitAuthStatus::Checking));
+
+        // Esc aborts the in-flight check and drops the pending source.
+        let out = handle_key(&mut s, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(out, PickRepoOutcome::Stay);
+        assert_eq!(s.git_auth_status, None);
+        assert_eq!(s.pending_clone_source, None);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/git/operations.rs
+++ b/ainb-tui/crates/ainb-core/src/git/operations.rs
@@ -67,10 +67,15 @@ fn commit_and_push_cli(worktree_path: &Path, commit_message: &str) -> Result<Str
             return Err(anyhow::anyhow!("git commit failed: {}", stderr));
         }
 
-        // Push changes - let git use its configured credential helper
-        // Don't set GIT_TERMINAL_PROMPT=0 as it breaks credential helpers
+        // Suppress interactive credential prompts — token-based helpers
+        // (gh, osxkeychain) work fine. Without this, git hangs waiting for
+        // stdin inside the TUI's raw-mode terminal.
         debug!("Pushing changes...");
-        let push_output = Command::new("git").args(&["push"]).output()?;
+        let push_output = Command::new("git")
+            .args(&["push"])
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", "echo")
+            .output()?;
 
         if !push_output.status.success() {
             let stderr = String::from_utf8_lossy(&push_output.stderr);

--- a/ainb-tui/crates/ainb-core/src/git/operations.rs
+++ b/ainb-tui/crates/ainb-core/src/git/operations.rs
@@ -58,13 +58,20 @@ fn commit_and_push_cli(worktree_path: &Path, commit_message: &str) -> Result<Str
             .args(&["commit", "--no-gpg-sign", "-m", commit_message])
             .output()?;
 
+        let mut created_commit = true;
         if !commit_output.status.success() {
             let stderr = String::from_utf8_lossy(&commit_output.stderr);
-            // Check if it's "nothing to commit" which isn't really an error
+            // "nothing to commit" is not a hard error: a previous run may have
+            // committed locally but failed at `push` (auth not yet configured).
+            // Returning here would strand that ahead commit forever, since the
+            // retry always hits "nothing to commit" before reaching push. Skip
+            // the commit and fall through to push so ahead commits still ship.
             if stderr.contains("nothing to commit") || stderr.contains("no changes added") {
-                return Err(anyhow::anyhow!("Nothing to commit - no changes staged"));
+                debug!("Nothing to commit — proceeding to push any ahead commits");
+                created_commit = false;
+            } else {
+                return Err(anyhow::anyhow!("git commit failed: {}", stderr));
             }
-            return Err(anyhow::anyhow!("git commit failed: {}", stderr));
         }
 
         // Suppress interactive credential prompts — token-based helpers
@@ -97,7 +104,11 @@ fn commit_and_push_cli(worktree_path: &Path, commit_message: &str) -> Result<Str
         }
 
         debug!("CLI git push succeeded");
-        Ok(format!("Committed and pushed: {}", commit_message))
+        if created_commit {
+            Ok(format!("Committed and pushed: {}", commit_message))
+        } else {
+            Ok("Nothing new to commit — pushed existing commits".to_string())
+        }
     })();
 
     // Always restore original directory

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -88,6 +88,8 @@ impl RemoteRepoManager {
 
         let output = Command::new("git")
             .args(["ls-remote", "--heads", "--refs", &url])
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", "echo")
             .output()
             .map_err(|e| RemoteRepoError::NetworkError(e.to_string()))?;
 
@@ -154,6 +156,8 @@ impl RemoteRepoManager {
 
         let output = Command::new("git")
             .args(["ls-remote", "--symref", &url, "HEAD"])
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", "echo")
             .output()
             .ok()?;
 
@@ -210,6 +214,8 @@ impl RemoteRepoManager {
         let output = Command::new("git")
             .args(["clone", &url])
             .arg(&cache_path)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", "echo")
             .output()
             .map_err(|e| RemoteRepoError::CloneFailed(e.to_string()))?;
 
@@ -228,6 +234,8 @@ impl RemoteRepoManager {
 
         let output = Command::new("git")
             .args(["fetch", "--all", "--prune"])
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", "echo")
             .current_dir(cache_path)
             .output()
             .map_err(|e| RemoteRepoError::NetworkError(e.to_string()))?;

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -221,6 +221,20 @@ impl RemoteRepoManager {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            // `git clone` can leave a partially-initialised directory behind on
+            // failure (e.g. auth rejected mid-transfer). `is_cached()` only
+            // checks for a `.git` entry, so a broken partial would be treated as
+            // a warm cache on the next attempt and never re-cloned after the
+            // user fixes credentials. Remove it so the retry starts clean.
+            if cache_path.exists() {
+                if let Err(e) = std::fs::remove_dir_all(&cache_path) {
+                    warn!(
+                        "Failed to remove partial clone at {}: {}",
+                        cache_path.display(),
+                        e
+                    );
+                }
+            }
             return Err(classify_git_error(&stderr, &url));
         }
 

--- a/ainb-tui/crates/ainb-core/src/git/repo_source.rs
+++ b/ainb-tui/crates/ainb-core/src/git/repo_source.rs
@@ -361,6 +361,18 @@ pub fn head_branch(path: &Path) -> Option<String> {
     head.shorthand().map(str::to_string)
 }
 
+/// True when an HTTPS clone URL points at `github.com` (case-insensitive host
+/// match). Used to gate the `gh auth status` pre-check: that probe is
+/// GitHub-specific, so GitLab / Bitbucket / self-hosted HTTPS remotes must NOT
+/// be routed through it (they'd hit an irrelevant GitHub auth screen). Returns
+/// `false` for unparseable URLs and any non-GitHub host.
+pub fn is_github_host(https_url: &str) -> bool {
+    url::Url::parse(https_url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|h| h.eq_ignore_ascii_case("github.com")))
+        .unwrap_or(false)
+}
+
 /// Expand ~ to home directory
 fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix('~') {
@@ -478,6 +490,24 @@ mod tests {
         let source = RepoSource::from_input("https://github.com/user/repo").unwrap();
         assert!(matches!(source, RepoSource::HttpsUrl(_)));
         assert!(source.is_remote());
+    }
+
+    #[test]
+    fn test_is_github_host_gates_the_auth_precheck() {
+        // GitHub HTTPS — the only HTTPS host that should trigger `gh auth`.
+        assert!(is_github_host("https://github.com/user/repo"));
+        assert!(is_github_host("https://github.com/user/repo.git"));
+        // Case-insensitive host match.
+        assert!(is_github_host("https://GitHub.com/user/repo"));
+        // Non-GitHub HTTPS remotes must NOT be routed through `gh auth status`.
+        assert!(!is_github_host("https://gitlab.com/user/repo"));
+        assert!(!is_github_host("https://bitbucket.org/user/repo"));
+        assert!(!is_github_host("https://git.example.com/user/repo"));
+        // A look-alike host that merely contains "github.com" is not GitHub.
+        assert!(!is_github_host("https://github.com.evil.example/user/repo"));
+        // Garbage / non-URL input fails closed.
+        assert!(!is_github_host("not a url"));
+        assert!(!is_github_host(""));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/tests/tripwire_new_session_github_auth_no_gh.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_new_session_github_auth_no_gh.rs
@@ -1,0 +1,199 @@
+//! Tripwire: the GitHub auth pre-check prompt appears (and exits gracefully)
+//! when `gh` is logged out — the credential prompt never hangs the TUI.
+//!
+//! Regression guard for PR #155. Before the pre-check, selecting a remote
+//! GitHub repo with no `gh` auth handed straight to `git clone`, whose
+//! interactive `Username for 'https://github.com':` prompt blocked on stdin
+//! that crossterm owns in raw mode — the whole TUI froze with no way out.
+//!
+//! This drives the real binary with a stubbed, logged-out `gh` (a fake `gh`
+//! on PATH that exits non-zero, exactly like `gh auth status` when signed
+//! out) and asserts:
+//!   1. pressing Enter on the GitHub favorite row surfaces the inline amber
+//!      "GitHub auth required" prompt with the `gh auth login` remediation,
+//!   2. the pane NEVER shows a git credential prompt (`Username for` /
+//!      `Password for`) — i.e. it did not fall through to `git clone`,
+//!   3. pressing Esc dismisses the prompt and returns to the picker
+//!      (graceful exit, per the return-path rule in the tmux-ui-tripwire
+//!      skill).
+
+#[allow(dead_code)]
+mod tripwire_new_session_common;
+use tripwire_new_session_common::*;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+/// Write a fake `gh` onto an isolated bin dir that behaves like a logged-out
+/// CLI: `gh auth status …` exits 1 (and prints the real CLI's "not logged
+/// into" line to stderr, which the app discards). Returns the bin dir to
+/// prepend onto PATH.
+fn seed_logged_out_gh(home: &Path) -> std::path::PathBuf {
+    let bin = home.join("fakebin");
+    fs::create_dir_all(&bin).unwrap();
+    let gh = bin.join("gh");
+    fs::write(
+        &gh,
+        "#!/bin/sh\n\
+         # Stub: simulates `gh` installed but signed out.\n\
+         echo 'You are not logged into any GitHub hosts. To log in, run: gh auth login' 1>&2\n\
+         exit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&gh, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    bin
+}
+
+/// Suppress the first-run "install ainb-hooks?" nudge that otherwise opens a
+/// modal on the Home screen and swallows the `n` keystroke. Mirrors what
+/// `notifyd::dismiss_prompt` writes: an empty install record with
+/// `prompt_dismissed = true` at `~/.agents-in-a-box/install.json`.
+fn seed_dismiss_notify_prompt(home: &Path) {
+    let root = home.join(".agents-in-a-box");
+    fs::create_dir_all(&root).unwrap();
+    let install_json = r#"{
+  "agents": [],
+  "hook_script": "",
+  "claude_plugin_dir": null,
+  "codex_hooks_json": null,
+  "plugin_version": null,
+  "prompt_dismissed": true
+}
+"#;
+    fs::write(root.join("install.json"), install_json).unwrap();
+}
+
+#[test]
+fn github_auth_prompt_shows_and_exits_without_credential_hang() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+    // Seeds an `ainb-tui` GithubShorthand favorite — the row we Enter on.
+    seed_new_session_fixtures(home_tmp.path());
+    // Skip the first-run notify-install modal that would eat the `n` key.
+    seed_dismiss_notify_prompt(home_tmp.path());
+    let fakebin = seed_logged_out_gh(home_tmp.path());
+
+    let session = format!("tripwire-gh-auth-{}", std::process::id());
+    let ainb = ainb_bin();
+
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "180", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success());
+
+    // Prepend the stub bin so `gh` resolves to our logged-out fake. `exec`
+    // replaces the shell so keystrokes hit ainb directly; `$PATH` expands in
+    // the launch shell before exec.
+    let cmd = format!(
+        "HOME={home} PATH={fake}:$PATH AINB_DISABLE_PLUGINS=1 exec {bin} tui",
+        home = home_tmp.path().display(),
+        fake = fakebin.display(),
+        bin = ainb.display(),
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux launch");
+
+    // Wait for HomeScreen.
+    let home_deadline = Instant::now() + Duration::from_secs(45);
+    if poll_capture(&session, home_deadline, |c| {
+        c.contains("Stats") && c.contains("[i]")
+    })
+    .is_none()
+    {
+        let last = capture(&session);
+        kill_session(&session);
+        panic!("HomeScreen never rendered; last:\n---\n{last}\n---");
+    }
+
+    // Open PickRepo (retry once if `n` is dropped under load).
+    send_key(&session, "n");
+    let pick_deadline = Instant::now() + Duration::from_secs(5);
+    let mut on_pick = poll_capture(&session, pick_deadline, |c| {
+        c.contains("New Session") && c.contains("Enter=Select")
+    });
+    if on_pick.is_none() {
+        send_key(&session, "n");
+        let retry_deadline = Instant::now() + Duration::from_secs(8);
+        on_pick = poll_capture(&session, retry_deadline, |c| {
+            c.contains("New Session") && c.contains("Enter=Select")
+        });
+    }
+    let pre = on_pick.unwrap_or_else(|| {
+        let last = capture(&session);
+        kill_session(&session);
+        panic!("PickRepo never opened after `n`; last:\n---\n{last}\n---");
+    });
+    // The favorite row is present and we are NOT yet showing an auth prompt.
+    assert!(
+        pre.contains("ainb-tui"),
+        "favorite row missing on PickRepo:\n---\n{pre}\n---"
+    );
+    assert!(
+        !pre.contains("auth required"),
+        "auth prompt shown before Enter:\n---\n{pre}\n---"
+    );
+
+    // Enter on the highlighted GithubShorthand favorite → StartClone →
+    // CheckGitAuth → (stub gh exits 1) → NotAuthenticated prompt.
+    send_key(&session, "Enter");
+
+    let prompt_deadline = Instant::now() + Duration::from_secs(20);
+    let prompted = poll_capture(&session, prompt_deadline, |c| {
+        c.contains("auth required") && c.contains("gh auth login")
+    });
+    let prompt_cap = prompted.unwrap_or_else(|| {
+        let last = capture(&session);
+        kill_session(&session);
+        panic!(
+            "inline GitHub auth prompt never rendered after Enter on the \
+             GitHub favorite with a logged-out gh; last:\n---\n{last}\n---"
+        );
+    });
+
+    // THE point of the PR: it must NOT have fallen through to `git clone`'s
+    // interactive credential prompt. Those strings would only appear if git
+    // were blocking on stdin — exactly the hang this feature prevents.
+    assert!(
+        !prompt_cap.contains("Username for") && !prompt_cap.contains("Password for"),
+        "git credential prompt leaked into the TUI — the pre-check did not \
+         intercept the clone:\n---\n{prompt_cap}\n---"
+    );
+    // The remediation + key hints are visible so the user knows how to recover.
+    assert!(
+        prompt_cap.contains("Retry") && prompt_cap.contains("Skip") && prompt_cap.contains("Back"),
+        "auth prompt key hints (Retry/Skip/Back) missing:\n---\n{prompt_cap}\n---"
+    );
+
+    // Return path: Esc dismisses the prompt and lands back on the picker.
+    send_key(&session, "Escape");
+    let back_deadline = Instant::now() + Duration::from_secs(10);
+    let back = poll_capture(&session, back_deadline, |c| {
+        c.contains("Enter=Select") && !c.contains("auth required")
+    });
+
+    let final_cap = back.clone().unwrap_or_else(|| capture(&session));
+    kill_session(&session);
+
+    assert!(
+        back.is_some(),
+        "Esc did not return to the picker (graceful exit) within 10s:\n---\n{final_cap}\n---"
+    );
+    assert!(
+        !final_cap.contains("auth required"),
+        "auth prompt still visible after Esc:\n---\n{final_cap}\n---"
+    );
+}


### PR DESCRIPTION
## Summary

- Set `GIT_TERMINAL_PROMPT=0` + `GIT_ASKPASS=echo` on **all** network-facing git CLI calls (`ls-remote`, `clone`, `fetch`, `push`) — prevents interactive credential prompts from hanging the TUI in raw-mode terminal
- Add inline GitHub auth pre-check in the PickRepo screen: when an HTTPS or GitHub-shorthand URL is selected, runs `gh auth status --hostname github.com` before advancing to Configure
- Inline status renders under the selected row: spinner while checking, amber instructions with `gh auth login && gh auth setup-git` if unauthenticated, green badge on success
- Key handling: **Enter** retries, **s** skips auth check, **Esc** cancels — SSH URLs bypass the check entirely
- Extracted `advance_pick_repo_to_configure()` for DRY PickRepo→Configure transition

## Context

Retrofitted onto the redesigned 2-screen preset-driven wizard (PR #166). Original issue: pasting a remote HTTPS URL with no GitHub auth configured caused a credential prompt to hang the entire TUI.

## Test plan

- [ ] Build passes (`cargo build` — verified)
- [ ] Paste HTTPS GitHub URL with no `gh auth` → inline amber instructions appear
- [ ] Press Enter to retry after authenticating in another terminal
- [ ] Press `s` to skip auth check and proceed to clone
- [ ] Press Esc to dismiss and return to picker
- [ ] SSH URLs (`git@github.com:…`) bypass auth check entirely
- [ ] `git push` from git view works with token-based credential helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline GitHub auth pre-check before cloning HTTPS repos with UI states: checking, authenticated, not-authenticated; keyboard controls for retry, skip, or cancel.

* **Improvements**
  * Git commands now suppress interactive credential prompts for reliable non-interactive behavior.
  * Pre-check advances flow automatically when auth succeeds and preserves chooser state.

* **Bug Fixes**
  * Push now proceeds even when there are no new commits to create, with clearer success messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->