### PR TITLE
docs(site): fix duplicate page titles across the docsite

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 title: "agents-in-a-box — documentation"
 ---
 
-# agents-in-a-box — documentation
-
 Canonical source of truth for the monorepo. Everything published to the website
 under `/docs/*` is rendered from these files.
 

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -2,8 +2,6 @@
 title: "Building from source"
 ---
 
-# Building from source
-
 > **Status:** stub. Authoritative content currently lives at `ainb-tui/CLAUDE.md + main README §Development`.
 > Migration of that file into this path is gated on Stevie's approval.
 

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -2,8 +2,6 @@
 title: "CI / CD"
 ---
 
-# CI / CD
-
 Four GitHub Actions workflows live under `.github/workflows/`. Each is path-filtered so it only runs when the area it covers changes.
 
 ## `ci.yml` — Rust CI

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -2,8 +2,6 @@
 title: "Release process"
 ---
 
-# Release process
-
 > **Status:** stub. Authoritative content currently lives at `ainb-tui/CHANGELOG.md + .github/workflows/release.yml`.
 > Migration of that file into this path is gated on Stevie's approval.
 

--- a/docs/knowledge/overview.md
+++ b/docs/knowledge/overview.md
@@ -2,8 +2,6 @@
 title: "Knowledge & Memory System"
 ---
 
-# Knowledge & Memory System
-
 > "Correct once, never again. Solve once, never re-research."
 
 This document explains the complete knowledge capture, storage, indexing, and

--- a/docs/knowledge/reflect-cli.md
+++ b/docs/knowledge/reflect-cli.md
@@ -2,8 +2,6 @@
 title: "`reflect` CLI reference"
 ---
 
-# `reflect` CLI reference
-
 The `reflect` command is the command-line interface to the agents-in-a-box knowledge base. It is shipped by the Python package **`reflect-kb`** (source: [`reflect-kb/`](https://github.com/stevengonsalvez/agents-in-a-box/tree/main/reflect-kb)) and provides the **capture → index → recall** loop: `reflect add` captures a learning, `reflect reindex` rebuilds the GraphRAG + vector index, and `reflect search` recalls the most relevant prior learnings.
 
 ## Two version streams

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -2,8 +2,6 @@
 title: "Plugins — disambiguation"
 ---
 
-# Plugins — disambiguation
-
 > **Read this first.** The word "plugin" means two different things in this monorepo. Picking the wrong path costs you hours.
 
 ---

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -2,8 +2,6 @@
 title: "ainb plugin authoring"
 ---
 
-# ainb plugin authoring
-
 Developer-facing reference for shipping a v2 plugin. For end-user install/CLI docs see [./user-guide.md](./user-guide.md). For the wire contract see [./spec-v2.md](./spec-v2.md).
 
 ## What you're building

--- a/docs/plugins/burndown.md
+++ b/docs/plugins/burndown.md
@@ -3,8 +3,6 @@ title: "burndown plugin"
 description: "Owns the Analytics screen and the ainb usage CLI — renders usage data published by session-reader over the event bus."
 ---
 
-# burndown
-
 `burndown` is the in-tree **screen-owner** reference plugin: it paints the full Analytics dashboard and owns the `ainb usage` CLI tree. It is also the consumer half of the event-bus **publish/subscribe** pattern — it does not scan any session files itself, it renders the snapshots `session-reader` publishes.
 
 ## How it works

--- a/docs/plugins/changelog.md
+++ b/docs/plugins/changelog.md
@@ -2,8 +2,6 @@
 title: "Plugin contract changelog"
 ---
 
-# Plugin contract changelog
-
 Tracks how the plugin contract (`./spec-v2.md`) evolves.
 
 ## Versioning policy

--- a/docs/plugins/notifyd.md
+++ b/docs/plugins/notifyd.md
@@ -3,8 +3,6 @@ title: "notifyd plugin"
 description: "Notification daemon + Inbox screen that captures Claude Code and Codex hook events into SQLite."
 ---
 
-# notifyd
-
 `notifyd` owns the **Inbox** screen and ships a standalone notification daemon (`ainb-notifyd`) that captures Claude Code and Codex lifecycle hook events into SQLite. It is the reference for an **event-capturing, screen-owning** integration — but, unlike the subprocess plugins (`burndown`, `session-reader`, `witr`), it is **compiled in-tree into the host** rather than spawned over JSON-RPC. The `ainb-plugin-notifyd` crate is a library + daemon binary that `ainb-core` links against directly.
 
 ## How it works

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -2,8 +2,6 @@
 title: "ainb v2 plugins — overview"
 ---
 
-# ainb v2 plugins — overview
-
 What a v2 subprocess plugin is, conceptually. New here? Read [README.md](./README.md) first — it disambiguates from Claude Code plugins.
 
 For the user CLI flow, jump to [user-guide.md](./user-guide.md). To write one, [authoring.md](./authoring.md). For the wire contract, [spec-v2.md](./spec-v2.md).

--- a/docs/plugins/session-reader.md
+++ b/docs/plugins/session-reader.md
@@ -3,8 +3,6 @@ title: "session-reader plugin"
 description: "Pure-publisher reference plugin — scans per-provider session logs and chunk-publishes a UsageData snapshot on the event bus."
 ---
 
-# session-reader
-
 A pure data-plane plugin: it owns **no screen and no CLI namespace**. It walks the per-provider session-log directories, aggregates a `UsageData` snapshot, and chunk-publishes it on the `sessions.usage_data` topic for downstream consumers (`burndown`, and the host) to render. It is the canonical **publisher** example — the inverse of a screen-owning plugin, exercising only the event bus, log-read, and plugin-data capabilities.
 
 ## How it works

--- a/docs/plugins/spec-v2.md
+++ b/docs/plugins/spec-v2.md
@@ -2,8 +2,6 @@
 title: "ainb plugin contract — v2 (subprocess)"
 ---
 
-# ainb plugin contract — v2 (subprocess)
-
 **Status:** stable.
 **Host versions covered:** `2.x.y` (additive minor bumps stay in v2).
 **Successor:** tracked in [CHANGELOG.md](./CHANGELOG.md). A new contract version (`v3`) ships only when an existing signature changes incompatibly.

--- a/docs/plugins/user-guide.md
+++ b/docs/plugins/user-guide.md
@@ -2,8 +2,6 @@
 title: "Plugin user guide"
 ---
 
-# Plugin user guide
-
 User-facing reference for the `ainb plugin` family of commands. New to plugins? Read [overview.md](./overview.md) first. Writing one? [authoring.md](./authoring.md). Wire contract: [spec-v2.md](./spec-v2.md).
 
 ## Status of the install / marketplace flow

--- a/docs/plugins/witr.md
+++ b/docs/plugins/witr.md
@@ -3,8 +3,6 @@ title: "witr plugin"
 description: "Wraps the external witr binary to surface process-causality tracing as an ainb screen, CLI, and slash command."
 ---
 
-# witr
-
 `witr` surfaces process-causality tracing inside ainb by wrapping the external [`witr`](https://github.com/pranshuparmar/witr) binary (>= 0.3.2 on `PATH`). It is the canonical **subprocess-wrapping** reference — and it exemplifies *two* integration patterns at once: a host-embedded **foreign TTY** for its interactive screen, and a `spawn_subprocess` **exec-and-parse** flow for its CLI and slash command.
 
 ## How it works

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -2,8 +2,6 @@
 title: "Whole-system architecture"
 ---
 
-# Whole-system architecture
-
 How the four components of agents-in-a-box fit together.
 
 > For component-level deep dives, see [TUI architecture](../tui/architecture.md), [plugin spec v2](../plugins/spec-v2.md), and [knowledge system overview](../knowledge/overview.md).

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -2,8 +2,6 @@
 title: "Value proposition"
 ---
 
-# Value proposition
-
 What you get when you adopt agents-in-a-box.
 
 ---

--- a/docs/product/what-is-ainb.md
+++ b/docs/product/what-is-ainb.md
@@ -2,8 +2,6 @@
 title: "What is agents-in-a-box?"
 ---
 
-# What is agents-in-a-box?
-
 A terminal-native ecosystem for managing AI coding agents. Three components share one monorepo, plus a supporting knowledge library:
 
 | # | Component | What it is |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -2,8 +2,6 @@
 title: "Architecture deep-dive"
 ---
 
-# Architecture deep-dive
-
 > **Status:** stub. Authoritative content currently lives at `docs/product/architecture.md + ainb-tui/CLAUDE.md`.
 > Migration of that file into this path is gated on Stevie's approval.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -2,8 +2,6 @@
 title: "Glossary"
 ---
 
-# Glossary
-
 Definitions for the terms that recur across the agents-in-a-box docs. Where a term has a precise contract, the authoritative source is linked.
 
 ## Agents, sessions, worktrees

--- a/docs/solutions/performance-issues/ainb-tui-mouse-event-hot-paths.md
+++ b/docs/solutions/performance-issues/ainb-tui-mouse-event-hot-paths.md
@@ -14,8 +14,6 @@ provenance:
   merge_commit: ba7c57c
 ---
 
-# AINB TUI Mouse Event Hot Paths
-
 ## Problem
 
 Mouse-first TUI behavior can make the UI feel jittery if move or drag paths do heavy work, schedule async actions, persist configuration, or trigger subprocess/Docker/tmux calls.

--- a/docs/solutions/tooling-setup/worktree-merge-commit-to-main.md
+++ b/docs/solutions/tooling-setup/worktree-merge-commit-to-main.md
@@ -14,8 +14,6 @@ provenance:
   merge_commit: ba7c57c
 ---
 
-# Worktree Merge Commit To Main
-
 ## Problem
 
 `main` may already be checked out in another worktree, and that worktree may be dirty or far behind. A direct checkout from the feature worktree fails because Git prevents one branch from being checked out by multiple worktrees.

--- a/docs/toolkit/agents.md
+++ b/docs/toolkit/agents.md
@@ -2,8 +2,6 @@
 title: "Agents (37)"
 ---
 
-# Agents (37)
-
 37 specialised AI agents organised by domain.
 
 ## By category

--- a/docs/toolkit/bootstrap.md
+++ b/docs/toolkit/bootstrap.md
@@ -2,8 +2,6 @@
 title: "Bootstrap engine"
 ---
 
-# Bootstrap engine
-
 `toolkit/bootstrap.js` deploys packages from `toolkit/packages/` into each supported tool's home directory. It is driven by a `TOOL_CONFIG` map (13 entries) plus an `external-dependencies.yaml` manifest.
 
 ## Per-tool home directories

--- a/docs/toolkit/overview.md
+++ b/docs/toolkit/overview.md
@@ -2,8 +2,6 @@
 title: "Toolkit overview"
 ---
 
-# Toolkit overview
-
 One canonical source tree, many AI tools. Author a skill, agent, or workflow once under `toolkit/packages/` and `bootstrap.js` deploys it into each supported tool's home directory.
 
 ## What lives in `toolkit/packages/`

--- a/docs/toolkit/skills.md
+++ b/docs/toolkit/skills.md
@@ -2,8 +2,6 @@
 title: "Skills (91)"
 ---
 
-# Skills (91)
-
 All 91 skills grouped by purpose. Each links to its SKILL.md source.
 
 ## Planning & Workflow (14)

--- a/docs/tui/architecture.md
+++ b/docs/tui/architecture.md
@@ -2,8 +2,6 @@
 title: "TUI architecture"
 ---
 
-# TUI architecture
-
 `ainb` is a Cargo **workspace** rooted at `ainb-tui/`. The TUI application and CLI live in the `ainb-core` crate; the rest of the workspace is the v2 plugin platform (runtime, SDK, reference plugins, conformance + test tooling).
 
 ## Workspace crates

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2,8 +2,6 @@
 title: "ainb CLI Reference"
 ---
 
-# ainb CLI Reference
-
 `ainb` is both an interactive terminal UI and a scriptable CLI. Every session operation the TUI can perform is also exposed as a subcommand, so agents and automation can drive it end-to-end without opening the UI.
 
 Run `ainb` with no arguments to launch the TUI, or use any subcommand below for non-interactive work.

--- a/docs/tui/faq.md
+++ b/docs/tui/faq.md
@@ -2,8 +2,6 @@
 title: "FAQ & Tips"
 ---
 
-# FAQ & Tips
-
 Common questions and tips for using agents-in-a-box effectively.
 
 ---

--- a/docs/tui/install.md
+++ b/docs/tui/install.md
@@ -2,8 +2,6 @@
 title: "Install the TUI"
 ---
 
-# Install the TUI
-
 ## Quick install (curl)
 
 The install script detects your platform and downloads a prebuilt binary from GitHub Releases:

--- a/docs/tui/keyboard-shortcuts.md
+++ b/docs/tui/keyboard-shortcuts.md
@@ -2,8 +2,6 @@
 title: "Keyboard shortcuts"
 ---
 
-# Keyboard shortcuts
-
 Keys verified against the in-app help overlay (`?`) and the event handlers in `crates/ainb-core/src/app/events.rs`.
 
 ## Home screen navigation

--- a/docs/tui/overview.md
+++ b/docs/tui/overview.md
@@ -2,8 +2,6 @@
 title: "ainb TUI — overview"
 ---
 
-# ainb TUI — overview
-
 `ainb` is the terminal UI and CLI for Agents-in-a-Box: a Rust + ratatui app that spawns and manages AI coding sessions (Claude Code, Codex, Gemini, Copilot) in isolated git worktrees, each driven inside its own tmux session.
 
 Run `ainb` with no arguments to launch the TUI. Every operation the TUI performs is also exposed as a subcommand, so agents and automation can drive it headlessly. See the [CLI reference](cli.md) for the full subcommand list.

--- a/docs/tui/quickstart.md
+++ b/docs/tui/quickstart.md
@@ -2,8 +2,6 @@
 title: "Quickstart — first session in 60 seconds"
 ---
 
-# Quickstart — first session in 60 seconds
-
 From install to your first running agent session.
 
 ## 1. Pre-flight


### PR DESCRIPTION
Every docsite page rendered its title twice — Starlight auto-renders the frontmatter `title:` as the page `<h1>`, and each markdown body also opened with its own `# Heading`. Stripped the leading body H1 from all 34 docs pages; the frontmatter title is now the single heading.

Astro build verified: exactly one `<h1>` per page (e.g. `/plugins/user-guide` was 2, now 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized documentation page structure and formatting across all sections.
  * Enhanced plugin documentation with expanded architectural details and implementation guidance.
  * Improved documentation organization with consistent metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->