### PR TITLE
docs(plugins): per-plugin docsite pages + diagrams + accuracy fixes

### DIFF
--- a/docs/assets/diagrams/burndown.svg
+++ b/docs/assets/diagrams/burndown.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#d97757"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7b8b5c"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#8c6f5a"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#b45309"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9a6fb0"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#d97757"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#8f8a80"/>
+    </marker>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 24px; font-weight: 700; fill: #141413; }
+    .subtitle { font-size: 13px; font-weight: 500; fill: #8f8a80; }
+    .section { font-size: 13px; font-weight: 700; fill: #8b7355; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #b4aba0; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #141413; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b6257; }
+    .node-type { font-size: 11px; font-weight: 700; fill: #a29a8f; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b6257; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b6257; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #a29a8f; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#f8f6f3"/>
+  <text x="48.0" y="48" text-anchor="start" class="title">burndown — screen-owner reference plugin</text>
+  <text x="48.0" y="72" text-anchor="start" class="subtitle">subscribes to the data plane, owns the Analytics screen and the `ainb usage` CLI</text>
+  <line x1="48" y1="100" x2="912.0" y2="100" stroke="#ded8cf" stroke-width="1"/>
+  <path d="M 300.0,198.0 L 375.0,198.0" fill="none" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <path d="M 585.0,198.0 L 660.0,198.0" fill="none" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <path d="M 775.0,130.0 L 775.0,129.6 L 480.0,129.6 L 480.0,150.0" fill="none" stroke="#d97757" stroke-width="2.0" marker-end="url(#arrowA)" stroke-dasharray="6,4"/>
+  <path d="M 775.0,266.0 L 775.0,286.4 L 635.4,455.0 L 615.0,455.0" fill="none" stroke="#8c6f5a" stroke-width="2.0" marker-end="url(#arrowC)"/>
+  <path d="M 775.0,266.0 L 775.0,286.4 L 790.0,389.6 L 790.0,410.0" fill="none" stroke="#8c6f5a" stroke-width="2.0" marker-end="url(#arrowC)"/>
+  <rect x="70.0" y="150.0" width="230.0" height="96.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="185.0" y="168.0" text-anchor="middle" class="node-type">PUBLISHER PLUGIN</text>
+  <text x="185.0" y="204.0" text-anchor="middle" class="node-title">session-reader</text>
+  <text x="185.0" y="226.0" text-anchor="middle" class="node-sub">scans ~/.claude + ~/.codex</text>
+  <rect x="375.0" y="150.0" width="210.0" height="96.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="2.0"/>
+  <rect x="381.0" y="156.0" width="198.0" height="84.0" rx="7.0" fill="none" stroke="#d9d0c3" stroke-width="1.2" opacity="0.65"/>
+  <text x="480.0" y="168.0" text-anchor="middle" class="node-type">AINB-CORE HOST</text>
+  <text x="480.0" y="204.0" text-anchor="middle" class="node-title">host event bus</text>
+  <text x="480.0" y="226.0" text-anchor="middle" class="node-sub">snapshot store (last publish)</text>
+  <rect x="660.0" y="130.0" width="230.0" height="136.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="775.0" y="148.0" text-anchor="middle" class="node-type">SCREEN-OWNER PLUGIN</text>
+  <text x="775.0" y="204.0" text-anchor="middle" class="node-title">burndown</text>
+  <text x="775.0" y="226.0" text-anchor="middle" class="node-sub">chunk accumulator + filter cache</text>
+  <rect x="375.0" y="400.0" width="240.0" height="110.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="2.0"/>
+  <rect x="375.0" y="400.0" width="240.0" height="18" rx="10.0" fill="#1f2937" opacity="0.95"/>
+  <circle cx="391.0" cy="409.0" r="4" fill="#ef4444"/>
+  <circle cx="405.0" cy="409.0" r="4" fill="#f59e0b"/>
+  <circle cx="419.0" cy="409.0" r="4" fill="#10b981"/>
+  <text x="393.0" y="444.0" font-size="28" font-weight="700" fill="#10b981">$</text>
+  <text x="413.0" y="444.0" font-size="22" font-weight="500" fill="#6b6257">_</text>
+  <text x="495.0" y="418.0" text-anchor="middle" class="node-type">TUI</text>
+  <text x="495.0" y="496.0" text-anchor="middle" class="node-title">Analytics screen</text>
+  <text x="495.0" y="530.0" text-anchor="middle" class="node-sub">WireBuffer / frame</text>
+  <path d="M 690.0 410.0 L 872.0 410.0 L 890.0 428.0 L 890.0 510.0 L 690.0 510.0 Z" fill="#fffcf7" stroke="#d9d0c3" stroke-width="2.0"/>
+  <path d="M 872.0 410.0 L 872.0 428.0 L 890.0 428.0" fill="none" stroke="#d9d0c3" stroke-width="2.0"/>
+  <line x1="708.0" y1="436.0" x2="862.0" y2="436.0" stroke="#c4b5fd" stroke-width="1.2"/>
+  <line x1="708.0" y1="450.0" x2="862.0" y2="450.0" stroke="#c4b5fd" stroke-width="1.2"/>
+  <line x1="708.0" y1="464.0" x2="862.0" y2="464.0" stroke="#c4b5fd" stroke-width="1.2"/>
+  <line x1="708.0" y1="478.0" x2="862.0" y2="478.0" stroke="#c4b5fd" stroke-width="1.2"/>
+  <text x="790.0" y="428.0" text-anchor="middle" class="node-type">CLI TREE</text>
+  <text x="790.0" y="536.0" text-anchor="middle" class="node-title">ainb usage ...</text>
+  <text x="790.0" y="554.0" text-anchor="middle" class="node-sub">report · today · export</text>
+  <rect x="281.5" y="184.0" width="112" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="337.5" y="198.0" text-anchor="middle" class="arrow-label">publish chunks</text>
+  <rect x="549.0" y="184.0" width="147" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="622.5" y="198.0" text-anchor="middle" class="arrow-label">sessions.usage_data</text>
+  <rect x="568.0" y="99.6" width="119" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="627.5" y="113.6" text-anchor="middle" class="arrow-label">refresh_request</text>
+  <rect x="652.7" y="340.7" width="105" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="705.2" y="354.7" text-anchor="middle" class="arrow-label">plugin/render</text>
+  <rect x="709.0" y="308.0" width="147" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="782.5" y="322.0" text-anchor="middle" class="arrow-label">plugin/cli_dispatch</text>
+  <line x1="42.0" y1="600.0" x2="72.0" y2="600.0" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <text x="82.0" y="604.0" class="legend">data (msgpack snapshot)</text>
+  <line x1="42.0" y1="622.0" x2="72.0" y2="622.0" stroke="#d97757" stroke-width="2.0" marker-end="url(#arrowA)"/>
+  <text x="82.0" y="626.0" class="legend">control (publish trigger)</text>
+  <line x1="42.0" y1="644.0" x2="72.0" y2="644.0" stroke="#8c6f5a" stroke-width="2.0" marker-end="url(#arrowC)"/>
+  <text x="82.0" y="648.0" class="legend">render / dispatch</text>
+  <text x="42.0" y="684.0" class="footnote">burndown holds no scanner — it renders what session-reader publishes.</text>
+</svg>

--- a/docs/assets/diagrams/notifyd.svg
+++ b/docs/assets/diagrams/notifyd.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6b7280"/>
+    </marker>
+    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowGlass" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#020617" flood-opacity="0.28"/>
+    </filter>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 30px; font-weight: 700; fill: #111827; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #6b7280; }
+    .section { font-size: 13px; font-weight: 700; fill: #2563eb; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #111827; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .node-type { font-size: 12px; font-weight: 700; fill: #9ca3af; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b7280; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#ffffff"/>
+  <text x="480.0" y="56" text-anchor="middle" class="title">notifyd — hook-capture daemon + Inbox screen</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">Claude Code / Codex hook events flow through a Unix socket into ainb-notifyd, then SQLite, then the Inbox</text>
+  <path d="M 154.0,192.0 L 154.0,278.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 252.0,324.0 L 392.0,324.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 154.0,370.0 L 154.0,456.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)" stroke-dasharray="6,4"/>
+  <path d="M 472.0,278.0 L 472.0,210.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 154.0,540.0 L 154.0,394.0 L 339.6,394.0 L 339.6,157.0 L 360.0,157.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)" stroke-dasharray="6,4"/>
+  <path d="M 584.0,157.0 L 692.0,157.0" fill="none" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <path d="M 360.0,157.0 L 336.0,157.0 L 336.0,498.0 L 360.0,498.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 794.0,210.0 L 794.0,230.4 L 778.0,257.6 L 778.0,278.0" fill="none" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <path d="M 896.0,157.0 L 924.0,157.0 L 924.0,498.0 L 896.0,498.0" fill="none" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <rect x="56.0" y="104.0" width="196.0" height="88.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="154.0" y="122.0" text-anchor="middle" class="node-type">HOOK SOURCE</text>
+  <text x="154.0" y="154.0" text-anchor="middle" class="node-title">Claude Code / Codex</text>
+  <text x="154.0" y="176.0" text-anchor="middle" class="node-sub">host agents fire hooks</text>
+  <rect x="56.0" y="278.0" width="196.0" height="92.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="154.0" y="296.0" text-anchor="middle" class="node-type">BASH HOOK</text>
+  <text x="154.0" y="330.0" text-anchor="middle" class="node-title">ainb-hooks notify.sh</text>
+  <text x="154.0" y="352.0" text-anchor="middle" class="node-sub">normalize to envelope</text>
+  <rect x="56.0" y="456.0" width="196.0" height="84.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="154.0" y="474.0" text-anchor="middle" class="node-type">FALLBACK</text>
+  <text x="154.0" y="504.0" text-anchor="middle" class="node-title">fallback.jsonl</text>
+  <text x="154.0" y="526.0" text-anchor="middle" class="node-sub">queue while down</text>
+  <rect x="392.0" y="278.0" width="160.0" height="92.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="472.0" y="296.0" text-anchor="middle" class="node-type">TRANSPORT</text>
+  <text x="472.0" y="330.0" text-anchor="middle" class="node-title">notify.sock</text>
+  <text x="472.0" y="352.0" text-anchor="middle" class="node-sub">Unix socket · 0600</text>
+  <rect x="360.0" y="104.0" width="224.0" height="106.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="472.0" y="122.0" text-anchor="middle" class="node-type">TOKIO DAEMON</text>
+  <text x="472.0" y="163.0" text-anchor="middle" class="node-title">ainb-notifyd</text>
+  <text x="472.0" y="185.0" text-anchor="middle" class="node-sub">accept · parse · replay</text>
+  <rect x="360.0" y="456.0" width="224.0" height="84.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="472.0" y="474.0" text-anchor="middle" class="node-type">DEBOUNCED 60s</text>
+  <text x="472.0" y="504.0" text-anchor="middle" class="node-title">OS notification</text>
+  <text x="472.0" y="526.0" text-anchor="middle" class="node-sub">osascript / notify-send</text>
+  <rect x="692.0" y="104.0" width="204.0" height="106.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="794.0" y="122.0" text-anchor="middle" class="node-type">STORE</text>
+  <text x="794.0" y="163.0" text-anchor="middle" class="node-title">notifications.db</text>
+  <text x="794.0" y="185.0" text-anchor="middle" class="node-sub">SQLite WAL · 7d / 10k</text>
+  <rect x="660.0" y="278.0" width="236.0" height="92.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="778.0" y="296.0" text-anchor="middle" class="node-type">AINB-CORE TUI</text>
+  <text x="778.0" y="330.0" text-anchor="middle" class="node-title">Inbox screen</text>
+  <text x="778.0" y="352.0" text-anchor="middle" class="node-sub">two-pane · poll-on-tick · key I</text>
+  <rect x="660.0" y="456.0" width="236.0" height="84.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="778.0" y="474.0" text-anchor="middle" class="node-type">SESSION LIST</text>
+  <text x="778.0" y="504.0" text-anchor="middle" class="node-title">Sessions unread badge</text>
+  <text x="778.0" y="526.0" text-anchor="middle" class="node-sub">unread_by_cwd to per-session N</text>
+  <rect x="87.0" y="221.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="136.0" y="235.0" text-anchor="middle" class="arrow-label">stdin / argv</text>
+  <rect x="287.0" y="294.0" width="70" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="322.0" y="308.0" text-anchor="middle" class="arrow-label">envelope</text>
+  <rect x="104.5" y="399.0" width="63" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="136.0" y="413.0" text-anchor="middle" class="arrow-label">on fail</text>
+  <rect x="426.0" y="230.0" width="56" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="454.0" y="244.0" text-anchor="middle" class="arrow-label">accept</text>
+  <rect x="180.3" y="396.0" width="133" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="246.8" y="410.0" text-anchor="middle" class="arrow-label">replay at startup</text>
+  <rect x="582.0" y="143.0" width="112" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="638.0" y="157.0" text-anchor="middle" class="arrow-label">insert + prune</text>
+  <rect x="280.0" y="313.5" width="112" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="336.0" y="327.5" text-anchor="middle" class="arrow-label">if user-facing</text>
+  <rect x="705.5" y="214.0" width="161" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="786.0" y="228.0" text-anchor="middle" class="arrow-label">list / mark / dismiss</text>
+  <rect x="907.0" y="313.5" width="70" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="942.0" y="327.5" text-anchor="middle" class="arrow-label">unread N</text>
+  <line x1="372.0" y1="600.0" x2="402.0" y2="600.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <text x="412.0" y="604.0" class="legend">hook control</text>
+  <line x1="372.0" y1="622.0" x2="402.0" y2="622.0" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <text x="412.0" y="626.0" class="legend">envelope data</text>
+  <line x1="372.0" y1="644.0" x2="402.0" y2="644.0" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <text x="412.0" y="648.0" class="legend">SQLite write</text>
+  <line x1="372.0" y1="666.0" x2="402.0" y2="666.0" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <text x="412.0" y="670.0" class="legend">store read</text>
+  <line x1="372.0" y1="688.0" x2="402.0" y2="688.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <text x="412.0" y="692.0" class="legend">OS notify</text>
+</svg>

--- a/docs/assets/diagrams/session-reader.svg
+++ b/docs/assets/diagrams/session-reader.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6b7280"/>
+    </marker>
+    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowGlass" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#020617" flood-opacity="0.28"/>
+    </filter>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 30px; font-weight: 700; fill: #111827; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #6b7280; }
+    .section { font-size: 13px; font-weight: 700; fill: #2563eb; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #111827; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .node-type { font-size: 12px; font-weight: 700; fill: #9ca3af; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b7280; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#ffffff"/>
+  <text x="480.0" y="56" text-anchor="middle" class="title">session-reader — pure publisher data plane</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">scans provider session logs and chunk-publishes UsageData on sessions.usage_data</text>
+  <path d="M 125.0,300.0 L 125.0,185.0 L 290.0,185.0" fill="none" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <path d="M 395.0,240.0 L 395.0,300.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 395.0,410.0 L 395.0,470.0" fill="none" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)" stroke-dasharray="6,4"/>
+  <path d="M 500.0,355.0 L 620.0,355.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 695.0,300.0 L 695.0,200.0 L 800.0,200.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 695.0,410.0 L 695.0,510.0 L 800.0,510.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 870.0,250.0 L 870.0,270.4 L 520.4,355.0 L 500.0,355.0" fill="none" stroke="#ef4444" stroke-width="2.4" marker-end="url(#arrowG)" stroke-dasharray="6,4"/>
+  <rect x="30.0" y="300.0" width="190.0" height="130.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="125.0" y="318.0" text-anchor="middle" class="node-type">FILESYSTEM RO</text>
+  <text x="125.0" y="371.0" text-anchor="middle" class="node-title">Session logs</text>
+  <text x="125.0" y="393.0" text-anchor="middle" class="node-sub">.claude · .codex · gemini</text>
+  <rect x="290.0" y="130.0" width="210.0" height="110.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="395.0" y="148.0" text-anchor="middle" class="node-type">SCAN + PARSE</text>
+  <text x="395.0" y="191.0" text-anchor="middle" class="node-title">scanner</text>
+  <text x="395.0" y="213.0" text-anchor="middle" class="node-sub">walk + parse per file</text>
+  <rect x="290.0" y="470.0" width="210.0" height="110.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="395.0" y="488.0" text-anchor="middle" class="node-type">WRITE_PLUGIN_DATA</text>
+  <text x="395.0" y="531.0" text-anchor="middle" class="node-title">parse cache</text>
+  <text x="395.0" y="553.0" text-anchor="middle" class="node-sub">(mtime,size) short-circuit</text>
+  <rect x="290.0" y="300.0" width="210.0" height="110.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="395.0" y="318.0" text-anchor="middle" class="node-type">MSGPACK CHUNKER</text>
+  <text x="395.0" y="361.0" text-anchor="middle" class="node-title">chunk_usage_data</text>
+  <text x="395.0" y="383.0" text-anchor="middle" class="node-sub">split tail vecs &lt; 2 MiB</text>
+  <rect x="620.0" y="300.0" width="150.0" height="110.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="695.0" y="318.0" text-anchor="middle" class="node-type">EVENT_BUS</text>
+  <text x="695.0" y="361.0" text-anchor="middle" class="node-title">host event bus</text>
+  <text x="695.0" y="383.0" text-anchor="middle" class="node-sub">per-topic latest</text>
+  <rect x="800.0" y="150.0" width="140.0" height="100.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="870.0" y="168.0" text-anchor="middle" class="node-type">SUBSCRIBER</text>
+  <text x="870.0" y="206.0" text-anchor="middle" class="node-title">burndown</text>
+  <text x="870.0" y="228.0" text-anchor="middle" class="node-sub">Analytics screen</text>
+  <rect x="800.0" y="460.0" width="140.0" height="100.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="870.0" y="478.0" text-anchor="middle" class="node-type">CONSUMER</text>
+  <text x="870.0" y="516.0" text-anchor="middle" class="node-title">ainb host</text>
+  <text x="870.0" y="538.0" text-anchor="middle" class="node-sub">snapshot store</text>
+  <rect x="165.5" y="155.0" width="84" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="207.5" y="169.0" text-anchor="middle" class="arrow-label">read JSONL</text>
+  <rect x="338.5" y="256.0" width="77" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="377.0" y="270.0" text-anchor="middle" class="arrow-label">UsageData</text>
+  <rect x="328.0" y="426.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="377.0" y="440.0" text-anchor="middle" class="arrow-label">cache parses</text>
+  <rect x="493.5" y="341.0" width="133" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="560.0" y="355.0" text-anchor="middle" class="arrow-label">publish (chunked)</text>
+  <rect x="628.0" y="236.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="677.0" y="250.0" text-anchor="middle" class="arrow-label">handle_event</text>
+  <rect x="628.0" y="446.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="677.0" y="460.0" text-anchor="middle" class="arrow-label">snapshot/get</text>
+  <rect x="635.7" y="298.7" width="119" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="695.2" y="312.7" text-anchor="middle" class="arrow-label">refresh_request</text>
+  <line x1="42.0" y1="556.0" x2="72.0" y2="556.0" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <text x="82.0" y="560.0" class="legend">read sessions</text>
+  <line x1="42.0" y1="578.0" x2="72.0" y2="578.0" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <text x="82.0" y="582.0" class="legend">UsageData chunks</text>
+  <line x1="42.0" y1="600.0" x2="72.0" y2="600.0" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <text x="82.0" y="604.0" class="legend">cache write</text>
+  <line x1="42.0" y1="622.0" x2="72.0" y2="622.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <text x="82.0" y="626.0" class="legend">event delivery</text>
+  <line x1="42.0" y1="644.0" x2="72.0" y2="644.0" stroke="#ef4444" stroke-width="2.4" marker-end="url(#arrowG)"/>
+  <text x="82.0" y="648.0" class="legend">refresh trigger</text>
+</svg>

--- a/docs/assets/diagrams/witr.svg
+++ b/docs/assets/diagrams/witr.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#d97757"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7b8b5c"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#8c6f5a"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#b45309"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9a6fb0"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#d97757"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#8f8a80"/>
+    </marker>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 24px; font-weight: 700; fill: #141413; }
+    .subtitle { font-size: 13px; font-weight: 500; fill: #8f8a80; }
+    .section { font-size: 13px; font-weight: 700; fill: #8b7355; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #b4aba0; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #141413; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b6257; }
+    .node-type { font-size: 11px; font-weight: 700; fill: #a29a8f; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b6257; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b6257; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #a29a8f; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#f8f6f3"/>
+  <text x="48.0" y="48" text-anchor="start" class="title">witr plugin — two paths to one external binary</text>
+  <text x="48.0" y="72" text-anchor="start" class="subtitle">press w → foreign-TTY embed   ·   ainb witr / slash → witr --json parse</text>
+  <line x1="48" y1="100" x2="912.0" y2="100" stroke="#ded8cf" stroke-width="1"/>
+  <path d="M 278.0,155.0 L 360.0,155.0" fill="none" stroke="#d97757" stroke-width="2.0" marker-end="url(#arrowA)"/>
+  <path d="M 590.0,155.0 L 670.0,155.0" fill="none" stroke="#d97757" stroke-width="2.0" marker-end="url(#arrowA)"/>
+  <path d="M 163.0,470.0 L 163.0,346.0 L 340.0,346.0" fill="none" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <path d="M 485.0,392.0 L 485.0,412.4 L 475.0,449.6 L 475.0,470.0" fill="none" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <path d="M 590.0,511.0 L 670.0,511.0" fill="none" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <path d="M 785.0,472.0 L 785.0,385.0" fill="none" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <path d="M 785.0,550.0 L 785.0,641.0 L 650.0,641.0" fill="none" stroke="#7b8b5c" stroke-width="2.0" marker-end="url(#arrowB)"/>
+  <rect x="48.0" y="120.0" width="230.0" height="70.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="163.0" y="138.0" text-anchor="middle" class="node-type">USER · SCREEN</text>
+  <text x="163.0" y="161.0" text-anchor="middle" class="node-title">press `w` / sidebar tile</text>
+  <text x="163.0" y="183.0" text-anchor="middle" class="node-sub">AppEvent::GoToWitr</text>
+  <rect x="360.0" y="116.0" width="230.0" height="78.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="475.0" y="134.0" text-anchor="middle" class="node-type">HOST · AttachWitr</text>
+  <text x="475.0" y="161.0" text-anchor="middle" class="node-title">ainb-core host</text>
+  <text x="475.0" y="183.0" text-anchor="middle" class="node-sub">suspend TUI · attach · resume</text>
+  <rect x="670.0" y="118.0" width="230.0" height="74.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="785.0" y="136.0" text-anchor="middle" class="node-type">FOREIGN TTY</text>
+  <text x="785.0" y="161.0" text-anchor="middle" class="node-title">tmux: witr -i</text>
+  <text x="785.0" y="183.0" text-anchor="middle" class="node-sub">full-screen process browser</text>
+  <rect x="340.0" y="300.0" width="290.0" height="92.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="485.0" y="318.0" text-anchor="middle" class="node-type">PLUGIN · JSON-RPC</text>
+  <text x="485.0" y="352.0" text-anchor="middle" class="node-title">WitrPlugin (subprocess)</text>
+  <text x="485.0" y="374.0" text-anchor="middle" class="node-sub">cli_dispatch · render · on_init</text>
+  <rect x="670.0" y="305.0" width="230.0" height="80.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="785.0" y="323.0" text-anchor="middle" class="node-type">RENDER</text>
+  <text x="785.0" y="351.0" text-anchor="middle" class="node-title">ancestry / tabs / text</text>
+  <text x="785.0" y="373.0" text-anchor="middle" class="node-sub">4-tab screen · --tree · --warnings</text>
+  <rect x="48.0" y="470.0" width="230.0" height="78.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="163.0" y="488.0" text-anchor="middle" class="node-type">USER · CLI / SLASH</text>
+  <text x="163.0" y="515.0" text-anchor="middle" class="node-title">ainb witr &lt;target&gt;  ·  /witr</text>
+  <text x="163.0" y="537.0" text-anchor="middle" class="node-sub">host routes argv → plugin</text>
+  <rect x="360.0" y="470.0" width="230.0" height="82.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="475.0" y="488.0" text-anchor="middle" class="node-type">EXEC</text>
+  <text x="475.0" y="517.0" text-anchor="middle" class="node-title">exec witr --json</text>
+  <text x="475.0" y="539.0" text-anchor="middle" class="node-sub">spawn_subprocess · 5s · no shell</text>
+  <rect x="670.0" y="472.0" width="230.0" height="78.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="785.0" y="490.0" text-anchor="middle" class="node-type">DECODE</text>
+  <text x="785.0" y="517.0" text-anchor="middle" class="node-title">parse → WitrSnapshot</text>
+  <text x="785.0" y="539.0" text-anchor="middle" class="node-sub">JSON wins despite non-zero exit</text>
+  <rect x="360.0" y="610.0" width="290.0" height="62.0" rx="10.0" fill="#fffcf7" stroke="#d9d0c3" stroke-width="1.8"/>
+  <text x="505.0" y="628.0" text-anchor="middle" class="node-type">EVENT BUS</text>
+  <text x="505.0" y="647.0" text-anchor="middle" class="node-title">publish witr.snapshot</text>
+  <text x="505.0" y="669.0" text-anchor="middle" class="node-sub">host/snapshot/publish (TUI path only)</text>
+  <rect x="284.0" y="125.0" width="70" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="319.0" y="139.0" text-anchor="middle" class="arrow-label">GoToWitr</text>
+  <rect x="574.0" y="141.0" width="112" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="630.0" y="155.0" text-anchor="middle" class="arrow-label">spawn + attach</text>
+  <rect x="202.5" y="316.0" width="98" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="251.5" y="330.0" text-anchor="middle" class="arrow-label">cli_dispatch</text>
+  <rect x="431.0" y="401.0" width="98" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="480.0" y="415.0" text-anchor="middle" class="arrow-label">scan(target)</text>
+  <rect x="602.0" y="481.0" width="56" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="630.0" y="495.0" text-anchor="middle" class="arrow-label">stdout</text>
+  <rect x="732.0" y="414.5" width="70" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="767.0" y="428.5" text-anchor="middle" class="arrow-label">snapshot</text>
+  <rect x="686.0" y="611.0" width="63" height="20" rx="6" fill="#f8f6f3" opacity="0.96"/>
+  <text x="717.5" y="625.0" text-anchor="middle" class="arrow-label">publish</text>
+  <line x1="747.0" y1="250.0" x2="777.0" y2="250.0" stroke="#d97757" stroke-width="2.0" marker-end="url(#arrowA)"/>
+  <text x="787.0" y="254.0" class="legend">control / handoff</text>
+  <line x1="747.0" y1="272.0" x2="777.0" y2="272.0" stroke="#b45309" stroke-width="2.0" marker-end="url(#arrowE)"/>
+  <text x="787.0" y="276.0" class="legend">data / JSON</text>
+  <line x1="747.0" y1="294.0" x2="777.0" y2="294.0" stroke="#7b8b5c" stroke-width="2.0" marker-end="url(#arrowB)"/>
+  <text x="787.0" y="298.0" class="legend">event bus</text>
+</svg>

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -20,7 +20,7 @@ A plugin can:
 - **Read host-managed state** — sessions, Claude/Codex logs (capability-gated)
 - **Invoke host actions** — call out to host-owned operations via `host/action/invoke`
 
-The bundled `ainb-plugin-burndown` is the canonical reference: owns the Analytics screen, the `ainb usage` CLI tree, and a statusline segment. `ainb-plugin-session-reader` is the canonical pure-publisher example. `ainb-plugin-witr` is the canonical **subprocess-wrapping** example: it declares `spawn_subprocess`, detects an external binary (`witr`) on `PATH`, gates its UI on a version check, and execs `witr --json <target>` to back its screen and `ainb witr` CLI — the template for surfacing any external tool as a plugin without vendoring its code.
+The bundled `ainb-plugin-burndown` is the canonical reference: owns the Analytics screen, the `ainb usage` CLI tree, and a statusline segment. `ainb-plugin-session-reader` is the canonical pure-publisher example. `ainb-plugin-witr` is the canonical **subprocess-wrapping** example: it declares `spawn_subprocess`, detects an external binary (`witr`) on `PATH`, gates on a version check, and execs `witr --json <target>` to back its `ainb witr` CLI + `/witr` slash (its *screen* is a host-embedded `witr -i` TTY, not a `WireBuffer` render) — the template for surfacing any external tool as a plugin without vendoring its code. Each has a dedicated page under [Plugins → In-tree plugins](./overview.md#reference-plugins).
 
 ## Scaffold
 

--- a/docs/plugins/burndown.md
+++ b/docs/plugins/burndown.md
@@ -1,0 +1,51 @@
+---
+title: "burndown plugin"
+description: "Owns the Analytics screen and the ainb usage CLI — renders usage data published by session-reader over the event bus."
+---
+
+# burndown
+
+`burndown` is the in-tree **screen-owner** reference plugin: it paints the full Analytics dashboard and owns the `ainb usage` CLI tree. It is also the consumer half of the event-bus **publish/subscribe** pattern — it does not scan any session files itself, it renders the snapshots `session-reader` publishes.
+
+## How it works
+
+![burndown plugin — how it works](../assets/diagrams/burndown.svg)
+
+`burndown` is **eager-spawned** (manifest `[lifecycle].spawn = "eager"`). On `plugin/init` it subscribes to `sessions.usage_data` and `sessions.scan_progress`, then publishes an empty payload on `sessions.refresh_request` to kick `session-reader` into a fresh scan with the subscription already on the wire — closing the race where chunk 0 of an in-flight publish would otherwise be missed.
+
+`session-reader` scans `~/.claude/projects/**` and `~/.codex/sessions/**` and publishes the aggregated usage to the host event bus. The host delivers each publish to `burndown` as a `plugin/handle_event` call on the subscribed topic. Large snapshots arrive **chunked**: chunk 0 carries the bounded aggregates, follow-on chunks extend the `calls` / `sessions` / `shell_commands` tails, and the `is_final` chunk assembles the accumulator into the live `UsageData` (a wire-version mismatch latches a schema-upgrade hint instead). Progress ticks on `sessions.scan_progress` drive the "Scanning sessions… N/M" skeleton until real data lands.
+
+For the **Analytics screen**, the host sends `plugin/render` with a `Viewport`; `burndown` paints a ratatui `Buffer`, converts it to a sparse `WireBuffer` cell stream, and the host blits it each frame. Filtering (`analyze_turns` + per-day/project/model rollups) is memoised in a one-deep cache keyed on `(data_generation, filters+period+provider)` so idle re-renders are O(1). Keystrokes arrive via `plugin/handle_key` — most mutate local UI state (period `1`–`5`/`m`/`q`/`a`, provider `←`/`→`/`p`, panel focus `Tab`, zoom `z`, drill-down `Enter`); `r` re-publishes `sessions.refresh_request` and `F` publishes `sessions.flush_cache_request`.
+
+For the **CLI**, the host routes `ainb usage …` through `plugin/cli_dispatch`. `burndown` strips the host-level `--format` flag, re-parses the rest with clap, and runs the report against its latest in-memory snapshot — capturing the legacy report writer's stdout into the JSON-RPC reply. If no snapshot has arrived yet it returns the "install session-reader" hint and the host CLI shim retries until the deadline.
+
+## Capabilities
+
+Declared in `plugin.toml` `[capabilities]` (everything not listed defaults to deny):
+
+| Capability | Why it is needed |
+| --- | --- |
+| `read_sessions` | Read access to `~/.agents-in-a-box/sessions/**`. |
+| `write_plugin_data` | Persist plugin-local config (model aliases, display currency) under the plugin data dir. |
+| `event_bus` | Exposes `host/snapshot/get` + `host/snapshot/publish` + `host/log` on the reverse channel — required to subscribe to `sessions.usage_data` and publish `sessions.refresh_request`. |
+
+It does **not** declare `read_claude_logs`, `read_codex_logs`, `spawn_subprocess`, or `network` — burndown no longer scans logs itself; `session-reader` owns the data plane.
+
+## Using it
+
+- **Screen** — the manifest provides the `analytics` screen. Open it from the host's screen navigation; you get the full analytics dashboard (per-day / per-project / per-model panels, drill-down chips, provider filter). In-screen keys: `1`–`5` / `m` / `q` / `a` (period), `←` `→` / `p` (provider), `Tab` / `Shift+Tab` (panel focus), `z` (zoom), `Enter` (drill-down chip), `X` (exclude chip), `C` (clear chips), `Backspace` (pop chip / exit zoom), `k` (scroll up), `r` (refresh), `F` (flush cache + rescan). `Esc` is host-reserved for navigate-back.
+- **CLI namespace** — provides `cli_namespaces = ["usage"]`, dispatched as `ainb usage <subcommand>`:
+  - `ainb usage report` — compact burndown report
+  - `ainb usage today` / `ainb usage month` / `ainb usage status`
+  - `ainb usage models [--by-task]` — per-model rollup or model × activity matrix
+  - `ainb usage export` — CSV / JSON export
+  - `ainb usage optimize` / `ainb usage compare` / `ainb usage yield`
+  - `ainb usage plan …` / `ainb usage currency …` / `ainb usage model-alias …` — config subtrees
+  - `ainb usage cache info` / `ainb usage cache clear`
+  - The host-level `--format <text|json|csv>` flag is honoured on report subcommands.
+- **Slash commands** — provides `/usage` and `/burndown`.
+- **Snapshot topics** — provides no published topics (`provides.snapshots = []`). It **subscribes** to `sessions.usage_data` (the data plane) and `sessions.scan_progress` (skeleton ticks), and **publishes** the control topics `sessions.refresh_request` and `sessions.flush_cache_request` to drive `session-reader`.
+
+## Source
+
+`crates/ainb-plugin-burndown` — the screen-owner reference plugin: renders the Analytics dashboard from `session-reader`'s published snapshots and serves the `ainb usage` CLI. Diagram generated via /fireworks-tech-graph.

--- a/docs/plugins/changelog.md
+++ b/docs/plugins/changelog.md
@@ -28,7 +28,7 @@ Surface area (full reference in [v2.md](./v2.md)):
 - **Chunked publishes**: `WIRE_VERSION` + `chunk_index` + `is_final` ordering contract; subscribers MUST drop follow-on chunks that arrived without chunk 0.
 - **Priority key channel** (2026-05-15): host runtime drains `plugin/handle_key` notifications ahead of `plugin/handle_event` to prevent FIFO starvation during chunked publishes.
 
-`ainb-plugin-cts-v2` ships with 14 conformance axes. In-tree dogfood plugins: `burndown` (analytics screen + `ainb usage` CLI), `session-reader` (chunked usage_data publisher), and `witr` (process-causality screen + `ainb witr` CLI; wraps the external `witr` binary via `spawn_subprocess`).
+`ainb-plugin-cts-v2` ships with 14 conformance axes. In-tree dogfood plugins: `burndown` (analytics screen + `ainb usage` CLI), `session-reader` (chunked usage_data publisher), and `witr` (`ainb witr` CLI + `/witr` slash wrapping the external `witr` binary via `spawn_subprocess`; its process-causality screen is a host-embedded `witr -i` TTY). See [Plugins → In-tree plugins](./overview.md#reference-plugins) for per-plugin pages.
 
 ## v1 — historical, removed 2026-05-15
 

--- a/docs/plugins/notifyd.md
+++ b/docs/plugins/notifyd.md
@@ -1,0 +1,47 @@
+---
+title: "notifyd plugin"
+description: "Notification daemon + Inbox screen that captures Claude Code and Codex hook events into SQLite."
+---
+
+# notifyd
+
+`notifyd` owns the **Inbox** screen and ships a standalone notification daemon (`ainb-notifyd`) that captures Claude Code and Codex lifecycle hook events into SQLite. It is the reference for an **event-capturing, screen-owning** integration — but, unlike the subprocess plugins (`burndown`, `session-reader`, `witr`), it is **compiled in-tree into the host** rather than spawned over JSON-RPC. The `ainb-plugin-notifyd` crate is a library + daemon binary that `ainb-core` links against directly.
+
+## How it works
+
+![notifyd plugin — how it works](../assets/diagrams/notifyd.svg)
+
+The capture path starts outside ainb. The `ainb-hooks` plugin (a thin bash hook, `notify.sh`) is installed into Claude Code (`~/.claude/plugins/ainb-hooks/`) and Codex (`~/.codex/hooks.json`). When a host agent fires a lifecycle hook — `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `Notification`, `Stop`, `PreCompact` — the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
+
+`ainb-notifyd` is a tokio accept-loop daemon. On startup it replays (and clears) any queued `notify.fallback.jsonl`, then binds the `0600` socket and writes a PID file. Each accepted connection is parsed into an `Envelope`, persisted via `insert_and_prune`, and — if the event is "user-facing" (a `Stop`, `Notification`, `PermissionRequest`, `agent-turn-complete`, approval/wait event, etc., never telemetry like `SessionStart`) — emitted as a native OS notification, debounced per `(session_id, raw_event)` on a 60s window. Telemetry events are stored but stay silent.
+
+Storage is a dedicated SQLite database, `~/.agents-in-a-box/notifications.db`, opened in WAL mode so the daemon (writer) and TUI (reader) never block each other. It is intentionally separate from `session-reader`'s `usage.db` — different lifecycles, independent migrations. A retention sweep runs on every insert (default: prune rows older than 7 days, cap the table at 10,000 rows, oldest first).
+
+The render side lives in `ainb-core`. The **Inbox** screen (`components/inbox.rs`) holds a long-lived `Store` handle and re-queries SQLite on every render tick (cheap with WAL + `LIMIT 200`). It paints a two-pane list + detail view, and supports mark-read, dismiss, dismiss-all-visible, an archived toggle, and an agent filter. The Sessions screen also reads the store's `unread_by_cwd` grouping to draw a per-session `●N` unread badge, correlating an ainb session to its hook events by working directory. Because `notifyd` is in-tree, it reaches the filesystem, the socket, and the OS notifier directly — there is no JSON-RPC boundary, no `plugin/render` / `plugin/cli_dispatch`, and no `host/snapshot/publish`.
+
+## Capabilities
+
+`notifyd` is **not** a v2 subprocess plugin: it has no `manifest.toml` and declares **no capabilities**. It is part of the host binary (the `ainb-plugin-notifyd` crate is a path dependency of `ainb-core`), so the capability gate that governs subprocess plugins does not apply to it. For reference, the host-side resources it touches directly are:
+
+| Resource | Why it is needed |
+|----------|------------------|
+| `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist captured envelopes; back the Inbox list and the unread badge. |
+| `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from the `ainb-hooks` script. |
+| `~/.agents-in-a-box/notify.pid`, `notify.fallback.jsonl` | Single-instance guard; recover events queued while the daemon was down. |
+| `~/.claude/plugins/ainb-hooks/`, `~/.codex/hooks.json` (read+write) | The `install` / `uninstall` verbs wire the hook into the host agents. |
+| `osascript` / `notify-send` (subprocess) | Emit the native OS notification for user-facing events. |
+
+## Using it
+
+- **Inbox screen** — press **`I`** (Shift+i) from the home screen. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read, `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex), `r` force refresh, `q`/`Esc` back. Unread events also surface as a `●N` badge on the Sessions screen, grouped by working directory.
+- **Daemon + installer CLI** — the user-facing CLI is the standalone `ainb-notifyd` binary (not an `ainb <ns>` subcommand). Verbs:
+  - `ainb-notifyd run` — run the daemon in the foreground (default if no subcommand). The hook script lazy-spawns it as `ainb notifyd` when the socket is missing.
+  - `ainb-notifyd install --claude --codex` (or `--all`) — install the `ainb-hooks` hook for the chosen agents.
+  - `ainb-notifyd uninstall --claude --codex` (or `--all`) — reverse the install; preserves user-authored Codex hooks.
+  - `ainb-notifyd status` — report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness.
+  - `ainb-notifyd stop` — send `SIGTERM` to a running daemon via its PID file.
+- **Snapshot topics** — none. `notifyd` does not publish or subscribe on the event bus; the Inbox reads SQLite directly. There is no slash command.
+
+## Source
+
+`crates/ainb-plugin-notifyd` — in-tree library + `ainb-notifyd` daemon binary: envelope wire format, the SQLite `Store`, the tokio listener, OS-notify dispatch, and the `ainb-hooks` install/uninstall logic. The Inbox screen itself lives in `crates/ainb-core/src/components/inbox.rs`. Diagram generated via /fireworks-tech-graph.

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -16,9 +16,7 @@ Plugins only see the host capabilities they declare in their manifest, and they 
 
 ## Architecture at a glance
 
-<p align="center">
-  <img src="../assets/diagrams/plugin-architecture.svg" alt="ainb v2 plugin architecture — host, JSON-RPC stdio, plugin subprocesses, capability gate, event bus" width="900">
-</p>
+![ainb v2 plugin architecture — host, JSON-RPC stdio, plugin subprocesses, capability gate, event bus](../assets/diagrams/plugin-architecture.svg)
 
 The host (`ainb-core`) spawns each plugin as a child process and drives it over **JSON-RPC 2.0 / Content-Length-framed stdio**. Host→plugin methods: `plugin/init` (with the granted capabilities), `plugin/render` (host sends a `Viewport`, plugin returns a `WireBuffer`), `plugin/handle_key`, `plugin/handle_event`, `plugin/cli_dispatch`, `plugin/shutdown`. Plugin→host (reverse) calls: `host/snapshot/publish` + `host/snapshot/subscribe` (the **event bus**) and `host/action/invoke`. The `ainb-plugin-runtime` enforces capabilities — an ungranted host-fn call comes back as JSON-RPC `-32001` (`CAPABILITY_DENIED`).
 
@@ -40,16 +38,16 @@ The host (`ainb-core`) spawns each plugin as a child process and drives it over 
 
 Four plugins ship in-tree as the canonical examples:
 
-- **`burndown`** — owns the Analytics screen and the `ainb usage` CLI subcommand tree. Full screen-owner reference.
-- **`notifyd`** — owns the Inbox screen and runs a notification daemon that captures Claude Code and Codex hook events into SQLite (binary `ainb-notifyd`; also installs/uninstalls the `ainb-hooks` agent hooks). Reference for an event-capturing, screen-owning plugin.
-- **`session-reader`** — pure publisher. Scans `~/.claude/projects/**` and `~/.codex/sessions/**` and chunked-publishes usage snapshots on the `sessions.usage_data` topic for `burndown` to render. Canonical publisher example.
-- **`witr`** — owns the process-causality screen (press `w`) and the `ainb witr` CLI. Wraps the external [`witr`](https://github.com/pranshuparmar/witr) binary via the `spawn_subprocess` capability: execs `witr --json <target>`, parses stdout, and renders the ancestry tree. Canonical **subprocess-wrapping** reference — the pattern for surfacing any external CLI as a plugin.
+- **[`burndown`](./burndown.md)** — screen-owner reference. Owns the Analytics screen (renders a ratatui dashboard into a `WireBuffer` each frame) and the `ainb usage` CLI tree; subscribes to `sessions.usage_data` from `session-reader`.
+- **[`session-reader`](./session-reader.md)** — pure-publisher reference. No screen. Scans `~/.claude/projects/**`, `~/.codex/sessions/**` (and more) and chunk-publishes usage snapshots on `sessions.usage_data` for `burndown` to render.
+- **[`witr`](./witr.md)** — subprocess-wrapper reference. The `ainb witr <target>` CLI + `/witr` slash run `witr --json <target>` and parse the ancestry JSON; its **screen** is a host-embedded foreign TTY (`w` hands the terminal to `witr -i` — see [the two render paths](#two-ways-a-plugin-screen-renders)). Declares `spawn_subprocess` + `event_bus`.
+- **[`notifyd`](./notifyd.md)** — note: *not* a v2 subprocess plugin. It's an in-tree daemon (binary `ainb-notifyd`) compiled into `ainb-core` that owns the Inbox screen and captures Claude Code / Codex hook events into SQLite; documented here as a sibling for completeness.
 
-<p align="center">
-  <img src="../assets/screenshots/burndown.png" alt="Burndown plugin — full analytics dashboard" width="900">
-  <br>
-  <em>The burndown plugin rendering the full analytics dashboard against real <code>~/.claude/projects</code> data.</em>
-</p>
+Each links to its own page with a `/fireworks-tech-graph` diagram of how it works.
+
+![Burndown plugin — full analytics dashboard](../assets/screenshots/burndown.png)
+
+*The burndown plugin rendering the full analytics dashboard against real `~/.claude/projects` data.*
 
 ## Where plugins live on disk
 
@@ -60,9 +58,6 @@ dist/plugins/
 ├── burndown/
 │   ├── burndown            (native executable, ad-hoc signed on macOS)
 │   └── manifest.toml
-├── notifyd/
-│   ├── ainb-notifyd
-│   └── manifest.toml
 ├── session-reader/
 │   ├── session-reader
 │   └── manifest.toml
@@ -70,6 +65,8 @@ dist/plugins/
     ├── witr
     └── manifest.toml
 ```
+
+(`notifyd` is **not** here — it's a daemon compiled into `ainb-core`, not a staged subprocess plugin; see [its page](./notifyd.md).)
 
 That layout is what `just stage-plugins` produces from in-tree crates, and what the host walks on startup. The `AINB_PLUGIN_ROOT` env var overrides it (defaults to `<workspace-root>/dist/plugins`).
 

--- a/docs/plugins/session-reader.md
+++ b/docs/plugins/session-reader.md
@@ -1,0 +1,47 @@
+---
+title: "session-reader plugin"
+description: "Pure-publisher reference plugin — scans per-provider session logs and chunk-publishes a UsageData snapshot on the event bus."
+---
+
+# session-reader
+
+A pure data-plane plugin: it owns **no screen and no CLI namespace**. It walks the per-provider session-log directories, aggregates a `UsageData` snapshot, and chunk-publishes it on the `sessions.usage_data` topic for downstream consumers (`burndown`, and the host) to render. It is the canonical **publisher** example — the inverse of a screen-owning plugin, exercising only the event bus, log-read, and plugin-data capabilities.
+
+## How it works
+
+![session-reader plugin — how it works](../assets/diagrams/session-reader.svg)
+
+The plugin never paints anything — its `Plugin::render` returns an empty `0×0` `WireBuffer` and the host's render path tolerates that. On `plugin/init` it does *not* publish; instead it subscribes (`host/snapshot/subscribe`) to two trigger topics and then sits idle. Publishing on startup would race the consumer's own subscription and lose chunks, so the design is strictly pull: a consumer asks, the plugin answers.
+
+When a `plugin/handle_event` for `sessions.refresh_request` arrives, the plugin scans the four provider roots (`~/.claude/projects/**`, `~/.codex/sessions/**`, `~/.gemini/sessions`, `~/.config/github-copilot/sessions`, plus Cursor) on a blocking task, parses each file, and aggregates a `UsageData` snapshot. Parses are cached in a SQLite file under the plugin's own data dir — files whose `(mtime, size)` are unchanged short-circuit, so a warm rescan is cheap. While the cold scan runs it streams per-file progress on `sessions.scan_progress` so `burndown` can render a "Scanning sessions…" line.
+
+The aggregated `UsageData` is then split by `chunk_usage_data` into one or more msgpack envelopes, each kept under ~2 MiB so the post-base64 JSON-RPC body stays well under the host framer's 16 MiB cap. Chunk 0 carries the bounded aggregates; follow-on chunks carry slices of the unbounded tail vecs (`calls`, `sessions`, `shell_commands`); the last chunk is flagged `is_final`. Each chunk is pushed via `host/snapshot/publish` on `sessions.usage_data`.
+
+The host's event bus stores the latest publish per topic and fans `plugin/handle_event` deliveries to subscribers (`burndown`); the host itself can also pull the stored snapshot via `host/snapshot/get`. The `sessions.flush_cache_request` topic is the recovery escape hatch — it wipes the parse cache and forces a cold rescan (driven by `burndown`'s `F` key).
+
+## Capabilities
+
+These are the exact `[capabilities]` from `manifest.toml`. Every flag defaults to deny; the plugin grants only what its data plane needs.
+
+| Capability | Value | Why it's needed |
+|---|---|---|
+| `read_claude_logs` | `true` | Read `~/.claude/projects/**/*.jsonl` session histories. |
+| `read_codex_logs` | `true` | Read `~/.codex/sessions/**` rollout logs (also covers the Gemini/Copilot/Cursor roots the scanner walks). |
+| `event_bus` | `true` | Subscribe to trigger topics and publish the snapshot + progress on the bus. |
+| `write_plugin_data` | `true` | Persist the SQLite parse cache under the plugin's own data dir for warm rescans. |
+| `network` | `[]` | No network access. |
+| `spawn_subprocess` | `false` | No child processes. |
+
+## Using it
+
+There is **nothing to open and nothing to type** — by design. The plugin provides no screen, no slash command, and no `ainb <ns> ...` CLI namespace. You interact with it only indirectly, through the topics it publishes and subscribes:
+
+- **Publishes** (`[provides] snapshots`): `sessions.usage_data` — the chunked `UsageData` snapshot consumed by `burndown` (and the host). It also publishes `sessions.scan_progress` while a cold scan is in flight.
+- **Subscribes** (`[subscribes] snapshots`): `sessions.refresh_request` (any publisher forces a re-scan + re-publish) and `sessions.flush_cache_request` (wipe the parse cache, then cold re-scan — backing `burndown`'s `F` key).
+- **Lifecycle**: declared `spawn = "eager"` so the first snapshot is ready before `burndown` asks; idle-reaped after 600s.
+
+To see its output, open the **Analytics** screen owned by `burndown` (or run `ainb usage`) — that screen renders the snapshot this plugin produces.
+
+## Source
+
+`crates/ainb-plugin-session-reader` — the data backend for ainb's usage analytics: scans provider session logs, caches parses, and chunk-publishes the `UsageData` snapshot. Diagram generated via /fireworks-tech-graph.

--- a/docs/plugins/witr.md
+++ b/docs/plugins/witr.md
@@ -1,0 +1,46 @@
+---
+title: "witr plugin"
+description: "Wraps the external witr binary to surface process-causality tracing as an ainb screen, CLI, and slash command."
+---
+
+# witr
+
+`witr` surfaces process-causality tracing inside ainb by wrapping the external [`witr`](https://github.com/pranshuparmar/witr) binary (>= 0.3.2 on `PATH`). It is the canonical **subprocess-wrapping** reference — and it exemplifies *two* integration patterns at once: a host-embedded **foreign TTY** for its interactive screen, and a `spawn_subprocess` **exec-and-parse** flow for its CLI and slash command.
+
+## How it works
+
+![witr plugin — how it works](../assets/diagrams/witr.svg)
+
+There is no single render path here — witr is two surfaces fused onto one external binary, and the diagram shows them as two lanes.
+
+**The screen is not a `WireBuffer`.** witr's value is its own interactive all-process browser (sortable process list + ancestry pane), which has no machine-readable render — it lives only in `witr -i`. So pressing `w` (or the sidebar tile) does a host-level handoff, not a `plugin/render` call. The host (`ainb-core`) emits `AppEvent::GoToWitr`, which queues `AsyncAction::AttachWitr`: ainb runs `tmux new-session -A -d -s ainb-witr "witr -i"`, suspends its own TUI, and attaches full-screen to witr's native interactive browser — the same suspend/attach/resume mechanism ainb uses to embed agent sessions. When the user quits witr, ainb resumes. This wiring lives entirely in `ainb-core`; the plugin's `render` is never invoked for the screen.
+
+**The CLI and slash run `witr --json` and parse it.** `ainb witr <target>` is routed by the host to the plugin's `plugin/cli_dispatch` (namespace `witr`); `/witr <target>` reaches `handle_slash`. Both call the plugin's single `scan()` authority, which execs `witr --json <target>` under the `spawn_subprocess` capability (argv array, no shell; bounded by a 5s timeout) and decodes stdout into a typed `WitrSnapshot`. The decode tolerates two real witr quirks: witr exits non-zero to signal that *warnings* are present even when it printed a complete, valid JSON snapshot — so a successful parse wins regardless of exit code — and Go's `encoding/json` marshals empty slices/maps as `null`, which is mapped back to empty collections. From the snapshot, the CLI emits text / `--tree` / `--warnings` / canonical `--format json`, while the slash opens a detail overlay.
+
+**Fresh scans publish on the event bus.** When a scan runs from a live host channel (the TUI refresh path), the parsed snapshot is published to the `witr.snapshot` topic via `host/snapshot/publish`, msgpack-encoded and byte-deterministic. The one-shot `ainb witr` CLI invocation passes no host channel — there are no bus subscribers during a single CLI run — so the publish is skipped there.
+
+## Capabilities
+
+These are the exact non-default capabilities declared in `manifest.toml`. Every other capability (`read_sessions`, `read_claude_logs`, `read_codex_logs`, `write_plugin_data`, `network`) is left at its deny default.
+
+| Capability | Declared value | Why it is needed |
+|---|---|---|
+| `spawn_subprocess` | `["witr"]` | Exec `witr --version` (detect on init) and `witr --json <target>` (every scan). The list form is per-binary audit metadata. |
+| `event_bus` | `true` | Publish each fresh scan on the `witr.snapshot` topic via `host/snapshot/publish`. |
+
+## Using it
+
+- **Screen** — open it by pressing `w` from the home surface or selecting the witr sidebar tile. Instead of a plugin-rendered screen, ainb hands the terminal to witr's native `witr -i` interactive browser full-screen (sortable all-process list + ancestry pane); quit witr to return to ainb. If witr is missing or below 0.3.2, the plugin renders an install/upgrade empty state instead.
+- **CLI** (`cli_namespaces = ["witr"]`) — `ainb witr` execs the wrapped binary and renders the parsed snapshot:
+  - `ainb witr nginx` — trace a process by name (positional; witr fuzzy-matches)
+  - `ainb witr --pid 1234`, `ainb witr --port 5432`, `ainb witr --file /var/run/x.lock`, `ainb witr --container redis` — typed targets
+  - `ainb witr nginx --tree` — ancestry chain as an indented tree
+  - `ainb witr --port 5432 --warnings` — just the warnings list
+  - `ainb witr --pid 1234 --format json` — canonical JSON re-emit of the snapshot
+  - `ainb witr nginx --short` — raw `witr <target>` passthrough (no JSON re-parse; cannot be combined with `--format json`)
+- **Slash command** (`/witr`) — `/witr <target>` scans the target and opens a focused detail overlay over the current screen.
+- **Published topic** — `witr.snapshot` (msgpack-encoded `WitrSnapshot`), emitted on each fresh scan from a live host channel. The plugin subscribes to nothing.
+
+## Source
+
+`crates/ainb-plugin-witr` — detects the external `witr` binary, owns the `ainb witr` CLI + `/witr` slash via `witr --json` exec-and-parse, publishes `witr.snapshot`, and renders the missing/outdated empty state; the foreign-TTY screen handoff (`w` → `witr -i`) is wired in `ainb-core`. Diagram generated via /fireworks-tech-graph.

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -75,6 +75,15 @@ export default defineConfig({
             { label: 'User guide', slug: 'plugins/user-guide' },
             { label: 'Authoring guide', slug: 'plugins/authoring' },
             { label: 'Wire spec v2', slug: 'plugins/spec-v2' },
+            {
+              label: 'In-tree plugins',
+              items: [
+                { label: 'burndown', slug: 'plugins/burndown' },
+                { label: 'session-reader', slug: 'plugins/session-reader' },
+                { label: 'witr', slug: 'plugins/witr' },
+                { label: 'notifyd', slug: 'plugins/notifyd' },
+              ],
+            },
             { label: 'Changelog', slug: 'plugins/changelog' },
           ],
         },


### PR DESCRIPTION
Adds a dedicated docsite page (with a /fireworks-tech-graph diagram) for each in-tree plugin — burndown, session-reader, witr, notifyd — wired into the Starlight sidebar under **Plugins → In-tree plugins**.

Each page: how-it-works + diagram + exact declared capabilities + provided surfaces (screen/CLI/slash/topics) + source pointer, all cross-checked against each crate's manifest/code.

Also:
- Corrects stale witr framing (screen is a host-embedded `witr -i` TTY, not a WireBuffer ancestry render; `witr --json` backs only the CLI/slash) across overview/authoring/changelog.
- Documents notifyd accurately as an in-tree daemon (no manifest, not a v2 subprocess plugin); removed the phantom `dist/plugins/notifyd/manifest.toml` from the disk-layout.
- Fixes a pre-existing docsite bug: doc images used raw `<img>` relative src which Astro passes through (404 in the deployed site) — switched to markdown image syntax so they're emitted. The burndown screenshot was affected too.

Astro build verified locally: 37 pages, all 4 plugin pages render, all diagrams + the screenshot emitted into `_astro/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for in-tree plugins including burndown, session-reader, witr, and notifyd
  * Enhanced plugin architecture overview and reference materials
  * Updated navigation to improve discoverability of plugin documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->