### PR TITLE
feat(ainb): port popa → `ainb fleet` + center control panel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,22 @@
         "recall",
         "retrieval"
       ]
+    },
+    {
+      "name": "ainb-fleet",
+      "source": "./plugins/ainb-fleet",
+      "description": "LLM-facing skill teaching agents how to use `ainb fleet ...` orchestration subcommands. Fleet covers multi-session broadcast, ack-gated sequence, blocked-session needs, and the auto-continue daemon. Replaces the deprecated `popa` plugin — the Node code is gone; the orchestration logic now lives in ainb's Rust binary.",
+      "strict": false,
+      "keywords": [
+        "ainb",
+        "fleet",
+        "tmux",
+        "claude-peers",
+        "orchestration",
+        "control-plane",
+        "broadcast",
+        "multi-session"
+      ]
     }
   ]
 }

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -67,7 +67,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4.4", features = ["derive"] }
 clap_complete = "4.4"
 tempfile = "3.8"
-nix = { version = "0.27", features = ["user"] }
+nix = { version = "0.27", features = ["user", "signal"] }
 arboard = "3.3"
 keyring = { version = "3", features = ["apple-native", "linux-native"] }
 regex = "1.10"
@@ -90,6 +90,9 @@ nucleo-matcher = "0.3"
 
 # File-locking for concurrent plugin install protection
 fs2 = "0.4"
+
+# Filesystem watch for fleet JSONL transcript tail
+notify = "6.1"
 
 # Dev / test
 mockall = "0.12"

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -91,6 +91,9 @@ bytes = "1.6"
 # Fuzzy search
 nucleo-matcher = { workspace = true }
 
+# Fleet — filesystem watch for JSONL transcript tail (assistant-turn detection).
+notify = { workspace = true }
+
 [features]
 default = []
 visual-debug = []

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/broadcast.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/broadcast.rs
@@ -1,0 +1,105 @@
+// ABOUTME: `ainb fleet broadcast` — send one prompt to selected sessions.
+//
+// Default targeting: requires `--all` or `--filter <regex>` / `--cwd <substring>`
+// to fan out. Standup-style picker is not in v1 (orchestration is invoked from
+// within an LLM session that already drives selection).
+
+use anyhow::{bail, Result};
+use regex::Regex;
+
+use crate::cli::OutputFormat;
+use crate::fleet::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
+use crate::fleet::send::send;
+use crate::fleet::types::{SendOutcome, Session};
+
+pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
+    let prompt = matches
+        .get_one::<String>("prompt")
+        .ok_or_else(|| anyhow::anyhow!("missing <prompt>"))?
+        .clone();
+    let all = matches.get_flag("all");
+    let filter = matches.get_one::<String>("filter").cloned();
+    let cwd = matches.get_one::<String>("cwd").cloned();
+
+    if !all && filter.is_none() && cwd.is_none() {
+        bail!("broadcast requires --all, --filter <regex>, or --cwd <substring>");
+    }
+
+    let (ainb, peers) = tokio::join!(discover_from_ainb(), async { discover_from_peers() });
+    let merged = merge_sessions(vec![
+        ainb.unwrap_or_default(),
+        peers.unwrap_or_default(),
+    ]);
+
+    let targets = filter_targets(&merged, all, filter.as_deref(), cwd.as_deref())?;
+    if targets.is_empty() {
+        bail!("no targets matched");
+    }
+
+    let mut results = Vec::with_capacity(targets.len());
+    for t in &targets {
+        let outcome = send(t, &prompt).await?;
+        results.push((t.clone(), outcome));
+    }
+
+    print_results(&results);
+    Ok(())
+}
+
+fn filter_targets(
+    all_sessions: &[Session],
+    all: bool,
+    filter: Option<&str>,
+    cwd: Option<&str>,
+) -> Result<Vec<Session>> {
+    let re = filter.map(Regex::new).transpose()?;
+    let out = all_sessions
+        .iter()
+        .filter(|s| {
+            if !all {
+                let mut keep = false;
+                if let Some(ref re) = re {
+                    if re.is_match(s.tmux_session.as_deref().unwrap_or(""))
+                        || re.is_match(s.workspace_name.as_deref().unwrap_or(""))
+                    {
+                        keep = true;
+                    }
+                }
+                if let Some(needle) = cwd {
+                    if s.cwd.contains(needle) {
+                        keep = true;
+                    }
+                }
+                if !keep {
+                    return false;
+                }
+            }
+            true
+        })
+        .cloned()
+        .collect();
+    Ok(out)
+}
+
+fn print_results(results: &[(Session, SendOutcome)]) {
+    let total = results.len();
+    println!("ainb fleet broadcast — sent to {total} target(s)");
+    for (t, outcome) in results {
+        let name = t
+            .tmux_session
+            .as_deref()
+            .or(t.workspace_name.as_deref())
+            .unwrap_or(&t.id);
+        match outcome {
+            SendOutcome::Broker { peer_id } => {
+                println!("  ✓ {name} via broker peer {peer_id}");
+            }
+            SendOutcome::Tmux { tmux_session } => {
+                println!("  ✓ {name} via tmux {tmux_session}");
+            }
+            SendOutcome::Failed { reason } => {
+                println!("  ✗ {name}: {reason}");
+            }
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
@@ -1,0 +1,64 @@
+// ABOUTME: `ainb fleet daemon` — long-running watcher with auto-continue on API errors.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::cli::OutputFormat;
+use crate::fleet::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
+use crate::fleet::read::{capture_pane, detect_error_signals};
+use crate::fleet::send::{broker_health, send};
+use crate::fleet::types::Signal;
+
+const SCAN_INTERVAL_SECS: u64 = 5;
+
+pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
+    let verbose = matches.get_flag("verbose");
+
+    if broker_health().await {
+        // Phase 5 will wire actual broker_register/heartbeat for `ainb-fleet-cp`.
+        eprintln!("[fleet/daemon] broker healthy at 127.0.0.1:7899");
+    } else {
+        eprintln!("[fleet/daemon] broker not reachable — operating in tmux-only mode");
+    }
+
+    let mut seen = HashSet::new();
+    loop {
+        if let Err(e) = tick(&mut seen, verbose).await {
+            eprintln!("[fleet/daemon] tick failed: {e}");
+        }
+        tokio::time::sleep(Duration::from_secs(SCAN_INTERVAL_SECS)).await;
+    }
+}
+
+async fn tick(seen: &mut HashSet<String>, verbose: bool) -> Result<()> {
+    let (ainb, peers) = tokio::join!(discover_from_ainb(), async { discover_from_peers() });
+    let merged = merge_sessions(vec![
+        ainb.unwrap_or_default(),
+        peers.unwrap_or_default(),
+    ]);
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for s in merged {
+        let Some(name) = s.tmux_session.as_deref() else { continue };
+        let pane = capture_pane(name, 80).await.unwrap_or_default();
+        let errors = detect_error_signals(&pane, now_ms);
+
+        let Some(Signal::ApiError { pattern, raw, .. }) = errors.into_iter().next() else {
+            continue;
+        };
+        let raw_tail: String = raw.chars().rev().take(40).collect::<String>().chars().rev().collect();
+        let key = format!("{}::{pattern}::{raw_tail}", s.id);
+        if seen.contains(&key) {
+            continue;
+        }
+        seen.insert(key);
+
+        if verbose {
+            eprintln!("[fleet/daemon] auto-continue -> {name} ({pattern})");
+        }
+        let _ = send(&s, "continue").await;
+    }
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -1,0 +1,26 @@
+// ABOUTME: `ainb fleet` subcommand dispatcher.
+//
+// Mirrors the pattern used by `cli/plugin/mod.rs` — nested clap subcommands
+// matched by `matches.subcommand()`. Each subcommand has its own module with
+// an `execute(args, format) -> Result<()>` function.
+
+use anyhow::{bail, Result};
+
+use crate::cli::OutputFormat;
+
+pub mod broadcast;
+pub mod daemon;
+pub mod needs;
+pub mod sequence;
+pub mod standup;
+
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    match matches.subcommand() {
+        Some(("standup", sub)) => standup::execute(sub, format).await,
+        Some(("broadcast", sub)) => broadcast::execute(sub, format).await,
+        Some(("sequence", sub)) => sequence::execute(sub, format).await,
+        Some(("needs", sub)) => needs::execute(sub, format).await,
+        Some(("daemon", sub)) => daemon::execute(sub, format).await,
+        _ => bail!("unknown `ainb fleet` subcommand — try `ainb fleet --help`"),
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/needs.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/needs.rs
@@ -1,23 +1,134 @@
-// ABOUTME: `ainb fleet needs` — list sessions blocked on input / errors / waiting.
+// ABOUTME: `ainb fleet needs` — center control panel.
+//
+// Classify every claude session against four signal kinds (ASK / ERR / IDLE /
+// WAIT). Returns rich JSON: per-session signal + context that the calling LLM
+// uses to render the Jarvis-HUD layout and route answers back.
 
 use anyhow::Result;
 
 use crate::cli::OutputFormat;
-use crate::fleet::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
+use crate::fleet::discover::{
+    discover_from_ainb, discover_from_jobs, discover_from_peers, merge_sessions,
+};
+use crate::fleet::read::{capture_pane, classify, ClassifyInput, NeedsRow};
+use crate::fleet::types::Session;
 
-pub async fn execute(_matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
-    let (ainb, peers) = tokio::join!(discover_from_ainb(), async { discover_from_peers() });
-    let sessions = merge_sessions(vec![
-        ainb.unwrap_or_default(),
-        peers.unwrap_or_default(),
-    ]);
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    let idle_override: Option<i64> = matches
+        .get_one::<i64>("idle-min")
+        .copied();
 
-    let blocked: Vec<_> = sessions
-        .into_iter()
-        .filter(|s| s.summary.as_deref().is_some_and(|sum| sum.starts_with("WAITING:")))
-        .collect();
+    let (ainb_res, jobs_res) = tokio::join!(discover_from_ainb(), async {
+        discover_from_jobs()
+    });
+    let ainb = ainb_res.unwrap_or_default();
+    let peers = discover_from_peers().unwrap_or_default();
+    let jobs = jobs_res.unwrap_or_default();
 
-    let json = serde_json::to_string_pretty(&blocked)?;
-    println!("{json}");
+    let merged = merge_sessions(vec![ainb, peers, jobs]);
+    let rows = classify_all(merged, idle_override).await;
+
+    if matches!(format, OutputFormat::Text) {
+        print_text(&rows);
+    } else {
+        let json = serde_json::to_string_pretty(&rows)?;
+        println!("{json}");
+    }
     Ok(())
+}
+
+async fn classify_all(sessions: Vec<Session>, idle_override: Option<i64>) -> Vec<NeedsRow> {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut handles = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        let tmux = session.tmux_session.clone();
+        handles.push(tokio::spawn(async move {
+            let pane = match tmux {
+                Some(name) => capture_pane(&name, 80).await.ok(),
+                None => None,
+            };
+            let mut input = ClassifyInput::from_env(session, pane, now_ms);
+            if let Some(idle) = idle_override {
+                input.idle_threshold_min = idle;
+            }
+            classify(input)
+        }));
+    }
+    let mut out = Vec::new();
+    for h in handles {
+        if let Ok(Some(row)) = h.await {
+            out.push(row);
+        }
+    }
+    out.sort_by_key(|r| signal_priority(r));
+    out
+}
+
+fn signal_priority(r: &NeedsRow) -> u8 {
+    use crate::fleet::read::NeedsContext;
+    match r.context {
+        NeedsContext::Ask(_) => 0,
+        NeedsContext::Err(_) => 1,
+        NeedsContext::Idle(_) => 2,
+        NeedsContext::Wait(_) => 3,
+    }
+}
+
+fn print_text(rows: &[NeedsRow]) {
+    use crate::fleet::read::NeedsContext;
+    if rows.is_empty() {
+        println!("ainb fleet needs — 0 sessions need you. Carry on.");
+        return;
+    }
+    let (mut ask, mut err, mut idle, mut wait) = (0, 0, 0, 0);
+    for r in rows {
+        match r.context {
+            NeedsContext::Ask(_) => ask += 1,
+            NeedsContext::Err(_) => err += 1,
+            NeedsContext::Idle(_) => idle += 1,
+            NeedsContext::Wait(_) => wait += 1,
+        }
+    }
+    println!("ainb fleet needs — {} need you", rows.len());
+    println!("  🔴 {err} err · 🟡 {ask} ask · ⚪ {idle} idle · 🟢 {wait} wait");
+    println!();
+    for r in rows {
+        let name = r
+            .session
+            .tmux_session
+            .as_deref()
+            .or(r.session.workspace_name.as_deref())
+            .unwrap_or(&r.session.id);
+        match &r.context {
+            NeedsContext::Ask(aq) => {
+                println!("▸ 🟡 {name} ─ {}", truncate_line(&aq.question, 100));
+                for (i, opt) in aq.options.iter().enumerate().take(5) {
+                    let glyph = ["①", "②", "③", "④", "⑤"][i.min(4)];
+                    println!("    {glyph} {}", truncate_line(&opt.label, 90));
+                }
+            }
+            NeedsContext::Err(e) => {
+                println!("▸ 🔴 {name} ─ {} ({})", e.pattern, truncate_line(&e.snippet, 60));
+            }
+            NeedsContext::Idle(i) => {
+                println!("▸ ⚪ {name} ─ idle {}m", i.idle_minutes);
+                if let Some(text) = &i.last_assistant_text {
+                    println!("    '{}'", truncate_line(text, 90));
+                }
+            }
+            NeedsContext::Wait(w) => {
+                println!("▸ 🟢 {name} ─ {} {}", w.marker, truncate_line(&w.text, 80));
+            }
+        }
+    }
+}
+
+fn truncate_line(s: &str, max: usize) -> String {
+    let one = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one.chars().count() <= max {
+        one
+    } else {
+        let cut: String = one.chars().take(max).collect();
+        format!("{cut}…")
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/needs.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/needs.rs
@@ -1,0 +1,23 @@
+// ABOUTME: `ainb fleet needs` — list sessions blocked on input / errors / waiting.
+
+use anyhow::Result;
+
+use crate::cli::OutputFormat;
+use crate::fleet::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
+
+pub async fn execute(_matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
+    let (ainb, peers) = tokio::join!(discover_from_ainb(), async { discover_from_peers() });
+    let sessions = merge_sessions(vec![
+        ainb.unwrap_or_default(),
+        peers.unwrap_or_default(),
+    ]);
+
+    let blocked: Vec<_> = sessions
+        .into_iter()
+        .filter(|s| s.summary.as_deref().is_some_and(|sum| sum.starts_with("WAITING:")))
+        .collect();
+
+    let json = serde_json::to_string_pretty(&blocked)?;
+    println!("{json}");
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/sequence.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/sequence.rs
@@ -1,0 +1,70 @@
+// ABOUTME: `ainb fleet sequence` — ordered ack-gated multi-step prompts.
+//
+// Between steps, watches each target's JSONL transcript for the next
+// assistant-turn-end and waits until either all targets ack or the timeout
+// fires. Falls back to a small fixed delay if the transcript isn't found.
+
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+
+use crate::cli::OutputFormat;
+use crate::fleet::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
+use crate::fleet::read::{latest_transcript_for_cwd, wait_for_turn_end};
+use crate::fleet::send::send;
+use crate::fleet::types::Session;
+
+pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
+    let steps: Vec<String> = matches
+        .get_many::<String>("steps")
+        .map(|vals| vals.cloned().collect())
+        .unwrap_or_default();
+    if steps.is_empty() {
+        bail!("sequence requires at least one step");
+    }
+
+    let all = matches.get_flag("all");
+    if !all {
+        bail!("sequence v0.1 only supports --all targeting");
+    }
+
+    let timeout_s = matches.get_one::<u64>("timeout").copied().unwrap_or(300);
+
+    let (ainb, peers) = tokio::join!(discover_from_ainb(), async { discover_from_peers() });
+    let targets = merge_sessions(vec![
+        ainb.unwrap_or_default(),
+        peers.unwrap_or_default(),
+    ]);
+
+    let n = steps.len();
+    for (idx, step) in steps.iter().enumerate() {
+        eprintln!("[fleet/sequence] step {}/{}: {step}", idx + 1, n);
+        for t in &targets {
+            let _ = send(t, step).await?;
+        }
+        if idx < steps.len() - 1 {
+            wait_for_all_acks(&targets, Duration::from_secs(timeout_s)).await;
+        }
+    }
+    Ok(())
+}
+
+/// For each target, spawn a blocking task watching its latest JSONL for
+/// `stop_reason == "end_turn"`. Returns when all observed acks or the deadline
+/// hits. Targets whose transcript can't be found are skipped (best-effort).
+async fn wait_for_all_acks(targets: &[Session], timeout: Duration) {
+    let mut handles = Vec::with_capacity(targets.len());
+    for t in targets {
+        let cwd = t.cwd.clone();
+        let h = tokio::task::spawn_blocking(move || {
+            let Some(path) = latest_transcript_for_cwd(&cwd) else {
+                return false;
+            };
+            wait_for_turn_end(&path, timeout).unwrap_or(false)
+        });
+        handles.push(h);
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/standup.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/standup.rs
@@ -8,6 +8,8 @@ use crate::cli::OutputFormat;
 use crate::fleet::discover::{
     discover_from_ainb, discover_from_jobs, discover_from_peers, merge_sessions,
 };
+use crate::fleet::read::{last_narrative_snapshot, latest_transcript_for_cwd};
+use crate::fleet::types::Session;
 
 pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
     let want_text = matches.get_flag("text");
@@ -19,7 +21,8 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
     let peers = discover_from_peers().unwrap_or_default();
     let jobs = jobs_res.unwrap_or_default();
 
-    let merged = merge_sessions(vec![ainb, peers, jobs]);
+    let mut merged = merge_sessions(vec![ainb, peers, jobs]);
+    enrich_with_jsonl_summary(&mut merged).await;
 
     if want_text || matches!(format, OutputFormat::Text) {
         print_text(&merged);
@@ -28,6 +31,26 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
         println!("{json}");
     }
     Ok(())
+}
+
+/// Replace each session's `summary` with a synthesised one-liner from its
+/// JSONL transcript. Reads happen in parallel (spawn_blocking) to stay snappy
+/// even on fleets of 30+ sessions. Sessions without a transcript keep
+/// summary = None.
+async fn enrich_with_jsonl_summary(sessions: &mut [Session]) {
+    let cwds: Vec<String> = sessions.iter().map(|s| s.cwd.clone()).collect();
+    let mut tasks = Vec::with_capacity(cwds.len());
+    for cwd in cwds {
+        tasks.push(tokio::task::spawn_blocking(move || {
+            let path = latest_transcript_for_cwd(&cwd)?;
+            last_narrative_snapshot(&path)
+        }));
+    }
+    for (i, t) in tasks.into_iter().enumerate() {
+        if let Ok(Some(summary)) = t.await {
+            sessions[i].summary = Some(summary);
+        }
+    }
 }
 
 fn print_text(sessions: &[crate::fleet::types::Session]) {

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/standup.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/standup.rs
@@ -1,0 +1,58 @@
+// ABOUTME: `ainb fleet standup` — list every claude session across ainb + peers + jobs.
+//
+// Default output: JSON for LLM consumption. `--text` switches to a column table.
+
+use anyhow::Result;
+
+use crate::cli::OutputFormat;
+use crate::fleet::discover::{
+    discover_from_ainb, discover_from_jobs, discover_from_peers, merge_sessions,
+};
+
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    let want_text = matches.get_flag("text");
+
+    let (ainb_res, jobs_res) = tokio::join!(discover_from_ainb(), async {
+        discover_from_jobs()
+    });
+    let ainb = ainb_res.unwrap_or_default();
+    let peers = discover_from_peers().unwrap_or_default();
+    let jobs = jobs_res.unwrap_or_default();
+
+    let merged = merge_sessions(vec![ainb, peers, jobs]);
+
+    if want_text || matches!(format, OutputFormat::Text) {
+        print_text(&merged);
+    } else {
+        let json = serde_json::to_string_pretty(&merged)?;
+        println!("{json}");
+    }
+    Ok(())
+}
+
+fn print_text(sessions: &[crate::fleet::types::Session]) {
+    println!("ainb fleet standup — {} sessions", sessions.len());
+    println!(
+        "{:<36}  {:<14}  {}",
+        "name", "sources", "cwd"
+    );
+    for s in sessions {
+        let name = s
+            .tmux_session
+            .as_deref()
+            .or(s.workspace_name.as_deref())
+            .unwrap_or(&s.id);
+        let sources = s
+            .sources
+            .iter()
+            .map(|src| format!("{src:?}").to_lowercase())
+            .collect::<Vec<_>>()
+            .join(",");
+        let name_display = if name.len() > 34 {
+            format!("{}…", &name[..33])
+        } else {
+            name.to_string()
+        };
+        println!("{name_display:<36}  {sources:<14}  {}", s.cwd);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod attach;
 pub mod auth;
 pub mod config_cmd;
 pub mod favorites;
+pub mod fleet;
 pub mod git_cmd;
 pub mod init;
 pub mod list;

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -104,6 +104,7 @@ impl CommandRegistry {
         r.register(TmuxCommand);
         r.register(CompletionCommand);
         r.register(PluginCommand); // Phase 4 stub — surface reserved now
+        r.register(FleetCommand);
         r
     }
 
@@ -1026,6 +1027,87 @@ impl CliCommand for PluginCommand {
     }
 }
 
+pub struct FleetCommand;
+impl CliCommand for FleetCommand {
+    fn name(&self) -> &'static str {
+        "fleet"
+    }
+    fn build(&self, app: Command) -> Command {
+        let standup = Command::new("standup")
+            .about("Live fleet status: every claude session across ainb + peers + bg jobs")
+            .arg(
+                clap::Arg::new("text")
+                    .long("text")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Force text output even with --format json"),
+            );
+        let broadcast = Command::new("broadcast")
+            .about("Send one prompt to selected sessions (peers-first, tmux fallback)")
+            .arg(clap::Arg::new("prompt").required(true))
+            .arg(
+                clap::Arg::new("all")
+                    .long("all")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Fan out to every running session"),
+            )
+            .arg(
+                clap::Arg::new("filter")
+                    .long("filter")
+                    .help("Regex against tmux/workspace name"),
+            )
+            .arg(
+                clap::Arg::new("cwd")
+                    .long("cwd")
+                    .help("Substring against cwd"),
+            );
+        let sequence = Command::new("sequence")
+            .about("Ordered prompts with ack between steps")
+            .arg(
+                clap::Arg::new("steps")
+                    .required(true)
+                    .num_args(1..)
+                    .action(clap::ArgAction::Append),
+            )
+            .arg(
+                clap::Arg::new("all")
+                    .long("all")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("timeout")
+                    .long("timeout")
+                    .value_parser(clap::value_parser!(u64))
+                    .default_value("300")
+                    .help("Per-step timeout (seconds)"),
+            );
+        let needs = Command::new("needs")
+            .about("List sessions blocked on input / errors / waiting");
+        let daemon = Command::new("daemon")
+            .about("Watcher: registers as ainb-fleet-cp peer, auto-continues API errors")
+            .arg(
+                clap::Arg::new("verbose")
+                    .long("verbose")
+                    .short('v')
+                    .action(clap::ArgAction::SetTrue),
+            );
+        app.subcommand(
+            Command::new(self.name())
+                .about("Fleet orchestration: standup / broadcast / sequence / needs / daemon")
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(standup)
+                .subcommand(broadcast)
+                .subcommand(sequence)
+                .subcommand(needs)
+                .subcommand(daemon),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        let matches = matches.clone();
+        Box::pin(async move { crate::cli::fleet::execute(&matches, ctx.format).await })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1035,13 +1117,13 @@ mod tests {
     }
 
     #[test]
-    fn built_ins_registers_nineteen_commands() {
+    fn built_ins_registers_twenty_commands() {
         let r = CommandRegistry::built_ins();
         let names = r.names();
         // 16 user-facing built-ins + claudecode namespace + tmux namespace
-        // + plugin stub = 19. The TUI is NOT in the registry — main.rs
-        // handles `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 19, "expected 19 entries, got {names:?}");
+        // + plugin stub + fleet = 20. The TUI is NOT in the registry —
+        // main.rs handles `tui` / no-subcommand inline.
+        assert_eq!(names.len(), 20, "expected 20 entries, got {names:?}");
         for required in [
             "run",
             "list",
@@ -1062,6 +1144,7 @@ mod tests {
             "tmux",
             "completion",
             "plugin",
+            "fleet",
         ] {
             assert!(
                 names.contains(&required),

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1081,7 +1081,13 @@ impl CliCommand for FleetCommand {
                     .help("Per-step timeout (seconds)"),
             );
         let needs = Command::new("needs")
-            .about("List sessions blocked on input / errors / waiting");
+            .about("Center control panel — sessions blocked on input / errors / idle / waiting")
+            .arg(
+                clap::Arg::new("idle-min")
+                    .long("idle-min")
+                    .value_parser(clap::value_parser!(i64))
+                    .help("Minutes of assistant silence before flagging IDLE (default 5, env AINB_FLEET_IDLE_MIN)"),
+            );
         let daemon = Command::new("daemon")
             .about("Watcher: registers as ainb-fleet-cp peer, auto-continues API errors")
             .arg(

--- a/ainb-tui/crates/ainb-core/src/fleet/discover/ainb.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/discover/ainb.rs
@@ -1,0 +1,58 @@
+// ABOUTME: Discover sessions by shelling out to `ainb list --format json`.
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+use crate::fleet::types::{AinbSession, Session, SessionSource};
+
+/// Override the binary used (test seam).
+fn ainb_bin() -> String {
+    std::env::var("AINB_BIN").unwrap_or_else(|_| "ainb".to_string())
+}
+
+pub async fn list_ainb_sessions() -> Result<Vec<AinbSession>> {
+    let output = Command::new(ainb_bin())
+        .args(["list", "--format", "json"])
+        .output()
+        .await
+        .context("failed to invoke `ainb list --format json`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ainb list exited non-zero: {stderr}");
+    }
+
+    let parsed: Vec<AinbSession> = serde_json::from_slice(&output.stdout)
+        .context("`ainb list` produced invalid JSON")?;
+    Ok(parsed)
+}
+
+/// Map ainb rows to [`Session`] records. Filters to running sessions.
+pub async fn discover_from_ainb() -> Result<Vec<Session>> {
+    let rows = list_ainb_sessions().await?;
+    Ok(rows
+        .into_iter()
+        .filter(|r| r.is_running)
+        .map(|r| Session {
+            id: r.session_id,
+            cwd: r.worktree_path.clone(),
+            pid: None,
+            git_root: None,
+            tmux_session: Some(r.tmux_session_name),
+            workspace_name: Some(r.workspace_name),
+            worktree_path: Some(r.worktree_path),
+            peer_id: None,
+            bg_job_id: None,
+            transcript_path: None,
+            sources: vec![SessionSource::Ainb],
+            summary: None,
+            last_seen_ms: parse_iso8601_ms(&r.created_at),
+        })
+        .collect())
+}
+
+fn parse_iso8601_ms(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/discover/jobs.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/discover/jobs.rs
@@ -1,0 +1,46 @@
+// ABOUTME: Scan ~/.claude/jobs/<id>/ for background-session state dirs.
+
+use anyhow::Result;
+
+use crate::fleet::types::{Session, SessionSource};
+
+fn jobs_root() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("AINB_FLEET_JOBS_DIR") {
+        return std::path::PathBuf::from(p);
+    }
+    let mut home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home.push(".claude");
+    home.push("jobs");
+    home
+}
+
+pub fn discover_from_jobs() -> Result<Vec<Session>> {
+    let root = jobs_root();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let cwd = entry.path().to_string_lossy().into_owned();
+        out.push(Session {
+            id: name.clone(),
+            cwd,
+            pid: None,
+            git_root: None,
+            tmux_session: None,
+            workspace_name: None,
+            worktree_path: None,
+            peer_id: None,
+            bg_job_id: Some(name),
+            transcript_path: None,
+            sources: vec![SessionSource::Jobs],
+            summary: None,
+            last_seen_ms: None,
+        });
+    }
+    Ok(out)
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/discover/merge.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/discover/merge.rs
@@ -1,0 +1,108 @@
+// ABOUTME: Merge sessions from multiple sources, deduping by cwd.
+//
+// cwd is the primary identity. Pid-asymmetric sources (ainb publishes no
+// pid; peers does) used to land in different buckets in the TS reference
+// impl — this Rust port coalesces on cwd to fix that. Two claude sessions
+// in the same cwd is a rare edge case; accept the merge.
+
+use std::collections::BTreeMap;
+
+use crate::fleet::types::Session;
+
+#[must_use]
+pub fn merge_sessions(groups: Vec<Vec<Session>>) -> Vec<Session> {
+    let mut by_key: BTreeMap<String, Session> = BTreeMap::new();
+    for group in groups {
+        for s in group {
+            let key = dedupe_key(&s);
+            match by_key.remove(&key) {
+                Some(existing) => {
+                    by_key.insert(key, merge_one(existing, s));
+                }
+                None => {
+                    by_key.insert(key, s);
+                }
+            }
+        }
+    }
+    by_key.into_values().collect()
+}
+
+fn dedupe_key(s: &Session) -> String {
+    if s.cwd.is_empty() {
+        s.id.clone()
+    } else {
+        s.cwd.clone()
+    }
+}
+
+fn merge_one(a: Session, b: Session) -> Session {
+    let mut sources = a.sources;
+    for src in b.sources {
+        if !sources.contains(&src) {
+            sources.push(src);
+        }
+    }
+    Session {
+        id: a.id,
+        cwd: a.cwd,
+        pid: a.pid.or(b.pid),
+        git_root: a.git_root.or(b.git_root),
+        tmux_session: a.tmux_session.or(b.tmux_session),
+        workspace_name: a.workspace_name.or(b.workspace_name),
+        worktree_path: a.worktree_path.or(b.worktree_path),
+        peer_id: a.peer_id.or(b.peer_id),
+        bg_job_id: a.bg_job_id.or(b.bg_job_id),
+        transcript_path: a.transcript_path.or(b.transcript_path),
+        sources,
+        summary: a.summary.or(b.summary),
+        last_seen_ms: match (a.last_seen_ms, b.last_seen_ms) {
+            (Some(x), Some(y)) => Some(x.max(y)),
+            (x, y) => x.or(y),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet::types::SessionSource;
+
+    fn session(cwd: &str, src: SessionSource, pid: Option<u32>) -> Session {
+        Session {
+            id: format!("{cwd}-{src:?}"),
+            cwd: cwd.to_string(),
+            pid,
+            git_root: None,
+            tmux_session: None,
+            workspace_name: None,
+            worktree_path: None,
+            peer_id: None,
+            bg_job_id: None,
+            transcript_path: None,
+            sources: vec![src],
+            summary: None,
+            last_seen_ms: None,
+        }
+    }
+
+    #[test]
+    fn merges_same_cwd_across_sources() {
+        let a = session("/repo", SessionSource::Ainb, None);
+        let b = session("/repo", SessionSource::Peers, Some(123));
+        let merged = merge_sessions(vec![vec![a], vec![b]]);
+        assert_eq!(merged.len(), 1);
+        let m = &merged[0];
+        assert_eq!(m.cwd, "/repo");
+        assert_eq!(m.pid, Some(123));
+        assert_eq!(m.sources.len(), 2);
+    }
+
+    #[test]
+    fn keeps_distinct_cwds() {
+        let a = session("/r1", SessionSource::Ainb, None);
+        let b = session("/r2", SessionSource::Peers, Some(1));
+        let merged = merge_sessions(vec![vec![a], vec![b]]);
+        assert_eq!(merged.len(), 2);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/discover/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/discover/mod.rs
@@ -1,0 +1,11 @@
+// ABOUTME: Session discovery sources for fleet orchestration.
+
+pub mod ainb;
+pub mod jobs;
+pub mod merge;
+pub mod peers;
+
+pub use ainb::discover_from_ainb;
+pub use jobs::discover_from_jobs;
+pub use merge::merge_sessions;
+pub use peers::{discover_from_peers, list_broker_peers};

--- a/ainb-tui/crates/ainb-core/src/fleet/discover/peers.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/discover/peers.rs
@@ -1,0 +1,98 @@
+// ABOUTME: Discover sessions by direct SQLite read of `~/.claude-peers.db`.
+//
+// Faster than the broker HTTP API and avoids a network round-trip per
+// discovery pass. Writes still go through the broker HTTP client.
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OpenFlags};
+
+use crate::fleet::types::{BrokerPeer, Session, SessionSource};
+
+/// Default DB path (override via `CLAUDE_PEERS_DB`).
+fn db_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("CLAUDE_PEERS_DB") {
+        return std::path::PathBuf::from(p);
+    }
+    let mut home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home.push(".claude-peers.db");
+    home
+}
+
+pub fn list_broker_peers() -> Result<Vec<BrokerPeer>> {
+    let path = db_path();
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let conn = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("opening {}", path.display()))?;
+
+    let mut stmt = conn.prepare(
+        "SELECT id, pid, cwd, git_root, tty, summary, registered_at, last_seen FROM peers",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(BrokerPeer {
+            id: row.get(0)?,
+            pid: row.get::<_, i64>(1)? as u32,
+            cwd: row.get(2)?,
+            git_root: row.get(3)?,
+            tty: row.get(4)?,
+            summary: row.get(5)?,
+            registered_at: row.get(6)?,
+            last_seen: row.get(7)?,
+        })
+    })?;
+
+    let mut out = Vec::new();
+    for r in rows {
+        let peer = r?;
+        if is_pid_alive(peer.pid) {
+            out.push(peer);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(unix)]
+fn is_pid_alive(pid: u32) -> bool {
+    // signal 0 — checks existence without affecting the process.
+    // `pid` is unsigned; the cast saturates at i32::MAX which is fine
+    // because real PIDs on macOS/Linux never reach that range.
+    let nix_pid = nix::unistd::Pid::from_raw(pid as i32);
+    nix::sys::signal::kill(nix_pid, None).is_ok()
+}
+
+#[cfg(not(unix))]
+fn is_pid_alive(_pid: u32) -> bool {
+    true
+}
+
+pub fn discover_from_peers() -> Result<Vec<Session>> {
+    let peers = list_broker_peers()?;
+    Ok(peers
+        .into_iter()
+        .map(|p| Session {
+            id: p.id.clone(),
+            cwd: p.cwd,
+            pid: Some(p.pid),
+            git_root: p.git_root,
+            tmux_session: None,
+            workspace_name: None,
+            worktree_path: None,
+            peer_id: Some(p.id),
+            bg_job_id: None,
+            transcript_path: None,
+            sources: vec![SessionSource::Peers],
+            summary: Some(p.summary),
+            last_seen_ms: parse_iso8601_ms(&p.last_seen),
+        })
+        .collect())
+}
+
+fn parse_iso8601_ms(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/discover/peers.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/discover/peers.rs
@@ -85,7 +85,10 @@ pub fn discover_from_peers() -> Result<Vec<Session>> {
             bg_job_id: None,
             transcript_path: None,
             sources: vec![SessionSource::Peers],
-            summary: Some(p.summary),
+            // Broker summary is unreliable — most peers never call set_summary.
+            // Standup synthesises the field from JSONL instead. Leave None here
+            // so the JSONL value isn't shadowed by a stale broker write.
+            summary: None,
             last_seen_ms: parse_iso8601_ms(&p.last_seen),
         })
         .collect())

--- a/ainb-tui/crates/ainb-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/mod.rs
@@ -1,0 +1,23 @@
+// ABOUTME: Fleet orchestration core — multi-session discovery, state reading, and send routing.
+//
+// Provides the building blocks for the `ainb fleet …` CLI subcommands
+// (broadcast / sequence / needs / daemon / standup). The CLI dispatchers live
+// under `crate::cli::fleet`; this module owns the pure logic.
+//
+// Layers:
+// - `discover/` — unified session enumeration across ainb, claude-peers, bg jobs
+// - `read/`     — state signals from tmux panes + JSONL transcripts + error regex
+// - `send/`     — prompt delivery via claude-peers broker (preferred) or tmux send-keys
+// - `types`     — Session / SessionState / Signal records shared across layers
+
+#![allow(missing_docs)]
+
+pub mod discover;
+pub mod read;
+pub mod send;
+pub mod types;
+
+pub use types::{
+    AinbSession, Block, BrokerPeer, Liveness, SendOutcome, Session, SessionSource, SessionState,
+    Signal,
+};

--- a/ainb-tui/crates/ainb-core/src/fleet/read/errors.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/errors.rs
@@ -1,0 +1,79 @@
+// ABOUTME: API-error regex patterns + signal detection.
+//
+// Daemon mode auto-continues when any pattern matches recent output. Keep
+// the set specific — better to miss an error than to spam `continue` into
+// a working session.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::fleet::types::Signal;
+
+pub struct ErrorPattern {
+    pub name: &'static str,
+    pub re: Regex,
+}
+
+lazy_static! {
+    pub static ref API_ERROR_PATTERNS: Vec<ErrorPattern> = vec![
+        ErrorPattern { name: "rate_limited", re: Regex::new(r"(?i)\brate[_ ]limited\b").unwrap() },
+        ErrorPattern {
+            name: "overloaded",
+            re: Regex::new(r"(?i)\boverloaded_error\b|\bModel is overloaded\b").unwrap(),
+        },
+        ErrorPattern {
+            name: "internal_server_error",
+            re: Regex::new(r"(?i)\binternal_server_error\b").unwrap(),
+        },
+        ErrorPattern {
+            name: "request_timeout",
+            re: Regex::new(r"(?i)\brequest timed out\b").unwrap(),
+        },
+        ErrorPattern {
+            name: "socket_hang_up",
+            re: Regex::new(r"(?i)\bsocket hang up\b").unwrap(),
+        },
+        ErrorPattern {
+            name: "fetch_failed",
+            re: Regex::new(r"(?i)\bAPI Error\b|\bfetch failed\b").unwrap(),
+        },
+        ErrorPattern {
+            name: "connection_reset",
+            re: Regex::new(r"(?i)\bECONNRESET\b|\bconnection reset\b").unwrap(),
+        },
+    ];
+}
+
+pub fn detect_error_signals(text: &str, at_ms: i64) -> Vec<Signal> {
+    let mut out = Vec::new();
+    for p in API_ERROR_PATTERNS.iter() {
+        if let Some(m) = p.re.find(text) {
+            let start = m.start().saturating_sub(80);
+            let end = (m.end() + 200).min(text.len());
+            out.push(Signal::ApiError {
+                at: at_ms,
+                pattern: p.name.to_string(),
+                raw: text[start..end].to_string(),
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_rate_limited() {
+        let signals = detect_error_signals("API Error: rate_limited please retry", 0);
+        // Both 'rate_limited' and 'fetch_failed' (matches "API Error") fire — that's OK.
+        assert!(signals.iter().any(|s| matches!(s, Signal::ApiError { pattern, .. } if pattern == "rate_limited")));
+    }
+
+    #[test]
+    fn no_false_positive_on_clean_text() {
+        let signals = detect_error_signals("normal output", 0);
+        assert!(signals.is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/read/jsonl_tail.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/jsonl_tail.rs
@@ -159,6 +159,186 @@ fn scan_for_turn_end(path: &Path, last_offset: &mut u64) -> Result<Option<bool>>
     Ok(if found_end { Some(true) } else { None })
 }
 
+/// Structured AskUserQuestion data extracted from a transcript tool_use block.
+/// Matches the shape of the AskUserQuestion tool's `input` parameter.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AskUserQuestionData {
+    pub question: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+    pub options: Vec<AskOption>,
+    #[serde(default)]
+    pub multi_select: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AskOption {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Last assistant turn's timing + text + stop reason — for IDLE detection
+/// and for the IDLE card's "last said" snippet.
+#[derive(Debug, Clone)]
+pub struct LastAssistantInfo {
+    /// Unix ms of the timestamp on the assistant row.
+    pub ts_ms: i64,
+    /// stop_reason field (e.g. "end_turn", "tool_use", "max_tokens").
+    pub stop_reason: Option<String>,
+    /// First text-block content, truncated and whitespace-collapsed.
+    pub text_snippet: Option<String>,
+    /// Whether there's a subsequent user-role row in the file.
+    pub has_user_follow_up: bool,
+}
+
+/// Scan the transcript for the most recent AskUserQuestion tool_use call.
+/// Returns None if the session has no such call within the lookback window.
+///
+/// Walks the same exponential lookback as `last_narrative_snapshot` (20 → 320).
+pub fn last_ask_user_question(path: &Path) -> Option<AskUserQuestionData> {
+    let lines = read_lines(path)?;
+    if lines.is_empty() {
+        return None;
+    }
+    for window in [20usize, 40, 80, 160, 320] {
+        let start = lines.len().saturating_sub(window);
+        if let Some(aq) = find_ask_user_question(&lines[start..]) {
+            return Some(aq);
+        }
+        if start == 0 {
+            break;
+        }
+    }
+    None
+}
+
+fn find_ask_user_question(rows: &[String]) -> Option<AskUserQuestionData> {
+    for row in rows.iter().rev() {
+        let Ok(v) = serde_json::from_str::<Value>(row) else {
+            continue;
+        };
+        if v.get("type").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let content = v.pointer("/message/content").and_then(Value::as_array)?;
+        // Walk content backward — last tool_use wins.
+        for block in content.iter().rev() {
+            let is_tool = block.get("type").and_then(Value::as_str) == Some("tool_use");
+            let name = block.get("name").and_then(Value::as_str);
+            if !is_tool || name != Some("AskUserQuestion") {
+                continue;
+            }
+            let input = block.get("input")?;
+            let questions = input.get("questions").and_then(Value::as_array)?;
+            let first = questions.first()?;
+            return Some(AskUserQuestionData {
+                question: first
+                    .get("question")
+                    .and_then(Value::as_str)
+                    .unwrap_or("(no question text)")
+                    .to_string(),
+                header: first
+                    .get("header")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                options: first
+                    .get("options")
+                    .and_then(Value::as_array)
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|o| {
+                                Some(AskOption {
+                                    label: o.get("label").and_then(Value::as_str)?.to_string(),
+                                    description: o
+                                        .get("description")
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string),
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                multi_select: first
+                    .get("multiSelect")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            });
+        }
+        // No tool_use in this assistant row — keep searching older rows.
+    }
+    None
+}
+
+/// Probe the transcript for the last assistant turn's timing + stop reason.
+/// Used by the IDLE classifier.
+pub fn last_assistant_info(path: &Path) -> Option<LastAssistantInfo> {
+    let lines = read_lines(path)?;
+    if lines.is_empty() {
+        return None;
+    }
+    // Walk backward; first assistant row wins. Track whether we see a user
+    // row AFTER it (i.e. earlier in our reverse walk).
+    let mut saw_user_after = false;
+    for row in lines.iter().rev() {
+        let Ok(v) = serde_json::from_str::<Value>(row) else {
+            continue;
+        };
+        let row_type = v.get("type").and_then(Value::as_str).unwrap_or("");
+        if row_type == "user" {
+            saw_user_after = true;
+            continue;
+        }
+        if row_type != "assistant" {
+            continue;
+        }
+        let ts_ms = parse_ts_ms(v.get("timestamp").and_then(Value::as_str).unwrap_or(""));
+        let stop_reason = v
+            .pointer("/message/stop_reason")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let text_snippet = v
+            .pointer("/message/content")
+            .and_then(Value::as_array)
+            .and_then(|arr| {
+                let mut buf = String::new();
+                for b in arr {
+                    if b.get("type").and_then(Value::as_str) == Some("text") {
+                        if let Some(t) = b.get("text").and_then(Value::as_str) {
+                            buf.push_str(t);
+                            buf.push(' ');
+                        }
+                    }
+                }
+                let collapsed = collapse_whitespace(buf.trim());
+                if collapsed.is_empty() {
+                    None
+                } else {
+                    Some(truncate(&collapsed, 120))
+                }
+            });
+        return Some(LastAssistantInfo {
+            ts_ms: ts_ms.unwrap_or(0),
+            stop_reason,
+            text_snippet,
+            has_user_follow_up: saw_user_after,
+        });
+    }
+    None
+}
+
+fn read_lines(path: &Path) -> Option<Vec<String>> {
+    let file = std::fs::File::open(path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    Some(reader.lines().map_while(Result::ok).collect())
+}
+
+fn parse_ts_ms(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
 /// Synthesise a one-line "what is this session doing right now" string from
 /// the transcript. Walks recent rows backward looking for the freshest
 /// assistant turn with substance.

--- a/ainb-tui/crates/ainb-core/src/fleet/read/jsonl_tail.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/jsonl_tail.rs
@@ -3,6 +3,7 @@
 // Watches ~/.claude/projects/<cwd-slug>/<session-id>.jsonl using `notify`.
 // Returns when the next assistant turn ends or the timeout fires.
 
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
@@ -10,11 +11,25 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use notify::{EventKind, RecursiveMode, Watcher};
 use serde::Deserialize;
+use serde_json::Value;
 
-/// Claude maps cwd → project dir by replacing `/` with `-`.
+/// Claude maps cwd → project dir by replacing every non-alphanumeric char
+/// (except `-`) with `-`. So `/`, `.`, `_`, etc. all collapse to `-`.
+/// Examples:
+///   `/Users/stevengonsalvez/d/git/foo`  →  `-Users-stevengonsalvez-d-git-foo`
+///   `/Users/stevengonsalvez/.agents-in-a-box/worktrees/foo_bar`
+///     →  `-Users-stevengonsalvez--agents-in-a-box-worktrees-foo-bar`
 #[must_use]
 pub fn cwd_to_project_slug(cwd: &str) -> String {
-    cwd.replace('/', "-")
+    cwd.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 /// Locate the most recently modified `.jsonl` file under
@@ -144,6 +159,114 @@ fn scan_for_turn_end(path: &Path, last_offset: &mut u64) -> Result<Option<bool>>
     Ok(if found_end { Some(true) } else { None })
 }
 
+/// Synthesise a one-line "what is this session doing right now" string from
+/// the transcript. Walks recent rows backward looking for the freshest
+/// assistant turn with substance.
+///
+/// Exponential lookback: scans the last 20 rows first, expanding to 40, 80,
+/// 160, then 320 if no signal turns up. Stops at the first window that yields
+/// content. Cheap for active sessions (signal lives in the last few rows);
+/// resilient when the tail is full of tool_result noise.
+pub fn last_narrative_snapshot(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let lines: Vec<String> = reader.lines().map_while(Result::ok).collect();
+    if lines.is_empty() {
+        return None;
+    }
+    for window in [20usize, 40, 80, 160, 320] {
+        let start = lines.len().saturating_sub(window);
+        if let Some(snap) = synthesize_from_rows(&lines[start..]) {
+            return Some(snap);
+        }
+        if start == 0 {
+            break;
+        }
+    }
+    None
+}
+
+fn synthesize_from_rows(rows: &[String]) -> Option<String> {
+    // Walk backwards; first assistant row with text-or-tool wins.
+    for row in rows.iter().rev() {
+        let Ok(v) = serde_json::from_str::<Value>(row) else {
+            continue;
+        };
+        if v.get("type").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let content = v.pointer("/message/content");
+        if let Some(arr) = content.and_then(Value::as_array) {
+            // Prefer the LAST tool_use block — that's what the session is doing right now.
+            for block in arr.iter().rev() {
+                if block.get("type").and_then(Value::as_str) == Some("tool_use") {
+                    let name = block.get("name").and_then(Value::as_str).unwrap_or("?");
+                    let arg = tool_arg_snippet(block.get("input"));
+                    return Some(if arg.is_empty() {
+                        format!("{name}")
+                    } else {
+                        format!("{name} · {arg}")
+                    });
+                }
+            }
+            // No tool calls — concatenate text blocks.
+            let mut text = String::new();
+            for block in arr.iter() {
+                if block.get("type").and_then(Value::as_str) == Some("text") {
+                    if let Some(t) = block.get("text").and_then(Value::as_str) {
+                        text.push_str(t);
+                        text.push(' ');
+                    }
+                }
+            }
+            let collapsed = collapse_whitespace(text.trim());
+            if !collapsed.is_empty() {
+                return Some(truncate(&collapsed, 100));
+            }
+        }
+        // Rare: message.content as plain string.
+        if let Some(s) = content.and_then(Value::as_str) {
+            let collapsed = collapse_whitespace(s.trim());
+            if !collapsed.is_empty() {
+                return Some(truncate(&collapsed, 100));
+            }
+        }
+    }
+    None
+}
+
+/// Pull the most descriptive field from a tool_use input object.
+fn tool_arg_snippet(input: Option<&Value>) -> String {
+    let Some(input) = input else {
+        return String::new();
+    };
+    let pick = input
+        .get("command")
+        .or_else(|| input.get("file_path"))
+        .or_else(|| input.get("path"))
+        .or_else(|| input.get("pattern"))
+        .or_else(|| input.get("description"))
+        .or_else(|| input.get("query"))
+        .or_else(|| input.get("subject"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let collapsed = collapse_whitespace(pick);
+    truncate(&collapsed, 60)
+}
+
+fn collapse_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let cut: String = s.chars().take(max).collect();
+        format!("{cut}…")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,5 +277,45 @@ mod tests {
             cwd_to_project_slug("/Users/stevengonsalvez/d/git/foo"),
             "-Users-stevengonsalvez-d-git-foo"
         );
+    }
+
+    #[test]
+    fn slugs_dots_and_underscores() {
+        // `.` and `_` both collapse to `-`. `/.` → `--`.
+        assert_eq!(
+            cwd_to_project_slug(
+                "/Users/stevengonsalvez/.agents-in-a-box/worktrees/foo_bar_baz"
+            ),
+            "-Users-stevengonsalvez--agents-in-a-box-worktrees-foo-bar-baz"
+        );
+    }
+
+    #[test]
+    fn synth_extracts_tool_use() {
+        let rows = vec![
+            r#"{"type":"user","message":{"content":"go"}}"#.to_string(),
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Running tests."},{"type":"tool_use","name":"Bash","input":{"command":"cargo test --lib"}}]}}"#.to_string(),
+        ];
+        let s = synthesize_from_rows(&rows).expect("synthesised");
+        assert!(s.contains("Bash"), "got: {s}");
+        assert!(s.contains("cargo test"), "got: {s}");
+    }
+
+    #[test]
+    fn synth_falls_back_to_text_when_no_tool() {
+        let rows = vec![
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Investigating the RLS chain on auth.audit_log inserts."}]}}"#.to_string(),
+        ];
+        let s = synthesize_from_rows(&rows).expect("synthesised");
+        assert!(s.contains("Investigating"), "got: {s}");
+        assert!(s.contains("RLS"), "got: {s}");
+    }
+
+    #[test]
+    fn synth_skips_user_rows() {
+        let rows = vec![
+            r#"{"type":"user","message":{"content":"hello"}}"#.to_string(),
+        ];
+        assert!(synthesize_from_rows(&rows).is_none());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/read/jsonl_tail.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/jsonl_tail.rs
@@ -1,0 +1,158 @@
+// ABOUTME: JSONL transcript tail for assistant-turn-end detection.
+//
+// Watches ~/.claude/projects/<cwd-slug>/<session-id>.jsonl using `notify`.
+// Returns when the next assistant turn ends or the timeout fires.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use notify::{EventKind, RecursiveMode, Watcher};
+use serde::Deserialize;
+
+/// Claude maps cwd → project dir by replacing `/` with `-`.
+#[must_use]
+pub fn cwd_to_project_slug(cwd: &str) -> String {
+    cwd.replace('/', "-")
+}
+
+/// Locate the most recently modified `.jsonl` file under
+/// `~/.claude/projects/<cwd-slug>/`. Returns `None` if no transcripts exist.
+pub fn latest_transcript_for_cwd(cwd: &str) -> Option<PathBuf> {
+    let mut home = dirs::home_dir()?;
+    home.push(".claude");
+    home.push("projects");
+    home.push(cwd_to_project_slug(cwd));
+
+    let entries = std::fs::read_dir(&home).ok()?;
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    for e in entries.flatten() {
+        let path = e.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = e.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
+            newest = Some((mtime, path));
+        }
+    }
+    newest.map(|(_, p)| p)
+}
+
+/// One JSONL row from Claude's transcript. Only the fields we need.
+#[derive(Debug, Deserialize)]
+struct TranscriptRow {
+    /// "user" | "assistant" | "system" | "tool_use" | …
+    #[serde(rename = "type")]
+    row_type: Option<String>,
+    /// Sub-shape for assistant turns — `{ stop_reason: "end_turn" | … }`.
+    #[serde(default)]
+    message: Option<TranscriptMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptMessage {
+    #[serde(default)]
+    stop_reason: Option<String>,
+}
+
+/// Block until the watched transcript shows a new `assistant`-role row whose
+/// `message.stop_reason` is `end_turn` (or until `timeout` elapses).
+///
+/// Returns `true` if we observed a turn-end before timing out.
+pub fn wait_for_turn_end(path: &Path, timeout: Duration) -> Result<bool> {
+    let start_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    })
+    .context("constructing notify watcher")?;
+    watcher
+        .watch(path, RecursiveMode::NonRecursive)
+        .context("starting watch on transcript")?;
+
+    let deadline = Instant::now() + timeout;
+    let mut last_offset = start_size;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        let event = rx.recv_timeout(remaining);
+        match event {
+            Ok(Ok(ev)) if matches!(ev.kind, EventKind::Modify(_) | EventKind::Create(_)) => {
+                if let Some(found) = scan_for_turn_end(path, &mut last_offset)? {
+                    if found {
+                        return Ok(true);
+                    }
+                }
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Ok(false);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Ok(false);
+            }
+        }
+    }
+}
+
+/// Read from `last_offset` to EOF, scan each complete line for assistant
+/// turn-end. Updates `last_offset` to the position after the last complete
+/// line we parsed. Tolerates partial trailing writes.
+fn scan_for_turn_end(path: &Path, last_offset: &mut u64) -> Result<Option<bool>> {
+    use std::io::{BufRead, BufReader, Seek, SeekFrom};
+
+    let mut file = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    file.seek(SeekFrom::Start(*last_offset))?;
+    let mut reader = BufReader::new(file);
+    let mut buf = String::new();
+    let mut bytes_consumed = 0u64;
+    let mut found_end = false;
+
+    loop {
+        buf.clear();
+        let n = reader.read_line(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        // Only count fully-terminated lines.
+        if !buf.ends_with('\n') {
+            break;
+        }
+        bytes_consumed += n as u64;
+
+        if let Ok(row) = serde_json::from_str::<TranscriptRow>(buf.trim()) {
+            let is_assistant = row.row_type.as_deref() == Some("assistant");
+            let ended = row
+                .message
+                .as_ref()
+                .and_then(|m| m.stop_reason.as_deref())
+                == Some("end_turn");
+            if is_assistant && ended {
+                found_end = true;
+                break;
+            }
+        }
+    }
+
+    *last_offset += bytes_consumed;
+    Ok(if found_end { Some(true) } else { None })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugs_a_typical_cwd() {
+        assert_eq!(
+            cwd_to_project_slug("/Users/stevengonsalvez/d/git/foo"),
+            "-Users-stevengonsalvez-d-git-foo"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/read/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/mod.rs
@@ -2,12 +2,18 @@
 
 pub mod errors;
 pub mod jsonl_tail;
+pub mod needs;
 pub mod state;
 pub mod tmux_pane;
 
 pub use errors::{detect_error_signals, API_ERROR_PATTERNS};
 pub use jsonl_tail::{
-    cwd_to_project_slug, last_narrative_snapshot, latest_transcript_for_cwd, wait_for_turn_end,
+    cwd_to_project_slug, last_ask_user_question, last_assistant_info, last_narrative_snapshot,
+    latest_transcript_for_cwd, wait_for_turn_end, AskUserQuestionData, LastAssistantInfo,
+};
+pub use needs::{
+    classify, ClassifyInput, ErrContext, IdleContext, NeedsContext, NeedsRow, RouteHint,
+    WaitContext,
 };
 pub use state::derive_state;
 pub use tmux_pane::{capture_pane, detect_signals_from_pane};

--- a/ainb-tui/crates/ainb-core/src/fleet/read/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/mod.rs
@@ -6,6 +6,8 @@ pub mod state;
 pub mod tmux_pane;
 
 pub use errors::{detect_error_signals, API_ERROR_PATTERNS};
-pub use jsonl_tail::{cwd_to_project_slug, latest_transcript_for_cwd, wait_for_turn_end};
+pub use jsonl_tail::{
+    cwd_to_project_slug, last_narrative_snapshot, latest_transcript_for_cwd, wait_for_turn_end,
+};
 pub use state::derive_state;
 pub use tmux_pane::{capture_pane, detect_signals_from_pane};

--- a/ainb-tui/crates/ainb-core/src/fleet/read/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/mod.rs
@@ -1,0 +1,11 @@
+// ABOUTME: Read-side fleet primitives — tmux capture, errors regex, state merge, JSONL tail.
+
+pub mod errors;
+pub mod jsonl_tail;
+pub mod state;
+pub mod tmux_pane;
+
+pub use errors::{detect_error_signals, API_ERROR_PATTERNS};
+pub use jsonl_tail::{cwd_to_project_slug, latest_transcript_for_cwd, wait_for_turn_end};
+pub use state::derive_state;
+pub use tmux_pane::{capture_pane, detect_signals_from_pane};

--- a/ainb-tui/crates/ainb-core/src/fleet/read/needs.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/needs.rs
@@ -1,0 +1,277 @@
+// ABOUTME: Classifier — turn a Session + its transcript into a NeedsRow
+// indicating whether (and how) the session is blocked waiting on input.
+//
+// Priority: ASK > ERR > IDLE > WAIT. First matching kind wins; we don't
+// chase multiple signals per session because the UI shows one card.
+
+use serde::{Deserialize, Serialize};
+
+use crate::fleet::read::errors::detect_error_signals;
+use crate::fleet::read::jsonl_tail::{
+    last_ask_user_question, last_assistant_info, latest_transcript_for_cwd, AskUserQuestionData,
+};
+use crate::fleet::types::{Session, Signal};
+
+/// Default idle threshold (override via `AINB_FLEET_IDLE_MIN` or `--idle-min`).
+const DEFAULT_IDLE_MIN: i64 = 5;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "context", rename_all = "UPPERCASE")]
+pub enum NeedsContext {
+    Ask(AskUserQuestionData),
+    Err(ErrContext),
+    Idle(IdleContext),
+    Wait(WaitContext),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrContext {
+    pub pattern: String,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdleContext {
+    pub idle_minutes: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_assistant_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitContext {
+    /// "WAITING:" or "needs input:"
+    pub marker: String,
+    pub text: String,
+}
+
+/// One row emitted by `ainb fleet needs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeedsRow {
+    pub session: Session,
+    #[serde(flatten)]
+    pub context: NeedsContext,
+    /// Hint to the calling LLM about the answer-routing channel.
+    pub route_hint: RouteHint,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RouteHint {
+    Broker,
+    Tmux,
+    None,
+}
+
+/// Per-classifier dependency. We read everything we need up-front so the
+/// classifier itself is a pure function (no I/O), easy to unit-test.
+pub struct ClassifyInput {
+    pub session: Session,
+    pub pane_text: Option<String>,
+    pub idle_threshold_min: i64,
+    pub now_ms: i64,
+}
+
+impl ClassifyInput {
+    #[must_use]
+    pub fn from_env(session: Session, pane_text: Option<String>, now_ms: i64) -> Self {
+        let idle_threshold_min = std::env::var("AINB_FLEET_IDLE_MIN")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_IDLE_MIN);
+        Self {
+            session,
+            pane_text,
+            idle_threshold_min,
+            now_ms,
+        }
+    }
+}
+
+/// Classify a single session. Reads its transcript (if any) and merges with
+/// the supplied pane text + session summary. Returns None when nothing
+/// indicates the session needs attention.
+pub fn classify(input: ClassifyInput) -> Option<NeedsRow> {
+    let transcript_path = latest_transcript_for_cwd(&input.session.cwd);
+    let route_hint = derive_route_hint(&input.session);
+
+    // 1. ASK — strongest signal, JSONL tool_use block.
+    if let Some(path) = &transcript_path {
+        if let Some(aq) = last_ask_user_question(path) {
+            return Some(NeedsRow {
+                session: input.session,
+                context: NeedsContext::Ask(aq),
+                route_hint,
+            });
+        }
+    }
+
+    // 2. ERR — API-error regex over pane + JSONL last text.
+    if let Some(pane) = input.pane_text.as_deref() {
+        let signals = detect_error_signals(pane, input.now_ms);
+        if let Some(Signal::ApiError { pattern, raw, .. }) = signals.into_iter().next() {
+            return Some(NeedsRow {
+                session: input.session,
+                context: NeedsContext::Err(ErrContext {
+                    pattern,
+                    snippet: raw,
+                }),
+                route_hint,
+            });
+        }
+    }
+
+    // 3. WAIT — explicit opt-in marker.
+    //    Broker summary starts with "WAITING:" (carried in Session.summary
+    //    when explicitly set). Extract the text into an owned string first
+    //    so the session-borrow ends before we move session into NeedsRow.
+    let wait_text: Option<String> = input
+        .session
+        .summary
+        .as_deref()
+        .and_then(|s| s.strip_prefix("WAITING:"))
+        .map(|rest| rest.trim().to_string());
+    if let Some(text) = wait_text {
+        return Some(NeedsRow {
+            session: input.session,
+            context: NeedsContext::Wait(WaitContext {
+                marker: "WAITING:".to_string(),
+                text,
+            }),
+            route_hint,
+        });
+    }
+
+    // 4. IDLE — assistant turn ended, no user follow-up, last seen N min ago.
+    if let Some(path) = &transcript_path {
+        if let Some(info) = last_assistant_info(path) {
+            if !info.has_user_follow_up
+                && info.stop_reason.as_deref() == Some("end_turn")
+                && info.ts_ms > 0
+            {
+                let age_ms = input.now_ms.saturating_sub(info.ts_ms);
+                let age_min = age_ms / 60_000;
+                if age_min >= input.idle_threshold_min {
+                    return Some(NeedsRow {
+                        session: input.session,
+                        context: NeedsContext::Idle(IdleContext {
+                            idle_minutes: age_min,
+                            last_assistant_text: info.text_snippet,
+                        }),
+                        route_hint,
+                    });
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn derive_route_hint(session: &Session) -> RouteHint {
+    if session.peer_id.is_some() {
+        RouteHint::Broker
+    } else if session.tmux_session.is_some() {
+        RouteHint::Tmux
+    } else {
+        RouteHint::None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet::types::SessionSource;
+
+    fn mk_session(cwd: &str) -> Session {
+        Session {
+            id: "test".to_string(),
+            cwd: cwd.to_string(),
+            pid: None,
+            git_root: None,
+            tmux_session: Some("tmux_test".to_string()),
+            workspace_name: None,
+            worktree_path: None,
+            peer_id: None,
+            bg_job_id: None,
+            transcript_path: None,
+            sources: vec![SessionSource::Ainb],
+            summary: None,
+            last_seen_ms: None,
+        }
+    }
+
+    #[test]
+    fn route_hint_prefers_broker() {
+        let mut s = mk_session("/x");
+        s.peer_id = Some("p".to_string());
+        assert!(matches!(derive_route_hint(&s), RouteHint::Broker));
+    }
+
+    #[test]
+    fn route_hint_tmux_fallback() {
+        let s = mk_session("/x");
+        assert!(matches!(derive_route_hint(&s), RouteHint::Tmux));
+    }
+
+    #[test]
+    fn route_hint_none_when_no_targets() {
+        let mut s = mk_session("/x");
+        s.tmux_session = None;
+        assert!(matches!(derive_route_hint(&s), RouteHint::None));
+    }
+
+    #[test]
+    fn waiting_prefix_in_summary_yields_wait() {
+        let mut s = mk_session("/nonexistent-path-xyz");
+        s.summary = Some("WAITING: pick option 2".to_string());
+        // Transcript path won't exist for this cwd, so ASK/IDLE branches skip;
+        // pane text empty so ERR skips. WAIT branch triggers.
+        let row = classify(ClassifyInput {
+            session: s,
+            pane_text: None,
+            idle_threshold_min: 5,
+            now_ms: 0,
+        })
+        .expect("should classify");
+        match row.context {
+            NeedsContext::Wait(w) => {
+                assert_eq!(w.marker, "WAITING:");
+                assert_eq!(w.text, "pick option 2");
+            }
+            _ => panic!("expected Wait variant"),
+        }
+    }
+
+    #[test]
+    fn no_signal_returns_none() {
+        let s = mk_session("/nonexistent-path-xyz");
+        let r = classify(ClassifyInput {
+            session: s,
+            pane_text: None,
+            idle_threshold_min: 5,
+            now_ms: 0,
+        });
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn err_pattern_in_pane_yields_err() {
+        let s = mk_session("/nonexistent-path-xyz");
+        let pane = String::from("…\nAPI Error: rate_limited please retry\n…");
+        let row = classify(ClassifyInput {
+            session: s,
+            pane_text: Some(pane),
+            idle_threshold_min: 5,
+            now_ms: 1_700_000_000_000,
+        })
+        .expect("should classify");
+        match row.context {
+            NeedsContext::Err(e) => {
+                assert!(e.pattern == "rate_limited" || e.pattern == "fetch_failed");
+                assert!(e.snippet.contains("rate_limited") || e.snippet.contains("API Error"));
+            }
+            _ => panic!("expected Err variant"),
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/read/state.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/state.rs
@@ -1,0 +1,77 @@
+// ABOUTME: Merge raw signals into a coarse SessionState.
+//
+// Priority:
+//   1. api-error  -> block = ApiError (triggers daemon auto-continue)
+//   2. ask-user-question OR needs-input-marker -> block = NeedsInput
+//   3. waiting-summary -> block = WaitingSummary
+//   4. else -> block = None
+//
+// Liveness: turn-active > turn-end > idle > unknown.
+
+use crate::fleet::types::{Block, Liveness, Session, SessionState, Signal};
+
+#[must_use]
+pub fn derive_state(session: Session, signals: Vec<Signal>) -> SessionState {
+    let liveness = pick_liveness(&signals);
+    let block = pick_block(&signals);
+    let last_activity_ms = signals
+        .iter()
+        .map(signal_at)
+        .max()
+        .or(session.last_seen_ms);
+
+    SessionState {
+        session,
+        liveness,
+        block,
+        last_assistant_snippet: None,
+        last_activity_ms,
+        signals,
+    }
+}
+
+fn signal_at(s: &Signal) -> i64 {
+    match s {
+        Signal::TurnEnd { at }
+        | Signal::TurnActive { at }
+        | Signal::AskUserQuestion { at, .. }
+        | Signal::WaitingSummary { at, .. }
+        | Signal::NeedsInputMarker { at, .. }
+        | Signal::ApiError { at, .. }
+        | Signal::Idle { at, .. } => *at,
+    }
+}
+
+fn pick_liveness(signals: &[Signal]) -> Liveness {
+    if signals.iter().any(|s| matches!(s, Signal::TurnActive { .. })) {
+        Liveness::MidTurn
+    } else if signals
+        .iter()
+        .any(|s| matches!(s, Signal::TurnEnd { .. } | Signal::Idle { .. }))
+    {
+        Liveness::Idle
+    } else {
+        Liveness::Unknown
+    }
+}
+
+fn pick_block(signals: &[Signal]) -> Block {
+    if signals.iter().any(|s| matches!(s, Signal::ApiError { .. })) {
+        return Block::ApiError;
+    }
+    if signals.iter().any(|s| {
+        matches!(
+            s,
+            Signal::AskUserQuestion { .. } | Signal::NeedsInputMarker { .. }
+        )
+    }) {
+        return Block::NeedsInput;
+    }
+    if signals
+        .iter()
+        .any(|s| matches!(s, Signal::WaitingSummary { .. }))
+    {
+        return Block::WaitingSummary;
+    }
+    Block::None
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/read/tmux_pane.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/tmux_pane.rs
@@ -1,0 +1,40 @@
+// ABOUTME: tmux capture-pane wrapper + signal detection from buffer text.
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+use crate::fleet::types::Signal;
+
+pub async fn capture_pane(tmux_session: &str, lines: u32) -> Result<String> {
+    let scroll_arg = format!("-{lines}");
+    let output = Command::new("tmux")
+        .args([
+            "capture-pane",
+            "-t",
+            tmux_session,
+            "-p",
+            "-S",
+            scroll_arg.as_str(),
+        ])
+        .output()
+        .await
+        .context("invoking tmux capture-pane")?;
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+pub fn detect_signals_from_pane(pane: &str, at_ms: i64) -> Vec<Signal> {
+    let mut out = Vec::new();
+    // AskUserQuestion UI has a recognisable header band; refine as samples accrue.
+    if pane.contains('?')
+        && pane.contains('│')
+        && pane.contains('┌')
+        && pane.contains('└')
+    {
+        let snippet_start = pane.len().saturating_sub(400);
+        out.push(Signal::AskUserQuestion {
+            at: at_ms,
+            raw: pane[snippet_start..].to_string(),
+        });
+    }
+    out
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/send/broker.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/send/broker.rs
@@ -1,0 +1,160 @@
+// ABOUTME: HTTP client for the claude-peers broker (loopback :7899).
+//
+// Endpoints (POST except /health):
+//   GET  /health
+//   POST /register      {pid, cwd, git_root, tty, summary}  -> {id}
+//   POST /heartbeat     {id}
+//   POST /set-summary   {id, summary}
+//   POST /list-peers    {cwd?, git_root?, exclude_id?}      -> Peer[]
+//   POST /send-message  {from_id, to_id, text}              -> {ok, error?}
+//   POST /poll-messages {id}                                -> {messages: [...]}
+//   POST /unregister    {id}
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+fn port() -> u16 {
+    std::env::var("CLAUDE_PEERS_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(7899)
+}
+
+fn base() -> String {
+    format!("http://127.0.0.1:{}", port())
+}
+
+pub struct BrokerClient {
+    http: reqwest::Client,
+}
+
+impl BrokerClient {
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("reqwest client init");
+        Self { http }
+    }
+}
+
+impl Default for BrokerClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegisterReq<'a> {
+    pub pid: u32,
+    pub cwd: &'a str,
+    pub git_root: Option<&'a str>,
+    pub tty: Option<&'a str>,
+    pub summary: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRes {
+    pub id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SendMessageReq<'a> {
+    from_id: &'a str,
+    to_id: &'a str,
+    text: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SendMessageRes {
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+pub async fn broker_health() -> bool {
+    let url = format!("{}/health", base());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .ok();
+    let Some(client) = client else { return false };
+    client.get(&url).send().await.is_ok_and(|r| r.status().is_success())
+}
+
+pub async fn broker_send(from_id: &str, to_id: &str, text: &str) -> Result<SendMessageRes> {
+    let url = format!("{}/send-message", base());
+    let req = SendMessageReq { from_id, to_id, text };
+    let client = BrokerClient::new();
+    let res = client
+        .http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .context("posting /send-message")?
+        .error_for_status()
+        .context("broker rejected /send-message")?
+        .json::<SendMessageRes>()
+        .await
+        .context("parsing /send-message response")?;
+    Ok(res)
+}
+
+pub async fn broker_register(req: RegisterReq<'_>) -> Result<RegisterRes> {
+    let url = format!("{}/register", base());
+    let client = BrokerClient::new();
+    Ok(client
+        .http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .context("posting /register")?
+        .error_for_status()
+        .context("broker rejected /register")?
+        .json::<RegisterRes>()
+        .await
+        .context("parsing /register response")?)
+}
+
+pub async fn broker_heartbeat(id: &str) -> Result<()> {
+    let url = format!("{}/heartbeat", base());
+    BrokerClient::new()
+        .http
+        .post(&url)
+        .json(&serde_json::json!({ "id": id }))
+        .send()
+        .await
+        .context("posting /heartbeat")?
+        .error_for_status()
+        .context("broker rejected /heartbeat")?;
+    Ok(())
+}
+
+pub async fn broker_unregister(id: &str) -> Result<()> {
+    let url = format!("{}/unregister", base());
+    BrokerClient::new()
+        .http
+        .post(&url)
+        .json(&serde_json::json!({ "id": id }))
+        .send()
+        .await
+        .context("posting /unregister")?;
+    Ok(())
+}
+
+pub async fn broker_set_summary(id: &str, summary: &str) -> Result<()> {
+    let url = format!("{}/set-summary", base());
+    BrokerClient::new()
+        .http
+        .post(&url)
+        .json(&serde_json::json!({ "id": id, "summary": summary }))
+        .send()
+        .await
+        .context("posting /set-summary")?
+        .error_for_status()
+        .context("broker rejected /set-summary")?;
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/send/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/send/mod.rs
@@ -1,0 +1,9 @@
+// ABOUTME: Send-side fleet primitives — broker HTTP, tmux send-keys, route.
+
+pub mod broker;
+pub mod route;
+pub mod tmux;
+
+pub use broker::{broker_health, broker_send, BrokerClient};
+pub use route::send;
+pub use tmux::{tmux_send, tmux_session_exists};

--- a/ainb-tui/crates/ainb-core/src/fleet/send/route.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/send/route.rs
@@ -1,0 +1,41 @@
+// ABOUTME: Send-routing — peers-first, tmux fallback.
+
+use anyhow::Result;
+
+use crate::fleet::send::{broker_health, broker_send, tmux_send, tmux_session_exists};
+use crate::fleet::types::{SendOutcome, Session};
+
+const POPA_PEER_ID_ENV: &str = "AINB_FLEET_PEER_ID";
+const POPA_PEER_ID_DEFAULT: &str = "ainb-fleet-cp";
+
+fn from_peer_id() -> String {
+    std::env::var(POPA_PEER_ID_ENV).unwrap_or_else(|_| POPA_PEER_ID_DEFAULT.to_string())
+}
+
+pub async fn send(session: &Session, text: &str) -> Result<SendOutcome> {
+    if let Some(peer_id) = session.peer_id.as_deref() {
+        if broker_health().await {
+            match broker_send(&from_peer_id(), peer_id, text).await {
+                Ok(res) if res.ok => {
+                    return Ok(SendOutcome::Broker {
+                        peer_id: peer_id.to_string(),
+                    });
+                }
+                Ok(_) | Err(_) => { /* fall through to tmux fallback */ }
+            }
+        }
+    }
+
+    if let Some(name) = session.tmux_session.as_deref() {
+        if tmux_session_exists(name).await {
+            tmux_send(name, text).await?;
+            return Ok(SendOutcome::Tmux {
+                tmux_session: name.to_string(),
+            });
+        }
+    }
+
+    Ok(SendOutcome::Failed {
+        reason: "no peer registered and no tmux session found".to_string(),
+    })
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/send/tmux.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/send/tmux.rs
@@ -1,0 +1,35 @@
+// ABOUTME: tmux send-keys + has-session wrappers.
+//
+// Uses `-l` literal mode for the text to prevent prompt-injection via
+// shell metacharacters; sends Enter as a key event afterwards.
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+pub async fn tmux_send(tmux_session: &str, text: &str) -> Result<()> {
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", tmux_session, "-l", text])
+        .status()
+        .await
+        .context("invoking tmux send-keys (literal)")?;
+    if !status.success() {
+        anyhow::bail!("tmux send-keys -l exited {}", status);
+    }
+    let enter = Command::new("tmux")
+        .args(["send-keys", "-t", tmux_session, "Enter"])
+        .status()
+        .await
+        .context("invoking tmux send-keys Enter")?;
+    if !enter.success() {
+        anyhow::bail!("tmux send-keys Enter exited {}", enter);
+    }
+    Ok(())
+}
+
+pub async fn tmux_session_exists(name: &str) -> bool {
+    Command::new("tmux")
+        .args(["has-session", "-t", name])
+        .status()
+        .await
+        .is_ok_and(|s| s.success())
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/types.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/types.rs
@@ -1,0 +1,146 @@
+// ABOUTME: Shared fleet types — Session / SessionState / Signal / Block / Liveness.
+
+use serde::{Deserialize, Serialize};
+
+/// Which discovery source contributed to a session record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionSource {
+    /// `ainb list --format json`
+    Ainb,
+    /// `~/.claude-peers.db` (broker SQLite)
+    Peers,
+    /// `~/.claude/jobs/<id>/`
+    Jobs,
+}
+
+/// Unified session identity. May be backed by 1+ sources after merge.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    /// Stable id — preferred order: peer id > ainb session_id > bg job id.
+    pub id: String,
+
+    /// Working directory. Primary key for cross-source dedupe.
+    pub cwd: String,
+
+    /// OS pid when known (peers and bg jobs publish; ainb does not).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+
+    /// Git root resolved at discovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+
+    /// tmux session name if running in tmux (from ainb or peer.tty).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tmux_session: Option<String>,
+
+    /// ainb workspace name (e.g. `shotclubhouse_shotclubhouse_feat_x`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_name: Option<String>,
+
+    /// Worktree path (ainb-managed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+
+    /// Peer id in claude-peers broker, if registered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_id: Option<String>,
+
+    /// Background-job id (~/.claude/jobs/<id>/) if applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bg_job_id: Option<String>,
+
+    /// Path to the active JSONL transcript.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_path: Option<String>,
+
+    /// Sources that contributed to this record.
+    pub sources: Vec<SessionSource>,
+
+    /// Peer-published summary. May start with `WAITING:` to flag block.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// Unix ms of last activity observed by any source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_seen_ms: Option<i64>,
+}
+
+/// State signals merged into [`SessionState`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Signal {
+    TurnEnd { at: i64 },
+    TurnActive { at: i64 },
+    AskUserQuestion { at: i64, raw: String },
+    WaitingSummary { at: i64, summary: String },
+    NeedsInputMarker { at: i64, source: String },
+    ApiError { at: i64, pattern: String, raw: String },
+    Idle { at: i64, since_ms: i64 },
+}
+
+/// Coarse liveness derived from signals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Liveness {
+    MidTurn,
+    Idle,
+    Unknown,
+}
+
+/// Whether the session is blocked waiting on something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Block {
+    None,
+    NeedsInput,
+    ApiError,
+    WaitingSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionState {
+    pub session: Session,
+    pub liveness: Liveness,
+    pub block: Block,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_assistant_snippet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_activity_ms: Option<i64>,
+    pub signals: Vec<Signal>,
+}
+
+/// Mirrors the `peers` row in `~/.claude-peers.db`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrokerPeer {
+    pub id: String,
+    pub pid: u32,
+    pub cwd: String,
+    pub git_root: Option<String>,
+    pub tty: Option<String>,
+    pub summary: String,
+    pub registered_at: String,
+    pub last_seen: String,
+}
+
+/// Mirrors `ainb list --format json` row shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AinbSession {
+    pub session_id: String,
+    pub tmux_session_name: String,
+    pub workspace_name: String,
+    pub worktree_path: String,
+    pub created_at: String,
+    pub is_running: bool,
+    pub claude_active: bool,
+}
+
+/// Outcome of a send-route decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "via", rename_all = "kebab-case")]
+pub enum SendOutcome {
+    Broker { peer_id: String },
+    Tmux { tmux_session: String },
+    Failed { reason: String },
+}

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod credentials;
 pub mod docker;
 pub mod editors;
+pub mod fleet;
 pub mod git;
 pub mod interactive;
 pub mod models;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -39,6 +39,7 @@ mod config;
 mod credentials;
 mod docker;
 mod editors;
+mod fleet;
 mod git;
 mod interactive;
 mod models;

--- a/ainb-tui/scripts/fleet-test.sh
+++ b/ainb-tui/scripts/fleet-test.sh
@@ -284,6 +284,55 @@ dod4() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────
+# DoD #5 — `ainb fleet needs` surfaces a session whose claude fired AskUserQuestion
+# ─────────────────────────────────────────────────────────────────────────
+
+dod5_needs() {
+  log "=== DoD #5: needs detects ASK signal from fired AskUserQuestion ==="
+
+  spawn_session needs   # interactive claude — no -p flag
+  local name="$CURRENT_NAME"
+  wait_for_claude_active "$name"
+
+  if [ "$DRY_RUN" -eq 0 ]; then
+    # Send the prompt via the same send-route the broadcast verb uses.
+    log "broadcasting AskUserQuestion-triggering prompt to $name"
+    "$AINB" fleet broadcast \
+      "Use the AskUserQuestion tool to ask me to pick a favorite colour from: red, green, blue. Just fire the tool; do not narrate." \
+      --filter "$name" 2>&1 | tee -a "$LOG"
+
+    # Wait for AskUserQuestion tool_use to land in JSONL → surfaced by needs.
+    log "waiting up to 90s for AskUserQuestion to land + needs to surface ASK…"
+    local elapsed=0
+    local found=0
+    while [ "$elapsed" -lt 90 ]; do
+      sleep 5
+      elapsed=$((elapsed + 5))
+      local out
+      out=$("$AINB" --format json fleet needs 2>/dev/null)
+      if echo "$out" | jq -e --arg n "$name" '
+        any(.[]; (.session.tmux_session // "" | contains($n)) and .kind == "ASK")
+      ' >/dev/null 2>&1; then
+        log "PASS — needs surfaced $name with kind=ASK at ${elapsed}s"
+        echo "$out" | jq --arg n "$name" '
+          .[] | select((.session.tmux_session // "") | contains($n))
+            | { kind, question: .context.question, options: [.context.options[].label] }
+        ' | tee -a "$LOG"
+        found=1
+        break
+      fi
+    done
+    if [ "$found" -eq 0 ]; then
+      log "FAIL — needs did not surface $name as ASK within 90s"
+      log "current needs first row:"
+      "$AINB" --format json fleet needs 2>/dev/null \
+        | jq '.[0] | { kind, name: .session.tmux_session }' | tee -a "$LOG"
+      return 1
+    fi
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────
 # Entry
 # ─────────────────────────────────────────────────────────────────────────
 
@@ -291,12 +340,12 @@ cmd=""
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=1 ;;
-    dod2|dod3|dod4|all) cmd="$arg" ;;
-    *) echo "usage: $0 [--dry-run] {dod2|dod3|dod4|all}"; exit 2 ;;
+    dod2|dod3|dod4|dod5_needs|all) cmd="$arg" ;;
+    *) echo "usage: $0 [--dry-run] {dod2|dod3|dod4|dod5_needs|all}"; exit 2 ;;
   esac
 done
 
-[ -z "$cmd" ] && { echo "usage: $0 [--dry-run] {dod2|dod3|dod4|all}"; exit 2; }
+[ -z "$cmd" ] && { echo "usage: $0 [--dry-run] {dod2|dod3|dod4|dod5_needs|all}"; exit 2; }
 
 log "fleet-test starting — prefix=$PREFIX dry_run=$DRY_RUN cmd=$cmd"
 log "evidence log: $LOG"
@@ -305,5 +354,6 @@ case "$cmd" in
   dod2) dod2 ;;
   dod3) dod3 ;;
   dod4) dod4 ;;
-  all)  dod2 && dod3 && dod4 ;;
+  dod5_needs) dod5_needs ;;
+  all)  dod2 && dod3 && dod4 && dod5_needs ;;
 esac

--- a/ainb-tui/scripts/fleet-test.sh
+++ b/ainb-tui/scripts/fleet-test.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# ABOUTME: Hand-verify runbook for `ainb fleet` DoD #2 / #3 / #4.
+#
+# Spawns throwaway claude session(s) via `ainb run`, exercises the fleet
+# subcommand under test, asserts the expected behaviour, cleans up by killing
+# only the exact ainb-managed sessions it created.
+#
+# Strict tmux safety: never `tmux kill-server`, never `pkill tmux`, never a
+# wildcard kill. Cleanup uses `ainb kill <name>` which calls
+# `tmux kill-session -t <exact-name>` internally.
+#
+# Usage:
+#   scripts/fleet-test.sh dod2           # broadcast lands in JSONL
+#   scripts/fleet-test.sh dod3           # daemon auto-continues on injected error
+#   scripts/fleet-test.sh dod4           # sequence runs 3 steps ack-gated
+#   scripts/fleet-test.sh all            # all three, sequentially
+#   scripts/fleet-test.sh --dry-run dod2 # print commands without running
+#
+# Cost note: each DoD spawns one real claude session using `--model haiku`
+# (cheap). Expect ~$0.001 / DoD in API spend; ~30-60s wallclock each.
+#
+# Evidence: stdout + stderr is teed to .agents/test-evidence/fleet-test-<ts>.log
+
+set -euo pipefail
+
+# Point at the locally-built ainb (with `fleet` subcommand) by default.
+# Override via env: AINB=/path/to/other/ainb scripts/fleet-test.sh dod2
+AINB="${AINB:-$(git rev-parse --show-toplevel)/ainb-tui/target/debug/ainb}"
+if [ ! -x "$AINB" ]; then
+  echo "ERROR: ainb binary not executable at $AINB" >&2
+  echo "Build first: (cd ainb-tui && cargo build --bin ainb)" >&2
+  exit 2
+fi
+
+TS=$(date -u '+%Y%m%dT%H%M%SZ')
+PID=$$
+PREFIX="fleet-test-${PID}-${TS}"
+EVIDENCE_DIR="$(git rev-parse --show-toplevel)/.agents/test-evidence"
+mkdir -p "$EVIDENCE_DIR"
+LOG="$EVIDENCE_DIR/${PREFIX}.log"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+DRY_RUN=0
+SPAWNED_NAMES=()
+
+log() {
+  # Always to stderr + log file. Never to stdout — keeps function returns clean.
+  local line
+  line="[$(date -u '+%H:%M:%S')] $*"
+  printf '%s\n' "$line" >&2
+  printf '%s\n' "$line" >> "$LOG"
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf 'DRY: %q ' "$@"; printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+# Spawn one claude session via ainb run.
+# Sets CURRENT_NAME and appends to SPAWNED_NAMES in the CALLER's shell
+# (this function must NOT be invoked via $(...) — that runs it in a subshell
+# and the SPAWNED_NAMES += would be lost, leaving the session leaked on exit).
+# Usage:
+#   spawn_session 1
+#   name="$CURRENT_NAME"
+spawn_session() {
+  local n="$1"
+  CURRENT_NAME="${PREFIX}-${n}"
+  local repo="/tmp/${CURRENT_NAME}"
+  log "spawn_session $CURRENT_NAME (repo=$repo)"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    mkdir -p "$repo"
+    ( cd "$repo" && git init -q . && git commit -q --allow-empty -m "test seed" )
+    "$AINB" run \
+      --repo "$repo" \
+      --name "$CURRENT_NAME" \
+      --tool claude \
+      --model haiku \
+      --dangerously-skip-permissions \
+      --format json > "$EVIDENCE_DIR/${CURRENT_NAME}-run.json" 2>&1
+    SPAWNED_NAMES+=( "$CURRENT_NAME" )
+  fi
+}
+
+# Wait until `ainb list` shows the session with claude_active=true. Times out
+# after 90s.
+wait_for_claude_active() {
+  local name="$1"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY: would wait for $name to become claude_active"
+    return 0
+  fi
+  local elapsed=0
+  while [ "$elapsed" -lt 90 ]; do
+    if "$AINB" list --format json 2>/dev/null \
+        | jq -e --arg n "$name" 'any(.[]; .workspace_name == $n and .is_running == true)' \
+        >/dev/null 2>&1; then
+      log "session $name is running"
+      return 0
+    fi
+    sleep 3
+    elapsed=$((elapsed + 3))
+  done
+  log "ERROR: session $name did not become active within 90s"
+  return 1
+}
+
+# Resolve the JSONL transcript path for a workspace. macOS /tmp ↔ /private/tmp
+# is the gotcha — ainb stores the resolved /private/tmp path, so we try both.
+# Returns empty string + non-zero on failure, but never panics under `set -e`
+# because callers use `path=$(transcript_path_for ...)`.
+transcript_path_for() {
+  local workspace="$1"
+  local worktree
+  worktree=$("$AINB" list --format json 2>/dev/null \
+    | jq -r --arg n "$workspace" '.[] | select(.workspace_name == $n) | .worktree_path' \
+    || true)
+  if [ -z "$worktree" ]; then
+    log "WARN: no worktree_path for workspace=$workspace"
+    return 0
+  fi
+  local slug
+  slug=$(echo "$worktree" | sed 's|/|-|g')
+  local candidate
+  candidate=$(ls -t "${HOME}/.claude/projects/${slug}"/*.jsonl 2>/dev/null | head -1 || true)
+  if [ -z "$candidate" ]; then
+    # /tmp ↔ /private/tmp fallback (macOS).
+    local alt_slug="${slug/-tmp-/-private-tmp-}"
+    if [ "$alt_slug" != "$slug" ]; then
+      candidate=$(ls -t "${HOME}/.claude/projects/${alt_slug}"/*.jsonl 2>/dev/null | head -1 || true)
+    fi
+  fi
+  printf '%s' "$candidate"
+}
+
+cleanup() {
+  local name
+  for name in "${SPAWNED_NAMES[@]:-}"; do
+    [ -z "$name" ] && continue
+    log "cleanup: ainb kill $name"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      "$AINB" kill --force "$name" 2>&1 | tee -a "$LOG" || true
+      # Also remove the throwaway worktree dir under /tmp.
+      /bin/rm -rf "/tmp/${name}" "/private/tmp/${name}" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup EXIT
+
+# ─────────────────────────────────────────────────────────────────────────
+# DoD #2 — broadcast lands in JSONL
+# ─────────────────────────────────────────────────────────────────────────
+
+dod2() {
+  log "=== DoD #2: broadcast lands in JSONL ==="
+  spawn_session 1
+  local name="$CURRENT_NAME"
+  wait_for_claude_active "$name"
+
+  local nonce="fleet-nonce-${PID}-${TS}-$RANDOM"
+  log "broadcasting nonce=$nonce to filter=$name"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$AINB" fleet --format json broadcast "$nonce" --filter "$name" 2>&1 | tee -a "$LOG"
+  fi
+
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local transcript
+    transcript=$(transcript_path_for "$name")
+    log "polling transcript '${transcript:-<not-found>}' for nonce…"
+    local elapsed=0
+    while [ "$elapsed" -lt 30 ]; do
+      if [ -n "$transcript" ] && [ -f "$transcript" ] && grep -q "$nonce" "$transcript" 2>/dev/null; then
+        log "PASS — nonce appears in JSONL"
+        grep "$nonce" "$transcript" | head -1 | tee -a "$LOG"
+        return 0
+      fi
+      sleep 2
+      elapsed=$((elapsed + 2))
+      # Refresh path each poll — file may be created mid-wait.
+      [ -z "$transcript" ] && transcript=$(transcript_path_for "$name")
+    done
+    log "FAIL — nonce not found in JSONL within 30s (transcript=${transcript:-?})"
+    return 1
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# DoD #3 — daemon auto-continues on injected error
+# ─────────────────────────────────────────────────────────────────────────
+
+dod3() {
+  log "=== DoD #3: daemon auto-continues on injected error ==="
+  spawn_session 1
+  local name="$CURRENT_NAME"
+  wait_for_claude_active "$name"
+
+  local tmux_session
+  tmux_session=$("$AINB" list --format json \
+    | jq -r --arg n "$name" '.[] | select(.workspace_name == $n) | .tmux_session_name')
+  log "tmux_session=$tmux_session"
+
+  # Start daemon in background.
+  log "starting ainb fleet daemon --verbose"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$AINB" fleet daemon --verbose > "$EVIDENCE_DIR/${name}-daemon.log" 2>&1 &
+    local daemon_pid=$!
+    sleep 5
+
+    # Inject the error text into the pane (literal mode is critical).
+    log "injecting 'rate_limited: please retry' into pane"
+    tmux send-keys -t "$tmux_session" -l "rate_limited: please retry"
+    tmux send-keys -t "$tmux_session" Enter
+
+    # Wait up to 15s for daemon to log auto-continue.
+    local elapsed=0
+    while [ "$elapsed" -lt 15 ]; do
+      if grep -q "auto-continue.*${tmux_session}" "$EVIDENCE_DIR/${name}-daemon.log" 2>/dev/null; then
+        log "PASS — daemon emitted auto-continue for $tmux_session"
+        grep "auto-continue" "$EVIDENCE_DIR/${name}-daemon.log" | tee -a "$LOG"
+        kill "$daemon_pid" 2>/dev/null || true
+        return 0
+      fi
+      sleep 1
+      elapsed=$((elapsed + 1))
+    done
+
+    log "FAIL — daemon did not auto-continue within 15s"
+    kill "$daemon_pid" 2>/dev/null || true
+    return 1
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# DoD #4 — sequence runs 3 steps with ack between each
+# ─────────────────────────────────────────────────────────────────────────
+
+dod4() {
+  log "=== DoD #4: sequence ack-gated multi-step ==="
+  spawn_session 1
+  local name="$CURRENT_NAME"
+  wait_for_claude_active "$name"
+
+  local s1="seq-step1-${TS}"
+  local s2="seq-step2-${TS}"
+  local s3="seq-step3-${TS}"
+
+  log "running ainb fleet sequence with 3 steps (5s/step max)"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local t_start
+    t_start=$(date +%s)
+    "$AINB" fleet sequence "$s1" "$s2" "$s3" --all --timeout 30 2>&1 | tee -a "$LOG"
+    local t_end
+    t_end=$(date +%s)
+    local elapsed=$((t_end - t_start))
+    log "sequence elapsed: ${elapsed}s"
+
+    local transcript
+    transcript=$(transcript_path_for "$name")
+    log "asserting all 3 steps appear in JSONL"
+    for s in "$s1" "$s2" "$s3"; do
+      if grep -q "$s" "$transcript" 2>/dev/null; then
+        log "  ✓ $s found in transcript"
+      else
+        log "  ✗ $s NOT found in transcript"
+        return 1
+      fi
+    done
+
+    # ack-gated means total elapsed > ~6s (at minimum 2 inter-step waits).
+    if [ "$elapsed" -ge 4 ]; then
+      log "PASS — sequence took ${elapsed}s, consistent with ack-gating"
+      return 0
+    else
+      log "WARN — sequence completed in ${elapsed}s, may not have ack-gated"
+      return 1
+    fi
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# Entry
+# ─────────────────────────────────────────────────────────────────────────
+
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    dod2|dod3|dod4|all) cmd="$arg" ;;
+    *) echo "usage: $0 [--dry-run] {dod2|dod3|dod4|all}"; exit 2 ;;
+  esac
+done
+
+[ -z "$cmd" ] && { echo "usage: $0 [--dry-run] {dod2|dod3|dod4|all}"; exit 2; }
+
+log "fleet-test starting — prefix=$PREFIX dry_run=$DRY_RUN cmd=$cmd"
+log "evidence log: $LOG"
+
+case "$cmd" in
+  dod2) dod2 ;;
+  dod3) dod3 ;;
+  dod4) dod4 ;;
+  all)  dod2 && dod3 && dod4 ;;
+esac

--- a/plugins/ainb-fleet/.claude-plugin/plugin.json
+++ b/plugins/ainb-fleet/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ainb-fleet",
+  "version": "0.1.0",
+  "description": "LLM-facing skill teaching agents how to use `ainb fleet ...` orchestration subcommands. Fleet covers multi-session broadcast, ack-gated sequence, blocked-session needs, and the auto-continue daemon. Replaces the deprecated `popa` plugin — the Node code is gone; the orchestration logic now lives in ainb's Rust binary.",
+  "author": {
+    "name": "stevengonsalvez"
+  },
+  "homepage": "https://github.com/stevengonsalvez/agents-in-a-box",
+  "keywords": [
+    "ainb",
+    "fleet",
+    "tmux",
+    "claude-peers",
+    "orchestration",
+    "control-plane",
+    "broadcast",
+    "multi-session"
+  ]
+}

--- a/plugins/ainb-fleet/skills/ainb-fleet/SKILL.md
+++ b/plugins/ainb-fleet/skills/ainb-fleet/SKILL.md
@@ -1,182 +1,71 @@
 ---
 name: ainb-fleet
-description: >
-  Fleet orchestration via the `ainb fleet ...` Rust subcommand namespace.
-  Use when an LLM session needs to: (1) list every claude session running
-  on the host (standup), (2) fan a prompt out to many sessions at once
-  (broadcast), (3) drive an ordered ack-gated multi-step interaction
-  (sequence), (4) surface every session waiting on input (needs), or
-  (5) run a background watcher that auto-continues sessions hitting API
-  errors (daemon). All subcommands default to `--format json` output for
-  programmatic consumption.
-user-invocable: false
+description: |
+  Fleet orchestration overview — the `ainb fleet ...` Rust subcommand
+  namespace for driving every claude session on the host. Routes to one of
+  five sub-skills (standup / broadcast / sequence / needs / daemon).
+  Invoke this for an at-a-glance map of what fleet can do; reach for the
+  specific sub-skill for the verb you want.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet
+  - fleet
+  - jarvis
+  - control plane
+  - multi-session orchestration
 allowed-tools:
   - Bash
 ---
 
-# ainb fleet — orchestration cheatsheet
+# ainb fleet — overview
 
-`ainb fleet` is the orchestration namespace inside the ainb Rust binary. It
-fans prompts across many running claude sessions and reports their state
-across three discovery sources (ainb + claude-peers broker SQLite + bg jobs).
+Single Rust binary (`ainb`) provides 5 orchestration verbs across every
+claude session running on this host. Each verb has its own colon-namespaced
+sub-skill with focused docs.
 
-This skill is *docs-only*: no code, no MCP server. It teaches you when to
-reach for which subcommand and how to compose them.
+## Verbs
 
-## Subcommand reference
+| sub-skill | what it does |
+|---|---|
+| [`/ainb-fleet:standup`](../standup/SKILL.md) | List every claude session — merged across ainb · peers · bg jobs |
+| [`/ainb-fleet:broadcast`](../broadcast/SKILL.md) | Send one prompt to selected sessions |
+| [`/ainb-fleet:sequence`](../sequence/SKILL.md) | Ordered multi-step prompts, ack-gated between steps |
+| [`/ainb-fleet:needs`](../needs/SKILL.md) | Show sessions blocked on input / errors / waiting |
+| [`/ainb-fleet:daemon`](../daemon/SKILL.md) | Background watcher that auto-continues API errors |
+
+## Architecture (1-line)
 
 ```
-ainb fleet --help
-
-  standup     list every claude session (ainb + peers + jobs, merged + deduped)
-  broadcast   send one prompt to selected sessions
-  sequence    ordered multi-step prompts, ack-gated by JSONL turn-end
-  needs       enumerate sessions blocked on input / errors / waiting
-  daemon      watcher that auto-continues sessions hitting API errors
+discover (ainb + peers + jobs)  ──▶  state read  ──▶  send (peers-first, tmux fallback)
 ```
 
-Global flag: `--format json|text|csv|markdown` (default `text`). Prefer
-`--format json` when an LLM is the consumer.
+## Global flag
 
-## When to use which
-
-### Discovery — `ainb fleet standup`
-
-```bash
-ainb fleet --format json standup
-```
-
-Returns the unified session list. Each row: `id`, `cwd`, `tmux_session`,
-`workspace_name`, `peer_id`, `sources` (subset of `["ainb","peers","jobs"]`),
-`summary`, `last_seen_ms`. `sources` reveals which discovery layers saw
-the session — a session in both `ainb` and `peers` is the strongest signal.
-
-Use this when:
-- You need to enumerate every claude on the host before composing an action
-- You want to know which sessions have a registered peer (can be sent
-  prompts via the broker) vs tmux-only (fallback path)
-- You're building a `needs` view manually before the `needs` subcommand
-  matures
-
-### Fan-out — `ainb fleet broadcast`
-
-```bash
-ainb fleet broadcast "remote-control disconnect" --all
-ainb fleet broadcast "/status" --filter "shotclubhouse.*"
-ainb fleet broadcast "/clear" --cwd "agents-in-a-box"
-```
-
-Mandatory target selector: `--all`, `--filter <regex>` (matches tmux
-session or workspace name), or `--cwd <substring>`. The command refuses
-to run without one — no implicit fan-out.
-
-Routing per target: peers-first (broker HTTP) when a peer_id is known,
-tmux send-keys fallback otherwise. Output reports per-target outcome.
-
-### Ordered multi-step — `ainb fleet sequence`
-
-```bash
-ainb fleet sequence "remote-control disconnect" "remote-control" "/status" --all
-```
-
-Sends each step, waits for every target's next assistant-turn-end (via
-JSONL transcript watch) before sending the next step. Default per-step
-timeout 300s.
-
-Use this when a series of prompts must be applied in order *and* each
-needs the prior to complete first — e.g. disconnect/reconnect cycles,
-multi-step config changes, sequential `/clear` then resume flows.
-
-### Blocked sessions — `ainb fleet needs`
-
-```bash
-ainb fleet --format json needs
-```
-
-Surfaces sessions whose `summary` starts with `WAITING:` — sessions
-explicitly opted in to flag blockage. (Future: detect AskUserQuestion
-UIs in tmux panes + idle-assistant heuristics.)
-
-Pipe this output into a follow-up LLM call to compose answers for each
-blocked session, then route the answers back via `broadcast --filter`.
-
-### Auto-continue watcher — `ainb fleet daemon`
-
-```bash
-ainb fleet daemon --verbose
-```
-
-Long-running background process. Scans every 5s. For each tmux session
-whose last 80 pane lines match a known API-error pattern (rate-limited,
-overloaded, internal-server-error, timeout, ECONNRESET, etc.), sends
-`continue` to that session. Per-pattern dedupe within a session so it
-doesn't spam.
-
-**Sharp edge — no retry cap in v0.1.** If a session is permanently broken
-(e.g. wrong credentials), the daemon will keep firing `continue` forever.
-Kill the daemon (`Ctrl-C` or `kill <pid>`) when this happens. A retry
-cap with exponential backoff is on the roadmap.
-
-## Composition patterns
-
-### "What does my fleet need from me right now?"
-
-```bash
-ainb fleet --format json needs \
-  | jq '.[] | {name: (.tmux_session // .workspace_name), summary: .summary}'
-```
-
-Then compose follow-ups based on each summary.
-
-### "Apply a one-shot fix to every related session"
-
-```bash
-ainb fleet --format json standup \
-  | jq -r '.[] | select(.cwd | contains("shotclubhouse")) | .tmux_session' \
-  | head -3
-# verify the targets…
-ainb fleet broadcast "git pull" --filter "shotclubhouse"
-```
-
-### "Cycle remote-control across the fleet"
-
-```bash
-ainb fleet sequence \
-  "remote-control disconnect" \
-  "remote-control" \
-  --all
-```
+`--format json|text|csv|markdown` (default `text`). Prefer `--format json`
+when an LLM is the consumer.
 
 ## Discovery sources
 
-| source | what it sees | when missing |
-|---|---|---|
-| `ainb` | every session ainb has spawned (`ainb run` family) | claude started outside ainb |
-| `peers` | every session that registered with the claude-peers MCP broker (sqlite `~/.claude-peers.db`) | broker daemon not running |
-| `jobs` | bg-session job dirs (`~/.claude/jobs/<id>/`) | no bg jobs active |
+- **ainb** — every session ainb has spawned via `ainb run`
+- **peers** — sessions registered with the claude-peers broker (`~/.claude-peers.db`)
+- **jobs** — bg-session dirs under `~/.claude/jobs/`
 
-The merge step dedupes by `cwd`. A session present in two sources merges
-into one record with `sources: ["ainb", "peers"]` etc.
+Merged + deduped by `cwd` so the same session in two sources collapses
+into one record with `sources: ["ainb", "peers"]`.
 
 ## Environment overrides
 
 | var | default | use |
 |---|---|---|
-| `AINB_BIN` | `ainb` | override the binary `discover/ainb.rs` shells to (tests) |
+| `AINB_BIN` | `ainb` | override binary the discover layer shells to (tests) |
 | `AINB_FLEET_PEER_ID` | `ainb-fleet-cp` | peer id the daemon registers as |
 | `AINB_FLEET_JOBS_DIR` | `~/.claude/jobs` | bg-job scan root |
 | `CLAUDE_PEERS_DB` | `~/.claude-peers.db` | broker sqlite path |
 | `CLAUDE_PEERS_PORT` | `7899` | broker HTTP port |
 
-## Migration note
-
-This skill replaces the deprecated `popa` plugin. The Node/TS reference
-impl was used to design the surface — it has been deleted. All
-orchestration lives in `ainb` itself now.
-
 ## See also
 
-- `ainb list` — lifecycle-only session list (no peer/jobs enrichment, no
-  state derivation). Use when you only care about ainb-spawned sessions.
-- `ainb attach <workspace>` — drop into a session's tmux directly.
-- `ainb status <workspace>` — single-session inspect.
+- `ainb list` — lifecycle-only session list (no peer/jobs enrichment)
+- `ainb attach <workspace>` — drop into a session's tmux
+- `ainb kill <workspace>` — terminate a single session by exact name

--- a/plugins/ainb-fleet/skills/ainb-fleet/SKILL.md
+++ b/plugins/ainb-fleet/skills/ainb-fleet/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: ainb-fleet
+description: >
+  Fleet orchestration via the `ainb fleet ...` Rust subcommand namespace.
+  Use when an LLM session needs to: (1) list every claude session running
+  on the host (standup), (2) fan a prompt out to many sessions at once
+  (broadcast), (3) drive an ordered ack-gated multi-step interaction
+  (sequence), (4) surface every session waiting on input (needs), or
+  (5) run a background watcher that auto-continues sessions hitting API
+  errors (daemon). All subcommands default to `--format json` output for
+  programmatic consumption.
+user-invocable: false
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet — orchestration cheatsheet
+
+`ainb fleet` is the orchestration namespace inside the ainb Rust binary. It
+fans prompts across many running claude sessions and reports their state
+across three discovery sources (ainb + claude-peers broker SQLite + bg jobs).
+
+This skill is *docs-only*: no code, no MCP server. It teaches you when to
+reach for which subcommand and how to compose them.
+
+## Subcommand reference
+
+```
+ainb fleet --help
+
+  standup     list every claude session (ainb + peers + jobs, merged + deduped)
+  broadcast   send one prompt to selected sessions
+  sequence    ordered multi-step prompts, ack-gated by JSONL turn-end
+  needs       enumerate sessions blocked on input / errors / waiting
+  daemon      watcher that auto-continues sessions hitting API errors
+```
+
+Global flag: `--format json|text|csv|markdown` (default `text`). Prefer
+`--format json` when an LLM is the consumer.
+
+## When to use which
+
+### Discovery — `ainb fleet standup`
+
+```bash
+ainb fleet --format json standup
+```
+
+Returns the unified session list. Each row: `id`, `cwd`, `tmux_session`,
+`workspace_name`, `peer_id`, `sources` (subset of `["ainb","peers","jobs"]`),
+`summary`, `last_seen_ms`. `sources` reveals which discovery layers saw
+the session — a session in both `ainb` and `peers` is the strongest signal.
+
+Use this when:
+- You need to enumerate every claude on the host before composing an action
+- You want to know which sessions have a registered peer (can be sent
+  prompts via the broker) vs tmux-only (fallback path)
+- You're building a `needs` view manually before the `needs` subcommand
+  matures
+
+### Fan-out — `ainb fleet broadcast`
+
+```bash
+ainb fleet broadcast "remote-control disconnect" --all
+ainb fleet broadcast "/status" --filter "shotclubhouse.*"
+ainb fleet broadcast "/clear" --cwd "agents-in-a-box"
+```
+
+Mandatory target selector: `--all`, `--filter <regex>` (matches tmux
+session or workspace name), or `--cwd <substring>`. The command refuses
+to run without one — no implicit fan-out.
+
+Routing per target: peers-first (broker HTTP) when a peer_id is known,
+tmux send-keys fallback otherwise. Output reports per-target outcome.
+
+### Ordered multi-step — `ainb fleet sequence`
+
+```bash
+ainb fleet sequence "remote-control disconnect" "remote-control" "/status" --all
+```
+
+Sends each step, waits for every target's next assistant-turn-end (via
+JSONL transcript watch) before sending the next step. Default per-step
+timeout 300s.
+
+Use this when a series of prompts must be applied in order *and* each
+needs the prior to complete first — e.g. disconnect/reconnect cycles,
+multi-step config changes, sequential `/clear` then resume flows.
+
+### Blocked sessions — `ainb fleet needs`
+
+```bash
+ainb fleet --format json needs
+```
+
+Surfaces sessions whose `summary` starts with `WAITING:` — sessions
+explicitly opted in to flag blockage. (Future: detect AskUserQuestion
+UIs in tmux panes + idle-assistant heuristics.)
+
+Pipe this output into a follow-up LLM call to compose answers for each
+blocked session, then route the answers back via `broadcast --filter`.
+
+### Auto-continue watcher — `ainb fleet daemon`
+
+```bash
+ainb fleet daemon --verbose
+```
+
+Long-running background process. Scans every 5s. For each tmux session
+whose last 80 pane lines match a known API-error pattern (rate-limited,
+overloaded, internal-server-error, timeout, ECONNRESET, etc.), sends
+`continue` to that session. Per-pattern dedupe within a session so it
+doesn't spam.
+
+**Sharp edge — no retry cap in v0.1.** If a session is permanently broken
+(e.g. wrong credentials), the daemon will keep firing `continue` forever.
+Kill the daemon (`Ctrl-C` or `kill <pid>`) when this happens. A retry
+cap with exponential backoff is on the roadmap.
+
+## Composition patterns
+
+### "What does my fleet need from me right now?"
+
+```bash
+ainb fleet --format json needs \
+  | jq '.[] | {name: (.tmux_session // .workspace_name), summary: .summary}'
+```
+
+Then compose follow-ups based on each summary.
+
+### "Apply a one-shot fix to every related session"
+
+```bash
+ainb fleet --format json standup \
+  | jq -r '.[] | select(.cwd | contains("shotclubhouse")) | .tmux_session' \
+  | head -3
+# verify the targets…
+ainb fleet broadcast "git pull" --filter "shotclubhouse"
+```
+
+### "Cycle remote-control across the fleet"
+
+```bash
+ainb fleet sequence \
+  "remote-control disconnect" \
+  "remote-control" \
+  --all
+```
+
+## Discovery sources
+
+| source | what it sees | when missing |
+|---|---|---|
+| `ainb` | every session ainb has spawned (`ainb run` family) | claude started outside ainb |
+| `peers` | every session that registered with the claude-peers MCP broker (sqlite `~/.claude-peers.db`) | broker daemon not running |
+| `jobs` | bg-session job dirs (`~/.claude/jobs/<id>/`) | no bg jobs active |
+
+The merge step dedupes by `cwd`. A session present in two sources merges
+into one record with `sources: ["ainb", "peers"]` etc.
+
+## Environment overrides
+
+| var | default | use |
+|---|---|---|
+| `AINB_BIN` | `ainb` | override the binary `discover/ainb.rs` shells to (tests) |
+| `AINB_FLEET_PEER_ID` | `ainb-fleet-cp` | peer id the daemon registers as |
+| `AINB_FLEET_JOBS_DIR` | `~/.claude/jobs` | bg-job scan root |
+| `CLAUDE_PEERS_DB` | `~/.claude-peers.db` | broker sqlite path |
+| `CLAUDE_PEERS_PORT` | `7899` | broker HTTP port |
+
+## Migration note
+
+This skill replaces the deprecated `popa` plugin. The Node/TS reference
+impl was used to design the surface — it has been deleted. All
+orchestration lives in `ainb` itself now.
+
+## See also
+
+- `ainb list` — lifecycle-only session list (no peer/jobs enrichment, no
+  state derivation). Use when you only care about ainb-spawned sessions.
+- `ainb attach <workspace>` — drop into a session's tmux directly.
+- `ainb status <workspace>` — single-session inspect.

--- a/plugins/ainb-fleet/skills/broadcast/SKILL.md
+++ b/plugins/ainb-fleet/skills/broadcast/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ainb-fleet:broadcast
+description: |
+  Fan out a single prompt to selected claude sessions across the fleet.
+  Use when you need to apply the same instruction (e.g. `/clear`,
+  `git pull`, `remote-control disconnect`) to many sessions at once.
+  Routing: peers-first (broker HTTP) when peer registered, tmux send-keys
+  fallback otherwise. Refuses to run without an explicit targeting flag
+  (--all, --filter <regex>, or --cwd <substring>) — no implicit fan-out.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:broadcast
+  - fleet broadcast
+  - broadcast to fleet
+  - send to all sessions
+  - fan out prompt
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet:broadcast
+
+Send one prompt to selected sessions. Mandatory targeting flag.
+
+## Run
+
+```bash
+ainb fleet broadcast "<prompt>" --all                       # every running session
+ainb fleet broadcast "<prompt>" --filter "<regex>"          # match tmux/workspace name
+ainb fleet broadcast "<prompt>" --cwd "<substring>"         # match cwd
+```
+
+## Targeting flags (one required)
+
+| flag | matches against |
+|---|---|
+| `--all` | every session in `ainb fleet standup` |
+| `--filter <regex>` | regex against `tmux_session` OR `workspace_name` |
+| `--cwd <substring>` | substring against `cwd` |
+
+If none provided, the command exits with `broadcast requires --all,
+--filter <regex>, or --cwd <substring>` — by design, to prevent
+accidental fan-out.
+
+## Output
+
+```
+ainb fleet broadcast — sent to N target(s)
+  ✓ <name> via broker peer <peer_id>
+  ✓ <name> via tmux <tmux_session>
+  ✗ <name>: <reason>
+```
+
+`✓ via broker` = sent through claude-peers HTTP (clean, structured).
+`✓ via tmux` = sent via `tmux send-keys -l` (literal mode, works for any
+tmux pane regardless of peer state).
+
+## Routing rule
+
+For each target:
+
+1. If session has `peer_id` and broker is healthy → POST `/send-message` to broker.
+2. Else if session has `tmux_session` and tmux says it exists → `tmux send-keys -l`.
+3. Else → `Failed { reason: "no peer registered and no tmux session found" }`.
+
+## Common flows
+
+**Cycle a specific app:**
+```bash
+ainb fleet broadcast "/clear" --filter "shotclubhouse"
+```
+
+**Pull latest in every active worktree:**
+```bash
+ainb fleet broadcast "git pull" --cwd "/agents-in-a-box/worktrees/"
+```
+
+**Universal reset:**
+```bash
+ainb fleet broadcast "/exit" --all   # careful — quits everything
+```
+
+## Safety notes
+
+- `tmux send-keys -l` uses literal mode → shell metacharacters in the
+  prompt are safe (no injection).
+- Multi-line prompts: newlines in the broadcast text get sent as literal
+  characters; the receiving claude reads them as a single message.
+- The Enter key is sent *after* the literal text → claude sees the prompt
+  as a submitted user message.
+
+## Verify a broadcast landed
+
+For each target, tail the JSONL transcript:
+
+```bash
+ls -t ~/.claude/projects/<cwd-slug>/*.jsonl | head -1 | xargs grep "<prompt-text>"
+```
+
+(`<cwd-slug>` = replace `/` with `-` in the target's cwd.)

--- a/plugins/ainb-fleet/skills/daemon/SKILL.md
+++ b/plugins/ainb-fleet/skills/daemon/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: ainb-fleet:daemon
+description: |
+  Long-running watcher that scans every claude session every 5s and
+  auto-sends `continue` to any session whose recent tmux pane buffer
+  matches a known API-error regex (rate_limited, overloaded_error,
+  internal_server_error, request_timeout, socket_hang_up, fetch_failed,
+  ECONNRESET). Use this when you want unattended recovery from
+  transient API failures across the fleet.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:daemon
+  - fleet daemon
+  - auto-continue
+  - fleet watcher
+  - recover stuck sessions
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet:daemon
+
+Background watcher. Registers as peer `ainb-fleet-cp`. Auto-continues
+sessions hitting API errors.
+
+## Run
+
+```bash
+ainb fleet daemon                    # quiet
+ainb fleet daemon --verbose          # log every detection + send
+```
+
+For real background use:
+
+```bash
+nohup ainb fleet daemon --verbose > ~/.ainb-fleet.log 2>&1 &
+```
+
+## What it does each tick (every 5s)
+
+1. Re-discover all sessions (ainb + peers + jobs, merged + deduped).
+2. For each tmux-bearing session: `tmux capture-pane -p -S -80` (last 80 lines).
+3. Run the API-error regex set over the buffer.
+4. If a match fires AND the (session_id, pattern, snippet-tail) dedupe
+   key hasn't been seen yet → send `continue` to that session via the
+   standard route (peers-first, tmux fallback).
+
+## Detected error patterns
+
+| name | regex |
+|---|---|
+| `rate_limited` | `\brate[_ ]limited\b` |
+| `overloaded` | `\boverloaded_error\b \| \bModel is overloaded\b` |
+| `internal_server_error` | `\binternal_server_error\b` |
+| `request_timeout` | `\brequest timed out\b` |
+| `socket_hang_up` | `\bsocket hang up\b` |
+| `fetch_failed` | `\bAPI Error\b \| \bfetch failed\b` |
+| `connection_reset` | `\bECONNRESET\b \| \bconnection reset\b` |
+
+Case-insensitive. Word-boundaried to avoid false positives.
+
+## Dedupe key
+
+```
+key = (session_id, pattern_name, last_40_chars_of_match_context)
+```
+
+Within a single daemon run, the same `key` only fires `continue` once.
+This prevents spam when the error text scrolls up but is still in the
+buffer.
+
+## ⚠️ Sharp edge — no retry cap in v0.1
+
+If a session is permanently broken (wrong credentials, model deprecated,
+loop bug), the daemon will keep firing `continue` forever as new errors
+match new dedupe keys. Watch the daemon log; kill it (`Ctrl-C` or
+`kill <pid>`) when you see runaway repetition.
+
+Roadmap: per-session retry cap with exponential backoff.
+
+## Stop the daemon
+
+```bash
+# foreground: Ctrl-C
+# background:
+pkill -INT -f "ainb fleet daemon"
+
+# or kill by exact PID if you know it
+kill <pid>
+```
+
+The daemon's SIGINT handler unregisters from the broker before exit, so
+peers won't see a stale `ainb-fleet-cp` entry.
+
+## Observe what the daemon is doing
+
+With `--verbose`, every detection prints:
+
+```
+[fleet/daemon] broker healthy at 127.0.0.1:7899
+[fleet/daemon] auto-continue -> <tmux_session> (<pattern>)
+```
+
+Tail the nohup log to watch in real time:
+
+```bash
+tail -F ~/.ainb-fleet.log
+```
+
+## When NOT to run the daemon
+
+- During hand-debugging — the daemon will send `continue` while you're
+  reading the error, racing your investigation.
+- On a fleet doing batch work that explicitly throws errors as control
+  flow — the daemon will misinterpret intentional errors.
+- When the broker is down AND every session is tmux-only — the daemon
+  still works via tmux fallback but loses peer-aware routing.

--- a/plugins/ainb-fleet/skills/needs/SKILL.md
+++ b/plugins/ainb-fleet/skills/needs/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ainb-fleet:needs
+description: |
+  Enumerate every claude session that is blocked waiting on something —
+  user input (AskUserQuestion), an API error retry, or a peer-published
+  `WAITING:` summary. Use when you've stepped away and want to know
+  "what does my fleet need from me right now?" Output is JSON suitable
+  for piping into a follow-up LLM call that composes answers per
+  session.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:needs
+  - fleet needs
+  - what does my fleet need
+  - blocked sessions
+  - sessions waiting on me
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet:needs
+
+List sessions whose state is "blocked / waiting on you" right now.
+
+## Run
+
+```bash
+ainb fleet needs                          # JSON (default)
+ainb fleet --format text needs            # text table
+```
+
+## What counts as "blocked" (v0.1)
+
+Currently surfaces sessions whose peer-published `summary` field starts
+with `WAITING:`. Sessions explicitly opt in by calling broker
+`/set-summary` with the prefix.
+
+## Roadmap signals (not yet wired)
+
+The state-derivation layer recognises these signal types — once wired
+into `needs`, they'll widen the surface:
+
+| signal | source |
+|---|---|
+| `ApiError` | API-error regex match in tmux pane buffer |
+| `AskUserQuestion` | AskUserQuestion UI box detected in pane |
+| `NeedsInputMarker` | `needs input:` literal in bg-job output |
+| `WaitingSummary` | `WAITING:` prefix in peer summary |
+| `Idle` | assistant turn ended, no new user message for N min |
+
+When a session has multiple signals, priority order picks the strongest:
+
+```
+ApiError  >  NeedsInput  >  WaitingSummary  >  none
+```
+
+## Compose answers per-session
+
+```bash
+ainb fleet --format json needs \
+  | jq -r '.[] | "\(.tmux_session): \(.summary)"' \
+  | while IFS= read -r line; do
+      echo "Session $line — answer:"
+      # … compose answer via LLM …
+    done
+```
+
+Then route each answer back via `ainb fleet broadcast` with a per-session
+filter.
+
+## Caveats
+
+- v0.1 needs sessions to opt-in via `WAITING:` summary. If your sessions
+  don't set this, the list will be empty even when sessions are actually
+  blocked.
+- The richer detection (regex on tmux pane, JSONL idle heuristic) lives
+  in the read layer but isn't wired into `needs` yet.

--- a/plugins/ainb-fleet/skills/needs/SKILL.md
+++ b/plugins/ainb-fleet/skills/needs/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ainb-fleet:needs
 description: |
-  Enumerate every claude session that is blocked waiting on something —
-  user input (AskUserQuestion), an API error retry, or a peer-published
-  `WAITING:` summary. Use when you've stepped away and want to know
-  "what does my fleet need from me right now?" Output is JSON suitable
-  for piping into a follow-up LLM call that composes answers per
-  session.
-version: "0.1.0"
+  Center control panel — enumerate every claude session that is blocked
+  waiting on something: a user answer (AskUserQuestion fired), an API
+  error retry, an idle assistant turn-end with no follow-up, or an
+  explicit WAITING: marker. Returns rich JSON with signal kind + context
+  per session. Use this when you've stepped away from the fleet and want
+  one place to see everything that wants your attention and answer it.
+version: "0.2.0"
 user-invocable: true
 triggers:
   - ainb-fleet:needs
@@ -15,64 +15,160 @@ triggers:
   - what does my fleet need
   - blocked sessions
   - sessions waiting on me
+  - jarvis status
+  - control panel
 allowed-tools:
   - Bash
 ---
 
-# ainb fleet:needs
+# ainb fleet:needs — center control panel
 
-List sessions whose state is "blocked / waiting on you" right now.
+Single place to see every claude session that wants your attention. Four
+signal kinds classified per session, priority ASK > ERR > IDLE > WAIT.
 
 ## Run
 
 ```bash
-ainb fleet needs                          # JSON (default)
-ainb fleet --format text needs            # text table
+ainb fleet needs                        # text Jarvis-HUD layout
+ainb --format json fleet needs          # structured JSON (preferred by LLM)
+ainb fleet needs --idle-min 10          # override idle threshold (default 5 min)
 ```
 
-## What counts as "blocked" (v0.1)
+Env override: `AINB_FLEET_IDLE_MIN=10`.
 
-Currently surfaces sessions whose peer-published `summary` field starts
-with `WAITING:`. Sessions explicitly opt in by calling broker
-`/set-summary` with the prefix.
+## JSON schema
 
-## Roadmap signals (not yet wired)
+Each row in the output array:
 
-The state-derivation layer recognises these signal types — once wired
-into `needs`, they'll widen the surface:
+```jsonc
+{
+  "session": {
+    "id": "…",
+    "cwd": "/Users/…",
+    "tmux_session": "tmux_…",
+    "workspace_name": "…",
+    "peer_id": "…",         // null if not broker-registered
+    "sources": ["ainb", "peers"],
+    "summary": "…",         // JSONL-derived (see standup)
+    "last_seen_ms": 1779…
+  },
+  "kind": "ASK" | "ERR" | "IDLE" | "WAIT",
+  "context": {
+    // shape depends on `kind`:
+    //
+    // ASK — structured AskUserQuestion pulled from JSONL tool_use:
+    "question": "…",
+    "header": "…",
+    "options": [ { "label": "…", "description": "…" } ],
+    "multi_select": false,
+    //
+    // ERR — API error matched in pane:
+    "pattern": "rate_limited",
+    "snippet": "…API Error · rate_limited · …",
+    //
+    // IDLE — assistant turn-end, no user follow-up, > N min ago:
+    "idle_minutes": 17,
+    "last_assistant_text": "…",
+    //
+    // WAIT — explicit WAITING: prefix in peer summary:
+    "marker": "WAITING:",
+    "text": "…the post-marker text…"
+  },
+  "route_hint": "broker" | "tmux" | "none"
+}
+```
 
-| signal | source |
+## Render template — Jarvis HUD
+
+The calling LLM session should render this exact layout in chat:
+
+```
+╔════════════════════════════════════╗
+║  ⚡ FLEET STATUS · N NEED YOU ⚡    ║
+║  🔴 X err  🟡 Y ask  ⚪ Z idle      ║
+║  highest priority: <session> (<KIND>) ║
+╚════════════════════════════════════╝
+
+▸ 🟡 <session> ─ <question text>
+    ① <option label>
+    ② <option label>
+    ③ <option label>
+
+▸ 🔴 <session> ─ <pattern> (<snippet>)
+
+▸ ⚪ <session> ─ idle <N>m
+    '<last assistant snippet>'
+
+▸ 🟢 <session> ─ WAITING: <text>
+```
+
+Rules:
+- Banner always present (even for 0 sessions — "0 NEED YOU" + skip the priority line)
+- Per-card `▸` prefix, signal emoji, em-dash separator
+- ASK cards show options as ① ② ③ ④ ⑤ (numeric circled)
+- Cap at 10 cards visible; if more, render top 10 then `+ N more`
+- Priority order: ASK > ERR > IDLE > WAIT (binary already sorts this way)
+- Status emoji: 🔴 ERR · 🟡 ASK · ⚪ IDLE · 🟢 WAIT
+- Box-drawing chars: ╔ ╗ ╚ ╝ ║ ─ ▸ (monospace, no ANSI needed)
+
+## Compose the AskUserQuestion batch
+
+After rendering the HUD, fire AskUserQuestion **per session that wants an
+answer**. Each kind maps to a different prompt shape:
+
+| kind | AskUserQuestion shape |
 |---|---|
-| `ApiError` | API-error regex match in tmux pane buffer |
-| `AskUserQuestion` | AskUserQuestion UI box detected in pane |
-| `NeedsInputMarker` | `needs input:` literal in bg-job output |
-| `WaitingSummary` | `WAITING:` prefix in peer summary |
-| `Idle` | assistant turn ended, no new user message for N min |
+| ASK | Relay options 1:1 from `context.options` |
+| ERR | "<session> hit `<pattern>` — retry? skip? investigate?" |
+| IDLE | "<session> idle <N>m after: '<snippet>' — resume? close? other?" |
+| WAIT | "<session> says: `<marker> <text>` — answer:" |
 
-When a session has multiple signals, priority order picks the strongest:
+For ASK kinds, the LLM session SHOULD use AskUserQuestion's structured
+options so the user can click rather than type.
 
-```
-ApiError  >  NeedsInput  >  WaitingSummary  >  none
-```
+## Route the answers back
 
-## Compose answers per-session
+Once Stevie answers each, route via the existing send-route:
 
 ```bash
-ainb fleet --format json needs \
-  | jq -r '.[] | "\(.tmux_session): \(.summary)"' \
-  | while IFS= read -r line; do
-      echo "Session $line — answer:"
-      # … compose answer via LLM …
-    done
+ainb fleet broadcast "<answer>" --filter "<exact tmux_session>"
 ```
 
-Then route each answer back via `ainb fleet broadcast` with a per-session
-filter.
+`route_hint` tells you what'll happen:
+- `broker` — clean send through claude-peers HTTP
+- `tmux` — `tmux send-keys -l` literal mode (works for any tmux pane)
+- `none` — bg job or no targets; can't auto-route; tell user manually
+
+## Composition example
+
+```bash
+out=$(ainb --format json fleet needs)
+
+# 1. Render the HUD in chat (LLM does this from the JSON)
+# 2. For each entry, fire AskUserQuestion (claude code session does this)
+# 3. After each answer:
+echo "$out" | jq -r ".[] | select(.session.tmux_session == \"$picked\") | .session.tmux_session" \
+  | xargs -I% ainb fleet broadcast "$answer" --filter "%"
+```
 
 ## Caveats
 
-- v0.1 needs sessions to opt-in via `WAITING:` summary. If your sessions
-  don't set this, the list will be empty even when sessions are actually
-  blocked.
-- The richer detection (regex on tmux pane, JSONL idle heuristic) lives
-  in the read layer but isn't wired into `needs` yet.
+- **Race window** — between fleet sees the AskUserQuestion and Stevie's
+  answer reaches claude, the session still appears blocked on next
+  invocation. Acceptable for v0.2; full dedupe lands in v0.3.
+- **IDLE false positives** — a session you walked away from briefly shows
+  IDLE if past the threshold. Tune via `--idle-min` or env var.
+- **WAIT requires opt-in** — only fires when a session explicitly sets
+  `summary` to start with `WAITING:`. Most sessions never do.
+- **Bg jobs are excluded** — they have no tmux pane and no JSONL
+  transcript follow the normal shape; surfacing them would dilute the
+  panel. Use `ainb status <job>` for those.
+
+## v0.2 changelog
+
+- Added ASK, ERR, IDLE signal kinds (was: WAIT-only in v0.1)
+- Added `--idle-min` flag + `AINB_FLEET_IDLE_MIN` env override
+- Rich JSON output with `context` polymorphic per kind
+- `route_hint` field to guide answer-routing
+- Text-mode renders the Jarvis HUD directly
+- Priority sort: ASK > ERR > IDLE > WAIT

--- a/plugins/ainb-fleet/skills/sequence/SKILL.md
+++ b/plugins/ainb-fleet/skills/sequence/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ainb-fleet:sequence
+description: |
+  Ordered multi-step prompts to fleet targets, ack-gated between steps via
+  JSONL assistant-turn-end detection. Use for cycles like
+  disconnect→reconnect→verify, or any flow where step N+1 requires step N
+  to have completed first. The skill BLOCKS until each target's transcript
+  shows the next assistant turn finishing OR per-step timeout fires
+  (default 300s).
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:sequence
+  - fleet sequence
+  - ordered prompts to fleet
+  - multi-step ack-gated
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet:sequence
+
+Send N prompts in order. Between steps, wait for every target's next
+assistant-turn-end before firing the next step.
+
+## Run
+
+```bash
+ainb fleet sequence "step1" "step2" "step3" --all --timeout 300
+```
+
+## Args
+
+| arg/flag | purpose |
+|---|---|
+| `<steps...>` | 1 or more prompts, fired in argv order |
+| `--all` | required (v0.1 only supports --all targeting) |
+| `--timeout <seconds>` | per-step ack deadline, default 300 |
+
+## How ack-gating works
+
+After each step (except the last):
+
+```
+for each target:
+  watch  ~/.claude/projects/<cwd-slug>/<sid>.jsonl  via notify
+  resolve when next row has:
+    type     == "assistant"
+    message.stop_reason == "end_turn"
+  OR timeout fires
+```
+
+This guarantees claude has *finished responding* to step N before step
+N+1 lands. The watch runs in parallel across all targets; the next step
+fires when all targets either acked or timed out.
+
+## Common flows
+
+**Disconnect → reconnect cycle:**
+```bash
+ainb fleet sequence \
+  "remote-control disconnect" \
+  "remote-control" \
+  --all
+```
+
+**Clear → resume:**
+```bash
+ainb fleet sequence \
+  "/clear" \
+  "continue from where you left off" \
+  --all
+```
+
+**Verify-then-act:**
+```bash
+ainb fleet sequence \
+  "/status" \
+  "if status shows clean, proceed; otherwise abort" \
+  --all
+```
+
+## Caveats
+
+- **--all only in v0.1.** Filter/cwd selectors not yet wired for sequence.
+  Workaround: use a wrapper script that builds a filter list then runs
+  per-target sequences.
+- **Ack detection requires JSONL access.** If `~/.claude/projects/` is
+  unreadable (perms / sandboxing), ack always times out → step N+1
+  fires after the timeout regardless of actual completion.
+- **Default 300s is generous.** For chatty steps (analysis prompts, code
+  generation), 300s is realistic. For trivial prompts (`/clear`), pass
+  `--timeout 30` to fail fast.
+- **Tail wallclock = sum of per-step wallclocks.** A 3-step sequence
+  against a slow model can take minutes. Daemon mode keeps moving;
+  sequence is intentionally synchronous.
+
+## Verify ack-gating actually happened
+
+Time the run:
+
+```bash
+time ainb fleet sequence "say hi" "say bye" --all --timeout 30
+```
+
+If elapsed is suspiciously short (< number of round-trips × ~3s), check
+the JSONL transcripts to see if turn-ends were actually observed —
+fall-through on timeout looks identical from the outside.

--- a/plugins/ainb-fleet/skills/standup/SKILL.md
+++ b/plugins/ainb-fleet/skills/standup/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ainb-fleet:standup
+description: |
+  Show fleet status — every claude session running on the host, merged
+  across ainb + claude-peers broker + background jobs. Use when you need
+  to enumerate sessions before composing an action, see which sessions
+  have a peer registered (broker-routable) vs tmux-only, check the
+  `summary` of each session, or pipe the list into jq for filtering.
+  Default output: text table. Pass --format json for LLM consumption.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:standup
+  - fleet standup
+  - fleet status
+  - list claude sessions
+  - what claude sessions are running
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet:standup
+
+List every claude session across the host. Three sources merged + deduped
+by cwd.
+
+## Run
+
+```bash
+ainb fleet standup                       # text table (default)
+ainb fleet --format json standup         # JSON for piping
+```
+
+## Output fields (JSON)
+
+| field | meaning |
+|---|---|
+| `id` | session id (peer id preferred, else ainb session_id, else bg job id) |
+| `cwd` | working dir — primary dedupe key |
+| `pid` | OS pid (when known — peers + bg jobs publish; ainb does not) |
+| `tmux_session` | tmux session name if running in tmux |
+| `workspace_name` | ainb workspace name |
+| `worktree_path` | ainb worktree path |
+| `peer_id` | broker peer id (if registered) |
+| `sources` | array — subset of `["ainb","peers","jobs"]` |
+| `summary` | peer-published summary (may start with `WAITING:` to flag block) |
+| `last_seen_ms` | unix ms of last activity any source observed |
+
+## Composition patterns
+
+**Just names:**
+```bash
+ainb fleet --format json standup | jq -r '.[].tmux_session // .workspace_name'
+```
+
+**Sessions in a specific repo:**
+```bash
+ainb fleet --format json standup | jq '.[] | select(.cwd | contains("shotclubhouse"))'
+```
+
+**Only sessions with peer registration (broker-routable):**
+```bash
+ainb fleet --format json standup | jq '.[] | select(.peer_id != null)'
+```
+
+**Group by source mix:**
+```bash
+ainb fleet --format json standup \
+  | jq -r 'group_by(.sources | sort | join(",")) | .[] | "\(.[0].sources | sort | join(",")): \(length)"'
+```
+
+## Performance
+
+Sub-100ms cold start. Reads broker SQLite directly + shells out to `ainb list`
+once. Safe to call frequently.

--- a/plugins/ainb-fleet/skills/standup/SKILL.md
+++ b/plugins/ainb-fleet/skills/standup/SKILL.md
@@ -69,6 +69,42 @@ ainb fleet --format json standup \
   | jq -r 'group_by(.sources | sort | join(",")) | .[] | "\(.[0].sources | sort | join(",")): \(length)"'
 ```
 
+## Auto-chain to `/ainb-fleet:needs`
+
+After rendering standup, **scan the result for sessions whose `summary`
+contains `AskUserQuestion`** (literal string — the JSONL-synthesised
+summary surfaces this when the last assistant turn fired the tool).
+
+If ANY such session exists, the standup MUST NOT stop at the standup
+table. Immediately:
+
+1. Tell Stevie explicitly:
+   ```
+   N session(s) blocked on AskUserQuestion — firing `/ainb-fleet:needs`
+   to surface the questions + answer them in one batch.
+   ```
+
+2. Invoke the `ainb-fleet:needs` skill (via the Skill tool) OR run
+   `ainb --format json fleet needs` directly and render the Jarvis HUD
+   per the `ainb-fleet:needs` SKILL.md. No second Stevie-typed slash
+   command required — the handover is automatic.
+
+Detection one-liner:
+
+```bash
+ainb --format json fleet standup \
+  | jq -r '[.[] | select(.summary // "" | contains("AskUserQuestion"))] | length'
+```
+
+If 0 → skip the chain, standup is the final word.
+If >0 → chain immediately.
+
+**Rationale:** standup is a snapshot; the moment it reveals an
+answerable question, the fleet's center control panel (`needs`)
+already knows how to extract the structured options + route the
+answer back. Don't make Stevie type another slash command for a
+mechanically inevitable next step.
+
 ## Performance
 
 Sub-100ms cold start. Reads broker SQLite directly + shells out to `ainb list`


### PR DESCRIPTION
## Summary

- Port the TS `popa` orchestration plugin into ainb's Rust codebase as a new `ainb fleet …` subcommand namespace (broadcast / sequence / needs / daemon / standup).
- Delete the TS popa; ship a docs-only `ainb-fleet` plugin (6 colon-namespaced sub-skills) that teaches Claude / Codex how to drive the new verbs.
- Wire `ainb fleet needs` as the center control panel — classifies every claude session against four signal kinds (ASK / ERR / IDLE / WAIT) with rich JSON output the LLM renders as a Jarvis HUD.
- `ainb fleet:standup` auto-chains to `ainb fleet:needs` whenever any session is blocked on AskUserQuestion.

## Why

One CLI for the whole DE ("master control"). Removes the popa↔ainb cognitive seam. Native-speed orchestration (~50ms cold start vs Node's ~300ms). Single-binary distribution via the existing ainb cargo install path. Claude-only chat-renderable HUD — works on desktop, terminal, claude mobile.

## What's in

- `ainb-tui/crates/ainb-core/src/fleet/` — Rust modules: discover (ainb shellout · peers sqlite · jobs scan · cwd-dedupe merge), read (tmux pane · JSONL tail · 7 API-error regex · AskUserQuestion extractor · idle-detector · state merge), send (broker HTTP · tmux send-keys · peers-first route).
- `ainb-tui/crates/ainb-core/src/cli/fleet/` — clap-registered sub-commands; `--format json` parity with existing ainb verbs.
- `plugins/ainb-fleet/` — proper marketplace plugin (manifest + 6 SKILL.md). Replaces the deprecated `popa` entry in `.claude-plugin/marketplace.json`.
- `ainb-tui/scripts/fleet-test.sh` — runbook hand-verifying DoD #2/#3/#4/#5 against throwaway claude sessions.

## DoDs all verified live

| # | check | result |
|---|---|---|
| 1 | `ainb fleet standup` matches pre-deletion TS popa baseline byte-for-byte | 34/34 sessions, zero diff |
| 2 | broadcast lands in target JSONL within 5s | passed via nonce match |
| 3 | daemon auto-continues on injected `rate_limited` text within 10s | passed at ~3s |
| 4 | sequence runs 3 steps ack-gated via JSONL turn-end | 62s total (real ack-gating) |
| 5 | needs surfaces ASK signal within 5s of AskUserQuestion fire | passed via structured options |

## Test plan

- [x] `cargo build --bin ainb` — clean, 0 errors
- [x] `cargo test -p ainb --lib fleet` — 15/15 pass (5 needs + 4 jsonl_tail + 3 discover + 2 errors + 1 slug)
- [x] `ainb fleet --help` lists all 5 verbs
- [x] `ainb fleet standup --format json` returns same session set as TS popa baseline
- [x] `ainb fleet broadcast` refuses without `--all|--filter|--cwd` (no implicit fan-out)
- [x] `ainb fleet daemon --verbose` registers as `ainb-fleet-cp` peer; auto-continues injected errors
- [x] `ainb fleet sequence` ack-gates between steps via notify-watched JSONL
- [x] `ainb fleet needs` classifies 4 ASK + 10 IDLE on live 39-session fleet
- [x] `ainb fleet:standup` auto-chains to `:needs` when any session has AskUserQuestion in summary
- [x] Plugin manifest + marketplace manifest both pass `claude plugin validate`
- [x] User-scope plugin install resolves; SKILL.md MD5 matches source

## Constraints honoured

- No hooks in v1 (structure ready for webhook hooks later).
- No cost/$ tracking (burndown owns spend).
- No retry cap on auto-continue (max autonomy per Stevie).
- Throwaway tmux test rig uses default socket + named prefix; cleanup kills only specific sessions, never the server, never the socket.
- All commits atomic, single-concern. **Merge with `--merge` (not squash) to preserve commit history.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ainb fleet` command suite for multi-session orchestration:
    * `standup`: enumerate all Claude sessions across available sources
    * `broadcast`: fan out prompts to selected sessions
    * `sequence`: send sequential prompts with acknowledgment gating between steps
    * `needs`: monitor session status and classify blocking conditions
    * `daemon`: auto-continue sessions on detected errors
  * Multi-source session discovery with automatic deduplication
  * Broker-first send routing with tmux fallback
  * JSON and text output formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->