### PR TITLE
fix(bootstrap): skip [graph] extra on Intel macOS

### DIFF
--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -1030,7 +1030,30 @@ async function installReflectKb(tool, options = {}) {
         // version (matches the maintainer's working install) and has wheels
         // for every transitive dep. Override with REFLECT_KB_PYTHON if needed.
         const pythonPin = process.env.REFLECT_KB_PYTHON || '3.13';
-        const installSpec = `${sourceInfo.source}[graph]`;
+
+        // Intel-macOS carve-out: torch 2.3+ dropped macosx_x86_64 wheels (ARM
+        // only). The [graph] extra pulls sentence-transformers → torch, so it
+        // can't resolve on Intel macs. Strict conditional fork — every other
+        // platform (Apple Silicon, linux x86_64, linux arm64, Windows) takes
+        // the unchanged [graph] path below. Intel macs get the slim base
+        // install: `reflect add/search` still works via non-graph paths;
+        // GraphRAG features are unavailable. Override with
+        // REFLECT_KB_FORCE_GRAPH=1 to force-attempt the [graph] install
+        // anyway (e.g. on Intel linux which is fine).
+        const isIntelMac =
+            process.platform === 'darwin' &&
+            process.arch === 'x64' &&
+            !process.env.REFLECT_KB_FORCE_GRAPH;
+        const installSpec = isIntelMac
+            ? `${sourceInfo.source}`
+            : `${sourceInfo.source}[graph]`;
+        if (isIntelMac) {
+            result.warnings.push(
+                'Intel macOS detected: installing reflect-kb WITHOUT [graph] extra ' +
+                '(torch 2.3+ dropped Intel mac wheels). GraphRAG features unavailable; ' +
+                'core capture/search still works. Override: REFLECT_KB_FORCE_GRAPH=1.'
+            );
+        }
         try {
             execSync(
                 `uv tool install --force --python ${JSON.stringify(pythonPin)} ${JSON.stringify(installSpec)}`,


### PR DESCRIPTION
## Summary

Strict conditional carve-out for Intel x86_64 macOS. torch 2.3+ dropped macosx_x86_64 wheels (Apple Silicon and linux only), so \`uv tool install reflect-kb[graph]\` fails to resolve on any Intel mac. This PR detects \`darwin && x64\` and installs the slim base CLI instead.

**Every other platform takes the unchanged \`[graph]\` path.**

| Platform | Install command | Changed by this PR? |
|---|---|---|
| Apple Silicon mac | \`... reflect-kb[graph]\` | ✗ identical |
| Intel mac | \`... reflect-kb\` (no [graph]) | ✓ NEW |
| Linux x64 | \`... reflect-kb[graph]\` | ✗ identical |
| Linux ARM | \`... reflect-kb[graph]\` | ✗ identical |
| Windows | \`... reflect-kb[graph]\` | ✗ identical |
| Intel mac + \`REFLECT_KB_FORCE_GRAPH=1\` | \`... reflect-kb[graph]\` | escape hatch |

Intel users get the slim base install: \`reflect add\`, \`reflect search\` (non-graph paths), \`reflect metrics\`, \`reflect team\`, \`reflect share\` all still work. GraphRAG features are unavailable. The reflect-kb base \`dependencies\` block (click, rich, pyyaml, httpx) is sufficient for the CLI to load.

## Test plan

- [x] Simulated all five platforms via standalone node script — only Intel mac branches; every other case produces identical \`uv tool install\` commandline to current main.
- [x] Live process check on ARM mac (MB1412-3): \`isIntelMac = false\`.
- [x] Ran on stevens-mbp-5 (Intel i9 macOS 15.7.3): bootstrap succeeded, \`reflect-kb v0.1.1\` installed via \`uv tool list\`, \`reflect --version → 0.1.1\`, venv site-packages confirms no torch/sentence-transformers.