### PR TITLE
fix(tui): persist config Default Workspace edits to config.toml

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4115,6 +4115,24 @@ impl EventHandler {
                             }
                         }
                     }
+
+                    // Auto-persist: apply the edited settings to the live
+                    // config and write config.toml immediately, so the change
+                    // *becomes* the config (and survives a reopen/restart)
+                    // without the user having to remember `S` save-all. `S`
+                    // remains as an explicit save-all; `Esc` still cancels the
+                    // single edit before it reaches here.
+                    state.config_screen_state.apply_to_app_config(&mut state.app_config);
+                    match state.app_config.save() {
+                        Ok(()) => {
+                            state.add_success_notification(
+                                "Setting saved to config.toml".to_string(),
+                            );
+                        }
+                        Err(e) => {
+                            state.add_error_notification(format!("Failed to save setting: {}", e));
+                        }
+                    }
                 }
                 state.config_popup_state.close();
             }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1797,10 +1797,24 @@ impl ConfigScreenState {
                             } else {
                                 std::path::PathBuf::from(path)
                             };
-                            // Add to scan paths if not already present
-                            if !config.workspace_defaults.workspace_scan_paths.contains(&expanded) {
-                                config.workspace_defaults.workspace_scan_paths.push(expanded);
-                            }
+                            // "Default Workspace" is surfaced as
+                            // `workspace_scan_paths.first()` in `from_app_config`,
+                            // so it must be written back as the *primary* entry.
+                            // The old code pushed to the end, leaving `first()`
+                            // pointing at the stale path — editing the field then
+                            // appeared to do nothing on reopen.
+                            //
+                            // Rebuild as: edited path first, then every other
+                            // distinct scan dir. This replaces the old primary
+                            // (index 0), de-dups the edited path, and — crucially
+                            // — preserves the remaining scan dirs even on a no-op
+                            // confirm (drop the old primary, never the tail).
+                            let paths = &mut config.workspace_defaults.workspace_scan_paths;
+                            let tail: Vec<std::path::PathBuf> =
+                                paths.iter().skip(1).filter(|p| *p != &expanded).cloned().collect();
+                            paths.clear();
+                            paths.push(expanded);
+                            paths.extend(tail);
                         }
                     }
                     "branch_prefix" => {

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -590,4 +590,119 @@ mod tests {
             "invalidation must drop the cached entry"
         );
     }
+
+    // ========================================================================
+    // Config "Default Workspace" round-trip
+    //
+    // Regression: editing Default Workspace appended to `workspace_scan_paths`
+    // while the field is displayed from `first()`, so the edit never showed on
+    // reopen ("back to the same folder"). It must replace the primary entry.
+    // ========================================================================
+
+    use crate::app::state::{ConfigCategory, ConfigScreenState, ConfigValue};
+    use crate::config::AppConfig;
+
+    fn set_default_workspace(screen: &mut ConfigScreenState, value: &str) {
+        let settings = screen
+            .settings
+            .get_mut(&ConfigCategory::Workspace)
+            .expect("Workspace category present");
+        let setting = settings
+            .iter_mut()
+            .find(|s| s.key == "default_workspace")
+            .expect("default_workspace setting present");
+        setting.value = ConfigValue::Text(value.to_string());
+    }
+
+    fn displayed_default_workspace(screen: &ConfigScreenState) -> String {
+        screen
+            .settings
+            .get(&ConfigCategory::Workspace)
+            .unwrap()
+            .iter()
+            .find(|s| s.key == "default_workspace")
+            .unwrap()
+            .value
+            .display()
+    }
+
+    #[test]
+    fn default_workspace_edit_replaces_primary_and_round_trips() {
+        let mut config = AppConfig::default();
+        config.workspace_defaults.workspace_scan_paths = vec![PathBuf::from("/a/git")];
+
+        let mut screen = ConfigScreenState::from_app_config(&config);
+        set_default_workspace(&mut screen, "/a/projects");
+        screen.apply_to_app_config(&mut config);
+
+        // Primary scan path is the edited value, not appended to the tail.
+        assert_eq!(
+            config.workspace_defaults.workspace_scan_paths.first(),
+            Some(&PathBuf::from("/a/projects"))
+        );
+        // Reopening the screen now shows the saved value.
+        let reopened = ConfigScreenState::from_app_config(&config);
+        assert_eq!(displayed_default_workspace(&reopened), "/a/projects");
+    }
+
+    #[test]
+    fn default_workspace_edit_preserves_other_scan_dirs() {
+        let mut config = AppConfig::default();
+        config.workspace_defaults.workspace_scan_paths =
+            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")];
+
+        let mut screen = ConfigScreenState::from_app_config(&config);
+        set_default_workspace(&mut screen, "/a/projects");
+        screen.apply_to_app_config(&mut config);
+
+        // Old primary replaced; the secondary scan dir is kept.
+        assert_eq!(
+            config.workspace_defaults.workspace_scan_paths,
+            vec![PathBuf::from("/a/projects"), PathBuf::from("/a/work")]
+        );
+    }
+
+    #[test]
+    fn default_workspace_noop_confirm_keeps_secondary_dirs() {
+        // Opening the popup and confirming without changing the value must NOT
+        // drop other configured scan dirs (regression: a de-dup that stripped
+        // the unchanged primary then overwrote slot 0 lost the secondary).
+        let mut config = AppConfig::default();
+        config.workspace_defaults.workspace_scan_paths =
+            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")];
+
+        let mut screen = ConfigScreenState::from_app_config(&config);
+        // first() is /a/git — re-confirm it unchanged.
+        set_default_workspace(&mut screen, "/a/git");
+        screen.apply_to_app_config(&mut config);
+
+        assert_eq!(
+            config.workspace_defaults.workspace_scan_paths,
+            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")]
+        );
+    }
+
+    #[test]
+    fn default_workspace_edit_does_not_duplicate_existing_path() {
+        let mut config = AppConfig::default();
+        config.workspace_defaults.workspace_scan_paths =
+            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")];
+
+        let mut screen = ConfigScreenState::from_app_config(&config);
+        // Promote an already-present path to primary.
+        set_default_workspace(&mut screen, "/a/work");
+        screen.apply_to_app_config(&mut config);
+
+        assert_eq!(
+            config.workspace_defaults.workspace_scan_paths.first(),
+            Some(&PathBuf::from("/a/work"))
+        );
+        let dupes = config
+            .workspace_defaults
+            .workspace_scan_paths
+            .iter()
+            .filter(|p| *p == &PathBuf::from("/a/work"))
+            .count();
+        assert_eq!(dupes, 1, "edited path must not be duplicated");
+    }
 }


### PR DESCRIPTION
## Problem

Editing **Config → Workspace → Default Workspace** didn't stick — on reopen it showed the old folder. Two separate bugs:

```
 popup Enter ─▶ ConfigPopupConfirm ─▶ in-memory display only      ✗ NO toml write
   press S   ─▶ ConfigSaveAll ──────▶ apply_to_app_config+save() ─▶ toml ✓
   press Esc ─▶ ConfigBack ─────────▶ home screen                  ✗ discards
```

1. **Enter didn't persist.** `ConfigPopupConfirm` only updated the in-memory settings map; only `S` (save-all) wrote `config.toml`, and `Esc` discarded the edit.
2. **Default Workspace appended instead of replaced.** The field is displayed from `workspace_scan_paths.first()`, but `apply_to_app_config` *pushed* the edited path onto the end of the list. So `first()` kept pointing at the stale path → "back to the same folder", even after saving.

## Fix

- **`fix(tui): write Default Workspace edit as primary scan path`** — replace slot 0 (de-dup, preserve other scan dirs) instead of appending, so the edit round-trips through `first()`.
- **`feat(tui): auto-save config edits to config.toml on popup confirm`** — apply + `save()` on Enter, with a success/error notification. The edit *becomes* the config immediately and survives restart. `S` stays as explicit save-all; `Esc` still cancels.

Net: edit Default Workspace → Enter → it's written to `config.toml`, takes effect in-session, and shows the new path on reopen.

## Tests

3 new round-trip tests in `state_tests.rs`: primary replace + reopen display, secondary-dir preservation, no-duplicate on promoting an existing path. `cargo test -p ainb --lib` green for `default_workspace` + `config_popup`; lib + binary compile clean.