### PR TITLE
docs: ainb-hooks notifications — inbox guide + plugin README (with diagrams)

### DIFF
--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -3,56 +3,317 @@ title: "Inbox & notifications"
 description: "The ainb-tui Inbox screen + the ainb-notifyd daemon that captures Claude Code and Codex hook events into SQLite. Host code, not a plugin."
 ---
 
-The **Inbox** screen and the **`ainb-notifyd`** daemon are part of the `ainb` host binary — **not** an ainb plugin. This page documents them together because they are two halves of one feature: the daemon captures Claude Code / Codex lifecycle hook events into SQLite, and the Inbox screen (plus the per-session `●N` badges) renders them inside `ainb-tui`.
+The **Inbox** screen and the **`ainb-notifyd`** daemon are part of the `ainb` host binary — **not** an ainb plugin. This page documents them together because they are two halves of one feature: the daemon captures Claude Code / Codex lifecycle hook events into SQLite, and the Inbox screen (plus the per-session attention markers) renders them inside `ainb-tui`.
 
-> **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins — `burndown`, `session-reader`, `witr` — which run as spawned child processes over stdio JSON-RPC and are governed by the capability gate. The **only** plugin in this feature is [`ainb-hooks`](../toolkit/plugins/ainb-hooks.md), and that is a plugin of the *host agent* (Claude Code / Codex), installed into their config dirs — not a plugin of `ainb`.
+> **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins — `burndown`, `session-reader`, `witr` — which run as spawned child processes over stdio JSON-RPC. The **only** plugin in this feature is [`ainb-hooks`](../toolkit/plugins/ainb-hooks.md), a thin bash hook installed into Claude Code and Codex CLI — not into `ainb`.
 
 ![The Inbox screen in ainb-tui](../assets/screenshots/notifyd-inbox.png)
 
-*Press `I` (Shift+i) in ainb to open the Inbox — captured Claude Code / Codex lifecycle events with a list + detail pane, agent filter, and per-session unread badges.*
+*Press `b` anywhere in ainb to open the Inbox — captured Claude Code / Codex lifecycle events with a list + detail pane, agent filter, and per-session unread badges.*
 
-## How it works
+## Architecture
 
-![Inbox & notifications — how it works](../assets/diagrams/notifyd.svg)
+### End-to-end flow
 
-The capture path starts outside ainb. The `ainb-hooks` plugin (a thin bash hook, `notify.sh`) is installed into Claude Code (`~/.claude/plugins/ainb-hooks/`) and Codex (`~/.codex/hooks.json`). It registers only the **actionable** lifecycle events — `Notification` (idle / awaiting-input + permission prompts) and `Stop` (turn finished). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
+```mermaid
+flowchart LR
+    A["Claude / Codex<br/>session event"] -->|hook fires| B["notify.sh<br/>(ainb-hooks)"]
+    B -->|JSON envelope via nc/socat| C{"notify.sock<br/>present?"}
+    C -->|yes| D["ainb-notifyd<br/>(tokio accept loop)"]
+    C -->|no| E["lazy spawn<br/>ainb notifyd"]
+    E --> F{"spawn ok?"}
+    F -->|yes, retry send| D
+    F -->|no| G["notify.fallback.jsonl<br/>(append)"]
+    G -->|replayed on next startup| D
+    D -->|insert_and_prune| H[("notifications.db<br/>SQLite WAL")]
+    D -->|is_user_facing?| I{"user-facing?"}
+    I -->|yes + debounce ok| J["OS banner<br/>osascript / notify-send"]
+    I -->|no| K["dropped"]
+    H -->|poll every tick| L["Inbox screen<br/>(ainb-tui)"]
+    H -->|unread count| M["Global menu badge<br/>● N · b inbox"]
+    P["tmux pane<br/>(captured ~5s)"] -->|live_attention_from_pane| N["Session-list marker<br/>[?] waiting"]
+```
 
-Telemetry events (`SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`) are deliberately **not** hooked — `PostToolUse` alone fires dozens of times per turn and would bury the signal. So the inbox only ever contains things that need you.
+> The per-session **`[?]` marker is live state**, derived from the tmux
+> pane — **not** from the notifications database. The database backs the
+> Inbox screen and the global unread badge; the session-list marker
+> reflects what a session is doing *right now*.
 
-`ainb-notifyd` is a tokio accept-loop daemon. On startup it replays (and clears) any queued `notify.fallback.jsonl`, then binds the `0600` socket and writes a PID file. Each accepted connection is parsed into an `Envelope` and checked against `is_user_facing`: non-actionable events (telemetry like `SessionStart` / `PostToolUse`) are **dropped before persistence** — a defensive second filter on top of the trimmed hook registration, so a stale install never accumulates noise either. User-facing events (`Stop`, `Notification`, `PermissionRequest`, `agent-turn-complete`, approval/wait events, etc.) are persisted via `insert_and_prune` and emitted as a native OS notification, debounced per `(session_id, raw_event)` on a 60s window.
+### Single-event sequence
 
-Storage is a dedicated SQLite database, `~/.agents-in-a-box/notifications.db`, opened in WAL mode so the daemon (writer) and TUI (reader) never block each other. It is intentionally separate from `session-reader`'s `usage.db` — different lifecycles, independent migrations. A retention sweep runs on every insert (default: prune rows older than 7 days, cap the table at 10,000 rows, oldest first).
+```mermaid
+sequenceDiagram
+    participant C as Claude / Codex
+    participant H as notify.sh
+    participant D as ainb-notifyd
+    participant DB as notifications.db
+    participant OS as OS NotifCenter
+    participant TUI as ainb-tui
 
-The render side lives in `ainb-core`. The **Inbox** screen (`components/inbox.rs`) holds a long-lived `Store` handle and re-queries SQLite on every render tick (cheap with WAL + `LIMIT 200`). It paints a two-pane list + detail view, and supports mark-read, dismiss, dismiss-all-visible, an archived toggle, and an agent filter. The Sessions screen also reads the store's `unread_by_cwd` grouping to draw a per-session `●N` unread badge, correlating an ainb session to its hook events by working directory. Because `notifyd` is in-tree, it reaches the filesystem, the socket, and the OS notifier directly — there is no JSON-RPC boundary, no `plugin/render` / `plugin/cli_dispatch`, and no `host/snapshot/publish`.
+    C->>H: hook fires (Stop / Notification / PermissionRequest)
+    H->>H: build Envelope JSON<br/>{protocol_version, agent, raw_event,<br/>session_id, cwd, project, ts, payload}
+    H->>D: write envelope to notify.sock (nc/socat)
+    Note over H,D: If socket absent: lazy-spawn ainb notifyd,<br/>retry once, else append to fallback.jsonl
+    H-->>C: exit 0 (never blocks the agent)
+    D->>D: parse + validate Envelope
+    D->>D: is_user_facing? (drop SessionStart / PostToolUse etc.)
+    D->>DB: INSERT + prune (retention: 7 days / 10k rows)
+    D->>D: debounce check (session_id, raw_event, 60s window)
+    D->>OS: osascript / notify-send<br/>"Claude session finished" / "…waiting for you" / "…needs permission"
+    DB-->>TUI: Inbox poll (every render tick via WAL)
+    DB-->>TUI: unread count → global ● N menu badge
+```
 
-## Host resources it touches
+### Data flow legend
 
-Because this is host code, there is **no manifest and no capability declaration** — the capability gate that governs subprocess plugins does not apply. It reaches the filesystem, the socket, and the OS notifier directly. For reference, the host-side resources it touches are:
+| Path | Details |
+|---|---|
+| Hook → socket | One newline-terminated JSON line per event; `nc -U` or `socat` |
+| Fallback file | `~/.agents-in-a-box/notify.fallback.jsonl` — replayed + cleared on daemon start |
+| Database | `~/.agents-in-a-box/notifications.db` — WAL mode, separate from `usage.db` |
+| OS banner | macOS: `osascript -e 'display notification …'`; Linux: `notify-send --app-name=ainb` |
+| TUI poll | `Store::list(…, LIMIT 200)` on every render tick; cheap via WAL |
+| cwd bridge | Inbox `Enter` resolves a row's `cwd` to the matching `Session.workspace_path` (exact or subdir) and attaches into that session's tmux |
 
-| Resource | Why it is needed |
-|----------|------------------|
-| `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist captured envelopes; back the Inbox list and the unread badge. |
-| `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from the `ainb-hooks` script. |
-| `~/.agents-in-a-box/notify.pid`, `notify.fallback.jsonl` | Single-instance guard; recover events queued while the daemon was down. |
-| `~/.claude/plugins/ainb-hooks/`, `~/.codex/hooks.json` (read+write) | The `install` / `uninstall` verbs wire the hook into the host agents. |
-| `osascript` / `notify-send` (subprocess) | Emit the native OS notification for user-facing events. |
+### What gets filtered
 
-## Using it
+Telemetry events are intentionally excluded at two layers:
 
-- **Discoverability surfaces** — three places advertise the Inbox so users don't have to memorise a hidden shortcut:
-  - The home screen sidebar lists `📥 Inbox  [b]` between Sessions and Recovery — press `Enter` on the tile, or `b` globally, to open it. (`b` for "in-**B**ox" — picked to avoid the case-pair confusion between `i` Stats and the earlier `I` Inbox binding.)
-  - The bottom menu bar (every split-pane screen) always shows `b inbox`. When the store has unread + non-dismissed events the hint becomes `● N · b inbox`, so the global unread count is visible even when the Inbox screen is closed.
-  - The Sessions screen renders a `● N` row badge next to any session whose `workspace_path` matches a notification's `cwd` (exact equality or `workspace_path/`-prefix for worktree sub-directories). This is the primary surface — notifications are tied to the session that produced them, not a separate destination.
-- **Inbox screen** — press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex), `r` force refresh, `q`/`Esc` back.
-- **cwd-based correlation (jump-to-tmux)** — every envelope carries the agent's `cwd` at hook-fire time, and every ainb `Session` carries a `workspace_path`. When the user presses `Enter` on an Inbox row, notifyd resolves the row's `cwd` to the first ainb workspace whose path matches (exact or `workspace_path/`-prefix to cover worktree subdirs), picks a session in that workspace, and queues an `AttachToOtherTmux` action with that session's `tmux_session_name`. There is no shared session-id namespace between the host agents' `session_id` strings and ainb's `Session.id` `Uuid`; the cwd is the bridge.
-- **Daemon + installer CLI** — the documented entrypoint is the standalone `ainb-notifyd` binary. The same verbs are also available as a **hidden `ainb notifyd …` subcommand** on the main `ainb` binary (it delegates to the identical `ainb_plugin_notifyd` functions). The hidden alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd` — the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
-  - `ainb-notifyd run` (or `ainb notifyd run` / bare `ainb notifyd`) — run the daemon in the foreground. The hook script lazy-spawns `ainb notifyd` when the socket is missing; if `ainb` is on `PATH` the daemon auto-starts and the event is delivered live (no fallback file).
-  - `ainb-notifyd install --claude --codex` (or `--all`) — install the `ainb-hooks` hook for the chosen agents.
-  - `ainb-notifyd uninstall --claude --codex` (or `--all`) — reverse the install; preserves user-authored Codex hooks.
-  - `ainb-notifyd status` — report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness.
-  - `ainb-notifyd stop` — send `SIGTERM` to a running daemon via its PID file.
-- **Snapshot topics** — none. `notifyd` does not publish or subscribe on the event bus; the Inbox reads SQLite directly. There is no slash command.
+1. **Hook registration** — `plugin.json` and `hooks.json` register only `Notification` and `Stop`. `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact` are **not registered**.
+2. **Daemon filter** — `is_user_facing()` (`osnotify.rs:67`) drops any non-actionable event that arrives anyway (e.g. from a stale install or future hook changes). Only `Stop`, `Notification`, `PermissionRequest`, `agent-turn-complete`, `task_complete`, `request_user_input`, `exec_approval_request`, `apply_patch_approval_request`, `wait_for_user`, `permission_request` pass the filter.
+
+`PostToolUse` alone fires dozens of times per turn. Without these filters, the inbox would be unusable.
+
+## Install
+
+The `ainb-hooks` plugin is installed into your agent CLIs via the `ainb notifyd install` subcommand (also available as the standalone `ainb-notifyd` binary):
+
+```bash
+# Install for both Claude Code and Codex CLI (default)
+ainb notifyd install
+
+# Claude only
+ainb notifyd install --claude
+
+# Codex only
+ainb notifyd install --codex
+
+# Check status
+ainb notifyd status
+
+# Remove
+ainb notifyd uninstall
+ainb notifyd uninstall --claude
+ainb notifyd uninstall --codex
+```
+
+All plugin files are baked into the binary via `include_str!` at compile time — no network, no separate download.
+
+**What `install` writes to disk:**
+
+| Path | What |
+|---|---|
+| `~/.agents-in-a-box/hooks/notify.sh` | Canonical hook script (chmod 755) — single source of truth |
+| `~/.claude/plugins/ainb-hooks/.claude-plugin/plugin.json` | Claude Code plugin manifest |
+| `~/.claude/plugins/ainb-hooks/hooks/notify.sh` | Symlink (or copy) → canonical script |
+| `~/.codex/hooks.json` | Managed block merged in; user hooks are preserved, never overwritten |
+| `~/.agents-in-a-box/install.json` | Install record + `plugin_version` for drift detection |
+
+**The install command does NOT start the daemon.** The daemon is lazy-spawned by `notify.sh` on the first event after install. See [Daemon management](#daemon-management) below.
+
+> **Hooks load at session start.** Already-running Claude / Codex sessions will not pick up the newly installed hook until they are restarted. Inside a running Claude session, run `/hooks` to confirm `ainb-hooks` is listed.
+
+### First-run prompt and drift detection
+
+On startup, `ainb-tui` calls `prompt_state()` (`install.rs:242`):
+
+- **Nothing installed + user hasn't declined** → offers to install (`OfferInstall`).
+- **Installed, but the running binary embeds a newer manifest** → offers to re-install (`OfferUpdate { installed, embedded }`). This fires after an `ainb` upgrade.
+- **Up to date or user declined** → silent (`None`).
+
+Declining the first-run prompt sets `prompt_dismissed = true` in `install.json` and suppresses the offer permanently. Re-installing clears that flag.
+
+## What you see
+
+### Surface 1 — OS notification banner
+
+<!-- SCREENSHOT: macOS Notification Center banner showing "Claude session finished" or "Claude is waiting for you" — caption: "Native macOS banner emitted when a session finishes or parks at a prompt" -->
+
+Fires when:
+- The daemon is running, **and**
+- The event passes `is_user_facing()`, **and**
+- The `(session_id, raw_event)` pair has not fired within the last 60 seconds (debounce window).
+
+Banner titles:
+
+| Event | Title |
+|---|---|
+| `Stop`, `agent-turn-complete`, `task_complete` | `Claude / Codex session finished` |
+| `Notification`, `request_user_input`, `wait_for_user` | `Claude / Codex is waiting for you` |
+| `PermissionRequest`, `exec_approval_request`, `apply_patch_approval_request`, `permission_request` | `Claude / Codex needs permission` |
+
+The banner body is taken from `payload.message` if present; otherwise falls back to the project name or `cwd`.
+
+On macOS, `osascript -e 'display notification …'` is used — no extra dependencies required. If no banner appears, check Notification Center permissions for the terminal host (see [Troubleshooting](#troubleshooting)).
+
+### Surface 2 — per-session attention marker in the session list
+
+<!-- SCREENSHOT: Session list showing an amber [?] tag on a session parked at /interview or AskUserQuestion — caption: "A session parked at an interactive prompt shows [?] in the session list" -->
+
+The session list renders a colored marker to the right of the session name when `session.live_attention` is set. This value is derived from the tmux pane state every ~5 seconds (`AppState::live_attention_from_pane`) — **not** from notification history, so it reflects what the session is doing *right now* and clears the moment the session resumes.
+
+| Marker | Color | Meaning |
+|---|---|---|
+| `[?]` | Amber | Agent is parked at an interactive prompt — `/interview`, AskUserQuestion, or a permission prompt — and needs you (`AlertKind::WaitingOnUser`) |
+
+Today, live detection emits **only `[?]`**: a session is "waiting" when its agent is not generating *and* the visible screen tail shows a box-drawn prompt panel containing `?`. Sessions that are actively working or idle show **no marker** — those states are already conveyed by the row's `●` / `○` status indicator, so a marker there would be redundant.
+
+> **Reserved variants.** The renderer (`session_list.rs`) also maps `AlertKind::NeedsPermission` → red `[!]` and `AlertKind::Finished` → green `[✓]`, but the live pane detector does not currently emit them — they're reserved for future, more granular detection (e.g. distinguishing a permission prompt from a question, or a transient "just finished" state). You will only see `[?]` in the current release.
+
+### Surface 3 — global unread badge in the menu bar
+
+<!-- SCREENSHOT: Bottom menu bar showing "● 3 · b inbox" when unread notifications are present — caption: "Global unread badge in the menu bar; press b to open the Inbox" -->
+
+Visible on every split-pane screen. When `Store::unread_count()` > 0, the Inbox hint becomes `● N · b inbox` where N is the total count of unread + non-dismissed events. When the count is zero, the hint shows only `b inbox`.
+
+### Surface 4 — Inbox screen
+
+<!-- SCREENSHOT: Inbox screen with the two-pane list + detail view showing several notification rows — caption: "The Inbox screen (press b) with list and detail panes" -->
+
+Press **`b`** from the home screen (or `Enter` on the `📥 Inbox` sidebar tile) to open the Inbox. It shows a two-pane list + detail view of all captured events, newest first.
+
+**Key bindings inside the Inbox:**
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` or `k` / `j` | Move selection |
+| `PageUp` / `PageDown` | Jump 10 rows |
+| `Enter` | Open detail + mark read + jump to the matching session's tmux pane |
+| `d` | Dismiss selected row |
+| `Shift+C` | Dismiss every currently-visible row |
+| `a` | Toggle archived (dismissed) rows |
+| `p` | Cycle agent filter: all → claude → codex → all |
+| `r` | Force refresh from store |
+| `q` / `Esc` | Return to previous screen |
+
+**Jump-to-tmux on Enter:** every envelope carries the agent's `cwd` at hook-fire time. When you press `Enter` on an Inbox row, `ainb` resolves the row's `cwd` against `Session.workspace_path` (exact match or `workspace_path/`-prefix for worktree subdirs), picks the matching session, and issues an `AttachToOtherTmux` action. The host agent's `session_id` string and ainb's internal `Uuid` are in separate namespaces — `cwd` is the correlation bridge.
+
+## Daemon management
+
+The daemon is **not started by `install`**. `notify.sh` lazy-spawns it (`nohup ainb notifyd &`) on the first event after a session starts. This is normal — seeing the daemon absent in `status` before any event has fired is expected.
+
+```bash
+# Check status (install + daemon report — read-only, always safe)
+ainb notifyd status
+
+# Run daemon in foreground (useful for debugging)
+ainb notifyd run
+
+# Stop a running daemon (sends SIGTERM via PID file)
+ainb notifyd stop
+```
+
+`ainb notifyd` and `ainb-notifyd` are the same code — the former is a hidden subcommand on the main `ainb` binary (guaranteed to be on `PATH`), the latter is the standalone daemon binary.
+
+## How to check it's firing
+
+**1. Status report:**
+
+```bash
+ainb notifyd status
+```
+
+Healthy output looks like:
+```
+agent    installed  hook_ok  socket_ok  last_event
+claude   yes        yes      yes        Stop (claude)
+codex    yes        yes      yes        Stop (codex)
+```
+
+**2. Query the database directly:**
+
+```bash
+sqlite3 ~/.agents-in-a-box/notifications.db \
+  "SELECT agent, raw_event, datetime(ts/1000,'unixepoch','localtime')
+   FROM notifications ORDER BY ts DESC LIMIT 5;"
+```
+
+**3. Manual smoke-test — fire the hook directly:**
+
+```bash
+printf '{"hook_event_name":"Stop","session_id":"test","cwd":"'"$PWD"'","payload":{"message":"smoke-test"}}' \
+  | AINB_AGENT=claude bash ~/.agents-in-a-box/hooks/notify.sh
+```
+
+After this runs:
+- A row appears in `notifications.db`.
+- A macOS banner pops (if the daemon is up and Notification Center permission is granted).
+- `ainb notifyd status` shows `daemon: pid N (running)` and the last event.
+
+## Troubleshooting
+
+### No OS banner on macOS
+
+The most common cause: Notification Center permission for the terminal (or `osascript`) is denied.
+
+1. Open **System Settings → Notifications**.
+2. Find your terminal app (Terminal, iTerm2, Ghostty, etc.) or `osascript`.
+3. Enable "Allow notifications" and set alert style to "Alerts" or "Banners".
+
+Confirm the daemon is up: `ainb notifyd status`. If `socket_ok: no`, the daemon hasn't started yet — fire a smoke-test event (see above) to trigger the lazy spawn.
+
+### Installed a session hook, but events aren't appearing
+
+Hooks load at **session start**. An already-running Claude or Codex session will not pick up the hook until it is restarted.
+
+Confirm inside a running Claude session:
+```
+/hooks
+```
+`ainb-hooks` must appear in the hook list. If it's absent, restart the Claude session.
+
+### Daemon not running (socket_ok: no)
+
+This is normal before the first event fires. The daemon is lazy-spawned by `notify.sh` on first use. To start it manually:
+
+```bash
+ainb notifyd run &
+# or foreground for debugging:
+ainb notifyd run
+```
+
+If `ainb notifyd run` immediately exits, check `~/.agents-in-a-box/notify.pid` — another instance may already be running.
+
+### Events accumulating in notify.fallback.jsonl
+
+The fallback file is written when delivery to the socket fails (daemon not running at the time). They are replayed and cleared automatically on the next daemon startup. You can force replay by running `ainb notifyd run` — it drains the fallback file before binding the socket.
+
+### Inbox shows old / stale events
+
+Press `r` inside the Inbox to force a store refresh. The default poll is every render tick; if the display looks wrong, `r` guarantees a fresh read.
+
+## Host resources
+
+Because `notifyd` is host code (not a subprocess plugin), there is no capability declaration. For reference:
+
+| Resource | Purpose |
+|---|---|
+| `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist envelopes; back the Inbox list and unread badge |
+| `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from `notify.sh` |
+| `~/.agents-in-a-box/notify.pid` | Single-instance guard; used by `stop` verb |
+| `~/.agents-in-a-box/notify.fallback.jsonl` | Buffer events queued while daemon was down |
+| `~/.agents-in-a-box/install.json` | Install record + plugin version for drift detection |
+| `~/.claude/plugins/ainb-hooks/`, `~/.codex/hooks.json` | Written by `install` / `uninstall` verbs |
+| `osascript` / `notify-send` (subprocess) | Native OS notification |
+
+Retention defaults: 7 days, 10,000 rows maximum. Oldest rows pruned on every insert.
 
 ## Source
 
-`crates/ainb-plugin-notifyd` — in-tree library + `ainb-notifyd` daemon binary: envelope wire format, the SQLite `Store`, the tokio listener, OS-notify dispatch, and the `ainb-hooks` install/uninstall logic. The Inbox screen itself lives in `crates/ainb-core/src/components/inbox.rs`. Diagram generated via /fireworks-tech-graph.
+| Crate / file | Purpose |
+|---|---|
+| `ainb-tui/crates/ainb-plugin-notifyd/` | Daemon binary + library: envelope wire format, SQLite store, tokio listener, OS-notify dispatch, install/uninstall logic |
+| `ainb-tui/crates/ainb-core/src/components/inbox.rs` | Inbox TUI screen |
+| `ainb-tui/crates/ainb-core/src/components/session_list.rs` | Per-session live `[?]` waiting marker |
+| `ainb-tui/crates/ainb-core/src/app/state.rs` | `live_attention_from_pane` — derives the marker from the tmux pane |
+| `plugins/ainb-hooks/` | Hook plugin source: `notify.sh`, `plugin.json`, `codex/hooks.json` |

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -1,110 +1,251 @@
 # ainb-hooks
 
-Plugin that emits Claude Code and Codex CLI lifecycle events to the
-**ainb notification inbox** via a Unix socket. Powers session-state
-badges, the dedicated Inbox screen, and optional OS notifications in
-`ainb-tui`.
+A **Claude Code / Codex CLI plugin** — installed into the host agent CLIs, not into `ainb` itself. Captures actionable session lifecycle events and forwards them to the `ainb-notifyd` daemon, powering the Inbox screen, per-session attention markers, and OS notification banners in `ainb-tui`.
 
-## How it works
+## What it does
 
 ```
-┌─ Claude / Codex session ─────┐
-│ hook fires (Stop, Notification│
-│   :idle_prompt, ...)         │
-│ ────────────────────────────▶│ notify.sh
-└──────────────────────────────┘    │
-                                    ▼
-                       ~/.agents-in-a-box/notify.sock
-                                    │
-                                    ▼
-                              ainb-notifyd
-                                    │
-                       ┌────────────┴───────────────┐
-                       ▼                              ▼
-            notifications.db (SQLite)       broadcast → ainb-tui
+┌─ Claude / Codex session ─────────────────┐
+│  hook fires: Stop / Notification /       │
+│  PermissionRequest / agent-turn-complete │
+└──────────────────────────────────────────┘
+                    │
+                    ▼
+              notify.sh (this plugin)
+                    │
+          build normalized Envelope JSON
+                    │
+              ┌─────▼──────┐
+              │ notify.sock │  ← Unix domain socket
+              └─────┬──────┘
+    socket absent?  │
+         ┌──────────┘
+         ▼
+    lazy-spawn: nohup ainb notifyd
+    retry send once
+         │  still fails?
+         ▼
+    notify.fallback.jsonl  (replayed on next daemon start)
+                    │
+                    ▼
+              ainb-notifyd
+              ┌─────────────────────┐
+              │  notifications.db   │  SQLite WAL
+              │  OS banner          │  osascript / notify-send
+              │  Inbox TUI screen   │  press b
+              └─────────────────────┘
 ```
 
-If the socket is unreachable (daemon not running), `notify.sh` writes
-the envelope to `~/.agents-in-a-box/notify.fallback.jsonl`. Notifyd
-replays + clears that file on its next startup. The hook always exits 0
-so a delivery failure never blocks the host agent.
+> The session list's live `[?]` "waiting" marker is **not** produced by
+> this plugin or the daemon — the ainb TUI derives it directly from each
+> session's tmux pane. See [Inbox & notifications](../../docs/tui/inbox-notifications.md).
+
+The hook always exits `0`. A delivery failure (socket absent, daemon not started) never blocks the host agent.
 
 ## Layout
 
 ```
 plugins/ainb-hooks/
 ├── .claude-plugin/
-│   └── plugin.json          # Claude Code marketplace manifest
+│   └── plugin.json          # Claude Code plugin manifest (name, version, hooks block)
 ├── codex/
 │   └── hooks.json           # Codex ~/.codex/hooks.json merge template
 ├── hooks/
-│   └── notify.sh            # universal hook script (claude + codex)
+│   └── notify.sh            # Universal hook script (Claude + Codex)
 └── README.md
 ```
 
-The same `notify.sh` is used by both agents:
+All three artefacts are baked into the `ainb-notifyd` binary via `include_str!` at compile time. Install extracts them to disk; no network access is required.
 
-- **Claude Code** pipes the hook payload as JSON on stdin.
-- **Codex CLI** passes the hook payload as JSON in `argv[1]`.
+## Hook registration
 
-`notify.sh` autodetects the source and uses the right input. The agent
-is identified via `AINB_AGENT={claude,codex}` set in the registering
-command line.
+Only events that require human attention are registered. Telemetry is explicitly excluded.
 
-## Install
+**Registered (Claude Code — `plugin.json`):**
 
-The recommended install path is the `ainb hooks install` CLI (in `ainb-tui`),
-which handles plugin manifests, config merges, and notifyd lifecycle:
+| Event | Fires when |
+|---|---|
+| `Notification` | Agent is awaiting user input (`Notification:idle_prompt`) or surfacing a permission prompt |
+| `Stop` | Agent turn / session finishes |
 
-```bash
-ainb hooks install --claude --codex
-ainb hooks status
-ainb hooks uninstall --all
-```
+**Registered (Codex CLI — `hooks.json`):**
 
-The CLI:
+Codex uses the same two event names: `Notification` and `Stop`.
 
-1. Drops `.claude-plugin/plugin.json` at `~/.claude/plugins/ainb-hooks/` (Claude).
-2. Merges this directory's `codex/hooks.json` into `~/.codex/hooks.json` as a
-   managed block (Codex).
-3. Extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh` and rewrites
-   the `__AINB_HOOK_SCRIPT__` placeholder in the codex template to that
-   absolute path.
-4. Records the install method in `~/.agents-in-a-box/install.json` so
-   `ainb hooks uninstall` is fully reversible.
+**Not registered (intentionally):** `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`. `PostToolUse` alone fires dozens of times per agent turn and would bury the inbox signal.
 
-## Hook events
+As a second line of defence, `ainb-notifyd` also drops any non-user-facing event on arrival (`osnotify.rs:is_user_facing`), so a stale install never accumulates noise.
 
-Both agents use identical PascalCase event names: `SessionStart`,
-`UserPromptSubmit`, `PostToolUse`, `Notification`, `Stop`, `PreCompact`.
+### Claude vs Codex wiring
 
-The matcher `Notification:idle_prompt` (Claude) and Codex's variants
-(`request_user_input`, `wait_for_user`, etc.) all carry the same
-semantic meaning ("agent awaiting user input"). `notify.sh` preserves
-the raw event name in the `raw_event` field of the envelope so UI
-mapping happens in the consumer, not at the wire.
+The same `notify.sh` script handles both agents. The difference is how the payload arrives and how the agent is identified.
 
-## Envelope shape
+| | Claude Code | Codex CLI |
+|---|---|---|
+| Payload delivery | JSON on **stdin** | JSON as **argv[1]** |
+| Agent identification | `AINB_AGENT=claude` set in the hook command | `AINB_AGENT=codex` set in the hook command |
+| Hook config | `~/.claude/plugins/ainb-hooks/.claude-plugin/plugin.json` | Managed block in `~/.codex/hooks.json` |
+| Hook command | `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh` | `AINB_AGENT=codex /abs/path/to/notify.sh` |
+
+`notify.sh` autodetects the input source when `AINB_AGENT` is not set — argv-delivery implies Codex, stdin-delivery implies Claude. The explicit env var is preferred and always set by the installer.
+
+## Envelope schema
+
+Every event is normalized into a single JSON envelope before delivery to the socket.
 
 ```json
 {
   "protocol_version": 1,
   "agent": "claude",
   "raw_event": "Notification:idle_prompt",
-  "session_id": "7f2a...",
+  "session_id": "7f2a3b...",
   "cwd": "/Users/stevie/d/git/ai-coder-rules",
   "project": "ai-coder-rules",
   "ts": 1717000000000,
-  "payload": { "...full original hook JSON..." }
+  "payload": { "...verbatim original hook JSON..." }
 }
 ```
 
-`payload` is the verbatim original JSON from the host agent so the
-inbox detail view can show full forensics.
+| Field | Type | Notes |
+|---|---|---|
+| `protocol_version` | `u8` | Currently `1`. Bumped only on breaking wire changes. |
+| `agent` | `string` | `"claude"` or `"codex"` |
+| `raw_event` | `string` | Verbatim event name, preserving matcher suffix (e.g. `Notification:idle_prompt`). Not canonicalized across agents — mapping happens in the consumer. |
+| `session_id` | `string` | Host agent's session identifier. May be empty in rare edge cases. |
+| `cwd` | `string` | Working directory at the moment the hook fired. Used by the TUI to correlate notifications with ainb sessions. |
+| `project` | `string` | `basename(cwd)` — pre-computed for display. |
+| `ts` | `i64` | Epoch milliseconds. Falls back to `date +%s * 1000` when `%3N` is unavailable (macOS BSD date). |
+| `payload` | `object` | Verbatim original JSON from the host agent. Preserved for full forensics in the Inbox detail pane. |
+
+The schema is defined in `ainb-tui/crates/ainb-plugin-notifyd/src/envelope.rs`.
+
+## Install
+
+### Via `ainb notifyd install` (recommended)
+
+The `ainb notifyd` subcommand (or standalone `ainb-notifyd` binary) handles everything:
+
+```bash
+# Install for both agents
+ainb notifyd install
+
+# Claude Code only
+ainb notifyd install --claude
+
+# Codex CLI only
+ainb notifyd install --codex
+
+# Check what's installed
+ainb notifyd status
+
+# Remove
+ainb notifyd uninstall
+ainb notifyd uninstall --claude
+ainb notifyd uninstall --codex
+```
+
+Install is **idempotent** — running it twice produces the same state. The install record at `~/.agents-in-a-box/install.json` records the plugin version stamped at install time so `ainb-tui` can detect drift after an `ainb` upgrade and offer to re-install.
+
+What the installer does, step by step:
+
+1. Extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh` (chmod 755).
+2. **Claude:** creates `~/.claude/plugins/ainb-hooks/.claude-plugin/plugin.json` and symlinks (or copies) `notify.sh` into `~/.claude/plugins/ainb-hooks/hooks/notify.sh`.
+3. **Codex:** reads `~/.codex/hooks.json` (if present), strips any prior ainb-managed entries tagged `_ainb_managed: true`, and merges the new block in — user hooks are never touched.
+4. Writes `~/.agents-in-a-box/install.json` with the list of installed agents + `plugin_version`.
+
+Uninstall is fully reversible: the Codex managed block is stripped by walking the JSON and removing entries tagged `_ainb_managed`, leaving user-authored hooks intact.
+
+### Manual / standalone install
+
+For environments where the `ainb` binary is not available, you can wire the hook manually.
+
+**Claude Code:**
+
+```bash
+# 1. Create plugin dir
+mkdir -p ~/.claude/plugins/ainb-hooks/.claude-plugin
+mkdir -p ~/.claude/plugins/ainb-hooks/hooks
+mkdir -p ~/.agents-in-a-box/hooks
+
+# 2. Copy notify.sh (from this repo's plugins/ainb-hooks/hooks/)
+cp plugins/ainb-hooks/hooks/notify.sh ~/.agents-in-a-box/hooks/notify.sh
+chmod 755 ~/.agents-in-a-box/hooks/notify.sh
+ln -sf ~/.agents-in-a-box/hooks/notify.sh ~/.claude/plugins/ainb-hooks/hooks/notify.sh
+
+# 3. Copy plugin.json
+cp plugins/ainb-hooks/.claude-plugin/plugin.json \
+   ~/.claude/plugins/ainb-hooks/.claude-plugin/plugin.json
+```
+
+**Codex CLI:**
+
+Merge the following block into `~/.codex/hooks.json` under the top-level `"hooks"` key, replacing `__AINB_HOOK_SCRIPT__` with the absolute path to `notify.sh`:
+
+```json
+"Notification": [
+  {
+    "hooks": [
+      {
+        "type": "command",
+        "command": "AINB_AGENT=codex /absolute/path/to/notify.sh",
+        "timeout": 5,
+        "_ainb_managed": true
+      }
+    ]
+  }
+],
+"Stop": [
+  {
+    "hooks": [
+      {
+        "type": "command",
+        "command": "AINB_AGENT=codex /absolute/path/to/notify.sh",
+        "timeout": 5,
+        "_ainb_managed": true
+      }
+    ]
+  }
+]
+```
+
+> **Note:** Hooks load at session start. Restart any running Claude or Codex session after installing. Inside Claude, run `/hooks` to confirm `ainb-hooks` is listed.
+
+## Daemon lifecycle
+
+This plugin does **not** start `ainb-notifyd`. The daemon is lazy-spawned by `notify.sh` on the first event:
+
+1. `notify.sh` attempts delivery to `~/.agents-in-a-box/notify.sock`.
+2. If the socket is absent, it runs `nohup ainb notifyd &` (guarded by a `flock` to avoid concurrent spawn races) and waits up to 500ms for the socket to appear.
+3. If the spawn succeeds, it retries delivery.
+4. If the spawn fails (e.g. `ainb` is not on `PATH`), it appends the envelope to `~/.agents-in-a-box/notify.fallback.jsonl`. The daemon replays and clears this file on its next startup.
+
+The daemon can also be started manually: `ainb notifyd run`.
+
+## Smoke-test
+
+Fire the installed hook directly to confirm end-to-end delivery:
+
+```bash
+printf '{"hook_event_name":"Stop","session_id":"test","cwd":"'"$PWD"'","payload":{"message":"smoke-test"}}' \
+  | AINB_AGENT=claude bash ~/.agents-in-a-box/hooks/notify.sh
+```
+
+Then verify:
+
+```bash
+# Check daemon status
+ainb notifyd status
+
+# Check database
+sqlite3 ~/.agents-in-a-box/notifications.db \
+  "SELECT agent, raw_event, datetime(ts/1000,'unixepoch','localtime') FROM notifications ORDER BY ts DESC LIMIT 3;"
+```
+
+A row should appear and a macOS banner should pop (if Notification Center permission is granted for your terminal).
 
 ## See also
 
-- `crates/ainb-plugin-notifyd/` — the `ainb-notifyd` daemon
-- `crates/ainb-core/src/cli/hooks.rs` — the `ainb hooks` CLI
-- `crates/ainb-core/src/screens/inbox/` — the Inbox TUI screen
-- `.agents/specs/2026-05-27-ainb-hooks-plugin-stub-spec.md` — design spec
+- [Inbox & notifications](../../docs/tui/inbox-notifications.md) — comprehensive guide to the daemon, Inbox screen, and all four UI surfaces
+- `ainb-tui/crates/ainb-plugin-notifyd/` — daemon source (envelope, store, listener, osnotify, install)
+- `ainb-tui/crates/ainb-core/src/components/inbox.rs` — Inbox TUI screen
+- `ainb-tui/crates/ainb-core/src/components/session_list.rs` — per-session attention markers


### PR DESCRIPTION
Documentation for the ainb-hooks notification system (companion to the v1.3.x notification work). Authored by the documentation-specialist, then corrected for accuracy against the **post-#199 live-marker** behaviour.

## Files
- **`docs/tui/inbox-notifications.md`** (docsite, Starlight) — full rewrite:
  - Two-layer architecture (ainb-hooks plugin vs in-binary notifyd + Inbox)
  - **Mermaid** flowchart (event → hook → socket/fallback → daemon → SQLite → OS banner + TUI surfaces) + sequence diagram
  - Independent CLI install (`ainb notifyd install/uninstall/status/run/stop` + flags), first-run prompt, drift detection
  - The UI surfaces, how to verify it's firing (status / sqlite / smoke-test), troubleshooting
  - Screenshot placeholders (consistent `<!-- SCREENSHOT: … -->` markers) for Stevie to fill
- **`plugins/ainb-hooks/README.md`** — plugin-half reference: envelope schema, telemetry filter, Claude(stdin)/Codex(argv) wiring, install + standalone manual wiring, Codex managed-block mechanics, lazy-spawn lifecycle.

## Accuracy corrections applied (vs the agent's first draft)
The draft described `[?]`/`[!]`/`[✓]` as all appearing and tied the per-session marker to the removed `unread_by_cwd` path. Fixed to match reality:
- Per-session marker is **live pane state, `[?]` only**; `[!]`/`[✓]` documented as **reserved** renderer variants the live detector doesn't emit yet.
- The DB backs the **Inbox + global `● N` badge**, not the per-session marker.
- The cwd bridge is the **Inbox `Enter` deeplink** (resolve row cwd → session tmux), not marker correlation.

## Notes
- Screenshots pending — Stevie will attach (placeholders are in place).
- Docs-only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Inbox/notifications feature documentation with clarified architecture and comprehensive setup guides.
  * Global Inbox keybinding changed from `I`/`Shift+i` to `b`.
  * Enhanced daemon installation and troubleshooting documentation.
  * Expanded hooks plugin documentation with detailed setup and operational instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->