### PR TITLE
docs: full resync of READMEs + doc site to current code (v1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A Rust-based terminal application for managing AI coding sessions with git workt
 - **Usage analytics** — Built-in token + session tracking by day, week, provider, and project. Know where your budget went
 - **Easy onboarding** — First-run setup wizard checks dependencies, configures auth, and gets you creating sessions in minutes
 - **Live log streaming** — Real-time viewer with level filtering and search across all running sessions
-- **Scriptable CLI** — 15 commands with `--format json` output for every piece of state. **[📘 Full CLI reference →](docs/tui/cli.md)**
+- **Scriptable CLI** — 20 commands with `--format json` output for every piece of state. **[📘 Full CLI reference →](docs/tui/cli.md)**
 
 ### Feature Showcase
 
@@ -166,7 +166,7 @@ ainb config set authentication.default_model opus
 ainb completion zsh > ~/.zsh/completions/_ainb
 ```
 
-**15 top-level commands** — `run`, `list`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `presets`, `completion`, `tui` — with nested subcommands for recover / config / git / favorites / presets.
+**20 top-level commands** — `tui`, `run`, `list`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `presets`, `usage`, `claudecode`, `completion`, `plugin`, `fleet`, `help` — with nested subcommands for recover / config / git / favorites / presets / plugin / fleet.
 
 **[📘 Full CLI reference → docs/tui/cli.md](docs/tui/cli.md)**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 </p>
 
 <p align="center">
-  <code>115 Rust Modules</code> · <code>71 Skills</code> · <code>37 Agents</code> · <code>9 AI Tools</code> · <code>Knowledge Graph</code>
+  <code>115 Rust Modules</code> · <code>91 Skills</code> · <code>37 Agents</code> · <code>9 AI Tools</code> · <code>Knowledge Graph</code>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A terminal-native ecosystem for managing AI coding agents. Built around a Rust T
 | Component | What it does | Scale |
 |-----------|-------------|-------|
 | **[ainb TUI](#ainb--terminal-ui)** | Rust terminal app for managing Claude Code sessions | 115 modules |
-| **[Toolkit](#toolkit)** | Portable skills, agents, and workflows for AI coding tools | 71 skills, 37 agents |
+| **[Toolkit](#toolkit)** | Portable skills, agents, and workflows for AI coding tools | 91 skills, 37 agents |
 | **[Knowledge System](#knowledge-system)** | GraphRAG + QMD learning capture and retrieval | [Architecture docs](docs/knowledge/overview.md) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ node create-rule.js --tool=codex              # Deploy to ~/.codex/
 
 ## Links
 
+- [Website](https://stevengonsalvez.github.io/agents-in-a-box/)
 - [Releases](https://github.com/stevengonsalvez/agents-in-a-box/releases)
 - [Homebrew Tap](https://github.com/stevengonsalvez/homebrew-ainb)
 - [Issues](https://github.com/stevengonsalvez/agents-in-a-box/issues)

--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ agents-in-a-box/
 └── .github/workflows/
     ├── ci.yml                  #   Rust CI (fmt, clippy, test, deny, machete)
     ├── toolkit-validation.yml  #   Toolkit structure & install validation
-    └── release.yml             #   Cross-platform binary releases
+    ├── release.yml             #   Cross-platform binary releases
+    └── deploy-pages.yml        #   Build & deploy the website to GitHub Pages
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Skills are reusable capabilities that any supported AI tool can invoke.
 <details>
 <summary><b>Agent Architecture</b></summary>
 
-`skill-creator` · `agent-ops` · `autonomous-loops` · `cost-aware-pipeline` · `media-processing` · `nano-banana-pro` · `sync-learnings` · `claude-developer-platform`
+`skill-creator` · `agent-ops` · `autonomous-loops` · `cost-aware-pipeline` · `media-processing` · `nano-banana-pro` · `sync-learnings`
 </details>
 
 ### Agents (37)

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ agents-in-a-box/
 │
 ├── toolkit/                    # Portable AI agent toolkit (internal agent infrastructure)
 │   ├── packages/
-│   │   ├── skills/             #   71 reusable skills
+│   │   ├── skills/             #   91 reusable skills
 │   │   ├── agents/             #   37 agent definitions
 │   │   │   ├── universal/      #     Cross-stack specialists
 │   │   │   ├── engineering/    #     Backend & infra agents

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ A portable AI coding agent toolkit: skills, agents, workflows, and configuration
 | **Roo** | Project root | Project directory |
 | **Clawdhub** | Project root | Project directory |
 
-### Skills (71)
+### Skills (91)
 
 Skills are reusable capabilities that any supported AI tool can invoke.
 

--- a/README.md
+++ b/README.md
@@ -383,18 +383,19 @@ The `/reflect` skill captures learnings. The `/research` and `/prime` skills ret
 ```
 agents-in-a-box/
 │
-├── ainb-tui/                   # Rust TUI application
-│   ├── src/                    # 115 modules
-│   │   ├── app/                #   State machine & event handling
-│   │   ├── components/         #   TUI screen components
-│   │   ├── widgets/            #   Reusable UI widgets
-│   │   ├── docker/             #   Container management
-│   │   ├── tmux/               #   Session & PTY integration
-│   │   ├── git/                #   Worktree operations
-│   │   ├── claude/             #   Claude API client
-│   │   ├── models/             #   Data models
-│   │   └── config/             #   Configuration handling
-│   ├── Formula/                #   Homebrew formula
+├── ainb-tui/                   # Rust Cargo workspace
+│   ├── crates/
+│   │   ├── ainb-core/          #   TUI application (app, components, tmux, git, claude, config)
+│   │   ├── ainb-plugin-runtime/        #   Plugin host runtime
+│   │   ├── ainb-plugin-protocol/       #   Plugin JSON-RPC protocol
+│   │   ├── ainb-plugin-sdk-rust/       #   Rust plugin SDK
+│   │   ├── ainb-plugin-types-sessions/ #   Shared session types
+│   │   ├── ainb-plugin-burndown/       #   v2 analytics plugin
+│   │   ├── ainb-plugin-notifyd/        #   v2 notifications plugin
+│   │   ├── ainb-plugin-session-reader/ #   v2 data-backend plugin
+│   │   ├── ainb-plugin-cts-v2/         #   Conformance test suite (14 axes)
+│   │   └── ainb-plugin-testkit/        #   Plugin author test harness
+│   ├── config/                 #   Homebrew formula & packaging
 │   └── install.sh              #   One-liner installer
 │
 ├── reflect-kb/                 # Python library — `reflect` CLI + GraphRAG/QMD engine

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ node create-rule.js --tool=codex              # Deploy to ~/.codex/
 
 - [Website](https://stevengonsalvez.github.io/agents-in-a-box/)
 - [Releases](https://github.com/stevengonsalvez/agents-in-a-box/releases)
-- [Homebrew Tap](https://github.com/stevengonsalvez/homebrew-ainb)
+- [Homebrew Tap](https://github.com/stevengonsalvez/homebrew-agents-in-a-box)
 - [Issues](https://github.com/stevengonsalvez/agents-in-a-box/issues)
 - [Knowledge System Architecture](docs/knowledge/overview.md)
 - [Toolkit Documentation](toolkit/README.md)

--- a/README.md
+++ b/README.md
@@ -404,7 +404,9 @@ agents-in-a-box/
 │   └── pyproject.toml          #   Workspace member
 │
 ├── plugins/                    # Claude Code plugins (root-level, sibling to reflect-kb/)
-│   └── reflect/                #   `reflect@agents-in-a-box` plugin — skills, hooks, adapters
+│   ├── reflect/                #   `reflect@agents-in-a-box` plugin — skills, hooks, adapters
+│   ├── ainb-fleet/             #   Backs the `ainb fleet` CLI (standup/broadcast/sequence/needs/daemon)
+│   └── ainb-hooks/             #   ainb lifecycle hooks
 │
 ├── toolkit/                    # Portable AI agent toolkit (internal agent infrastructure)
 │   ├── packages/

--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -28,39 +28,40 @@ just fix                       # Auto-fix formatting & lint
 ## Architecture
 
 ```
-src/
-├── main.rs              # Entry point, CLI parsing, TUI loop
-├── lib.rs               # Public API exports
-├── app/                 # Application state & event handling
-│   ├── state.rs         # App state machine
-│   ├── events.rs        # Event definitions
-│   └── attach_handler.rs
-├── components/          # TUI screen components
-│   ├── layout.rs        # Main layout orchestration
-│   ├── session_list.rs  # Session list view
-│   ├── git_view.rs      # Git operations panel
-│   ├── logs_viewer.rs   # Log streaming view
-│   └── ...
-├── widgets/             # Reusable UI widgets
-│   ├── message_router.rs
-│   ├── syntax_highlighter.rs
-│   └── ...
-├── docker/              # Container management
-│   ├── container_manager.rs
-│   ├── session_lifecycle.rs
-│   └── agents_dev.rs
-├── tmux/                # Tmux/PTY integration
-│   ├── session.rs
-│   ├── capture.rs
-│   └── pty_wrapper.rs
-├── git/                 # Git operations
-│   ├── repository.rs
-│   ├── operations.rs
-│   └── worktree_manager.rs
-├── claude/              # Claude API client
-├── models/              # Data models
-├── config/              # Configuration handling
-└── agent_parsers/       # Parse agent output
+ainb-tui/                       # Cargo workspace root
+├── Cargo.toml                  # [workspace] members + default-members = ainb-core
+├── xtask/                      # Workspace task runner crate
+└── crates/
+    ├── ainb-core/              # The TUI + CLI binary (default build target)
+    │   └── src/
+    │       ├── main.rs         # Entry point, clap CLI, TUI loop
+    │       ├── lib.rs          # Public API exports
+    │       ├── app/            # Application state & event handling
+    │       │   ├── state.rs        # App state machine
+    │       │   ├── events.rs       # Event definitions
+    │       │   └── attach_handler.rs
+    │       ├── cli/            # CLI subcommands (run, list, fleet/, plugin/, ...)
+    │       ├── components/     # TUI screen components (layout.rs, session_list.rs, ...)
+    │       ├── widgets/        # Reusable UI widgets (message_router.rs, ...)
+    │       ├── fleet/          # `ainb fleet` discover/read/send internals
+    │       ├── docker/         # Container management
+    │       ├── tmux/           # Tmux/PTY integration
+    │       ├── git/            # Git operations
+    │       ├── claude/         # Claude API client
+    │       ├── providers/      # Agent provider integrations
+    │       ├── plugins.rs      # Plugin host
+    │       ├── models/         # Data models
+    │       ├── config/         # Configuration handling
+    │       └── agent_parsers/  # Parse agent output
+    ├── ainb-plugin-protocol/   # v2 plugin JSON-RPC protocol types
+    ├── ainb-plugin-runtime/    # Plugin host runtime
+    ├── ainb-plugin-sdk-rust/   # Rust SDK for plugin authors
+    ├── ainb-plugin-types-sessions/ # Shared session types
+    ├── ainb-plugin-burndown/   # In-tree v2 plugin: usage analytics
+    ├── ainb-plugin-notifyd/    # In-tree v2 plugin: notifications
+    ├── ainb-plugin-session-reader/ # In-tree v2 plugin: data backend
+    ├── ainb-plugin-cts-v2/     # Conformance test suite (14 axes)
+    └── ainb-plugin-testkit/    # Plugin test harness for authors
 ```
 
 ## TUI Style Guide

--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -105,16 +105,16 @@ const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
 
 ### Adding a New Component
 
-1. Create `src/components/my_component.rs`
+1. Create `crates/ainb-core/src/components/my_component.rs`
 2. Add state struct + render impl following template in skill
-3. Add to `src/components/mod.rs`
-4. Add events to `src/app/events.rs`
-5. Wire into `src/components/layout.rs`
+3. Add to `crates/ainb-core/src/components/mod.rs`
+4. Add events to `crates/ainb-core/src/app/events.rs`
+5. Wire into `crates/ainb-core/src/components/layout.rs`
 
 ### Adding a New Widget
 
-1. Create `src/widgets/my_widget.rs`
-2. Add to `src/widgets/mod.rs`
+1. Create `crates/ainb-core/src/widgets/my_widget.rs`
+2. Add to `crates/ainb-core/src/widgets/mod.rs`
 3. Use in components via `message_router.rs`
 
 ## Testing

--- a/ainb-tui/README.md
+++ b/ainb-tui/README.md
@@ -33,3 +33,17 @@ ainb usage yield --period week
 ```
 
 AINB reads `~/.claude/projects/**/*.jsonl` and `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` or `$CODEX_HOME/sessions/...`. Parsing is read-only. Cost values are estimates; unknown model prices are omitted while tokens/calls remain visible.
+
+## Fleet Orchestration
+
+`ainb fleet` drives every Claude session on the host. Subcommands:
+
+```bash
+ainb fleet standup      # live fleet status across ainb + peers + background jobs
+ainb fleet broadcast    # send one prompt to selected sessions (peers-first, tmux fallback)
+ainb fleet sequence     # ordered prompts with an ack between steps
+ainb fleet needs        # sessions blocked on input / errors / idle / waiting
+ainb fleet daemon       # watcher that registers as a peer and auto-continues API errors
+```
+
+Add `--format json` to any subcommand for machine-readable output. The in-tree `plugins/ainb-fleet/` package backs this command family.

--- a/ainb-tui/README.md
+++ b/ainb-tui/README.md
@@ -1,6 +1,19 @@
 # AINB TUI
 
-Terminal UI and CLI for Agents-in-a-Box.
+Terminal UI and CLI for Agents-in-a-Box (`ainb`). Built in Rust (ratatui) as a Cargo workspace under `crates/`; the TUI and `ainb` binary live in `crates/ainb-core`.
+
+## Overview
+
+Run `ainb` (or `ainb tui`) for the interactive terminal UI, or use one of the CLI subcommands for scripted workflows: `run`, `list`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `presets`, `usage`, `plugin`, and `fleet`. See `ainb --help` for the full list.
+
+Build and run from the workspace root:
+
+```bash
+cargo build --release   # build the ainb binary
+cargo run               # launch the TUI
+```
+
+Developer setup and architecture live in CLAUDE.md.
 
 ## Usage Analytics
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,8 +96,9 @@ The pre-restructure layout had docs scattered across three places. Here's the ma
 | `docs/plugins/changelog.md` | `docs/plugin-spec/CHANGELOG.md` |
 | `docs/knowledge/overview.md` | `docs/how-reflection-works.md` |
 
-Until the migration is approved, those legacy paths remain authoritative. Files
-in this new tree marked "stub — pulls from \<legacy path\>" are placeholders.
+The migration is complete: every page in this tree is now authoritative and the
+legacy paths have been removed. The table above is retained only to document
+provenance.
 
 ---
 

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -4,17 +4,38 @@ title: "CI / CD"
 
 # CI / CD
 
-> **Status:** stub. Authoritative content currently lives at `.github/workflows/*.yml + main README §CI/CD`.
-> Migration of that file into this path is gated on Stevie's approval.
+Four GitHub Actions workflows live under `.github/workflows/`. Each is path-filtered so it only runs when the area it covers changes.
 
-What runs on every push, every PR, every tag.
+## `ci.yml` — Rust CI
 
-## What this page will contain
+Runs on push and PR to `main` / `v2` when `ainb-tui/**`, `plugins/ainb-hooks/**`, `Cargo.*`, or the workflow itself changes. Jobs:
 
-- Rust CI (fmt, clippy pedantic+nursery, nextest on Ubuntu+macOS, deny, machete)
-- Toolkit validation workflow
-- Release workflow (cross-platform binaries)
-- Homebrew tap auto-update on tagged release
+- **Rustfmt** — `cargo fmt --all --check` (Ubuntu).
+- **Test** — `cargo nextest run --lib --all-features --no-fail-fast` on a `ubuntu-latest` + `macos-latest` matrix, skipping a small set of environment-dependent tests (`docker::`, a Claude provider-install test, and an inclusive-range usage test).
+- **ainb-hooks** — daemon + plugin integration on both OSes: parses `plugins/ainb-hooks/hooks/notify.sh`, runs `ainb-plugin-notifyd` lib tests and the `end_to_end` (hook → socket → SQLite) test, plus the `tripwire_inbox_opens_and_renders` tripwire against the `ainb` binary. Installs `tmux` + `jq` on the Linux runner.
+- **Cargo Machete** — `bnjbvr/cargo-machete` unused-dependency scan against `ainb-tui/Cargo.toml`.
+
+## `release.yml` — tagged release + Homebrew tap
+
+Manual `workflow_dispatch` (inputs: `version`, `prerelease`). Jobs run in sequence:
+
+- **Prepare Release** — validates the semver `version`, generates changelog notes from conventional commits, bumps `ainb-tui/Cargo.toml`, updates `CHANGELOG.md`, commits, and creates + pushes the `v<version>` tag.
+- **Build** — cross-platform release binaries on a matrix of `aarch64-apple-darwin` (macOS) and `x86_64-unknown-linux-gnu` (Linux), packaged as `.tar.gz` + `.sha256`.
+- **Create Release** — `softprops/action-gh-release` publishes a GitHub Release with the artifacts and install instructions.
+- **Update Homebrew Tap** — regenerates `Formula/ainb.rb` in `stevengonsalvez/homebrew-agents-in-a-box` with the new version and per-platform SHA256s, then commits and pushes.
+
+## `toolkit-validation.yml` — toolkit structure + install checks
+
+Runs on push and PR touching `toolkit/**`. Jobs:
+
+- **Validate Packages Structure** — asserts `packages/{agents,skills,workflows,utilities}` exist and enforces minimum counts (agents ≥ 30, skills ≥ 60).
+- **Test Tool Installations** — runs `bootstrap.js` into a fake `$HOME` for a `claude-code-4.5` / `codex` / `gemini` matrix, asserting the install dir, a minimum file count (≥ 100), a `skills/` dir, and an `agents/` dir for `claude-code-4.5`.
+- **Check Template Substitution** — installs `claude-code-4.5` and greps for unsubstituted `{{TOOL_DIR}}` / `{{HOME_TOOL_DIR}}` placeholders.
+- **Verify claude-code-4.5 is thin layer** — asserts `toolkit/claude-code-4.5` carries only the thin-layer files (no `agents`/`commands`/`skills`/etc. dirs).
+
+## `deploy-pages.yml` — docs site to GitHub Pages
+
+Runs on push to `main` touching `website/site/**`, `docs/**`, or the workflow itself (also `workflow_dispatch`). Builds the Astro + Starlight site under `website/site` with Node 22 and `npm ci` + `npm run build`, then deploys to GitHub Pages (`https://stevengonsalvez.github.io/agents-in-a-box/`). Uses a `pages` concurrency group so an in-flight deploy finishes while queued runs are cancelled.
 
 ## See also
 

--- a/docs/knowledge/reflect-cli.md
+++ b/docs/knowledge/reflect-cli.md
@@ -4,21 +4,67 @@ title: "`reflect` CLI reference"
 
 # `reflect` CLI reference
 
-> **Status:** stub. Authoritative content currently lives at `reflect-kb/README.md + reflect-kb/cli source`.
-> Migration of that file into this path is gated on Stevie's approval.
+The `reflect` command is the command-line interface to the agents-in-a-box knowledge base. It is shipped by the Python package **`reflect-kb`** (source: [`reflect-kb/`](https://github.com/stevengonsalvez/agents-in-a-box/tree/main/reflect-kb)) and provides the **capture → index → recall** loop: `reflect add` captures a learning, `reflect reindex` rebuilds the GraphRAG + vector index, and `reflect search` recalls the most relevant prior learnings.
 
-Command-line interface to the knowledge base.
+## Two version streams
 
-## What this page will contain
+There are **two** independent versions and they are easy to confuse:
 
-- Install (`uv tool install`)
-- `reflect add` — capture a learning
-- `reflect search` — query the KB
-- `reflect ingest` — bulk-index from memory dirs
-- `reflect visualize` — interactive HTML graph
-- `reflect status` — KB health
-- Configuration (`reflect.toml`, `.reflect.toml`)
+| Component | Package / manifest | Version | Source of truth |
+|---|---|---|---|
+| `reflect` **CLI** | Python package `reflect-kb` | `0.1.1` | [`reflect-kb/pyproject.toml`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/reflect-kb/pyproject.toml) |
+| `reflect` **plugin** (Claude Code wiring) | [`plugins/reflect/`](https://github.com/stevengonsalvez/agents-in-a-box/tree/main/plugins/reflect) | `3.6.0` | [`plugins/reflect/.claude-plugin/plugin.json`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/plugins/reflect/.claude-plugin/plugin.json) |
+
+`reflect --version` reports the CLI version (`0.1.x`). The plugin version describes the harness wiring (hooks, skills, adapters) and is documented separately in the plugin architecture docs.
+
+## Install
+
+Recommended — `uv tool install` with the `[graph]` extra (pulls the full GraphRAG + vector stack):
+
+```bash
+uv tool install --upgrade 'git+https://github.com/stevengonsalvez/agents-in-a-box.git#subdirectory=reflect-kb[graph]'
+```
+
+Verify the install:
+
+```bash
+reflect --version   # prints 0.1.x
+```
+
+> The `[graph]` extra will not resolve cleanly with plain `pip` on Python >= 3.11 because `nano-graphrag` pulls `graspologic -> hyppo -> numba -> llvmlite` (Python < 3.10 only). Use the `uv`/`pipx` `--no-deps` flow documented in [`reflect-kb/README.md`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/reflect-kb/README.md).
+
+## Subcommands
+
+| Command | What it does |
+|---|---|
+| `reflect init` | Initialise the KB at `~/.claude/global-learnings/`. |
+| `reflect add <file>` | Add a learning document. `--entities <file>` attaches an entity sidecar; `--force` overwrites non-interactively (required in subprocess / non-TTY contexts). |
+| `reflect search <query>` | Hybrid GraphRAG + vector search over the KB. Flags: `--mode`, `--tags/-t`, `--category/-c`, `--limit/-l`. |
+| `reflect reindex` | Rebuild the full graph index from all documents. `--force` clears the cache and rebuilds from scratch. |
+| `reflect stats` | Show KB metrics (document count, entities, relationships, confidence). |
+| `reflect critical-patterns` | Surface high-confidence, widely-applicable patterns. Filter with `--language/-l`, `--domain/-d`. |
+| `reflect generate-sidecars` | Backfill missing `.entities.yaml` sidecars heuristically (no LLM). `--force` regenerates all. |
+| `reflect metrics stats` | Aggregate the recall-metrics JSONL log (total events, hit rate, p50/p95 latency, top tags). Supports `--format json` and `--window-days`. |
+| `reflect timeline --explain <ROW>` | Drill down on a statusline dashboard row (`REC`, `MEM`, `ING`, `DRN`, `TOK`, `ERR`, `COM`, `AGT`, or `all`). Shells out to the reflect plugin's helper. |
+
+The Python `console_scripts` entry point is `reflect = reflect_kb.cli.main:main` ([`pyproject.toml`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/reflect-kb/pyproject.toml)).
+
+## Quick start
+
+```bash
+reflect init                                              # one time per machine
+reflect add ./my-solution.md --entities ./my-solution.entities.yaml
+reflect search "how did we fix the tokio runtime panic"
+reflect stats
+reflect timeline --explain TOK
+```
+
+## Content directory
+
+The CLI is the data layer; it knows nothing about Claude Code. Knowledge content lives in a separate directory at `~/.claude/global-learnings/` (override with `$GLOBAL_LEARNINGS_PATH`), holding `documents/*.md`, `documents/*.entities.yaml` sidecars, the gitignored `nano_graphrag_cache/` index, and the rotated `metrics.jsonl` telemetry log.
 
 ## See also
 
+- [Knowledge base overview](./overview.md)
+- [`reflect-kb/README.md`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/reflect-kb/README.md)
 - [Docs hub](../README.md)

--- a/docs/knowledge/reflect-cli.md
+++ b/docs/knowledge/reflect-cli.md
@@ -63,6 +63,33 @@ reflect timeline --explain TOK
 
 The CLI is the data layer; it knows nothing about Claude Code. Knowledge content lives in a separate directory at `~/.claude/global-learnings/` (override with `$GLOBAL_LEARNINGS_PATH`), holding `documents/*.md`, `documents/*.entities.yaml` sidecars, the gitignored `nano_graphrag_cache/` index, and the rotated `metrics.jsonl` telemetry log.
 
+## Plugin: skills, adapters and hooks
+
+The `reflect` plugin (version `3.6.0`) wires the CLI into the agent harness. It ships:
+
+**Six colon-namespaced skills** ([`plugins/reflect/skills/`](https://github.com/stevengonsalvez/agents-in-a-box/tree/main/plugins/reflect/skills)):
+
+| Skill | Purpose |
+|---|---|
+| `reflect:reflect` | Full conversation scan for self-improvement; classifies corrections + knowledge signals. |
+| `reflect:recall` | Retrieve relevant prior learnings (hybrid vector + graph search). |
+| `reflect:ingest` | Global knowledge indexer; harvests memory sources across all tools into the KB. |
+| `reflect:consolidate` | Project-level memory consolidation; merges orphaned worktree memory dirs. |
+| `reflect:reflect-status` | Read-only views into reflect system state; can approve/reject pending items. |
+| `reflect:errors-ack` | Acknowledge captured error signals. |
+
+**Cross-harness adapters** ([`plugins/reflect/adapters/`](https://github.com/stevengonsalvez/agents-in-a-box/tree/main/plugins/reflect/adapters)): a shared `base.py` plus per-harness adapters under `claude/`, `codex/`, and `copilot/`.
+
+**Five lifecycle hooks** (declared in [`plugin.json`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/plugins/reflect/.claude-plugin/plugin.json)):
+
+| Hook | Action |
+|---|---|
+| `SessionStart` | Runs `recall` and kicks off the background ingest drainer. |
+| `UserPromptSubmit` | Runs `recall` against the prompt. |
+| `PostToolUse` | Arms low-cost mini-learning capture. |
+| `Stop` | Enqueues short-session reflection. |
+| `PreCompact` | Runs `precompact_reflect.py --auto --verbose` — **auto-installed**, so reflection fires before context compaction without manual setup. |
+
 ## See also
 
 - [Knowledge base overview](./overview.md)

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -19,7 +19,7 @@ What the rest of this directory documents.
 - **Runtime:** the `ainb` TUI spawns each plugin as a native child process and talks JSON-RPC 2.0 over framed stdio
 - **What they can do:** own a TUI screen, claim a CLI subcommand tree, publish/subscribe to snapshot topics, paint statusline segments
 - **Capability model:** deny-by-default; manifest declares grants for filesystem, network, subprocess, event bus
-- **Reference plugins:** `burndown` (analytics) + `session-reader` (data backend) — both ship in-tree
+- **Reference plugins:** `burndown` (analytics), `notifyd` (notifications), and `session-reader` (data backend) — all ship in-tree
 
 If you want to **add a screen / CLI / dashboard to the TUI**, you want this kind of plugin. Continue to:
 - [overview.md](overview.md) — what a v2 plugin is, conceptually

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -25,9 +25,10 @@ Plugins only see the host capabilities they declare in their manifest, and they 
 
 ## Reference plugins
 
-Two plugins ship in-tree as the canonical examples:
+Three plugins ship in-tree as the canonical examples:
 
 - **`burndown`** — owns the Analytics screen and the `ainb usage` CLI subcommand tree. Full screen-owner reference.
+- **`notifyd`** — owns the Inbox screen and runs a notification daemon that captures Claude Code and Codex hook events into SQLite (binary `ainb-notifyd`; also installs/uninstalls the `ainb-hooks` agent hooks). Reference for an event-capturing, screen-owning plugin.
 - **`session-reader`** — pure publisher. Scans `~/.claude/projects/**` and `~/.codex/sessions/**` and chunked-publishes usage snapshots on the `sessions.usage_data` topic for `burndown` to render. Canonical publisher example.
 
 <p align="center">
@@ -44,6 +45,9 @@ The host discovers plugins from a flat staging directory:
 dist/plugins/
 ├── burndown/
 │   ├── burndown            (native executable, ad-hoc signed on macOS)
+│   └── manifest.toml
+├── notifyd/
+│   ├── ainb-notifyd
 │   └── manifest.toml
 └── session-reader/
     ├── session-reader

--- a/docs/plugins/spec-v2.md
+++ b/docs/plugins/spec-v2.md
@@ -295,6 +295,8 @@ Denied capability → `RpcError { code: -32001, message: "capability denied: <ca
 
 Plugins MUST pass every axis their manifest's capability + provides surface implies. Axes for surface a plugin doesn't expose are skipped.
 
+> **Author tooling.** Two crates back this: `ainb-plugin-cts-v2` is the subprocess conformance runner described above (canary plugins + host-side `tests/axes.rs`), and `ainb-plugin-testkit` is an in-process harness that drives a `Plugin` trait impl over a `tokio::io::DuplexStream` pair — exercising the full JSON-RPC + Content-Length framing path without spawning a subprocess or staging a binary on disk. Use `testkit` for fast unit-style assertions while authoring; use `cts-v2` for the authoritative per-axis pass/fail gate.
+
 ## 11. Stability promise
 
 The host MUST NOT introduce a breaking change to any signature in this document inside the v2 series. Permitted additive changes that stay in v2:

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -40,7 +40,7 @@ Every TUI operation is also a CLI subcommand. `--format json` on every command. 
 
 ### A portable toolkit that follows you across tools
 
-86 skills (plan, implement, validate, reflect, swarm-create, …) and 37 specialised agents (backend-developer, code-reviewer, security-agent, …). Write them once; deploy to Claude Code, Codex, Copilot, Gemini, Amazon Q, Cursor, Cline, Roo, Hermes, nanoclaw, Clawdhub. One source, nine targets.
+86 skills (plan, implement, validate, reflect, swarm-create, …) and 37 specialised agents (backend-developer, code-reviewer, security-agent, …). Write them once; deploy to Claude Code, Codex, Copilot, Gemini, Amazon Q, Cursor, Cline, Roo, Hermes, nanoclaw, Clawdhub. One source, 11 targets.
 
 ### A plugin system you can actually use
 

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -56,7 +56,7 @@ Add a TUI screen, a CLI subcommand, a statusline segment without forking the hos
 
 - **One install command.** `brew install ainb` (macOS, Linux). One-liner `install.sh` for everything else.
 - **No subscription.** MIT-licensed. No accounts, no metering.
-- **No vendor lock-in.** Toolkit deploys to nine AI tools; the TUI orchestrates four providers. You can swap out any layer.
+- **No vendor lock-in.** Toolkit deploys to 11 AI tools; the TUI orchestrates four providers. You can swap out any layer.
 - **No cloud dependency.** Everything runs locally. The only network traffic is what your AI provider (Claude, Codex, etc.) makes on your behalf.
 
 ---

--- a/docs/product/what-is-ainb.md
+++ b/docs/product/what-is-ainb.md
@@ -9,7 +9,7 @@ A terminal-native ecosystem for managing AI coding agents. Three components shar
 | # | Component | What it is |
 |---|---|---|
 | 1 | **`ainb` TUI + CLI** | Rust terminal app for spawning and supervising AI coding sessions. Each session gets its own git worktree and tmux session. Multi-provider: Claude Code, Codex, Gemini, Copilot, Kiro, raw shell, SSH. |
-| 2 | **Toolkit** | Portable skills + agents + workflows that deploy to 9 different AI coding tools from a single source. 86 skills, 37 agents. |
+| 2 | **Toolkit** | Portable skills + agents + workflows that deploy to 11 different AI coding tools from a single source. 86 skills, 37 agents. |
 | 3 | **Plugins (v2 ABI)** | Native-binary plugins for the TUI host. Capability-gated, JSON-RPC over stdio. Own screens, CLIs, statusline segments. Two reference plugins ship in-tree (`burndown`, `session-reader`). |
 | 4 | **`reflect-kb`** | Knowledge capture and retrieval library. Two-tier: QMD for fast vector search + nano-graphrag for cross-project entity-relation queries. Installed as the `reflect` CLI. |
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -28,6 +28,16 @@ Definitions for the terms that recur across the agents-in-a-box docs. Where a te
 
 **Workflow** — a multi-phase orchestration that chains skills (plan → implement → validate) under a structured delivery process.
 
+## Knowledge base
+
+**QMD** — the vector / semantic search engine of the knowledge base; answers "what matches?" via embedding similarity (BM25 + vector hybrid).
+
+**GraphRAG** — the graph search engine; answers "what's connected?" by traversing the entity-relationship graph. Built with `nano-graphrag` using a passthrough LLM that consumes pre-extracted entity sidecars (no external LLM calls during indexing).
+
+**Sidecar** — an `.entities.yaml` file sitting next to a knowledge document (`doc.md` + `doc.entities.yaml`). It carries the pre-extracted entities and relationships that feed GraphRAG indexing directly.
+
+**Community report** — a GraphRAG-generated summary of a cluster (community) of related entities, used to answer higher-level questions about a connected region of the graph.
+
 ## See also
 
 - [Architecture](./architecture.md)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -4,20 +4,33 @@ title: "Glossary"
 
 # Glossary
 
-> **Status:** stub. Authoritative content currently lives at `new — synthesises across the codebase`.
-> Migration of that file into this path is gated on Stevie's approval.
+Definitions for the terms that recur across the agents-in-a-box docs. Where a term has a precise contract, the authoritative source is linked.
 
-Definitions for every term that shows up across the docs.
+## Agents, sessions, worktrees
 
-## What this page will contain
+**Agent** — an AI coding harness instance (Claude Code, Codex CLI, GitHub Copilot, Gemini). agents-in-a-box is harness-agnostic: skills, agents, and plugins are deployed to each harness's config directory.
 
-- agent / session / worktree
-- plugin (v2 subprocess) vs Claude Code plugin
-- skill / agent / workflow (toolkit)
-- QMD / GraphRAG / sidecar / community report
-- tmux / PTY / pane / window
-- ABI / wire version / CTS / canary
+**Session** — a single conversation/run of an agent against a project. The TUI lists, attaches to, and recovers sessions; session logs are walked per-provider by the `session-reader` plugin.
+
+**Worktree** — a git worktree giving a task its own isolated checkout and branch (architecture: worktree-per-task). Lets multiple agents work in parallel without colliding on the same working tree.
+
+## Plugins
+
+**Plugin (v2, subprocess)** — an ainb plugin that conforms to the [v2 contract](../plugins/spec-v2.md): a native executable spawned by the host as a child process, exchanging **JSON-RPC 2.0** over framed stdio (stdin = requests from host, stdout = responses + reverse-calls, stderr = host log output). Governed by capability grants in its manifest.
+
+**Claude Code plugin** — a *different* concept: a Claude Code harness extension (e.g. the `reflect` plugin) that bundles skills, hooks, and adapters and is installed with `claude plugin install`. It does not implement the ainb v2 subprocess contract; the two senses of "plugin" are unrelated.
+
+## Toolkit units
+
+**Skill** — a structured workflow invoked by slash command (e.g. `/commit`, `/plan`), shared across harnesses from `toolkit/packages/skills/`.
+
+**Agent (toolkit)** — a specialised sub-agent definition (e.g. `code-reviewer`, `distinguished-engineer`) from `toolkit/packages/agents/`, delegated to for focused work.
+
+**Workflow** — a multi-phase orchestration that chains skills (plan → implement → validate) under a structured delivery process.
 
 ## See also
 
+- [Architecture](./architecture.md)
+- [Plugin contract — v2](../plugins/spec-v2.md)
+- [Knowledge base overview](../knowledge/overview.md)
 - [Docs hub](../README.md)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -38,6 +38,16 @@ Definitions for the terms that recur across the agents-in-a-box docs. Where a te
 
 **Community report** — a GraphRAG-generated summary of a cluster (community) of related entities, used to answer higher-level questions about a connected region of the graph.
 
+## Terminal & tmux
+
+**tmux** — terminal multiplexer used to run persistent, detachable agent and dev-server sessions. Sessions survive disconnects and are reattached with `tmux attach -t <session>`.
+
+**PTY** — pseudo-terminal; the kernel device pair that lets the TUI and tmux drive a child process as if it had a real terminal (handles resize, raw input, ANSI output).
+
+**Pane** — a single rectangular split inside a tmux window running one shell/process.
+
+**Window** — a full-screen tab within a tmux session; a window contains one or more panes.
+
 ## See also
 
 - [Architecture](./architecture.md)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -48,6 +48,22 @@ Definitions for the terms that recur across the agents-in-a-box docs. Where a te
 
 **Window** — a full-screen tab within a tmux session; a window contains one or more panes.
 
+## Plugin contract & runtime
+
+**ABI** — Application Binary Interface; the host/plugin runtime contract version. A v2 plugin declares `abi_version = 2` in its manifest and must match the host's `ABI_VERSION` (currently `2`). See [spec-v2 §5.4](../plugins/spec-v2.md).
+
+**Wire version** — the schema version of a snapshot/event type. Plugin types crates (e.g. `ainb-plugin-types-sessions`) carry a `pub const WIRE_VERSION: u32` (currently `3`); subscribers must check `event.version == WIRE_VERSION` and reject mismatches gracefully rather than panicking.
+
+**CTS (Conformance Test Suite)** — the executable form of the plugin spec. `ainb-plugin-cts-v2` covers **14 axes** (manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot pub/sub, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, chunked publish ordering). A plugin author runs it via `cargo test` for a per-axis pass/fail report.
+
+**Canary** — a minimal plugin written to exercise exactly one CTS axis, living at `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/`.
+
+**`cts-v2`** — the `ainb-plugin-cts-v2` crate: the host-side conformance test runner (14 axes) plus its canary plugins.
+
+**`testkit`** — the `ainb-plugin-testkit` crate: an in-process test harness for plugin authors. A plugin author hands their `Plugin` impl to testkit to exercise it without spawning a real subprocess.
+
+**`notifyd`** — the `ainb-plugin-notifyd` crate: the ainb-owned notification daemon. Listens on a Unix domain socket at `~/.agents-in-a-box/notify.sock` and is one of the in-tree v2 reference plugins (alongside `burndown` for analytics and `session-reader` for the session data backend).
+
 ## See also
 
 - [Architecture](./architecture.md)

--- a/docs/toolkit/agents.md
+++ b/docs/toolkit/agents.md
@@ -4,20 +4,39 @@ title: "Agents (37)"
 
 # Agents (37)
 
-> **Status:** stub. Authoritative content currently lives at `toolkit/packages/agents/`.
-> Migration of that file into this path is gated on Stevie's approval.
-
 37 specialised AI agents organised by domain.
 
-## What this page will contain
+## By category
 
-- Universal (backend-developer · frontend-developer · superstar-engineer)
-- Orchestrators (tech-lead, project-analyst, team-configurator)
-- Engineering (api-architect, security-agent, code-reviewer, …)
-- Design (ui-designer)
-- Swarm (worker · leader)
-- Meta (agentmaker · reflect)
-- Root (distinguished-engineer · web-search-researcher)
+37 agents across 6 nested categories plus 2 root-level agents.
+
+### Universal (3)
+
+`backend-developer` `frontend-developer` `superstar-engineer`
+
+### Orchestrators (3)
+
+`tech-lead-orchestrator` `project-analyst` `team-configurator`
+
+### Engineering (24)
+
+`api-architect` `architecture-reviewer` `code-archaeologist` `code-reviewer` `dev-cleanup-wizard` `devops-automator` `documentation-specialist` `focused-repository-analyzer` `gatekeeper` `integration-tests` `lead-orchestrator` `migration` `performance-optimizer` `planner` `playwright-test-validator` `property-mutation` `release-manager` `security-agent` `service-codegen` `solution-architect` `supabase-security-reviewer` `tailwind-css-expert` `test-analyser` `test-writer-fixer`
+
+### Design (1)
+
+`ui-designer`
+
+### Swarm (2)
+
+`worker` `leader`
+
+### Meta (2)
+
+`agentmaker` `reflect`
+
+### Root (2)
+
+`distinguished-engineer` `web-search-researcher`
 
 ## See also
 

--- a/docs/toolkit/bootstrap.md
+++ b/docs/toolkit/bootstrap.md
@@ -4,20 +4,69 @@ title: "Bootstrap engine"
 
 # Bootstrap engine
 
-> **Status:** stub. Authoritative content currently lives at `toolkit/bootstrap.js`.
-> Migration of that file into this path is gated on Stevie's approval.
+`toolkit/bootstrap.js` deploys packages from `toolkit/packages/` into each supported tool's home directory. It is driven by a `TOOL_CONFIG` map (13 entries) plus an `external-dependencies.yaml` manifest.
 
-How toolkit/bootstrap.js auto-deploys packages to each supported tool's home directory.
+## Per-tool home directories
 
-## What this page will contain
+Each `TOOL_CONFIG` entry sets a `targetSubdir` and a `ruleDir`. The eleven user-facing targets:
 
-- Per-tool home directories + naming conventions
-- Template substitutions ({{TOOL_DIR}}, {{HOME_TOOL_DIR}})
-- The skills-lock.json catalog
-- `--verify` mode
-- Adding a new target tool
-- External-dependencies manifest schema
+| Tool key | `targetSubdir` |
+|---|---|
+| `claude-code-4.5` | `.claude` |
+| `codex` | `.codex` |
+| `copilot` | `.copilot` |
+| `gemini` | `.gemini` |
+| `hermes-agent` | `.hermes` |
+| `nanoclaw` | `.claude` (shared with Claude) |
+| `amazonq` | `.amazonq/rules` |
+| `cursor` | `.cursor/rules` |
+| `cline` | `.clinerules` |
+| `roo` | `.roo/rules` |
+| `clawdhub` | `skills` |
+
+Two additional internal entries, `claude` and `packages`, back the rules-glob and copy-entire-folder code paths and are not selected directly as deploy targets.
+
+## Package mappings
+
+For tools with `usePackagesStructure: true`, `packageMappings` controls which `packages/` subtrees land where. For `claude-code-4.5`:
+
+| Source under `packages/` | Target under `~/.claude/` |
+|---|---|
+| `skills` | `skills` |
+| `agents` | `agents` |
+| `utilities/utils` | `utils` |
+| `utilities/hooks` | `hooks` |
+| `utilities/output-styles` | `output-styles` |
+| `utilities/reflections` | `reflections` |
+
+`codex` and `copilot` map only `skills` and `utilities/reflections` (no agents).
+
+## Template substitutions
+
+Each tool config declares `templateSubstitutions` keyed by glob (`**/*.md`, `**/*.sh`, `**/*.py`, `**/*.js`, `**/*.ts`, `**/*.json`, `**/*.yaml`, `**/*.yml`, `**/*.toml`). Two tokens are rewritten per tool so deployed files reference the correct home dir:
+
+| Token | `claude-code-4.5` | `codex` | `copilot` |
+|---|---|---|---|
+| `TOOL_DIR` | `.claude` | `.codex` | `.copilot` |
+| `HOME_TOOL_DIR` | `~/.claude` | `~/.codex` | `~/.copilot` |
+
+This is why skills must use `{{TOOL_DIR}}` / `{{HOME_TOOL_DIR}}` placeholders rather than hardcoded `.claude` paths.
+
+## `--verify` mode
+
+```bash
+node bootstrap.js --tool=<X> --verify
+```
+
+Read-only. Checks every applicable manifest entry has its `SKILL.md` at the expected path, and reports per-tool parity and orphans. Makes no changes.
+
+## Adding a new target tool
+
+1. Add a `TOOL_CONFIG` entry with `ruleDir`, `targetSubdir`, `packageMappings`, and `templateSubstitutions`.
+2. If the tool consumes the manifest, add it to the relevant `applies-to` lists in `external-dependencies.yaml` (and to `TOOL_CANONICAL_NAMES` if its manifest name differs from its key).
+3. Run `node bootstrap.js --tool=<new> --verify` to confirm parity.
 
 ## See also
 
+- [Toolkit overview](overview.md)
 - [Docs hub](../README.md)

--- a/docs/toolkit/overview.md
+++ b/docs/toolkit/overview.md
@@ -4,19 +4,65 @@ title: "Toolkit overview"
 
 # Toolkit overview
 
-> **Status:** stub. Authoritative content currently lives at `toolkit/README.md`.
-> Migration of that file into this path is gated on Stevie's approval.
+One canonical source tree, many AI tools. Author a skill, agent, or workflow once under `toolkit/packages/` and `bootstrap.js` deploys it into each supported tool's home directory.
 
-Portable skills, agents, workflows that deploy to 9 AI tools from one source.
+## What lives in `toolkit/packages/`
 
-## What this page will contain
+| Path | Contents |
+|---|---|
+| `packages/skills/` | 91 agent-invokable `SKILL.md` bundles |
+| `packages/agents/` | 37 agent definitions across 6 categories (`design/`, `engineering/`, `meta/`, `orchestrators/`, `swarm/`, `universal/`) |
+| `packages/utilities/` | Shared `config/`, `hooks/`, `output-styles/`, `reflections/`, and `utils/` |
+| `packages/workflows/single-agent/` | Guided plan -> implement -> validate flows |
+| `packages/knowledge/` | Knowledge/docs templates |
 
-- What lives in `toolkit/packages/`
-- Supported tools (Claude Code, Codex, Copilot, Gemini, Hermes, nanoclaw, Amazon Q, Cursor, Cline, Roo, Clawdhub)
-- How bootstrap deploys to each
-- External dependencies (`external-dependencies.yaml`)
-- Spec-Driven Development integration
+The `reflect` Claude Code plugin lives at root-level `plugins/reflect/` (beside its companion library), not under `toolkit/packages/`. The reflect/recall knowledge-base CLI lives at root-level `reflect-kb/` and is installed via `uv tool install` by `bootstrap.js`.
+
+## Supported tools
+
+`bootstrap.js` defines 13 `TOOL_CONFIG` entries. Eleven are user-facing deploy targets; two (`claude` and `packages`) are internal aliases used by the rules/full-copy code paths.
+
+| Tool key | Home dir | Notes |
+|---|---|---|
+| `claude-code-4.5` | `~/.claude/` | Primary. Plugins + npx-skills + agent-skills |
+| `codex` | `~/.codex/` | `AGENTS.md` copied to project root |
+| `copilot` | `~/.copilot/` | GitHub Copilot CLI |
+| `gemini` | `~/.gemini/` | Gemini CLI |
+| `hermes-agent` | `~/.hermes/` | Reads `~/.claude/skills/` via `external_dirs`; no direct external installs |
+| `nanoclaw` | `~/.claude/` (shared) | Successor to OpenClaw, shares the Claude dir |
+| `amazonq` | `PROJECT/.amazonq/rules/` | Project-scoped |
+| `cursor` | `PROJECT/.cursor/rules/` | Project-scoped rule files |
+| `cline` | `PROJECT/.clinerules/` | Project-scoped rule files |
+| `roo` | `PROJECT/.roo/rules/` | Project-scoped rule files |
+| `clawdhub` | `workspace/skills/` | Clawdhub skill format |
+
+## How bootstrap deploys
+
+```bash
+cd toolkit && npm install
+node bootstrap.js --tool=claude-code-4.5   # one tool
+node bootstrap.js --tool=claude-code-4.5 --verify   # read-only parity check
+```
+
+Each target gets its own home-dir population; repeat per tool. See [Bootstrap engine](bootstrap.md) for the deploy mechanics.
+
+## External dependencies
+
+Externally-authored skills and plugins are declared in `toolkit/external-dependencies.yaml` and installed by the generated `setup-external.sh`. Sections include `agent-skills` (git clones), `npx-skills`, `claude-plugins`, `nanoclaw-skills`, `mcp-servers`, `mcporter-servers`, and `marketplaces`. Each entry's `applies-to` field controls which tools install it.
+
+## Spec-Driven Development
+
+Spec Kit integration drives a spec -> plan -> tasks flow via slash commands:
+
+```bash
+node bootstrap.js --sdd --targetFolder=<project>
+```
+
+Artifacts land under `specs/<feature-branch>/`.
 
 ## See also
 
+- [Bootstrap engine](bootstrap.md)
+- [Skills](skills.md)
+- [Agents](agents.md)
 - [Docs hub](../README.md)

--- a/docs/toolkit/skills.md
+++ b/docs/toolkit/skills.md
@@ -4,24 +4,55 @@ title: "Skills (91)"
 
 # Skills (91)
 
-> **Status:** stub. Authoritative content currently lives at `toolkit/packages/skills/*/SKILL.md + toolkit/README.md §Skills at a glance`.
-> Migration of that file into this path is gated on Stevie's approval.
-
 All 91 skills grouped by purpose. Each links to its SKILL.md source.
 
-## What this page will contain
+## Planning & Workflow (14)
 
-- Planning + workflow (14)
-- Coding + GitHub (12)
-- Multi-agent / swarm (7)
-- Session + learning (9)
-- Testing (5)
-- Design + UI (12)
-- Dev infra + tooling (10)
-- Security + observability (4)
-- Research + knowledge (3)
-- Productivity (5)
-- Meta + autonomous patterns (5)
+`plan` `plan-gh` `plan-tdd` `implement` `validate` `workflow` `discuss` `brainstorm` `interview` `critique` `research` `handover` `prime` `recover-sessions`
+
+## Coding & GitHub (12)
+
+`coding-agent` `spawn-agent` `attach-agent-worktree` `list-agent-worktrees` `cleanup-agent-worktree` `merge-agent-work` `do-issues` `gh-issue` `make-github-issues` `find-missing-tests` `commit` `sync-learnings`
+
+## Multi-agent / Swarm (7)
+
+`swarm-create` `swarm-join` `swarm-status` `swarm-inbox` `swarm-shutdown` `swarm-orchestration` `swarm-agent-troubleshooting`
+
+## Session & Learning (8)
+
+`session-info` `session-metrics` `session-summary` `health-check` `instincts` `reflect` `compound-docs` `research-cache`
+
+## Testing (5)
+
+`expect-test` `webapp-testing` `browser-verify` `test-driven-development` `mobile-e2e-mcp`
+
+## Design & UI (13)
+
+`frontend-design` `frontend-slides` `liquid-glass` `tui-style-guide` `ui-ux-pro-max` `react-components` `stitch-design` `stitch-loop` `shadcn-ui` `design-md` `enhance-prompt` `remotion` `remotion-best-practices`
+
+## Dev infra & tooling (10)
+
+`tmux-monitor` `tmux-status` `start-local` `start-ios` `start-android` `expose` `plugins` `oracle` `debug-bridge` `media-processing`
+
+## Security & Observability (4)
+
+`security-audit` `security-scan` `sentry-cli` `posthog-replay-analysis`
+
+## Research & Knowledge (3)
+
+`crypto-research` `nano-banana-pro` `notebooklm`
+
+## Productivity (5)
+
+`resume-formatter` `ats-resume-matcher` `retro-pdf` `skill-creator` `token-usage`
+
+## Meta / autonomous patterns (5)
+
+`autonomous-loops` `agent-ops` `cost-aware-pipeline` `scrapling-official` `fireworks-tech-graph`
+
+## Recently added (7)
+
+Not yet folded into the grouped lists above: `claude-langfuse` `explain-to-me` `git-history-surgery` `langfuse-setup` `make-a-goal` `standup` `tmux-message`
 
 ## See also
 

--- a/docs/toolkit/skills.md
+++ b/docs/toolkit/skills.md
@@ -1,13 +1,13 @@
 ---
-title: "Skills (86)"
+title: "Skills (91)"
 ---
 
-# Skills (86)
+# Skills (91)
 
 > **Status:** stub. Authoritative content currently lives at `toolkit/packages/skills/*/SKILL.md + toolkit/README.md §Skills at a glance`.
 > Migration of that file into this path is gated on Stevie's approval.
 
-All 86 skills grouped by purpose. Each links to its SKILL.md source.
+All 91 skills grouped by purpose. Each links to its SKILL.md source.
 
 ## What this page will contain
 

--- a/docs/tui/architecture.md
+++ b/docs/tui/architecture.md
@@ -56,6 +56,23 @@ crates/ainb-core/src/
 └── plugins.rs           # Plugin install/management CLI surface
 ```
 
+## Plugin runtime
+
+`ainb-plugin-runtime` is the host-side supervisor that loads v2 plugins as native subprocess binaries speaking JSON-RPC over stdio (the `ainb-plugin-protocol` types). Authors build against `ainb-plugin-sdk-rust` and validate with `ainb-plugin-testkit` and the `ainb-plugin-cts-v2` conformance suite. The three in-tree reference plugins — `burndown` (analytics), `notifyd` (notifications), and `session-reader` (data backend) — double as worked examples. Install and inspect plugins via `ainb plugin install|list|lint|watch|tail` (see the [CLI reference](cli.md)).
+
+## Style guide
+
+Components follow the shared palette in `.claude/skills/tui-screen/SKILL.md`: cornflower-blue borders (`Rgb(100,149,237)`), gold titles/CTAs (`Rgb(255,215,0)`), green active state (`Rgb(100,200,100)`), `BorderType::Rounded` on all panels, a `▶` selection indicator, and a gold-keys / muted-descriptions bottom help bar.
+
+## Testing surface
+
+Tests live under `crates/ainb-core/tests/`:
+
+- **Unit + model tests** — `test_app_state.rs`, `test_events.rs`, `test_session_model.rs`, etc.
+- **Behavioral** — `behavioral.rs` and the `behavioral/` suite.
+- **E2E PTY** — `e2e_pty_tests.rs`, `interactive_mode_tests.rs` (real PTY drive).
+- **Tripwires** — `tripwire_*.rs` tmux-driven end-to-end screen assertions (burndown, inbox, crash recovery, new-session, …).
+
 ## See also
 
 - [Overview](overview.md)

--- a/docs/tui/architecture.md
+++ b/docs/tui/architecture.md
@@ -4,20 +4,30 @@ title: "TUI architecture"
 
 # TUI architecture
 
-> **Status:** stub. Authoritative content currently lives at `ainb-tui/CLAUDE.md + ainb-tui/src/ source tree`.
-> Migration of that file into this path is gated on Stevie's approval.
+`ainb` is a Cargo **workspace** rooted at `ainb-tui/`. The TUI application and CLI live in the `ainb-core` crate; the rest of the workspace is the v2 plugin platform (runtime, SDK, reference plugins, conformance + test tooling).
 
-How the 115-module Rust codebase is organised, including the plugin runtime.
+## Workspace crates
 
-## What this page will contain
+Members are declared in `ainb-tui/Cargo.toml` (`default-members = ["crates/ainb-core"]`):
 
-- Crate layout (`ainb-core`, `ainb-plugin-runtime`, `ainb-plugin-sdk-rust`, …)
-- Module tree (`app/`, `components/`, `widgets/`, `docker/`, `tmux/`, `git/`, `claude/`)
-- Event flow + state machine
-- Plugin runtime hookup (where the v2 ABI plugs in)
-- Style guide reference (cornflower/gold palette, BorderType::Rounded)
-- Testing surface (unit · VT100 · E2E PTY · tripwire)
+| Crate | Role |
+|-------|------|
+| `ainb-core` | The TUI app + `ainb` CLI binary. All screens, event loop, session/git/tmux/docker integration. |
+| `ainb-plugin-runtime` | Host-side plugin runtime that loads and supervises v2 plugins. |
+| `ainb-plugin-sdk-rust` | Rust SDK for authoring v2 plugins. |
+| `ainb-plugin-protocol` | Wire protocol / JSON-RPC types shared by host and plugins. |
+| `ainb-plugin-types-sessions` | Shared session data types exposed to plugins. |
+| `ainb-plugin-burndown` | In-tree v2 reference plugin: usage/burndown analytics. |
+| `ainb-plugin-notifyd` | In-tree v2 reference plugin: notifications. |
+| `ainb-plugin-session-reader` | In-tree v2 reference plugin: session data backend. |
+| `ainb-plugin-cts-v2` | Conformance test suite for the v2 plugin ABI. |
+| `ainb-plugin-testkit` | Test harness for plugin authors. |
+| `xtask` | Workspace task runner (build/release helpers). |
+
+The workspace pins `version = "1.2.0"`, Rust edition 2021, and forbids `unsafe_code`.
 
 ## See also
 
+- [Overview](overview.md)
+- [Keyboard shortcuts](keyboard-shortcuts.md)
 - [Docs hub](../README.md)

--- a/docs/tui/architecture.md
+++ b/docs/tui/architecture.md
@@ -26,6 +26,36 @@ Members are declared in `ainb-tui/Cargo.toml` (`default-members = ["crates/ainb-
 
 The workspace pins `version = "1.2.0"`, Rust edition 2021, and forbids `unsafe_code`.
 
+## ainb-core module tree
+
+App code lives under `ainb-tui/crates/ainb-core/src/`:
+
+```
+crates/ainb-core/src/
+├── main.rs              # Entry point, CLI parsing, TUI loop
+├── lib.rs               # Crate exports
+├── app/                 # App state machine + event handling (state.rs, events.rs)
+├── components/          # TUI screens (session_list, git_view, logs_viewer, home_screen, …)
+├── widgets/             # Reusable UI widgets
+├── cli/                 # Non-interactive subcommand implementations
+├── fleet/               # `ainb fleet` orchestration (standup/broadcast/sequence/needs/daemon)
+├── providers/           # Multi-provider (claude/codex/gemini/copilot) abstractions
+├── claude/              # Claude API client
+├── docker/              # Container management
+├── tmux/                # Tmux / PTY integration
+├── git/                 # Git + worktree operations
+├── config/              # Configuration loading
+├── models/              # Data models
+├── agents/              # Agent registry
+├── agent_parsers/       # Parse agent output
+├── interactive/         # Interactive-mode helpers
+├── usage_cache/         # Persistent usage-analytics cache
+├── audit.rs             # Audit helpers
+├── credentials.rs       # Credential storage
+├── editors.rs           # Editor integration
+└── plugins.rs           # Plugin install/management CLI surface
+```
+
 ## See also
 
 - [Overview](overview.md)

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -35,7 +35,10 @@ Run `ainb` with no arguments to launch the TUI, or use any subcommand below for 
   - [`favorites`](#ainb-favorites) — saved repositories
   - [`init`](#ainb-init) — first-time setup & factory reset
   - [`presets`](#ainb-presets) — session presets
+  - [`claudecode`](#ainb-claudecode) — Claude Code provider-specific commands (statusline)
   - [`completion`](#ainb-completion) — shell completions
+  - [`plugin`](#ainb-plugin) — manage ainb plugins
+  - [`fleet`](#ainb-fleet) — orchestrate the claude session fleet
   - [`usage`](#ainb-usage) — local usage analytics and export
 - [Scripting recipes](#scripting-recipes)
 

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -514,6 +514,40 @@ Wire it into Claude Code's `settings.json` as the `statusLine` command so the TU
 
 ---
 
+### `ainb plugin`
+
+Manage ainb plugins — install from marketplaces, update, remove, and inspect runtime events.
+
+```bash
+ainb plugin <SUBCOMMAND>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `install <PLUGIN> [-y]` | Install a plugin from a marketplace. `<PLUGIN>` is a plugin id, e.g. `burndown` or `ainb-plugins/burndown@0.1.0`. `-y, --yes` skips the capability-approval prompt. |
+| `update <PLUGIN> [-y]` | Update an installed plugin to the latest matching version. `-y, --yes` skips prompts when new capabilities are requested. |
+| `remove <PLUGIN> [-y]` | Remove an installed plugin. `-y, --yes` skips the data-directory deletion prompt. |
+| `list` | List installed plugins. |
+| `search <QUERY>` | Search registered marketplaces by plugin name. |
+| `marketplace <SUBCOMMAND>` | Manage marketplace registries: `add <URL\|PATH>`, `remove <NAME>`, `list`. |
+| `lint <PLUGIN>` | Validate a plugin manifest + binary (ABI 2.0 sanity checks). Accepts a plugin id, staging dir, or `manifest.toml` path. |
+| `watch <PLUGIN> [--duration <SECS>]` | Live-tail lifecycle + snapshot events for a registered plugin. `--duration` defaults to 30s. |
+| `tail <PLUGIN> [--level <LVL>] [--since <TS>] [--duration <SECS>]` | Stream the host's tracing layer filtered to one plugin id. `--level` is `trace\|debug\|info\|warn\|error` (default `debug`); `--since` is an RFC-3339 timestamp; `--duration` defaults to 30s. |
+
+**Examples**
+
+```bash
+ainb plugin marketplace add https://github.com/stevengonsalvez/ainb-plugins
+ainb plugin search burndown
+ainb plugin install burndown -y
+ainb plugin list --format json
+ainb plugin watch burndown --duration 60
+```
+
+In-tree v2 reference plugins: `burndown` (analytics), `notifyd` (notifications), `session-reader` (data backend).
+
+---
+
 ## Scripting recipes
 
 **Agent-friendly: list running sessions as JSON, exit non-zero if none**

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -492,6 +492,28 @@ Supported: `bash`, `zsh`, `fish`, `powershell`, `elvish`.
 
 ---
 
+### `ainb claudecode`
+
+Provider-namespaced commands for Claude Code. Other providers grow their own namespace; today only the statusline hook lives here.
+
+```bash
+ainb claudecode <SUBCOMMAND>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `statusline` | Claude Code statusline hook: reads session JSON on stdin, caches rate-limit windows for the TUI, and emits a powerline status string on stdout. |
+
+**`statusline` flags**
+
+| Flag | Description |
+|------|-------------|
+| `--cache-only` | Side-channel mode: write the rate-limit cache only and emit nothing on stdout. |
+
+Wire it into Claude Code's `settings.json` as the `statusLine` command so the TUI can surface live rate-limit windows.
+
+---
+
 ## Scripting recipes
 
 **Agent-friendly: list running sessions as JSON, exit non-zero if none**

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -548,6 +548,36 @@ In-tree v2 reference plugins: `burndown` (analytics), `notifyd` (notifications),
 
 ---
 
+### `ainb fleet`
+
+Orchestrate every claude session running on the host — merged across ainb's registry, the claude-peers broker, and background jobs.
+
+```bash
+ainb fleet <SUBCOMMAND>
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `standup [--text]` | Live fleet status: every claude session across ainb + peers + background jobs. `--text` forces text output even with `--format json`. |
+| `broadcast <PROMPT> (--all \| --filter <REGEX> \| --cwd <SUBSTR>)` | Send one prompt to selected sessions (peers-first, tmux fallback). Requires an explicit targeting flag — no implicit fan-out. `--filter` matches a regex against tmux/workspace name; `--cwd` matches a substring of the session cwd. |
+| `sequence <STEPS>... [--all] [--timeout <SECS>]` | Send ordered prompts with an ack between each step. `--timeout` is the per-step timeout in seconds (default `300`). |
+| `needs [--idle-min <MIN>]` | Center control panel — list sessions blocked on input / errors / idle / waiting. `--idle-min` is minutes of assistant silence before flagging IDLE (default 5, env `AINB_FLEET_IDLE_MIN`). |
+| `daemon [-v]` | Watcher: registers as the `ainb-fleet-cp` peer and auto-continues sessions hitting API errors. `-v, --verbose` for detailed logging. |
+
+**Examples**
+
+```bash
+ainb fleet standup --format json | jq '.[] | .workspace_name'
+ainb fleet needs --idle-min 10
+ainb fleet broadcast "git pull" --filter '^feat-'
+ainb fleet sequence "run tests" "commit" --all --timeout 600
+ainb fleet daemon -v
+```
+
+Backed by the in-tree `plugins/ainb-fleet/` plugin.
+
+---
+
 ## Scripting recipes
 
 **Agent-friendly: list running sessions as JSON, exit non-zero if none**

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -8,7 +8,7 @@ title: "ainb CLI Reference"
 
 Run `ainb` with no arguments to launch the TUI, or use any subcommand below for non-interactive work.
 
-> **Version documented:** `ainb 0.5.5-beta1`
+> **Version documented:** `ainb 1.2.0`
 > **Source of truth:** output of `ainb <cmd> --help`. If this doc drifts, trust `--help`.
 
 ---

--- a/docs/tui/install.md
+++ b/docs/tui/install.md
@@ -4,20 +4,59 @@ title: "Install the TUI"
 
 # Install the TUI
 
-> **Status:** stub. Authoritative content currently lives at `ainb-tui/install.sh + Homebrew tap README + main README §Installation`.
-> Migration of that file into this path is gated on Stevie's approval.
+## Quick install (curl)
 
-Every supported install method, in order of preference.
+The install script detects your platform and downloads a prebuilt binary from GitHub Releases:
 
-## What this page will contain
+```bash
+curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
+```
 
-- Homebrew (macOS / Linux, recommended)
-- One-liner curl install (any Unix)
-- Cargo from source
-- WSL2 for Windows
-- Verifying the install
-- Troubleshooting (Homebrew CLT, formula collisions)
+Prebuilt binaries are published for:
+
+| Platform | Target |
+|----------|--------|
+| macOS (Apple Silicon) | `aarch64-apple-darwin` |
+| Linux (x86_64) | `x86_64-unknown-linux-gnu` |
+
+The script installs to `/usr/local/bin` when writable, otherwise `~/.local/bin` (add it to your `PATH` if prompted). Override the location with `INSTALL_DIR`, or pin a version with `VERSION`:
+
+```bash
+INSTALL_DIR=$HOME/bin VERSION=1.2.0 \
+  curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
+```
+
+The script verifies the release checksum when a `.sha256` file is present.
+
+## From source (cargo)
+
+Intel macOS and ARM64 Linux do not have prebuilt binaries — install from source instead. This also works on any platform with a Rust toolchain:
+
+```bash
+cargo install --git https://github.com/stevengonsalvez/agents-in-a-box --branch main ainb
+```
+
+Or build the workspace directly from a clone:
+
+```bash
+git clone https://github.com/stevengonsalvez/agents-in-a-box
+cd agents-in-a-box/ainb-tui
+cargo build --release   # binary at target/release/ainb
+```
+
+## Windows
+
+Windows is not supported natively. Use WSL2 and follow the Linux instructions above.
+
+## Verify the install
+
+```bash
+ainb --version
+ainb init --check    # confirm prerequisites (git, tmux, a provider CLI)
+```
 
 ## See also
 
+- [Quickstart](quickstart.md)
+- [Overview](overview.md)
 - [Docs hub](../README.md)

--- a/docs/tui/keyboard-shortcuts.md
+++ b/docs/tui/keyboard-shortcuts.md
@@ -4,20 +4,88 @@ title: "Keyboard shortcuts"
 
 # Keyboard shortcuts
 
-> **Status:** stub. Authoritative content currently lives at `ainb-tui/src/components/*.rs + README §Keyboard Shortcuts`.
-> Migration of that file into this path is gated on Stevie's approval.
+Keys verified against the in-app help overlay (`?`) and the event handlers in `crates/ainb-core/src/app/events.rs`.
 
-Every key binding across every TUI screen.
+## Home screen navigation
 
-## What this page will contain
+| Key | Action |
+|-----|--------|
+| `s` | Sessions |
+| `a` | Agents (agent selection) |
+| `R` | Recovery |
+| `i` | Stats (usage analytics) |
+| `k` | Skills |
+| `I` (or `Shift`+`i`) | Inbox (notifications) |
+| `c` | Catalog |
+| `C` | Config |
+| `v` | Changelog |
+| `n` | New session |
+| `Tab` | Toggle focus (sidebar ↔ content) |
+| `?` | Toggle help |
+| `q` | Quit |
 
-- Global keys
-- Sessions screen (j/k, n, d, r, Space, Shift+D)
-- Recovery screen
-- Logs viewer
-- Stats / Burndown
-- Setup wizard
+## Navigation (lists)
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `h` / `←` | Previous workspace |
+| `l` / `→` | Next workspace |
+| `g` | Go to top |
+| `G` | Go to bottom |
+
+## Session actions
+
+| Key | Action |
+|-----|--------|
+| `n` | New session (local or remote) |
+| `a` | Attach to session |
+| `e` | Restart stopped session |
+| `r` | Re-authenticate credentials |
+| `d` | Delete session |
+| `x` | Cleanup orphaned containers |
+| `f` | Refresh workspaces |
+| `Space` | Toggle multi-select |
+| `Shift`+`D` | Delete all selected sessions |
+
+## Recovery screen
+
+| Key | Action |
+|-----|--------|
+| `Space` | Toggle select |
+| `Shift`+`D` | Delete selected |
+
+## Git actions
+
+| Key | Action |
+|-----|--------|
+| `g` | Show git view |
+| `p` | Commit & push |
+
+## Usage / Stats screen
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Switch usage tab (Daily/Weekly/Project/Burndown/Optimize) |
+| `1`–`5` | Today / Week / 30 days / Month / All |
+| `p` | Cycle provider (All / Claude / Codex) |
+| `/` | Add include filter |
+| `x` | Add exclude filter |
+| `d` | Enter custom `YYYY-MM-DD YYYY-MM-DD` range |
+| `c` | Clear filters |
+| `r` | Reload |
+
+## General
+
+| Key | Action |
+|-----|--------|
+| `?` | Toggle help overlay |
+| `q` / `Esc` | Back / quit |
+| `Ctrl`+`C` | Force quit |
 
 ## See also
 
+- [Overview](overview.md)
+- [CLI reference](cli.md)
 - [Docs hub](../README.md)

--- a/docs/tui/overview.md
+++ b/docs/tui/overview.md
@@ -4,19 +4,50 @@ title: "ainb TUI — overview"
 
 # ainb TUI — overview
 
-> **Status:** stub. Authoritative content currently lives at `ainb-tui/README.md + ainb-tui/CLAUDE.md`.
-> Migration of that file into this path is gated on Stevie's approval.
+`ainb` is the terminal UI and CLI for Agents-in-a-Box: a Rust + ratatui app that spawns and manages AI coding sessions (Claude Code, Codex, Gemini, Copilot) in isolated git worktrees, each driven inside its own tmux session.
 
-The ainb terminal app: what it is, how to launch it, and a tour of every screen.
+Run `ainb` with no arguments to launch the TUI. Every operation the TUI performs is also exposed as a subcommand, so agents and automation can drive it headlessly. See the [CLI reference](cli.md) for the full subcommand list.
 
-## What this page will contain
+## Launching
 
-- Launch + first-run flow
-- Screen-by-screen tour (Home · Sessions · Agents · Recovery · Logs · Stats · Setup)
-- Multi-provider session model
-- Worktree + tmux integration model
-- Recommended terminal + tmux configuration
+```bash
+ainb            # launch the TUI (default when no command is given)
+ainb init       # first-time setup + prerequisite check
+ainb auth       # set up authentication
+```
+
+First launch runs an onboarding flow that checks prerequisites (git, tmux, a provider CLI) and helps you authenticate. Use `ainb init --check` to verify prerequisites without changing anything, or `ainb init --status` to see onboarding completion.
+
+## Screen tour
+
+From the home screen, single keys jump to each screen (see [Keyboard shortcuts](keyboard-shortcuts.md)):
+
+| Screen | Key | What it does |
+|--------|-----|--------------|
+| Home | — | Landing screen with the sidebar + tile navigation |
+| Sessions | `s` | List, attach, restart, and delete agent sessions |
+| Agents | `a` | Pick a provider/agent before spawning a session |
+| Recovery | `R` | Find and resume orphaned sessions / broken worktrees |
+| Stats | `i` | Usage analytics: Daily, Weekly, Project, Burndown, Optimize |
+| Skills | `k` | Browse available skills |
+| Inbox | `I` | ainb-hooks notification inbox |
+| Config | `C` | View configuration |
+
+Git operations, log streaming, and a tmux preview are available from within the session views.
+
+## Multi-provider session model
+
+A session pairs a repository checkout with an AI tool. `ainb run` accepts `--tool claude|codex|gemini|copilot` (default `claude`) and `--model` (default `sonnet`). Each session gets its own tmux session you can attach to and detach from without killing the agent.
+
+## Worktree + tmux integration
+
+With `--worktree`, each session is isolated in a fresh git worktree (default branch prefix `agents/`), so parallel sessions never collide on the same working tree. The agent process runs inside a dedicated tmux session; `ainb attach <name>` drops you into it, and detaching leaves it running. Claude Code emits very high-frequency screen updates, so a tuned tmux config is recommended — see [Architecture](architecture.md) and `ainb-tui/config/tmux.conf`.
 
 ## See also
 
+- [Install the TUI](install.md)
+- [Quickstart](quickstart.md)
+- [CLI reference](cli.md)
+- [Keyboard shortcuts](keyboard-shortcuts.md)
+- [Architecture](architecture.md)
 - [Docs hub](../README.md)

--- a/docs/tui/quickstart.md
+++ b/docs/tui/quickstart.md
@@ -4,20 +4,62 @@ title: "Quickstart — first session in 60 seconds"
 
 # Quickstart — first session in 60 seconds
 
-> **Status:** stub. Authoritative content currently lives at `new — synthesises README quickstart + first-session UX`.
-> Migration of that file into this path is gated on Stevie's approval.
+From install to your first running agent session.
 
-From `brew install` to your first running agent session.
+## 1. Pre-flight
 
-## What this page will contain
+Make sure you have `git`, `tmux`, and a provider CLI (e.g. Claude Code) installed, then:
 
-- Pre-flight (tmux, git, claude CLI)
-- `ainb` — first launch
-- Pick a repo · spawn a session · attach
-- Detach + reattach
-- Killing a session safely
-- Where to go next
+```bash
+ainb init --check    # verify prerequisites without changing anything
+ainb auth            # set up authentication if needed
+```
 
-## See also
+## 2. Launch
 
+```bash
+ainb
+```
+
+First launch runs onboarding. From the home screen, press `s` for Sessions or `n` to start a new session immediately.
+
+## 3. Spawn a session (CLI)
+
+You can also start a session straight from the shell. Isolate it in a worktree and attach in one step:
+
+```bash
+ainb run --repo . --worktree --attach
+```
+
+Useful variants:
+
+```bash
+ainb run --repo .                              # current directory, no worktree
+ainb run --repo . --create-branch feat/new     # new branch + worktree
+ainb run --tool codex --repo .                  # use Codex instead of Claude
+ainb run --remote-repo owner/repo               # clone a GitHub repo first
+ainb run --repo . -p "fix the failing tests"  # send an initial prompt
+```
+
+## 4. Attach, detach, reattach
+
+```bash
+ainb list                 # see running sessions
+ainb attach my-project    # drop into the session's tmux
+```
+
+Detach with your tmux detach key (default `Ctrl-b d`) — the agent keeps running. Reattach any time with `ainb attach <name>`.
+
+## 5. Kill a session safely
+
+```bash
+ainb kill my-project       # prompts for confirmation
+ainb kill my-project -f     # force, no prompt
+```
+
+## Where to go next
+
+- [Overview](overview.md) — every screen
+- [CLI reference](cli.md) — every subcommand and flag
+- [Keyboard shortcuts](keyboard-shortcuts.md)
 - [Docs hub](../README.md)

--- a/plugins/reflect/README.md
+++ b/plugins/reflect/README.md
@@ -201,7 +201,7 @@ Each sub-sparkline: 24 cells × 5 minutes = 2 hours, right edge = now. Heights e
 Wire it into your statusline by adding this block at the end (after `printf '%b\n %b' "$L1" "$L2"`):
 
 ```bash
-TIMELINE_HELPER="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/agents-in-a-box/reflect/3.3.1}/scripts/reflect_timeline.sh"
+TIMELINE_HELPER="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/agents-in-a-box/reflect/3.6.0}/scripts/reflect_timeline.sh"
 if [[ "${REFLECT_TIMELINE_DISABLE:-0}" != "1" ]] && [[ -x "$TIMELINE_HELPER" ]]; then
   "$TIMELINE_HELPER" 2>/dev/null
 fi
@@ -282,7 +282,7 @@ uv tool install --force --upgrade 'git+https://github.com/stevengonsalvez/agents
 ## Verify it's working
 
 ```bash
-# Should list reflect@agents-in-a-box, version 3.1.0
+# Should list reflect@agents-in-a-box, version 3.6.0
 claude plugin list
 
 # Should print pending reflections, KB stats, sidecar coverage

--- a/plugins/reflect/README.md
+++ b/plugins/reflect/README.md
@@ -243,6 +243,7 @@ clicks always show fresh data.
 | `reflect:recall` | Query the KB on demand (also runs automatically at SessionStart) |
 | `reflect:ingest` | Bulk-index existing memories from any tool (Claude/Codex/Copilot/Gemini) into the global KB |
 | `reflect:consolidate` | Project-level memory consolidation — merges orphaned worktree memory dirs into a single `.agents/MEMORY.md` |
+| `reflect:errors-ack` | Triage and acknowledge entries in the reflect errors sink (`~/.reflect/errors.json`) — drain poison, parser crashes, ingest failures, hook timeouts. Invoked from the statusline ⚠N badge. |
 | `reflect-status` | Read-only metrics: pending reviews, sidecar coverage, GraphRAG health. Approve/reject low-confidence items. |
 
 ---

--- a/plugins/reflect/docs/architecture.md
+++ b/plugins/reflect/docs/architecture.md
@@ -561,47 +561,32 @@ Without this section, all dashboard commands exit 0 with "dashboard not configur
 
 ### `~/.claude/settings.json` — hooks (managed by Claude adapter)
 
-The Claude adapter writes and later removes these entries:
+As a Claude Code plugin, reflect declares its hooks in `.claude-plugin/plugin.json`; installing the plugin auto-wires all five lifecycle hooks (no manual settings.json editing required). The wired entries are:
 
 ```json
 {
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "uv run /Users/<you>/.claude/skills/recall/hooks/session_start_recall.py"
-          }
-        ]
-      }
-    ]
+    "SessionStart":    [{ "matcher": "", "hooks": [
+      { "type": "command", "command": "uv run ${CLAUDE_PLUGIN_ROOT}/skills/recall/hooks/session_start_recall.py" },
+      { "type": "command", "command": "(nohup ${CLAUDE_PLUGIN_ROOT}/hooks/reflect-drain-bg.sh >/dev/null 2>&1 &) >/dev/null 2>&1", "timeout": 5 }
+    ]}],
+    "UserPromptSubmit":[{ "matcher": "", "hooks": [
+      { "type": "command", "command": "uv run ${CLAUDE_PLUGIN_ROOT}/skills/recall/hooks/user_prompt_submit_recall.py" }
+    ]}],
+    "PostToolUse":     [{ "matcher": "", "hooks": [
+      { "type": "command", "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse_minilearning.py" }
+    ]}],
+    "Stop":            [{ "matcher": "", "hooks": [
+      { "type": "command", "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/stop_reflect.py" }
+    ]}],
+    "PreCompact":      [{ "matcher": "", "hooks": [
+      { "type": "command", "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/precompact_reflect.py --auto --verbose" }
+    ]}]
   }
 }
 ```
 
-The PreCompact hook is NOT auto-installed. Users copy it from `hooks/settings-snippet.json` manually:
-
-```json
-{
-  "hooks": {
-    "PreCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "uv run /Users/<you>/.claude/skills/reflect/hooks/precompact_reflect.py --remind"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Switch `--remind` to `--auto` after running `/reflect on` to enable automatic episode creation.
+The PreCompact hook IS auto-installed via `plugin.json` and runs `precompact_reflect.py --auto --verbose`, so PreCompact reflection capture is on by default — no manual settings.json edit is needed. The standalone snippet in `hooks/settings-snippet.json` is only a reference for users hand-wiring the hook outside the plugin install path.
 
 ### `reflect.toml` — plugin defaults (toolkit-bundled, layer 1)
 

--- a/plugins/reflect/docs/architecture.md
+++ b/plugins/reflect/docs/architecture.md
@@ -40,9 +40,12 @@ flowchart TD
         SS["reflect-status"]
     end
 
-    subgraph Hooks["Lifecycle Hooks"]
-        SSH["SessionStart\nsession_start_recall.py"]
-        PCH["PreCompact\nprecompact_reflect.py"]
+    subgraph Hooks["Lifecycle Hooks (plugin.json)"]
+        SSH["SessionStart\nsession_start_recall.py\n+ reflect-drain-bg.sh"]
+        UPH["UserPromptSubmit\nuser_prompt_submit_recall.py"]
+        PTH["PostToolUse\nposttooluse_minilearning.py"]
+        STH["Stop\nstop_reflect.py"]
+        PCH["PreCompact\nprecompact_reflect.py --auto --verbose"]
     end
 
     subgraph RecallPipeline["Recall Pipeline (recall.py)"]
@@ -98,8 +101,12 @@ flowchart TD
     XA --> Skills
     PA --> Skills
     CC -- "SessionStart" --> SSH
+    CC -- "UserPromptSubmit" --> UPH
+    CC -- "PostToolUse" --> PTH
+    CC -- "Stop" --> STH
     CC -- "PreCompact" --> PCH
     SSH --> RecallPipeline
+    UPH --> RecallPipeline
     RecallPipeline --> KB
     CapturePipeline --> KB
     HIGH --> KB

--- a/plugins/reflect/hooks/README.md
+++ b/plugins/reflect/hooks/README.md
@@ -4,9 +4,22 @@ This directory contains hooks for integrating the reflect skill with Claude Code
 
 ## Available Hooks
 
+The `reflect` plugin wires five Claude Code lifecycle events via `.claude-plugin/plugin.json`. Most hook scripts live in this directory; the two `recall` hooks live under `../skills/recall/hooks/`.
+
+| Event | Script | Purpose |
+|-------|--------|---------|
+| `SessionStart` | `../skills/recall/hooks/session_start_recall.py` | Hybrid-search the KB and auto-inject the top learnings into the new session |
+| `SessionStart` | `reflect-drain-bg.sh` | Background-drain queued reflections from prior sessions (spawned detached) |
+| `UserPromptSubmit` | `../skills/recall/hooks/user_prompt_submit_recall.py` | Recall against the submitted prompt before the turn runs |
+| `PostToolUse` | `posttooluse_minilearning.py` | Arm low-cost mini-learning capture after each tool call |
+| `Stop` | `stop_reflect.py` | Enqueue short-session reflection when the agent turn ends |
+| `PreCompact` | `precompact_reflect.py --auto --verbose` | Queue the transcript for reflection before context compaction |
+
+This README documents `precompact_reflect.py` in detail below; the other scripts are wired automatically by the plugin and need no manual install.
+
 ### precompact_reflect.py
 
-Integrates with the `PreCompact` hook event to trigger reflection before context compaction.
+Integrates with the `PreCompact` hook event to queue reflection before context compaction.
 
 **Modes:**
 

--- a/reflect-kb/README.md
+++ b/reflect-kb/README.md
@@ -73,7 +73,8 @@ reflect timeline --explain TOK
 | [`reflect stats`](docs/usage.md#reflect-stats) | Show KB metrics (doc count, entities, relationships, confidence) |
 | [`reflect critical-patterns`](docs/usage.md#reflect-critical-patterns) | Surface high-confidence, widely-applicable patterns |
 | [`reflect generate-sidecars`](docs/usage.md#reflect-generate-sidecars) | Backfill missing `.entities.yaml` sidecars (heuristic, no LLM) |
-| [`reflect metrics stats`](docs/usage.md#reflect-metrics-stats) | Aggregate the recall-metrics JSONL log (hit rate, latency) |
+| [`reflect metrics`](docs/usage.md#reflect-metrics) | Command group for recall-metrics aggregation (subcommands below) |
+| &nbsp;&nbsp;↳ [`reflect metrics stats`](docs/usage.md#reflect-metrics-stats) | Aggregate the recall-metrics JSONL log: total events, hit rate, p50/p95 latency, top tags |
 | [`reflect timeline`](docs/usage.md#reflect-timeline) | Drill down on statusline dashboard rows (REC/MEM/ING/DRN/TOK/ERR/COM/AGT) |
 
 See [docs/usage.md](docs/usage.md) for per-subcommand synopsis, all flags, examples, and common errors.

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -78,9 +78,9 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 </details>
 
 <details>
-<summary><b>Coding & GitHub</b> (12)</summary>
+<summary><b>Coding & GitHub</b> (13)</summary>
 
-`coding-agent` · `spawn-agent` · `attach-agent-worktree` · `list-agent-worktrees` · `cleanup-agent-worktree` · `merge-agent-work` · `do-issues` · `gh-issue` · `make-github-issues` · `find-missing-tests` · `commit` · `sync-learnings`
+`coding-agent` · `spawn-agent` · `attach-agent-worktree` · `list-agent-worktrees` · `cleanup-agent-worktree` · `merge-agent-work` · `do-issues` · `gh-issue` · `make-github-issues` · `find-missing-tests` · `commit` · `sync-learnings` · `git-history-surgery`
 </details>
 
 <details>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -40,7 +40,7 @@ The canonical source tree. Everything under `packages/` gets distributed to tool
 
 ```
 packages/
-├── skills/              86 skills — agent-invokable SKILL.md bundles
+├── skills/              91 skills — agent-invokable SKILL.md bundles
 ├── agents/              37 agents across 6 categories
 │   ├── design/          UI/UX designers
 │   ├── engineering/     backend, frontend, security, perf, code-review

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -72,9 +72,9 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 ### Skills at a glance (91 total, grouped by purpose)
 
 <details>
-<summary><b>Planning & Workflow</b> (14)</summary>
+<summary><b>Planning & Workflow</b> (15)</summary>
 
-`plan` · `plan-gh` · `plan-tdd` · `implement` · `validate` · `workflow` · `discuss` · `brainstorm` · `interview` · `critique` · `research` · `handover` · `prime` · `recover-sessions`
+`plan` · `plan-gh` · `plan-tdd` · `implement` · `validate` · `workflow` · `discuss` · `brainstorm` · `interview` · `critique` · `research` · `handover` · `prime` · `recover-sessions` · `make-a-goal`
 </details>
 
 <details>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -102,7 +102,7 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 </details>
 
 <details>
-<summary><b>Design & UI</b> (12)</summary>
+<summary><b>Design & UI</b> (13)</summary>
 
 `frontend-design` · `frontend-slides` · `liquid-glass` · `tui-style-guide` · `ui-ux-pro-max` · `react-components` · `stitch-design` · `stitch-loop` · `shadcn-ui` · `design-md` · `enhance-prompt` · `remotion` · `remotion-best-practices`
 </details>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -237,6 +237,7 @@ Frontmatter-native tools (Cursor, AmazonQ, Claude Code) use the frontmatter dire
 ## References
 
 - **Manifest**: [`external-dependencies.yaml`](external-dependencies.yaml)
+- **Internal catalog**: [`catalog.yaml`](catalog.yaml) — auto-generated filesystem-derived manifest of every toolkit-owned skill, plugin, agent, workflow, and utility (the "internal" set; anything installed but not listed here is external). Regenerate with `bash toolkit/bin/generate-catalog.sh`.
 - **Bootstrap source**: [`bootstrap.js`](bootstrap.js)
 - **Parity regression test**: [`test-bootstrap-parity.sh`](test-bootstrap-parity.sh)
 - **Main project README**: [`../README.md`](../README.md)

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -90,7 +90,7 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 </details>
 
 <details>
-<summary><b>Session & Learning</b> (9)</summary>
+<summary><b>Session & Learning</b> (8)</summary>
 
 `session-info` · `session-metrics` · `session-summary` · `health-check` · `instincts` · `reflect` · `compound-docs` · `research-cache`
 </details>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -120,9 +120,9 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 </details>
 
 <details>
-<summary><b>Research & Knowledge</b> (3)</summary>
+<summary><b>Research & Knowledge</b> (4)</summary>
 
-`crypto-research` · `nano-banana-pro` · `notebooklm`
+`crypto-research` · `nano-banana-pro` · `notebooklm` · `explain-to-me`
 </details>
 
 <details>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -108,9 +108,9 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 </details>
 
 <details>
-<summary><b>Dev infra & tooling</b> (10)</summary>
+<summary><b>Dev infra & tooling</b> (12)</summary>
 
-`tmux-monitor` · `tmux-status` · `start-local` · `start-ios` · `start-android` · `expose` · `plugins` · `oracle` · `debug-bridge` · `media-processing`
+`tmux-monitor` · `tmux-status` · `start-local` · `start-ios` · `start-android` · `expose` · `plugins` · `oracle` · `debug-bridge` · `media-processing` · `standup` · `tmux-message`
 </details>
 
 <details>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -69,7 +69,7 @@ via `uv tool install` by `bootstrap.js` (from the
 `git+https://github.com/stevengonsalvez/agents-in-a-box.git#subdirectory=reflect-kb`
 URL). See the bootstrap's `installReflectKb()` function for details.
 
-### Skills at a glance (86 total, grouped by purpose)
+### Skills at a glance (91 total, grouped by purpose)
 
 <details>
 <summary><b>Planning & Workflow</b> (14)</summary>

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -114,9 +114,9 @@ URL). See the bootstrap's `installReflectKb()` function for details.
 </details>
 
 <details>
-<summary><b>Security & Observability</b> (4)</summary>
+<summary><b>Security & Observability</b> (6)</summary>
 
-`security-audit` · `security-scan` · `sentry-cli` · `posthog-replay-analysis`
+`security-audit` · `security-scan` · `sentry-cli` · `posthog-replay-analysis` · `claude-langfuse` · `langfuse-setup`
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Full documentation audit + resync. Six parallel auditors found ~56 drift findings across 30+ doc surfaces; a dynamic workflow then produced 11 per-surface commit plans and applied them as **62 atomic commits** (one per concern — counts, command lists, stub replacements, hook diagrams, etc.), strictly serialized to keep each markdown change reviewable.

Doc site build verified: `cd website/site && npm run build` → **PASS**, 33 pages, Pagefind index + sitemap clean. Zero `Status: stub` markers remain.

## What changed, by surface

**docs/ site content (was mostly placeholder stubs)**
- `docs/tui/{overview,install,quickstart,architecture,keyboard-shortcuts}.md` — stubs replaced with real content; architecture now uses the `crates/` workspace layout
- `docs/toolkit/{overview,bootstrap,skills,agents}.md` — stubs replaced; correct counts (91 skills, 35 agents) + real deploy-target list
- `docs/knowledge/reflect-cli.md` — real reflect CLI reference (v3.6.0, 6 skills incl. errors-ack)
- `docs/reference/glossary.md` — real glossary (agent/session/worktree, v2-plugin vs Claude-Code plugin, QMD/GraphRAG/sidecar, cts-v2, testkit, notifyd, …)
- `docs/tui/cli.md` — version 0.5.5-beta1 → 1.2.0; added the missing `claudecode`, `plugin`, `fleet` subcommand sections + TOC (16 → 20 commands)
- `docs/plugins/{README,overview}.md` — added `notifyd` reference plugin
- `docs/plugins/spec-v2.md` — noted `cts-v2` + `testkit` crates in the conformance section
- `docs/contributing/ci-cd.md` — stub unfolded with the 4 real workflows (ci, release, toolkit-validation, deploy-pages)
- `docs/product/{what-is-ainb,value}.md` — reconciled "9 tools" → 11 deploy targets
- `docs/README.md` — migration-complete note

**plugins/reflect/** (Stevie flagged as most outdated)
- `README.md` — version refs 3.1.0/3.3.1 → 3.6.0; `errors-ack` added to sub-skills table
- `hooks/README.md` — documents all 5 wired lifecycle hooks (was 1)
- `docs/architecture.md` — hook diagram shows all 5 hooks; **corrected the false "PreCompact is NOT auto-installed" claim** (it auto-wires with `--auto --verbose` per plugin.json)

**Root + package READMEs**
- `README.md` — skill count 71/86 → 91, CLI 15 → 20 commands + full list, `ainb-fleet` plugin in tree, `deploy-pages` workflow, website link, removed non-existent `claude-developer-platform`, source tree → crates workspace, stale Homebrew tap link
- `toolkit/README.md` — 86 → 91 skills, fixed group counts, added 8 missing skills (make-a-goal, git-history-surgery, standup, tmux-message, claude-langfuse, langfuse-setup, explain-to-me), documented catalog.yaml
- `ainb-tui/README.md` + `CLAUDE.md` — flat `src/` → `crates/` workspace; component paths; project intro; `ainb fleet` family
- `reflect-kb/README.md` — `metrics stats` nested correctly under the metrics group

## How it was produced

`/workflow` dynamic run `wp11np3d9`: **Plan** (11 parallel agents, each verifying facts against code) → **Apply** (sequential, one file at a time → 61 atomic commits, no git-index races) → **Verify** (site build + stub/link sweep). +1 follow-up commit for the migration-complete note = 62.

## Test plan

- [x] `npm run build` passes (33 pages)
- [x] No `Status: stub` markers remain repo-wide
- [x] Skill/agent/command counts verified against the actual tree (91/35/20)
- [ ] Reviewer spot-check a few high-traffic pages (cli.md, reflect README, root README)