### PR TITLE
feat(ainb-fleet): configurable hangar enrich model (default haiku)

### DIFF
--- a/plugins/ainb-fleet/workflows/hangar.js
+++ b/plugins/ainb-fleet/workflows/hangar.js
@@ -4,7 +4,7 @@ export const meta = {
   whenToUse: 'Invoked by the per-verb skills under ainb-fleet (fleet-needs / standup-rich / sequence). Args = {verb, ...opts}. Default verb = "needs" when omitted.',
   phases: [
     { title: 'Discover',   detail: 'ainb fleet <verb> --json (Rust does the JSONL read)' },
-    { title: 'Enrich',     detail: 'parallel Haiku per blocked session — needs verb only' },
+    { title: 'Enrich',     detail: 'parallel enrich per blocked session (model configurable, default haiku) — needs verb only' },
     { title: 'Prioritize', detail: 'sort + render-ready {banner,cards,asks} — needs verb only' },
     { title: 'Step',       detail: 'per-step send-then-ack — sequence verb only' },
   ],
@@ -36,7 +36,12 @@ throw new Error('hangar: unknown verb "' + verb + '" — valid: needs | standup 
 // ===========================================================================
 // VERB: needs — the Jarvis panel (former fleet-needs flow)
 // ===========================================================================
-async function runNeeds(_opts) {
+async function runNeeds(opts) {
+  // Enrich model is configurable via args.enrichModel; defaults to haiku
+  // (cheap — one agent per blocked session, can fan out wide). Pass e.g.
+  // {verb:'needs', enrichModel:'sonnet'} or 'opus' for richer suggestions.
+  const enrichModel = (opts && typeof opts.enrichModel === 'string' && opts.enrichModel.trim()) || 'haiku'
+
   phase('Discover')
 
   const DISCOVER_SCHEMA = {
@@ -66,6 +71,7 @@ async function runNeeds(_opts) {
   log('discovered ' + sessions.length + ' · ASK:' + (kCounts.ASK || 0) + ' ERR:' + (kCounts.ERR || 0) + ' IDLE:' + (kCounts.IDLE || 0) + ' WAIT:' + (kCounts.WAIT || 0))
 
   phase('Enrich')
+  log('enrich model: ' + enrichModel)
 
   const ENRICH_SCHEMA = {
     type: 'object',
@@ -114,7 +120,7 @@ async function runNeeds(_opts) {
           'Return `line`: one terse operator-facing summary (<=12 words) of what this session needs.\n' +
           'Return `suggestion`: for ASK, the single best option label verbatim from the options; ' +
           'for ERR, one of retry|skip|investigate; for IDLE, one of resume|close; otherwise empty string.',
-        { label: label, phase: 'Enrich', schema: ENRICH_SCHEMA },
+        { label: label, phase: 'Enrich', model: enrichModel, schema: ENRICH_SCHEMA },
       )
         .then((e) => { onDone(); return { row: s, enriched: e } })
         .catch(() => { onDone(); return { row: s, enriched: null } })


### PR DESCRIPTION
Enrich fans out one agent per blocked session. It was inheriting the session model (Opus) — measured ~766k tokens on a 14-session live run. This:

- Defaults `enrichModel` to **haiku** (cheap, fits the wide fan-out — the prior baseline)
- Makes it **configurable** per-run: `Workflow({name:'ainb-fleet:hangar', args:{verb:'needs', enrichModel:'sonnet'}})`
- Logs the chosen model in the `/workflows` monitor (`enrich model: haiku`)
- Updates the phase `detail` (was hardcoded "parallel Haiku")

Discover/Prioritize unaffected; parity block untouched. 16/16 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * The hangar workflow's enrich phase now supports configurable model selection, allowing users to specify their preferred model for enrichment processing instead of a fixed default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevengonsalvez/agents-in-a-box/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->