### PR TITLE
feat(ainb-fleet): hangar workflow + fleet-needs Jarvis cockpit

### DIFF
--- a/plugins/ainb-fleet/skills/fleet-needs/SKILL.md
+++ b/plugins/ainb-fleet/skills/fleet-needs/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: ainb-fleet:fleet-needs
+description: |
+  Workflow-backed Jarvis control panel. Runs the deterministic `fleet-needs`
+  workflow (discover → classify → enrich → prioritize), renders the Jarvis
+  HUD from its render-ready cards, fires AskUserQuestion per blocked session,
+  and routes each answer back via `ainb fleet broadcast`. Requires the
+  workflow gate (CLAUDE_CODE_WORKFLOWS=1). If the gate is off, fall back to
+  the prompt-driven `/ainb-fleet:needs` skill.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:fleet-needs
+  - fleet needs workflow
+  - jarvis panel
+  - control panel workflow
+allowed-tools:
+  - Bash
+  - Workflow
+  - AskUserQuestion
+---
+
+# ainb fleet:fleet-needs — workflow-backed cockpit
+
+The session "face" of the sensor-fusion hybrid. The deterministic brain is the
+`fleet-needs` workflow; this skill renders its output and handles the
+irreducibly-interactive last mile (HUD + AskUserQuestion + routing).
+
+```
+SESSION (this skill) ──Workflow({name:'ainb-fleet:fleet-needs'})──▶ brain
+   render HUD ◀──{banner,cards,asks}──────────────────────────────┘
+   AskUserQuestion per ask  ──answer──▶  tmux send-keys (write leg)
+```
+
+## Read/write split — architectural principle
+
+| Direction | Channel | Why |
+|-----------|---------|-----|
+| **Reads** | JSONL (source of truth) — `ainb fleet needs/standup` tails JSONL + pane | content already committed; replayable; ground truth |
+| **Writes** | **tmux send-keys** — direct keystrokes to the target pane (verify with capture-pane) | deterministic, no broker latency or delivery gap |
+| Fallback writes | peers/broker via `ainb fleet broadcast` | only when no tmux_session known; broker has a known delivery gap |
+
+All write routing below uses tmux first. Broker is a last resort, not the default.
+
+## Step 0 — gate check (fallback if workflows off)
+
+```bash
+[ -n "$CLAUDE_CODE_WORKFLOWS" ] && echo "gate on" || echo "gate off"
+```
+
+If gate off → **stop and invoke `/ainb-fleet:needs`** (the prompt-skill).
+The workflow path only works when `CLAUDE_CODE_WORKFLOWS=1` is set.
+
+## Step 1 — run the hangar workflow with verb=needs
+
+`hangar` is the single multi-verb workflow under `ainb-fleet`. The `needs`
+verb runs the Discover ▸ Enrich ▸ Prioritize chain and returns the render-ready
+panel data. Other verbs (`standup`, `sequence`) are wired into the same workflow.
+
+```
+Workflow({ name: 'ainb-fleet:hangar', args: { verb: 'needs' } })
+```
+
+It runs in background; wait for completion. The result is render-ready:
+
+```jsonc
+{ "banner": { "need", "err", "ask", "idle", "wait", "top": {session,kind} },
+  "cards":  [ { "emoji", "kind", "session", "line", "enriched", "options?" } ],
+  "asks":   [ { "question", "header", "options[{label,description}]",
+               "multiSelect", "suggestion", "route": {target,hint} } ] }
+```
+
+## Step 2 — render the Jarvis HUD
+
+From `banner` + `cards`, render this exact layout in chat:
+
+```
+╔════════════════════════════════════╗
+║  ⚡ FLEET STATUS · N NEED YOU ⚡    ║
+║  🔴 X err  🟡 Y ask  ⚪ Z idle      ║
+║  top: <banner.top.session> (<KIND>) ║
+╚════════════════════════════════════╝
+
+▸ <emoji> <session> ─ <line>
+    [suggest: <enriched>]
+    ① <option>  ② <option>  ③ <option>      (ASK only)
+```
+
+Rules:
+- Banner always present (0 → "0 NEED YOU", skip top line).
+- One `▸` card per `cards[]` entry, in order (already priority-sorted).
+- `[suggest: …]` line only when `enriched` is non-null.
+- ASK cards show `options` as ① ② ③ ④ ⑤.
+- Cap at 10 cards; if more, render 10 then `+ N more`.
+
+## Step 3 — fire AskUserQuestion (batched ≤ 4)
+
+`asks[]` are AskUserQuestion-ready. **The tool caps at 4 questions per call** —
+batch in groups of 4 (highest-priority first, asks[] is already sorted):
+
+```
+for batch of up to 4 asks:
+  AskUserQuestion({ questions: batch.map(a => ({
+    question: a.question, header: a.header,
+    options: a.options, multiSelect: a.multiSelect })) })
+```
+
+When `suggestion` is set, mention it ("recommended: <suggestion>") so Stevie
+can one-tap the drafted choice.
+
+## Step 4 — route answers back
+
+Two routes, picked by ask `kind`:
+
+### 4a — ASK kind → **key-route** (click the target's picker)
+
+The target session already has its own AskUserQuestion picker open and is
+waiting for `Down`/`Enter`. Sending the answer as TEXT would land as a fresh
+user message the target then has to re-interpret. Worse, the broker-delivery
+path has a known gap. So for ASK answers, **press the picker keys directly via
+tmux send-keys** — the same UI keystrokes the human would use:
+
+```bash
+# idx = 0-based index of the option Stevie picked in asks[].options
+# target = the ask's route.target (the target's tmux_session)
+for _ in $(seq 1 "$idx"); do tmux send-keys -t "$target" Down; done
+tmux send-keys -t "$target" Enter
+```
+
+The picker explicitly advertises `Enter to select · Tab/Arrow keys to navigate`
+in its footer — that's the contract.
+
+**Caveats:**
+- The picker must still be the active surface in the target pane. If the
+  target moved on (Esc'd / scrolled away), arrow-Enter lands somewhere
+  unintended. `route.hint == 'broker'` doesn't help — the underlying race
+  is the same.
+- Option ordering matters and is preserved by the workflow (the target's
+  `context.options[]` is returned verbatim).
+
+### 4b — ERR / IDLE / WAIT kinds → **text-route via tmux send-keys**
+
+No picker on the target; the answer is a normal prompt. Per the read/write
+principle, prefer tmux directly — it lands reliably and is verifiable via
+capture-pane. Broker is fallback only.
+
+```bash
+# default: write via tmux, verify via capture-pane
+tmux send-keys -t "$target" -l "<answer text>"
+tmux send-keys -t "$target" Enter
+
+# verify it landed in the pane (the matching read)
+tmux capture-pane -t "$target" -p -S -40 | grep -F "<answer text>" && echo "✓"
+```
+
+Only when `tmux_session` is unknown (rare — bg jobs, dead tmux), fall back to:
+
+```bash
+ainb fleet broadcast "<answer>" --filter "<route.target>"   # broker — last resort
+```
+
+### Verify the write landed (capture-pane is the matching read)
+
+```bash
+# the read leg that matches the write
+tmux capture-pane -t "$target" -p -S -50 | grep -F "<answer>"
+# slower confirmation: target's JSONL transcript records the user message
+ls -t ~/.claude/projects/<cwd-slug>/*.jsonl | head -1 | xargs grep -F "<answer>"
+```
+
+## Caveats
+
+- **AskUserQuestion is session-only** — the workflow cannot fire it; that's why
+  this skill exists. The workflow only produces the `asks[]` shape.
+- **Enrich cost** — one Haiku agent per blocked session, unbounded. A 17-session
+  fleet measured ~920k tokens / ~175s on a cold run; resume is ~0 tokens.
+- **Race window** — a just-answered session may reappear once before its tail
+  moves; always-fresh discover re-reads live each invocation.
+- **`unknown` session targets** — sessions ainb can't name (bg jobs, dead tmux)
+  surface with `route.target: "unknown"`; those can't auto-route — tell Stevie.

--- a/plugins/ainb-fleet/skills/fleet-needs/SKILL.md
+++ b/plugins/ainb-fleet/skills/fleet-needs/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: ainb-fleet:fleet-needs
 description: |
-  Workflow-backed Jarvis control panel. Runs the deterministic `fleet-needs`
-  workflow (discover → classify → enrich → prioritize), renders the Jarvis
-  HUD from its render-ready cards, fires AskUserQuestion per blocked session,
-  and routes each answer back via `ainb fleet broadcast`. Requires the
-  workflow gate (CLAUDE_CODE_WORKFLOWS=1). If the gate is off, fall back to
-  the prompt-driven `/ainb-fleet:needs` skill.
+  Workflow-backed Jarvis control panel. Runs the deterministic `hangar`
+  workflow with verb=needs (discover → enrich → prioritize), renders the
+  Jarvis HUD from its render-ready cards, fires AskUserQuestion per blocked
+  session, and routes each answer back via tmux send-keys (broker fallback
+  only). Requires the workflow gate (CLAUDE_CODE_WORKFLOWS=1). If the gate is
+  off, fall back to the prompt-driven `/ainb-fleet:needs` skill.
 version: "0.1.0"
 user-invocable: true
 triggers:
@@ -23,12 +23,12 @@ allowed-tools:
 # ainb fleet:fleet-needs — workflow-backed cockpit
 
 The session "face" of the sensor-fusion hybrid. The deterministic brain is the
-`fleet-needs` workflow; this skill renders its output and handles the
+`hangar` workflow (verb=needs); this skill renders its output and handles the
 irreducibly-interactive last mile (HUD + AskUserQuestion + routing).
 
 ```
-SESSION (this skill) ──Workflow({name:'ainb-fleet:fleet-needs'})──▶ brain
-   render HUD ◀──{banner,cards,asks}──────────────────────────────┘
+SESSION (this skill) ──Workflow({name:'ainb-fleet:hangar', args:{verb:'needs'}})──▶ brain
+   render HUD ◀──{banner,cards,asks}──────────────────────────────────────────┘
    AskUserQuestion per ask  ──answer──▶  tmux send-keys (write leg)
 ```
 

--- a/plugins/ainb-fleet/workflows/.gitignore
+++ b/plugins/ainb-fleet/workflows/.gitignore
@@ -1,0 +1,8 @@
+# Runtime + agent-scratch artifacts that land in this dir when it's the cwd.
+# Never ship these with the plugin.
+logs/
+.agents/
+
+# Process docs kept local-only (proof reports, brainstormed strategy).
+DELIVERABLE.md
+TEST-STRATEGY.md

--- a/plugins/ainb-fleet/workflows/hangar.js
+++ b/plugins/ainb-fleet/workflows/hangar.js
@@ -1,0 +1,329 @@
+export const meta = {
+  name: 'hangar',
+  description: 'Multi-verb fleet orchestrator. One deterministic workflow that dispatches by args.verb. Verbs today: `needs` (the Jarvis panel — discover → enrich → prioritize → render-ready cards), `standup` (raw fleet listing via ainb), `sequence` (ordered ack-gated multi-step send via pipeline). Reads always go through ainb (which tails JSONL + pane); writes always happen in the calling session (tmux send-keys), never inside the sandbox.',
+  whenToUse: 'Invoked by the per-verb skills under ainb-fleet (fleet-needs / standup-rich / sequence). Args = {verb, ...opts}. Default verb = "needs" when omitted.',
+  phases: [
+    { title: 'Discover',   detail: 'ainb fleet <verb> --json (Rust does the JSONL read)' },
+    { title: 'Enrich',     detail: 'parallel Haiku per blocked session — needs verb only' },
+    { title: 'Prioritize', detail: 'sort + render-ready {banner,cards,asks} — needs verb only' },
+    { title: 'Step',       detail: 'per-step send-then-ack — sequence verb only' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Verb dispatch
+// ---------------------------------------------------------------------------
+const parsed = (() => {
+  if (typeof args === 'object' && args !== null) return args
+  if (typeof args === 'string' && args.trim().length > 0) return { verb: args.trim() }
+  return { verb: 'needs' }
+})()
+const verb = parsed.verb || 'needs'
+
+log('hangar verb=' + verb)
+
+if (verb === 'needs') {
+  return await runNeeds(parsed)
+}
+if (verb === 'standup') {
+  return await runStandup(parsed)
+}
+if (verb === 'sequence') {
+  return await runSequence(parsed)
+}
+throw new Error('hangar: unknown verb "' + verb + '" — valid: needs | standup | sequence')
+
+// ===========================================================================
+// VERB: needs — the Jarvis panel (former fleet-needs flow)
+// ===========================================================================
+async function runNeeds(_opts) {
+  phase('Discover')
+
+  const DISCOVER_SCHEMA = {
+    type: 'object',
+    required: ['json'],
+    properties: { json: { type: 'string', description: 'raw verbatim stdout of `ainb --format json fleet needs`' } },
+  }
+
+  const discovered = await agent(
+    'Run EXACTLY this command and return its raw stdout verbatim in the `json` field — ' +
+      'no commentary, no markdown code fences, just the JSON the command printed:\n\n' +
+      '    ainb --format json fleet needs\n\n' +
+      'If the command errors, prints nothing, or there is no fleet, return json = "[]".',
+    { label: 'discover', phase: 'Discover', schema: DISCOVER_SCHEMA },
+  )
+
+  let sessions = []
+  try {
+    sessions = JSON.parse(discovered.json)
+  } catch (_e) {
+    sessions = []
+  }
+  if (!Array.isArray(sessions)) sessions = []
+
+  // post-Discover kind breakdown
+  const kCounts = sessions.reduce((acc, s) => { const k = (s && s.kind) || 'WAIT'; acc[k] = (acc[k] || 0) + 1; return acc }, {})
+  log('discovered ' + sessions.length + ' · ASK:' + (kCounts.ASK || 0) + ' ERR:' + (kCounts.ERR || 0) + ' IDLE:' + (kCounts.IDLE || 0) + ' WAIT:' + (kCounts.WAIT || 0))
+
+  phase('Enrich')
+
+  const ENRICH_SCHEMA = {
+    type: 'object',
+    required: ['line', 'suggestion'],
+    properties: {
+      line: { type: 'string', description: 'one terse operator-facing summary, <= 12 words' },
+      suggestion: { type: 'string', description: 'ASK: best option label verbatim; ERR: retry|skip|investigate; IDLE: resume|close; else empty' },
+    },
+  }
+
+  // Label helpers: rich agent labels in the /workflows monitor.
+  const tagOf = (kind, ctx) => {
+    if (kind === 'IDLE' && ctx && typeof ctx.idle_minutes === 'number') return '[IDLE ' + ctx.idle_minutes + 'm]'
+    return '[' + (kind || 'WAIT') + ']'
+  }
+  const idOf = (sess, idx) => {
+    const tm = sess.tmux_session || sess.workspace_name
+    if (tm) return tm
+    const cwd = sess.cwd || ''
+    const segs = cwd.split('/').filter(Boolean)
+    const tail = (segs[segs.length - 1] || '').slice(0, 30)
+    const peer = sess.peer_id || ''
+    const skipTails = new Set(['tmp', 'private', 'home', 'Users'])
+    if (tail && !skipTails.has(tail)) return peer ? tail + ':' + peer : tail
+    return peer || ('session-' + idx)
+  }
+
+  let done = 0
+  const total = sessions.length
+  const enriched = await parallel(
+    sessions.map((s, i) => () => {
+      const kind = (s && s.kind) || 'WAIT'
+      const ctx = (s && s.context) || {}
+      const sess = (s && s.session) || {}
+      const sid = sess.id || idOf(sess, i)
+      const ctxStr = JSON.stringify(ctx).slice(0, 900)
+      const label = tagOf(kind, ctx) + ' enrich:' + idOf(sess, i) + '  route:' + (s.route_hint || 'tmux')
+      const onDone = () => {
+        done++
+        if (done % 5 === 0 || done === total) log('enriched ' + done + '/' + total)
+      }
+      return agent(
+        'A claude session is blocked.\n' +
+          'session_id=' + sid + ' kind=' + kind + '\n' +
+          'context=' + ctxStr + '\n\n' +
+          'Return `line`: one terse operator-facing summary (<=12 words) of what this session needs.\n' +
+          'Return `suggestion`: for ASK, the single best option label verbatim from the options; ' +
+          'for ERR, one of retry|skip|investigate; for IDLE, one of resume|close; otherwise empty string.',
+        { label: label, phase: 'Enrich', schema: ENRICH_SCHEMA },
+      )
+        .then((e) => { onDone(); return { row: s, enriched: e } })
+        .catch(() => { onDone(); return { row: s, enriched: null } })
+    }),
+  )
+
+  phase('Prioritize')
+
+  const panel = buildPanel(enriched)
+
+  // post-Prioritize: top ASK picks digest
+  const topPicks = panel.cards
+    .filter((c) => c.kind === 'ASK' && c.enriched)
+    .slice(0, 5)
+    .map((c) => c.session.replace(/^tmux_/, '').slice(0, 18) + '=' + c.enriched.slice(0, 30))
+    .join(' · ')
+  if (topPicks) log('top picks: ' + topPicks)
+  log('prioritized ' + panel.cards.length + ' card(s), ' + panel.asks.length + ' ask(s)')
+
+  return { verb: 'needs', ...panel }
+}
+
+// ===========================================================================
+// VERB: standup — raw fleet listing
+// ===========================================================================
+async function runStandup(opts) {
+  phase('Discover')
+
+  const STANDUP_SCHEMA = {
+    type: 'object',
+    required: ['json'],
+    properties: { json: { type: 'string', description: 'raw stdout of `ainb --format json fleet standup`' } },
+  }
+
+  const filterArg = opts && typeof opts.filter === 'string' ? (' (note: caller wants to filter on "' + opts.filter + '" client-side)') : ''
+
+  const discovered = await agent(
+    'Run EXACTLY: ainb --format json fleet standup\nReturn raw stdout verbatim in the `json` field. ' +
+      'No commentary, no markdown fences. If empty, return json = "[]".' + filterArg,
+    { label: 'standup', phase: 'Discover', schema: STANDUP_SCHEMA },
+  )
+
+  let sessions = []
+  try {
+    sessions = JSON.parse(discovered.json)
+  } catch (_e) {
+    sessions = []
+  }
+  if (!Array.isArray(sessions)) sessions = []
+
+  if (opts && typeof opts.filter === 'string' && opts.filter.length > 0) {
+    const needle = opts.filter.toLowerCase()
+    sessions = sessions.filter((s) => {
+      const tmux = (s.tmux_session || '').toLowerCase()
+      const ws = (s.workspace_name || '').toLowerCase()
+      const cwd = (s.cwd || '').toLowerCase()
+      return tmux.includes(needle) || ws.includes(needle) || cwd.includes(needle)
+    })
+  }
+
+  log('standup: ' + sessions.length + ' session(s)' + (filterArg ? ' after filter' : ''))
+
+  return { verb: 'standup', count: sessions.length, sessions }
+}
+
+// ===========================================================================
+// VERB: sequence — ordered ack-gated multi-step send (skeleton, Phase 2 of spec)
+// ===========================================================================
+async function runSequence(opts) {
+  const steps = (opts && Array.isArray(opts.steps)) ? opts.steps : []
+  const filter = (opts && typeof opts.filter === 'string') ? opts.filter : ''
+  if (steps.length === 0) {
+    throw new Error('hangar(sequence): args.steps must be a non-empty array of prompts')
+  }
+  if (!filter) {
+    throw new Error('hangar(sequence): args.filter is required (regex against tmux/workspace name)')
+  }
+
+  // pipeline: send → ack. Each step proceeds only after the previous one's ack lands.
+  const results = []
+  for (let i = 0; i < steps.length; i++) {
+    phase('Step')
+
+    const SEQ_SCHEMA = {
+      type: 'object',
+      required: ['sent', 'acked'],
+      properties: {
+        sent:  { type: 'array', items: { type: 'string' } },
+        acked: { type: 'array', items: { type: 'string' } },
+        timed_out: { type: 'array', items: { type: 'string' } },
+      },
+    }
+
+    const step = steps[i]
+    const stepIdx = i + 1
+    const r = await agent(
+      'Run EXACTLY:\n' +
+        '    ainb fleet sequence "' + String(step).replace(/"/g, '\\"') + '" --filter "' + filter + '" --timeout 60\n\n' +
+        'Capture which targets sent vs acked. Return sent[], acked[] (tmux_session names), and timed_out[] if any.',
+      { label: 'step:' + stepIdx, phase: 'Step', schema: SEQ_SCHEMA },
+    )
+    log('sequence step ' + stepIdx + '/' + steps.length + ': sent=' + (r.sent?.length ?? 0) + ' acked=' + (r.acked?.length ?? 0))
+    results.push({ step: stepIdx, prompt: step, ...r })
+  }
+
+  return { verb: 'sequence', filter, total_steps: steps.length, results }
+}
+
+// ===========================================================================
+// PURE BUILDER — verbatim copy of fleet-needs.logic.mjs (parity-guarded)
+// ===========================================================================
+
+// PARITY-START
+function buildPanel(enriched) {
+  const PRIORITY = { ASK: 0, ERR: 1, IDLE: 2, WAIT: 3 }
+  const EMOJI = { ASK: '\u{1F7E1}', ERR: '\u{1F534}', IDLE: '\u{26AA}', WAIT: '\u{1F7E2}' }
+
+  const rows = (enriched || []).filter(Boolean)
+  rows.sort((a, b) => (PRIORITY[a.row && a.row.kind] ?? 9) - (PRIORITY[b.row && b.row.kind] ?? 9))
+
+  const tmuxOf = (r) => {
+    const sess = (r.row && r.row.session) || {}
+    return sess.tmux_session || sess.workspace_name || 'unknown'
+  }
+
+  const banner = {
+    need: rows.length,
+    err: rows.filter((r) => r.row.kind === 'ERR').length,
+    ask: rows.filter((r) => r.row.kind === 'ASK').length,
+    idle: rows.filter((r) => r.row.kind === 'IDLE').length,
+    wait: rows.filter((r) => r.row.kind === 'WAIT').length,
+    top: rows[0] ? { session: tmuxOf(rows[0]), kind: rows[0].row.kind } : null,
+  }
+
+  const cards = rows.map((r) => {
+    const kind = r.row.kind
+    const ctx = r.row.context || {}
+    const en = r.enriched || {}
+    let line = en.line || ''
+    if (!line) {
+      if (kind === 'ASK') line = ctx.question || 'question'
+      else if (kind === 'ERR') line = ctx.pattern || 'error'
+      else if (kind === 'IDLE') line = 'idle ' + (ctx.idle_minutes ?? '?') + 'm'
+      else line = ctx.text || 'waiting'
+    }
+    return {
+      emoji: EMOJI[kind] || '•',
+      kind,
+      session: tmuxOf(r),
+      line,
+      enriched: en.suggestion || null,
+      options: kind === 'ASK' ? (ctx.options || []).map((o) => o.label) : undefined,
+    }
+  })
+
+  const asks = rows.map((r) => {
+    const kind = r.row.kind
+    const ctx = r.row.context || {}
+    const en = r.enriched || {}
+    const tmux = tmuxOf(r)
+    const route = { target: tmux, hint: r.row.route_hint || 'tmux' }
+    const header = tmux.slice(0, 12)
+    if (kind === 'ASK') {
+      return {
+        question: (ctx.header ? ctx.header + ': ' : '') + (ctx.question || 'needs input'),
+        header,
+        options: (ctx.options || []).map((o) => ({ label: o.label, description: o.description || '' })),
+        multiSelect: !!ctx.multi_select,
+        suggestion: en.suggestion || null,
+        route,
+      }
+    }
+    if (kind === 'ERR') {
+      return {
+        question: tmux + ' hit `' + (ctx.pattern || 'error') + '` — what now?',
+        header,
+        options: [
+          { label: 'Retry', description: 'send continue' },
+          { label: 'Skip', description: 'leave it' },
+          { label: 'Investigate', description: 'open the session' },
+        ],
+        multiSelect: false,
+        suggestion: en.suggestion || null,
+        route,
+      }
+    }
+    if (kind === 'IDLE') {
+      return {
+        question: tmux + ' idle ' + (ctx.idle_minutes ?? '?') + 'm — resume?',
+        header,
+        options: [
+          { label: 'Resume', description: 'send continue' },
+          { label: 'Close', description: 'leave idle' },
+        ],
+        multiSelect: false,
+        suggestion: en.suggestion || null,
+        route,
+      }
+    }
+    return {
+      question: tmux + ' says: ' + (ctx.text || 'waiting'),
+      header,
+      options: [{ label: 'Acknowledge', description: 'respond' }],
+      multiSelect: false,
+      suggestion: en.suggestion || null,
+      route,
+    }
+  })
+
+  return { banner, cards, asks }
+}
+// PARITY-END

--- a/plugins/ainb-fleet/workflows/hangar.logic.mjs
+++ b/plugins/ainb-fleet/workflows/hangar.logic.mjs
@@ -1,0 +1,113 @@
+// Pure builder logic for hangar (verb=needs). SOURCE OF TRUTH.
+//
+// The SES workflow sandbox cannot `import` this module at runtime, so
+// hangar.js inlines a VERBATIM copy of `buildPanel` between the
+// PARITY markers. parity.test.mjs asserts the two copies never drift.
+//
+// Keep `buildPanel` pure: no agent()/phase()/log(), only data transform.
+
+export const PRIORITY = { ASK: 0, ERR: 1, IDLE: 2, WAIT: 3 }
+export const EMOJI = { ASK: '\u{1F7E1}', ERR: '\u{1F534}', IDLE: '\u{26AA}', WAIT: '\u{1F7E2}' }
+
+// PARITY-START
+function buildPanel(enriched) {
+  const PRIORITY = { ASK: 0, ERR: 1, IDLE: 2, WAIT: 3 }
+  const EMOJI = { ASK: '\u{1F7E1}', ERR: '\u{1F534}', IDLE: '\u{26AA}', WAIT: '\u{1F7E2}' }
+
+  const rows = (enriched || []).filter(Boolean)
+  rows.sort((a, b) => (PRIORITY[a.row && a.row.kind] ?? 9) - (PRIORITY[b.row && b.row.kind] ?? 9))
+
+  const tmuxOf = (r) => {
+    const sess = (r.row && r.row.session) || {}
+    return sess.tmux_session || sess.workspace_name || 'unknown'
+  }
+
+  const banner = {
+    need: rows.length,
+    err: rows.filter((r) => r.row.kind === 'ERR').length,
+    ask: rows.filter((r) => r.row.kind === 'ASK').length,
+    idle: rows.filter((r) => r.row.kind === 'IDLE').length,
+    wait: rows.filter((r) => r.row.kind === 'WAIT').length,
+    top: rows[0] ? { session: tmuxOf(rows[0]), kind: rows[0].row.kind } : null,
+  }
+
+  const cards = rows.map((r) => {
+    const kind = r.row.kind
+    const ctx = r.row.context || {}
+    const en = r.enriched || {}
+    let line = en.line || ''
+    if (!line) {
+      if (kind === 'ASK') line = ctx.question || 'question'
+      else if (kind === 'ERR') line = ctx.pattern || 'error'
+      else if (kind === 'IDLE') line = 'idle ' + (ctx.idle_minutes ?? '?') + 'm'
+      else line = ctx.text || 'waiting'
+    }
+    return {
+      emoji: EMOJI[kind] || '•',
+      kind,
+      session: tmuxOf(r),
+      line,
+      enriched: en.suggestion || null,
+      options: kind === 'ASK' ? (ctx.options || []).map((o) => o.label) : undefined,
+    }
+  })
+
+  const asks = rows.map((r) => {
+    const kind = r.row.kind
+    const ctx = r.row.context || {}
+    const en = r.enriched || {}
+    const tmux = tmuxOf(r)
+    const route = { target: tmux, hint: r.row.route_hint || 'tmux' }
+    const header = tmux.slice(0, 12)
+    if (kind === 'ASK') {
+      return {
+        question: (ctx.header ? ctx.header + ': ' : '') + (ctx.question || 'needs input'),
+        header,
+        options: (ctx.options || []).map((o) => ({ label: o.label, description: o.description || '' })),
+        multiSelect: !!ctx.multi_select,
+        suggestion: en.suggestion || null,
+        route,
+      }
+    }
+    if (kind === 'ERR') {
+      return {
+        question: tmux + ' hit `' + (ctx.pattern || 'error') + '` — what now?',
+        header,
+        options: [
+          { label: 'Retry', description: 'send continue' },
+          { label: 'Skip', description: 'leave it' },
+          { label: 'Investigate', description: 'open the session' },
+        ],
+        multiSelect: false,
+        suggestion: en.suggestion || null,
+        route,
+      }
+    }
+    if (kind === 'IDLE') {
+      return {
+        question: tmux + ' idle ' + (ctx.idle_minutes ?? '?') + 'm — resume?',
+        header,
+        options: [
+          { label: 'Resume', description: 'send continue' },
+          { label: 'Close', description: 'leave idle' },
+        ],
+        multiSelect: false,
+        suggestion: en.suggestion || null,
+        route,
+      }
+    }
+    return {
+      question: tmux + ' says: ' + (ctx.text || 'waiting'),
+      header,
+      options: [{ label: 'Acknowledge', description: 'respond' }],
+      multiSelect: false,
+      suggestion: en.suggestion || null,
+      route,
+    }
+  })
+
+  return { banner, cards, asks }
+}
+// PARITY-END
+
+export { buildPanel }

--- a/plugins/ainb-fleet/workflows/hangar.logic.test.mjs
+++ b/plugins/ainb-fleet/workflows/hangar.logic.test.mjs
@@ -1,0 +1,137 @@
+// L1 — pure builder tests (GATE 1: shape + sort). Deterministic, no runtime.
+//   node --test hangar.logic.test.mjs
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildPanel, PRIORITY } from './hangar.logic.mjs'
+
+const ask = {
+  row: {
+    session: { id: 'a1', tmux_session: 'tmux_scratch-ask', workspace_name: 'scratch' },
+    kind: 'ASK',
+    context: {
+      header: 'Approve lineup',
+      question: 'approve bead shape?',
+      options: [
+        { label: 'Approve as-is', description: 'create all' },
+        { label: 'Skip B21', description: 'fewer beads' },
+        { label: 'Split schema', description: 'more atomic' },
+      ],
+      multi_select: false,
+    },
+    route_hint: 'broker',
+  },
+  enriched: { line: '24-bead epic ready; approve shape', suggestion: 'Approve as-is' },
+}
+const err = {
+  row: {
+    session: { tmux_session: 'tmux_scratch-err' },
+    kind: 'ERR',
+    context: { pattern: 'rate_limited' },
+    route_hint: 'tmux',
+  },
+  enriched: { line: '3rd 429 in 2m', suggestion: 'retry' },
+}
+const idle = {
+  row: {
+    session: { tmux_session: 'tmux_scratch-idle' },
+    kind: 'IDLE',
+    context: { idle_minutes: 17 },
+    route_hint: 'tmux',
+  },
+  enriched: { line: 'idle 17m, work complete', suggestion: 'close' },
+}
+const wait = {
+  row: {
+    session: { tmux_session: 'tmux_scratch-wait' },
+    kind: 'WAIT',
+    context: { marker: 'WAITING:', text: 'need a token' },
+    route_hint: 'broker',
+  },
+  enriched: { line: 'awaiting token', suggestion: '' },
+}
+
+test('3-mixed: banner counts correct', () => {
+  const { banner } = buildPanel([idle, ask, err])
+  assert.equal(banner.need, 3)
+  assert.equal(banner.ask, 1)
+  assert.equal(banner.err, 1)
+  assert.equal(banner.idle, 1)
+})
+
+test('3-mixed: priority sort ASK>ERR>IDLE', () => {
+  const { cards, banner } = buildPanel([idle, ask, err])
+  assert.equal(cards[0].kind, 'ASK')
+  assert.equal(cards[1].kind, 'ERR')
+  assert.equal(cards[2].kind, 'IDLE')
+  assert.equal(banner.top.kind, 'ASK')
+})
+
+test('full priority order ASK>ERR>IDLE>WAIT', () => {
+  const { cards } = buildPanel([wait, idle, err, ask])
+  assert.deepEqual(cards.map((c) => c.kind), ['ASK', 'ERR', 'IDLE', 'WAIT'])
+  assert.deepEqual(Object.values(PRIORITY), [0, 1, 2, 3])
+})
+
+test('ASK card carries emoji, line, enriched, options[]', () => {
+  const { cards } = buildPanel([ask])
+  assert.equal(cards[0].emoji, '\u{1F7E1}')
+  assert.equal(cards[0].enriched, 'Approve as-is')
+  assert.deepEqual(cards[0].options, ['Approve as-is', 'Skip B21', 'Split schema'])
+})
+
+test('non-ASK cards have no options key', () => {
+  const { cards } = buildPanel([err, idle])
+  assert.equal(cards[0].options, undefined)
+  assert.equal(cards[1].options, undefined)
+})
+
+test('card line falls back to context when enrich missing', () => {
+  const bare = { row: { session: { tmux_session: 't' }, kind: 'ERR', context: { pattern: 'overloaded' } }, enriched: null }
+  const { cards } = buildPanel([bare])
+  assert.equal(cards[0].line, 'overloaded')
+})
+
+test('ASK ask maps options 1:1 with label+description', () => {
+  const { asks } = buildPanel([ask])
+  assert.equal(asks[0].question, 'Approve lineup: approve bead shape?')
+  assert.equal(asks[0].options.length, 3)
+  assert.deepEqual(asks[0].options[0], { label: 'Approve as-is', description: 'create all' })
+  assert.equal(asks[0].route.target, 'tmux_scratch-ask')
+  assert.equal(asks[0].route.hint, 'broker')
+})
+
+test('ERR ask offers Retry/Skip/Investigate', () => {
+  const { asks } = buildPanel([err])
+  assert.deepEqual(asks[0].options.map((o) => o.label), ['Retry', 'Skip', 'Investigate'])
+})
+
+test('IDLE ask offers Resume/Close', () => {
+  const { asks } = buildPanel([idle])
+  assert.match(asks[0].question, /idle 17m/)
+  assert.deepEqual(asks[0].options.map((o) => o.label), ['Resume', 'Close'])
+})
+
+test('WAIT ask surfaces the marker text', () => {
+  const { asks } = buildPanel([wait])
+  assert.match(asks[0].question, /need a token/)
+})
+
+test('0-session: empty panel, banner.need=0, top=null', () => {
+  const { banner, cards, asks } = buildPanel([])
+  assert.equal(banner.need, 0)
+  assert.equal(banner.top, null)
+  assert.deepEqual(cards, [])
+  assert.deepEqual(asks, [])
+})
+
+test('null/garbage rows filtered out', () => {
+  const { banner } = buildPanel([null, ask, undefined, false])
+  assert.equal(banner.need, 1)
+})
+
+test('unknown kind sorts last, session falls back to workspace_name', () => {
+  const weird = { row: { session: { workspace_name: 'ws-only' }, kind: 'MYSTERY', context: {} }, enriched: null }
+  const { cards } = buildPanel([weird, ask])
+  assert.equal(cards[0].kind, 'ASK')
+  assert.equal(cards[1].session, 'ws-only')
+})

--- a/plugins/ainb-fleet/workflows/parity.test.mjs
+++ b/plugins/ainb-fleet/workflows/parity.test.mjs
@@ -1,0 +1,45 @@
+// L2 — parity guard. The SES sandbox can't import the lib, so hangar.js
+// inlines a verbatim copy of buildPanel. This asserts the two never drift.
+//   node --test parity.test.mjs
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+function extractParityBlock(path) {
+  const src = readFileSync(join(here, path), 'utf8')
+  const start = src.indexOf('// PARITY-START')
+  const end = src.indexOf('// PARITY-END')
+  assert.ok(start !== -1, `PARITY-START marker missing in ${path}`)
+  assert.ok(end !== -1, `PARITY-END marker missing in ${path}`)
+  assert.ok(end > start, `PARITY markers out of order in ${path}`)
+  return src
+    .slice(start + '// PARITY-START'.length, end)
+    .split('\n')
+    .map((l) => l.replace(/\s+$/, ''))
+    .join('\n')
+    .trim()
+}
+
+test('buildPanel is byte-identical in lib and workflow', () => {
+  const lib = extractParityBlock('hangar.logic.mjs')
+  const wf = extractParityBlock('hangar.js')
+  assert.equal(
+    wf,
+    lib,
+    'hangar.js inline buildPanel drifted from hangar.logic.mjs — re-sync the PARITY block in both files',
+  )
+})
+
+test('hangar starts with the required meta export', () => {
+  const wf = readFileSync(join(here, 'hangar.js'), 'utf8')
+  assert.match(wf.trimStart(), /^export const meta = \{/)
+})
+
+test('hangar.meta.name is "hangar"', () => {
+  const wf = readFileSync(join(here, 'hangar.js'), 'utf8')
+  assert.match(wf, /name:\s*'hangar'/)
+})


### PR DESCRIPTION
Lands the deterministic **hangar** workflow and the **fleet-needs** cockpit skill — the workflow-backed Jarvis control plane for an `ainb`-managed claude fleet. Builds on the fleet Rust verbs already merged via #169.

## What this adds

| File | Role |
|---|---|
| `workflows/hangar.js` | Multi-verb workflow (dispatches by `args.verb`): `needs` · `standup` · `sequence` |
| `workflows/hangar.logic.mjs` | Pure panel builder — node-tested source of truth |
| `workflows/hangar.logic.test.mjs` + `parity.test.mjs` | 16 tests: shape, sort, edges + drift guard (SES sandbox can't `import`, so the builder is inlined into the workflow + parity-checked) |
| `skills/fleet-needs/SKILL.md` | Session cockpit: invokes hangar(needs) → renders Jarvis HUD → AskUserQuestion → routes answers |
| `workflows/.gitignore` | keeps runtime `logs/` + local scratch out of git |

## Architecture (sensor-fusion hybrid)

- **Workflow = brain** (SES-sandboxed, deterministic): discover → enrich → prioritize → `{banner,cards,asks}`
- **Session = face**: HUD render + AskUserQuestion + answer routing (the irreducibly-interactive last mile the sandbox can't do)
- **Rust = hands**: `ainb fleet …` reads JSONL; tmux send-keys writes

## Read/write principle (codified)

Reads go through `ainb` (JSONL source of truth); writes go through tmux send-keys (ASK = key-route into the target picker, ERR/IDLE/WAIT = text-route), broker as fallback only — after empirically hitting the broker delivery gap.

## Verification

- 16/16 node tests green (logic + parity)
- live 17-session run: correct `{banner,cards,asks}` shape, ASK>ERR>IDLE>WAIT sort
- resume cache: 18 agents → 0 tokens / 3ms (engine `resumeFromRunId` working as documented)

Gated behind `CLAUDE_CODE_WORKFLOWS=1`; falls back to the prompt-driven `/ainb-fleet:needs` when the gate is off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fleet-needs workflow supporting three operational modes: needs assessment, standup reporting, and sequential multi-session command execution.
  * Includes dashboard rendering of prioritized session status with interactive prompts and response routing.

* **Tests**
  * Added comprehensive test coverage for workflow functionality and consistency verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->