### PR TITLE
fix(tui): add Ctrl+V clipboard paste to config text popups

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -254,6 +254,7 @@ pub enum AppEvent {
     ConfigPopupInputChar(char), // Input character in text/number input
     ConfigPopupBackspace,       // Backspace in text/number input
     ConfigPopupPaste(String),   // Insert clipboard text at cursor (bracketed paste)
+    ConfigPopupPasteClipboard,  // Read OS clipboard and insert (Ctrl+V; no bracketed paste needed)
     ConfigPopupDelete,          // Forward-delete char under cursor (Delete)
     ConfigPopupCursorLeft,      // Move cursor left in text input
     ConfigPopupCursorRight,     // Move cursor right in text input
@@ -2114,8 +2115,21 @@ impl EventHandler {
                 // Text/Number input mode. Cursor-movement keys are no-ops on
                 // NumberInput (handled at the state layer) but let the text
                 // field behave like a normal editable line: arrows to move,
-                // Delete to forward-delete, paste handled via Event::Paste.
+                // Delete to forward-delete.
+                //
+                // Two paste routes: Cmd+V arrives as a bracketed-paste
+                // `Event::Paste` (handled in the main loop) when the terminal
+                // delivers it; Ctrl+V is a real keystroke we always receive, so
+                // it reads the OS clipboard directly via arboard. The second
+                // route works even when bracketed paste isn't passed through
+                // (e.g. some tmux / mouse-capture setups), which is why the
+                // Cmd+V-only path appeared to "do nothing".
                 match key_event.code {
+                    KeyCode::Char('v' | 'V')
+                        if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                    {
+                        Some(AppEvent::ConfigPopupPasteClipboard)
+                    }
                     KeyCode::Esc => Some(AppEvent::ConfigPopupCancel),
                     KeyCode::Enter => Some(AppEvent::ConfigPopupConfirm),
                     KeyCode::Backspace => Some(AppEvent::ConfigPopupBackspace),
@@ -4149,6 +4163,17 @@ impl EventHandler {
             AppEvent::ConfigPopupPaste(text) => {
                 state.config_popup_state.insert_str(&text);
             }
+            AppEvent::ConfigPopupPasteClipboard => {
+                // Ctrl+V: read the OS clipboard directly (works regardless of
+                // whether the terminal delivers bracketed-paste events).
+                match Self::get_clipboard_text() {
+                    Ok(text) => state.config_popup_state.insert_str(&text),
+                    Err(e) => {
+                        tracing::warn!("Clipboard paste failed: {}", e);
+                        state.add_error_notification(format!("Could not read clipboard: {}", e));
+                    }
+                }
+            }
             AppEvent::ConfigPopupDelete => {
                 state.config_popup_state.delete_forward();
             }
@@ -5053,6 +5078,32 @@ mod text_input_guard_tests {
         let evt = EventHandler::handle_key_event(char_key('H'), &mut state)
             .expect("Shift+H in Config navigation must dispatch ToggleHelp");
         assert!(matches!(evt, AppEvent::ToggleHelp));
+    }
+
+    /// Ctrl+V in a Config text popup must route to the direct-clipboard
+    /// paste (arboard), not type a literal `v`. This is the reliable paste
+    /// path that does not depend on the terminal delivering bracketed
+    /// `Event::Paste` — the reason Cmd+V "did nothing" in some setups.
+    #[test]
+    fn ctrl_v_in_config_text_popup_routes_to_clipboard_paste() {
+        let mut state = AppState::default();
+        state.current_screen = screen_ids::CONFIG.to_string();
+        state.config_popup_state.open_text(
+            "Default Workspace",
+            "Default directory for new sessions",
+            "default_workspace",
+            "/Users/me/git",
+        );
+
+        let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        let evt = EventHandler::handle_key_event(ctrl_v, &mut state)
+            .expect("Ctrl+V in a text popup must dispatch a paste event");
+        assert!(matches!(evt, AppEvent::ConfigPopupPasteClipboard));
+
+        // A bare `v` (no modifier) must still type normally.
+        let evt = EventHandler::handle_key_event(char_key('v'), &mut state)
+            .expect("plain 'v' must dispatch a char input");
+        assert!(matches!(evt, AppEvent::ConfigPopupInputChar('v')));
     }
 
     /// Esc inside a text input while help is visible must close help,

--- a/ainb-tui/crates/ainb-core/src/components/config_popup.rs
+++ b/ainb-tui/crates/ainb-core/src/components/config_popup.rs
@@ -557,7 +557,12 @@ impl ConfigPopupComponent {
                 vec![("↑↓", "select"), ("Enter", "confirm"), ("Esc", "cancel")]
             }
             ConfigPopupType::TextInput { .. } => {
-                vec![("←→", "move"), ("Enter", "save"), ("Esc", "cancel")]
+                vec![
+                    ("←→", "move"),
+                    ("^V", "paste"),
+                    ("Enter", "save"),
+                    ("Esc", "cancel"),
+                ]
             }
             ConfigPopupType::NumberInput { .. } => {
                 vec![("Enter", "save"), ("Esc", "cancel")]


### PR DESCRIPTION
## Problem

After the earlier paste work merged, pasting into **Config → Workspace → Default Workspace** still did nothing for some setups.

Root cause: the merged fix routes **Cmd+V** via a bracketed-paste `Event::Paste`, which requires the terminal/multiplexer to deliver it. In tmux and some mouse-capture configurations that event is never forwarded, so the app sees nothing — and it can't bind Cmd+V itself (the terminal intercepts it as a paste action).

```
Cmd+V ─▶ terminal ─▶ bracketed paste ─▶ (tmux/mouse-capture drops it) ─▶ ✗ nothing
Ctrl+V ─▶ app keystroke ─▶ arboard read clipboard ─▶ insert ─▶ ✓ always works
```

## Fix

Wire **Ctrl+V** — a real keystroke the app always receives — to read the OS clipboard directly via `arboard`'s `get_clipboard_text()` (which existed in the tree but was dead code) and insert at the cursor. This is independent of bracketed paste, so it works in tmux/mouse-capture too. The existing Cmd+V/`Event::Paste` path stays for terminals that do deliver it.

- New `ConfigPopupPasteClipboard` event; `Ctrl+V`/`Ctrl+Shift+V` in a text/number popup → read clipboard → `insert_str`.
- Help bar shows `^V paste`.
- Plain `v` still types normally.

## Tests

- `ctrl_v_in_config_text_popup_routes_to_clipboard_paste` — end-to-end: Ctrl+V → `ConfigPopupPasteClipboard`, bare `v` → `ConfigPopupInputChar('v')`.
- 9 `config_popup` tests still green; lib + release binary compile clean.

Note: Cmd+V will work once bracketed paste is passed through (e.g. tmux `set -g set-clipboard on`), but Ctrl+V sidesteps that entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration text input popups now support clipboard pasting via the Ctrl+V keyboard shortcut.
  * Help bar has been updated to display the new paste shortcut (^V) alongside existing keyboard controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->