### PR TITLE
fix(tui): enable paste and cursor editing in config text popups

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -253,6 +253,12 @@ pub enum AppEvent {
     ConfigPopupCancel,          // Cancel popup (Esc)
     ConfigPopupInputChar(char), // Input character in text/number input
     ConfigPopupBackspace,       // Backspace in text/number input
+    ConfigPopupPaste(String),   // Insert clipboard text at cursor (bracketed paste)
+    ConfigPopupDelete,          // Forward-delete char under cursor (Delete)
+    ConfigPopupCursorLeft,      // Move cursor left in text input
+    ConfigPopupCursorRight,     // Move cursor right in text input
+    ConfigPopupCursorHome,      // Move cursor to start (Home)
+    ConfigPopupCursorEnd,       // Move cursor to end (End)
     // Log history viewer events
     LogHistoryBack,          // Return to home screen (Esc)
     LogHistoryNextSession,   // Navigate to next session
@@ -654,7 +660,15 @@ impl EventHandler {
     /// Configure prompt textarea. Both own their own paste handling via the
     /// component-local `handle_key` arms, so paste events never need to be
     /// dispatched at the host event-router level.
-    pub fn handle_paste_event(_text: String, _state: &AppState) -> Option<AppEvent> {
+    ///
+    /// The Config screen text popups (e.g. Default Workspace) are the
+    /// exception — they live behind the host router, so a bracketed paste
+    /// has to be forwarded here or it gets dropped silently (the bug where
+    /// you couldn't paste a path into the workspace folder field).
+    pub fn handle_paste_event(text: String, state: &AppState) -> Option<AppEvent> {
+        if state.config_popup_state.is_text_entry() {
+            return Some(AppEvent::ConfigPopupPaste(text));
+        }
         None
     }
 
@@ -2097,11 +2111,19 @@ impl EventHandler {
                 }
             }
             ConfigPopupType::TextInput { .. } | ConfigPopupType::NumberInput { .. } => {
-                // Text/Number input mode
+                // Text/Number input mode. Cursor-movement keys are no-ops on
+                // NumberInput (handled at the state layer) but let the text
+                // field behave like a normal editable line: arrows to move,
+                // Delete to forward-delete, paste handled via Event::Paste.
                 match key_event.code {
                     KeyCode::Esc => Some(AppEvent::ConfigPopupCancel),
                     KeyCode::Enter => Some(AppEvent::ConfigPopupConfirm),
                     KeyCode::Backspace => Some(AppEvent::ConfigPopupBackspace),
+                    KeyCode::Delete => Some(AppEvent::ConfigPopupDelete),
+                    KeyCode::Left => Some(AppEvent::ConfigPopupCursorLeft),
+                    KeyCode::Right => Some(AppEvent::ConfigPopupCursorRight),
+                    KeyCode::Home => Some(AppEvent::ConfigPopupCursorHome),
+                    KeyCode::End => Some(AppEvent::ConfigPopupCursorEnd),
                     KeyCode::Char(c) => Some(AppEvent::ConfigPopupInputChar(c)),
                     _ => None,
                 }
@@ -4105,6 +4127,24 @@ impl EventHandler {
             }
             AppEvent::ConfigPopupBackspace => {
                 state.config_popup_state.backspace();
+            }
+            AppEvent::ConfigPopupPaste(text) => {
+                state.config_popup_state.insert_str(&text);
+            }
+            AppEvent::ConfigPopupDelete => {
+                state.config_popup_state.delete_forward();
+            }
+            AppEvent::ConfigPopupCursorLeft => {
+                state.config_popup_state.cursor_left();
+            }
+            AppEvent::ConfigPopupCursorRight => {
+                state.config_popup_state.cursor_right();
+            }
+            AppEvent::ConfigPopupCursorHome => {
+                state.config_popup_state.cursor_home();
+            }
+            AppEvent::ConfigPopupCursorEnd => {
+                state.config_popup_state.cursor_end();
             }
             // Log history viewer events
             AppEvent::LogHistoryBack => {

--- a/ainb-tui/crates/ainb-core/src/components/config_popup.rs
+++ b/ainb-tui/crates/ainb-core/src/components/config_popup.rs
@@ -189,11 +189,35 @@ impl ConfigPopupState {
                 cursor_position,
             } => {
                 value.insert(*cursor_position, c);
-                *cursor_position += 1;
+                *cursor_position += c.len_utf8();
             }
             ConfigPopupType::NumberInput { input_buffer, .. } => {
                 if c.is_ascii_digit() || (c == '-' && input_buffer.is_empty()) {
                     input_buffer.push(c);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Insert a string at the cursor (paste). Newlines and other control
+    /// characters are stripped because these popups are single-line fields —
+    /// a pasted path with a trailing `\n` should not break the layout.
+    pub fn insert_str(&mut self, s: &str) {
+        match &mut self.popup_type {
+            ConfigPopupType::TextInput {
+                value,
+                cursor_position,
+            } => {
+                let cleaned: String = s.chars().filter(|c| !c.is_control()).collect();
+                value.insert_str(*cursor_position, &cleaned);
+                *cursor_position += cleaned.len();
+            }
+            ConfigPopupType::NumberInput { input_buffer, .. } => {
+                for c in s.chars() {
+                    if c.is_ascii_digit() || (c == '-' && input_buffer.is_empty()) {
+                        input_buffer.push(c);
+                    }
                 }
             }
             _ => {}
@@ -208,14 +232,88 @@ impl ConfigPopupState {
                 cursor_position,
             } => {
                 if *cursor_position > 0 {
-                    *cursor_position -= 1;
-                    value.remove(*cursor_position);
+                    // Step back to the previous char boundary so multibyte
+                    // characters are removed whole.
+                    let mut new_pos = *cursor_position - 1;
+                    while new_pos > 0 && !value.is_char_boundary(new_pos) {
+                        new_pos -= 1;
+                    }
+                    value.remove(new_pos);
+                    *cursor_position = new_pos;
                 }
             }
             ConfigPopupType::NumberInput { input_buffer, .. } => {
                 input_buffer.pop();
             }
             _ => {}
+        }
+    }
+
+    /// Forward-delete the character under the cursor (Delete key).
+    pub fn delete_forward(&mut self) {
+        if let ConfigPopupType::TextInput {
+            value,
+            cursor_position,
+        } = &mut self.popup_type
+        {
+            if *cursor_position < value.len() {
+                value.remove(*cursor_position);
+            }
+        }
+    }
+
+    /// Move the cursor one character left (text input only).
+    pub fn cursor_left(&mut self) {
+        if let ConfigPopupType::TextInput {
+            value,
+            cursor_position,
+        } = &mut self.popup_type
+        {
+            if *cursor_position > 0 {
+                let mut new_pos = *cursor_position - 1;
+                while new_pos > 0 && !value.is_char_boundary(new_pos) {
+                    new_pos -= 1;
+                }
+                *cursor_position = new_pos;
+            }
+        }
+    }
+
+    /// Move the cursor one character right (text input only).
+    pub fn cursor_right(&mut self) {
+        if let ConfigPopupType::TextInput {
+            value,
+            cursor_position,
+        } = &mut self.popup_type
+        {
+            if *cursor_position < value.len() {
+                let mut new_pos = *cursor_position + 1;
+                while new_pos < value.len() && !value.is_char_boundary(new_pos) {
+                    new_pos += 1;
+                }
+                *cursor_position = new_pos;
+            }
+        }
+    }
+
+    /// Move the cursor to the start of the field (Home).
+    pub fn cursor_home(&mut self) {
+        if let ConfigPopupType::TextInput {
+            cursor_position, ..
+        } = &mut self.popup_type
+        {
+            *cursor_position = 0;
+        }
+    }
+
+    /// Move the cursor to the end of the field (End).
+    pub fn cursor_end(&mut self) {
+        if let ConfigPopupType::TextInput {
+            value,
+            cursor_position,
+        } = &mut self.popup_type
+        {
+            *cursor_position = value.len();
         }
     }
 
@@ -458,7 +556,10 @@ impl ConfigPopupComponent {
             ConfigPopupType::Choice { .. } | ConfigPopupType::Boolean { .. } => {
                 vec![("↑↓", "select"), ("Enter", "confirm"), ("Esc", "cancel")]
             }
-            ConfigPopupType::TextInput { .. } | ConfigPopupType::NumberInput { .. } => {
+            ConfigPopupType::TextInput { .. } => {
+                vec![("←→", "move"), ("Enter", "save"), ("Esc", "cancel")]
+            }
+            ConfigPopupType::NumberInput { .. } => {
                 vec![("Enter", "save"), ("Esc", "cancel")]
             }
         };
@@ -486,5 +587,124 @@ impl ConfigPopupComponent {
 impl Default for ConfigPopupComponent {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_value(state: &ConfigPopupState) -> (&str, usize) {
+        match &state.popup_type {
+            ConfigPopupType::TextInput {
+                value,
+                cursor_position,
+            } => (value.as_str(), *cursor_position),
+            other => panic!("expected TextInput, got {other:?}"),
+        }
+    }
+
+    fn open_path() -> ConfigPopupState {
+        let mut s = ConfigPopupState::new();
+        s.open_text(
+            "Default Workspace",
+            "dir",
+            "default_workspace",
+            "/Users/me/git",
+        );
+        s
+    }
+
+    #[test]
+    fn open_text_places_cursor_at_end() {
+        let s = open_path();
+        let (value, cursor) = text_value(&s);
+        assert_eq!(value, "/Users/me/git");
+        assert_eq!(cursor, value.len());
+    }
+
+    #[test]
+    fn paste_inserts_at_cursor() {
+        let mut s = open_path();
+        // Cursor is at end; paste appends.
+        s.insert_str("/extra");
+        let (value, cursor) = text_value(&s);
+        assert_eq!(value, "/Users/me/git/extra");
+        assert_eq!(cursor, value.len());
+    }
+
+    #[test]
+    fn paste_in_the_middle_after_cursor_move() {
+        let mut s = open_path();
+        s.cursor_home();
+        s.insert_str("~"); // user replaces leading segment manually later
+        let (value, cursor) = text_value(&s);
+        assert_eq!(value, "~/Users/me/git");
+        assert_eq!(cursor, 1);
+    }
+
+    #[test]
+    fn paste_strips_newlines_and_control_chars() {
+        let mut s = ConfigPopupState::new();
+        s.open_text("Default Workspace", "dir", "default_workspace", "");
+        s.insert_str("/Users/me/projects\n");
+        s.insert_str("\t/more");
+        let (value, _) = text_value(&s);
+        assert_eq!(value, "/Users/me/projects/more");
+    }
+
+    #[test]
+    fn cursor_left_right_home_end() {
+        let mut s = open_path();
+        let end = "/Users/me/git".len();
+        s.cursor_home();
+        assert_eq!(text_value(&s).1, 0);
+        s.cursor_right();
+        assert_eq!(text_value(&s).1, 1);
+        s.cursor_end();
+        assert_eq!(text_value(&s).1, end);
+        s.cursor_left();
+        assert_eq!(text_value(&s).1, end - 1);
+    }
+
+    #[test]
+    fn backspace_and_delete_at_cursor() {
+        let mut s = ConfigPopupState::new();
+        s.open_text("t", "d", "k", "abc");
+        s.cursor_home();
+        s.delete_forward(); // removes 'a'
+        assert_eq!(text_value(&s), ("bc", 0));
+        s.cursor_end();
+        s.backspace(); // removes 'c'
+        assert_eq!(text_value(&s), ("b", 1));
+    }
+
+    #[test]
+    fn editing_respects_multibyte_chars() {
+        let mut s = ConfigPopupState::new();
+        s.open_text("t", "d", "k", "");
+        s.input_char('é'); // 2 bytes
+        s.input_char('x');
+        let (value, cursor) = text_value(&s);
+        assert_eq!(value, "éx");
+        assert_eq!(cursor, value.len());
+        s.cursor_home();
+        s.cursor_right(); // should land after 'é', not mid-codepoint
+        assert_eq!(text_value(&s).1, "é".len());
+        s.backspace(); // removes whole 'é'
+        assert_eq!(text_value(&s), ("x", 0));
+    }
+
+    #[test]
+    fn number_input_paste_keeps_only_digits() {
+        let mut s = ConfigPopupState::new();
+        s.open_number("Max", "d", "max_repositories", 500);
+        s.insert_str("12ab3");
+        match &s.popup_type {
+            ConfigPopupType::NumberInput { input_buffer, .. } => {
+                assert_eq!(input_buffer, "500123");
+            }
+            other => panic!("expected NumberInput, got {other:?}"),
+        }
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/config_popup.rs
+++ b/ainb-tui/crates/ainb-core/src/components/config_popup.rs
@@ -696,6 +696,19 @@ mod tests {
     }
 
     #[test]
+    fn delete_forward_removes_whole_multibyte_char() {
+        // Forward-delete must remove the entire codepoint under the cursor;
+        // a byte-only remove would panic on a non-boundary index.
+        let mut s = ConfigPopupState::new();
+        s.open_text("t", "d", "k", "é/x"); // 'é' is 2 bytes
+        s.cursor_home();
+        s.delete_forward(); // removes whole 'é'
+        assert_eq!(text_value(&s), ("/x", 0));
+        s.delete_forward(); // removes '/'
+        assert_eq!(text_value(&s), ("x", 0));
+    }
+
+    #[test]
     fn number_input_paste_keeps_only_digits() {
         let mut s = ConfigPopupState::new();
         s.open_number("Max", "d", "max_repositories", 500);


### PR DESCRIPTION
## Problem

In the **Config → Workspace → Default Workspace** popup (and every other Config-screen text field), you could only **append characters** and **backspace from the end**. Pasting a path did nothing and there was no way to edit mid-string.

Two root causes:

```
key press ──▶ handle_config_popup_keys ──▶ AppEvent ──▶ state
   Char/Bksp ─────────── wired ──────────────▶ edit ✓
   Left/Right/Home/End ── NOT wired ──────────▶ (dropped)   ◀── no mid-string edit
Event::Paste ─▶ handle_paste_event ─▶ return None ─────────▶ (dropped)   ◀── paste lost
```

`handle_paste_event` returned `None` unconditionally, so bracketed paste was swallowed. The popup state already tracked `cursor_position` and inserted at the cursor — the movement keys were simply never routed.

## Fix

- **Paste**: `handle_paste_event` now forwards bracketed paste to the popup when it is a text-entry field (`ConfigPopupPaste`). `insert_str` inserts at the cursor and strips newlines/control chars (single-line field).
- **Cursor editing**: wire `Left` / `Right` / `Home` / `End` / `Delete` to the popup's existing `cursor_position`.
- **Robustness**: `backspace` and `input_char` are now multibyte-safe (char-boundary aware).
- **UX**: text-input help bar shows `←→ move`.

Result: Cmd+V pastes, arrows move the cursor, Home/End jump, Delete forward-deletes — a proper editable line.

## Tests

9 new unit tests in `config_popup` covering paste-at-cursor, newline/control stripping, cursor nav, multibyte editing, backspace+delete, and number-input digit filtering. `cargo test -p ainb --lib config_popup` green; lib + binary compile clean.