### PR TITLE
fix(tui): drive session [?]/[!]/[✓] marker from hook events, not idle state

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2451,6 +2451,17 @@ pub struct AppState {
     pub workspace_load_started: Option<Instant>,
     /// Channel receiver for background workspace loading results
     pub workspace_load_receiver: Option<mpsc::UnboundedReceiver<WorkspaceLoadResult>>,
+
+    /// Per-session "cleared up to" timestamp (epoch ms). A hook event
+    /// only marks a session if its `ts` is newer than this. Bumped to
+    /// "now" while the user is attached, so re-marking only happens for
+    /// activity that arrives after they look away. Defaults to
+    /// [`AppState::app_started_ms`] for sessions never attached.
+    pub attention_baseline: HashMap<Uuid, i64>,
+    /// Epoch ms captured at app start. Floors the attention query so
+    /// pre-existing notification history never lights up markers on
+    /// launch.
+    pub app_started_ms: i64,
 }
 
 /// Result of background workspace loading
@@ -2858,6 +2869,10 @@ impl Default for AppState {
             workspace_load_error: None,
             workspace_load_started: None,
             workspace_load_receiver: None,
+
+            // Per-session attention markers, driven by ainb-hooks events.
+            attention_baseline: HashMap::new(),
+            app_started_ms: chrono::Utc::now().timestamp_millis(),
         }
     }
 }
@@ -8150,21 +8165,153 @@ impl AppState {
         }
     }
 
-    /// Derive a session's live "needs you" marker from whether its agent
-    /// is actively generating.
+    /// The ainb-hooks `agent` string a session's events are recorded
+    /// under, or `None` for session types that don't emit hook events
+    /// (plain shell / SSH, and the not-yet-wired Gemini/Copilot/Kiro).
+    const fn agent_hook_name(agent: SessionAgentType) -> Option<&'static str> {
+        match agent {
+            SessionAgentType::Claude => Some("claude"),
+            SessionAgentType::Codex => Some("codex"),
+            _ => None,
+        }
+    }
+
+    /// Decide a single session's attention marker from recent hook
+    /// events. Pure + deterministic (no clock / IO) so it is directly
+    /// unit-testable.
     ///
-    /// Returns `Some(WaitingOnUser)` whenever the agent is NOT generating
-    /// (`claude_running == false`) — the session has ended its turn /
-    /// gone idle / parked at a prompt and is waiting on the user. It
-    /// clears the instant generation resumes. Intentionally broad: every
-    /// parked session reads as "needs you", which — with the `●` running
-    /// dot marking the busy ones — gives an at-a-glance view of exactly
-    /// which sessions are waiting for you across the fleet.
-    const fn live_attention_for(claude_running: bool) -> Option<ainb_plugin_notifyd::AlertKind> {
-        if claude_running {
-            None
-        } else {
-            Some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
+    /// `recent` MUST be newest-first (as [`Store::recent_since`] returns
+    /// it). The marker is the kind implied by the newest user-facing
+    /// event for this session's `(cwd, agent)` whose `ts` is strictly
+    /// newer than `baseline_ms` — unless the agent is currently
+    /// `generating` (suppressed; the `●` busy dot covers it) or the only
+    /// match is a `Finished` turn past its short TTL. Returns `None`
+    /// (blank — no marker) when nothing qualifies, which is the common
+    /// case for an idle session with no pending hook event.
+    fn attention_for_session(
+        session_cwd: &str,
+        agent: Option<&str>,
+        generating: bool,
+        baseline_ms: i64,
+        now_ms: i64,
+        recent: &[ainb_plugin_notifyd::NotificationRecord],
+    ) -> Option<ainb_plugin_notifyd::AlertKind> {
+        use ainb_plugin_notifyd::{AlertKind, classify_attention};
+        // A `[✓]` Finished marker is informational; retire it after this.
+        const FINISHED_TTL_MS: i64 = 5 * 60 * 1000;
+
+        if generating {
+            return None;
+        }
+        let agent = agent?;
+        let cwd = session_cwd.trim_end_matches('/');
+
+        for rec in recent {
+            // `recent` is newest-first and `ts`-sorted globally, so the
+            // first row at/under the baseline means none remain newer.
+            if rec.ts <= baseline_ms {
+                break;
+            }
+            if rec.agent != agent || rec.cwd.trim_end_matches('/') != cwd {
+                continue;
+            }
+            let Some(kind) = classify_attention(&rec.raw_event) else {
+                continue;
+            };
+            // Newest qualifying event wins. A long-finished turn isn't
+            // worth a marker — and it supersedes any older question, so
+            // we stop rather than fall back to a staler event.
+            if kind == AlertKind::Finished && now_ms.saturating_sub(rec.ts) > FINISHED_TTL_MS {
+                return None;
+            }
+            return Some(kind);
+        }
+        None
+    }
+
+    /// Recent user-facing hook events across the fleet, newest-first, or
+    /// `None` when the notifications store doesn't exist yet (daemon
+    /// never ran) or can't be read. Floored at app start so pre-existing
+    /// history never marks, and windowed so a long-lived TUI doesn't
+    /// accrue stale markers.
+    ///
+    /// Opens the store per call rather than holding a handle: the read
+    /// is microseconds, runs at most every preview-refresh interval
+    /// (~5s), and keeps the daemon as the DB's sole long-lived owner.
+    /// The `exists()` guard avoids `Store::open` creating an empty DB on
+    /// machines where notifications were never set up.
+    fn recent_attention_events(
+        &self,
+        now_ms: i64,
+    ) -> Option<Vec<ainb_plugin_notifyd::NotificationRecord>> {
+        // Ignore events older than this regardless of when the app started.
+        const LOOKBACK_MS: i64 = 6 * 60 * 60 * 1000;
+        // Bounds query cost; ample for any realistic active fleet.
+        const QUERY_LIMIT: u32 = 500;
+
+        let db = ainb_plugin_notifyd::Paths::from_home().ok()?.db;
+        if !db.exists() {
+            return None;
+        }
+        let store = ainb_plugin_notifyd::Store::open(&db).ok()?;
+        let floor = (now_ms - LOOKBACK_MS).max(self.app_started_ms);
+        match store.recent_since(floor, QUERY_LIMIT) {
+            Ok(rows) => Some(rows),
+            Err(e) => {
+                debug!("attention: notifications store read failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Recompute every session's attention marker (`[!]`/`[?]`/`[✓]`)
+    /// from recent ainb-hooks events. Attached sessions never nag and
+    /// have their baseline advanced to "now", so re-marking only happens
+    /// for activity that arrives after the user looks away.
+    fn refresh_attention_markers(&mut self, now_ms: i64) {
+        let Some(recent) = self.recent_attention_events(now_ms) else {
+            return;
+        };
+
+        // Phase 1 — read-only compute (no mutable borrow of self).
+        let mut marks: Vec<(Uuid, Option<ainb_plugin_notifyd::AlertKind>, bool)> = Vec::new();
+        for ws in &self.workspaces {
+            for s in &ws.sessions {
+                if s.is_attached {
+                    marks.push((s.id, None, true));
+                    continue;
+                }
+                let generating = matches!(s.status, crate::models::SessionStatus::Running);
+                let baseline =
+                    self.attention_baseline.get(&s.id).copied().unwrap_or(self.app_started_ms);
+                let kind = Self::attention_for_session(
+                    &s.workspace_path,
+                    Self::agent_hook_name(s.agent_type),
+                    generating,
+                    baseline,
+                    now_ms,
+                    &recent,
+                );
+                marks.push((s.id, kind, false));
+            }
+        }
+
+        // Phase 2 — apply. Bumping an attached session's baseline and
+        // writing its marker are separate self borrows, taken in turn.
+        let mut changed = false;
+        for (id, kind, attached) in marks {
+            if attached {
+                self.attention_baseline.insert(id, now_ms);
+            }
+            if let Some(s) = self.find_session_mut(id) {
+                if s.live_attention != kind {
+                    s.live_attention = kind;
+                    changed = true;
+                }
+            }
+        }
+        if changed {
+            self.ui_needs_refresh = true;
         }
     }
 
@@ -8184,9 +8331,11 @@ impl AppState {
         }
         self.last_preview_update = Some(now);
 
-        // updates: (session_id, content, claude_running, live_attention) for the selected session
+        // updates: (session_id, content, claude_running) for the selected session.
+        // Attention markers are derived separately from hook events in
+        // `refresh_attention_markers`, not from live pane state.
         let mut updates = Vec::new();
-        // status_updates: (session_id, claude_running, live_attention) for non-selected sessions
+        // status_updates: (session_id, claude_running) for non-selected sessions
         let mut status_updates = Vec::new();
         let detector = ClaudeProcessDetector::new();
 
@@ -8221,8 +8370,7 @@ impl AppState {
                 match capture_pane(tmux_session.name(), opts).await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);
-                        let attention = Self::live_attention_for(claude_running);
-                        updates.push((*session_id, content, claude_running, attention));
+                        updates.push((*session_id, content, claude_running));
                     }
                     Err(e) => {
                         debug!("Failed to capture selected session {}: {}", session_id, e);
@@ -8234,8 +8382,7 @@ impl AppState {
                 match tmux_session.capture_pane_content().await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);
-                        let attention = Self::live_attention_for(claude_running);
-                        status_updates.push((*session_id, claude_running, attention));
+                        status_updates.push((*session_id, claude_running));
                     }
                     Err(e) => {
                         trace!("Non-selected session {} capture skipped: {}", session_id, e);
@@ -8245,7 +8392,7 @@ impl AppState {
         }
 
         // Apply status-only updates for non-selected sessions
-        for (session_id, claude_running, attention) in status_updates {
+        for (session_id, claude_running) in status_updates {
             // Accumulate the change flag inside the session borrow, then
             // touch `self.ui_needs_refresh` only after it ends (avoids a
             // borrow conflict between `find_session_mut` and `self`).
@@ -8261,10 +8408,6 @@ impl AppState {
                     session.set_status(new_status);
                     changed = true;
                 }
-                if session.live_attention != attention {
-                    session.live_attention = attention;
-                    changed = true;
-                }
             }
             if changed {
                 self.ui_needs_refresh = true;
@@ -8273,7 +8416,7 @@ impl AppState {
 
         // Apply updates for the selected session (preview always changes,
         // so this loop unconditionally requests a refresh).
-        for (session_id, content, claude_running, attention) in updates {
+        for (session_id, content, claude_running) in updates {
             if let Some(session) = self.find_session_mut(session_id) {
                 session.set_preview(content);
 
@@ -8287,11 +8430,16 @@ impl AppState {
                 if session.status != new_status {
                     session.set_status(new_status);
                 }
-                session.live_attention = attention;
             }
 
             self.ui_needs_refresh = true;
         }
+
+        // Now that per-session running/idle status is current, recompute
+        // each session's attention marker (`[!]`/`[?]`/`[✓]`) from recent
+        // ainb-hooks events. Independent of pane capture, so it also
+        // covers sessions with no live pane (stopped / never-captured).
+        self.refresh_attention_markers(chrono::Utc::now().timestamp_millis());
 
         // Update shell session preview (only the selected workspace's shell)
         let selected_workspace_idx = self.selected_workspace_index;

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -707,26 +707,165 @@ mod tests {
     }
 
     // ========================================================================
-    // Live per-session attention marker (waiting = not generating)
+    // Per-session attention marker — derived from real ainb-hooks events
+    // (NeedsPermission `[!]` / WaitingOnUser `[?]` / Finished `[✓]`), not
+    // from "is the pane generating right now".
     // ========================================================================
 
+    /// Build a notification record for the marker tests. `recent` slices
+    /// passed to `attention_for_session` must be newest-first.
+    fn rec(
+        agent: &str,
+        cwd: &str,
+        raw_event: &str,
+        ts: i64,
+    ) -> ainb_plugin_notifyd::NotificationRecord {
+        ainb_plugin_notifyd::NotificationRecord {
+            id: format!("id-{ts}"),
+            ts,
+            agent: agent.into(),
+            session_id: format!("s-{ts}"),
+            cwd: cwd.into(),
+            project: cwd.rsplit('/').next().unwrap_or("").into(),
+            raw_event: raw_event.into(),
+            payload_json: "{}".into(),
+            read: false,
+            dismissed: false,
+        }
+    }
+
+    const NOW: i64 = 1_000_000_000;
+    const CWD: &str = "/work/feat-x";
+
     #[test]
-    fn live_attention_marks_any_idle_session() {
+    fn attention_permission_event_marks_needs_permission() {
         use ainb_plugin_notifyd::AlertKind;
-
-        // Not generating (turn ended / idle / parked at a prompt) →
-        // waiting on the user.
+        let recent = vec![rec("claude", CWD, "PermissionRequest", NOW - 1000)];
         assert_eq!(
-            AppState::live_attention_for(false),
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &recent),
+            Some(AlertKind::NeedsPermission),
+        );
+    }
+
+    #[test]
+    fn attention_notification_event_marks_waiting() {
+        use ainb_plugin_notifyd::AlertKind;
+        let recent = vec![rec("claude", CWD, "Notification:idle_prompt", NOW - 1000)];
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &recent),
             Some(AlertKind::WaitingOnUser),
-            "a not-generating session must show the waiting marker"
         );
+    }
 
-        // Actively generating → no marker; the `●` running dot covers it.
+    #[test]
+    fn attention_fresh_stop_marks_finished_stale_stop_clears() {
+        use ainb_plugin_notifyd::AlertKind;
+        let fresh = vec![rec("claude", CWD, "Stop", NOW - 1000)];
         assert_eq!(
-            AppState::live_attention_for(true),
-            None,
-            "an actively-generating session must not show a waiting marker"
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &fresh),
+            Some(AlertKind::Finished),
         );
+        // Older than the 5-minute Finished TTL → retired, no marker.
+        let stale = vec![rec("claude", CWD, "Stop", NOW - 6 * 60 * 1000)];
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &stale),
+            None,
+        );
+    }
+
+    #[test]
+    fn attention_suppressed_while_generating() {
+        let recent = vec![rec("claude", CWD, "PermissionRequest", NOW - 1000)];
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), true, 0, NOW, &recent),
+            None,
+            "a generating session shows the busy dot, not an attention marker",
+        );
+    }
+
+    #[test]
+    fn attention_blank_without_a_matching_event() {
+        // No events at all → blank (this is the common idle case the old
+        // "[?] on everything" behaviour got wrong).
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &[]),
+            None,
+        );
+        // Events exist, but for a different cwd or a different agent —
+        // must not bleed across sessions.
+        let other = vec![
+            rec("codex", CWD, "Notification", NOW - 50),
+            rec("claude", "/work/other", "Notification", NOW - 100),
+        ];
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &other),
+            None,
+        );
+    }
+
+    #[test]
+    fn attention_ignores_events_at_or_before_baseline() {
+        use ainb_plugin_notifyd::AlertKind;
+        let recent = vec![rec("claude", CWD, "Notification", 500)];
+        // Baseline at/after the event (e.g. user just attached) → cleared.
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 500, NOW, &recent),
+            None,
+        );
+        // Baseline just before the event → still marks.
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 499, NOW, &recent),
+            Some(AlertKind::WaitingOnUser),
+        );
+    }
+
+    #[test]
+    fn attention_newest_event_wins() {
+        use ainb_plugin_notifyd::AlertKind;
+        // Question asked, then the turn finished — newest (Stop) supersedes
+        // the older Notification.
+        let recent = vec![
+            rec("claude", CWD, "Stop", NOW - 1000),
+            rec("claude", CWD, "Notification", NOW - 5000),
+        ];
+        assert_eq!(
+            AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &recent),
+            Some(AlertKind::Finished),
+        );
+    }
+
+    #[test]
+    fn attention_none_agent_never_marks() {
+        // Shell / SSH session (no hook agent) → never a marker, even with
+        // a permission event sitting in the same cwd.
+        let recent = vec![rec("claude", CWD, "PermissionRequest", NOW - 1000)];
+        assert_eq!(
+            AppState::attention_for_session(CWD, None, false, 0, NOW, &recent),
+            None,
+        );
+    }
+
+    #[test]
+    fn attention_matches_cwd_ignoring_trailing_slash() {
+        use ainb_plugin_notifyd::AlertKind;
+        let recent = vec![rec("claude", "/work/feat-x/", "Notification", NOW - 100)];
+        assert_eq!(
+            AppState::attention_for_session("/work/feat-x", Some("claude"), false, 0, NOW, &recent),
+            Some(AlertKind::WaitingOnUser),
+        );
+    }
+
+    #[test]
+    fn agent_hook_name_maps_claude_and_codex_only() {
+        assert_eq!(
+            AppState::agent_hook_name(SessionAgentType::Claude),
+            Some("claude")
+        );
+        assert_eq!(
+            AppState::agent_hook_name(SessionAgentType::Codex),
+            Some("codex")
+        );
+        assert_eq!(AppState::agent_hook_name(SessionAgentType::Shell), None);
+        assert_eq!(AppState::agent_hook_name(SessionAgentType::Gemini), None);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -41,7 +41,7 @@ pub use install::{
     install as install_for, install_under_home, prompt_state, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
-pub use osnotify::AlertKind;
+pub use osnotify::{AlertKind, classify_attention};
 pub use paths::Paths;
 pub use pid::PidFile;
 pub use store::{NotificationRecord, RetentionPolicy, Store, StoreError};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -64,25 +64,9 @@ impl Debouncer {
 ///
 /// Returns `false` for telemetry / lifecycle events; `true` for
 /// events that signal "human attention needed" or "session ended".
+/// Equivalent to [`classify_attention`] returning `Some`.
 pub fn is_user_facing(env: &Envelope) -> bool {
-    // Codex variants and Claude variants for the same semantic
-    // event share the substring at the start of the raw event.
-    let evt = env.raw_event.as_str();
-    // Strip any matcher suffix (e.g. `Notification:idle_prompt`).
-    let head = evt.split(':').next().unwrap_or(evt);
-    matches!(
-        head,
-        "Stop"
-            | "Notification"
-            | "PermissionRequest"
-            | "agent-turn-complete"
-            | "task_complete"
-            | "request_user_input"
-            | "exec_approval_request"
-            | "apply_patch_approval_request"
-            | "wait_for_user"
-            | "permission_request"
-    )
+    classify_attention(&env.raw_event).is_some()
 }
 
 /// The attention state a hook event implies for the session that
@@ -97,6 +81,33 @@ pub enum AlertKind {
     WaitingOnUser,
     /// Agent finished its turn — informational, no action required.
     Finished,
+}
+
+/// Map a host agent's `raw_event` to the attention state it implies,
+/// or `None` for telemetry / lifecycle events that don't warrant a
+/// marker. This is the single source of truth for which hook events
+/// are "user-facing" — both [`is_user_facing`] (OS notifications) and
+/// the ainb-tui per-session marker classify through here so the two
+/// surfaces never drift apart.
+///
+/// Codex and Claude name the same semantic event differently; both
+/// variants map to the same [`AlertKind`]. A matcher suffix
+/// (e.g. `Notification:idle_prompt`) is stripped before matching.
+pub fn classify_attention(raw_event: &str) -> Option<AlertKind> {
+    let head = raw_event.split(':').next().unwrap_or(raw_event);
+    Some(match head {
+        // Blocked on an approval — most urgent.
+        "PermissionRequest"
+        | "permission_request"
+        | "exec_approval_request"
+        | "apply_patch_approval_request" => AlertKind::NeedsPermission,
+        // Asked the user something / idle awaiting input.
+        "Notification" | "request_user_input" | "wait_for_user" => AlertKind::WaitingOnUser,
+        // Turn ended — informational.
+        "Stop" | "agent-turn-complete" | "task_complete" => AlertKind::Finished,
+        // Telemetry / lifecycle (PreToolUse, PostToolUse, UserPromptSubmit, …).
+        _ => return None,
+    })
 }
 
 /// Render a short, human-readable title from an envelope.
@@ -241,6 +252,46 @@ mod tests {
         assert!(is_user_facing(&env("agent-turn-complete", "codex")));
         assert!(is_user_facing(&env("request_user_input", "codex")));
         assert!(is_user_facing(&env("exec_approval_request", "codex")));
+    }
+
+    #[test]
+    fn classify_attention_maps_each_kind() {
+        // Permission / approval (Claude + Codex) → NeedsPermission.
+        for e in [
+            "PermissionRequest",
+            "permission_request",
+            "exec_approval_request",
+            "apply_patch_approval_request",
+        ] {
+            assert_eq!(
+                classify_attention(e),
+                Some(AlertKind::NeedsPermission),
+                "{e}"
+            );
+        }
+        // Asked / awaiting input → WaitingOnUser.
+        for e in [
+            "Notification",
+            "Notification:idle_prompt",
+            "request_user_input",
+            "wait_for_user",
+        ] {
+            assert_eq!(classify_attention(e), Some(AlertKind::WaitingOnUser), "{e}");
+        }
+        // Turn ended → Finished.
+        for e in ["Stop", "agent-turn-complete", "task_complete"] {
+            assert_eq!(classify_attention(e), Some(AlertKind::Finished), "{e}");
+        }
+        // Telemetry / lifecycle → no marker.
+        for e in [
+            "PreToolUse",
+            "PostToolUse",
+            "UserPromptSubmit",
+            "SessionStart",
+            "",
+        ] {
+            assert_eq!(classify_attention(e), None, "{e}");
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
@@ -438,6 +438,47 @@ impl Store {
         )?;
         Ok(n as u64)
     }
+
+    /// Every non-dismissed notification with `ts > since_ms`, newest
+    /// first, capped at `limit`. Backs the ainb-tui per-session
+    /// attention marker: the TUI pulls recent hook activity in one
+    /// cheap read (the `ts` filter keeps it off the full table) and
+    /// classifies each row via
+    /// [`classify_attention`](crate::classify_attention) to decide the
+    /// `[!]` / `[?]` / `[✓]` marker for the originating session.
+    pub fn recent_since(
+        &self,
+        since_ms: i64,
+        limit: u32,
+    ) -> Result<Vec<NotificationRecord>, StoreError> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT id, ts, agent, session_id, cwd, project, raw_event, payload, read, dismissed
+             FROM notifications
+             WHERE ts > ?1 AND dismissed = 0
+             ORDER BY ts DESC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![since_ms, limit], |r| {
+            Ok(NotificationRecord {
+                id: r.get(0)?,
+                ts: r.get(1)?,
+                agent: r.get(2)?,
+                session_id: r.get(3)?,
+                cwd: r.get(4)?,
+                project: r.get(5)?,
+                raw_event: r.get(6)?,
+                payload_json: r.get(7)?,
+                read: r.get::<_, i64>(8)? != 0,
+                dismissed: r.get::<_, i64>(9)? != 0,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
 }
 
 #[cfg(test)]
@@ -522,6 +563,26 @@ mod tests {
         store.dismiss(&id).unwrap();
         assert_eq!(store.list(false, None, None, 10).unwrap().len(), 0);
         assert_eq!(store.list(true, None, None, 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn recent_since_filters_by_ts_and_skips_dismissed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("a.db")).unwrap();
+        store.insert(&env("claude", "Stop", 100)).unwrap();
+        store.insert(&env("claude", "Notification", 200)).unwrap();
+        let dismissed = store.insert(&env("claude", "PermissionRequest", 300)).unwrap();
+        store.dismiss(&dismissed).unwrap();
+
+        // `since` is exclusive: ts=100 is excluded, 200 included, 300 dismissed.
+        let rows = store.recent_since(100, 10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].ts, 200);
+        assert_eq!(rows[0].raw_event, "Notification");
+
+        // Newest-first ordering across the window.
+        let all = store.recent_since(0, 10).unwrap();
+        assert_eq!(all.iter().map(|r| r.ts).collect::<Vec<_>>(), vec![200, 100]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Every session row in the workspace list showed amber `[?]`. The marker was driven by `live_attention_for(claude_running)`:

```rust
if claude_running { None } else { Some(WaitingOnUser) }  // [?]
```

`claude_running` is true only while Claude's status bar/spinner is on screen *right now*. So **any** session not mid-generation — idle, parked at a prompt, detached, stopped, even plain shells — got `[?]`. A marker on 100% of rows carries zero information.

History: PR #199 moved the marker off the notifications store onto live pane state; PR #203 then broadened it to "every non-generating session" → the all-`[?]` screenshot.

## Fix — event-driven marker (hybrid)

The authoritative signal already exists on disk: ainb-hooks writes every hook event into `notifications.db` (`store.rs`), and `osnotify.rs` already classifies event → `AlertKind`. The marker just stopped reading it. This restores + fixes that.

```
 hook event (Stop/Notify/Perm)         pane scan (status bar)
        │                                      │
        ▼                                      ▼
   classify_attention                   generating? y/n
        │                                      │
        ▼                                      ▼
  ┌──────────────────┐   generating ──▶ suppress (● busy dot)
  │ per-cwd+agent     │   attached    ──▶ clear + baseline=now
  │ recent events     │
  └──────────────────┘
        ▼
  [!] perm   [?] waiting   [✓] done   (else blank)
```

### Status matrix (now)

| Session state | Marker | Source | Clears when |
|---|---|---|---|
| Blocked on permission/approval | `[!]` red | hook `PermissionRequest`/`exec_approval`/`apply_patch` | attach / agent resumes |
| Asked question / awaiting input | `[?]` amber | hook `Notification`/`wait_for_user`/`request_user_input` | attach / agent resumes |
| Turn finished | `[✓]` green | hook `Stop`/`agent-turn-complete`/`task_complete` | attach / 5-min TTL / next turn |
| Actively generating | — (busy `●`) | pane status bar | — |
| Idle, no pending event | **blank** | — | — |
| Stopped / detached / shell / non-agent | **blank** | — | — |

The key change: **idle-with-no-event is blank**, not `[?]`. The marker is sparse and meaningful again.

## How it works

- **`classify_attention(raw_event)`** (notifyd) — single source of truth for event→`AlertKind`; `is_user_facing` now delegates to it so the OS-notification filter and the TUI marker can't drift.
- **`Store::recent_since(ts, limit)`** (notifyd) — non-dismissed events newer than `ts`, newest-first.
- **`attention_for_session(cwd, agent, generating, baseline, now, recent)`** (core) — pure/deterministic; newest qualifying event for the session's `(cwd, agent)` wins; `Finished` retired after a 5-min TTL; suppressed while generating.
- Join key is `(workspace_path, agent_type)` ↔ store `(cwd, agent)` (trailing-slash tolerant). Recomputed every preview refresh (~5s), independent of pane capture so stopped sessions are covered. Store opened per refresh **only if the DB exists** — no daemon, no DB → markers stay blank (safe default) and the TUI never creates an empty DB.
- No render change: `session_list.rs` already renders all three kinds.

## Tests

- notifyd: `classify_attention_maps_each_kind`, `recent_since_filters_by_ts_and_skips_dismissed` (56 lib tests pass).
- core: replaced the old `live_attention_marks_any_idle_session` (encoded the bug) with a 10-case matrix — perm/waiting/finished, stale-finished TTL, suppressed-while-generating, blank-without-event, cross-session isolation, baseline cutoff, newest-wins, none-agent, trailing-slash join. All pass.
- `cargo build --workspace` ✓ · `cargo fmt --all --check` ✓ · clippy clean on changed code.

## Notes / scope

- Container-mode sessions (hook cwd = container path ≠ host worktree) won't match the cwd join — they stay blank. Acceptable for v1.
- Across a TUI restart, a pending `[?]` from before launch won't re-show until a new event arrives (app-start floor — deliberate, kills launch-time history noise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved attention marker detection by computing state from notification history instead of session state snapshots, enhancing accuracy and consistency.
  * Consolidated event classification logic to ensure uniform handling of permission requests, user input waits, and session completion markers.

* **Tests**
  * Expanded unit test coverage for attention state classification, including edge cases, event filtering, and timeline-based marker retirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->