### PR TITLE
feat(tmux): rich Catppuccin Mocha conf + ainb tmux install/status + onboarding step

### DIFF
--- a/ainb-tui/config/known-old-confs/v1-88lines.tmux.conf
+++ b/ainb-tui/config/known-old-confs/v1-88lines.tmux.conf
@@ -1,0 +1,88 @@
+# ============================================================================
+# Recommended tmux configuration for agents-in-a-box
+# ============================================================================
+# This configuration optimizes tmux for use with Claude Code and other AI CLIs
+# that generate high-frequency screen updates.
+#
+# Installation:
+#   cp config/tmux.conf ~/.tmux.conf
+#   tmux source-file ~/.tmux.conf  # reload in existing sessions
+#
+# Or append to existing config:
+#   cat config/tmux.conf >> ~/.tmux.conf
+# ============================================================================
+
+# === History & Scrollback ===
+# Large scrollback buffer for reviewing long conversations
+set -g history-limit 1000000
+
+# === Mouse Support ===
+# Enable mouse for scrolling and pane selection
+set -g mouse on
+
+# === Anti-flicker Settings for Claude Code ===
+# Claude Code generates 4,000-6,700 scroll events/second when updating.
+# These settings help reduce (but not eliminate) visual flickering.
+# See: https://github.com/anthropics/claude-code/issues/9935
+
+# Eliminate escape sequence delay (default 500ms causes lag)
+set -sg escape-time 0
+
+# Reduce status bar refresh frequency (default 15s)
+# Higher = less CPU, but stale status info
+set -g status-interval 30
+
+# Disable automatic window rename (reduces CPU overhead)
+setw -g automatic-rename off
+
+# Disable title updates (prevents some terminal flicker)
+set -g set-titles off
+
+# === Terminal Compatibility ===
+# Proper terminal type for 256 colors
+set -g default-terminal "tmux-256color"
+
+# Enable RGB/true color support (tmux 3.2+)
+set -as terminal-features ",*:RGB"
+
+# === Optional: Focus Events ===
+# Useful for editors that respond to focus changes
+set -g focus-events on
+
+# === Optional: Message Display ===
+# How long messages are displayed (milliseconds)
+set -g display-time 4000
+
+# === Clipboard Integration (macOS) ===
+# Enable OSC 52 clipboard support (works with iTerm2, Kitty, Ghostty, etc.)
+set -s set-clipboard on
+
+# Use vi keybindings in copy mode
+setw -g mode-keys vi
+
+# Copy with mouse drag release
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# Vi-style copy bindings
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# Paste from system clipboard (prefix + P)
+bind P run "pbpaste | tmux load-buffer - && tmux paste-buffer"
+
+# === macOS User Namespace Access ===
+# Enables access to macOS user-session services from within tmux:
+# - Audio (say command, sound playback)
+# - Notifications
+# - Keychain
+# Install: brew install reattach-to-user-namespace
+if-shell 'command -v reattach-to-user-namespace >/dev/null' \
+  'set -g default-command "reattach-to-user-namespace -l $SHELL"'
+
+# === Linux Clipboard (if xclip available) ===
+# Uncomment these and comment out pbcopy lines above for Linux
+# bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+# bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+# bind P run "xclip -selection clipboard -o | tmux load-buffer - && tmux paste-buffer"

--- a/ainb-tui/config/tmux-helpers/git_branch.sh
+++ b/ainb-tui/config/tmux-helpers/git_branch.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# git_branch.sh — print the git branch of the focused pane's cwd, or empty.
+# Used by ~/.tmux.conf status-right via #(~/.tmux/scripts/git_branch.sh).
+#
+# Why a helper instead of inline `#( git -C #{pane_current_path} ... )`:
+# tmux only sometimes interpolates format vars inside #(...). Asking tmux for
+# the path via display-message inside the shell command always works and
+# avoids platform-specific escape gymnastics in the conf.
+
+path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+[ -d "$path" ] || exit 0
+branch=$(git -C "$path" symbolic-ref --short HEAD 2>/dev/null) || exit 0
+printf ' %s ' "$branch"

--- a/ainb-tui/config/tmux.conf
+++ b/ainb-tui/config/tmux.conf
@@ -1,88 +1,248 @@
 # ============================================================================
-# Recommended tmux configuration for agents-in-a-box
+# agents-in-a-box · rich tmux configuration
 # ============================================================================
-# This configuration optimizes tmux for use with Claude Code and other AI CLIs
-# that generate high-frequency screen updates.
+# Optimized for ainb-tui + Claude Code / Codex / Gemini CLIs that generate
+# high-frequency screen updates. Includes:
 #
-# Installation:
+#   * Catppuccin Mocha theme (inline — no plugin needed)
+#   * TPM (Tmux Plugin Manager) auto-bootstrap on first launch
+#   * Plugins: tmux-resurrect, tmux-continuum, tmux-yank
+#   * Vim-style pane navigation (h/j/k/l) + intuitive splits (| and -)
+#   * Discoverable detach hint in status bar (C-b ← or C-b d)
+#   * Anti-flicker tuning for AI agent output
+#
+# Install (recommended):
+#   ainb tmux install              # backup + diff + install + reload
+#
+# Install (manual):
 #   cp config/tmux.conf ~/.tmux.conf
-#   tmux source-file ~/.tmux.conf  # reload in existing sessions
-#
-# Or append to existing config:
-#   cat config/tmux.conf >> ~/.tmux.conf
+#   tmux source-file ~/.tmux.conf
 # ============================================================================
 
-# === History & Scrollback ===
-# Large scrollback buffer for reviewing long conversations
+
+# ───────────────────────────────────────────────────────────────────────────
+# History & scrollback
+# ───────────────────────────────────────────────────────────────────────────
 set -g history-limit 1000000
 
-# === Mouse Support ===
-# Enable mouse for scrolling and pane selection
+
+# ───────────────────────────────────────────────────────────────────────────
+# Mouse
+# ───────────────────────────────────────────────────────────────────────────
 set -g mouse on
 
-# === Anti-flicker Settings for Claude Code ===
-# Claude Code generates 4,000-6,700 scroll events/second when updating.
-# These settings help reduce (but not eliminate) visual flickering.
-# See: https://github.com/anthropics/claude-code/issues/9935
 
-# Eliminate escape sequence delay (default 500ms causes lag)
+# ───────────────────────────────────────────────────────────────────────────
+# Anti-flicker (Claude Code & friends emit 4k-6k scroll events/sec)
+#   https://github.com/anthropics/claude-code/issues/9935
+# ───────────────────────────────────────────────────────────────────────────
 set -sg escape-time 0
-
-# Reduce status bar refresh frequency (default 15s)
-# Higher = less CPU, but stale status info
-set -g status-interval 30
-
-# Disable automatic window rename (reduces CPU overhead)
+set -g status-interval 5
 setw -g automatic-rename off
-
-# Disable title updates (prevents some terminal flicker)
 set -g set-titles off
 
-# === Terminal Compatibility ===
-# Proper terminal type for 256 colors
+
+# ───────────────────────────────────────────────────────────────────────────
+# Terminal compatibility (256 colors + true colour)
+# ───────────────────────────────────────────────────────────────────────────
 set -g default-terminal "tmux-256color"
-
-# Enable RGB/true color support (tmux 3.2+)
 set -as terminal-features ",*:RGB"
-
-# === Optional: Focus Events ===
-# Useful for editors that respond to focus changes
 set -g focus-events on
-
-# === Optional: Message Display ===
-# How long messages are displayed (milliseconds)
 set -g display-time 4000
 
-# === Clipboard Integration (macOS) ===
-# Enable OSC 52 clipboard support (works with iTerm2, Kitty, Ghostty, etc.)
-set -s set-clipboard on
 
-# Use vi keybindings in copy mode
+# ───────────────────────────────────────────────────────────────────────────
+# Indexing (1-based; matches keyboard layout)
+# ───────────────────────────────────────────────────────────────────────────
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+
+# ===========================================================================
+# Catppuccin Mocha theme (inline — no plugin dependency)
+#   https://github.com/catppuccin/catppuccin
+# ===========================================================================
+#   base       #1e1e2e   mantle     #181825
+#   surface0   #313244   surface1   #45475a
+#   text       #cdd6f4   subtext0   #a6adc8
+#   mauve      #cba6f7   pink       #f5c2e7
+#   yellow     #f9e2af   green      #a6e3a1
+#   teal       #94e2d5   peach      #fab387
+#   red        #f38ba8   blue       #89b4fa
+# ===========================================================================
+
+# Status bar shell
+set -g status on
+set -g status-position bottom
+set -g status-justify left
+set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
+set -g status-left-length 40
+set -g status-right-length 200
+
+# Status left: session name pill (mauve), truncated to 20 chars so long
+# branch-derived session names don't eat the window list.
+# NOTE: use `session_name` (long form), not `#S` shorthand — tmux modifiers
+# don't combine with the # shortcuts.
+set -g status-left "#[bg=#cba6f7,fg=#1e1e2e,bold] #{=-20:session_name} #[bg=#1e1e2e,fg=#cba6f7]#[default] "
+
+# Status right:
+#   * git branch of focused pane (peach — empty if not a repo)
+#   * hotkey hints (yellow detach, teal reload)
+#   * clock (blue, HH:MM)
+# Branch comes from a helper script deployed by `ainb tmux install` to
+# ~/.tmux/scripts/git_branch.sh — it queries tmux for the pane path itself,
+# sidestepping the unreliable #(...) format-var interpolation.
+#
+# Folder is intentionally omitted: in fleets where the session name is derived
+# from the worktree dir (e.g. `tmux_<repo>_<branch>`), folder basename just
+# duplicates the session pill on the left. Add it back if your sessions are
+# named independently from cwd.
+set -g status-right "#[fg=#fab387]#(~/.tmux/scripts/git_branch.sh)#[fg=#45475a]│ #[fg=#f9e2af]C-b ← detach #[fg=#45475a]│ #[fg=#94e2d5]C-b r reload #[fg=#45475a]│ #[fg=#89b4fa,bold] %H:%M #[default]"
+
+# Window list — show what's RUNNING in each window (claude / zsh / vim / etc.)
+# instead of the literal window name (would be "reattach-to-user-namespace"
+# under the macOS namespace shim) or the cwd basename (would just duplicate
+# the session pill on the left for branch-named worktrees).
+#
+# The folder + branch already live in status-right, so the window list focuses
+# on activity — at-a-glance "which window is the agent vs which is my shell".
+setw -g window-status-format "#[fg=#a6adc8,bg=#1e1e2e] #I:#{=-15:pane_current_command} "
+setw -g window-status-separator ""
+
+# Window list — active (pink highlight + zoom marker)
+setw -g window-status-current-format "#[fg=#1e1e2e,bg=#f5c2e7,bold] #I:#{=-15:pane_current_command}#{?window_zoomed_flag, ,} #[bg=#1e1e2e,fg=#f5c2e7]#[default]"
+
+# Window activity / bell
+setw -g window-status-activity-style "fg=#fab387,bg=#1e1e2e"
+setw -g window-status-bell-style     "fg=#f38ba8,bg=#1e1e2e,bold"
+
+# Pane borders
+set -g pane-border-style        "fg=#45475a"
+set -g pane-active-border-style "fg=#cba6f7"
+
+# Messages (prefix prompts, errors)
+set -g message-style         "bg=#f9e2af,fg=#1e1e2e,bold"
+set -g message-command-style "bg=#cba6f7,fg=#1e1e2e,bold"
+
+# Copy-mode (selection / search)
+setw -g mode-style "bg=#cba6f7,fg=#1e1e2e,bold"
+
+# Clock-mode (prefix + t)
+setw -g clock-mode-colour "#94e2d5"
+setw -g clock-mode-style 24
+
+
+# ===========================================================================
+# Key bindings
+# ===========================================================================
+
+# Reload conf (prefix + r) — instant visual confirmation
+bind r source-file ~/.tmux.conf \; display-message "✓ ~/.tmux.conf reloaded"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Detach — extra discoverable binding alongside default `prefix + d`
+# ───────────────────────────────────────────────────────────────────────────
+bind Left detach-client
+
+# ───────────────────────────────────────────────────────────────────────────
+# Pane splits — intuitive `|` (vertical) and `-` (horizontal)
+#   Defaults `"` and `%` still work via the explicit bind below.
+#   New splits open in the current pane's working directory.
+# ───────────────────────────────────────────────────────────────────────────
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# New windows inherit cwd
+bind c new-window -c "#{pane_current_path}"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Pane navigation — vim-style hjkl (arrow keys still work via defaults)
+# ───────────────────────────────────────────────────────────────────────────
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Pane resize — vim-style HJKL (uppercase, repeatable)
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Window switch — repeatable, no need to re-prefix
+bind -r , previous-window
+bind -r . next-window
+
+
+# ===========================================================================
+# Copy mode — vi keys + system clipboard
+# ===========================================================================
 setw -g mode-keys vi
 
-# Copy with mouse drag release
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+# Enable OSC 52 clipboard (iTerm2, Kitty, Ghostty, modern xterm)
+set -s set-clipboard on
 
-# Vi-style copy bindings
-bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+# Mouse drag → clipboard
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode      MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# Vim-style: v = begin selection, y / Enter = copy + exit
+bind -T copy-mode-vi v     send-keys -X begin-selection
+bind -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "pbcopy"
 bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
 
 # Paste from system clipboard (prefix + P)
 bind P run "pbpaste | tmux load-buffer - && tmux paste-buffer"
 
-# === macOS User Namespace Access ===
-# Enables access to macOS user-session services from within tmux:
-# - Audio (say command, sound playback)
-# - Notifications
-# - Keychain
-# Install: brew install reattach-to-user-namespace
+
+# ===========================================================================
+# macOS user-namespace shim (audio, notifications, keychain)
+#   brew install reattach-to-user-namespace
+# ===========================================================================
 if-shell 'command -v reattach-to-user-namespace >/dev/null' \
   'set -g default-command "reattach-to-user-namespace -l $SHELL"'
 
-# === Linux Clipboard (if xclip available) ===
-# Uncomment these and comment out pbcopy lines above for Linux
-# bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+
+# ===========================================================================
+# Linux clipboard (xclip / wl-clipboard) — uncomment for Linux
+# ===========================================================================
 # bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+# bind -T copy-mode-vi y                 send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+# bind -T copy-mode-vi Enter             send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
 # bind P run "xclip -selection clipboard -o | tmux load-buffer - && tmux paste-buffer"
+
+
+# ===========================================================================
+# Plugins (TPM)
+#
+# First boot: `ainb tmux install` auto-clones TPM and runs the install hook.
+# Manual bootstrap:
+#   git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+#   prefix + I    (capital I, inside a tmux session) to install plugins
+# ===========================================================================
+set -g @plugin 'tmux-plugins/tpm'
+
+# Session persistence — save and restore tmux state across reboots
+#   prefix + C-s   save
+#   prefix + C-r   restore
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @resurrect-capture-pane-contents 'on'
+set -g @resurrect-strategy-vim  'session'
+set -g @resurrect-strategy-nvim 'session'
+
+# Auto-save every 15 min + auto-restore on tmux start
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+
+# Better clipboard yank
+#   y in copy-mode-vi → system clipboard
+#   Y                  → copy command line
+set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @yank_selection 'clipboard'
+
+# Initialize TPM (KEEP AT BOTTOM)
+run '~/.tmux/plugins/tpm/tpm'

--- a/ainb-tui/crates/ainb-core/src/cli/init.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/init.rs
@@ -74,6 +74,9 @@ struct StatusReport {
     config_path: String,
     config_exists: bool,
     skipped_dependencies: Vec<String>,
+    /// State of `~/.tmux.conf` relative to ainb's rich bundled conf.
+    /// See [`crate::cli::tmux_install::OnboardingTmuxState`].
+    tmux_conf_state: String,
 }
 
 /// Validate that at most one mode flag is set
@@ -288,6 +291,15 @@ fn cmd_setup(format: OutputFormat) -> Result<()> {
         let _ = run_statusline_step(&mut std::io::stdin().lock(), &mut std::io::stdout().lock());
     }
 
+    // Tmux conf step — mirrors statusline shape. Only prompts on Missing or
+    // a recognisable-old ainb default; never touches custom user confs.
+    if matches!(format, OutputFormat::Text) {
+        let _ = crate::cli::tmux_install::run_tmux_setup_step(
+            &mut std::io::stdin().lock(),
+            &mut std::io::stdout().lock(),
+        );
+    }
+
     match format {
         OutputFormat::Json => {
             let output = serde_json::json!({
@@ -325,6 +337,10 @@ fn cmd_status(format: OutputFormat) -> Result<()> {
     let user_dir = AppConfig::get_user_config_dir()?;
     let config_path = user_dir.join("config.toml");
 
+    let tmux_state = crate::cli::tmux_install::detect_onboarding_state_default()
+        .map(|s| s.label().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
     let report = StatusReport {
         completed: onboarding.completed,
         completed_at: onboarding.completed_at.clone(),
@@ -334,6 +350,7 @@ fn cmd_status(format: OutputFormat) -> Result<()> {
         config_path: config_path.display().to_string(),
         config_exists: config_path.exists(),
         skipped_dependencies: onboarding.skipped_dependencies.clone(),
+        tmux_conf_state: tmux_state,
     };
 
     match format {
@@ -372,6 +389,16 @@ fn cmd_status(format: OutputFormat) -> Result<()> {
                     "    Skipped deps: {}",
                     report.skipped_dependencies.join(", ")
                 );
+            }
+            // Tmux conf state — informational, never errors out.
+            let tmux_marker = match report.tmux_conf_state.as_str() {
+                "up to date" => "\u{2713}",
+                "custom (not managed by ainb)" => "\u{2139}", // info ⓘ
+                _ => "\u{26A0}",                              // ⚠ for missing / old
+            };
+            println!("  {tmux_marker} Tmux conf:    {}", report.tmux_conf_state);
+            if matches!(report.tmux_conf_state.as_str(), "missing" | "old ainb default (upgradable)") {
+                println!("    \u{21B3} run `ainb tmux install` to install the rich conf");
             }
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -22,6 +22,7 @@ pub mod run;
 pub mod status;
 pub mod statusline;
 pub mod statusline_install;
+pub mod tmux_install;
 pub mod usage;
 pub mod util;
 

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -101,6 +101,7 @@ impl CommandRegistry {
         r.register(UsageCommand);
         r.register(StatuslineCommand);
         r.register(ClaudecodeCommand);
+        r.register(TmuxCommand);
         r.register(CompletionCommand);
         r.register(PluginCommand); // Phase 4 stub — surface reserved now
         r
@@ -807,6 +808,64 @@ impl CliCommand for ClaudecodeCommand {
     }
 }
 
+/// `ainb tmux {install,status}` — manage the bundled rich tmux.conf at
+/// `~/.tmux.conf`. See `crate::cli::tmux_install` for the implementation.
+pub struct TmuxCommand;
+impl CliCommand for TmuxCommand {
+    fn name(&self) -> &'static str {
+        "tmux"
+    }
+    fn build(&self, app: Command) -> Command {
+        let install = <crate::cli::tmux_install::InstallArgs as clap::Args>::augment_args(
+            Command::new("install").about(
+                "Install or upgrade the bundled rich tmux.conf to ~/.tmux.conf \
+                 (backs up any existing file, shows a diff preview, then reloads \
+                 live sessions).",
+            ),
+        );
+        let status = <crate::cli::tmux_install::StatusArgs as clap::Args>::augment_args(
+            Command::new("status").about(
+                "Report whether ~/.tmux.conf is missing, up to date, or stale \
+                 relative to the bundled rich conf.",
+            ),
+        );
+        app.subcommand(
+            Command::new(self.name())
+                .about(
+                    "Manage the rich tmux.conf shipped with ainb-tui \
+                     (Catppuccin Mocha + TPM + resurrect/continuum/yank + \
+                     discoverable detach hints).",
+                )
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(install)
+                .subcommand(status),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        match matches.subcommand() {
+            Some(("install", m)) => match crate::cli::tmux_install::InstallArgs::from_arg_matches(m)
+            {
+                Ok(args) => Box::pin(async move {
+                    crate::cli::tmux_install::install(args, ctx.format).await
+                }),
+                Err(e) => boxed_err(e),
+            },
+            Some(("status", m)) => match crate::cli::tmux_install::StatusArgs::from_arg_matches(m) {
+                Ok(args) => {
+                    Box::pin(async move { crate::cli::tmux_install::status(args, ctx.format).await })
+                }
+                Err(e) => boxed_err(e),
+            },
+            _ => Box::pin(async move {
+                Err(anyhow::anyhow!(
+                    "tmux requires a subcommand: install | status"
+                ))
+            }),
+        }
+    }
+}
+
 pub struct CompletionCommand;
 impl CliCommand for CompletionCommand {
     fn name(&self) -> &'static str {
@@ -976,13 +1035,13 @@ mod tests {
     }
 
     #[test]
-    fn built_ins_registers_eighteen_commands() {
+    fn built_ins_registers_nineteen_commands() {
         let r = CommandRegistry::built_ins();
         let names = r.names();
-        // 16 user-facing built-ins + claudecode namespace + plugin stub = 18.
-        // The TUI is NOT in the registry — main.rs handles `tui` /
-        // no-subcommand inline.
-        assert_eq!(names.len(), 18, "expected 18 entries, got {names:?}");
+        // 16 user-facing built-ins + claudecode namespace + tmux namespace
+        // + plugin stub = 19. The TUI is NOT in the registry — main.rs
+        // handles `tui` / no-subcommand inline.
+        assert_eq!(names.len(), 19, "expected 19 entries, got {names:?}");
         for required in [
             "run",
             "list",
@@ -1000,6 +1059,7 @@ mod tests {
             "usage",
             "statusline",
             "claudecode",
+            "tmux",
             "completion",
             "plugin",
         ] {

--- a/ainb-tui/crates/ainb-core/src/cli/tmux_install.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/tmux_install.rs
@@ -7,9 +7,8 @@
 //   3. If different → show a unified diff preview, prompt y/N (unless --yes).
 //   4. Back up the existing file to ~/.tmux.conf.bak.<UTC-timestamp>.
 //   5. Write the bundled conf to ~/.tmux.conf.
-//   6. Deploy the bundled helper script(s) under ~/.tmux/scripts/.
-//   7. Best-effort: clone TPM (~/.tmux/plugins/tpm) and install plugins.
-//   8. Best-effort: `tmux source-file ~/.tmux.conf` to reload live sessions.
+//   6. Best-effort: clone TPM (~/.tmux/plugins/tpm) and install plugins.
+//   7. Best-effort: `tmux source-file ~/.tmux.conf` to reload live sessions.
 //
 // `status` workflow: report not-installed / installed / stale, and show
 // where the backup lives (if any).
@@ -23,6 +22,7 @@ use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 
 use super::OutputFormat;
+use crate::config::AppConfig;
 
 /// The bundled rich tmux.conf shipped with the `ainb` binary.
 const BUNDLED_CONF: &str = include_str!("../../../../config/tmux.conf");
@@ -32,17 +32,16 @@ const BUNDLED_CONF: &str = include_str!("../../../../config/tmux.conf");
 const GIT_BRANCH_HELPER: &str =
     include_str!("../../../../config/tmux-helpers/git_branch.sh");
 
-/// Default install path: `~/.tmux.conf`.
-fn tmux_conf_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
-    Ok(home.join(".tmux.conf"))
-}
-
-/// TPM clone destination: `~/.tmux/plugins/tpm`.
-fn tpm_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
-    Ok(home.join(".tmux/plugins/tpm"))
-}
+/// Known-old ainb default tmux confs. If the user's `~/.tmux.conf` byte-matches
+/// any entry, the onboarding wizard treats it as "an old ainb default we shipped
+/// previously" and offers to upgrade. Anything else is treated as custom and the
+/// wizard SKIPS the prompt (so we never overwrite personal configs silently).
+///
+/// Add a new entry every time the bundled conf header/structure changes in a
+/// way users may already have on disk from a prior ainb install.
+const KNOWN_OLD_AINB_CONFS: &[&str] = &[
+    include_str!("../../../../config/known-old-confs/v1-88lines.tmux.conf"),
+];
 
 /// Where the git-branch helper gets deployed.
 fn helper_script_path() -> Result<PathBuf> {
@@ -70,7 +69,21 @@ fn deploy_helpers() -> bool {
     true
 }
 
+/// Default install path: `~/.tmux.conf`.
+fn tmux_conf_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(home.join(".tmux.conf"))
+}
+
+/// TPM clone destination: `~/.tmux/plugins/tpm`.
+fn tpm_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(home.join(".tmux/plugins/tpm"))
+}
+
 /// Whether the user's `~/.tmux.conf` matches what we ship.
+///
+/// Used by the install path — coarse-grained: just "is it our exact bundle".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallState {
     /// File does not exist.
@@ -102,6 +115,64 @@ fn detect_state(path: &Path) -> Result<InstallState> {
     } else {
         InstallState::Stale
     })
+}
+
+/// Finer-grained state for the onboarding wizard. Distinguishes a recognisable
+/// previous-ainb-default from a foreign / personal conf so we can prompt for
+/// the former (safe upgrade) and silently skip the latter (sacred).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnboardingTmuxState {
+    /// `~/.tmux.conf` doesn't exist.
+    Missing,
+    /// On-disk byte-matches the bundled conf — already up to date.
+    UpToDate,
+    /// On-disk byte-matches a previously-shipped ainb default. Safe to upgrade.
+    KnownOldAinb,
+    /// On-disk doesn't match anything we recognise — treat as custom and DON'T
+    /// auto-prompt. Surfaced in `init --status` so the user knows they CAN run
+    /// `ainb tmux install` if they want.
+    Custom,
+}
+
+impl OnboardingTmuxState {
+    pub fn label(self) -> &'static str {
+        match self {
+            OnboardingTmuxState::Missing => "missing",
+            OnboardingTmuxState::UpToDate => "up to date",
+            OnboardingTmuxState::KnownOldAinb => "old ainb default (upgradable)",
+            OnboardingTmuxState::Custom => "custom (not managed by ainb)",
+        }
+    }
+
+    /// Should `ainb init` auto-prompt the user about this state?
+    pub fn should_prompt(self) -> bool {
+        matches!(
+            self,
+            OnboardingTmuxState::Missing | OnboardingTmuxState::KnownOldAinb
+        )
+    }
+}
+
+/// Detect the onboarding-relevant state of `~/.tmux.conf`. See
+/// [`OnboardingTmuxState`].
+pub fn detect_onboarding_state(path: &Path) -> Result<OnboardingTmuxState> {
+    if !path.exists() {
+        return Ok(OnboardingTmuxState::Missing);
+    }
+    let on_disk = fs::read_to_string(path)
+        .with_context(|| format!("read existing {}", path.display()))?;
+    if on_disk == BUNDLED_CONF {
+        return Ok(OnboardingTmuxState::UpToDate);
+    }
+    if KNOWN_OLD_AINB_CONFS.iter().any(|c| &on_disk == c) {
+        return Ok(OnboardingTmuxState::KnownOldAinb);
+    }
+    Ok(OnboardingTmuxState::Custom)
+}
+
+/// Shortcut for use by callers that have already resolved `~`.
+pub fn detect_onboarding_state_default() -> Result<OnboardingTmuxState> {
+    detect_onboarding_state(&tmux_conf_path()?)
 }
 
 /// Produce a unified-diff-ish preview between the on-disk conf and the
@@ -290,7 +361,17 @@ pub struct StatusArgs {
 }
 
 /// `ainb tmux install` entrypoint.
-pub async fn install(args: InstallArgs, _format: OutputFormat) -> Result<()> {
+///
+/// Thin async wrapper around [`install_sync`] so the CLI trait (which requires
+/// a `BoxFuture`) can call us, while the onboarding wizard — which is itself
+/// invoked from inside the tokio runtime — can call the sync core directly
+/// and avoid the "Cannot start a runtime from within a runtime" panic.
+pub async fn install(args: InstallArgs, format: OutputFormat) -> Result<()> {
+    install_sync(args, format)
+}
+
+/// Synchronous core of [`install`]. All filesystem + subprocess work; no awaits.
+pub fn install_sync(args: InstallArgs, _format: OutputFormat) -> Result<()> {
     let target = tmux_conf_path()?;
     let state = detect_state(&target)?;
 
@@ -444,6 +525,146 @@ pub async fn status(args: StatusArgs, _format: OutputFormat) -> Result<()> {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Onboarding-wizard step (called from `cli::init::cmd_setup`)
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Outcome of `run_tmux_setup_step`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TmuxStepOutcome {
+    /// User accepted; conf is now installed (or was already up-to-date).
+    Installed,
+    /// User explicitly declined.
+    Declined,
+    /// Step did nothing (already decided previously, or state didn't warrant
+    /// prompting — e.g. UpToDate or Custom).
+    Skipped,
+}
+
+/// Read a single line from `input`, trim it, and lowercase it. Returns the
+/// empty string on EOF. Used by the wizard prompt loop. (Local to keep this
+/// module self-contained; `init.rs` has its own copy for its own prompts.)
+fn read_line_lower<R: std::io::BufRead>(input: &mut R) -> Result<String> {
+    let mut buf = String::new();
+    let n = input.read_line(&mut buf).context("read prompt input")?;
+    if n == 0 {
+        return Ok(String::new());
+    }
+    Ok(buf.trim().to_ascii_lowercase())
+}
+
+/// Drive the tmux-conf wizard step against a `BufRead` + `Write` pair.
+/// Pure on its IO so tests can drive it with in-memory buffers, mirroring
+/// `init::run_statusline_step`.
+///
+/// Behavior matrix:
+///
+/// | State           | Decision was…      | Action                         |
+/// |-----------------|--------------------|--------------------------------|
+/// | UpToDate        | (any)              | silent Skipped                 |
+/// | Custom          | (any)              | one-line hint, Skipped         |
+/// | Missing/Old     | Declined           | Skipped (respect prior choice) |
+/// | Missing/Old     | Installed (prior)  | Skipped (assume still wanted)  |
+/// | Missing/Old     | Unset              | PROMPT [Y/n]                   |
+pub fn run_tmux_setup_step<R: std::io::BufRead, W: std::io::Write>(
+    input: &mut R,
+    out: &mut W,
+) -> Result<TmuxStepOutcome> {
+    use crate::config::TmuxDecision;
+
+    let mut app_config = AppConfig::load().unwrap_or_default();
+    let prior = app_config.ui_preferences.tmux_decision;
+
+    let state = detect_onboarding_state_default()?;
+
+    writeln!(out).ok();
+    writeln!(out, "Tmux configuration:").ok();
+    writeln!(out, "  Current state: {}", state.label()).ok();
+
+    match state {
+        OnboardingTmuxState::UpToDate => {
+            writeln!(out, "  ✓ ainb's rich tmux conf already installed.").ok();
+            // Make sure the decision sticks to Installed in case it was Unset.
+            if prior == TmuxDecision::Unset {
+                app_config.ui_preferences.tmux_decision = TmuxDecision::Installed;
+                let _ = app_config.save();
+            }
+            return Ok(TmuxStepOutcome::Skipped);
+        }
+        OnboardingTmuxState::Custom => {
+            writeln!(
+                out,
+                "  ~/.tmux.conf exists but isn't recognised as an ainb default."
+            )
+            .ok();
+            writeln!(
+                out,
+                "  Leaving it alone. Run `ainb tmux install` later if you want \
+                 to switch to ainb's rich conf (it will back yours up first)."
+            )
+            .ok();
+            return Ok(TmuxStepOutcome::Skipped);
+        }
+        OnboardingTmuxState::Missing | OnboardingTmuxState::KnownOldAinb => {
+            if prior == TmuxDecision::Declined {
+                writeln!(out, "  Previously declined — skipping.").ok();
+                return Ok(TmuxStepOutcome::Skipped);
+            }
+        }
+    }
+
+    // Reaching here means: Missing or KnownOldAinb AND no prior decline.
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "  ainb ships a rich tmux conf:"
+    )
+    .ok();
+    writeln!(
+        out,
+        "    Catppuccin Mocha theme · TPM (resurrect + continuum + yank)"
+    )
+    .ok();
+    writeln!(
+        out,
+        "    Vim h/j/k/l pane nav · | and - splits · prefix-Left detach"
+    )
+    .ok();
+    writeln!(
+        out,
+        "    Status bar with detach/reload hints + git branch"
+    )
+    .ok();
+    writeln!(out).ok();
+    write!(out, "  Install? [Y/n] ").ok();
+    out.flush().ok();
+
+    let answer = read_line_lower(input)?;
+    if answer == "n" || answer == "no" {
+        app_config.ui_preferences.tmux_decision = TmuxDecision::Declined;
+        let _ = app_config.save();
+        writeln!(out, "  Skipped. (Run `ainb tmux install` any time to enable.)").ok();
+        return Ok(TmuxStepOutcome::Declined);
+    }
+
+    // Default to install on empty input or "y".
+    let args = InstallArgs {
+        yes: true,
+        no_plugins: false,
+        no_reload: false,
+    };
+
+    // Sync core — we're already inside the tokio runtime (init is async),
+    // so nesting another runtime would panic. install_sync does the same
+    // filesystem + subprocess work without awaits.
+    install_sync(args, OutputFormat::Text)?;
+
+    app_config.ui_preferences.tmux_decision = TmuxDecision::Installed;
+    let _ = app_config.save();
+    writeln!(out, "  ✓ Rich tmux conf installed.").ok();
+    Ok(TmuxStepOutcome::Installed)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Tests
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -496,5 +717,57 @@ mod tests {
         assert!(BUNDLED_CONF.contains("Catppuccin Mocha"));
         assert!(BUNDLED_CONF.contains("bind Left detach-client"));
         assert!(BUNDLED_CONF.contains("@plugin 'tmux-plugins/tpm'"));
+    }
+
+    #[test]
+    fn onboarding_state_missing_when_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.conf");
+        assert_eq!(
+            detect_onboarding_state(&path).unwrap(),
+            OnboardingTmuxState::Missing
+        );
+    }
+
+    #[test]
+    fn onboarding_state_uptodate_when_bundled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".tmux.conf");
+        fs::write(&path, BUNDLED_CONF).unwrap();
+        assert_eq!(
+            detect_onboarding_state(&path).unwrap(),
+            OnboardingTmuxState::UpToDate
+        );
+    }
+
+    #[test]
+    fn onboarding_state_known_old_when_matches_fixture() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".tmux.conf");
+        // Write the first known-old conf — should classify as KnownOldAinb.
+        fs::write(&path, KNOWN_OLD_AINB_CONFS[0]).unwrap();
+        assert_eq!(
+            detect_onboarding_state(&path).unwrap(),
+            OnboardingTmuxState::KnownOldAinb
+        );
+    }
+
+    #[test]
+    fn onboarding_state_custom_when_unrecognised() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".tmux.conf");
+        fs::write(&path, "# my totally custom tmux conf\nset -g prefix C-a\n").unwrap();
+        assert_eq!(
+            detect_onboarding_state(&path).unwrap(),
+            OnboardingTmuxState::Custom
+        );
+    }
+
+    #[test]
+    fn should_prompt_only_for_missing_or_old() {
+        assert!(OnboardingTmuxState::Missing.should_prompt());
+        assert!(OnboardingTmuxState::KnownOldAinb.should_prompt());
+        assert!(!OnboardingTmuxState::UpToDate.should_prompt());
+        assert!(!OnboardingTmuxState::Custom.should_prompt());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/tmux_install.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/tmux_install.rs
@@ -1,0 +1,500 @@
+// ABOUTME: `ainb tmux install` / `ainb tmux status` — manage the bundled
+// rich tmux.conf at ~/.tmux.conf.
+//
+// `install` workflow:
+//   1. Read existing ~/.tmux.conf (if any) and compare to the bundled conf.
+//   2. If identical → exit early with a friendly "already installed" message.
+//   3. If different → show a unified diff preview, prompt y/N (unless --yes).
+//   4. Back up the existing file to ~/.tmux.conf.bak.<UTC-timestamp>.
+//   5. Write the bundled conf to ~/.tmux.conf.
+//   6. Deploy the bundled helper script(s) under ~/.tmux/scripts/.
+//   7. Best-effort: clone TPM (~/.tmux/plugins/tpm) and install plugins.
+//   8. Best-effort: `tmux source-file ~/.tmux.conf` to reload live sessions.
+//
+// `status` workflow: report not-installed / installed / stale, and show
+// where the backup lives (if any).
+
+use std::fs;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow};
+use chrono::Utc;
+
+use super::OutputFormat;
+
+/// The bundled rich tmux.conf shipped with the `ainb` binary.
+const BUNDLED_CONF: &str = include_str!("../../../../config/tmux.conf");
+
+/// Helper script the rich conf shells out to from status-right to render the
+/// active pane's git branch.
+const GIT_BRANCH_HELPER: &str =
+    include_str!("../../../../config/tmux-helpers/git_branch.sh");
+
+/// Default install path: `~/.tmux.conf`.
+fn tmux_conf_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(home.join(".tmux.conf"))
+}
+
+/// TPM clone destination: `~/.tmux/plugins/tpm`.
+fn tpm_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(home.join(".tmux/plugins/tpm"))
+}
+
+/// Where the git-branch helper gets deployed.
+fn helper_script_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(home.join(".tmux/scripts/git_branch.sh"))
+}
+
+/// Deploy the embedded helper script and chmod +x. Best-effort: returns false
+/// on I/O failure but never errors the install.
+fn deploy_helpers() -> bool {
+    let Ok(dest) = helper_script_path() else { return false };
+    if let Some(parent) = dest.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return false;
+        }
+    }
+    if fs::write(&dest, GIT_BRANCH_HELPER).is_err() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&dest, fs::Permissions::from_mode(0o755));
+    }
+    true
+}
+
+/// Whether the user's `~/.tmux.conf` matches what we ship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallState {
+    /// File does not exist.
+    Missing,
+    /// File exists and is byte-identical to the bundled conf.
+    UpToDate,
+    /// File exists and differs from the bundled conf.
+    Stale,
+}
+
+impl InstallState {
+    fn label(self) -> &'static str {
+        match self {
+            InstallState::Missing => "not installed",
+            InstallState::UpToDate => "up to date",
+            InstallState::Stale => "stale (bundled conf differs from on-disk)",
+        }
+    }
+}
+
+fn detect_state(path: &Path) -> Result<InstallState> {
+    if !path.exists() {
+        return Ok(InstallState::Missing);
+    }
+    let on_disk = fs::read_to_string(path)
+        .with_context(|| format!("read existing {}", path.display()))?;
+    Ok(if on_disk == BUNDLED_CONF {
+        InstallState::UpToDate
+    } else {
+        InstallState::Stale
+    })
+}
+
+/// Produce a unified-diff-ish preview between the on-disk conf and the
+/// bundled conf, capped at `max_lines` so it fits comfortably in a terminal.
+/// Lines only on disk are prefixed `-`, lines only in the bundle `+`.
+fn diff_preview(on_disk: &str, bundled: &str, max_lines: usize) -> String {
+    let a: Vec<&str> = on_disk.lines().collect();
+    let b: Vec<&str> = bundled.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    let mut j = 0usize;
+    while i < a.len() && j < b.len() && out.len() < max_lines {
+        if a[i] == b[j] {
+            i += 1;
+            j += 1;
+            continue;
+        }
+        // Emit one removal + one addition, advance both — naive but fine for a
+        // preview. The user reviews intent, not byte-perfect diff alignment.
+        out.push(format!("- {}", a[i]));
+        if out.len() < max_lines {
+            out.push(format!("+ {}", b[j]));
+        }
+        i += 1;
+        j += 1;
+    }
+    while i < a.len() && out.len() < max_lines {
+        out.push(format!("- {}", a[i]));
+        i += 1;
+    }
+    while j < b.len() && out.len() < max_lines {
+        out.push(format!("+ {}", b[j]));
+        j += 1;
+    }
+    let remaining = (a.len().saturating_sub(i)) + (b.len().saturating_sub(j));
+    if remaining > 0 {
+        out.push(format!("  … {remaining} more line(s) differ"));
+    }
+    out.join("\n")
+}
+
+fn timestamp_suffix() -> String {
+    Utc::now().format("%Y%m%d-%H%M%S").to_string()
+}
+
+fn backup_existing(path: &Path) -> Result<PathBuf> {
+    let suffix = timestamp_suffix();
+    let backup = path.with_extension(format!("conf.bak.{suffix}"));
+    fs::copy(path, &backup)
+        .with_context(|| format!("backup {} → {}", path.display(), backup.display()))?;
+    Ok(backup)
+}
+
+fn write_conf(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create parent dir {}", parent.display()))?;
+    }
+    fs::write(path, BUNDLED_CONF).with_context(|| format!("write {}", path.display()))
+}
+
+fn prompt_yes_no(question: &str) -> Result<bool> {
+    print!("{question} [y/N] ");
+    io::stdout().flush().ok();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line).context("read stdin")?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(matches!(answer.as_str(), "y" | "yes"))
+}
+
+/// Best-effort: clone TPM if missing. Returns true if TPM is present after
+/// the call (either was already there, or we cloned it). Never errors —
+/// network failures are noted but not fatal to the install.
+fn ensure_tpm() -> bool {
+    let Ok(dest) = tpm_path() else { return false };
+    if dest.join("tpm").exists() {
+        return true;
+    }
+    if let Some(parent) = dest.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return false;
+        }
+    }
+    let status = Command::new("git")
+        .args([
+            "clone",
+            "--depth=1",
+            "https://github.com/tmux-plugins/tpm",
+            dest.to_str().unwrap_or(""),
+        ])
+        .status();
+    match status {
+        Ok(s) if s.success() => true,
+        _ => false,
+    }
+}
+
+/// Best-effort: run TPM's install hook so plugins are ready immediately.
+///
+/// `bin/install_plugins` needs `TMUX_PLUGIN_MANAGER_PATH` in its env, which is
+/// only set once the tmux server has sourced a conf containing TPM's `run`
+/// directive. So we invoke it via `tmux run-shell` to inherit the live server
+/// env. Falls back to a direct invocation (with the env var injected manually)
+/// when no server is running yet — that path silently no-ops if TPM init
+/// hasn't happened, which is fine: `prefix + I` inside tmux always works.
+fn run_tpm_install() -> bool {
+    let Ok(tpm) = tpm_path() else { return false };
+    let script = tpm.join("bin/install_plugins");
+    if !script.exists() {
+        return false;
+    }
+    let Ok(home) = dirs::home_dir().ok_or(()) else { return false };
+    let plugin_dir = home.join(".tmux/plugins/");
+    let script_str = script.to_str().unwrap_or("");
+
+    // Preferred: run inside the tmux server so TPM env vars exist.
+    let server_up = Command::new("tmux")
+        .args(["list-sessions"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if server_up {
+        return Command::new("tmux")
+            .args(["run-shell", script_str])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+    }
+
+    // Fallback: inject the env var and invoke directly.
+    Command::new(&script)
+        .env("TMUX_PLUGIN_MANAGER_PATH", &plugin_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Best-effort: reload every live tmux session with the new conf. Returns
+/// the number of sessions that were reloaded (0 if `tmux` isn't running or
+/// not installed).
+fn reload_live_sessions(path: &Path) -> usize {
+    // Check tmux server is up by listing sessions; a non-zero exit means no
+    // sessions / no server, which is fine.
+    let list = Command::new("tmux").args(["list-sessions", "-F", "#S"]).output();
+    let count = match list {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .count(),
+        _ => 0,
+    };
+    if count == 0 {
+        return 0;
+    }
+    let _ = Command::new("tmux")
+        .args(["source-file", path.to_str().unwrap_or("")])
+        .status();
+    count
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public CLI entrypoints
+// ──────────────────────────────────────────────────────────────────────────
+
+#[derive(clap::Args, Debug)]
+pub struct InstallArgs {
+    /// Skip the confirmation prompt (non-interactive use).
+    #[arg(long, short)]
+    pub yes: bool,
+
+    /// Skip TPM clone + plugin install. Useful in restricted environments
+    /// or for users who don't want plugins.
+    #[arg(long)]
+    pub no_plugins: bool,
+
+    /// Skip `tmux source-file` reload of live sessions.
+    #[arg(long)]
+    pub no_reload: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StatusArgs {
+    /// Show a diff preview if the on-disk conf is stale.
+    #[arg(long)]
+    pub diff: bool,
+}
+
+/// `ainb tmux install` entrypoint.
+pub async fn install(args: InstallArgs, _format: OutputFormat) -> Result<()> {
+    let target = tmux_conf_path()?;
+    let state = detect_state(&target)?;
+
+    match state {
+        InstallState::UpToDate => {
+            println!("✓ {} is already up to date.", target.display());
+            return Ok(());
+        }
+        InstallState::Missing => {
+            println!("No existing {} — installing fresh.", target.display());
+        }
+        InstallState::Stale => {
+            let on_disk = fs::read_to_string(&target)?;
+            println!(
+                "Found existing {} ({} lines).",
+                target.display(),
+                on_disk.lines().count()
+            );
+            println!(
+                "Proposed: ainb-tui bundled conf ({} lines).\n",
+                BUNDLED_CONF.lines().count()
+            );
+            println!("--- diff preview (first 40 lines) ---");
+            println!("{}", diff_preview(&on_disk, BUNDLED_CONF, 40));
+            println!("--- end diff ---\n");
+        }
+    }
+
+    if !args.yes && !prompt_yes_no("Apply?")? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    if matches!(state, InstallState::Stale) {
+        let backup = backup_existing(&target)?;
+        println!("✓ Backed up existing conf → {}", backup.display());
+    }
+
+    write_conf(&target)?;
+    println!("✓ Wrote {}", target.display());
+
+    if deploy_helpers() {
+        if let Ok(p) = helper_script_path() {
+            println!("✓ Deployed helper {}", p.display());
+        }
+    } else {
+        println!("! Failed to deploy git_branch.sh helper (status-right branch will be empty)");
+    }
+
+    // Step order matters here: TPM's `install_plugins` script needs
+    // `TMUX_PLUGIN_MANAGER_PATH`, which the tmux server only sets once it has
+    // sourced a conf containing TPM's `run` directive. So we:
+    //   1. Clone TPM (so the conf's `run` line has something to load).
+    //   2. Reload live sessions — this evaluates the new conf in-server,
+    //      registering the TPM env vars.
+    //   3. THEN invoke `install_plugins` via `tmux run-shell` so it inherits
+    //      the live server env.
+    let tpm_ready = if !args.no_plugins {
+        let ok = ensure_tpm();
+        if ok {
+            println!("✓ TPM present at ~/.tmux/plugins/tpm");
+        } else {
+            println!(
+                "! Could not clone TPM (network or git missing). \
+                 Plugins won't load until you run `prefix + I` inside tmux, or:\n  \
+                 git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm"
+            );
+        }
+        ok
+    } else {
+        false
+    };
+
+    if !args.no_reload {
+        let n = reload_live_sessions(&target);
+        if n > 0 {
+            println!("✓ Reloaded {n} live tmux session(s) via `tmux source-file`");
+        } else {
+            println!("· No live tmux sessions to reload.");
+        }
+    }
+
+    if !args.no_plugins && tpm_ready {
+        if run_tpm_install() {
+            println!("✓ TPM installed plugins (resurrect + continuum + yank)");
+            // Second reload: TPM's run-directive only loads plugins that exist
+            // on disk at source-time. The first reload happened before the
+            // clone, so the plugins' bindings (prefix+C-s save, prefix+C-r
+            // restore, etc.) weren't registered. Re-source now so they bind.
+            if !args.no_reload {
+                let n = reload_live_sessions(&target);
+                if n > 0 {
+                    println!(
+                        "✓ Re-sourced {n} session(s) so plugin bindings activate"
+                    );
+                }
+            }
+        } else {
+            println!(
+                "! TPM plugin install did not complete. Run `prefix + I` inside \
+                 any tmux session to retry."
+            );
+        }
+    }
+
+    println!("\nDone. Try:");
+    println!("  tmux new -s test     # start a session");
+    println!("  C-b ←                 # detach (new alternative binding)");
+    println!("  C-b r                 # reload conf");
+    Ok(())
+}
+
+/// `ainb tmux status` entrypoint.
+pub async fn status(args: StatusArgs, _format: OutputFormat) -> Result<()> {
+    let target = tmux_conf_path()?;
+    let state = detect_state(&target)?;
+
+    println!("Bundled conf:    {} lines", BUNDLED_CONF.lines().count());
+    println!("Install path:    {}", target.display());
+    println!("State:           {}", state.label());
+
+    if args.diff && matches!(state, InstallState::Stale) {
+        let on_disk = fs::read_to_string(&target)?;
+        println!("\n--- diff preview ---");
+        println!("{}", diff_preview(&on_disk, BUNDLED_CONF, 80));
+        println!("--- end diff ---");
+    }
+
+    // Surface the most recent backup, if any — handy for "what would
+    // uninstall restore?".
+    if let Some(parent) = target.parent() {
+        if let Ok(read) = fs::read_dir(parent) {
+            let mut backups: Vec<PathBuf> = read
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|n| n.starts_with(".tmux.conf.bak."))
+                        .unwrap_or(false)
+                })
+                .collect();
+            backups.sort();
+            if let Some(latest) = backups.last() {
+                println!("Latest backup:   {}", latest.display());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_state_missing_when_path_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.conf");
+        assert_eq!(detect_state(&path).unwrap(), InstallState::Missing);
+    }
+
+    #[test]
+    fn detect_state_up_to_date_when_identical() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".tmux.conf");
+        fs::write(&path, BUNDLED_CONF).unwrap();
+        assert_eq!(detect_state(&path).unwrap(), InstallState::UpToDate);
+    }
+
+    #[test]
+    fn detect_state_stale_when_byte_different() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".tmux.conf");
+        fs::write(&path, "set -g mouse off\n").unwrap();
+        assert_eq!(detect_state(&path).unwrap(), InstallState::Stale);
+    }
+
+    #[test]
+    fn diff_preview_marks_removed_and_added_lines() {
+        let preview = diff_preview("a\nb\nc\n", "a\nB\nc\n", 10);
+        assert!(preview.contains("- b"));
+        assert!(preview.contains("+ B"));
+    }
+
+    #[test]
+    fn diff_preview_truncates_at_cap() {
+        let on_disk: String = (0..50).map(|i| format!("old-{i}\n")).collect();
+        let bundle: String = (0..50).map(|i| format!("new-{i}\n")).collect();
+        let preview = diff_preview(&on_disk, &bundle, 10);
+        assert!(preview.lines().count() <= 11); // 10 diff lines + tail summary
+        assert!(preview.contains("more line(s) differ"));
+    }
+
+    #[test]
+    fn bundled_conf_contains_signature_markers() {
+        // Light smoke check that include_str! is wired to the right file.
+        assert!(BUNDLED_CONF.contains("Catppuccin Mocha"));
+        assert!(BUNDLED_CONF.contains("bind Left detach-client"));
+        assert!(BUNDLED_CONF.contains("@plugin 'tmux-plugins/tpm'"));
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -463,6 +463,13 @@ pub struct UiPreferences {
     /// (the Budget-panel CTA remains visible for power users).
     #[serde(default)]
     pub statusline_decision: StatuslineDecision,
+
+    /// User's response to the "install ainb's rich tmux conf" prompt.
+    /// Same shape as `statusline_decision`. `Unset` re-prompts on next
+    /// `ainb init` if the on-disk conf is Missing or a known-old ainb
+    /// default; `Declined` suppresses the prompt entirely.
+    #[serde(default)]
+    pub tmux_decision: TmuxDecision,
 }
 
 /// The user's recorded decision on the Claude Code statusline wiring.
@@ -479,6 +486,20 @@ pub enum StatuslineDecision {
     Installed,
 }
 
+/// The user's recorded decision on the ainb rich tmux conf installation.
+/// Mirrors [`StatuslineDecision`] semantics.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TmuxDecision {
+    /// Never asked, or dismissed without accepting/declining.
+    #[default]
+    Unset,
+    /// Explicitly opted out — suppress future prompts.
+    Declined,
+    /// Accepted; ainb has written ~/.tmux.conf (and deployed helpers).
+    Installed,
+}
+
 impl Default for UiPreferences {
     fn default() -> Self {
         Self {
@@ -490,6 +511,7 @@ impl Default for UiPreferences {
             sessions_sidebar_width: None,
             sessions_sidebar_collapsed: None,
             statusline_decision: StatuslineDecision::default(),
+            tmux_decision: TmuxDecision::default(),
         }
     }
 }
@@ -715,6 +737,12 @@ impl AppConfig {
             self.ui_preferences.sessions_sidebar_collapsed =
                 other.ui_preferences.sessions_sidebar_collapsed;
         }
+        // Decision fields: always trust on-disk, even when the value equals
+        // the default. "Unset" is itself a meaningful decision (means: prompt
+        // again next time), and "Declined" must round-trip across loads or
+        // the wizard would re-pester the user every run.
+        self.ui_preferences.statusline_decision = other.ui_preferences.statusline_decision;
+        self.ui_preferences.tmux_decision = other.ui_preferences.tmux_decision;
 
         // Override Docker settings
         if other.docker.host.is_some() {
@@ -1109,6 +1137,7 @@ mod old_config_tests {
                 sessions_sidebar_width: None,
                 sessions_sidebar_collapsed: None,
                 statusline_decision: StatuslineDecision::default(),
+                tmux_decision: TmuxDecision::default(),
             },
             docker: DockerConfig {
                 host: None,
@@ -1152,6 +1181,7 @@ mod old_config_tests {
                 sessions_sidebar_width: Some(46),
                 sessions_sidebar_collapsed: Some(true),
                 statusline_decision: StatuslineDecision::default(),
+                tmux_decision: TmuxDecision::default(),
             },
             docker: DockerConfig {
                 host: None,


### PR DESCRIPTION
## Summary

Three commits ship a rich tmux configuration story end-to-end for ainb-tui:

1. **`feat(tmux): rich Catppuccin Mocha conf + git branch helper`** — replaces the 88-line minimal default with a 231-line opinionated conf (Catppuccin Mocha inline theme, TPM + resurrect + continuum + yank, vim h/j/k/l nav, intuitive `|`/`-` splits, prefix-Left detach, prefix-r reload, status bar with detach/reload hints + git branch). Ships a `git_branch.sh` helper script and a `known-old-confs/` fixture so future upgrades can recognise old defaults.

2. **`feat(cli): ainb tmux install|status subcommand`** — `ainb tmux install` writes the bundled conf with a timestamped backup, deploys the helper, clones TPM, reloads all live sessions, then re-sources after plugin install so bindings activate in one shot. `ainb tmux status` reports Missing / UpToDate / Stale. Flags: `--yes`, `--no-plugins`, `--no-reload`. 6 unit tests.

3. **`feat(init): prompt for rich tmux conf in onboarding wizard`** — adds a tmux step to `ainb init` that detects 4 states (Missing / KnownOldAinb / Custom / UpToDate) and prompts only for the first two. Custom (personal) confs are sacred — never overwritten without explicit `ainb tmux install`. Decision persists as `TmuxDecision` (`Unset` / `Declined` / `Installed`); declined respected on re-run. Surfaced in `ainb init --status`. Also fixes a pre-existing bug where `statusline_decision` was silently reset to `Unset` on every config load. 5 new tests.

## Live verification

Installed against the author's own machine (43 live tmux sessions) during development:
- Status bar renders with 3 distinct axes (session pill / running command / git branch)
- All bindings live (`prefix h/j/k/l`, `|`, `-`, `Left`, `r`, `C-s`, `C-r`)
- TPM auto-bootstrap installs resurrect + continuum + yank on first run
- Backup chain at `~/.tmux.conf.bak.<UTC-timestamp>` for rollback

## Test plan

- [x] `cargo build --bin ainb` green
- [x] `cargo test -p ainb --lib 'cli::tmux_install'` — 11/11 pass
- [x] `cargo test -p ainb --lib 'cli::init'` — 23/23 pass
- [x] `cargo test -p ainb --lib 'cli::registry'` — 9/9 pass (count test updated from 18 → 19)
- [x] Live smoke test: `ainb tmux install --yes` on author's machine, all 4 onboarding states verified against sandbox HOME
- [ ] CI green