### PR TITLE
feat: ainb notifyd install registers the Claude plugin via the claude CLI (+ TUI status)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2777,23 +2777,42 @@ impl EventHandler {
                                     Some(AsyncAction::KillWorkspaceShell(workspace_idx));
                             }
                             crate::app::state::ConfirmAction::InstallNotifyHooks => {
-                                // Install the ainb-hooks plugin for both agents
-                                // in-process (ainb-core links ainb-plugin-notifyd).
-                                // Sync + fast — writes a few small files. The
-                                // daemon lazy-spawns on the first hook event.
+                                // Install the ainb-hooks plugin for both agents.
+                                // Codex + the canonical hook script are written
+                                // in-process; Claude is registered by shelling
+                                // out to `claude plugin install`. The daemon
+                                // lazy-spawns on the first hook event.
+                                use ainb_plugin_notifyd::ClaudeRegister;
                                 match ainb_plugin_notifyd::Paths::from_home().and_then(|p| {
                                     ainb_plugin_notifyd::install_for(
                                         &p,
                                         ainb_plugin_notifyd::Agent::ALL,
                                     )
                                 }) {
-                                    Ok(record) => {
-                                        state.add_info_notification(format!(
-                                            "Notifications enabled for {:?} — the Inbox (b) \
-                                             will light up when a session needs you.",
-                                            record.agents
-                                        ));
-                                    }
+                                    Ok(report) => match &report.claude {
+                                        Some(ClaudeRegister::Failed(e)) => {
+                                            state.add_error_notification(format!(
+                                                "Codex hooks installed, but the Claude plugin \
+                                                 failed to register: {e}"
+                                            ));
+                                        }
+                                        Some(ClaudeRegister::ClaudeCliMissing) => {
+                                            state.add_error_notification(
+                                                "Codex hooks installed, but `claude` CLI was not \
+                                                 found — Claude notifications not enabled. Install \
+                                                 it, then re-run."
+                                                    .to_string(),
+                                            );
+                                        }
+                                        _ => {
+                                            state.add_info_notification(
+                                                "Notifications enabled (Claude + Codex). Restart \
+                                                 your agent sessions to load the hooks; the Inbox \
+                                                 (b) lights up when a session needs you."
+                                                    .to_string(),
+                                            );
+                                        }
+                                    },
                                     Err(e) => {
                                         state.add_error_notification(format!(
                                             "Failed to install notification hooks: {e}"

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
@@ -10,7 +10,7 @@
 use anyhow::{Context, Result};
 use tracing::warn;
 
-use crate::install::Agent;
+use crate::install::{Agent, ClaudeRegister};
 use crate::{Paths, RunConfig, install_for, run_daemon, status, uninstall};
 
 /// Resolve the agent set from the three CLI flags. Empty selection or
@@ -64,14 +64,22 @@ pub fn cmd_stop() -> Result<()> {
 /// print the resolved on-disk paths.
 pub fn cmd_install(agents: &[Agent]) -> Result<()> {
     let paths = Paths::from_home()?;
-    let record = install_for(&paths, agents)?;
+    let report = install_for(&paths, agents)?;
+    let record = &report.record;
     println!("installed for: {:?}", record.agents);
     println!("hook script:   {}", record.hook_script.display());
-    if let Some(p) = &record.claude_plugin_dir {
-        println!("claude plugin: {}", p.display());
-    }
     if let Some(p) = &record.codex_hooks_json {
         println!("codex hooks:   {}", p.display());
+    }
+    match &report.claude {
+        Some(ClaudeRegister::Registered) => println!(
+            "claude plugin: registered (ainb-hooks@agents-in-a-box) — restart Claude to load it"
+        ),
+        Some(ClaudeRegister::ClaudeCliMissing) => {
+            println!("claude plugin: SKIPPED — `claude` CLI not found on PATH")
+        }
+        Some(ClaudeRegister::Failed(e)) => println!("claude plugin: FAILED — {e}"),
+        None => {}
     }
     Ok(())
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -19,6 +19,7 @@
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -144,12 +145,100 @@ pub fn extract_hook_script(paths: &Paths) -> Result<PathBuf> {
     Ok(dest)
 }
 
+/// Marketplace + plugin identifiers ainb-hooks is published under.
+const CLAUDE_PLUGIN_REF: &str = "ainb-hooks@agents-in-a-box";
+const CLAUDE_MARKETPLACE: &str = "agents-in-a-box";
+/// GitHub source used to register the marketplace on machines that don't
+/// already know it (e.g. a brew install with no repo checkout).
+const CLAUDE_MARKETPLACE_SOURCE: &str = "stevengonsalvez/agents-in-a-box";
+
+/// Outcome of registering the Claude plugin through the `claude` CLI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaudeRegister {
+    /// `claude plugin install` succeeded, or the plugin was already installed.
+    Registered,
+    /// The `claude` CLI is not on `PATH` — Claude wiring was skipped.
+    ClaudeCliMissing,
+    /// The CLI ran but failed; carries a short single-line reason.
+    Failed(String),
+}
+
+/// Report returned by [`install`]: the on-disk record, plus — when Claude
+/// was among the requested agents — the outcome of registering its plugin
+/// through the `claude` CLI (`None` when Claude was not requested).
+#[derive(Debug, Clone)]
+pub struct InstallReport {
+    /// The persisted install record (canonical script, codex wiring, etc.).
+    pub record: InstallRecord,
+    /// Claude marketplace-registration outcome, if Claude was targeted.
+    pub claude: Option<ClaudeRegister>,
+}
+
+/// First non-empty line of `stderr` (preferred) or `stdout`, trimmed and
+/// length-capped — for a tidy one-line status message.
+fn first_line(stderr: &[u8], stdout: &[u8]) -> String {
+    let pick = |b: &[u8]| {
+        String::from_utf8_lossy(b)
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .map(|l| l.chars().take(160).collect::<String>())
+    };
+    pick(stderr).or_else(|| pick(stdout)).unwrap_or_else(|| "unknown error".into())
+}
+
+/// Register the ainb-hooks plugin with Claude Code via its `claude plugin`
+/// CLI. Modern Claude only loads plugins from a registered marketplace, so
+/// dropping files under `~/.claude/plugins/` is inert — registration must
+/// go through the CLI. Best-effort + non-interactive; never panics.
+fn register_claude_plugin() -> ClaudeRegister {
+    // Probe for the CLI by listing marketplaces. A spawn error means
+    // `claude` is not on PATH.
+    let list = match Command::new("claude").args(["plugin", "marketplace", "list"]).output() {
+        Ok(o) => o,
+        Err(_) => return ClaudeRegister::ClaudeCliMissing,
+    };
+    // Register the marketplace only when Claude doesn't already know it —
+    // a local-directory source (a dev's repo checkout) must not be
+    // clobbered by adding the GitHub one.
+    let known = String::from_utf8_lossy(&list.stdout);
+    if !known.contains(CLAUDE_MARKETPLACE) {
+        let _ = Command::new("claude")
+            .args(["plugin", "marketplace", "add", CLAUDE_MARKETPLACE_SOURCE])
+            .output();
+    }
+    // Install (idempotent: an already-installed plugin counts as success).
+    match Command::new("claude").args(["plugin", "install", CLAUDE_PLUGIN_REF]).output() {
+        Ok(o) if o.status.success() => ClaudeRegister::Registered,
+        Ok(o) => {
+            let msg = first_line(&o.stderr, &o.stdout);
+            if msg.to_lowercase().contains("already") {
+                ClaudeRegister::Registered
+            } else {
+                ClaudeRegister::Failed(msg)
+            }
+        }
+        Err(e) => ClaudeRegister::Failed(e.to_string()),
+    }
+}
+
+/// Unregister the ainb-hooks plugin from Claude (mirror of
+/// [`register_claude_plugin`]). Best-effort; ignores all errors.
+fn unregister_claude_plugin() {
+    let _ = Command::new("claude").args(["plugin", "uninstall", CLAUDE_PLUGIN_REF]).output();
+}
+
 /// Install for one or more agents under the user's real `$HOME`.
-/// Idempotent — running install twice produces the same on-disk
-/// state. Tests use [`install_under_home`] with an explicit base.
-pub fn install(paths: &Paths, agents: &[Agent]) -> Result<InstallRecord> {
+///
+/// Does the file-based wiring (canonical hook script + Codex managed
+/// block + install record) via [`install_under_home`], then — if Claude
+/// was requested — registers the Claude plugin through the `claude` CLI
+/// and reports the outcome. Idempotent.
+pub fn install(paths: &Paths, agents: &[Agent]) -> Result<InstallReport> {
     let home = dirs::home_dir().context("resolving home dir")?;
-    install_under_home(paths, &home, agents)
+    let record = install_under_home(paths, &home, agents)?;
+    let claude = agents.contains(&Agent::Claude).then(register_claude_plugin);
+    Ok(InstallReport { record, claude })
 }
 
 /// Install variant that takes an explicit `$HOME` root. Lets tests
@@ -173,8 +262,12 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
     for agent in agents {
         match agent {
             Agent::Claude => {
-                let plugin_dir = install_claude(home, &hook_script)?;
-                record.claude_plugin_dir = Some(plugin_dir);
+                // Claude is wired through its plugin marketplace (see
+                // `register_claude_plugin`, invoked by `install`), NOT by
+                // dropping a plugin directory — modern Claude Code ignores
+                // unregistered dirs. Here we only record the agent and
+                // clear any legacy hand-dropped dir reference.
+                record.claude_plugin_dir = None;
                 push_unique(&mut record.agents, Agent::Claude);
             }
             Agent::Codex => {
@@ -274,36 +367,6 @@ fn push_unique<T: PartialEq>(v: &mut Vec<T>, item: T) {
     if !v.contains(&item) {
         v.push(item);
     }
-}
-
-/// Install Claude plugin: drop plugin.json + hook script into
-/// `<home>/.claude/plugins/ainb-hooks/`.
-fn install_claude(home: &Path, hook_script_canonical: &Path) -> Result<PathBuf> {
-    let plugin_dir = home.join(".claude").join("plugins").join("ainb-hooks");
-    let claude_plugin_meta = plugin_dir.join(".claude-plugin");
-    let claude_hooks_dir = plugin_dir.join("hooks");
-    std::fs::create_dir_all(&claude_plugin_meta)?;
-    std::fs::create_dir_all(&claude_hooks_dir)?;
-
-    // Drop the manifest verbatim — it references `${CLAUDE_PLUGIN_ROOT}`
-    // which Claude resolves at runtime.
-    std::fs::write(claude_plugin_meta.join("plugin.json"), CLAUDE_PLUGIN_JSON)?;
-
-    // Symlink the hook script into the plugin dir so a single edit to
-    // notify.sh propagates. On platforms where symlink fails (rare on
-    // POSIX) we fall back to a copy.
-    let claude_hook = claude_hooks_dir.join("notify.sh");
-    if claude_hook.exists() {
-        std::fs::remove_file(&claude_hook)?;
-    }
-    if std::os::unix::fs::symlink(hook_script_canonical, &claude_hook).is_err() {
-        std::fs::copy(hook_script_canonical, &claude_hook)?;
-        let mut perms = std::fs::metadata(&claude_hook)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&claude_hook, perms)?;
-    }
-    info!(plugin_dir = %plugin_dir.display(), "installed claude plugin");
-    Ok(plugin_dir)
 }
 
 /// Install Codex hooks: merge our managed block into
@@ -418,10 +481,15 @@ pub fn uninstall(paths: &Paths, agents: &[Agent]) -> Result<()> {
     for agent in agents {
         match agent {
             Agent::Claude => {
+                // Mirror of install: unregister the marketplace plugin via
+                // the `claude` CLI (best-effort).
+                unregister_claude_plugin();
+                // Legacy cleanup: remove a hand-dropped plugin dir left by
+                // older installs, if one is still recorded / present.
                 if let Some(dir) = record.claude_plugin_dir.take() {
                     if dir.exists() {
                         std::fs::remove_dir_all(&dir).with_context(|| {
-                            format!("removing claude plugin dir {}", dir.display())
+                            format!("removing legacy claude plugin dir {}", dir.display())
                         })?;
                     }
                 }
@@ -548,16 +616,23 @@ mod tests {
     }
 
     #[test]
-    fn install_claude_creates_plugin_dir_with_manifest() {
+    fn install_under_home_records_claude_without_dropping_a_dir() {
+        // Claude is wired via the marketplace CLI (done in `install`),
+        // not by dropping a plugin dir — so install_under_home must record
+        // the agent but leave `claude_plugin_dir` unset and create nothing
+        // under ~/.claude/plugins/.
         let dir = fake_home();
         let p = paths_under_home(dir.path());
         let record = install_under_home(&p, dir.path(), &[Agent::Claude]).unwrap();
-        let plugin_json =
-            record.claude_plugin_dir.as_ref().unwrap().join(".claude-plugin/plugin.json");
-        assert!(plugin_json.exists(), "missing: {}", plugin_json.display());
-        let manifest: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&plugin_json).unwrap()).unwrap();
-        assert_eq!(manifest["name"], "ainb-hooks");
+        assert!(record.agents.contains(&Agent::Claude));
+        assert!(
+            record.claude_plugin_dir.is_none(),
+            "must not drop a plugin dir"
+        );
+        assert!(
+            !dir.path().join(".claude/plugins/ainb-hooks").exists(),
+            "no hand-dropped plugin dir should be created"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -37,8 +37,9 @@ mod listener;
 pub use envelope::{Envelope, EnvelopeError};
 pub use fallback::FallbackFile;
 pub use install::{
-    Agent, InstallPrompt, InstallRecord, StatusRow, dismiss_prompt, embedded_plugin_version,
-    install as install_for, install_under_home, prompt_state, status, uninstall,
+    Agent, ClaudeRegister, InstallPrompt, InstallRecord, InstallReport, StatusRow, dismiss_prompt,
+    embedded_plugin_version, install as install_for, install_under_home, prompt_state, status,
+    uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
 pub use osnotify::AlertKind;


### PR DESCRIPTION
Fixes the install bug surfaced earlier: `ainb notifyd install` hand-dropped a Claude plugin dir that **modern Claude Code ignores** (it only loads marketplace-registered plugins), so the hooks never fired. Now the install actually registers Claude, and the TUI reports whether it worked.

## What changed
- **Claude wiring via the CLI**: `install()` now shells out to
  - `claude plugin marketplace add stevengonsalvez/agents-in-a-box` (only if the marketplace isn't already known — a dev's local-directory source isn't clobbered), then
  - `claude plugin install ainb-hooks@agents-in-a-box` (idempotent; "already installed" = success).
- **Status reported**: `install()` returns `InstallReport { record, claude: Option<ClaudeRegister> }` where `ClaudeRegister` ∈ `Registered | ClaudeCliMissing | Failed(reason)`.
  - **TUI** first-run prompt → success toast on `Registered`, **error toast** on `Failed`/`ClaudeCliMissing` (e.g. "`claude` CLI not found — Claude notifications not enabled").
  - **`ainb notifyd install`** prints a `claude plugin:` line (registered / SKIPPED / FAILED).
- **uninstall** mirrors it (`claude plugin uninstall …`) and still removes any legacy hand-dropped dir.
- Removed the dead `install_claude` dir-drop. `install_under_home` stays file-only (canonical script + Codex block + record) and fully testable — no `claude` CLI dependency in tests.

## Behaviour
```
ainb notifyd install
  ├─ canonical notify.sh + install.json        (file)
  ├─ Codex: managed block in ~/.codex/hooks.json (file)
  └─ Claude: claude plugin install ainb-hooks@agents-in-a-box  → ClaudeRegister
```
`claude` not on PATH → Codex still installs, Claude reported as skipped (no hard failure).

## Tests
- New `install_under_home_records_claude_without_dropping_a_dir` (no dir created, `claude_plugin_dir` unset).
- notifyd 54 lib + 14 install tests pass · ainb builds clean · `cargo fmt --all --check` clean · clippy clean on new code (CI doesn't gate clippy; verified locally).

## Note
`ainb notifyd status` still reports Claude `installed/hook_ok` from the record + canonical script (not from `claude plugin list`) — making it reflect *actual* Claude loading is a small follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error reporting for Claude plugin installation with specific feedback for registration failures and missing CLI tools.

* **Bug Fixes**
  * Improved Claude plugin registration and uninstall process for more reliable cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->