### PR TITLE
perf(tui): remove du -sm storm from session recovery refresh

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -94,8 +94,6 @@ pub struct OrphanedWorktree {
     pub source_repo: Option<String>,
     /// Type of orphan
     pub orphan_type: OrphanType,
-    /// Directory size in MB
-    pub size_mb: Option<u64>,
     /// Time since last modification
     pub time_ago: String,
     /// Agent type from sessions.json (if known)
@@ -118,7 +116,6 @@ impl Default for OrphanedWorktree {
             last_commit: None,
             source_repo: None,
             orphan_type: OrphanType::NoMetadata,
-            size_mb: None,
             time_ago: String::new(),
             agent_type: None,
         }
@@ -597,22 +594,6 @@ impl SessionRecoveryState {
                 }
             });
 
-        // Get directory size (approximate using du)
-        let size_mb = Command::new("du")
-            .args(["-sm", &path.to_string_lossy()])
-            .output()
-            .ok()
-            .and_then(|o| {
-                if o.status.success() {
-                    String::from_utf8_lossy(&o.stdout)
-                        .split_whitespace()
-                        .next()
-                        .and_then(|s| s.parse().ok())
-                } else {
-                    None
-                }
-            });
-
         // Calculate time ago from mtime
         let time_ago = std::fs::metadata(path)
             .and_then(|m| m.modified())
@@ -641,7 +622,6 @@ impl SessionRecoveryState {
             last_commit,
             source_repo,
             orphan_type,
-            size_mb,
             time_ago,
             agent_type: None, // Enriched later from sessions.json
         })
@@ -2091,15 +2071,6 @@ impl SessionRecovery {
                     commit.chars().take(60).collect::<String>(),
                     Style::default().fg(SOFT_WHITE),
                 ),
-            ]));
-            lines.push(Line::from(""));
-        }
-
-        // Size
-        if let Some(size) = worktree.size_mb {
-            lines.push(Line::from(vec![
-                Span::styled("Size:     ", Style::default().fg(MUTED_GRAY)),
-                Span::styled(format!("{} MB", size), Style::default().fg(SOFT_WHITE)),
             ]));
             lines.push(Line::from(""));
         }


### PR DESCRIPTION
## Summary
- Recovery-screen `refresh()` shelled out to `du -sm` per worktree synchronously on the event loop. With 200+ stale `by-session/` symlinks and several ainb sessions alive, this produced a continuous storm of `du` processes scanning `node_modules` / `target` / `.git` packs.
- `size_mb` was only ever rendered in the right-panel detail view for the **single selected worktree** — never in the list. Dropped the field and the `du` call entirely.

## Test plan
- [x] `cargo check -p ainb` — clean, 1m59s; no new warnings touching the edited regions.
- [ ] Manual: open Recovery screen, confirm no `du -sm <worktree>` processes spawn.

Diff: 29 deletions in one file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Removed worktree size information from the details panel to improve application performance and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->