### PR TITLE
docs(toolkit): Claude Code plugins section + per-plugin pages

### DIFF
--- a/docs/assets/diagrams/ainb-fleet.svg
+++ b/docs/assets/diagrams/ainb-fleet.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6b7280"/>
+    </marker>
+    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowGlass" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#020617" flood-opacity="0.28"/>
+    </filter>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 30px; font-weight: 700; fill: #111827; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #6b7280; }
+    .section { font-size: 13px; font-weight: 700; fill: #2563eb; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #111827; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .node-type { font-size: 12px; font-weight: 700; fill: #9ca3af; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b7280; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#ffffff"/>
+  <text x="480.0" y="56" text-anchor="middle" class="title">ainb-fleet</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">Claude Code skill bundle that teaches agents to drive `ainb fleet` orchestration</text>
+  <path d="M 230.0,348.0 L 250.4,348.0 L 279.6,220.0 L 300.0,220.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 590.0,220.0 L 610.4,220.0 L 649.6,330.0 L 670.0,330.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 445.0,320.0 L 445.0,380.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)" stroke-dasharray="6,4"/>
+  <path d="M 570.0,425.0 L 770.0,425.0 L 770.0,380.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 770.0,280.0 L 770.0,259.6 L 775.0,210.4 L 775.0,190.0" fill="none" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <path d="M 770.0,380.0 L 770.0,400.4 L 775.0,459.6 L 775.0,480.0" fill="none" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <path d="M 660.0,140.0 L 770.0,140.0 L 770.0,280.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)" stroke-dasharray="6,4"/>
+  <rect x="50.0" y="300.0" width="180.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="140.0" y="318.0" text-anchor="middle" class="node-type">HOST</text>
+  <text x="140.0" y="354.0" text-anchor="middle" class="node-title">Claude Code</text>
+  <text x="140.0" y="376.0" text-anchor="middle" class="node-sub">agent loads the skills</text>
+  <rect x="300.0" y="120.0" width="290.0" height="200.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="445.0" y="138.0" text-anchor="middle" class="node-type">TEACHING LAYER</text>
+  <text x="445.0" y="226.0" text-anchor="middle" class="node-title">ainb-fleet skills</text>
+  <text x="445.0" y="248.0" text-anchor="middle" class="node-sub">standup · broadcast · sequence · needs · fleet-needs · daemon</text>
+  <rect x="320.0" y="380.0" width="250.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="445.0" y="398.0" text-anchor="middle" class="node-type">DETERMINISTIC</text>
+  <text x="445.0" y="431.0" text-anchor="middle" class="node-title">hangar workflow</text>
+  <text x="445.0" y="453.0" text-anchor="middle" class="node-sub">discover · enrich · prioritize</text>
+  <rect x="670.0" y="280.0" width="200.0" height="100.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="770.0" y="298.0" text-anchor="middle" class="node-type">ENGINE</text>
+  <text x="770.0" y="336.0" text-anchor="middle" class="node-title">ainb fleet</text>
+  <text x="770.0" y="358.0" text-anchor="middle" class="node-sub">Rust orchestration engine</text>
+  <rect x="660.0" y="90.0" width="230.0" height="100.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="775.0" y="108.0" text-anchor="middle" class="node-type">READ</text>
+  <text x="775.0" y="146.0" text-anchor="middle" class="node-title">discover</text>
+  <text x="775.0" y="168.0" text-anchor="middle" class="node-sub">ainb · peers · jobs (dedupe by cwd)</text>
+  <rect x="660.0" y="480.0" width="230.0" height="100.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="775.0" y="498.0" text-anchor="middle" class="node-type">TARGETS</text>
+  <text x="775.0" y="536.0" text-anchor="middle" class="node-title">fleet sessions</text>
+  <text x="775.0" y="558.0" text-anchor="middle" class="node-sub">every claude session on host</text>
+  <rect x="184.5" y="270.0" width="161" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="265.0" y="284.0" text-anchor="middle" class="arrow-label">invokes /ainb-fleet:*</text>
+  <rect x="556.5" y="261.0" width="147" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="630.0" y="275.0" text-anchor="middle" class="arrow-label">shells `ainb fleet`</text>
+  <rect x="364.0" y="336.0" width="126" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="427.0" y="350.0" text-anchor="middle" class="arrow-label">fleet-needs runs</text>
+  <rect x="642.0" y="395.0" width="56" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="670.0" y="409.0" text-anchor="middle" class="arrow-label">--json</text>
+  <rect x="720.0" y="205.0" width="105" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="772.5" y="219.0" text-anchor="middle" class="arrow-label">reads sources</text>
+  <rect x="695.5" y="432.0" width="154" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="772.5" y="446.0" text-anchor="middle" class="arrow-label">tmux / broker writes</text>
+  <rect x="717.5" y="196.0" width="105" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="770.0" y="210.0" text-anchor="middle" class="arrow-label">merged roster</text>
+  <line x1="42.0" y1="578.0" x2="72.0" y2="578.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <text x="82.0" y="582.0" class="legend">control</text>
+  <line x1="42.0" y1="600.0" x2="72.0" y2="600.0" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <text x="82.0" y="604.0" class="legend">read</text>
+  <line x1="42.0" y1="622.0" x2="72.0" y2="622.0" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <text x="82.0" y="626.0" class="legend">write (tmux/broker)</text>
+  <line x1="42.0" y1="644.0" x2="72.0" y2="644.0" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <text x="82.0" y="648.0" class="legend">data</text>
+</svg>

--- a/docs/assets/diagrams/ainb-hooks.svg
+++ b/docs/assets/diagrams/ainb-hooks.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6b7280"/>
+    </marker>
+    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowGlass" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#020617" flood-opacity="0.28"/>
+    </filter>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 30px; font-weight: 700; fill: #111827; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #6b7280; }
+    .section { font-size: 13px; font-weight: 700; fill: #2563eb; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #111827; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .node-type { font-size: 12px; font-weight: 700; fill: #9ca3af; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b7280; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#ffffff"/>
+  <text x="480.0" y="56" text-anchor="middle" class="title">ainb-hooks — lifecycle events to the notification inbox</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">CLAUDE CODE / CODEX PLUGIN · v0.1.0</text>
+  <path d="M 280.0,180.0 L 380.0,180.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 590.0,180.0 L 690.0,180.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 790.0,225.0 L 790.0,330.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 485.0,225.0 L 485.0,330.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)" stroke-dasharray="6,4"/>
+  <path d="M 590.0,375.0 L 690.0,375.0" fill="none" stroke="#ef4444" stroke-width="2.4" marker-end="url(#arrowG)" stroke-dasharray="6,4"/>
+  <path d="M 790.0,420.0 L 790.0,440.4 L 635.0,499.6 L 635.0,520.0" fill="none" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <path d="M 790.0,420.0 L 790.0,440.4 L 855.0,499.6 L 855.0,520.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <rect x="70.0" y="130.0" width="210.0" height="100.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="175.0" y="148.0" text-anchor="middle" class="node-type">HOST AGENT</text>
+  <text x="175.0" y="186.0" text-anchor="middle" class="node-title">Claude / Codex</text>
+  <text x="175.0" y="208.0" text-anchor="middle" class="node-sub">session lifecycle hooks</text>
+  <rect x="380.0" y="135.0" width="210.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="485.0" y="153.0" text-anchor="middle" class="node-type">HOOK SCRIPT</text>
+  <text x="485.0" y="186.0" text-anchor="middle" class="node-title">notify.sh</text>
+  <text x="485.0" y="208.0" text-anchor="middle" class="node-sub">normalize → envelope</text>
+  <rect x="690.0" y="135.0" width="200.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="790.0" y="153.0" text-anchor="middle" class="node-type">UNIX SOCKET</text>
+  <text x="790.0" y="186.0" text-anchor="middle" class="node-title">notify.sock</text>
+  <text x="790.0" y="208.0" text-anchor="middle" class="node-sub">~/.agents-in-a-box/</text>
+  <rect x="690.0" y="330.0" width="200.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="790.0" y="348.0" text-anchor="middle" class="node-type">CONSUMER</text>
+  <text x="790.0" y="381.0" text-anchor="middle" class="node-title">ainb-notifyd</text>
+  <text x="790.0" y="403.0" text-anchor="middle" class="node-sub">daemon (lazy-spawned)</text>
+  <rect x="540.0" y="520.0" width="190.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="635.0" y="538.0" text-anchor="middle" class="node-type">STORE</text>
+  <text x="635.0" y="571.0" text-anchor="middle" class="node-title">notifications.db</text>
+  <text x="635.0" y="593.0" text-anchor="middle" class="node-sub">SQLite persistence</text>
+  <rect x="790.0" y="520.0" width="130.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="855.0" y="538.0" text-anchor="middle" class="node-type">UI</text>
+  <text x="855.0" y="571.0" text-anchor="middle" class="node-title">ainb-tui</text>
+  <text x="855.0" y="593.0" text-anchor="middle" class="node-sub">Inbox + badges</text>
+  <rect x="380.0" y="330.0" width="210.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="485.0" y="348.0" text-anchor="middle" class="node-type">FALLBACK</text>
+  <text x="485.0" y="381.0" text-anchor="middle" class="node-title">fallback.jsonl</text>
+  <text x="485.0" y="403.0" text-anchor="middle" class="node-sub">replayed on startup</text>
+  <rect x="281.0" y="166.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="330.0" y="180.0" text-anchor="middle" class="arrow-label">stdin / argv</text>
+  <rect x="587.5" y="166.0" width="105" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="640.0" y="180.0" text-anchor="middle" class="arrow-label">JSON envelope</text>
+  <rect x="730.0" y="263.5" width="84" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="772.0" y="277.5" text-anchor="middle" class="arrow-label">nc / socat</text>
+  <rect x="421.5" y="263.5" width="91" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="467.0" y="277.5" text-anchor="middle" class="arrow-label">socket down</text>
+  <rect x="573.5" y="361.0" width="133" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="640.0" y="375.0" text-anchor="middle" class="arrow-label">replay on startup</text>
+  <rect x="681.0" y="440.0" width="63" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="712.5" y="454.0" text-anchor="middle" class="arrow-label">persist</text>
+  <rect x="784.0" y="440.0" width="77" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="822.5" y="454.0" text-anchor="middle" class="arrow-label">broadcast</text>
+  <line x1="42.0" y1="578.0" x2="72.0" y2="578.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <text x="82.0" y="582.0" class="legend">hook trigger</text>
+  <line x1="42.0" y1="600.0" x2="72.0" y2="600.0" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <text x="82.0" y="604.0" class="legend">envelope delivery</text>
+  <line x1="42.0" y1="622.0" x2="72.0" y2="622.0" stroke="#ef4444" stroke-width="2.4" marker-end="url(#arrowG)"/>
+  <text x="82.0" y="626.0" class="legend">fallback / replay</text>
+  <line x1="42.0" y1="644.0" x2="72.0" y2="644.0" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <text x="82.0" y="648.0" class="legend">persist</text>
+</svg>

--- a/docs/assets/diagrams/reflect.svg
+++ b/docs/assets/diagrams/reflect.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+  <defs>
+    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
+    </marker>
+    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f97316"/>
+    </marker>
+    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/>
+    </marker>
+    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6b7280"/>
+    </marker>
+    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowGlass" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#020617" flood-opacity="0.28"/>
+    </filter>
+    <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
+    .title { font-size: 30px; font-weight: 700; fill: #111827; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #6b7280; }
+    .section { font-size: 13px; font-weight: 700; fill: #2563eb; letter-spacing: 1.4px; }
+    .section-sub { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    .node-title { font-size: 18px; font-weight: 700; fill: #111827; }
+    .node-sub { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .node-type { font-size: 12px; font-weight: 700; fill: #9ca3af; letter-spacing: 0.08em; }
+    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b7280; }
+    .legend { font-size: 12px; font-weight: 500; fill: #6b7280; }
+    .footnote { font-size: 12px; font-weight: 500; fill: #94a3b8; }
+    </style>
+  </defs>
+  <rect width="960.0" height="700.0" fill="#ffffff"/>
+  <text x="480.0" y="56" text-anchor="middle" class="title">reflect — Claude Code plugin</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">Lifecycle hooks capture corrections &amp; inject prior learnings · v3.6.0</text>
+  <path d="M 135.0,300.0 L 135.0,138.0 L 300.0,138.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 210.0,345.0 L 230.4,345.0 L 279.6,268.0 L 300.0,268.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 210.0,345.0 L 230.4,345.0 L 279.6,398.0 L 300.0,398.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 135.0,390.0 L 135.0,410.4 L 279.6,528.0 L 300.0,528.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 135.0,390.0 L 135.0,410.4 L 279.6,640.0 L 300.0,640.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 500.0,138.0 L 520.4,138.0 L 559.6,158.0 L 580.0,158.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 500.0,268.0 L 680.0,268.0 L 680.0,206.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 500.0,398.0 L 520.4,398.0 L 559.6,518.0 L 580.0,518.0" fill="none" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)" stroke-dasharray="6,4"/>
+  <path d="M 500.0,528.0 L 520.4,528.0 L 559.6,640.0 L 580.0,640.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 500.0,640.0 L 580.0,640.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <path d="M 680.0,600.0 L 680.0,566.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <path d="M 680.0,470.0 L 680.0,410.0" fill="none" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <path d="M 680.0,300.0 L 680.0,206.0" fill="none" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <path d="M 680.0,110.0 L 680.0,89.6 L 135.0,279.6 L 135.0,300.0" fill="none" stroke="#ef4444" stroke-width="2.4" marker-end="url(#arrowG)" stroke-dasharray="6,4"/>
+  <rect x="60.0" y="300.0" width="150.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="135.0" y="318.0" text-anchor="middle" class="node-type">HARNESS</text>
+  <text x="135.0" y="351.0" text-anchor="middle" class="node-title">Claude Code</text>
+  <text x="135.0" y="373.0" text-anchor="middle" class="node-sub">loads plugin: skills + hooks</text>
+  <rect x="300.0" y="90.0" width="200.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="400.0" y="108.0" text-anchor="middle" class="node-type">HOOK</text>
+  <text x="400.0" y="144.0" text-anchor="middle" class="node-title">SessionStart</text>
+  <text x="400.0" y="166.0" text-anchor="middle" class="node-sub">recall inject + bg drain</text>
+  <rect x="300.0" y="220.0" width="200.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="400.0" y="238.0" text-anchor="middle" class="node-type">HOOK</text>
+  <text x="400.0" y="274.0" text-anchor="middle" class="node-title">UserPromptSubmit</text>
+  <text x="400.0" y="296.0" text-anchor="middle" class="node-sub">recall inject + mini-learn</text>
+  <rect x="300.0" y="350.0" width="200.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="400.0" y="368.0" text-anchor="middle" class="node-type">HOOK</text>
+  <text x="400.0" y="404.0" text-anchor="middle" class="node-title">PostToolUse</text>
+  <text x="400.0" y="426.0" text-anchor="middle" class="node-sub">arm mini-learning on fail</text>
+  <rect x="300.0" y="480.0" width="200.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="400.0" y="498.0" text-anchor="middle" class="node-type">HOOK</text>
+  <text x="400.0" y="534.0" text-anchor="middle" class="node-title">Stop</text>
+  <text x="400.0" y="556.0" text-anchor="middle" class="node-sub">enqueue short-session reflect</text>
+  <rect x="300.0" y="600.0" width="200.0" height="80.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="400.0" y="618.0" text-anchor="middle" class="node-type">HOOK</text>
+  <text x="400.0" y="646.0" text-anchor="middle" class="node-title">PreCompact</text>
+  <text x="400.0" y="668.0" text-anchor="middle" class="node-sub">enqueue on compaction</text>
+  <rect x="580.0" y="470.0" width="200.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="680.0" y="488.0" text-anchor="middle" class="node-type">SKILL</text>
+  <text x="680.0" y="524.0" text-anchor="middle" class="node-title">/reflect</text>
+  <text x="680.0" y="546.0" text-anchor="middle" class="node-sub">scan · classify · note + sidecar</text>
+  <rect x="580.0" y="300.0" width="200.0" height="110.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="680.0" y="318.0" text-anchor="middle" class="node-type">KNOWLEDGE BASE</text>
+  <text x="680.0" y="361.0" text-anchor="middle" class="node-title">reflect-kb</text>
+  <text x="680.0" y="383.0" text-anchor="middle" class="node-sub">GraphRAG + qmd BM25</text>
+  <rect x="580.0" y="600.0" width="200.0" height="80.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="680.0" y="618.0" text-anchor="middle" class="node-type">STATE</text>
+  <text x="680.0" y="646.0" text-anchor="middle" class="node-title">pending queue</text>
+  <text x="680.0" y="668.0" text-anchor="middle" class="node-sub">~/.reflect drain → /reflect</text>
+  <rect x="580.0" y="110.0" width="200.0" height="96.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
+  <text x="680.0" y="128.0" text-anchor="middle" class="node-type">SKILL</text>
+  <text x="680.0" y="164.0" text-anchor="middle" class="node-title">/reflect:recall</text>
+  <text x="680.0" y="186.0" text-anchor="middle" class="node-sub">hybrid search · top-3 rerank</text>
+  <rect x="179.0" y="108.0" width="77" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="217.5" y="122.0" text-anchor="middle" class="arrow-label">lifecycle</text>
+  <rect x="477.0" y="134.0" width="126" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="540.0" y="148.0" text-anchor="middle" class="arrow-label">query cwd/branch</text>
+  <rect x="541.0" y="238.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="590.0" y="252.0" text-anchor="middle" class="arrow-label">query prompt</text>
+  <rect x="487.5" y="444.0" width="105" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="540.0" y="458.0" text-anchor="middle" class="arrow-label">mini-learning</text>
+  <rect x="508.5" y="554.0" width="63" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="540.0" y="568.0" text-anchor="middle" class="arrow-label">enqueue</text>
+  <rect x="508.5" y="610.0" width="63" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="540.0" y="624.0" text-anchor="middle" class="arrow-label">enqueue</text>
+  <rect x="637.5" y="569.0" width="49" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="662.0" y="583.0" text-anchor="middle" class="arrow-label">drain</text>
+  <rect x="606.0" y="426.0" width="112" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="662.0" y="440.0" text-anchor="middle" class="arrow-label">note + sidecar</text>
+  <rect x="654.0" y="239.0" width="112" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="710.0" y="253.0" text-anchor="middle" class="arrow-label">top-3 reranked</text>
+  <rect x="351.5" y="186.6" width="112" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
+  <text x="407.5" y="200.6" text-anchor="middle" class="arrow-label">inject context</text>
+  <line x1="42.0" y1="556.0" x2="72.0" y2="556.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
+  <text x="82.0" y="560.0" class="legend">control / lifecycle</text>
+  <line x1="42.0" y1="578.0" x2="72.0" y2="578.0" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
+  <text x="82.0" y="582.0" class="legend">query / enqueue (data)</text>
+  <line x1="42.0" y1="600.0" x2="72.0" y2="600.0" stroke="#10b981" stroke-width="2.4" marker-end="url(#arrowB)"/>
+  <text x="82.0" y="604.0" class="legend">write to KB</text>
+  <line x1="42.0" y1="622.0" x2="72.0" y2="622.0" stroke="#2563eb" stroke-width="2.4" marker-end="url(#arrowC)"/>
+  <text x="82.0" y="626.0" class="legend">read from KB</text>
+  <line x1="42.0" y1="644.0" x2="72.0" y2="644.0" stroke="#ef4444" stroke-width="2.4" marker-end="url(#arrowG)"/>
+  <text x="82.0" y="648.0" class="legend">inject into context</text>
+</svg>

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -27,17 +27,17 @@ If you want to **add a screen / CLI / dashboard to the TUI**, you want this kind
 
 ### 2. **Claude Code plugins** (Anthropic's plugin system)
 
-A separate system owned by Claude Code itself. The monorepo ships **one** Claude Code plugin: `reflect`.
+A separate system owned by Claude Code itself. The monorepo ships **three** Claude Code plugins, all under `plugins/<name>/` at the repo root (not inside `ainb-tui/`):
 
-- **Where it lives:** `plugins/reflect/` at the repo root (not inside `ainb-tui/`)
+- **[`reflect`](../toolkit/plugins/reflect.md)** — agent self-improvement + retrieval (skills + SessionStart/PostToolUse/Stop hooks). `claude plugin install reflect@agents-in-a-box`
+- **[`ainb-fleet`](../toolkit/plugins/ainb-fleet.md)** — LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration. `claude plugin install ainb-fleet@agents-in-a-box`
+- **[`ainb-hooks`](../toolkit/plugins/ainb-hooks.md)** — emits Claude Code / Codex lifecycle events to the ainb notification inbox (pairs with the `notifyd` in-tree plugin); wired by `ainb-notifyd install`.
+
 - **Distribution:** through `.claude-plugin/marketplace.json` at the repo root, which the Claude Code CLI reads
-- **Runtime:** Claude Code itself loads it as a skill/hook bundle; ainb is not involved
-- **What it does:** captures and retrieves learnings inside Claude Code sessions via the `reflect-kb` library
-- **Install:** `claude plugin install reflect@agents-in-a-box`
+- **Runtime:** Claude Code itself loads them as skill/hook bundles; the ainb TUI is not involved
+- **Full docs:** [Toolkit → Claude Code plugins](../toolkit/plugins/overview.md) — a page per plugin with how-it-works diagrams
 
-If you want to **add behaviour to Claude Code itself**, you want a Claude Code plugin. Documentation for that system is upstream:
-- [Claude Code plugin docs](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's authoritative reference
-- The `plugins/reflect/` directory in this repo is a working example you can read
+If you want to **add behaviour to Claude Code itself**, you want a Claude Code plugin. Anthropic's authoritative reference is the [Claude Code plugin docs](https://docs.anthropic.com/en/docs/claude-code); the `plugins/*/` directories here are working examples.
 
 ---
 

--- a/docs/toolkit/plugins/ainb-fleet.md
+++ b/docs/toolkit/plugins/ainb-fleet.md
@@ -1,0 +1,62 @@
+---
+title: "ainb-fleet"
+description: "Claude Code skill bundle that teaches agents to drive the `ainb fleet` multi-session orchestration subcommands."
+---
+
+`ainb-fleet` (v0.1.0) is a **Claude Code plugin** — loaded by Claude Code itself, not by the ainb TUI — that ships a bundle of LLM-facing skills teaching an agent how to use the `ainb fleet ...` orchestration subcommands: broadcasting a prompt to many sessions, ack-gated step sequences, surfacing blocked sessions ("needs"), an auto-continue daemon, and a fleet standup. The orchestration logic itself lives in the `ainb` Rust binary; this plugin is purely the teaching layer that points the agent at the right command for the job. It replaces the deprecated `popa` plugin, whose Node code is gone.
+
+## How it works
+
+![ainb-fleet — how it works](../../assets/diagrams/ainb-fleet.svg)
+
+This plugin registers **no hooks, no commands, and no agents** — it is a pure skill bundle. When you invoke one of its colon-namespaced skills (`/ainb-fleet:standup`, `/ainb-fleet:broadcast`, etc.), the skill teaches the agent the exact `ainb fleet ...` invocation to shell out to. All the real work — discovering sessions, reading transcripts, routing writes — happens inside the `ainb` Rust binary.
+
+The fleet engine discovers sessions from three sources — every session `ainb` has spawned, sessions registered with the claude-peers broker (`~/.claude-peers.db`), and background-job dirs under `~/.claude/jobs/` — then merges and dedupes them by `cwd`. Reads go through the source of truth (JSONL transcripts plus tmux pane buffers); writes go out peers-first via the broker when a peer is registered, falling back to `tmux send-keys` literal mode otherwise.
+
+The bundle has a top-level router skill (`ainb-fleet`) that maps the five verbs to their focused sub-skills, plus a workflow-backed variant of `needs`. The `fleet-needs` skill runs the deterministic `hangar` workflow (verb=`needs`: discover → enrich → prioritize → render-ready cards), then renders a "Jarvis HUD" of every blocked session and fires an `AskUserQuestion` per session so the user can answer the whole fleet in one batch; answers are routed back to each target's tmux pane.
+
+The daemon skill describes a long-running watcher that scans each session's recent pane buffer every 5 seconds and auto-sends `continue` to any session whose buffer matches a known API-error regex (`rate_limited`, `overloaded_error`, `internal_server_error`, `request_timeout`, `socket_hang_up`, `fetch_failed`, `connection_reset`), deduping on `(session_id, pattern, match-context)` so it fires once per error.
+
+## What it provides
+
+### Skills
+
+| Skill | Purpose |
+|---|---|
+| `ainb-fleet` | Overview / router — at-a-glance map of the five fleet verbs, discovery sources, and global flags |
+| `ainb-fleet:standup` | List every claude session on the host, merged + deduped across ainb · peers broker · bg jobs |
+| `ainb-fleet:broadcast` | Fan one prompt out to selected sessions (requires `--all`, `--filter <regex>`, or `--cwd <substring>`) |
+| `ainb-fleet:sequence` | Send ordered multi-step prompts, ack-gated between steps via JSONL turn-end detection |
+| `ainb-fleet:needs` | Center control panel — enumerate sessions blocked on ASK / ERR / IDLE / WAIT signals, render the Jarvis HUD |
+| `ainb-fleet:fleet-needs` | Workflow-backed `needs` — runs the `hangar` workflow, renders the HUD, fires `AskUserQuestion`, routes answers back |
+| `ainb-fleet:daemon` | Background watcher that auto-`continue`s sessions matching an API-error regex |
+
+### Workflow
+
+| Workflow | Purpose |
+|---|---|
+| `hangar` | Multi-verb deterministic orchestrator (verbs: `needs` / `standup` / `sequence`). Discover → enrich (per-session, Haiku by default) → prioritize / group / step. Backs the `fleet-needs` skill. |
+
+### Hooks / Commands / Agents
+
+None — this plugin registers no lifecycle hooks, slash commands, or sub-agents.
+
+## Install
+
+```sh
+claude plugin install ainb-fleet@agents-in-a-box
+```
+
+The plugin is published via this repo's root `.claude-plugin/marketplace.json` (marketplace name `agents-in-a-box`). It requires the `ainb` binary on `PATH` to do any real work — the skills shell out to `ainb fleet ...`.
+
+## Using it
+
+- **Get a fleet roster:** `/ainb-fleet:standup` (add `--format json` to pipe into `jq`).
+- **Apply one instruction everywhere:** `/ainb-fleet:broadcast` — e.g. `ainb fleet broadcast "/clear" --filter "shotclubhouse"`. A targeting flag is mandatory to prevent accidental fan-out.
+- **Run an ordered cycle:** `/ainb-fleet:sequence` — e.g. disconnect → reconnect → verify, waiting for each step's assistant turn-end before the next.
+- **See what wants your attention:** `/ainb-fleet:needs` (or `/ainb-fleet:fleet-needs` when `CLAUDE_CODE_WORKFLOWS=1`) renders a HUD of every blocked session and lets you answer them in one `AskUserQuestion` batch.
+- **Unattended error recovery:** `/ainb-fleet:daemon` runs a watcher that auto-`continue`s sessions hitting transient API errors (run via `nohup ... &` for real background use).
+
+## Source
+
+`plugins/ainb-fleet/` — a Claude Code skill bundle (7 skills + the `hangar` workflow) teaching agents to drive the `ainb fleet` Rust subcommands. Diagram generated via /fireworks-tech-graph.

--- a/docs/toolkit/plugins/ainb-hooks.md
+++ b/docs/toolkit/plugins/ainb-hooks.md
@@ -1,0 +1,66 @@
+---
+title: "ainb-hooks"
+description: "Claude Code / Codex plugin that emits session lifecycle events to the ainb notification inbox over a Unix socket."
+---
+
+`ainb-hooks` (v0.1.0) is a **Claude Code plugin** — it is loaded by the Claude Code (and Codex CLI) host agent, not by the `ainb` TUI. (Contrast with the ainb v2 subprocess plugins such as `burndown` and `witr`, which run inside `ainb`.) It registers lifecycle hooks on the host agent and forwards each event to the **ainb notification inbox** — the `ainb-notifyd` daemon — over a Unix socket, powering session-state badges, the Inbox screen, and optional OS notifications in `ainb-tui`. It pairs with the in-tree [notifyd](../../plugins/notifyd.md) plugin, which is the consumer on the other end of the socket.
+
+## How it works
+
+![ainb-hooks — how it works](../../assets/diagrams/ainb-hooks.svg)
+
+The plugin's `.claude-plugin/plugin.json` registers the host agent's lifecycle events with a single command: `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh`. The same six events are registered for Codex via `codex/hooks.json` (with `AINB_AGENT=codex`). Each hook has a 5-second timeout so a slow delivery never stalls the agent.
+
+`hooks/notify.sh` is the universal normalizer. Claude Code pipes the hook payload as JSON on stdin; Codex passes it as `argv[1]`. The script autodetects the source, extracts the event name, session id, and cwd (via `jq`, falling back to `grep` in minimal environments), and wraps the verbatim original payload in a normalized envelope: `{protocol_version, agent, raw_event, session_id, cwd, project, ts, payload}`. The `raw_event` field preserves the original event name (e.g. `Notification:idle_prompt`) so semantic mapping happens in the consumer, not on the wire.
+
+Delivery targets `~/.agents-in-a-box/notify.sock` via `nc` (or `socat`). If the socket is absent, the script attempts a best-effort lazy spawn of `ainb notifyd` (guarded by a `flock`) and retries once. If that still fails, it appends the envelope to `~/.agents-in-a-box/notify.fallback.jsonl`, which `ainb-notifyd` replays and clears on its next startup. The hook always exits 0, so a delivery failure never blocks the host agent.
+
+Downstream, `ainb-notifyd` persists envelopes to a SQLite `notifications.db` and broadcasts them to `ainb-tui` for live inbox/badge updates.
+
+## What it provides
+
+This plugin ships only hooks plus the shared `notify.sh` script — no skills, commands, or agents.
+
+### Hooks (registered for both Claude Code and Codex)
+
+| Event | What fires |
+| --- | --- |
+| `SessionStart` | Session begins — emits an envelope marking the session live |
+| `UserPromptSubmit` | User submits a prompt to the agent |
+| `PostToolUse` | A tool call completes |
+| `Notification` | Agent notifications, incl. `Notification:idle_prompt` ("awaiting user input") |
+| `Stop` | Agent turn / session stops |
+| `PreCompact` | Context is about to be compacted |
+
+### Components
+
+| File | Purpose |
+| --- | --- |
+| `.claude-plugin/plugin.json` | Claude Code plugin manifest (`hooks` block, name, version) |
+| `codex/hooks.json` | Codex `~/.codex/hooks.json` merge template (`__AINB_HOOK_SCRIPT__` placeholder) |
+| `hooks/notify.sh` | Universal hook script — normalizes the payload and delivers it to the socket |
+
+## Install
+
+`ainb-hooks` is **not** installed via the marketplace the normal way (it is absent from the root `marketplace.json` plugins list). It is wired by the `ainb-notifyd` binary's installer, which handles the plugin manifest, the Codex config merge, and the notifyd lifecycle:
+
+```bash
+ainb-notifyd install --claude --codex
+ainb-notifyd status
+ainb-notifyd uninstall --all
+```
+
+The installer drops `plugin.json` at `~/.claude/plugins/ainb-hooks/` (Claude), merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block (Codex), extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh` and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path, and records the install method in `~/.agents-in-a-box/install.json` so uninstall is fully reversible.
+
+> The plugin's README recommends a higher-level `ainb hooks install` wrapper; that `ainb hooks` CLI is planned but not yet on `main`, so use `ainb-notifyd install` (above) today.
+
+## Using it
+
+- Once installed, delivery is fully automatic — every registered lifecycle event on the host agent (SessionStart, UserPromptSubmit, PostToolUse, Notification, Stop, PreCompact) is forwarded to the inbox with no user action.
+- `Notification:idle_prompt` events surface in `ainb-tui` as "awaiting input" so you can see which sessions need you.
+- Events show up as session-state badges and in the dedicated Inbox screen in `ainb-tui`; the inbox detail view exposes the full original hook JSON (carried in `payload`) for forensics.
+- Run `ainb-notifyd status` to confirm the plugin is wired for each agent; if `ainb-notifyd` is not running, the next hook fire lazily spawns it (or buffers to the fallback file).
+
+## Source
+
+`plugins/ainb-hooks/` — a thin hook plugin: a manifest plus one `notify.sh` normalizer shared by Claude Code and Codex. Diagram generated via /fireworks-tech-graph.

--- a/docs/toolkit/plugins/overview.md
+++ b/docs/toolkit/plugins/overview.md
@@ -1,0 +1,24 @@
+---
+title: "Claude Code plugins"
+description: "The Claude Code plugins this repo ships — reflect, ainb-fleet, ainb-hooks — installable from the agents-in-a-box marketplace."
+---
+
+These are **Claude Code plugins** — bundles of skills, hooks, and commands that **Claude Code** (Anthropic's CLI) loads. They are a different system from [ainb v2 plugins](../../plugins/overview.md), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](../../plugins/readme.md) first.
+
+The repo publishes them through `.claude-plugin/marketplace.json` at the repo root; the source lives under `plugins/<name>/`. Add the marketplace, then install:
+
+```bash
+claude plugin marketplace add stevengonsalvez/agents-in-a-box
+claude plugin install reflect@agents-in-a-box
+claude plugin install ainb-fleet@agents-in-a-box
+```
+
+## The plugins
+
+| Plugin | What it does | Install |
+|---|---|---|
+| [reflect](./reflect.md) | Agent self-improvement + retrieval — captures learnings and auto-injects relevant prior ones at session start. | `claude plugin install reflect@agents-in-a-box` |
+| [ainb-fleet](./ainb-fleet.md) | LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration (broadcast, sequence, needs, daemon). | `claude plugin install ainb-fleet@agents-in-a-box` |
+| [ainb-hooks](./ainb-hooks.md) | Emits Claude Code / Codex lifecycle events to the ainb notification inbox (pairs with the [`notifyd`](../../plugins/notifyd.md) in-tree plugin). | `ainb-notifyd install --claude --codex` |
+
+Each page below has a `/fireworks-tech-graph` diagram of how the plugin works, the exact hooks/skills it registers, and how to use it.

--- a/docs/toolkit/plugins/reflect.md
+++ b/docs/toolkit/plugins/reflect.md
@@ -1,0 +1,68 @@
+---
+title: "reflect"
+description: "Claude Code plugin for agent self-improvement: captures corrections as learnings, indexes them, and auto-recalls the relevant ones into every new session."
+---
+
+`reflect` is a **Claude Code plugin** — it is loaded by Claude Code (Anthropic's plugin system: skills + hooks + commands), not by the ainb TUI. It captures the corrections and design decisions you make in a session as structured learnings, indexes them into a hybrid GraphRAG + BM25 knowledge base, and auto-injects the most relevant prior learnings into every new session. Philosophy: *correct once, never again; recall everything next time.* Current version: **3.6.0**.
+
+## How it works
+
+![reflect — how it works](../../assets/diagrams/reflect.svg)
+
+The plugin manifest registers five lifecycle hooks. **`SessionStart`** runs two commands: `session_start_recall.py` builds a query from the session's cwd, branch, and recent commits and injects the top-3 reranked learnings as `additionalContext`; and `reflect-drain-bg.sh` launches a detached background drainer that processes any reflections queued from prior sessions. **`UserPromptSubmit`** re-runs recall using the actual prompt as a sharper query (with per-session dedupe), and also completes the mini-learning capture — if a tool just failed and the prompt looks like a correction, it writes a low-confidence learning straight to disk without spending an LLM call.
+
+**`PostToolUse`** is the first half of that cheap capture path: when a tool call fails, it arms a watcher so the next `UserPromptSubmit` can detect a correction. **`Stop`** enqueues short sessions (that ended before compaction) for asynchronous reflection, and **`PreCompact`** enqueues long sessions when Claude Code compacts the conversation — both feed the same `~/.reflect/pending_reflections.jsonl` queue, deduped by `session_id`.
+
+Capture and indexing run through the sub-skills. `/reflect` scans a conversation, classifies corrections vs. successes, and writes a Markdown learning note plus a YAML entity sidecar (people, files, libraries, decisions). The background drainer replays queued transcripts through the same `/reflect` skill headlessly. Everything is dual-indexed into **reflect-kb** — nano-graphrag for semantic + entity-graph search and qmd for fast BM25 lexical search — both running locally.
+
+Retrieval closes the loop: `/reflect:recall` (the same engine the SessionStart and UserPromptSubmit hooks call automatically) runs hybrid search, reranks by confidence × recency × tag overlap, and surfaces the strongest learnings back into the agent's context before the first token is generated.
+
+## What it provides
+
+### Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `reflect` | Full conversation scan — detect behavioral corrections and knowledge signals, classify them, write a learning note with an entity sidecar for GraphRAG indexing |
+| `reflect:recall` | Retrieve relevant prior learnings from the global KB via hybrid vector + graph search, reranked by confidence, recency, and tag overlap (also runs automatically at SessionStart / UserPromptSubmit) |
+| `reflect:ingest` | The global knowledge indexer — harvest ALL memory sources across tools (Claude, Codex, Copilot, Gemini) into the unified GraphRAG + qmd KB, archiving originals and generating entity sidecars |
+| `reflect:consolidate` | Project-level memory consolidation — merge orphaned worktree memory dirs into a single `.agents/MEMORY.md` (deduplicates and sections; does not index into the global KB) |
+| `reflect:errors-ack` | Triage and acknowledge entries in the reflect errors sink (`~/.reflect/errors.json`) — drain poison, parser crashes, ingest failures, hook timeouts; invoked from the statusline ⚠N badge |
+| `reflect-status` | Read-only metrics — pending reviews, sidecar coverage, GraphRAG health; can approve/reject pending low-confidence items |
+
+### Hooks (registered in `plugin.json`)
+
+| Event | What fires |
+|-------|-----------|
+| `SessionStart` | `session_start_recall.py` injects top-3 learnings from cwd/branch/commits, plus a detached `reflect-drain-bg.sh` that drains the pending-reflections queue in the background |
+| `UserPromptSubmit` | `user_prompt_submit_recall.py` re-runs recall against the actual prompt (deduped) and writes a mini-learning if a prior tool failure is being corrected |
+| `PostToolUse` | `posttooluse_minilearning.py` arms a mini-learning watcher when a tool call fails (cheap, no LLM call) |
+| `Stop` | `stop_reflect.py` enqueues short sessions for asynchronous reflection, deduped against PreCompact |
+| `PreCompact` | `precompact_reflect.py --auto --verbose` enqueues the transcript for reflection when Claude Code compacts the conversation |
+
+## Install
+
+```bash
+claude plugin marketplace add stevengonsalvez/agents-in-a-box
+claude plugin install reflect@agents-in-a-box
+
+# install the underlying CLI (provides nano-graphrag + qmd)
+uv tool install --force --upgrade 'git+https://github.com/stevengonsalvez/agents-in-a-box.git#subdirectory=reflect-kb[graph]'
+```
+
+The plugin is published via the repo's root `.claude-plugin/marketplace.json` (marketplace name `agents-in-a-box`). Codex CLI and GitHub Copilot don't have a native plugin runtime — for those, use the Python adapters under `plugins/reflect/adapters/<codex|copilot>/`.
+
+## Using it
+
+- **Mostly automatic.** Once installed, the SessionStart hook fires `recall` at the start of every new session and surfaces relevant prior learnings before you type. UserPromptSubmit sharpens that with the actual prompt on each turn.
+- **Capture happens for free.** Failed tool calls + correction-shaped follow-ups become low-cost mini-learnings, and short / compacted sessions are queued and drained in the background — no manual step required.
+- **`/reflect`** — run it explicitly to scan the current conversation and write a learning note when you want to capture something deliberately.
+- **`/reflect:recall "<anything>"`** — query the knowledge base on demand.
+- **`/reflect:ingest`** — periodically bulk-index existing memories from any tool into the global KB.
+- **`/reflect:consolidate`** — merge scattered worktree memory dirs into one project `.agents/MEMORY.md`.
+- **`/reflect-status`** — view pipeline metrics, pending reviews, and KB health; approve/reject low-confidence items.
+- **`/reflect:errors-ack`** — triage the errors sink when the statusline shows a ⚠N badge.
+
+## Source
+
+`plugins/reflect/` — Claude Code plugin (skills + lifecycle hooks) backed by the `reflect-kb` GraphRAG + qmd library. Diagram generated via /fireworks-tech-graph.

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -65,6 +65,15 @@ export default defineConfig({
             { label: 'Skills', slug: 'toolkit/skills' },
             { label: 'Agents', slug: 'toolkit/agents' },
             { label: 'Bootstrap engine', slug: 'toolkit/bootstrap' },
+            {
+              label: 'Claude Code plugins',
+              items: [
+                { label: 'Overview', slug: 'toolkit/plugins/overview' },
+                { label: 'reflect', slug: 'toolkit/plugins/reflect' },
+                { label: 'ainb-fleet', slug: 'toolkit/plugins/ainb-fleet' },
+                { label: 'ainb-hooks', slug: 'toolkit/plugins/ainb-hooks' },
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
Adds a **Toolkit → Claude Code plugins** section documenting the three Claude Code plugins this repo ships — `reflect`, `ainb-fleet`, `ainb-hooks` — each with its own page, a /fireworks-tech-graph diagram, the exact hooks/skills it registers (cross-checked against each `plugin.json` + `SKILL.md`), and install/usage.

- New: an overview front-door + a page per plugin, wired into the Starlight sidebar under Toolkit.
- Fixes the plugins **disambiguation** page, which claimed the repo ships *one* Claude Code plugin (reflect) — it ships three.
- ainb-hooks documents the working `ainb-notifyd install` path (the README's `ainb hooks` wrapper isn't on main yet — verified).
- No body H1 (single Starlight title), markdown image syntax (Astro emits the diagrams). Astro build verified: all 4 pages render, 3 diagrams in `_astro/`, one `<h1>` per page.