### PR TITLE
fix: per-session marker reflects live waiting state, not stale notifications

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -8151,6 +8151,30 @@ impl AppState {
     }
 
     /// Update preview content for all tmux sessions (called from main update loop)
+    /// Derive a session's live attention marker from its tmux pane.
+    ///
+    /// Returns `Some(WaitingOnUser)` only when the agent is parked at an
+    /// interactive prompt — i.e. it is NOT actively generating
+    /// (`claude_running == false`) AND the visible screen tail shows a
+    /// box-drawn prompt panel containing a `?` (the AskUserQuestion /
+    /// interview / permission UI). Working and plain-idle sessions
+    /// return `None`: those states are already conveyed by the row's
+    /// `●` / `○` status indicator, so a marker there would be redundant
+    /// noise. Only the last ~30 lines are inspected so boxed scrollback
+    /// doesn't trigger a false "waiting".
+    fn live_attention_from_pane(
+        pane: &str,
+        claude_running: bool,
+    ) -> Option<ainb_plugin_notifyd::AlertKind> {
+        if claude_running {
+            return None;
+        }
+        let tail: String = pane.lines().rev().take(30).collect::<Vec<_>>().join("\n");
+        let at_prompt =
+            tail.contains('?') && tail.contains('│') && tail.contains('┌') && tail.contains('└');
+        at_prompt.then_some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
+    }
+
     pub async fn update_tmux_previews(&mut self) -> anyhow::Result<()> {
         use crate::tmux::ClaudeProcessDetector;
         use crate::tmux::capture::{CaptureOptions, capture_pane};
@@ -8166,9 +8190,9 @@ impl AppState {
         }
         self.last_preview_update = Some(now);
 
-        // updates: (session_id, content, claude_running) for the selected session
+        // updates: (session_id, content, claude_running, live_attention) for the selected session
         let mut updates = Vec::new();
-        // status_updates: (session_id, claude_running) for non-selected sessions (status only)
+        // status_updates: (session_id, claude_running, live_attention) for non-selected sessions
         let mut status_updates = Vec::new();
         let detector = ClaudeProcessDetector::new();
 
@@ -8203,7 +8227,8 @@ impl AppState {
                 match capture_pane(tmux_session.name(), opts).await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);
-                        updates.push((*session_id, content, claude_running));
+                        let attention = Self::live_attention_from_pane(&content, claude_running);
+                        updates.push((*session_id, content, claude_running, attention));
                     }
                     Err(e) => {
                         debug!("Failed to capture selected session {}: {}", session_id, e);
@@ -8215,7 +8240,8 @@ impl AppState {
                 match tmux_session.capture_pane_content().await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);
-                        status_updates.push((*session_id, claude_running));
+                        let attention = Self::live_attention_from_pane(&content, claude_running);
+                        status_updates.push((*session_id, claude_running, attention));
                     }
                     Err(e) => {
                         trace!("Non-selected session {} capture skipped: {}", session_id, e);
@@ -8225,7 +8251,11 @@ impl AppState {
         }
 
         // Apply status-only updates for non-selected sessions
-        for (session_id, claude_running) in status_updates {
+        for (session_id, claude_running, attention) in status_updates {
+            // Accumulate the change flag inside the session borrow, then
+            // touch `self.ui_needs_refresh` only after it ends (avoids a
+            // borrow conflict between `find_session_mut` and `self`).
+            let mut changed = false;
             if let Some(session) = self.find_session_mut(session_id) {
                 use crate::models::SessionStatus;
                 let new_status = if claude_running {
@@ -8235,13 +8265,21 @@ impl AppState {
                 };
                 if session.status != new_status {
                     session.set_status(new_status);
-                    self.ui_needs_refresh = true;
+                    changed = true;
                 }
+                if session.live_attention != attention {
+                    session.live_attention = attention;
+                    changed = true;
+                }
+            }
+            if changed {
+                self.ui_needs_refresh = true;
             }
         }
 
-        // Apply updates for the selected session
-        for (session_id, content, claude_running) in updates {
+        // Apply updates for the selected session (preview always changes,
+        // so this loop unconditionally requests a refresh).
+        for (session_id, content, claude_running, attention) in updates {
             if let Some(session) = self.find_session_mut(session_id) {
                 session.set_preview(content);
 
@@ -8255,9 +8293,10 @@ impl AppState {
                 if session.status != new_status {
                     session.set_status(new_status);
                 }
-
-                self.ui_needs_refresh = true;
+                session.live_attention = attention;
             }
+
+            self.ui_needs_refresh = true;
         }
 
         // Update shell session preview (only the selected workspace's shell)

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -705,4 +705,46 @@ mod tests {
             .count();
         assert_eq!(dupes, 1, "edited path must not be duplicated");
     }
+
+    // ========================================================================
+    // Live per-session attention marker (derived from the tmux pane)
+    // ========================================================================
+
+    #[test]
+    fn live_attention_marks_waiting_at_prompt_only() {
+        use ainb_plugin_notifyd::AlertKind;
+
+        // Box-drawn prompt panel containing '?' while the agent is NOT
+        // generating (no status bar → claude_running=false) → the user
+        // is needed.
+        let prompt_pane = "\
+some earlier output line
+┌──────────────────────────────┐
+│ What do you want to do next?  │
+│ ❯ 1. Plan                     │
+│   2. Submit                   │
+└──────────────────────────────┘";
+        assert_eq!(
+            AppState::live_attention_from_pane(prompt_pane, false),
+            Some(AlertKind::WaitingOnUser),
+            "box prompt + not generating must mark waiting-on-user"
+        );
+
+        // Same pane, but the agent is actively generating (status bar
+        // present). It's working, not waiting → no marker.
+        assert_eq!(
+            AppState::live_attention_from_pane(prompt_pane, true),
+            None,
+            "actively-generating session must not show a waiting marker"
+        );
+
+        // Plain finished/idle output with no prompt box → no marker
+        // (idle is conveyed by the row's `○` status indicator).
+        let idle_pane = "task complete.\nno box here\n$ ";
+        assert_eq!(
+            AppState::live_attention_from_pane(idle_pane, false),
+            None,
+            "idle output without a prompt box must not show a marker"
+        );
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/components/inbox.rs
+++ b/ainb-tui/crates/ainb-core/src/components/inbox.rs
@@ -19,7 +19,7 @@
 // All rendering follows the ainb-tui style guide (rounded borders,
 // gold titles, cornflower-blue panels, selection-green indicator).
 
-use ainb_plugin_notifyd::{AlertKind, NotificationRecord, Paths, Store, classify_event};
+use ainb_plugin_notifyd::{NotificationRecord, Paths, Store};
 use chrono::{DateTime, Local, TimeZone};
 use ratatui::{
     prelude::*,
@@ -261,54 +261,6 @@ impl InboxState {
     pub fn cycle_agent_filter(&mut self) {
         self.agent_filter = self.agent_filter.next();
         self.refresh();
-    }
-
-    /// Per-`cwd` attention summary used to render the coloured
-    /// per-session marker: maps each cwd to `(unread_count, latest
-    /// AlertKind, latest_ts)`. The kind is derived from the most-recent
-    /// unread event for that cwd; events that don't classify (telemetry)
-    /// fall back to [`AlertKind::Finished`] so the count still shows.
-    ///
-    /// Returns an empty map when the store is not open.
-    pub fn alert_by_cwd_map(&self) -> std::collections::HashMap<String, (u64, AlertKind, i64)> {
-        let mut out = std::collections::HashMap::new();
-        if let Some(store) = self.store.as_ref() {
-            if let Ok(rows) = store.unread_state_by_cwd() {
-                for (cwd, n, latest_event, latest_ts) in rows {
-                    let kind = classify_event(&latest_event).unwrap_or(AlertKind::Finished);
-                    out.insert(cwd, (n, kind, latest_ts));
-                }
-            }
-        }
-        out
-    }
-
-    /// Resolve the attention marker for a session whose root is
-    /// `workspace_path`: sums unread counts across every matching cwd
-    /// (exact or subdir) and returns the [`AlertKind`] of the
-    /// most-recent matching event — so a session shows its *current*
-    /// state, and a pending question/permission isn't masked by an
-    /// older "finished". `None` when the session has no unread rows.
-    pub fn alert_for_workspace_path(
-        alert_by_cwd: &std::collections::HashMap<String, (u64, AlertKind, i64)>,
-        workspace_path: &str,
-    ) -> Option<(u64, AlertKind)> {
-        if workspace_path.is_empty() {
-            return None;
-        }
-        let prefix_with_slash = format!("{workspace_path}/");
-        let mut total: u64 = 0;
-        let mut latest: Option<(i64, AlertKind)> = None;
-        for (cwd, (n, kind, ts)) in alert_by_cwd {
-            if cwd == workspace_path || cwd.starts_with(&prefix_with_slash) {
-                total += *n;
-                match latest {
-                    Some((best_ts, _)) if *ts <= best_ts => {}
-                    _ => latest = Some((*ts, *kind)),
-                }
-            }
-        }
-        latest.map(|(_, kind)| (total, kind))
     }
 }
 
@@ -619,60 +571,6 @@ mod tests {
         let s = fmt_ts(0);
         let parts: Vec<&str> = s.split(':').collect();
         assert_eq!(parts.len(), 3, "expected HH:MM:SS, got {s}");
-    }
-
-    #[test]
-    fn alert_for_workspace_path_matches_exact_and_prefix() {
-        use std::collections::HashMap;
-        // (count, kind, ts). The root bucket's event is older than the
-        // worktree bucket's, so the rolled-up marker must take the
-        // worktree's (more recent) kind while summing both counts.
-        let mut map: HashMap<String, (u64, AlertKind, i64)> = HashMap::new();
-        map.insert("/home/x/repo".to_string(), (3, AlertKind::Finished, 100));
-        map.insert(
-            "/home/x/repo/worktrees/branch-a".to_string(),
-            (2, AlertKind::WaitingOnUser, 200),
-        );
-        map.insert(
-            "/home/x/other".to_string(),
-            (5, AlertKind::NeedsPermission, 50),
-        );
-
-        // Exact match on the workspace path returns just that bucket;
-        // prefix-with-/ also rolls up any worktree under it, and the
-        // kind reflects the most-recent matching event.
-        assert_eq!(
-            InboxState::alert_for_workspace_path(&map, "/home/x/repo"),
-            Some((5, AlertKind::WaitingOnUser)),
-            "expected 3 (root) + 2 (worktree) = 5, kind from latest ts (worktree)"
-        );
-        assert_eq!(
-            InboxState::alert_for_workspace_path(&map, "/home/x/other"),
-            Some((5, AlertKind::NeedsPermission))
-        );
-        assert_eq!(
-            InboxState::alert_for_workspace_path(&map, "/home/x/missing"),
-            None
-        );
-        assert_eq!(
-            InboxState::alert_for_workspace_path(&map, ""),
-            None,
-            "empty workspace path must short-circuit to None"
-        );
-    }
-
-    #[test]
-    fn alert_for_workspace_path_does_not_substring_match() {
-        // /home/x/rep would otherwise prefix-match /home/x/repo if we
-        // weren't careful to append the trailing slash. Verify.
-        use std::collections::HashMap;
-        let mut map: HashMap<String, (u64, AlertKind, i64)> = HashMap::new();
-        map.insert("/home/x/repo".to_string(), (4, AlertKind::Finished, 1));
-        assert_eq!(
-            InboxState::alert_for_workspace_path(&map, "/home/x/rep"),
-            None,
-            "must not substring-match shorter prefixes"
-        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -243,13 +243,6 @@ impl SessionListComponent {
         // Load favorites to check which workspaces are starred
         let favorites = crate::config::FavoritesStore::load();
 
-        // ainb-hooks unread state, grouped by notification cwd. We
-        // query once per render (cheap with SQLite WAL + the indexed
-        // `unread` partial index) and look up per session/workspace
-        // path below to render a coloured `[?]N` / `[!]N` / `[✓]N`
-        // marker. Empty map when the store isn't open or nothing unread.
-        let alert_by_cwd = state.inbox_state.alert_by_cwd_map();
-
         // Must stay in lockstep with AppState::attachable_items_in_order;
         // divergence would attach the wrong session for a given digit.
         let mut attach_no: usize = 0;
@@ -435,17 +428,13 @@ impl SessionListComponent {
                     };
 
                     // ainb-hooks attention marker for this session row.
-                    // Match by session.workspace_path against the
-                    // notification cwd map (exact or prefix-with-/);
-                    // a session whose host agent fired a hook from
-                    // anywhere inside its workspace root gets a coloured
-                    // `[?]N` / `[!]N` / `[✓]N` tag reflecting its latest
-                    // unread event.
-                    let session_alert =
-                        crate::components::inbox::InboxState::alert_for_workspace_path(
-                            &alert_by_cwd,
-                            &session.workspace_path,
-                        );
+                    // Live attention marker, derived from the session's
+                    // tmux pane each refresh (NOT notification history):
+                    // `[?]` amber when the agent is parked at an
+                    // interactive prompt and needs the user. Working /
+                    // idle sessions carry no marker — that's already the
+                    // `●` / `○` status indicator.
+                    let session_alert = session.live_attention;
 
                     let mut session_spans = vec![
                         next_badge(&mut attach_no),
@@ -470,7 +459,7 @@ impl SessionListComponent {
                         ),
                         Span::styled(changes_text, Style::default().fg(WARNING_ORANGE)),
                     ];
-                    if let Some((count, kind)) = session_alert {
+                    if let Some(kind) = session_alert {
                         let (tag, color) = match kind {
                             AlertKind::NeedsPermission => ("[!]", ALERT_PERMISSION_RED),
                             AlertKind::WaitingOnUser => ("[?]", ALERT_WAITING_AMBER),
@@ -478,7 +467,7 @@ impl SessionListComponent {
                         };
                         session_spans.push(Span::raw("  "));
                         session_spans.push(Span::styled(
-                            format!("{tag}{count}"),
+                            tag.to_string(),
                             Style::default().fg(color).add_modifier(Modifier::BOLD),
                         ));
                     }

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -478,6 +478,15 @@ pub struct Session {
     pub tmux_session_name: Option<String>, // Name of the tmux session if using tmux backend
     pub preview_content: Option<String>,   // Cached preview content for display
     pub is_attached: bool,                 // Whether user is currently attached to the session
+
+    /// Live attention state derived from the tmux pane on each preview
+    /// refresh: `Some(WaitingOnUser)` when the agent is sitting at an
+    /// interactive prompt (AskUserQuestion / interview / permission),
+    /// `None` while working or idle (those are already conveyed by the
+    /// `status` indicator). Transient — never persisted; recomputed in
+    /// `AppState::update_tmux_previews`.
+    #[serde(skip)]
+    pub live_attention: Option<ainb_plugin_notifyd::AlertKind>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -703,6 +712,7 @@ impl Session {
             tmux_session_name: None,
             preview_content: None,
             is_attached: false,
+            live_attention: None,
         }
     }
 
@@ -731,6 +741,7 @@ impl Session {
             tmux_session_name: None,
             preview_content: None,
             is_attached: false,
+            live_attention: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -41,7 +41,7 @@ pub use install::{
     install as install_for, install_under_home, prompt_state, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
-pub use osnotify::{AlertKind, classify_event};
+pub use osnotify::AlertKind;
 pub use paths::Paths;
 pub use pid::PidFile;
 pub use store::{NotificationRecord, RetentionPolicy, Store, StoreError};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -99,24 +99,6 @@ pub enum AlertKind {
     Finished,
 }
 
-/// Classify a raw hook event string into an [`AlertKind`], or `None`
-/// for telemetry / lifecycle events that don't map to a user-facing
-/// session state. The grouping is kept in lockstep with
-/// [`render_title`] so the OS-notification title and the session-list
-/// marker can never disagree about what an event means.
-pub fn classify_event(raw_event: &str) -> Option<AlertKind> {
-    let head = raw_event.split(':').next().unwrap_or(raw_event);
-    match head {
-        "PermissionRequest"
-        | "exec_approval_request"
-        | "apply_patch_approval_request"
-        | "permission_request" => Some(AlertKind::NeedsPermission),
-        "Notification" | "request_user_input" | "wait_for_user" => Some(AlertKind::WaitingOnUser),
-        "Stop" | "agent-turn-complete" | "task_complete" => Some(AlertKind::Finished),
-        _ => None,
-    }
-}
-
 /// Render a short, human-readable title from an envelope.
 pub fn render_title(env: &Envelope) -> String {
     let head = env.raw_event.split(':').next().unwrap_or(&env.raw_event);
@@ -259,46 +241,6 @@ mod tests {
         assert!(is_user_facing(&env("agent-turn-complete", "codex")));
         assert!(is_user_facing(&env("request_user_input", "codex")));
         assert!(is_user_facing(&env("exec_approval_request", "codex")));
-    }
-
-    #[test]
-    fn classify_event_groups_match_render_title() {
-        // Permission / approval family → NeedsPermission.
-        assert_eq!(
-            classify_event("PermissionRequest"),
-            Some(AlertKind::NeedsPermission)
-        );
-        assert_eq!(
-            classify_event("exec_approval_request"),
-            Some(AlertKind::NeedsPermission)
-        );
-        assert_eq!(
-            classify_event("apply_patch_approval_request"),
-            Some(AlertKind::NeedsPermission)
-        );
-        // Question / idle family → WaitingOnUser (matcher suffix stripped).
-        assert_eq!(
-            classify_event("Notification:idle_prompt"),
-            Some(AlertKind::WaitingOnUser)
-        );
-        assert_eq!(
-            classify_event("request_user_input"),
-            Some(AlertKind::WaitingOnUser)
-        );
-        assert_eq!(
-            classify_event("wait_for_user"),
-            Some(AlertKind::WaitingOnUser)
-        );
-        // Turn-finished family → Finished.
-        assert_eq!(classify_event("Stop"), Some(AlertKind::Finished));
-        assert_eq!(
-            classify_event("agent-turn-complete"),
-            Some(AlertKind::Finished)
-        );
-        assert_eq!(classify_event("task_complete"), Some(AlertKind::Finished));
-        // Telemetry → None.
-        assert_eq!(classify_event("SessionStart"), None);
-        assert_eq!(classify_event("PostToolUse"), None);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
@@ -284,41 +284,6 @@ impl Store {
         Ok(out)
     }
 
-    /// Per-`cwd` unread *state*: the unread count, plus the `raw_event`
-    /// and `ts` of the most-recent unread row for that cwd. Lets the
-    /// session list render a per-session marker that reflects the
-    /// agent's current attention state (waiting / needs-permission /
-    /// finished), not just a flat count.
-    ///
-    /// Relies on SQLite's documented "bare column" semantics: when a
-    /// query has a single `MAX(ts)` aggregate, the other non-aggregated
-    /// columns (`raw_event`) take their values from the row that holds
-    /// that maximum. So `raw_event` here is the latest unread event's,
-    /// not an arbitrary row's. Returns `(cwd, count, latest_event,
-    /// latest_ts)` tuples.
-    pub fn unread_state_by_cwd(&self) -> Result<Vec<(String, u64, String, i64)>, StoreError> {
-        let conn = self.conn();
-        let mut stmt = conn.prepare(
-            "SELECT cwd, COUNT(*), raw_event, MAX(ts)
-             FROM notifications
-             WHERE read = 0 AND dismissed = 0 AND cwd != ''
-             GROUP BY cwd",
-        )?;
-        let rows = stmt.query_map([], |r| {
-            Ok((
-                r.get::<_, String>(0)?,
-                r.get::<_, u64>(1)?,
-                r.get::<_, String>(2)?,
-                r.get::<_, i64>(3)?,
-            ))
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
-    }
-
     /// Look up the most-recent notification whose `cwd` matches
     /// `target_cwd`. Used by the Inbox screen when the user presses
     /// Enter on a row: from the row's `cwd` we resolve back to ainb's


### PR DESCRIPTION
## Problem (found right after #198 merged)

A session sitting **live at an `/interview` / AskUserQuestion** (waiting on the user) showed a stale green `[✓]` finish marker. Root causes, proven against the db:

- **No recency bound** — the #198 marker = "latest *unread* notification", which lingers until read/dismissed or 7-day retention. A `Stop` from 2 days ago kept showing `[✓]`.
- **No signal for the wait** — an AskUserQuestion render fires **no Claude `Notification` hook**, so no `[?]` row ever existed. The marker could only show the old finish.

Net: the marker reflected notification *history*, not the session's *live* state.

## Fix — drive the marker from live pane state

`AppState::live_attention_from_pane` runs inside the existing `update_tmux_previews` pane-capture loop (~5s) and stores `Session.live_attention` (transient, `#[serde(skip)]`):

```
agent generating (status bar)        → None        (working → already the ● dot)
not generating + prompt box with '?' → [?] amber   (AskUserQuestion / interview / permission)
not generating, no prompt box        → None        (idle → already the ○ dot)
```

The session list renders `[?]` from that field. **No `[✓]`/count** — idle/done is already the `●`/`○` status indicator, so a marker there would be redundant noise (and was the source of the stale tick).

```
feat/blog at /interview:  before → [✓]1 (2-day-old Stop)   after → [?] (waiting NOW)
```

## Supersedes #198

The notification-cwd-correlation marker is replaced. Removed its now-dead plumbing: `InboxState::alert_by_cwd_map` / `alert_for_workspace_path` (+ tests), `Store::unread_state_by_cwd`, `classify_event` (+ test + export). `AlertKind` stays as the shared glyph vocab. Notifications still back the **Inbox screen** + **OS banners** (unchanged).

## Tests
- `live_attention_marks_waiting_at_prompt_only` (state_tests): box+not-generating → `[?]`; generating → none; idle → none.
- notifyd lib **54 pass**, ainb inbox/osnotify modules green.
- `cargo fmt --all --check` clean · scoped clippy adds no warnings · build green.

## Known limits (honest)
- Detection is a pane heuristic (box-drawn panel + `?` in the screen tail) — primarily tuned for Claude; Codex prompt UIs are best-effort.
- `[!]` permission-specific red and a transient "just finished" `[✓]` are possible follow-ups; deferred to keep this focused on the actionable waiting signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now dynamically display real-time indicators when waiting for user input, detected during preview updates.

* **Refactor**
  * Simplified session list attention markers to show cleaner visual indicators.
  * Streamlined internal alert classification logic and removed redundant helper methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->