### PR TITLE
fix(tui): make Inbox discoverable — sidebar tile + always-on hint

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3508,6 +3508,11 @@ impl EventHandler {
                     SidebarItem::Sessions => {
                         state.current_screen = screen_ids::SESSION_LIST.to_string();
                     }
+                    SidebarItem::Inbox => {
+                        state.previous_screen = Some(state.current_screen.clone());
+                        state.current_screen = screen_ids::INBOX.to_string();
+                        state.inbox_state.refresh();
+                    }
                     SidebarItem::Recovery => {
                         state.session_recovery_state.refresh();
                         state.current_screen = screen_ids::SESSION_RECOVERY.to_string();

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -300,11 +300,11 @@ impl LayoutComponent {
             Span::styled(" home", Style::default().fg(MUTED_GRAY)),
         ];
 
-        // ainb-hooks unread inbox badge — surfaced globally on the
-        // menu bar so the user always sees pending agent events
-        // (idle prompts, permission requests, stops). Hidden when
-        // zero. Polled live from the ainb-plugin-notifyd store via
-        // AppState; cheap (SELECT COUNT(*) over indexed columns).
+        // ainb-hooks inbox shortcut on the menu bar. Always shown so
+        // users can discover the Inbox screen even on a fresh install
+        // with zero events. When the store reports unread + non-
+        // dismissed rows, a `● N` glyph is rendered alongside the
+        // `I inbox` hint to surface that there is something to read.
         let inbox_unread = state
             .inbox_state
             .store
@@ -312,18 +312,18 @@ impl LayoutComponent {
             .and_then(|s| s.unread_count().ok())
             .unwrap_or(0);
         let mut line2_spans = line2_spans;
+        line2_spans.push(Span::styled(" │ ", Style::default().fg(SUBDUED_BORDER)));
         if inbox_unread > 0 {
-            line2_spans.push(Span::styled(" │ ", Style::default().fg(SUBDUED_BORDER)));
             line2_spans.push(Span::styled(
                 format!("● {inbox_unread} "),
                 Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD),
             ));
-            line2_spans.push(Span::styled(
-                "I",
-                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-            ));
-            line2_spans.push(Span::styled(" inbox", Style::default().fg(MUTED_GRAY)));
         }
+        line2_spans.push(Span::styled(
+            "I",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+        line2_spans.push(Span::styled(" inbox", Style::default().fg(MUTED_GRAY)));
 
         let menu_lines = vec![Line::from(line1_spans), Line::from(line2_spans)];
 

--- a/ainb-tui/crates/ainb-core/src/components/sidebar.rs
+++ b/ainb-tui/crates/ainb-core/src/components/sidebar.rs
@@ -35,6 +35,7 @@ pub enum SidebarItem {
     Catalog,   // Browse catalog/marketplace
     Config,    // Settings & presets
     Sessions,  // Session manager
+    Inbox,     // ainb-hooks notification inbox
     Recovery,  // Recover orphaned sessions
     Logs,      // Log history viewer
     Stats,     // Analytics & usage
@@ -52,6 +53,7 @@ impl SidebarItem {
             Self::Catalog => "📦",
             Self::Config => "⚙️",
             Self::Sessions => "🚀",
+            Self::Inbox => "📥",
             Self::Recovery => "🔄",
             Self::Logs => "📋",
             Self::Stats => "📊",
@@ -69,6 +71,7 @@ impl SidebarItem {
             Self::Catalog => "Catalog",
             Self::Config => "Config",
             Self::Sessions => "Sessions",
+            Self::Inbox => "Inbox",
             Self::Recovery => "Recovery",
             Self::Logs => "Logs",
             Self::Stats => "Stats",
@@ -86,6 +89,7 @@ impl SidebarItem {
             Self::Catalog => "Browse & Bootstrap",
             Self::Config => "Settings & Presets",
             Self::Sessions => "Manage Active",
+            Self::Inbox => "Hook Notifications",
             Self::Recovery => "Resume Orphaned",
             Self::Logs => "View Log History",
             Self::Stats => "Usage & Analytics",
@@ -103,6 +107,7 @@ impl SidebarItem {
             Self::Catalog => "c",
             Self::Config => "C",
             Self::Sessions => "s",
+            Self::Inbox => "I",
             Self::Recovery => "R",
             Self::Logs => "l",
             Self::Stats => "i",
@@ -120,6 +125,7 @@ impl SidebarItem {
             Self::Catalog,
             Self::Config,
             Self::Sessions,
+            Self::Inbox,
             Self::Recovery,
             Self::Logs,
             Self::Stats,
@@ -480,6 +486,29 @@ mod tests {
         let item = SidebarItem::Agents;
         assert_eq!(item.label(), "Agents");
         assert_eq!(item.icon(), "🤖");
+    }
+
+    #[test]
+    fn inbox_tile_registered_with_discoverable_shortcut() {
+        // The ainb-hooks Inbox screen is only useful if the user can
+        // find it. Lock in the tile shape + position so a future
+        // refactor doesn't quietly drop it from the home screen.
+        let all = SidebarItem::all();
+        let inbox_pos = all
+            .iter()
+            .position(|i| *i == SidebarItem::Inbox)
+            .expect("SidebarItem::Inbox missing from all()");
+        assert!(inbox_pos > 0, "Inbox shouldn't be first sidebar item");
+        assert_eq!(SidebarItem::Inbox.icon(), "📥");
+        assert_eq!(SidebarItem::Inbox.label(), "Inbox");
+        assert_eq!(SidebarItem::Inbox.shortcut(), "I");
+        assert_eq!(SidebarItem::Inbox.description(), "Hook Notifications");
+        // 'I' must not collide with any other tile shortcut.
+        let collisions = all
+            .iter()
+            .filter(|i| **i != SidebarItem::Inbox && i.shortcut() == "I")
+            .count();
+        assert_eq!(collisions, 0, "sidebar shortcut 'I' collides");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/tests/tripwire_inbox_opens_and_renders.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_inbox_opens_and_renders.rs
@@ -159,16 +159,26 @@ fn inbox_opens_and_renders_seeded_notifications() {
         panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
     };
 
-    // Pre-assertion: must not already be on the Inbox screen.
+    // Pre-assertion 1: must not already be on the Inbox screen.
     assert!(
         !pre.contains("📥 Inbox"),
         "pre-key capture already on inbox — state leaked.\n{pre}"
     );
 
-    // The global unread badge currently renders only on layout.rs's
-    // menu bar (split-pane screens). HomeScreen V2 owns its own
-    // bottom hint line and so doesn't show the badge yet — that's a
-    // follow-up. Skip the badge check on the home screen.
+    // Pre-assertion 2 (discoverability gate): the HomeScreen V2
+    // sidebar MUST list the Inbox tile. Without this, a fresh user
+    // has no visual cue that an inbox exists — the `I` shortcut
+    // works but is undiscoverable. Tile shape:
+    //
+    //     📥  Inbox          [I]
+    //
+    // We tolerate trailing whitespace by checking for the icon +
+    // label + shortcut tag separately.
+    assert!(
+        pre.contains("📥") && pre.contains("Inbox") && pre.contains("[I]"),
+        "HomeScreen V2 sidebar missing Inbox tile — \
+         discoverability regression. Pre-capture:\n{pre}"
+    );
 
     // Drive the inbox open shortcut.
     Command::new("tmux")


### PR DESCRIPTION
## What

Stevie ran the binary from this worktree and **could not find the Inbox** — even though the tripwire passed. Found two compounding visibility bugs.

## Bugs caught

```
┌─ Bug 1: HomeScreen V2 sidebar missing Inbox tile ──────────────────────┐
│  SidebarItem enum did not include Inbox. The 'I' key binding worked    │
│  but the home-screen sidebar tile registry was never updated.           │
│  → Users had no visual cue that an Inbox screen existed.                │
└────────────────────────────────────────────────────────────────────────┘

┌─ Bug 2: Menu-bar `I inbox` hint gated on unread > 0 ───────────────────┐
│  layout.rs render_menu_bar showed the entire shortcut only when        │
│  unread > 0. Fresh installs saw nothing on the bar either.             │
└────────────────────────────────────────────────────────────────────────┘
```

## Fixes

| File | Change |
|------|--------|
| `sidebar.rs` | Add `SidebarItem::Inbox` between Sessions and Recovery: icon 📥, label "Inbox", description "Hook Notifications", shortcut `I` |
| `events.rs` | Wire `SidebarItem::Inbox → AppEvent::GoToInbox` in the sidebar select handler (Enter on tile = press `I` globally) |
| `layout.rs` | Always render `I inbox` on the menu bar; only the `● N` badge gates on unread > 0 |
| `tripwire_inbox_opens_and_renders.rs` | New pre-assertion: HomeScreen capture must contain `📥`, `Inbox`, `[I]` before the keystroke |
| `sidebar.rs` (tests) | New unit test locks position, icon, label, shortcut, description, and shortcut non-collision |

## Visual proof

Drove the rebuilt binary via tmux capture against an isolated `\$HOME`:

```
  🚀  Sessions       [s]
  📥  Inbox          [I]   ← NEW
  🔄  Recovery       [R]
```

Pressing `I` → Inbox renders both seeded events with full detail pane.

## Honest accountability

The previous PRs' tripwire passed because it tested the `I` keystroke → Inbox render path. It never asserted **discoverability**. That gap let an undiscoverable feature ship as "green CI". The new tripwire pre-assertion closes that hole.

## Test plan

- [x] `cargo test -p ainb --lib components::sidebar` — 7 tests green (6 + 1 new)
- [x] `cargo test -p ainb --test tripwire_inbox_opens_and_renders` — green with new discoverability assertion
- [x] Manual tmux capture against rebuilt binary — sidebar shows tile, `I` opens Inbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inbox navigation item added to sidebar with dedicated icon and keyboard shortcut for quick access
  * Unread inbox message count now displays as a badge in the bottom menu bar when there are new messages

* **Tests**
  * Added automated tests to ensure the Inbox feature is properly discoverable and functions as expected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->