### PR TITLE
feat(skills): brainstorm orchestrator + /interview integration with ASCII previews

### DIFF
--- a/toolkit/packages/skills/brainstorm/SKILL.md
+++ b/toolkit/packages/skills/brainstorm/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: brainstorm
-description: Develop a thorough, step-by-step specification for a given idea
+description: Turn an idea into an approved design spec. Brainstorm is the orchestrator - it scaffolds a topic-stub with subject-type detection and ASCII preview hypotheses, then DELEGATES the iterative Q&A to /interview. After /interview returns a spec, brainstorm self-reviews, gates on user approval, and hands off to /plan. No HTML, no browser - terminal + ASCII previews only.
 user-invocable: true
 ---
 
-Develop a thorough, step-by-step specification for the provided idea: $ARGUMENTS
+Brainstorm idea: `$ARGUMENTS`. Output is an approved spec doc, not code. **Brainstorm is the orchestrator; `/interview` runs the actual Q&A.**
 
-Follow these steps:
+<HARD-GATE>
+Do NOT write code, scaffold a project, run install/build commands, or invoke any implementation skill (`/plan`, `/implement`, `/plan-tdd`, framework codegen) until a written spec exists in `.agents/specs/` AND the user has explicitly approved it via the user-review gate (Step 10). Once both conditions are satisfied, Step 12 (`/plan` handoff) is the intended terminal action. Applies to every project regardless of perceived simplicity.
+</HARD-GATE>
+
+## Anti-pattern: "too simple to need a design"
+
+Every brainstorm produces a spec. Todo list, single-function util, config change - all of them. "Simple" is where unexamined assumptions bite hardest. Spec can be 10 lines for trivial work, but it must exist and be approved.
 
 <!-- recall:begin -->
 
-## Step 0: Prior-art check (MANDATORY)
+## Step 1: Prior-art check (MANDATORY)
 
-Before brainstorming, recall prior learnings from the global knowledge base so we don't re-learn or re-decide something already captured:
+Recall prior learnings from the global knowledge base before brainstorming so we don't re-decide something already captured:
 
 ```bash
 uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
@@ -20,39 +26,404 @@ uv run "{{HOME_TOOL_DIR}}/skills/recall/scripts/recall.py" \
   --limit 5 --format markdown
 ```
 
-**Query construction for `/brainstorm`**: the topic or problem being brainstormed + any constraint hints from the user (e.g. `"caching strategy mobile offline"`).
+**Query construction**: topic + constraint hints (e.g. `"caching strategy mobile offline"`).
 
 **What to do with results:**
-
-- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant to the task — surface it to the user BEFORE proceeding with this skill's main flow.
-- If nothing relevant returns — proceed silently, no need to mention the check.
-- Never block on recall failure. Empty output / non-zero exit is expected when the KB is absent or the subprocess errors — treat it as "no prior art found", not as an error.
+- If a returned learning names a constraint, anti-pattern, or prior decision directly relevant - surface it to the user BEFORE proceeding.
+- If nothing relevant returns - proceed silently.
+- Never block on recall failure. Empty output / non-zero exit = "no prior art found", not error.
 
 <!-- recall:end -->
 
-1. **Ask clarifying questions** one at a time to understand the requirements:
-   - What is the core problem this solves?
-   - Who are the target users?
-   - What are the key features and functionality?
-   - What are the technical constraints or preferences?
-   - What is the expected timeline and scope?
+## Process flow
 
-2. **Build iteratively** on each answer to create a comprehensive spec that includes:
-   - Problem statement and goals
-   - User personas and use cases
-   - Functional requirements
-   - Technical architecture overview
-   - Data models and API design
-   - UI/UX considerations
-   - Testing strategy
-   - Deployment requirements
+```
+┌──────────────┐   ┌─────────────┐   ┌──────────────┐   ┌──────────────┐
+│ Recall +     │──▶│ Detect      │──▶│ Scaffold     │──▶│ INVOKE       │
+│ Project scan │   │ subject type│   │ topic-stub   │   │ /interview   │
+└──────────────┘   └─────────────┘   └──────────────┘   └──────┬───────┘
+                                                               │
+                            /interview runs the Q&A,           │
+                            uses ASCII previews from stub,     │
+                            writes <stub>-spec.md              │
+                                                               ▼
+┌──────────────┐   ┌─────────────┐   ┌──────────────┐   ┌──────────────┐
+│ /plan        │◀──│ User review │◀──│ Self-review  │◀──│ Read back    │
+│ handoff      │   │ gate        │   │ spec         │   │ spec from    │
+│              │   │             │   │              │   │ /interview   │
+└──────────────┘   └─────────────┘   └──────────────┘   └──────────────┘
+```
 
-3. **Save the specification** as `spec.md` with proper markdown formatting
+Terminal state = `/plan` invocation. Never invoke `/implement` or framework codegen direct from brainstorm.
 
-4. **Offer GitHub repository creation**:
-   - Ask if they want to create a new GitHub repository
-   - If yes, use `gh repo create` to create the repo
-   - Commit the `spec.md` file
-   - Push to the newly created repository
+## Division of labour
 
-Remember: Ask only one question at a time and build on previous answers iteratively.
+| Skill         | Role                                                            |
+|---------------|-----------------------------------------------------------------|
+| `/brainstorm` | Recall, project context, subject-type detection, stub scaffolding with ASCII previews, self-review, user-review gate, `/plan` handoff |
+| `/interview`  | The actual iterative AskUserQuestion-based Q&A loop, populating the spec file |
+
+Brainstorm is the orchestration layer. It writes one rich stub file, hands off, reads the result. The interview skill is the Q&A engine.
+
+## Checklist (track via TaskCreate)
+
+1. **Recall** prior learnings - Step 1 below
+2. **Scan project context** - files, docs, recent commits, existing patterns
+3. **Decompose if too large** - flag and split before refining details
+4. **Detect subject type** - drives which ASCII preview library slice to embed
+5. **Pre-stub clarifier (optional, ≤ 1 question)** - only if subject type / scope is ambiguous
+6. **Scaffold topic-stub.md** - `.agents/specs/YYYY-MM-DD-<topic>-stub.md` with hypotheses, ASCII slice, instructions, output template
+7. **Invoke `/interview <stub-path>`** via Skill tool - it runs the Q&A and writes `<stub>-spec.md`
+8. **Read back spec** - at `.agents/specs/YYYY-MM-DD-<topic>-stub-spec.md`
+9. **Self-review spec** - placeholder / contradiction / ambiguity / scope / YAGNI sweep
+10. **User-review gate** - explicit approval before handoff
+11. **Rename + commit** - move final spec to `.agents/specs/YYYY-MM-DD-<topic>.md`
+12. **Handoff** - invoke `/plan` skill with spec path
+
+## Step 2: Project context
+
+Before drafting the stub:
+- `git log --oneline -20` for recent direction
+- `ls` repo root + relevant subdirs
+- Read existing `docs/`, `README.md`, `AGENTS.md`, `CLAUDE.md`
+- Note existing patterns to follow
+
+## Step 3: Decompose check
+
+Before refining details, assess scope. If the request names multiple independent subsystems ("platform with chat + file storage + billing + analytics"), STOP and decompose:
+
+```
+┌─ Original idea ────────────────────┐
+│ "Build platform with X, Y, Z"      │
+└─────────────────┬──────────────────┘
+                  │
+        ┌─────────┼─────────┐
+        ▼         ▼         ▼
+    ┌───────┐ ┌───────┐ ┌───────┐
+    │ Sub-X │ │ Sub-Y │ │ Sub-Z │
+    └───────┘ └───────┘ └───────┘
+   spec→plan  spec→plan  spec→plan
+   (each runs its own brainstorm cycle)
+```
+
+Pick the first sub-project. Brainstorm THAT. Other sub-projects each get their own `/brainstorm` cycle later.
+
+## Step 4: Detect subject type
+
+Infer from `$ARGUMENTS` + project context. If ambiguous, ask ONE AskUserQuestion (Step 5). Often a single brainstorm spans 2-3 types (e.g. API + data model + CLI) - include the ASCII library slice for each.
+
+| Subject     | Preview shape                                  |
+|-------------|------------------------------------------------|
+| UI (web/mobile) | ASCII wireframe (header / sections / buttons) |
+| TUI         | ASCII screen mock (panes / status bar / keys) |
+| API         | endpoint + request/response JSON snippet      |
+| Data model  | entity box + relationship arrows              |
+| Architecture | component box + dataflow arrows              |
+| CLI         | command syntax + sample stdout               |
+| Config      | YAML/JSON snippet                            |
+| State machine | state node + transition arrows              |
+| Pure concept | (no preview - text description only)         |
+
+## Step 5: Pre-stub clarifier (optional, ≤ 1 question)
+
+Only if subject type or core scope is unclear. Use AskUserQuestion. Examples:
+- "What kind of artifact is this?" with options { Web UI, Mobile UI, TUI, API, CLI, library, mixed }
+- "Hard constraint?" with options { has deadline, no constraints, needs perf target }
+
+If you have enough context from `$ARGUMENTS` + project scan, **skip this step** and go straight to stub scaffolding. The point is to give `/interview` enough to run with, not to do its job for it.
+
+## Step 6: Scaffold the topic-stub
+
+**Read the ASCII library first**: `{{HOME_TOOL_DIR}}/skills/brainstorm/assets/ascii-library.md`. It has 8 subject-keyed sections (UI / TUI / API / Data model / Architecture / CLI / Config / State machine). Copy the matching slice(s) into the stub's `## ASCII preview library` section.
+
+**Resolve every `<placeholder>` from $ARGUMENTS + Step 2 context BEFORE writing the file.** The on-disk stub must contain no angle-bracket placeholders, no `TBD`, no `TODO` (per Stevie's `<paste_ready_artifacts>` rule). A placeholder-laden stub wastes /interview's first round on re-derivation.
+
+Write to `.agents/specs/YYYY-MM-DD-<topic-slug>-stub.md`. The stub IS the contract with `/interview` - it must contain EXACTLY these headings (interview matches them exactly):
+
+- `## Idea`
+- `## Project context (inferred)`
+- `## Subject type(s)`
+- `## Initial hypotheses`
+- `## ASCII preview library`
+- `## For /interview`
+- `## Output Spec Template`
+
+Template body:
+
+````markdown
+# Brainstorm topic stub: <title>
+
+> This is a brainstorm stub. The `/interview` skill will read it and run the iterative Q&A. Follow the instructions in the "For /interview" section.
+
+## Idea
+
+<one-paragraph problem statement from $ARGUMENTS + clarifier answer>
+
+## Project context (inferred)
+
+- Stack: <e.g. Rust + tokio>, <repo patterns spotted>
+- Existing patterns: <bullet list of relevant docs / code paths>
+- Constraints surfaced from recall: <if any>
+
+## Subject type(s)
+
+<UI | TUI | API | data model | architecture | CLI | config | state machine | mixed>
+
+## Initial hypotheses
+
+Three candidate approaches. **`/interview` MUST present these via AskUserQuestion in its first round, using the ASCII preview field shown below for each.**
+
+### A: <name>  (recommended)
+
+<one-line rationale>
+
+```
+<ASCII preview drawn from the matching library section>
+```
+
+### B: <name>
+
+<tradeoff vs A>
+
+```
+<ASCII preview>
+```
+
+### C: <name>  (optional - only if there's a real third path)
+
+<tradeoff>
+
+```
+<ASCII preview>
+```
+
+## ASCII preview library
+
+Inlined slices from `{{HOME_TOOL_DIR}}/skills/brainstorm/assets/ascii-library.md` that match this brainstorm's subject type(s). `/interview` uses these in subsequent AskUserQuestion `preview` fields.
+
+<paste the matching subject-type sections here>
+
+## For /interview
+
+**Read this carefully before starting the interview.**
+
+- **First round**: present the three approach hypotheses above via AskUserQuestion. Set `preview` to the ASCII block under each.
+- **Subsequent rounds**: drill into architecture, data model, interface, behavior, errors, testing. **Every option-style question MUST use `AskUserQuestion`** with `preview` populated from the library above when comparing concrete shapes.
+- **One question per turn** (or 2-4 if naturally batched). Multi-choice preferred.
+- **Topics to cover** (skip if N/A): architecture / data model / interface (UI/API/CLI/TUI) / happy path / 2-3 critical edge cases / error handling / testing strategy / out of scope / open questions.
+- **Output**: write the spec to `<this-stub-basename>-spec.md` using the "Output Spec Template" section below — **NOT** the default `/interview` corporate template.
+
+### Format preferences (apply to BOTH chat outputs AND spec file)
+
+Per Stevie's CLAUDE.md `<flow_diagrams>` rule. Boundary:
+
+| Content shape                                | Use                                              |
+|----------------------------------------------|--------------------------------------------------|
+| Flow / sequence / relationships / state      | ASCII box+arrow diagram (`┌─┐ │ └─┘ ─▶ ▼`)        |
+| Tabular DATA (rows × columns of facts)       | markdown pipe table                              |
+| Discrete items, no ordering                  | bullet list                                      |
+| Picks / open questions                       | `- [ ]` checklist                                |
+| Prose / narrative paragraphs                 | AVOID — break it into one of the above           |
+
+Rules:
+- **Diagram FIRST, table SECOND** when both apply to the same section.
+- Diagram width ≤ 80 chars.
+- Caveman inside boxes (short technical terms, never sentences).
+- Sequence diagrams (vertical lifelines) ONLY for protocol handshakes / back-and-forth.
+- Branching trees ONLY for explicit if/else logic.
+- No prose-only sections in the spec. Every section must be diagram + table + bullets.
+
+## Output Spec Template
+
+```markdown
+# Spec: <title>
+
+**Generated from:** <stub-path>
+**Date:** <YYYY-MM-DD>
+**Format:** diagram-first, table-second, no prose paragraphs
+
+## Problem
+
+| Question | Answer            |
+|----------|-------------------|
+| What?    | <one-liner>       |
+| Why?     | <motivator>       |
+| Who?     | <primary user>    |
+
+## Users + use cases
+
+| Persona     | Goal                | Primary use case          |
+|-------------|---------------------|---------------------------|
+| <persona 1> | <what they want>    | <core flow they trigger>  |
+| <persona 2> | <...>               | <...>                     |
+
+## Approach
+
+| Option | Summary       | Tradeoff           | Picked? |
+|--------|---------------|--------------------|---------|
+| A      | <name>        | <vs B and C>       |  ✓      |
+| B      | <name>        | <vs A>             |         |
+| C      | <name>        | <vs A>             |         |
+
+**Why A:** <one line>
+
+## Architecture
+
+<ASCII box+arrow diagram, ≤ 80 chars wide>
+
+| Component | Purpose      | Owns                |
+|-----------|--------------|---------------------|
+| <name>    | <one-liner>  | <data / behavior>   |
+
+## Data model
+
+<ASCII entity + relationship diagram>
+
+| Entity   | Fields (key only)        | Relationships    |
+|----------|--------------------------|------------------|
+| <name>   | id, ...                  | 1:N to <other>   |
+
+## Interface
+
+ASCII previews per applicable subject type (UI wireframe | TUI screen | API endpoints | CLI sample | config schema).
+
+| Surface    | Trigger              | Shape                 |
+|------------|----------------------|-----------------------|
+| <name>     | <user/system event>  | <method / screen / cmd> |
+
+## Behavior
+
+Happy path (ASCII flow):
+
+[start] ──action──▶ [state-1] ──action──▶ [state-2] ──ok──▶ [done]
+
+Edge cases:
+
+| Scenario          | Trigger              | Expected behavior        |
+|-------------------|----------------------|--------------------------|
+| <case 1>          | <condition>          | <what happens>           |
+| <case 2>          | <condition>          | <what happens>           |
+| <case 3>          | <condition>          | <what happens>           |
+
+## Errors
+
+| Failure mode    | User-visible surface       | Recovery              |
+|-----------------|----------------------------|-----------------------|
+| <e.g. 500>      | <toast / log / silent>     | <retry / fallback>    |
+| <network drop>  | <...>                      | <...>                 |
+
+## Testing strategy
+
+| Layer       | Scope                              | Coverage gate       |
+|-------------|------------------------------------|---------------------|
+| Integration | <flows covered>                    | <must-pass>         |
+| E2E         | <user-visible journeys>            | <must-pass>         |
+| Unit        | <only where logic is non-trivial>  | <if applicable>     |
+
+## Out of scope
+
+- <explicit item 1>
+- <explicit item 2>
+
+## Open questions for /plan
+
+- [ ] <question 1>
+- [ ] <question 2>
+```
+````
+
+After writing the stub, **DO NOT** answer the questions yourself. Hand off to `/interview`.
+
+## Step 7: Invoke /interview
+
+**Filename contract (used in Steps 8-11):** `/interview` writes its output as `<input-basename>-spec.md` next to the input file. So given `<topic>-stub.md` as input, the output is `<topic>-stub-spec.md`. Every path reference in this skill depends on this contract — if `/interview`'s output suffix ever changes, update Steps 8-11.
+
+Invoke:
+
+```
+Skill(skill: "interview", args: ".agents/specs/YYYY-MM-DD-<topic>-stub.md")
+```
+
+`/interview` will:
+- Read the stub
+- Detect the embedded `## Output Spec Template` section and use it (NOT the default template)
+- Detect `## Initial hypotheses`, `## ASCII preview library`, `## For /interview` sections and honor them
+- Run AskUserQuestion rounds — starting with the three approach hypotheses, then drilling into design
+- Write the spec to `.agents/specs/YYYY-MM-DD-<topic>-stub-spec.md`
+
+Wait for `/interview` to complete and return control.
+
+## Step 8: Read back the spec
+
+Read `.agents/specs/YYYY-MM-DD-<topic>-stub-spec.md`. Confirm it exists and is non-trivial.
+
+## Step 9: Spec self-review
+
+Fresh-eyes pass with these gates. Fix inline; don't re-loop.
+
+| Gate         | What to look for                                                |
+|--------------|-----------------------------------------------------------------|
+| Placeholder  | `TBD`, `TODO`, `<...>`, empty sections                          |
+| Consistency  | sections contradicting each other; arch ≠ behavior              |
+| Ambiguity    | requirements interpretable two ways - pick one, make explicit   |
+| Scope        | still one project, or did it bloat? if bloated, decompose again |
+| YAGNI        | unrequested features creeping in - strip                        |
+
+Only flag issues that would cause real planning problems. Minor wording, stylistic preferences - leave alone.
+
+## Step 10: User-review gate
+
+> "Spec written to `.agents/specs/YYYY-MM-DD-<topic>-stub-spec.md`. Review it. Changes welcome before we finalize + move to `/plan`."
+
+Wait for explicit approval. If changes requested → fix → re-run self-review → re-ask.
+
+## Step 11: Rename + commit
+
+After approval. The stub and stub-spec files were created by `Write` (untracked by git), so use plain `mv` / `rm`, NOT `git mv` / `git rm` (which require tracked files):
+
+```bash
+mv .agents/specs/YYYY-MM-DD-<topic>-stub-spec.md .agents/specs/YYYY-MM-DD-<topic>.md
+rm .agents/specs/YYYY-MM-DD-<topic>-stub.md
+git add .agents/specs/YYYY-MM-DD-<topic>.md
+git commit -m "feat(spec): add <topic> design spec"
+```
+
+One atomic commit; only the final spec lands in history (stub was scaffolding).
+
+## Step 12: Handoff to /plan
+
+Invoke `/plan` (via Skill tool) with the final spec path. Do NOT invoke `/implement`, framework codegen, or anything else.
+
+## ASCII Preview Library
+
+The library lives in a sibling file:
+
+```
+{{HOME_TOOL_DIR}}/skills/brainstorm/assets/ascii-library.md
+```
+
+**Read this file before scaffolding the stub (Step 6).** Embed the matching subject-type slice(s) inline in the stub's `## ASCII preview library` section so `/interview` has the templates available in-context.
+
+Subjects covered: UI / TUI / API / Data model / Architecture / CLI / Config / State machine.
+
+## Key principles
+
+- **Brainstorm orchestrates, /interview runs the Q&A** - don't duplicate Q&A logic
+- **The stub is the contract** - put everything /interview needs in there (hypotheses, ASCII library slice, output template, instructions)
+- **Heading exact-match** - stub headings (`## Initial hypotheses`, `## ASCII preview library`, `## For /interview`, `## Output Spec Template`) must EXACTLY match what /interview scans for. No em-dash suffixes, no rewording.
+- **AskUserQuestion mandatory** for any A/B/C decision (per CLAUDE.md `<option_presentation>`) — applies to both skills
+- **ASCII preview per option** when shapes are being compared
+- **Multi-choice preferred** over open-ended
+- **YAGNI ruthlessly** - strip unrequested features at every gate
+- **Spec is the deliverable**, not code
+- **Decompose before stub-ing** for large projects
+
+## Anti-patterns to avoid
+
+- Doing the Q&A inside `/brainstorm` instead of delegating → defeats the integration
+- Writing a thin stub that doesn't give `/interview` enough → it will ask shallow questions
+- Plaintext markdown option tables in stub or interview → AskUserQuestion only
+- HTML / browser companions → terminal + ASCII only
+- Writing a stub with unresolved `<placeholders>` → wastes /interview's first round (see HARD-GATE + Step 6)
+- Auto-running `/plan` without user-review gate → wait for explicit approval (HARD-GATE)
+- Renaming stub-spec with `git mv` instead of plain `mv` → fails on untracked files

--- a/toolkit/packages/skills/brainstorm/assets/ascii-library.md
+++ b/toolkit/packages/skills/brainstorm/assets/ascii-library.md
@@ -1,0 +1,176 @@
+# ASCII Preview Library
+
+Reference templates for `/brainstorm`. Pick the slice that matches your subject type and embed it into the topic-stub's "ASCII preview library" section. Keep each ≤ 80 chars wide. Caveman inside boxes (short technical terms, never sentences).
+
+## UI (web/mobile)
+
+```
+┌──────────────────────────────────────┐
+│ ☰  Logo            Sign in  [Get →]  │  ← header
+├──────────────────────────────────────┤
+│  Headline goes here                  │
+│  Subtext under headline              │
+│                                      │
+│  ┌────────────┐  ┌────────────┐      │
+│  │ Feature 1  │  │ Feature 2  │      │
+│  └────────────┘  └────────────┘      │
+│                                      │
+│  [ Primary CTA ]   [ Secondary ]     │
+└──────────────────────────────────────┘
+```
+
+Split-pane variant:
+```
+┌─────────────────────────────────────┐
+│ ┌────────┐ │  Detail pane           │
+│ │ List 1 │ │  ─────────             │
+│ │ List 2 │ │  Body content...       │
+│ │ List 3 │ │                        │
+│ └────────┘ │                        │
+└─────────────────────────────────────┘
+```
+
+## TUI (terminal UI)
+
+```
+┌─ Sessions ─────────────────────────────┐
+│ ▶ session-1     running   ainb-tui     │
+│   session-2     idle      website      │
+│   session-3     exited    research     │
+│                                        │
+│ [Space] select  [Enter] open  [q] quit │
+└────────────────────────────────────────┘
+```
+
+Two-pane TUI:
+```
+┌─ List ────────┬─ Detail ──────────────┐
+│ ▶ item-1      │ id:     abc123        │
+│   item-2      │ status: running       │
+│   item-3      │ since:  10m ago       │
+│               │ logs:   ...           │
+└───────────────┴───────────────────────┘
+status: 3 items │ filter: all │ q quit
+```
+
+Defer to `tui-style-guide` skill for chars and conventions.
+
+## API (REST resource)
+
+```
+GET    /v1/sessions          → list, paginated
+POST   /v1/sessions          → create
+GET    /v1/sessions/:id      → fetch one
+PATCH  /v1/sessions/:id      → update status
+DELETE /v1/sessions/:id      → terminate
+
+POST /v1/sessions
+{
+  "agent":  "claude",
+  "cwd":    "/path/to/project",
+  "title":  "string"
+}
+→ 201 Created
+{ "id": "uuid", "status": "running", "created_at": "..." }
+```
+
+GraphQL variant:
+```
+type Session {
+  id:        ID!
+  agent:     AgentKind!
+  status:    SessionStatus!
+  createdAt: DateTime!
+}
+type Mutation {
+  createSession(input: CreateSessionInput!): Session!
+}
+```
+
+## Data model
+
+```
+┌─ User ────────┐         ┌─ Session ─────────┐
+│ id      uuid  │──1:N──▶ │ id        uuid    │
+│ email   str   │         │ user_id   fk      │
+│ created ts    │         │ agent     enum    │
+└───────────────┘         │ status    enum    │
+                          │ started   ts      │
+                          │ ended     ts?     │
+                          └─────────┬─────────┘
+                                    │ 1:N
+                                    ▼
+                          ┌─ Message ─────────┐
+                          │ id        uuid    │
+                          │ session_id fk     │
+                          │ role      enum    │
+                          │ body      text    │
+                          │ ts        ts      │
+                          └───────────────────┘
+```
+
+## Architecture (component + dataflow)
+
+```
+┌─────────┐    HTTPS    ┌──────────┐    pgwire   ┌──────────┐
+│ Browser │────────────▶│ Edge Fn  │────────────▶│ Postgres │
+└─────────┘             └────┬─────┘             └──────────┘
+                             │
+                             │  webhook
+                             ▼
+                       ┌──────────┐
+                       │  Queue   │
+                       └────┬─────┘
+                            │ poll
+                            ▼
+                       ┌──────────┐
+                       │ Worker   │
+                       └──────────┘
+```
+
+## CLI (commands + sample output)
+
+```
+$ tool create --name foo --type bar
+✓ created  id=abc123  status=pending
+
+$ tool list
+NAME  TYPE  STATUS    AGE
+foo   bar   running   2m
+baz   bar   exited    5h
+
+$ tool logs foo --since 1m
+12:01:02  starting up
+12:01:03  bound :8080
+12:01:04  ready
+```
+
+## Config (schema variants)
+
+```yaml
+# Option A — flat
+service:
+  name:    foo
+  retries: 3
+  timeout: 30s
+```
+```yaml
+# Option B — nested with policy block
+service:
+  name: foo
+  retry_policy:
+    max:     3
+    backoff: exponential
+    jitter:  true
+  timeout: 30s
+```
+
+## State machine
+
+```
+[pending] ──start──▶ [running] ──ok──▶ [done]
+                         │
+                         ├──error──▶ [failed] ──retry──▶ [pending]
+                         │
+                         └──cancel─▶ [cancelled]
+```

--- a/toolkit/packages/skills/interview/SKILL.md
+++ b/toolkit/packages/skills/interview/SKILL.md
@@ -59,6 +59,17 @@ interview path/to/plan.md
 
 ## Interview Process
 
+```
+┌────────┐   ┌──────────────┐   ┌──────────────┐   ┌────────────┐
+│ Read   │──▶│ Detect       │──▶│ AskUser-     │──▶│ Write      │
+│ input  │   │ embedded     │   │ Question     │   │ spec.md    │
+│ file   │   │ sections     │   │ rounds 1..N  │   │ (template) │
+└────────┘   └──────────────┘   └──────┬───────┘   └────────────┘
+                                       │
+                              previews from input
+                              ASCII library section
+```
+
 ### Step 1: Read and Analyze the Plan
 
 Read the plan file provided as `$ARGUMENTS` (or `$1`):
@@ -74,6 +85,15 @@ Analyze the plan for:
 - **Dependencies** - What does this rely on?
 - **Gaps** - What's missing or underspecified?
 
+**Also scan for these embedded sections (used by `/brainstorm` topic stubs):**
+
+- `## For /interview` — explicit instructions from the upstream skill. Follow these verbatim; they typically dictate first-round question shape, ASCII preview usage, and topic coverage.
+- `## Initial hypotheses` — pre-populated A/B/C approach options. If present, your **first** AskUserQuestion round MUST present these as the options, with each option's ASCII code-block embedded in the `preview` field.
+- `## ASCII preview library` — reusable preview snippets keyed to subject type. Use these in subsequent AskUserQuestion `preview` fields whenever you compare concrete shapes (mockups, schemas, diagrams).
+- `## Output Spec Template` — a literal markdown template for the spec file output. If present, **use this template verbatim** for the spec instead of the default in Step 5.
+
+These sections are how `/brainstorm` hands off the design context. Honor them.
+
 ### Step 2: Conduct the Interview
 
 **MANDATORY: use a structured user-prompt tool. Do NOT dump questions in plaintext chat.**
@@ -86,6 +106,24 @@ Pick the tool in this order — first match wins:
 4. **Generic LLMs / no native tool**: only as last resort, fall back to a clearly-formatted plaintext block (`### Question 1: ...` / `### Question 2: ...`) and ask the user to answer inline.
 
 Why this is forced: free-form plaintext questioning is unreliable across runs — agents skip the structured tool when given an "or equivalent" out, which produces lower-quality interviews and bad follow-up. The tool produces typed answers the agent can branch on; plaintext does not.
+
+#### Format preferences for chat outputs and spec content
+
+When invoked from `/brainstorm`, the input stub contains a "Format preferences" section that dictates output shape. Honor it. The default convention (matching Stevie's CLAUDE.md `<flow_diagrams>` rule):
+
+| Content shape                                | Use                                              |
+|----------------------------------------------|--------------------------------------------------|
+| Flow / sequence / relationships / state      | ASCII box+arrow diagram (`┌─┐ │ └─┘ ─▶ ▼`)        |
+| Tabular DATA (rows × columns of facts)       | markdown pipe table                              |
+| Discrete items, no ordering                  | bullet list                                      |
+| Picks / open questions                       | `- [ ]` checklist                                |
+| Prose / narrative paragraphs                 | AVOID — break into one of the above              |
+
+Rules:
+- **Diagram FIRST, table SECOND** when both apply.
+- Diagram width ≤ 80 chars. Caveman inside boxes.
+- No prose-only sections in the produced spec. Every section = diagram + table + bullets.
+- AskUserQuestion `preview` fields should follow the same convention.
 
 Interview categories:
 
@@ -159,7 +197,16 @@ Once the interview is complete, write a comprehensive specification to the same 
 
 Example: `project-plan.md` → `project-plan-spec.md`
 
-#### Specification Template
+#### Template selection
+
+**If the input file contained an `## Output Spec Template` section** (typically present when invoked by `/brainstorm`):
+- Use that template verbatim for the output spec
+- Fill its placeholders from the interview answers
+- Do NOT mix in sections from the default template below
+
+**Otherwise**, use the default Specification Template below.
+
+#### Default Specification Template
 
 ```markdown
 # Specification: {Project/Feature Name}


### PR DESCRIPTION
## Summary

- Rewires `/brainstorm` as an orchestrator that scaffolds a topic-stub then delegates the iterative Q&A to `/interview` via the Skill tool
- `/interview` extended to scan input files for embedded `## For /interview`, `## Initial hypotheses`, `## ASCII preview library`, `## Output Spec Template` sections (the brainstorm-stub contract)
- Replaces the prior obra/superpowers-inspired HTML browser companion with terminal-native ASCII previews surfaced via `AskUserQuestion`'s `preview` field (side-by-side rendering, no HTML)
- Output spec template is diagram-first / pipe-table-for-data / no-prose per `<flow_diagrams>` rule
- ASCII library extracted to `brainstorm/assets/ascii-library.md` (8 subject types: UI / TUI / API / Data model / Architecture / CLI / Config / State machine)

## Pre-merge review fixes already baked in

A code-reviewer pass surfaced 1 BLOCKER + 4 MAJOR + 3 MINOR + 2 NIT — all fixed in commit 2 before push:

- Nested code fences use 4-backtick outer (CommonMark-safe)
- Step bodies numbered 1-12 (match checklist)
- Stub headings exact-match `/interview`'s scan list (no em-dash drift)
- Plain `mv`/`rm` instead of `git mv`/`git rm` on untracked scaffold files
- HARD-GATE wording disambiguated re Step 12 `/plan` terminal handoff
- Loop diagram added to `/interview` (eat-our-own-dogfood)
- Placeholder-resolution callout in Step 6
- Filename contract stated explicitly at Step 7

## Test plan

- [x] Both SKILL.md files parse (frontmatter intact, headings sequential)
- [x] `/interview` scan list and brainstorm stub headings match exactly
- [x] Nested code fences valid (4-backtick outer / 3-backtick inner)
- [x] ASCII library `assets/` ships via existing `copyDirectoryRecursive` bootstrap path (5 other skills already use this pattern)
- [x] No regressions to recall step (Step 1 preserved with original `<!-- recall:begin -->` markers)
- [x] Deployed to `~/.claude/skills/` and verified end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Brainstorm skill now orchestrates a coordinated workflow with mandatory prior-art checks, spec scaffolding, and approval gates before delegating to downstream planning.

* **Documentation**
  * Enhanced skill documentation with step-flow diagrams and format preferences for spec output.
  * Added ASCII preview library with reference templates for UI layouts, APIs, architecture diagrams, and data models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->