### PR TITLE
fix(ainb-tui): deletable orphaned sessions (stale crm entries lingering in UI)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -43,7 +43,12 @@ pub struct WorktreeManager {
 
 impl WorktreeManager {
     pub fn new() -> Result<Self> {
-        let home_dir = dirs::home_dir().context("Failed to get home directory")?;
+        // Honor `AINB_HOME` as a base-dir override (matches SessionStore), keeping
+        // production at `~/.agents-in-a-box/worktrees` while letting tests isolate.
+        let home_dir = match std::env::var_os("AINB_HOME") {
+            Some(h) => PathBuf::from(h),
+            None => dirs::home_dir().context("Failed to get home directory")?,
+        };
         let base_dir = home_dir.join(".agents-in-a-box").join("worktrees");
 
         std::fs::create_dir_all(&base_dir).with_context(|| {

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tokio::process::Command;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 #[derive(Error, Debug)]
@@ -134,11 +134,16 @@ impl SessionStore {
     }
 
     /// Get the storage file path
+    ///
+    /// Honors the `AINB_HOME` environment variable as an override for the base
+    /// directory (otherwise the user's home dir). This keeps the production path
+    /// at `~/.agents-in-a-box/sessions.json` while letting tests point the store
+    /// at an isolated temp directory.
     pub fn storage_path() -> PathBuf {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".agents-in-a-box")
-            .join("sessions.json")
+        let base = std::env::var_os("AINB_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")));
+        base.join(".agents-in-a-box").join("sessions.json")
     }
 
     /// Add or update a session
@@ -768,15 +773,21 @@ impl InteractiveSessionManager {
         let session_opt = self.active_sessions.remove(&session_id);
         info!("Session in active_sessions: {}", session_opt.is_some());
 
-        // Step 1: Kill tmux session
-        // If we have the session in memory, use its tmux_session_name
-        // Otherwise, try to find it by discovering from worktree
-        let tmux_session_name = if let Some(ref session) = session_opt {
+        // Step 1: Resolve the tmux session name, then kill it.
+        //
+        // Resolution order: in-memory session → worktree-derived name → the
+        // persisted sessions.json entry. The store fallback is what makes
+        // orphaned records deletable: an entry whose worktree/symlink is already
+        // gone (e.g. a shared worktree removed by a sibling session, or a record
+        // imported without a `by-session/<uuid>` symlink) still carries its
+        // `tmux_session_name`, so we can kill the tmux session and — crucially —
+        // always fall through to the store cleanup in Step 3 instead of bailing.
+        let tmux_session_name: Option<String> = if let Some(ref session) = session_opt {
             info!(
                 "Using tmux session name from memory: {}",
                 session.tmux_session_name
             );
-            session.tmux_session_name.clone()
+            Some(session.tmux_session_name.clone())
         } else {
             // Try to get worktree info and derive tmux session name
             info!("Session not in memory, discovering from worktree");
@@ -798,53 +809,88 @@ impl InteractiveSessionManager {
                         info!("Trying legacy tmux session name: {}", legacy_name);
                         legacy_name
                     };
-                    final_name
+                    Some(final_name)
                 }
                 Err(e) => {
-                    // Couldn't find worktree, can't determine tmux session name
-                    error!("Could not find worktree for session {}: {}", session_id, e);
-                    // Still try to remove worktree in case it exists
-                    if let Err(remove_err) = self.worktree_manager.remove_worktree(session_id) {
-                        warn!("Failed to remove worktree: {}", remove_err);
+                    // Couldn't resolve from the worktree (it's gone / never had a
+                    // symlink). Fall back to the persisted store so we can still
+                    // kill tmux and purge the record. Do NOT bail — bailing here is
+                    // exactly what left orphaned entries stuck in the UI.
+                    warn!(
+                        "Could not derive tmux name from worktree for session {} ({}); \
+                         falling back to sessions.json",
+                        session_id, e
+                    );
+                    let store_name = SessionStore::load()
+                        .sessions()
+                        .values()
+                        .find(|m| m.session_id == session_id)
+                        .map(|m| m.tmux_session_name.clone());
+                    if let Some(ref n) = store_name {
+                        info!("Resolved tmux name from sessions.json: {}", n);
+                    } else {
+                        info!(
+                            "No sessions.json entry for {} either — proceeding to cleanup by id",
+                            session_id
+                        );
                     }
-                    return Err(InteractiveSessionError::SessionNotFound(session_id));
+                    store_name
                 }
             }
         };
 
-        info!("Attempting to kill tmux session: {}", tmux_session_name);
-        let output = Command::new("tmux")
-            .args(["kill-session", "-t", &tmux_session_name])
-            .output()
-            .await?;
+        if let Some(ref name) = tmux_session_name {
+            info!("Attempting to kill tmux session: {}", name);
+            let output = Command::new("tmux").args(["kill-session", "-t", name]).output().await?;
 
-        if output.status.success() {
-            info!("Successfully killed tmux session: {}", tmux_session_name);
+            if output.status.success() {
+                info!("Successfully killed tmux session: {}", name);
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                warn!("Failed to kill tmux session '{}': {}", name, stderr);
+                // Continue anyway - session might already be dead
+            }
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!(
-                "Failed to kill tmux session '{}': {}",
-                tmux_session_name, stderr
+            info!(
+                "No tmux session name to kill for {} — skipping tmux step",
+                session_id
             );
-            // Continue anyway - session might already be dead
         }
 
         // Step 2: Remove worktree
+        //
+        // Worktree removal must NEVER block the sessions.json cleanup in Step 3.
+        // If it did, any session whose worktree is already gone (already deleted,
+        // a shared worktree removed by a sibling session, or an orphaned entry that
+        // never had a `by-session/<uuid>` symlink) could never be removed from the
+        // store — every delete would die here and the record would reappear in the
+        // UI on the next reload. A `NotFound` worktree already satisfies the
+        // post-condition (no worktree on disk), so we treat it as success; for any
+        // other error we log and still continue so the UI record is always cleared.
         info!("Attempting to remove worktree for session {}", session_id);
         match self.worktree_manager.remove_worktree(session_id) {
             Ok(()) => info!("Successfully removed worktree for session {}", session_id),
+            Err(crate::git::WorktreeError::NotFound(path)) => {
+                info!(
+                    "Worktree for session {} already gone ({}) — continuing to store cleanup",
+                    session_id, path
+                );
+            }
             Err(e) => {
-                error!(
-                    "Failed to remove worktree for session {}: {}",
+                // Non-fatal: leave any on-disk worktree for separate GC, but still
+                // purge the sessions.json record so the session leaves the UI.
+                warn!(
+                    "Failed to remove worktree for session {} ({}) — continuing to store cleanup",
                     session_id, e
                 );
-                return Err(e.into());
             }
         }
 
         // Step 3: Remove from sessions.json
         let mut store = SessionStore::load();
-        store.remove_by_tmux_name(&tmux_session_name);
+        if let Some(ref name) = tmux_session_name {
+            store.remove_by_tmux_name(name);
+        }
         store.remove_by_session_id(session_id); // Also remove by ID in case tmux name changed
         if let Err(e) = store.save() {
             warn!("Failed to update sessions.json after removal: {}", e);

--- a/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
+++ b/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
@@ -1,0 +1,95 @@
+// ABOUTME: Regression test for deleting orphaned sessions whose worktree is gone.
+//
+// Reproduces the "deleted session still shows in the UI" bug: a sessions.json
+// entry whose `by-session/<uuid>` symlink / worktree no longer exists (e.g. a
+// shared worktree removed by a sibling session, or an imported record that never
+// had a symlink). The old `remove_session` bailed at the worktree step and never
+// purged the store record, so the session reappeared on every reload.
+
+use ainb::interactive::session_manager::{
+    InteractiveSessionManager, SessionMetadata, SessionStore,
+};
+use ainb::models::session::SessionAgentType;
+use anyhow::Result;
+use chrono::Utc;
+use std::path::PathBuf;
+use std::process::Command;
+use uuid::Uuid;
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .args(["-V"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Deleting a session whose worktree is already gone must still remove its
+/// sessions.json record (otherwise it stays visible in the UI forever).
+#[tokio::test]
+async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return Ok(());
+    }
+
+    // Isolate both the session store and the worktree base under a temp AINB_HOME
+    // so we never touch the real ~/.agents-in-a-box. Safe to set process-wide:
+    // this is the only test in its binary, and no other test reads AINB_HOME.
+    let home = tempfile::tempdir()?;
+    std::env::set_var("AINB_HOME", home.path());
+
+    // Seed an orphan: a store entry with NO matching by-session symlink/worktree.
+    let orphan_id = Uuid::new_v4();
+    let tmux_name = format!("tmux_orphan-{}", &orphan_id.to_string()[..8]);
+    let keep_id = Uuid::new_v4();
+    let keep_name = format!("tmux_keep-{}", &keep_id.to_string()[..8]);
+
+    let mut store = SessionStore::default();
+    store.upsert(SessionMetadata {
+        session_id: orphan_id,
+        tmux_session_name: tmux_name.clone(),
+        worktree_path: home.path().join(".agents-in-a-box/worktrees/gone_worktree"),
+        workspace_name: "orphan-workspace".to_string(),
+        created_at: Utc::now(),
+        agent_type: SessionAgentType::default(),
+    });
+    store.upsert(SessionMetadata {
+        session_id: keep_id,
+        tmux_session_name: keep_name.clone(),
+        worktree_path: PathBuf::from("/path/keep"),
+        workspace_name: "keep-workspace".to_string(),
+        created_at: Utc::now(),
+        agent_type: SessionAgentType::default(),
+    });
+    store.save()?;
+    assert_eq!(SessionStore::load().sessions().len(), 2);
+
+    // Act: delete the orphan. The worktree lookup will fail (no symlink), which
+    // previously aborted the whole operation before the store cleanup.
+    let mut manager = InteractiveSessionManager::new()?;
+    let result = manager.remove_session(orphan_id).await;
+    assert!(
+        result.is_ok(),
+        "removing an orphaned session should succeed, got: {result:?}"
+    );
+
+    // Assert: orphan record gone, sibling untouched.
+    let after = SessionStore::load();
+    assert_eq!(
+        after.sessions().len(),
+        1,
+        "orphan record must be purged from sessions.json"
+    );
+    assert!(
+        after.find_by_tmux_name(&tmux_name).is_none(),
+        "orphan entry should no longer be present"
+    );
+    assert!(
+        after.find_by_tmux_name(&keep_name).is_some(),
+        "unrelated session must be preserved"
+    );
+
+    std::env::remove_var("AINB_HOME");
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Deleted sessions (e.g. the `feat/crm` ones) keep reappearing in the TUI on every reload.

## Root cause

`InteractiveSessionManager::remove_session` bailed before clearing the `sessions.json` record whenever the worktree couldn't be resolved or removed:

- `get_worktree_info()` failure branch returned `SessionNotFound` (early return, no store cleanup).
- The worktree-removal step propagated its error (early return, no store cleanup).

A freshly-constructed manager has an empty `active_sessions` map, so a UI delete always took the `get_worktree_info()` path. Any session whose worktree was already gone could therefore **never** be deleted:

- a **shared worktree** already removed by a sibling session (exactly the two `tmux_phase-0-admin-crm*` entries — both point at `shotclubhouse_shotclubhouse_feat_crm` but neither has a `by-session/<uuid>` symlink), or
- a record imported without a `by-session` symlink.

Every delete failed at the worktree step → the entry survived → it came back on reload.

```
UI delete → remove_session(uuid)
  resolve tmux name: active_sessions empty → get_worktree_info(uuid)
    by-session/<uuid> MISSING → fallback worktrees/<uuid> absent → Err(NotFound)
  → return Err(SessionNotFound)        ← BAILS, sessions.json never cleaned
```

## Fix

- When the worktree lookup fails, resolve the tmux session name from the **persisted store** instead of bailing.
- Treat worktree removal (`NotFound` or any error) as **non-fatal** — a missing worktree already satisfies the post-condition; deletion always proceeds to the `sessions.json` cleanup.
- Honor an `AINB_HOME` base-dir override in `SessionStore` and `WorktreeManager` so the regression test isolates state under a temp dir (production path unchanged).

## Test

New `tests/orphan_session_removal.rs`: seeds an orphan store entry whose worktree/symlink is absent, deletes it, asserts the record is purged and an unrelated session is preserved. Verified it **fails** against the old early-return behavior and **passes** with the fix.

> Note: this fix makes future deletes work. Existing stuck entries in your live `sessions.json` need a rebuild + re-delete via the UI (no live-data edits were made).