### PR TITLE
fix(tui): enable paste in the New Session repo picker

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -91,6 +91,7 @@ pub enum AppEvent {
     // the legacy 13-step variants; only `NewSessionCancel` survives as the
     // host-level Esc handler for the `Creating` step.
     NewSessionCancel,
+    PickRepoPaste(String), // Append bracketed-paste text to the repo-picker filter (Cmd+V)
     // Notification events
     ShowNotification(String), // Display a notification message to the user
     // File finder events for @ symbol trigger
@@ -669,6 +670,18 @@ impl EventHandler {
     pub fn handle_paste_event(text: String, state: &AppState) -> Option<AppEvent> {
         if state.config_popup_state.is_text_entry() {
             return Some(AppEvent::ConfigPopupPaste(text));
+        }
+        // New Session repo picker: the filter field accepts pasted
+        // owner/repo, URLs and paths. Like the config popup it lives behind
+        // the host router, so a bracketed paste must be forwarded here or it
+        // is dropped (Cmd+V appeared to do nothing).
+        let on_pick_repo = state
+            .new_session_state
+            .as_ref()
+            .map(|s| s.step == crate::app::state::NewSessionStep::PickRepo)
+            .unwrap_or(false);
+        if on_pick_repo {
+            return Some(AppEvent::PickRepoPaste(text));
         }
         None
     }
@@ -1365,6 +1378,27 @@ impl EventHandler {
 
             return match outcome {
                 PickRepoOutcome::Stay => None,
+                PickRepoOutcome::PasteFromClipboard => {
+                    // Ctrl+V on the picker: read the OS clipboard here (app
+                    // layer owns clipboard access) and append to the filter.
+                    match Self::get_clipboard_text() {
+                        Ok(text) => {
+                            if let Some(pick) = state
+                                .new_session_state
+                                .as_mut()
+                                .and_then(|s| s.pick_repo_state.as_mut())
+                            {
+                                pick.append_filter(&text);
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("PickRepo clipboard paste failed: {}", e);
+                            state
+                                .add_error_notification(format!("Could not read clipboard: {}", e));
+                        }
+                    }
+                    None
+                }
                 PickRepoOutcome::BackToHome => {
                     // Persist session-defaults at the screen boundary
                     // (finding #3) so arrow/Esc no longer write on every
@@ -2274,6 +2308,13 @@ impl EventHandler {
             }
             AppEvent::NewSessionCancel => {
                 state.cancel_new_session();
+            }
+            AppEvent::PickRepoPaste(text) => {
+                if let Some(pick) =
+                    state.new_session_state.as_mut().and_then(|s| s.pick_repo_state.as_mut())
+                {
+                    pick.append_filter(&text);
+                }
             }
             AppEvent::ConfigureBack => {
                 // Phase 5: Esc on Configure persists the half-typed prompt to
@@ -5104,6 +5145,23 @@ mod text_input_guard_tests {
         let evt = EventHandler::handle_key_event(char_key('v'), &mut state)
             .expect("plain 'v' must dispatch a char input");
         assert!(matches!(evt, AppEvent::ConfigPopupInputChar('v')));
+    }
+
+    /// A bracketed paste (Cmd+V) on the New Session repo picker must be
+    /// forwarded to the filter, not dropped. Regression: `handle_paste_event`
+    /// only routed the config popup, so Cmd+V on PickRepo did nothing.
+    #[test]
+    fn bracketed_paste_on_pick_repo_routes_to_filter() {
+        let mut state = AppState::default();
+        state.current_screen = screen_ids::NEW_SESSION.to_string();
+        state.new_session_state = Some(NewSessionState {
+            step: NewSessionStep::PickRepo,
+            ..NewSessionState::default()
+        });
+
+        let evt = EventHandler::handle_paste_event("owner/repo".to_string(), &state)
+            .expect("paste on PickRepo must dispatch a filter paste");
+        assert!(matches!(evt, AppEvent::PickRepoPaste(ref t) if t == "owner/repo"));
     }
 
     /// Esc inside a text input while help is visible must close help,

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -674,12 +674,16 @@ impl EventHandler {
         // New Session repo picker: the filter field accepts pasted
         // owner/repo, URLs and paths. Like the config popup it lives behind
         // the host router, so a bracketed paste must be forwarded here or it
-        // is dropped (Cmd+V appeared to do nothing).
-        let on_pick_repo = state
-            .new_session_state
-            .as_ref()
-            .map(|s| s.step == crate::app::state::NewSessionStep::PickRepo)
-            .unwrap_or(false);
+        // is dropped (Cmd+V appeared to do nothing). Gate on the visible
+        // screen too — `new_session_state` can linger after navigating away
+        // (e.g. via the sidebar), and a paste must not leak into a hidden
+        // picker.
+        let on_pick_repo = state.current_screen == crate::app::screens::ids::NEW_SESSION
+            && state
+                .new_session_state
+                .as_ref()
+                .map(|s| s.step == crate::app::state::NewSessionStep::PickRepo)
+                .unwrap_or(false);
         if on_pick_repo {
             return Some(AppEvent::PickRepoPaste(text));
         }

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -92,6 +92,11 @@ pub enum PickRepoOutcome {
     /// Source needs an async clone before advancing. Phase 5 wires the
     /// spinner display; Phase 4 stops here.
     StartClone(RepoSource),
+    /// Ctrl+V pressed — the caller (events.rs) reads the OS clipboard and
+    /// appends it to the filter via `append_filter`. Clipboard access lives
+    /// in the app layer (`EventHandler::get_clipboard_text`), keeping this
+    /// component pure and testable.
+    PasteFromClipboard,
 }
 
 /// Persistent state for the picker. Constructed once per new-session
@@ -146,6 +151,19 @@ impl PickRepoState {
     pub fn highlighted(&self) -> Option<&PickRepoRow> {
         let idx = *self.filtered_indices.get(self.selected)?;
         self.rows.get(idx)
+    }
+
+    /// Append pasted text to the filter (clipboard paste — Ctrl+V or
+    /// bracketed `Event::Paste`). Control characters are stripped because the
+    /// filter is a single-line field; a pasted `owner/repo\n` should filter,
+    /// not submit. Refilters so the list (and Enter's smart-parse) reflect it.
+    pub fn append_filter(&mut self, text: &str) {
+        let cleaned: String = text.chars().filter(|c| !c.is_control()).collect();
+        if cleaned.is_empty() {
+            return;
+        }
+        self.filter.push_str(&cleaned);
+        self.refilter();
     }
 
     /// Recompute `filtered_indices` when filter or rows change. Preserves
@@ -543,6 +561,13 @@ pub fn handle_key(state: &mut PickRepoState, key: KeyEvent) -> PickRepoOutcome {
                 }
                 return PickRepoOutcome::Stay;
             }
+            KeyCode::Char('v' | 'V') => {
+                // Ctrl+V: ask the caller to read the OS clipboard and append
+                // it (Cmd+V / bracketed paste isn't delivered to this field
+                // in some terminals — tmux, mouse-capture).
+                tracing::debug!("pick_repo: ^V clipboard paste");
+                return PickRepoOutcome::PasteFromClipboard;
+            }
             _ => {}
         }
     }
@@ -863,5 +888,48 @@ mod tests {
         assert_eq!(abbreviate_home(&home), "~");
         let outside = Path::new("/opt/elsewhere/Rosetta");
         assert_eq!(abbreviate_home(outside), outside.display().to_string());
+    }
+
+    fn one_row() -> Vec<PickRepoRow> {
+        vec![PickRepoRow {
+            id: "shotclubhouse".into(),
+            label: "shotclubhouse".into(),
+            source: RepoSource::Filter("shotclubhouse".into()),
+            kind: RowKind::Favorite,
+        }]
+    }
+
+    #[test]
+    fn ctrl_v_requests_clipboard_paste() {
+        let mut s = mk_state_with_rows(one_row());
+        let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert_eq!(
+            handle_key(&mut s, ctrl_v),
+            PickRepoOutcome::PasteFromClipboard
+        );
+        // The keystroke must NOT also type a literal 'v' into the filter.
+        assert_eq!(s.filter, "");
+    }
+
+    #[test]
+    fn plain_v_still_types_into_filter() {
+        let mut s = mk_state_with_rows(one_row());
+        let v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE);
+        assert_eq!(handle_key(&mut s, v), PickRepoOutcome::Stay);
+        assert_eq!(s.filter, "v");
+    }
+
+    #[test]
+    fn append_filter_strips_control_chars_and_refilters() {
+        let mut s = mk_state_with_rows(one_row());
+        // Simulate a pasted "owner/repo" with a trailing newline.
+        s.append_filter("shotclub\n");
+        assert_eq!(s.filter, "shotclub");
+        // The single row still matches the prefix, so it stays visible.
+        assert_eq!(s.filtered_indices.len(), 1);
+        // A non-matching paste empties the filtered list.
+        s.append_filter("zzz");
+        assert_eq!(s.filter, "shotclubzzz");
+        assert_eq!(s.filtered_indices.len(), 0);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -158,9 +158,20 @@ impl PickRepoState {
     /// filter is a single-line field; a pasted `owner/repo\n` should filter,
     /// not submit. Refilters so the list (and Enter's smart-parse) reflect it.
     pub fn append_filter(&mut self, text: &str) {
-        let cleaned: String = text.chars().filter(|c| !c.is_control()).collect();
+        // Cap total filter length so a pathological clipboard payload can't
+        // bloat the field / stall refilter. A repo URL or path is well under
+        // this; anything larger is not a sensible picker query.
+        const MAX_FILTER_LEN: usize = 4096;
+        let mut cleaned: String = text.chars().filter(|c| !c.is_control()).collect();
         if cleaned.is_empty() {
             return;
+        }
+        let room = MAX_FILTER_LEN.saturating_sub(self.filter.chars().count());
+        if room == 0 {
+            return;
+        }
+        if cleaned.chars().count() > room {
+            cleaned = cleaned.chars().take(room).collect();
         }
         self.filter.push_str(&cleaned);
         self.refilter();


### PR DESCRIPTION
## Problem

The New Session repo picker ("type to filter, **or paste owner/repo** · https://… · ssh://… · /local/path") accepted **neither** paste route:

```
Cmd+V  ─▶ bracketed Event::Paste ─▶ handle_paste_event (only routed config popup) ─▶ ✗ dropped
Ctrl+V ─▶ pick_repo::handle_key ─▶ Char(c) guard excludes CONTROL ─▶ _ => Stay ─▶ ✗ no-op
```

So pasting a repo URL/owner/path into the field did nothing — despite the prompt explicitly inviting a paste. (The earlier paste work only fixed the Config popups; this is a separate surface.)

## Fix

- **Ctrl+V** → new `PickRepoOutcome::PasteFromClipboard`; the dispatcher reads the OS clipboard (`arboard`, app layer) and appends via `PickRepoState::append_filter`. Keeps the component pure/testable.
- **Bracketed paste (Cmd+V)** → `handle_paste_event` now forwards to `AppEvent::PickRepoPaste` when on the `PickRepo` step; `process_event` appends to the filter.
- `append_filter` strips control chars (single-line filter — a pasted `owner/repo\n` should filter, not submit) and refilters so the list + Enter's smart-parse reflect it.

## Tests

- `ctrl_v_requests_clipboard_paste` — Ctrl+V → `PasteFromClipboard`, no literal `v` typed.
- `plain_v_still_types_into_filter` — bare `v` still types.
- `append_filter_strips_control_chars_and_refilters` — strip + refilter behaviour.
- `bracketed_paste_on_pick_repo_routes_to_filter` — Cmd+V → `PickRepoPaste`.

All `pick_repo` tests green; binary compiles clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now paste repository names directly into the repo picker filter using Ctrl+V during new session creation.

* **Tests**
  * Added test coverage for clipboard paste behavior in the repository picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->