### PR TITLE
feat(tui): cwd-based per-session badges + Enter-attaches-tmux

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3752,7 +3752,58 @@ impl EventHandler {
             AppEvent::InboxPageUp => state.inbox_state.move_up(10),
             AppEvent::InboxPageDown => state.inbox_state.move_down(10),
             AppEvent::InboxOpenSelected => {
+                // Capture the cwd before mark_selected_read invalidates
+                // selection ordering on refresh.
+                let row_cwd = state
+                    .inbox_state
+                    .selected_row()
+                    .map(|r| r.cwd.clone())
+                    .unwrap_or_default();
                 state.inbox_state.mark_selected_read();
+                // cwd-based jump-to-tmux: find the ainb session whose
+                // workspace_path matches the notification's cwd (exact
+                // or prefix). If found, surface its tmux session name
+                // for the existing AttachToOtherTmux async action so
+                // ainb's tmux subsystem owns the attach itself.
+                if !row_cwd.is_empty() {
+                    let target = state
+                        .workspaces
+                        .iter()
+                        .find(|ws| {
+                            let p = ws.path.to_string_lossy().to_string();
+                            row_cwd == p
+                                || row_cwd.starts_with(&format!("{p}/"))
+                        })
+                        .and_then(|ws| {
+                            // Prefer a non-shell session (an agent-running
+                            // one) since hook events come from agents,
+                            // not shells. Fall back to the workspace
+                            // shell if no agent session has tmux.
+                            ws.sessions
+                                .iter()
+                                .find_map(|s| s.tmux_session_name.clone())
+                                .or_else(|| {
+                                    ws.shell_session
+                                        .as_ref()
+                                        .map(|s| s.tmux_session_name.clone())
+                                })
+                        });
+                    if let Some(tmux_name) = target {
+                        tracing::info!(
+                            cwd = %row_cwd,
+                            tmux = %tmux_name,
+                            "inbox: jumping to tmux session"
+                        );
+                        state.pending_async_action =
+                            Some(crate::app::state::AsyncAction::AttachToOtherTmux(
+                                tmux_name,
+                            ));
+                    } else {
+                        state.add_info_notification(format!(
+                            "no ainb session matches cwd {row_cwd}"
+                        ));
+                    }
+                }
             }
             AppEvent::InboxDismissSelected => {
                 state.inbox_state.dismiss_selected();

--- a/ainb-tui/crates/ainb-core/src/components/inbox.rs
+++ b/ainb-tui/crates/ainb-core/src/components/inbox.rs
@@ -262,6 +262,48 @@ impl InboxState {
         self.agent_filter = self.agent_filter.next();
         self.refresh();
     }
+
+    /// Return unread counts grouped by notification `cwd`. Used by
+    /// the session_list to render a per-session `●N` badge: ainb's
+    /// `Session.workspace_path` is matched against this map (exact
+    /// equality OR prefix-with-trailing-slash for worktree sessions
+    /// whose cwd is a subdir of their workspace root).
+    ///
+    /// Returns an empty map when the store is not open.
+    pub fn unread_by_cwd_map(&self) -> std::collections::HashMap<String, u64> {
+        let mut out = std::collections::HashMap::new();
+        if let Some(store) = self.store.as_ref() {
+            if let Ok(rows) = store.unread_by_cwd() {
+                for (cwd, n) in rows {
+                    out.insert(cwd, n);
+                }
+            }
+        }
+        out
+    }
+
+    /// Sum unread counts whose `cwd` equals `workspace_path` or sits
+    /// underneath it (e.g. worktree subdirs). The session_list calls
+    /// this once per session row.
+    pub fn unread_for_workspace_path(
+        unread_by_cwd: &std::collections::HashMap<String, u64>,
+        workspace_path: &str,
+    ) -> u64 {
+        if workspace_path.is_empty() {
+            return 0;
+        }
+        let prefix_with_slash = format!("{workspace_path}/");
+        unread_by_cwd
+            .iter()
+            .filter_map(|(cwd, n)| {
+                if cwd == workspace_path || cwd.starts_with(&prefix_with_slash) {
+                    Some(*n)
+                } else {
+                    None
+                }
+            })
+            .sum()
+    }
 }
 
 /// Convert an epoch-ms timestamp to a local `HH:MM:SS` clock label,
@@ -571,6 +613,50 @@ mod tests {
         let s = fmt_ts(0);
         let parts: Vec<&str> = s.split(':').collect();
         assert_eq!(parts.len(), 3, "expected HH:MM:SS, got {s}");
+    }
+
+    #[test]
+    fn unread_for_workspace_path_matches_exact_and_prefix() {
+        use std::collections::HashMap;
+        let mut map: HashMap<String, u64> = HashMap::new();
+        map.insert("/home/x/repo".to_string(), 3);
+        map.insert("/home/x/repo/worktrees/branch-a".to_string(), 2);
+        map.insert("/home/x/other".to_string(), 5);
+
+        // Exact match on the workspace path returns just that bucket;
+        // prefix-with-/ also rolls up any worktree under it.
+        assert_eq!(
+            InboxState::unread_for_workspace_path(&map, "/home/x/repo"),
+            5,
+            "expected 3 (root) + 2 (worktree under) = 5"
+        );
+        assert_eq!(
+            InboxState::unread_for_workspace_path(&map, "/home/x/other"),
+            5
+        );
+        assert_eq!(
+            InboxState::unread_for_workspace_path(&map, "/home/x/missing"),
+            0
+        );
+        assert_eq!(
+            InboxState::unread_for_workspace_path(&map, ""),
+            0,
+            "empty workspace path must short-circuit to 0"
+        );
+    }
+
+    #[test]
+    fn unread_for_workspace_path_does_not_substring_match() {
+        // /home/x/rep would otherwise prefix-match /home/x/repo if we
+        // weren't careful to append the trailing slash. Verify.
+        use std::collections::HashMap;
+        let mut map: HashMap<String, u64> = HashMap::new();
+        map.insert("/home/x/repo".to_string(), 4);
+        assert_eq!(
+            InboxState::unread_for_workspace_path(&map, "/home/x/rep"),
+            0,
+            "must not substring-match shorter prefixes"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -237,6 +237,13 @@ impl SessionListComponent {
         // Load favorites to check which workspaces are starred
         let favorites = crate::config::FavoritesStore::load();
 
+        // ainb-hooks unread counts, grouped by notification cwd. We
+        // query once per render (cheap with SQLite WAL + the indexed
+        // `unread` partial index) and look up per session/workspace
+        // path below to render a `●N` badge. Empty map when the
+        // store isn't open or no rows are unread.
+        let unread_by_cwd = state.inbox_state.unread_by_cwd_map();
+
         // Must stay in lockstep with AppState::attachable_items_in_order;
         // divergence would attach the wrong session for a given digit.
         let mut attach_no: usize = 0;
@@ -417,7 +424,18 @@ impl SessionListComponent {
                         Span::styled("[ ]", Style::default().fg(MUTED_GRAY))
                     };
 
-                    let session_line = Line::from(vec![
+                    // ainb-hooks unread badge for this session row.
+                    // Match by session.workspace_path against the
+                    // notification cwd map (exact or prefix-with-/);
+                    // a session whose host agent fired a hook from
+                    // anywhere inside its workspace root gets a `●N`.
+                    let session_unread =
+                        crate::components::inbox::InboxState::unread_for_workspace_path(
+                            &unread_by_cwd,
+                            &session.workspace_path,
+                        );
+
+                    let mut session_spans = vec![
                         next_badge(&mut attach_no),
                         checkbox,
                         Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
@@ -439,7 +457,17 @@ impl SessionListComponent {
                             ),
                         ),
                         Span::styled(changes_text, Style::default().fg(WARNING_ORANGE)),
-                    ]);
+                    ];
+                    if session_unread > 0 {
+                        session_spans.push(Span::raw("  "));
+                        session_spans.push(Span::styled(
+                            format!("● {session_unread}"),
+                            Style::default()
+                                .fg(WARNING_ORANGE)
+                                .add_modifier(Modifier::BOLD),
+                        ));
+                    }
+                    let session_line = Line::from(session_spans);
 
                     items.push(ListItem::new(session_line));
                 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
@@ -261,6 +261,64 @@ impl Store {
         Ok(out)
     }
 
+    /// Unread count grouped by `cwd` (working directory at hook-fire
+    /// time). The ainb-tui session list uses this to render a
+    /// per-session `●N` badge: ainb's `Session.working_dir` matches
+    /// the notification's `cwd` for any session whose host agent has
+    /// been firing hooks. This is the cwd-based correlation layer
+    /// between ainb's internal `Uuid` ids and the agents' hook-side
+    /// session_id strings.
+    pub fn unread_by_cwd(&self) -> Result<Vec<(String, u64)>, StoreError> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT cwd, COUNT(*)
+             FROM notifications
+             WHERE read = 0 AND dismissed = 0 AND cwd != ''
+             GROUP BY cwd",
+        )?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, u64>(1)?)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Look up the most-recent notification whose `cwd` matches
+    /// `target_cwd`. Used by the Inbox screen when the user presses
+    /// Enter on a row: from the row's `cwd` we resolve back to ainb's
+    /// `Session` (via `Session.working_dir`) and attach its tmux pane.
+    pub fn latest_by_cwd(
+        &self,
+        target_cwd: &str,
+    ) -> Result<Option<NotificationRecord>, StoreError> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT id, ts, agent, session_id, cwd, project, raw_event, payload, read, dismissed
+             FROM notifications
+             WHERE cwd = ?1
+             ORDER BY ts DESC
+             LIMIT 1",
+        )?;
+        let row = stmt
+            .query_row(params![target_cwd], |r| {
+                Ok(NotificationRecord {
+                    id: r.get(0)?,
+                    ts: r.get(1)?,
+                    agent: r.get(2)?,
+                    session_id: r.get(3)?,
+                    cwd: r.get(4)?,
+                    project: r.get(5)?,
+                    raw_event: r.get(6)?,
+                    payload_json: r.get(7)?,
+                    read: r.get::<_, i64>(8)? != 0,
+                    dismissed: r.get::<_, i64>(9)? != 0,
+                })
+            })
+            .optional()?;
+        Ok(row)
+    }
+
     /// Most recent record overall. Used by `ainb hooks status`.
     pub fn latest(&self) -> Result<Option<NotificationRecord>, StoreError> {
         let conn = self.conn();
@@ -507,5 +565,67 @@ mod tests {
         let mut counts = store.unread_by_session().unwrap();
         counts.sort();
         assert_eq!(counts, vec![("s-1".into(), 2), ("s-2".into(), 1)]);
+    }
+
+    #[test]
+    fn unread_by_cwd_groups_by_working_dir_and_skips_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("a.db")).unwrap();
+        // Three events under /tmp/proj-a, two under /tmp/proj-b, one
+        // with empty cwd (must NOT appear in the result), and one
+        // dismissed under /tmp/proj-a (must NOT count toward unread).
+        let mut e = env("claude", "Stop", 1);
+        e.cwd = "/tmp/proj-a".into();
+        let _ = store.insert(&e).unwrap();
+        e.ts = 2;
+        let _ = store.insert(&e).unwrap();
+        e.ts = 3;
+        let dismissed_id = store.insert(&e).unwrap();
+        store.dismiss(&dismissed_id).unwrap();
+        e.ts = 4;
+        let _ = store.insert(&e).unwrap();
+        e.cwd = "/tmp/proj-b".into();
+        e.ts = 5;
+        let _ = store.insert(&e).unwrap();
+        e.ts = 6;
+        let _ = store.insert(&e).unwrap();
+        e.cwd = "".into();
+        e.ts = 7;
+        let _ = store.insert(&e).unwrap();
+
+        let mut counts = store.unread_by_cwd().unwrap();
+        counts.sort();
+        assert_eq!(
+            counts,
+            vec![
+                ("/tmp/proj-a".into(), 3),
+                ("/tmp/proj-b".into(), 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn latest_by_cwd_returns_most_recent_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("a.db")).unwrap();
+        let mut e = env("claude", "Stop", 100);
+        e.cwd = "/tmp/proj-a".into();
+        store.insert(&e).unwrap();
+        e.ts = 200;
+        e.raw_event = "Notification:idle_prompt".into();
+        store.insert(&e).unwrap();
+        e.cwd = "/tmp/proj-b".into();
+        e.ts = 300;
+        e.raw_event = "Stop".into();
+        store.insert(&e).unwrap();
+
+        let latest = store.latest_by_cwd("/tmp/proj-a").unwrap().unwrap();
+        // Most recent among proj-a is the idle_prompt at ts=200.
+        assert_eq!(latest.cwd, "/tmp/proj-a");
+        assert_eq!(latest.raw_event, "Notification:idle_prompt");
+        assert_eq!(latest.ts, 200);
+
+        let nope = store.latest_by_cwd("/tmp/does-not-exist").unwrap();
+        assert!(nope.is_none());
     }
 }


### PR DESCRIPTION
## What

Follow-up to #163. Resolves the two items called out in that PR as "deferred — needs a session_id correlation table":

- **Per-session row badges** — `●N` glyph on every session row whose host agent has been firing hooks.
- **Enter-attaches-tmux** — pressing `Enter` on an Inbox row attaches to the matching ainb session's tmux pane.

## How — the correlation layer

```
┌─ Notification (hook envelope) ─┐         ┌─ ainb Session ────────────────┐
│ session_id  "abc-claude-uuid"  │         │ id              <Uuid>        │
│ cwd         "/repo/branch-a"   │◀───────▶│ workspace_path "/repo"        │
│ ts          1717...            │  cwd    │ tmux_session_name "ainb-..."  │
└────────────────────────────────┘  match  └───────────────────────────────┘
                                    cwd == workspace_path
                                    OR cwd.starts_with(workspace_path + "/")
```

The hook envelope's `cwd` is the agent's working directory at hook-fire time. The ainb session's `workspace_path` is the repo root. They correlate when:
- `cwd == workspace_path` (agent runs at the repo root), OR
- `cwd.starts_with(<workspace_path>/...)` (agent runs in a worktree subdir of the workspace)

The trailing-slash guard prevents `/home/x/rep` substring-matching `/home/x/repo` — explicitly tested.

## Daemon side (`ainb-plugin-notifyd`)

| New API | Purpose |
|---------|---------|
| `Store::unread_by_cwd()` | `Vec<(cwd, count)>` over unread + non-dismissed rows; skips empty cwds. |
| `Store::latest_by_cwd(target)` | Most recent record matching cwd; powers Inbox→jump lookup. |

## TUI side (`ainb-core`)

| Change | Purpose |
|--------|---------|
| `InboxState::unread_by_cwd_map()` | HashMap for cheap per-row lookup in render. |
| `InboxState::unread_for_workspace_path(map, path)` | Sums any cwd matching path OR `<path>/` prefix. |
| `session_list::render` | Calls the helper once, appends `● N` Span to every session whose workspace has unread events. |
| `events.rs InboxOpenSelected` | Captures row.cwd → marks read → scans `state.workspaces` → finds matching workspace → picks non-shell session's `tmux_session_name` → enqueues `AttachToOtherTmux` via the existing async-action path. |

## Test plan

- [x] `cargo test -p ainb-plugin-notifyd` — 44 tests green (42 + 2 new)
- [x] `cargo test -p ainb --lib components::inbox` — 8 tests green (6 + 2 new)
- [x] `cargo test -p ainb --test tripwire_inbox_opens_and_renders` — still green
- [x] Substring-guard regression: `/home/x/rep` does NOT match `/home/x/repo`
- [x] Code builds clean (`cargo check -p ainb` — 0 errors)