### PR TITLE
chore: pin rust toolchain + light pre-commit fmt gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Light, fast pre-commit gate: surface the cheap CI failures BEFORE push.
+# Heavy compile/test stays in CI (the authority) — keeping commits quick so
+# nobody reaches for `--no-verify`.
+#
+#   one-time setup:  pip install pre-commit && pre-commit install
+#   run manually:    pre-commit run --all-files
+#
+# The Rust workspace lives in ainb-tui/; rust-toolchain.toml there pins the
+# rustfmt version so the fmt hook matches CI exactly.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=1024']
+      - id: check-toml
+
+  - repo: local
+    hooks:
+      # Mirror CI's `cargo fmt --all --check` (working-directory: ainb-tui).
+      # Fails the commit on any formatting drift; ~1s. Run from the
+      # workspace root so rust-toolchain.toml pins the rustfmt version.
+      - id: cargo-fmt-check
+        name: cargo fmt --check (ainb-tui)
+        entry: bash -c 'cd ainb-tui && cargo fmt --all --check'
+        language: system
+        files: '^ainb-tui/.*\.rs$'
+        pass_filenames: false

--- a/ainb-tui/rust-toolchain.toml
+++ b/ainb-tui/rust-toolchain.toml
@@ -1,0 +1,11 @@
+# Pin the Rust toolchain so local builds/formatting and CI use the SAME
+# compiler + rustfmt. Without this, CI's `dtolnay/rust-toolchain@stable`
+# floats to the newest stable while a contributor runs whatever they last
+# `rustup update`'d — a rustfmt version gap then produces "fmt clean
+# locally, Rustfmt red in CI" on files nobody touched (see PRs #189/#192).
+#
+# Bump `channel` deliberately when adopting a newer stable; rustup
+# auto-installs it on the next cargo invocation.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What

Closes the `Rustfmt`-red-in-CI-on-untouched-files class of failure (hit on PR #189; root-caused to PR #192 + a rustfmt version gap).

Two independent levers:

1. **`ainb-tui/rust-toolchain.toml`** — pins the channel to `1.96.0` (+ rustfmt, clippy). CI's `dtolnay/rust-toolchain@stable` floats to the newest stable; contributors run whatever they last `rustup update`'d. A rustfmt version gap then reformats files clean locally but red in CI. Pinning makes CI ⇄ local format **identically**. Bump deliberately to adopt a newer stable.

2. **`.pre-commit-config.yaml`** (repo root) — light, fast gate run before push:
   - `cargo fmt --all --check` scoped to `ainb-tui/**.rs` (mirrors CI's exact command + working-directory; the pinned toolchain guarantees the same rustfmt)
   - hygiene: trailing-whitespace, end-of-file-fixer, check-merge-conflict, check-added-large-files (1 MB), check-toml

Heavy `cargo check`/`test` deliberately **stay in CI** — keeping commits ~1s so nobody reaches for `--no-verify`.

## Setup (opt-in, per contributor)

```
pip install pre-commit && pre-commit install
```

## Verification

- Toolchain resolves to 1.96.0 via the pin; `cargo fmt --all --check` clean on main.
- `pre-commit run cargo-fmt-check --all-files` → **Passed** on clean code; injecting deliberate fmt drift → **Failed** (exit 1). Gate works both ways.
- General hooks pass on the added files; pinned pre-commit-hooks `v5.0.0` (no deprecated-stage warning).