### PR TITLE
docs+tui: document notifications (markers, install) + first-run prompt says Claude-only

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5356,11 +5356,11 @@ impl AppState {
         let (title, message, install_label) = match prompt_state(&paths) {
             InstallPrompt::OfferInstall => (
                 "Get notified when a session needs you?".to_string(),
-                "Install ainb-hooks into Claude Code + Codex so the Inbox \
-                 (press b) and per-session badges light up when an agent is \
-                 awaiting input or has finished. Only actionable events are \
-                 captured — no activity-log noise. Writes ~/.claude/plugins \
-                 and ~/.codex/hooks.json."
+                "Install ainb-hooks so the Inbox (press b) and the per-session \
+                 badges light up when an agent is awaiting input ([?]) or has \
+                 finished ([✓]). Only actionable events are captured — no \
+                 activity-log noise. Works with Claude Code today (registered \
+                 via the claude CLI); Codex support is experimental."
                     .to_string(),
                 "Install",
             ),

--- a/docs/toolkit/plugins/ainb-hooks.md
+++ b/docs/toolkit/plugins/ainb-hooks.md
@@ -44,7 +44,7 @@ Deliberately **not** registered (telemetry / activity noise — would bury the s
 
 ## Install
 
-`ainb-hooks` is **not** installed via the marketplace the normal way (it is absent from the root `marketplace.json` plugins list). It is wired by the `ainb-notifyd` binary's installer, which handles the plugin manifest, the Codex config merge, and the notifyd lifecycle:
+`ainb-hooks` is published in the `agents-in-a-box` plugin marketplace, but you don't install it by hand — the `ainb-notifyd` binary's installer wires it for the chosen agents and manages the notifyd lifecycle:
 
 ```bash
 ainb-notifyd install --claude --codex
@@ -52,7 +52,7 @@ ainb-notifyd status
 ainb-notifyd uninstall --all
 ```
 
-The installer drops `plugin.json` at `~/.claude/plugins/ainb-hooks/` (Claude), merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block (Codex), extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh` and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path, and records the install method in `~/.agents-in-a-box/install.json` so uninstall is fully reversible.
+For **Claude**, the installer shells out to the `claude` plugin CLI — ensuring the `agents-in-a-box` marketplace is known, then `claude plugin install ainb-hooks@agents-in-a-box` (idempotent; "already installed" counts as success) — so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex**, it merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block, extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh`, and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path. The install method is recorded in `~/.agents-in-a-box/install.json` so uninstall is fully reversible (`claude plugin uninstall` for Claude, managed-block removal for Codex). **Claude is the verified path today; Codex is experimental.**
 
 > The plugin's README recommends a higher-level `ainb hooks install` wrapper; that `ainb hooks` CLI is planned but not yet on `main`, so use `ainb-notifyd install` (above) today.
 

--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -1,21 +1,23 @@
 ---
 title: "Inbox & notifications"
-description: "The ainb-tui Inbox screen + the ainb-notifyd daemon that captures Claude Code and Codex hook events into SQLite. Host code, not a plugin."
+description: "How ainb captures Claude Code / Codex hook events into the Inbox and the per-session [!]/[?]/[✓] status markers, via the ainb-notifyd daemon. Host code, not a plugin."
 ---
 
-The **Inbox** screen and the **`ainb-notifyd`** daemon are part of the `ainb` host binary — **not** an ainb plugin. This page documents them together because they are two halves of one feature: the daemon captures Claude Code / Codex lifecycle hook events into SQLite, and the Inbox screen (plus the per-session `●N` badges) renders them inside `ainb-tui`.
+The **Inbox** screen, the per-session **status markers** (`[!]` / `[?]` / `[✓]`), and the **`ainb-notifyd`** daemon are all part of the `ainb` host binary — **not** an ainb plugin. This page is the single reference for how notifications work: the daemon captures Claude Code / Codex lifecycle hook events into SQLite, and `ainb-tui` renders them two ways — the Inbox screen (full history) and a live per-session marker (the one row glyph that tells you a session needs you).
+
+> **Claude Code today.** Notifications and status markers are wired and verified for **Claude Code** (registered through the `claude` plugin CLI). Codex hooks are installed too, but Codex end-to-end delivery is **experimental** — treat the Inbox and markers as a Claude feature for now.
 
 > **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins — `burndown`, `session-reader`, `witr` — which run as spawned child processes over stdio JSON-RPC and are governed by the capability gate. The **only** plugin in this feature is [`ainb-hooks`](../toolkit/plugins/ainb-hooks.md), and that is a plugin of the *host agent* (Claude Code / Codex), installed into their config dirs — not a plugin of `ainb`.
 
 ![The Inbox screen in ainb-tui](../assets/screenshots/notifyd-inbox.png)
 
-*Press `I` (Shift+i) in ainb to open the Inbox — captured Claude Code / Codex lifecycle events with a list + detail pane, agent filter, and per-session unread badges.*
+*Press `b` in ainb to open the Inbox — captured Claude Code / Codex lifecycle events with a list + detail pane, agent filter, and per-session unread counts.*
 
 ## How it works
 
 ![Inbox & notifications — how it works](../assets/diagrams/notifyd.svg)
 
-The capture path starts outside ainb. The `ainb-hooks` plugin (a thin bash hook, `notify.sh`) is installed into Claude Code (`~/.claude/plugins/ainb-hooks/`) and Codex (`~/.codex/hooks.json`). It registers only the **actionable** lifecycle events — `Notification` (idle / awaiting-input + permission prompts) and `Stop` (turn finished). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
+The capture path starts outside ainb, in a thin bash hook (`notify.sh`). For **Claude Code** it is registered through the plugin marketplace — `ainb notifyd install` shells out to `claude plugin install ainb-hooks@agents-in-a-box`, so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex** a managed block is merged into `~/.codex/hooks.json` pointing at the canonical `~/.agents-in-a-box/hooks/notify.sh`. Either way only the **actionable** lifecycle events are registered — `Notification` (idle / awaiting-input + permission prompts) and `Stop` (turn finished). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
 
 Telemetry events (`SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`) are deliberately **not** hooked — `PostToolUse` alone fires dozens of times per turn and would bury the signal. So the inbox only ever contains things that need you.
 
@@ -23,7 +25,37 @@ Telemetry events (`SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact
 
 Storage is a dedicated SQLite database, `~/.agents-in-a-box/notifications.db`, opened in WAL mode so the daemon (writer) and TUI (reader) never block each other. It is intentionally separate from `session-reader`'s `usage.db` — different lifecycles, independent migrations. A retention sweep runs on every insert (default: prune rows older than 7 days, cap the table at 10,000 rows, oldest first).
 
-The render side lives in `ainb-core`. The **Inbox** screen (`components/inbox.rs`) holds a long-lived `Store` handle and re-queries SQLite on every render tick (cheap with WAL + `LIMIT 200`). It paints a two-pane list + detail view, and supports mark-read, dismiss, dismiss-all-visible, an archived toggle, and an agent filter. The Sessions screen also reads the store's `unread_by_cwd` grouping to draw a per-session `●N` unread badge, correlating an ainb session to its hook events by working directory. Because `notifyd` is in-tree, it reaches the filesystem, the socket, and the OS notifier directly — there is no JSON-RPC boundary, no `plugin/render` / `plugin/cli_dispatch`, and no `host/snapshot/publish`.
+The render side lives in `ainb-core`. The **Inbox** screen (`components/inbox.rs`) holds a long-lived `Store` handle and re-queries SQLite on every render tick (cheap with WAL + `LIMIT 200`). It paints a two-pane list + detail view, and supports mark-read, dismiss, dismiss-all-visible, an archived toggle, and an agent filter. Separately, the Sessions screen reads recent store events to draw a live per-session **status marker** (`[!]` / `[?]` / `[✓]`) on each session row — see [Per-session status markers](#per-session-status-markers) below. Because `notifyd` is in-tree, it reaches the filesystem, the socket, and the OS notifier directly — there is no JSON-RPC boundary, no `plugin/render` / `plugin/cli_dispatch`, and no `host/snapshot/publish`.
+
+## Per-session status markers
+
+The Inbox is the full history; the **status marker** is the at-a-glance signal. Every session row in the Sessions screen shows one marker (or nothing), recomputed from the same hook events so you can see across the whole fleet which sessions need you without opening the Inbox. It is **sparse by design** — a session with no pending event shows nothing.
+
+Both agents register the same two hooks (`Notification`, `Stop`), so in practice you see `[?]` and `[✓]`. The mapping (identical for Claude and Codex):
+
+### Claude Code
+
+| Hook fired | Marker | Means | Shows until |
+|------------|--------|-------|-------------|
+| `Notification` | `[?]` amber | awaiting input — asked a question, needs permission, or the prompt sat idle (~60s) | the agent resumes generating · you attach · a newer `Stop` supersedes it — **no TTL** |
+| `Stop` | `[✓]` green | turn finished — over to you | **5-minute TTL** · the agent resumes · you attach · a newer event |
+| *(none — Claude has no permission hook)* | `[!]` red | "blocked on approval" | **never shows today** — Claude folds permission into `Notification`, so a permission-block reads as `[?]` |
+| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry — deliberately not hooked | — |
+
+### Codex (experimental)
+
+| Hook fired | Marker | Means | Shows until |
+|------------|--------|-------|-------------|
+| `Notification` (aliases `request_user_input`, `wait_for_user`) | `[?]` amber | awaiting input | the agent resumes · you attach · a newer `Stop` supersedes — **no TTL** |
+| `Stop` (aliases `agent-turn-complete`, `task_complete`) | `[✓]` green | turn finished | **5-minute TTL** · resumes · attach |
+| `exec_approval_request` · `apply_patch_approval_request` | `[!]` red | blocked on exec/patch approval | mapped, but **not registered today** (only `Notification` + `Stop` are wired) |
+| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry — not hooked | — |
+
+While a session is **actively generating**, the marker is suppressed (the busy state covers it). The marker recomputes every **~5 s** (the preview-refresh tick), so every appear/clear lands on that cadence rather than instantly.
+
+**Does it clear when I answer?** Yes — answering a session (typing a prompt, or approving a permission) makes the agent start responding, and the marker clears on the next ~5 s refresh once it does. It clears via *the agent resuming*, not the keystroke itself, so there's a ≤5 s window between hitting enter and the marker disappearing. **Attaching** to a session clears it immediately and advances a per-session baseline to "now", so it won't re-mark until *new* activity arrives after you look away.
+
+Markers are matched to sessions by **working directory + agent**: each hook event carries the `cwd` it fired in, joined to the ainb session whose `workspace_path` matches (trailing-slash tolerant). Events older than the app's start are ignored, so pre-existing history never lights up markers on launch.
 
 ## Host resources it touches
 
@@ -34,7 +66,7 @@ Because this is host code, there is **no manifest and no capability declaration*
 | `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist captured envelopes; back the Inbox list and the unread badge. |
 | `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from the `ainb-hooks` script. |
 | `~/.agents-in-a-box/notify.pid`, `notify.fallback.jsonl` | Single-instance guard; recover events queued while the daemon was down. |
-| `~/.claude/plugins/ainb-hooks/`, `~/.codex/hooks.json` (read+write) | The `install` / `uninstall` verbs wire the hook into the host agents. |
+| `claude` CLI (subprocess), `~/.codex/hooks.json` (read+write), `~/.agents-in-a-box/hooks/notify.sh` | The `install` / `uninstall` verbs wire the hook into the host agents — Claude via `claude plugin install/uninstall`, Codex via a managed `hooks.json` block. |
 | `osascript` / `notify-send` (subprocess) | Emit the native OS notification for user-facing events. |
 
 ## Using it
@@ -42,7 +74,7 @@ Because this is host code, there is **no manifest and no capability declaration*
 - **Discoverability surfaces** — three places advertise the Inbox so users don't have to memorise a hidden shortcut:
   - The home screen sidebar lists `📥 Inbox  [b]` between Sessions and Recovery — press `Enter` on the tile, or `b` globally, to open it. (`b` for "in-**B**ox" — picked to avoid the case-pair confusion between `i` Stats and the earlier `I` Inbox binding.)
   - The bottom menu bar (every split-pane screen) always shows `b inbox`. When the store has unread + non-dismissed events the hint becomes `● N · b inbox`, so the global unread count is visible even when the Inbox screen is closed.
-  - The Sessions screen renders a `● N` row badge next to any session whose `workspace_path` matches a notification's `cwd` (exact equality or `workspace_path/`-prefix for worktree sub-directories). This is the primary surface — notifications are tied to the session that produced them, not a separate destination.
+  - The Sessions screen renders a live **status marker** (`[!]` / `[?]` / `[✓]`) on the row of any session with a pending hook event, matched by `cwd` ↔ `workspace_path`. This is the primary surface — notifications are tied to the session that produced them, not a separate destination. See [Per-session status markers](#per-session-status-markers).
 - **Inbox screen** — press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex), `r` force refresh, `q`/`Esc` back.
 - **cwd-based correlation (jump-to-tmux)** — every envelope carries the agent's `cwd` at hook-fire time, and every ainb `Session` carries a `workspace_path`. When the user presses `Enter` on an Inbox row, notifyd resolves the row's `cwd` to the first ainb workspace whose path matches (exact or `workspace_path/`-prefix to cover worktree subdirs), picks a session in that workspace, and queues an `AttachToOtherTmux` action with that session's `tmux_session_name`. There is no shared session-id namespace between the host agents' `session_id` strings and ainb's `Session.id` `Uuid`; the cwd is the bridge.
 - **Daemon + installer CLI** — the documented entrypoint is the standalone `ainb-notifyd` binary. The same verbs are also available as a **hidden `ainb notifyd …` subcommand** on the main `ainb` binary (it delegates to the identical `ainb_plugin_notifyd` functions). The hidden alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd` — the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
@@ -55,4 +87,4 @@ Because this is host code, there is **no manifest and no capability declaration*
 
 ## Source
 
-`crates/ainb-plugin-notifyd` — in-tree library + `ainb-notifyd` daemon binary: envelope wire format, the SQLite `Store`, the tokio listener, OS-notify dispatch, and the `ainb-hooks` install/uninstall logic. The Inbox screen itself lives in `crates/ainb-core/src/components/inbox.rs`. Diagram generated via /fireworks-tech-graph.
+`crates/ainb-plugin-notifyd` — in-tree library + `ainb-notifyd` daemon binary: envelope wire format, the SQLite `Store` (`recent_since` backs the markers), event→marker classification (`classify_attention`), the tokio listener, OS-notify dispatch, and the `ainb-hooks` install/uninstall logic (Claude via the `claude` CLI). The Inbox screen lives in `crates/ainb-core/src/components/inbox.rs`; the per-session marker logic (`attention_for_session` / `refresh_attention_markers`) lives in `crates/ainb-core/src/app/state.rs`. Diagram generated via /fireworks-tech-graph.


### PR DESCRIPTION
Follow-up to #205 (Claude plugin CLI registration) and #206 (event-driven `[!]`/`[?]`/`[✓]` markers): make the user-facing prompt and the docs reflect what actually ships, and call out that notifications are a Claude feature today.

## 1. First-run prompt — Claude-only callout (code)
`maybe_prompt_notify_install` copy now:
- names the real markers (`[?]` awaiting input, `[✓]` finished),
- says it's registered via the `claude` CLI,
- **"Works with Claude Code today; Codex support is experimental."**

Replaces the stale *"into Claude Code + Codex … Writes ~/.claude/plugins and ~/.codex/hooks.json"* line (that dir-drop install was replaced by `claude plugin install` in #205).

## 2. One notifications reference — `docs/tui/inbox-notifications.md`
This is the single doc for how notifications work, and it's already wired into the docsite sidebar (`astro.config.mjs` → "Inbox & notifications"), so the same file serves repo + site.
- **New "Per-session status markers" section** — Claude + Codex tables: hook → marker → meaning → *how long it shows / when it clears*, plus the "clears when the agent resumes, not on the keystroke" behaviour and the `cwd`+agent join.
- Replaced the stale per-row `●N` unread-badge text with the live status marker (the row badge is now the marker, not a count).
- Corrected the install path (Claude via `claude plugin install ainb-hooks@agents-in-a-box`; Codex via managed `hooks.json`).
- Added a **"Claude Code today, Codex experimental"** callout.
- Fixed the screenshot caption shortcut (`b`, not `Shift+i`).

## 3. `docs/toolkit/plugins/ainb-hooks.md` install currency
Updated the Install section: marketplace-published + `claude plugin install/uninstall` (was "not installed via the marketplace … drops plugin.json at ~/.claude/plugins/").

## Notes
- No plugin reload/update needed for any of this — it's a binary + docs change. Docsite re-renders on the next pages deploy.
- Build + `cargo fmt --all --check` clean; no test pins the prompt copy.