### PR TITLE
feat(notifyd): first-run prompt to install notification hooks + drift detection

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2745,13 +2745,12 @@ impl EventHandler {
                                 // in-process (ainb-core links ainb-plugin-notifyd).
                                 // Sync + fast — writes a few small files. The
                                 // daemon lazy-spawns on the first hook event.
-                                match ainb_plugin_notifyd::Paths::from_home()
-                                    .and_then(|p| {
-                                        ainb_plugin_notifyd::install_for(
-                                            &p,
-                                            ainb_plugin_notifyd::Agent::ALL,
-                                        )
-                                    }) {
+                                match ainb_plugin_notifyd::Paths::from_home().and_then(|p| {
+                                    ainb_plugin_notifyd::install_for(
+                                        &p,
+                                        ainb_plugin_notifyd::Agent::ALL,
+                                    )
+                                }) {
                                     Ok(record) => {
                                         state.add_info_notification(format!(
                                             "Notifications enabled for {:?} — the Inbox (b) \

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2740,8 +2740,41 @@ impl EventHandler {
                                 state.pending_async_action =
                                     Some(AsyncAction::KillWorkspaceShell(workspace_idx));
                             }
+                            crate::app::state::ConfirmAction::InstallNotifyHooks => {
+                                // Install the ainb-hooks plugin for both agents
+                                // in-process (ainb-core links ainb-plugin-notifyd).
+                                // Sync + fast — writes a few small files. The
+                                // daemon lazy-spawns on the first hook event.
+                                match ainb_plugin_notifyd::Paths::from_home()
+                                    .and_then(|p| {
+                                        ainb_plugin_notifyd::install_for(
+                                            &p,
+                                            ainb_plugin_notifyd::Agent::ALL,
+                                        )
+                                    }) {
+                                    Ok(record) => {
+                                        state.add_info_notification(format!(
+                                            "Notifications enabled for {:?} — the Inbox (b) \
+                                             will light up when a session needs you.",
+                                            record.agents
+                                        ));
+                                    }
+                                    Err(e) => {
+                                        state.add_error_notification(format!(
+                                            "Failed to install notification hooks: {e}"
+                                        ));
+                                    }
+                                }
+                            }
+                            crate::app::state::ConfirmAction::DismissNotifyPrompt => {
+                                if let Ok(paths) = ainb_plugin_notifyd::Paths::from_home() {
+                                    let _ = ainb_plugin_notifyd::dismiss_prompt(&paths);
+                                }
+                            }
                             crate::app::state::ConfirmAction::Cancel => {
-                                // Explicit Cancel: dialog already taken; nothing to do.
+                                // Explicit Cancel ("Not now"): dialog already
+                                // taken; nothing persisted, so we re-ask next
+                                // launch.
                             }
                         }
                     }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5335,7 +5335,10 @@ impl AppState {
                     .to_string(),
                 "Install",
             ),
-            InstallPrompt::OfferUpdate { installed, embedded } => (
+            InstallPrompt::OfferUpdate {
+                installed,
+                embedded,
+            } => (
                 "Update notification hooks?".to_string(),
                 format!(
                     "ainb-hooks is installed at v{installed}, but this build \

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -680,6 +680,8 @@ pub enum ConfirmAction {
     KillOtherTmux(String), // Kill a non-agents-in-a-box tmux session by name
     KillOtherTmuxSessions(Vec<String>), // Kill multiple non-agents-in-a-box tmux sessions by name
     KillWorkspaceShell(usize), // Kill workspace shell by workspace index
+    InstallNotifyHooks, // Install the ainb-hooks notification plugin into Claude Code + Codex
+    DismissNotifyPrompt, // Remember "don't ask again" for the notify-install prompt
     Cancel,            // No-op terminator for tri-option dialogs
 }
 
@@ -3300,6 +3302,11 @@ impl AppState {
         self.onboarding_state = None;
         self.current_screen = screen_ids::HOME.to_string();
 
+        // New-user path: now that onboarding is done, offer to install
+        // the ainb-hooks notification plugin (existing users get this at
+        // startup in main.rs instead). No-op if declined or up to date.
+        self.maybe_prompt_notify_install();
+
         Ok(())
     }
 
@@ -5295,6 +5302,71 @@ impl AppState {
             selected_option: false,
             warning: Some("This closes all selected external tmux sessions.".to_string()),
             options: None,
+            selected_index: 0,
+        });
+    }
+
+    /// First-run / post-upgrade prompt for the ainb-hooks notification
+    /// plugin. Reads `ainb_plugin_notifyd::prompt_state`: offers to
+    /// install when nothing is set up (and the user hasn't declined),
+    /// or to update when this binary embeds a newer manifest than what's
+    /// on disk. A no-op when there's nothing to prompt, so callers can
+    /// fire it unconditionally on startup / after onboarding.
+    ///
+    /// Never shown while a dialog is already up or the user is mid-
+    /// onboarding — callers gate on that.
+    pub fn maybe_prompt_notify_install(&mut self) {
+        use ainb_plugin_notifyd::{InstallPrompt, Paths, prompt_state};
+
+        if self.confirmation_dialog.is_some() {
+            return;
+        }
+        let Ok(paths) = Paths::from_home() else {
+            return;
+        };
+        let (title, message, install_label) = match prompt_state(&paths) {
+            InstallPrompt::OfferInstall => (
+                "Get notified when a session needs you?".to_string(),
+                "Install ainb-hooks into Claude Code + Codex so the Inbox \
+                 (press b) and per-session badges light up when an agent is \
+                 awaiting input or has finished. Only actionable events are \
+                 captured — no activity-log noise. Writes ~/.claude/plugins \
+                 and ~/.codex/hooks.json."
+                    .to_string(),
+                "Install",
+            ),
+            InstallPrompt::OfferUpdate { installed, embedded } => (
+                "Update notification hooks?".to_string(),
+                format!(
+                    "ainb-hooks is installed at v{installed}, but this build \
+                     ships v{embedded}. Re-install to pick up the latest hook \
+                     set."
+                ),
+                "Update",
+            ),
+            InstallPrompt::None => return,
+        };
+        self.confirmation_dialog = Some(ConfirmationDialog {
+            title,
+            message,
+            // Binary mode is unused here; tri-option drives the choice.
+            confirm_action: ConfirmAction::InstallNotifyHooks,
+            selected_option: false,
+            warning: None,
+            options: Some(vec![
+                DialogOption {
+                    label: install_label.to_string(),
+                    action: ConfirmAction::InstallNotifyHooks,
+                },
+                DialogOption {
+                    label: "Not now".to_string(),
+                    action: ConfirmAction::Cancel,
+                },
+                DialogOption {
+                    label: "Don't ask again".to_string(),
+                    action: ConfirmAction::DismissNotifyPrompt,
+                },
+            ]),
             selected_index: 0,
         });
     }

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -72,6 +72,16 @@ impl LayoutComponent {
                 tracing::debug!("Rendering help overlay on {}", state.current_screen);
                 self.help.render(frame, frame_size);
             }
+            // The confirmation dialog is a universal, highest-priority
+            // overlay — it must paint on registry-backed screens too
+            // (HomeScreen, Inbox, …), not just the split-pane views.
+            // Key handling already runs pre-screen in `app::events`, so
+            // without this the dialog could be live + interactive but
+            // invisible (e.g. the first-run notify-install prompt fired
+            // on the HomeScreen).
+            if state.confirmation_dialog.is_some() {
+                self.confirmation_dialog.render(frame, frame_size, state);
+            }
             return;
         }
 

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -142,6 +142,13 @@ async fn main() -> Result<()> {
             if app::state::AppState::needs_onboarding() {
                 tracing::info!("First-time setup detected - starting onboarding wizard");
                 app_state.state.start_onboarding(false, None);
+            } else {
+                // Existing user (no onboarding to run): offer to install /
+                // update the ainb-hooks notification plugin if it's absent
+                // or stale. New users get this same prompt at the end of
+                // onboarding instead (see `complete_onboarding`). No-op
+                // when already up to date or previously declined.
+                app_state.state.maybe_prompt_notify_install();
             }
 
             // Always clear pending async actions after init to ensure clean startup

--- a/ainb-tui/crates/ainb-core/tests/tripwire_inbox_opens_and_renders.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_inbox_opens_and_renders.rs
@@ -91,6 +91,20 @@ git_directories = []
     };
     store.insert_and_prune(&claude, &no_retention).expect("seed claude row");
     store.insert_and_prune(&codex, &no_retention).expect("seed codex row");
+
+    // Seed an install.json marking hooks installed at the current
+    // version. A real machine with inbox data necessarily has the hooks
+    // installed (that's how the rows got there), so this matches
+    // reality — and crucially it makes `prompt_state` return `None`, so
+    // the first-run "install notification hooks?" dialog does NOT fire
+    // on startup. Without this the dialog pops on the HomeScreen and
+    // intercepts the `b` keypress before the Inbox can open.
+    let install_json = format!(
+        r#"{{"agents":["claude","codex"],"hook_script":"{}","plugin_version":"{}"}}"#,
+        paths.base.join("hooks/notify.sh").display(),
+        ainb_plugin_notifyd::embedded_plugin_version(),
+    );
+    fs::write(paths.base.join("install.json"), install_json).expect("seed install.json");
 }
 
 fn capture_pane(session: &str) -> String {

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -195,11 +195,7 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
 pub fn embedded_plugin_version() -> String {
     serde_json::from_str::<serde_json::Value>(CLAUDE_PLUGIN_JSON)
         .ok()
-        .and_then(|v| {
-            v.get("version")
-                .and_then(|s| s.as_str())
-                .map(str::to_string)
-        })
+        .and_then(|v| v.get("version").and_then(|s| s.as_str()).map(str::to_string))
         .unwrap_or_else(|| "0.0.0".to_string())
 }
 
@@ -253,12 +249,12 @@ pub fn prompt_state(paths: &Paths) -> InstallPrompt {
             InstallPrompt::OfferInstall
         }
     } else {
-        let installed = record
-            .plugin_version
-            .clone()
-            .unwrap_or_else(|| "0.0.0".to_string());
+        let installed = record.plugin_version.clone().unwrap_or_else(|| "0.0.0".to_string());
         if parse_semver(&installed) < parse_semver(&embedded) {
-            InstallPrompt::OfferUpdate { installed, embedded }
+            InstallPrompt::OfferUpdate {
+                installed,
+                embedded,
+            }
         } else {
             InstallPrompt::None
         }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -78,6 +78,18 @@ pub struct InstallRecord {
     pub claude_plugin_dir: Option<PathBuf>,
     /// Resolved per-agent config path (Codex only).
     pub codex_hooks_json: Option<PathBuf>,
+    /// The plugin manifest version that was written to disk at install
+    /// time. Compared against [`embedded_plugin_version`] on startup to
+    /// detect drift after an `ainb` upgrade. `None` for records written
+    /// before this field existed (treated as "0.0.0" → always stale).
+    #[serde(default)]
+    pub plugin_version: Option<String>,
+    /// Set when the user explicitly declined the first-run install
+    /// prompt ("don't ask again"). Suppresses the offer-to-install
+    /// prompt; does not affect the offer-to-update prompt (which only
+    /// applies once something is actually installed).
+    #[serde(default)]
+    pub prompt_dismissed: bool,
 }
 
 impl InstallRecord {
@@ -153,6 +165,11 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
 
     let mut record = InstallRecord::load(paths)?;
     record.hook_script = hook_script.clone();
+    // Stamp the manifest version we're writing so a later `ainb`
+    // upgrade can detect drift (see `prompt_state`). A fresh install
+    // also clears any prior "don't ask again" — the user is opting in.
+    record.plugin_version = Some(embedded_plugin_version());
+    record.prompt_dismissed = false;
     for agent in agents {
         match agent {
             Agent::Claude => {
@@ -169,6 +186,92 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
     }
     record.save(paths)?;
     Ok(record)
+}
+
+/// The plugin manifest version baked into this binary — parsed from
+/// the embedded `plugin.json`. Single source of truth: bump the
+/// version in `plugins/ainb-hooks/.claude-plugin/plugin.json` and both
+/// the install record and the drift check pick it up automatically.
+pub fn embedded_plugin_version() -> String {
+    serde_json::from_str::<serde_json::Value>(CLAUDE_PLUGIN_JSON)
+        .ok()
+        .and_then(|v| {
+            v.get("version")
+                .and_then(|s| s.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "0.0.0".to_string())
+}
+
+/// Parse a `major.minor.patch` string into a comparable tuple. Any
+/// non-numeric suffix on a component (e.g. `-rc1`) is ignored; missing
+/// components default to 0. Robust to the `v` prefix.
+fn parse_semver(v: &str) -> (u64, u64, u64) {
+    let mut parts = v.trim_start_matches('v').split('.').map(|p| {
+        p.split(|c: char| !c.is_ascii_digit())
+            .next()
+            .unwrap_or("0")
+            .parse::<u64>()
+            .unwrap_or(0)
+    });
+    (
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+    )
+}
+
+/// What the TUI should do about the notification hooks on startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallPrompt {
+    /// Nothing installed and the user hasn't declined — offer to
+    /// install.
+    OfferInstall,
+    /// Installed, but this binary embeds a newer manifest — offer to
+    /// re-install (drift after an `ainb` upgrade).
+    OfferUpdate {
+        /// Version currently on disk.
+        installed: String,
+        /// Version this binary would write.
+        embedded: String,
+    },
+    /// Up to date, or the user declined — show nothing.
+    None,
+}
+
+/// Decide whether the TUI should prompt the user about notification
+/// hooks. This is the single entry point the host calls on startup;
+/// it reads the install record and compares versions. Never errors —
+/// a missing/corrupt record is treated as "not installed".
+pub fn prompt_state(paths: &Paths) -> InstallPrompt {
+    let record = InstallRecord::load(paths).unwrap_or_default();
+    let embedded = embedded_plugin_version();
+    if record.agents.is_empty() {
+        if record.prompt_dismissed {
+            InstallPrompt::None
+        } else {
+            InstallPrompt::OfferInstall
+        }
+    } else {
+        let installed = record
+            .plugin_version
+            .clone()
+            .unwrap_or_else(|| "0.0.0".to_string());
+        if parse_semver(&installed) < parse_semver(&embedded) {
+            InstallPrompt::OfferUpdate { installed, embedded }
+        } else {
+            InstallPrompt::None
+        }
+    }
+}
+
+/// Persist the user's "don't ask again" choice so the offer-to-install
+/// prompt never fires again on this machine. Writes a record with no
+/// agents and `prompt_dismissed = true`.
+pub fn dismiss_prompt(paths: &Paths) -> Result<()> {
+    let mut record = InstallRecord::load(paths).unwrap_or_default();
+    record.prompt_dismissed = true;
+    record.save(paths)
 }
 
 fn push_unique<T: PartialEq>(v: &mut Vec<T>, item: T) {
@@ -544,5 +647,98 @@ mod tests {
             assert!(!r.installed);
             assert!(!r.socket_ok);
         }
+    }
+
+    #[test]
+    fn embedded_plugin_version_is_parsed_from_manifest() {
+        // Must match the version in
+        // plugins/ainb-hooks/.claude-plugin/plugin.json.
+        let v = embedded_plugin_version();
+        assert!(!v.is_empty() && v != "0.0.0", "got {v:?}");
+        // It parses as a semver tuple.
+        assert!(parse_semver(&v) > (0, 0, 0));
+    }
+
+    #[test]
+    fn parse_semver_handles_components_and_suffixes() {
+        assert_eq!(parse_semver("0.2.0"), (0, 2, 0));
+        assert_eq!(parse_semver("v1.2.3"), (1, 2, 3));
+        assert_eq!(parse_semver("0.10.0"), (0, 10, 0));
+        assert!(parse_semver("0.9.0") < parse_semver("0.10.0"), "numeric, not lexical");
+        assert_eq!(parse_semver("1.0.0-rc1"), (1, 0, 0));
+        assert_eq!(parse_semver("garbage"), (0, 0, 0));
+    }
+
+    #[test]
+    fn prompt_state_offers_install_when_nothing_installed() {
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        std::fs::create_dir_all(&p.base).unwrap();
+        assert_eq!(prompt_state(&p), InstallPrompt::OfferInstall);
+    }
+
+    #[test]
+    fn prompt_state_silent_after_dismiss() {
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        std::fs::create_dir_all(&p.base).unwrap();
+        dismiss_prompt(&p).unwrap();
+        assert_eq!(prompt_state(&p), InstallPrompt::None);
+    }
+
+    #[test]
+    fn prompt_state_silent_when_up_to_date() {
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        std::fs::create_dir_all(&p.base).unwrap();
+        let mut rec = InstallRecord::default();
+        rec.agents.push(Agent::Claude);
+        rec.plugin_version = Some(embedded_plugin_version());
+        rec.save(&p).unwrap();
+        assert_eq!(prompt_state(&p), InstallPrompt::None);
+    }
+
+    #[test]
+    fn prompt_state_offers_update_on_version_drift() {
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        std::fs::create_dir_all(&p.base).unwrap();
+        // Installed an older version than the binary embeds.
+        let mut rec = InstallRecord::default();
+        rec.agents.push(Agent::Claude);
+        rec.plugin_version = Some("0.0.1".to_string());
+        rec.save(&p).unwrap();
+        match prompt_state(&p) {
+            InstallPrompt::OfferUpdate { installed, embedded } => {
+                assert_eq!(installed, "0.0.1");
+                assert_eq!(embedded, embedded_plugin_version());
+            }
+            other => panic!("expected OfferUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_state_treats_missing_version_as_stale() {
+        // Records written before the version field existed parse with
+        // plugin_version = None → treated as 0.0.0 → offer update.
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        std::fs::create_dir_all(&p.base).unwrap();
+        std::fs::write(
+            p.base.join("install.json"),
+            r#"{"agents":["claude"],"hook_script":"/x/notify.sh"}"#,
+        )
+        .unwrap();
+        assert!(matches!(prompt_state(&p), InstallPrompt::OfferUpdate { .. }));
+    }
+
+    #[test]
+    fn install_then_prompt_state_is_none() {
+        // End-to-end: install stamps the current version, so an
+        // immediate prompt_state is silent.
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        install_under_home(&p, dir.path(), &[Agent::Claude]).unwrap();
+        assert_eq!(prompt_state(&p), InstallPrompt::None);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -660,7 +660,10 @@ mod tests {
         assert_eq!(parse_semver("0.2.0"), (0, 2, 0));
         assert_eq!(parse_semver("v1.2.3"), (1, 2, 3));
         assert_eq!(parse_semver("0.10.0"), (0, 10, 0));
-        assert!(parse_semver("0.9.0") < parse_semver("0.10.0"), "numeric, not lexical");
+        assert!(
+            parse_semver("0.9.0") < parse_semver("0.10.0"),
+            "numeric, not lexical"
+        );
         assert_eq!(parse_semver("1.0.0-rc1"), (1, 0, 0));
         assert_eq!(parse_semver("garbage"), (0, 0, 0));
     }
@@ -705,7 +708,10 @@ mod tests {
         rec.plugin_version = Some("0.0.1".to_string());
         rec.save(&p).unwrap();
         match prompt_state(&p) {
-            InstallPrompt::OfferUpdate { installed, embedded } => {
+            InstallPrompt::OfferUpdate {
+                installed,
+                embedded,
+            } => {
                 assert_eq!(installed, "0.0.1");
                 assert_eq!(embedded, embedded_plugin_version());
             }
@@ -725,7 +731,10 @@ mod tests {
             r#"{"agents":["claude"],"hook_script":"/x/notify.sh"}"#,
         )
         .unwrap();
-        assert!(matches!(prompt_state(&p), InstallPrompt::OfferUpdate { .. }));
+        assert!(matches!(
+            prompt_state(&p),
+            InstallPrompt::OfferUpdate { .. }
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -37,7 +37,8 @@ mod listener;
 pub use envelope::{Envelope, EnvelopeError};
 pub use fallback::FallbackFile;
 pub use install::{
-    Agent, InstallRecord, StatusRow, install as install_for, install_under_home, status, uninstall,
+    Agent, InstallPrompt, InstallRecord, StatusRow, dismiss_prompt, embedded_plugin_version,
+    install as install_for, install_under_home, prompt_state, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
 pub use paths::Paths;


### PR DESCRIPTION
## Why

> "we should just have a pop up ask to install it just on running ainb (which will underneath run the install notifyd). Like when ainb is started — should prompt (Do you want to install hooks to get notifications)" — Stevie

Having the binary ≠ hooks installed. A fresh `brew install ainb` gets the capability but zero notifications until someone runs `ainb notifyd install`. This adds the first-run prompt that closes the gap, plus version-drift detection so an `ainb` upgrade offers to refresh stale hooks.

## Flow

```
ainb starts
   │
   ▼
prompt_state(paths)
   ├─ OfferInstall  (nothing installed, not declined)   ─▶ dialog: Install / Not now / Don't ask again
   ├─ OfferUpdate   (binary embeds newer manifest)        ─▶ dialog: Update / Not now / Don't ask again
   └─ None          (up to date OR declined)              ─▶ silent
        │ Install
        ▼
   install_for(claude, codex)  in-process · daemon lazy-spawns on first event
```

Both populations covered with one dialog mechanism:
- **Existing users** → fired in `main.rs` after the onboarding check
- **New users** → fired at the end of `complete_onboarding()`

## Changes

| Layer | What |
|-------|------|
| `ainb-plugin-notifyd::install` | `InstallRecord` += `plugin_version` + `prompt_dismissed` (serde-default, old records still parse); `embedded_plugin_version()` (parses embedded plugin.json); `prompt_state()` → `OfferInstall`/`OfferUpdate{installed,embedded}`/`None`; `dismiss_prompt()`; numeric `parse_semver`. 8 new unit tests. |
| `ConfirmAction` | += `InstallNotifyHooks`, `DismissNotifyPrompt` |
| `AppState::maybe_prompt_notify_install()` | builds the tri-option dialog from `prompt_state`; no-op when nothing to prompt |
| `ConfirmationConfirm` handler | Install → `install_for(both)`; Dismiss → `dismiss_prompt` |
| `main.rs` + `complete_onboarding` | the two trigger points |
| `layout.rs` | **fix:** render the confirmation dialog on registry-backed screens (HomeScreen, Inbox) too — it was a universal overlay everywhere *except* the registry path, so the prompt was live but invisible on the HomeScreen |

## Drift detection

`install.json` now stores the manifest version written at install time. On startup, if the binary embeds a newer version (e.g. after `brew upgrade ainb`), the prompt becomes "Update notification hooks?" — solves the "stale 6-event hooks still on disk after upgrade" problem automatically. Records written before this field treat the version as `0.0.0` → offered an update.

## Verified end-to-end (tmux)

Fresh `$HOME` → launch ainb → prompt renders on HomeScreen ("Get notified when a session needs you?" · Install/Not now/Don't ask again) → press Install → `~/.claude/plugins/ainb-hooks/plugin.json` written (Notification + Stop only), `install.json` stamped `v0.2.0` → relaunch shows no prompt (up to date).

## Test plan

- [x] `cargo test -p ainb-plugin-notifyd --lib install` — 14 green (8 new: install/update/dismiss/up-to-date/missing-version-as-stale/semver)
- [x] `cargo test -p ainb --lib app::state` — green
- [x] `cargo build -p ainb` clean
- [x] tmux: prompt renders + Install writes hooks + no re-prompt on relaunch
- [x] daemon lazy-spawn already handles startup (relies on the `ainb notifyd` subcommand from #187)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a helpful startup prompt for existing users offering the option to install or update the ainb-hooks notification plugin, with three convenient choices: proceed immediately, skip for later, or permanently dismiss.

* **Bug Fixes**
  * Fixed confirmation dialogs failing to display on full-screen application views by improving dialog overlay rendering across all screen types and layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->