### PR TITLE
feat: color-coded per-session attention markers in session list

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/inbox.rs
+++ b/ainb-tui/crates/ainb-core/src/components/inbox.rs
@@ -19,7 +19,7 @@
 // All rendering follows the ainb-tui style guide (rounded borders,
 // gold titles, cornflower-blue panels, selection-green indicator).
 
-use ainb_plugin_notifyd::{NotificationRecord, Paths, Store};
+use ainb_plugin_notifyd::{AlertKind, NotificationRecord, Paths, Store, classify_event};
 use chrono::{DateTime, Local, TimeZone};
 use ratatui::{
     prelude::*,
@@ -263,46 +263,52 @@ impl InboxState {
         self.refresh();
     }
 
-    /// Return unread counts grouped by notification `cwd`. Used by
-    /// the session_list to render a per-session `●N` badge: ainb's
-    /// `Session.workspace_path` is matched against this map (exact
-    /// equality OR prefix-with-trailing-slash for worktree sessions
-    /// whose cwd is a subdir of their workspace root).
+    /// Per-`cwd` attention summary used to render the coloured
+    /// per-session marker: maps each cwd to `(unread_count, latest
+    /// AlertKind, latest_ts)`. The kind is derived from the most-recent
+    /// unread event for that cwd; events that don't classify (telemetry)
+    /// fall back to [`AlertKind::Finished`] so the count still shows.
     ///
     /// Returns an empty map when the store is not open.
-    pub fn unread_by_cwd_map(&self) -> std::collections::HashMap<String, u64> {
+    pub fn alert_by_cwd_map(&self) -> std::collections::HashMap<String, (u64, AlertKind, i64)> {
         let mut out = std::collections::HashMap::new();
         if let Some(store) = self.store.as_ref() {
-            if let Ok(rows) = store.unread_by_cwd() {
-                for (cwd, n) in rows {
-                    out.insert(cwd, n);
+            if let Ok(rows) = store.unread_state_by_cwd() {
+                for (cwd, n, latest_event, latest_ts) in rows {
+                    let kind = classify_event(&latest_event).unwrap_or(AlertKind::Finished);
+                    out.insert(cwd, (n, kind, latest_ts));
                 }
             }
         }
         out
     }
 
-    /// Sum unread counts whose `cwd` equals `workspace_path` or sits
-    /// underneath it (e.g. worktree subdirs). The session_list calls
-    /// this once per session row.
-    pub fn unread_for_workspace_path(
-        unread_by_cwd: &std::collections::HashMap<String, u64>,
+    /// Resolve the attention marker for a session whose root is
+    /// `workspace_path`: sums unread counts across every matching cwd
+    /// (exact or subdir) and returns the [`AlertKind`] of the
+    /// most-recent matching event — so a session shows its *current*
+    /// state, and a pending question/permission isn't masked by an
+    /// older "finished". `None` when the session has no unread rows.
+    pub fn alert_for_workspace_path(
+        alert_by_cwd: &std::collections::HashMap<String, (u64, AlertKind, i64)>,
         workspace_path: &str,
-    ) -> u64 {
+    ) -> Option<(u64, AlertKind)> {
         if workspace_path.is_empty() {
-            return 0;
+            return None;
         }
         let prefix_with_slash = format!("{workspace_path}/");
-        unread_by_cwd
-            .iter()
-            .filter_map(|(cwd, n)| {
-                if cwd == workspace_path || cwd.starts_with(&prefix_with_slash) {
-                    Some(*n)
-                } else {
-                    None
+        let mut total: u64 = 0;
+        let mut latest: Option<(i64, AlertKind)> = None;
+        for (cwd, (n, kind, ts)) in alert_by_cwd {
+            if cwd == workspace_path || cwd.starts_with(&prefix_with_slash) {
+                total += *n;
+                match latest {
+                    Some((best_ts, _)) if *ts <= best_ts => {}
+                    _ => latest = Some((*ts, *kind)),
                 }
-            })
-            .sum()
+            }
+        }
+        latest.map(|(_, kind)| (total, kind))
     }
 }
 
@@ -616,45 +622,55 @@ mod tests {
     }
 
     #[test]
-    fn unread_for_workspace_path_matches_exact_and_prefix() {
+    fn alert_for_workspace_path_matches_exact_and_prefix() {
         use std::collections::HashMap;
-        let mut map: HashMap<String, u64> = HashMap::new();
-        map.insert("/home/x/repo".to_string(), 3);
-        map.insert("/home/x/repo/worktrees/branch-a".to_string(), 2);
-        map.insert("/home/x/other".to_string(), 5);
+        // (count, kind, ts). The root bucket's event is older than the
+        // worktree bucket's, so the rolled-up marker must take the
+        // worktree's (more recent) kind while summing both counts.
+        let mut map: HashMap<String, (u64, AlertKind, i64)> = HashMap::new();
+        map.insert("/home/x/repo".to_string(), (3, AlertKind::Finished, 100));
+        map.insert(
+            "/home/x/repo/worktrees/branch-a".to_string(),
+            (2, AlertKind::WaitingOnUser, 200),
+        );
+        map.insert(
+            "/home/x/other".to_string(),
+            (5, AlertKind::NeedsPermission, 50),
+        );
 
         // Exact match on the workspace path returns just that bucket;
-        // prefix-with-/ also rolls up any worktree under it.
+        // prefix-with-/ also rolls up any worktree under it, and the
+        // kind reflects the most-recent matching event.
         assert_eq!(
-            InboxState::unread_for_workspace_path(&map, "/home/x/repo"),
-            5,
-            "expected 3 (root) + 2 (worktree under) = 5"
+            InboxState::alert_for_workspace_path(&map, "/home/x/repo"),
+            Some((5, AlertKind::WaitingOnUser)),
+            "expected 3 (root) + 2 (worktree) = 5, kind from latest ts (worktree)"
         );
         assert_eq!(
-            InboxState::unread_for_workspace_path(&map, "/home/x/other"),
-            5
+            InboxState::alert_for_workspace_path(&map, "/home/x/other"),
+            Some((5, AlertKind::NeedsPermission))
         );
         assert_eq!(
-            InboxState::unread_for_workspace_path(&map, "/home/x/missing"),
-            0
+            InboxState::alert_for_workspace_path(&map, "/home/x/missing"),
+            None
         );
         assert_eq!(
-            InboxState::unread_for_workspace_path(&map, ""),
-            0,
-            "empty workspace path must short-circuit to 0"
+            InboxState::alert_for_workspace_path(&map, ""),
+            None,
+            "empty workspace path must short-circuit to None"
         );
     }
 
     #[test]
-    fn unread_for_workspace_path_does_not_substring_match() {
+    fn alert_for_workspace_path_does_not_substring_match() {
         // /home/x/rep would otherwise prefix-match /home/x/repo if we
         // weren't careful to append the trailing slash. Verify.
         use std::collections::HashMap;
-        let mut map: HashMap<String, u64> = HashMap::new();
-        map.insert("/home/x/repo".to_string(), 4);
+        let mut map: HashMap<String, (u64, AlertKind, i64)> = HashMap::new();
+        map.insert("/home/x/repo".to_string(), (4, AlertKind::Finished, 1));
         assert_eq!(
-            InboxState::unread_for_workspace_path(&map, "/home/x/rep"),
-            0,
+            InboxState::alert_for_workspace_path(&map, "/home/x/rep"),
+            None,
             "must not substring-match shorter prefixes"
         );
     }

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -19,6 +19,12 @@ const LIST_HIGHLIGHT_BG: Color = Color::Rgb(40, 40, 60);
 const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
+// ainb-hooks per-session attention markers: `[?]` waiting on a user
+// answer, `[!]` blocked on permission/approval, `[✓]` finished.
+const ALERT_WAITING_AMBER: Color = Color::Rgb(230, 180, 80);
+const ALERT_PERMISSION_RED: Color = Color::Rgb(220, 90, 90);
+
+use ainb_plugin_notifyd::AlertKind;
 
 use crate::app::AppState;
 use crate::models::{SessionMode, SessionStatus, ShellSessionStatus, Workspace};
@@ -237,12 +243,12 @@ impl SessionListComponent {
         // Load favorites to check which workspaces are starred
         let favorites = crate::config::FavoritesStore::load();
 
-        // ainb-hooks unread counts, grouped by notification cwd. We
+        // ainb-hooks unread state, grouped by notification cwd. We
         // query once per render (cheap with SQLite WAL + the indexed
         // `unread` partial index) and look up per session/workspace
-        // path below to render a `●N` badge. Empty map when the
-        // store isn't open or no rows are unread.
-        let unread_by_cwd = state.inbox_state.unread_by_cwd_map();
+        // path below to render a coloured `[?]N` / `[!]N` / `[✓]N`
+        // marker. Empty map when the store isn't open or nothing unread.
+        let alert_by_cwd = state.inbox_state.alert_by_cwd_map();
 
         // Must stay in lockstep with AppState::attachable_items_in_order;
         // divergence would attach the wrong session for a given digit.
@@ -428,14 +434,16 @@ impl SessionListComponent {
                         Span::styled("[ ]", Style::default().fg(MUTED_GRAY))
                     };
 
-                    // ainb-hooks unread badge for this session row.
+                    // ainb-hooks attention marker for this session row.
                     // Match by session.workspace_path against the
                     // notification cwd map (exact or prefix-with-/);
                     // a session whose host agent fired a hook from
-                    // anywhere inside its workspace root gets a `●N`.
-                    let session_unread =
-                        crate::components::inbox::InboxState::unread_for_workspace_path(
-                            &unread_by_cwd,
+                    // anywhere inside its workspace root gets a coloured
+                    // `[?]N` / `[!]N` / `[✓]N` tag reflecting its latest
+                    // unread event.
+                    let session_alert =
+                        crate::components::inbox::InboxState::alert_for_workspace_path(
+                            &alert_by_cwd,
                             &session.workspace_path,
                         );
 
@@ -462,11 +470,16 @@ impl SessionListComponent {
                         ),
                         Span::styled(changes_text, Style::default().fg(WARNING_ORANGE)),
                     ];
-                    if session_unread > 0 {
+                    if let Some((count, kind)) = session_alert {
+                        let (tag, color) = match kind {
+                            AlertKind::NeedsPermission => ("[!]", ALERT_PERMISSION_RED),
+                            AlertKind::WaitingOnUser => ("[?]", ALERT_WAITING_AMBER),
+                            AlertKind::Finished => ("[✓]", SELECTION_GREEN),
+                        };
                         session_spans.push(Span::raw("  "));
                         session_spans.push(Span::styled(
-                            format!("● {session_unread}"),
-                            Style::default().fg(WARNING_ORANGE).add_modifier(Modifier::BOLD),
+                            format!("{tag}{count}"),
+                            Style::default().fg(color).add_modifier(Modifier::BOLD),
                         ));
                     }
                     let session_line = Line::from(session_spans);

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -41,6 +41,7 @@ pub use install::{
     install as install_for, install_under_home, prompt_state, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
+pub use osnotify::{AlertKind, classify_event};
 pub use paths::Paths;
 pub use pid::PidFile;
 pub use store::{NotificationRecord, RetentionPolicy, Store, StoreError};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -85,6 +85,38 @@ pub fn is_user_facing(env: &Envelope) -> bool {
     )
 }
 
+/// The attention state a hook event implies for the session that
+/// produced it. Drives the coloured per-session marker in the ainb-tui
+/// session list (`[!]` / `[?]` / `[✓]`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertKind {
+    /// Agent is blocked waiting for the user to approve something
+    /// (permission / command / patch approval). Most urgent.
+    NeedsPermission,
+    /// Agent asked the user a question or is idle awaiting input.
+    WaitingOnUser,
+    /// Agent finished its turn — informational, no action required.
+    Finished,
+}
+
+/// Classify a raw hook event string into an [`AlertKind`], or `None`
+/// for telemetry / lifecycle events that don't map to a user-facing
+/// session state. The grouping is kept in lockstep with
+/// [`render_title`] so the OS-notification title and the session-list
+/// marker can never disagree about what an event means.
+pub fn classify_event(raw_event: &str) -> Option<AlertKind> {
+    let head = raw_event.split(':').next().unwrap_or(raw_event);
+    match head {
+        "PermissionRequest"
+        | "exec_approval_request"
+        | "apply_patch_approval_request"
+        | "permission_request" => Some(AlertKind::NeedsPermission),
+        "Notification" | "request_user_input" | "wait_for_user" => Some(AlertKind::WaitingOnUser),
+        "Stop" | "agent-turn-complete" | "task_complete" => Some(AlertKind::Finished),
+        _ => None,
+    }
+}
+
 /// Render a short, human-readable title from an envelope.
 pub fn render_title(env: &Envelope) -> String {
     let head = env.raw_event.split(':').next().unwrap_or(&env.raw_event);
@@ -227,6 +259,46 @@ mod tests {
         assert!(is_user_facing(&env("agent-turn-complete", "codex")));
         assert!(is_user_facing(&env("request_user_input", "codex")));
         assert!(is_user_facing(&env("exec_approval_request", "codex")));
+    }
+
+    #[test]
+    fn classify_event_groups_match_render_title() {
+        // Permission / approval family → NeedsPermission.
+        assert_eq!(
+            classify_event("PermissionRequest"),
+            Some(AlertKind::NeedsPermission)
+        );
+        assert_eq!(
+            classify_event("exec_approval_request"),
+            Some(AlertKind::NeedsPermission)
+        );
+        assert_eq!(
+            classify_event("apply_patch_approval_request"),
+            Some(AlertKind::NeedsPermission)
+        );
+        // Question / idle family → WaitingOnUser (matcher suffix stripped).
+        assert_eq!(
+            classify_event("Notification:idle_prompt"),
+            Some(AlertKind::WaitingOnUser)
+        );
+        assert_eq!(
+            classify_event("request_user_input"),
+            Some(AlertKind::WaitingOnUser)
+        );
+        assert_eq!(
+            classify_event("wait_for_user"),
+            Some(AlertKind::WaitingOnUser)
+        );
+        // Turn-finished family → Finished.
+        assert_eq!(classify_event("Stop"), Some(AlertKind::Finished));
+        assert_eq!(
+            classify_event("agent-turn-complete"),
+            Some(AlertKind::Finished)
+        );
+        assert_eq!(classify_event("task_complete"), Some(AlertKind::Finished));
+        // Telemetry → None.
+        assert_eq!(classify_event("SessionStart"), None);
+        assert_eq!(classify_event("PostToolUse"), None);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
@@ -284,6 +284,41 @@ impl Store {
         Ok(out)
     }
 
+    /// Per-`cwd` unread *state*: the unread count, plus the `raw_event`
+    /// and `ts` of the most-recent unread row for that cwd. Lets the
+    /// session list render a per-session marker that reflects the
+    /// agent's current attention state (waiting / needs-permission /
+    /// finished), not just a flat count.
+    ///
+    /// Relies on SQLite's documented "bare column" semantics: when a
+    /// query has a single `MAX(ts)` aggregate, the other non-aggregated
+    /// columns (`raw_event`) take their values from the row that holds
+    /// that maximum. So `raw_event` here is the latest unread event's,
+    /// not an arbitrary row's. Returns `(cwd, count, latest_event,
+    /// latest_ts)` tuples.
+    pub fn unread_state_by_cwd(&self) -> Result<Vec<(String, u64, String, i64)>, StoreError> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT cwd, COUNT(*), raw_event, MAX(ts)
+             FROM notifications
+             WHERE read = 0 AND dismissed = 0 AND cwd != ''
+             GROUP BY cwd",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, u64>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, i64>(3)?,
+            ))
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Look up the most-recent notification whose `cwd` matches
     /// `target_cwd`. Used by the Inbox screen when the user presses
     /// Enter on a row: from the row's `cwd` we resolve back to ainb's


### PR DESCRIPTION
## What

Replaces the flat per-session unread dot (`● N`) in the session list with a **color-coded attention marker** that reflects each session's *current* state, derived from its latest unread ainb-hooks notification:

| Tag | Color | Meaning | Source events |
|-----|-------|---------|---------------|
| `[!]` | red | blocked on permission / approval | `PermissionRequest`, `*_approval_request`, `permission_request` |
| `[?]` | amber | agent asked a question / idle waiting | `Notification*`, `request_user_input`, `wait_for_user` |
| `[✓]` | green | turn finished (FYI) | `Stop`, `agent-turn-complete`, `task_complete` |

Pure-ASCII tags (no emoji-width risk in tmux/terminals). The global menu-bar badge stays a plain count.

## Why

The single `●N` count told you *something* fired but not *what* — you couldn't tell "agent is waiting on my answer" from "agent finished" at a glance. This surfaces the actionable state directly on the session row.

## How

**`ainb-plugin-notifyd` (commit 1 — standalone API):**
- `AlertKind { NeedsPermission, WaitingOnUser, Finished }` + `classify_event()`, grouped in lockstep with `render_title()` so the OS-notification title and the marker can never disagree.
- `Store::unread_state_by_cwd()` — per cwd: unread count + the `raw_event`/`ts` of the latest unread row (SQLite bare-column-with-MAX).

**`ainb-core` TUI (commit 2 — consumer):**
- `InboxState::alert_by_cwd_map()` + `alert_for_workspace_path()` — sums counts across matching cwds, takes the **most-recent** event's kind (a pending question isn't masked by an older finish). Supersedes `unread_by_cwd_map`/`unread_for_workspace_path`; their matching tests are ported.
- `session_list` renders the colored tag.

## Tests
- `classify_event_groups_match_render_title` (notifyd)
- `alert_for_workspace_path_matches_exact_and_prefix` + `_does_not_substring_match` (ported, ainb)
- `cargo test -p ainb-plugin-notifyd` 55 pass · `-p ainb` inbox/osnotify modules green
- rustfmt --check clean on all 5 files · scoped clippy adds no warnings

## Notes
- cwd-correlation only marks sessions whose workspace matches a notification cwd (unchanged behavior).
- Follow-on to the v1.3.0 notification work; will fold into the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbox and session lists now display colored attention markers—`[?]`, `[!]`, or `[✓]`—indicating session status instead of simple unread badges.
  * Status markers classify events by type: permission needed, waiting on user, or finished.

* **Refactor**
  * Updated how session status is calculated and presented using event classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->