### PR TITLE
fix: publish ainb-hooks to the marketplace so Claude actually loads it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,6 +38,21 @@
         "broadcast",
         "multi-session"
       ]
+    },
+    {
+      "name": "ainb-hooks",
+      "source": "./plugins/ainb-hooks",
+      "description": "Emit actionable Claude Code lifecycle events to the ainb notification inbox: Notification (awaiting-input / permission) and Stop (turn finished) are delivered to ainb-notifyd over a Unix socket, surfacing as native OS banners, the ainb-tui Inbox screen, and the per-session waiting marker. Telemetry events are intentionally not hooked. Install via `/plugin install ainb-hooks@agents-in-a-box` (Claude); Codex wiring is handled by `ainb notifyd install`.",
+      "strict": false,
+      "keywords": [
+        "ainb",
+        "notifications",
+        "hooks",
+        "inbox",
+        "notifyd",
+        "claude-code",
+        "awaiting-input"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Root cause (why no notifications)

`ainb notifyd install` hand-drops the Claude plugin at `~/.claude/plugins/ainb-hooks/`. **Current Claude Code only loads plugins registered through a marketplace** (`installed_plugins.json` → `cache/<marketplace>/<plugin>/`), not by scanning that directory — so the dropped files were inert and the `Notification`/`Stop` hooks never fired (no OS banners, no Inbox rows). It worked months ago under an older Claude that scanned the dir; Claude has since moved to registry-based loading.

Verified: `installed_plugins.json` (version 2) had no `ainb-hooks`; the marketplace manifest listed only `reflect` + `ainb-fleet`; the daemon/socket/script all work end-to-end (proven by firing the hook manually). The only broken link was Claude never loading the plugin.

## Fix

Add `ainb-hooks` to `.claude-plugin/marketplace.json` (source `./plugins/ainb-hooks`, where the valid `plugin.json` already lives) — same mechanism `reflect`/`ainb-fleet` use. Now it's installable via the registry.

## To activate (after merge)
```bash
# in the main checkout (/Users/stevengonsalvez/d/git/ai-coder-rules):
git pull            # fast-forward main with this change
# then inside Claude:
/plugin marketplace update agents-in-a-box
/plugin install ainb-hooks@agents-in-a-box
# then RESTART your claude sessions (hooks load at session start)
```

Codex is unaffected — its `~/.codex/hooks.json` managed block is wired correctly and fires on its own.

## Follow-up (not in this PR)
`ainb notifyd install` should stop hand-dropping the inert Claude plugin dir (and/or register via the marketplace) — its current Claude path is dead on modern Claude Code. Tracked separately.