### PR TITLE
feat: [?] marker on any waiting session (idle/turn-end), not just box prompts

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -8150,31 +8150,25 @@ impl AppState {
         }
     }
 
-    /// Update preview content for all tmux sessions (called from main update loop)
-    /// Derive a session's live attention marker from its tmux pane.
+    /// Derive a session's live "needs you" marker from whether its agent
+    /// is actively generating.
     ///
-    /// Returns `Some(WaitingOnUser)` only when the agent is parked at an
-    /// interactive prompt — i.e. it is NOT actively generating
-    /// (`claude_running == false`) AND the visible screen tail shows a
-    /// box-drawn prompt panel containing a `?` (the AskUserQuestion /
-    /// interview / permission UI). Working and plain-idle sessions
-    /// return `None`: those states are already conveyed by the row's
-    /// `●` / `○` status indicator, so a marker there would be redundant
-    /// noise. Only the last ~30 lines are inspected so boxed scrollback
-    /// doesn't trigger a false "waiting".
-    fn live_attention_from_pane(
-        pane: &str,
-        claude_running: bool,
-    ) -> Option<ainb_plugin_notifyd::AlertKind> {
+    /// Returns `Some(WaitingOnUser)` whenever the agent is NOT generating
+    /// (`claude_running == false`) — the session has ended its turn /
+    /// gone idle / parked at a prompt and is waiting on the user. It
+    /// clears the instant generation resumes. Intentionally broad: every
+    /// parked session reads as "needs you", which — with the `●` running
+    /// dot marking the busy ones — gives an at-a-glance view of exactly
+    /// which sessions are waiting for you across the fleet.
+    const fn live_attention_for(claude_running: bool) -> Option<ainb_plugin_notifyd::AlertKind> {
         if claude_running {
-            return None;
+            None
+        } else {
+            Some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
         }
-        let tail: String = pane.lines().rev().take(30).collect::<Vec<_>>().join("\n");
-        let at_prompt =
-            tail.contains('?') && tail.contains('│') && tail.contains('┌') && tail.contains('└');
-        at_prompt.then_some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
     }
 
+    /// Update preview content for all tmux sessions (called from main update loop)
     pub async fn update_tmux_previews(&mut self) -> anyhow::Result<()> {
         use crate::tmux::ClaudeProcessDetector;
         use crate::tmux::capture::{CaptureOptions, capture_pane};
@@ -8227,7 +8221,7 @@ impl AppState {
                 match capture_pane(tmux_session.name(), opts).await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);
-                        let attention = Self::live_attention_from_pane(&content, claude_running);
+                        let attention = Self::live_attention_for(claude_running);
                         updates.push((*session_id, content, claude_running, attention));
                     }
                     Err(e) => {
@@ -8240,7 +8234,7 @@ impl AppState {
                 match tmux_session.capture_pane_content().await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);
-                        let attention = Self::live_attention_from_pane(&content, claude_running);
+                        let attention = Self::live_attention_for(claude_running);
                         status_updates.push((*session_id, claude_running, attention));
                     }
                     Err(e) => {

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -707,44 +707,26 @@ mod tests {
     }
 
     // ========================================================================
-    // Live per-session attention marker (derived from the tmux pane)
+    // Live per-session attention marker (waiting = not generating)
     // ========================================================================
 
     #[test]
-    fn live_attention_marks_waiting_at_prompt_only() {
+    fn live_attention_marks_any_idle_session() {
         use ainb_plugin_notifyd::AlertKind;
 
-        // Box-drawn prompt panel containing '?' while the agent is NOT
-        // generating (no status bar → claude_running=false) → the user
-        // is needed.
-        let prompt_pane = "\
-some earlier output line
-┌──────────────────────────────┐
-│ What do you want to do next?  │
-│ ❯ 1. Plan                     │
-│   2. Submit                   │
-└──────────────────────────────┘";
+        // Not generating (turn ended / idle / parked at a prompt) →
+        // waiting on the user.
         assert_eq!(
-            AppState::live_attention_from_pane(prompt_pane, false),
+            AppState::live_attention_for(false),
             Some(AlertKind::WaitingOnUser),
-            "box prompt + not generating must mark waiting-on-user"
+            "a not-generating session must show the waiting marker"
         );
 
-        // Same pane, but the agent is actively generating (status bar
-        // present). It's working, not waiting → no marker.
+        // Actively generating → no marker; the `●` running dot covers it.
         assert_eq!(
-            AppState::live_attention_from_pane(prompt_pane, true),
+            AppState::live_attention_for(true),
             None,
-            "actively-generating session must not show a waiting marker"
-        );
-
-        // Plain finished/idle output with no prompt box → no marker
-        // (idle is conveyed by the row's `○` status indicator).
-        let idle_pane = "task complete.\nno box here\n$ ";
-        assert_eq!(
-            AppState::live_attention_from_pane(idle_pane, false),
-            None,
-            "idle output without a prompt box must not show a marker"
+            "an actively-generating session must not show a waiting marker"
         );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -428,12 +428,12 @@ impl SessionListComponent {
                     };
 
                     // ainb-hooks attention marker for this session row.
-                    // Live attention marker, derived from the session's
-                    // tmux pane each refresh (NOT notification history):
-                    // `[?]` amber when the agent is parked at an
-                    // interactive prompt and needs the user. Working /
-                    // idle sessions carry no marker — that's already the
-                    // `●` / `○` status indicator.
+                    // Live "needs you" marker, recomputed from the
+                    // session's generating-state each refresh (NOT
+                    // notification history): amber `[?]` on any session
+                    // that is not actively generating (idle / turn-ended /
+                    // at a prompt) and is therefore waiting on the user.
+                    // Clears the instant generation resumes.
                     let session_alert = session.live_attention;
 
                     let mut session_spans = vec![

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -479,12 +479,11 @@ pub struct Session {
     pub preview_content: Option<String>,   // Cached preview content for display
     pub is_attached: bool,                 // Whether user is currently attached to the session
 
-    /// Live attention state derived from the tmux pane on each preview
-    /// refresh: `Some(WaitingOnUser)` when the agent is sitting at an
-    /// interactive prompt (AskUserQuestion / interview / permission),
-    /// `None` while working or idle (those are already conveyed by the
-    /// `status` indicator). Transient — never persisted; recomputed in
-    /// `AppState::update_tmux_previews`.
+    /// Live "needs you" marker, recomputed every preview refresh:
+    /// `Some(WaitingOnUser)` whenever the agent is **not generating**
+    /// (turn ended / idle / parked at a prompt), `None` while it is
+    /// actively generating. Drives the amber `[?]` in the session list.
+    /// Transient — never persisted; set in `AppState::update_tmux_previews`.
     #[serde(skip)]
     pub live_attention: Option<ainb_plugin_notifyd::AlertKind>,
 }


### PR DESCRIPTION
Follow-up to the live-marker work. The `[?]` "needs you" marker was too narrow — it only fired for **box-drawn** AskUserQuestion / interview / permission popups, so a session sitting idle at a **plain prose question** (the common turn-end case) showed no marker at all.

## Change
`[?]` now appears on **any session that is not actively generating** — turn ended / idle / at any prompt = waiting on you. It clears the instant the agent resumes generating.

```
fix-stats        generating          → (● running dot, no [?])
pulse-sporthub   idle, prose question → [?]
feat/blog        at /interview        → [?]
biolift          idle at prompt       → [?]
```

`AppState::live_attention_from_pane(pane, running)` (box heuristic) → `live_attention_for(claude_running)`: **waiting == not generating**. Persists until generation resumes (recomputed every ~5s in `update_tmux_previews`, same as `SessionStatus`).

Idle is also the subtle `○` status dot; the amber `[?]` is the louder call-to-action across a fleet of parked agents (the `●` dot still marks the busy ones).

## Tests
- `live_attention_marks_any_idle_session`: not-generating → `[?]`; generating → none.
- build green · `cargo fmt --all --check` clean · clippy clean on new code (CI doesn't gate clippy; verified locally anyway).

## Note
This is the session-list **marker** only (ainb-side, no hooks needed — visible via `cargo run` immediately). The separate "no OS banners / empty Inbox" issue is the hooks not firing in long-running sessions (plugin not active at session start) — tracked separately.