### PR TITLE
fix(bootstrap): reflect-kb auto-install hardening + README disambiguation

### DIFF
--- a/reflect-kb/README.md
+++ b/reflect-kb/README.md
@@ -6,6 +6,15 @@
 [![Python](https://img.shields.io/badge/python-%3E%3D3.11-blue.svg)](https://www.python.org/)
 [![Version](https://img.shields.io/badge/version-0.1.1-green.svg)](./pyproject.toml)
 
+> **Two version streams — don't confuse them.** This directory hosts the `reflect`
+> **CLI** (Python package `reflect-kb`, semver `0.1.x`, version field in
+> [`pyproject.toml`](./pyproject.toml)). The Claude Code **plugin** that wires the
+> CLI into the agent harness lives at [`plugins/reflect/`](../plugins/reflect/)
+> and follows its **own** semver `3.x.x` (see
+> [`plugins/reflect/.claude-plugin/plugin.json`](../plugins/reflect/.claude-plugin/plugin.json)).
+> When asked "what version of reflect is installed?" you usually want **both**:
+> `reflect --version` for the CLI and the plugin manifest for the harness wiring.
+
 ## What it does
 
 reflect-kb implements the **capture → index → recall** loop for agent knowledge. After every session,

--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -1021,11 +1021,21 @@ async function installReflectKb(tool, options = {}) {
         }
         // 5. Install the package. The [graph] extra pulls heavy ML deps and is
         // mandatory — the recall/search workflow needs it.
+        //
+        // Pin Python: the [graph] extras drag in nano-graphrag → graspologic →
+        // hyppo → numba → llvmlite, and llvmlite ships wheels lagging the
+        // newest CPython by 1–2 minor versions. Without a pin, `uv tool
+        // install` picks the user's system python (often 3.14+ on bleeding-
+        // edge boxes) and the build dies on llvmlite. 3.13 is the known-good
+        // version (matches the maintainer's working install) and has wheels
+        // for every transitive dep. Override with REFLECT_KB_PYTHON if needed.
+        const pythonPin = process.env.REFLECT_KB_PYTHON || '3.13';
         const installSpec = `${sourceInfo.source}[graph]`;
         try {
-            execSync(`uv tool install --force ${JSON.stringify(installSpec)}`, {
-                stdio: 'pipe',
-            });
+            execSync(
+                `uv tool install --force --python ${JSON.stringify(pythonPin)} ${JSON.stringify(installSpec)}`,
+                { stdio: 'pipe' }
+            );
             result.installed = true;
         } catch (err) {
             const stderr = err.stderr ? err.stderr.toString() : err.message;

--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -841,6 +841,56 @@ function findUv() {
     }
 }
 
+// Make sure ~/.local/bin (where `uv tool install` drops shims) is on PATH for
+// both the current process AND future shells. Returns one of:
+//   { changed: false, reason: 'already-on-path' | 'rc-already-patched' | ... }
+//   { changed: true, rc, exportLine }            (rc file appended)
+//   { changed: false, reason: 'unsupported-shell', shell }   (warn-and-continue)
+//
+// Current-process PATH is patched in-memory so the smoke test in installReflectKb
+// can call the freshly-installed shim without requiring the user to source the
+// rc file first.
+function ensureLocalBinOnPath() {
+    const localBin = path.join(os.homedir(), '.local', 'bin');
+    if (!fs.existsSync(localBin)) {
+        return { changed: false, reason: 'no-local-bin' };
+    }
+
+    const pathParts = (process.env.PATH || '').split(path.delimiter).map(p => p.replace(/\/$/, ''));
+    const alreadyOnPath = pathParts.includes(localBin);
+
+    // Always patch in-memory PATH so the smoke test below sees the shim.
+    if (!alreadyOnPath) {
+        process.env.PATH = `${localBin}${path.delimiter}${process.env.PATH || ''}`;
+    }
+
+    if (alreadyOnPath) {
+        return { changed: false, reason: 'already-on-path' };
+    }
+
+    // Detect login shell + rc file. zsh and bash only — fish/nu/etc. need
+    // syntax we don't want to guess; warn and keep going.
+    const shell = process.env.SHELL || '';
+    let rc;
+    if (shell.endsWith('/zsh') || shell === 'zsh') {
+        rc = path.join(os.homedir(), '.zshrc');
+    } else if (shell.endsWith('/bash') || shell === 'bash') {
+        rc = path.join(os.homedir(), '.bashrc');
+    } else {
+        return { changed: false, reason: 'unsupported-shell', shell };
+    }
+
+    const sentinel = '# ai-coder-rules bootstrap: ensure uv tool shims on PATH';
+    const exportLine = 'export PATH="$HOME/.local/bin:$PATH"';
+    const existing = fs.existsSync(rc) ? fs.readFileSync(rc, 'utf8') : '';
+    if (existing.includes(sentinel) || existing.includes(exportLine)) {
+        return { changed: false, reason: 'rc-already-patched', rc };
+    }
+
+    fs.appendFileSync(rc, `\n${sentinel}\n${exportLine}\n`);
+    return { changed: true, rc, exportLine };
+}
+
 function getReflectInstalledVersion() {
     try {
         const out = execSync('reflect --version', { stdio: ['ignore', 'pipe', 'ignore'] });
@@ -936,16 +986,40 @@ async function installReflectKb(tool, options = {}) {
     }
     const sourceVersion = readPyprojectVersion(sourceInfo.dir);
 
-    // 3. Idempotency: if reflect is already on PATH and reports a version,
-    // skip the install unless --force is set. We deliberately don't compare
-    // to sourceVersion strictly because the CLI's version_option is hardcoded
-    // separately from pyproject (a known reflect-kb quirk); presence is enough.
+    // 3. Make sure ~/.local/bin is on PATH before we probe `reflect --version`.
+    // Patches the running process and appends to ~/.zshrc / ~/.bashrc when
+    // missing (so future shells inherit the fix). We do this BEFORE the
+    // idempotency check too — otherwise a previously-installed shim is
+    // invisible and we'd reinstall on every run with no PATH on the box.
+    const pathFix = ensureLocalBinOnPath();
+    if (pathFix.changed) {
+        result.warnings.push(
+            `appended PATH export to ${pathFix.rc}. Open a new shell or run ` +
+            `'source ${pathFix.rc}' to pick it up.`
+        );
+    } else if (pathFix.reason === 'unsupported-shell') {
+        result.warnings.push(
+            `~/.local/bin not on PATH and shell '${pathFix.shell}' is not zsh/bash; ` +
+            `add ~/.local/bin to PATH manually for your shell.`
+        );
+    }
+
+    // 4. Idempotency: skip install only when installed version matches source.
+    // If the source pyproject version is known and differs from the installed
+    // CLI, we upgrade — this catches the 'bootstrap ran once, repo bumped
+    // reflect-kb later, second bootstrap silently skipped' failure mode.
     const installedVersion = getReflectInstalledVersion();
-    if (installedVersion && !force) {
-        result.skippedReason = `reflect ${installedVersion} already installed`;
+    const versionsMatch = installedVersion && sourceVersion && installedVersion === sourceVersion;
+    if (installedVersion && !force && versionsMatch) {
+        result.skippedReason = `reflect ${installedVersion} already installed (matches source)`;
         result.version = installedVersion;
     } else {
-        // 4. Install the package. The [graph] extra pulls heavy ML deps and is
+        if (installedVersion && sourceVersion && !versionsMatch) {
+            result.warnings.push(
+                `upgrading reflect ${installedVersion} → ${sourceVersion} (source drift detected)`
+            );
+        }
+        // 5. Install the package. The [graph] extra pulls heavy ML deps and is
         // mandatory — the recall/search workflow needs it.
         const installSpec = `${sourceInfo.source}[graph]`;
         try {
@@ -959,7 +1033,7 @@ async function installReflectKb(tool, options = {}) {
             return result;
         }
 
-        // 5. Smoke test — fail loudly if the CLI didn't land on PATH.
+        // 6. Smoke test — fail loudly if the CLI didn't land on PATH.
         const postInstallVersion = getReflectInstalledVersion();
         if (!postInstallVersion) {
             result.errors.push(


### PR DESCRIPTION
## Summary

Three small fixes to the bootstrap reflect-kb installer + a README clarification, motivated by debugging a remote machine where the previous install path silently skipped upgrades and left the CLI off PATH.

- **docs(reflect-kb)**: callout box at top of README distinguishing the CLI version stream (\`reflect --version\` from pyproject, 0.1.x) from the Claude plugin version stream (\`plugins/reflect/.claude-plugin/plugin.json\`, 3.x). Multiple agents have grepped for "reflect version", landed on \`pyproject.toml\`, and missed the plugin stream entirely.
- **fix(bootstrap)** PATH + drift:
  - \`ensureLocalBinOnPath()\` patches the running process and appends an \`export PATH=\"\$HOME/.local/bin:\$PATH\"\` line with a sentinel comment to \`~/.zshrc\` or \`~/.bashrc\` when missing. Fish/nu/other shells get a warning rather than a guessed-wrong append.
  - Idempotency now compares installed CLI version to source \`pyproject.toml\` version. Previously any present \`reflect --version\` skipped install — so a repo bump from 0.1.0 → 0.1.1 stayed stuck at 0.1.0 on machines that had already bootstrapped once.
- **fix(bootstrap)** Python pin: \`uv tool install --python 3.13\`. The \`[graph]\` extra drags in \`llvmlite\` (via nano-graphrag → graspologic → hyppo → numba), which lags CPython releases by 1–2 minors. Without a pin, machines on 3.14+ die on the llvmlite build. \`REFLECT_KB_PYTHON\` overrides.

## Test plan

- [x] node --check toolkit/bootstrap.js
- [x] Ran on stevens-mbp-5 (remote Intel mac): drift detection fired (\`upgrading reflect 2.0.0 → 0.1.1\`), PATH fix correctly detected pre-existing \`.zshrc\` line as idempotent, llvmlite no longer blocks. Install still fails downstream on \`torch 2.12.0\` (Intel mac wheels dropped) — out of scope for this PR, tracked separately.
- [x] Ran on MB1412-3 (working ARM box): no regression — drift detection skips install correctly when versions match.