### PR TITLE
feat(tui): star stores remote indicator + sessions branch off remote default

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3359,50 +3359,70 @@ impl EventHandler {
                         ) {
                             Ok(fav) => {
                                 // Toggle off if already favorited — match on the
-                                // derived remote source, the alias, or a legacy
-                                // local-path entry for the same repo.
+                                // derived remote source, or a legacy local-path
+                                // entry for the same repo. NOT on alias: the alias
+                                // is folder-derived, so two distinct repos sharing
+                                // a folder name must not toggle each other off.
                                 let local_path_str = workspace_path.display().to_string();
                                 let existing = favorites_store
                                     .favorites
                                     .iter()
-                                    .find(|f| {
-                                        f.source == fav.source
-                                            || f.alias == alias
-                                            || f.source == local_path_str
-                                    })
+                                    .find(|f| f.source == fav.source || f.source == local_path_str)
                                     .map(|f| f.alias.clone());
 
                                 if let Some(existing_alias) = existing {
                                     favorites_store.remove(&existing_alias);
                                     if let Err(e) = favorites_store.save() {
                                         tracing::error!("Failed to save favorites: {}", e);
+                                        state.add_error_notification(format!(
+                                            "Could not update favorites: {e}"
+                                        ));
+                                    } else {
+                                        tracing::info!(
+                                            "Removed from favorites: {}",
+                                            existing_alias
+                                        );
+                                        state.add_success_notification(format!(
+                                            "★ Removed '{}' from favorites",
+                                            workspace_name
+                                        ));
                                     }
-                                    tracing::info!("Removed from favorites: {}", existing_alias);
-                                    state.add_success_notification(format!(
-                                        "★ Removed '{}' from favorites",
-                                        workspace_name
-                                    ));
                                 } else {
                                     let display_source = fav.source.clone();
                                     // Suffix the alias on collision so distinct
                                     // repos with the same folder name coexist.
-                                    if favorites_store.add(fav.clone()).is_err() {
+                                    let added = if favorites_store.add(fav.clone()).is_ok() {
+                                        true
+                                    } else {
                                         let mut suffixed = fav;
                                         suffixed.alias = format!(
                                             "{}-{}",
                                             alias,
                                             chrono::Utc::now().timestamp() % 1000
                                         );
-                                        let _ = favorites_store.add(suffixed);
-                                    }
-                                    if let Err(e) = favorites_store.save() {
+                                        favorites_store.add(suffixed).is_ok()
+                                    };
+                                    if !added {
+                                        tracing::warn!(
+                                            alias = %alias,
+                                            "could not add favorite (alias collision)"
+                                        );
+                                        state.add_error_notification(format!(
+                                            "★ Could not favorite '{}': alias already in use",
+                                            workspace_name
+                                        ));
+                                    } else if let Err(e) = favorites_store.save() {
                                         tracing::error!("Failed to save favorites: {}", e);
+                                        state.add_error_notification(format!(
+                                            "Could not save favorite: {e}"
+                                        ));
+                                    } else {
+                                        tracing::info!("Added to favorites: {}", display_source);
+                                        state.add_success_notification(format!(
+                                            "⭐ Added '{}' to favorites",
+                                            display_source
+                                        ));
                                     }
-                                    tracing::info!("Added to favorites: {}", display_source);
-                                    state.add_success_notification(format!(
-                                        "⭐ Added '{}' to favorites",
-                                        display_source
-                                    ));
                                 }
                             }
                             Err(e) => {

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1365,6 +1365,16 @@ impl EventHandler {
 
             return match outcome {
                 PickRepoOutcome::Stay => None,
+                PickRepoOutcome::Notice { message, is_error } => {
+                    // Favorite added/removed or a refusal (e.g. starring a repo
+                    // with no remote). Surface it and stay on the picker.
+                    if is_error {
+                        state.add_error_notification(message);
+                    } else {
+                        state.add_info_notification(message);
+                    }
+                    None
+                }
                 PickRepoOutcome::BackToHome => {
                     // Persist session-defaults at the screen boundary
                     // (finding #3) so arrow/Esc no longer write on every
@@ -3266,144 +3276,80 @@ impl EventHandler {
             AppEvent::StarSelectedWorkspace => {
                 tracing::info!("StarSelectedWorkspace event triggered");
                 if let Some(workspace_idx) = state.selected_workspace_index {
-                    if let Some(workspace) = state.workspaces.get(workspace_idx) {
-                        let workspace_name = workspace.name.clone();
-
-                        // Load favorites store
+                    // Clone the bits we need so the immutable borrow of `state`
+                    // ends before we notify (which borrows `state` mutably).
+                    if let Some((workspace_name, workspace_path)) = state
+                        .workspaces
+                        .get(workspace_idx)
+                        .map(|w| (w.name.clone(), w.path.clone()))
+                    {
                         let mut favorites_store = crate::config::FavoritesStore::load();
+                        let alias = workspace_name.to_lowercase().replace(' ', "-");
 
-                        // Try to get the remote URL from the git repository
-                        // This allows favoriting the REMOTE repo, not just the local path
-                        let (source, source_type, display_source) = if let Ok(git_repo) =
-                            crate::git::RepositoryManager::open(&workspace.path)
-                        {
-                            if let Ok(Some(remote_url)) = git_repo.get_remote_url() {
-                                // Parse the remote URL to get owner/repo.
-                                // `from_input` is deprecated for new
-                                // free-form input (finding #14), but the
-                                // URL here is already validated by
-                                // `get_remote_url()` so the legacy
-                                // fallible contract is fine.
-                                #[allow(deprecated)]
-                                if let Ok(repo_source) =
-                                    crate::git::RepoSource::from_input(&remote_url)
-                                {
-                                    if let Ok(parsed) = repo_source.parse_components() {
-                                        // Use GitHub shorthand if it's a GitHub repo
-                                        if parsed.host == "github.com" {
-                                            let shorthand =
-                                                format!("{}/{}", parsed.owner, parsed.repo_name);
-                                            (
-                                                shorthand.clone(),
-                                                crate::config::FavoriteSourceType::GithubShorthand,
-                                                shorthand,
-                                            )
-                                        } else {
-                                            // For other hosts, use the full URL
-                                            let source_type = if remote_url.starts_with("git@") {
-                                                crate::config::FavoriteSourceType::SshUrl
-                                            } else {
-                                                crate::config::FavoriteSourceType::HttpsUrl
-                                            };
-                                            let display =
-                                                format!("{}/{}", parsed.owner, parsed.repo_name);
-                                            (remote_url, source_type, display)
-                                        }
-                                    } else {
-                                        // Couldn't parse, use raw URL
-                                        let source_type = if remote_url.starts_with("git@") {
-                                            crate::config::FavoriteSourceType::SshUrl
-                                        } else {
-                                            crate::config::FavoriteSourceType::HttpsUrl
-                                        };
-                                        (remote_url.clone(), source_type, remote_url)
+                        // A star ALWAYS records the remote indicator. Derive it
+                        // from the repo's `origin`; refuse (no local-path
+                        // fallback) when there is no resolvable remote.
+                        match crate::config::favorite_from_local_repo(
+                            alias.clone(),
+                            &workspace_path,
+                        ) {
+                            Ok(fav) => {
+                                // Toggle off if already favorited — match on the
+                                // derived remote source, the alias, or a legacy
+                                // local-path entry for the same repo.
+                                let local_path_str = workspace_path.display().to_string();
+                                let existing = favorites_store
+                                    .favorites
+                                    .iter()
+                                    .find(|f| {
+                                        f.source == fav.source
+                                            || f.alias == alias
+                                            || f.source == local_path_str
+                                    })
+                                    .map(|f| f.alias.clone());
+
+                                if let Some(existing_alias) = existing {
+                                    favorites_store.remove(&existing_alias);
+                                    if let Err(e) = favorites_store.save() {
+                                        tracing::error!("Failed to save favorites: {}", e);
                                     }
+                                    tracing::info!("Removed from favorites: {}", existing_alias);
+                                    state.add_success_notification(format!(
+                                        "★ Removed '{}' from favorites",
+                                        workspace_name
+                                    ));
                                 } else {
-                                    // Fallback to local path
-                                    let path_str = workspace.path.display().to_string();
-                                    (
-                                        path_str.clone(),
-                                        crate::config::FavoriteSourceType::LocalPath,
-                                        path_str,
-                                    )
+                                    let display_source = fav.source.clone();
+                                    // Suffix the alias on collision so distinct
+                                    // repos with the same folder name coexist.
+                                    if favorites_store.add(fav.clone()).is_err() {
+                                        let mut suffixed = fav;
+                                        suffixed.alias = format!(
+                                            "{}-{}",
+                                            alias,
+                                            chrono::Utc::now().timestamp() % 1000
+                                        );
+                                        let _ = favorites_store.add(suffixed);
+                                    }
+                                    if let Err(e) = favorites_store.save() {
+                                        tracing::error!("Failed to save favorites: {}", e);
+                                    }
+                                    tracing::info!("Added to favorites: {}", display_source);
+                                    state.add_success_notification(format!(
+                                        "⭐ Added '{}' to favorites",
+                                        display_source
+                                    ));
                                 }
-                            } else {
-                                // No remote, use local path
-                                let path_str = workspace.path.display().to_string();
-                                (
-                                    path_str.clone(),
-                                    crate::config::FavoriteSourceType::LocalPath,
-                                    path_str,
-                                )
                             }
-                        } else {
-                            // Not a git repo, use local path
-                            let path_str = workspace.path.display().to_string();
-                            (
-                                path_str.clone(),
-                                crate::config::FavoriteSourceType::LocalPath,
-                                path_str,
-                            )
-                        };
-
-                        // Toggle: remove if exists, add if not
-                        // Check both source and local path for existing favorites
-                        let local_path_str = workspace.path.display().to_string();
-                        let existing = favorites_store
-                            .favorites
-                            .iter()
-                            .find(|f| f.source == source || f.source == local_path_str);
-
-                        if let Some(existing) = existing {
-                            let alias = existing.alias.clone();
-                            let removed_source = existing.source.clone();
-                            favorites_store.remove(&alias);
-                            if let Err(e) = favorites_store.save() {
-                                tracing::error!("Failed to save favorites: {}", e);
-                            }
-                            tracing::info!("Removed from favorites: {}", removed_source);
-                            state.add_success_notification(format!(
-                                "★ Removed '{}' from favorites",
-                                workspace_name
-                            ));
-                        } else {
-                            // Generate alias from workspace name
-                            let alias = workspace_name.to_lowercase().replace(' ', "-");
-                            let favorite = crate::config::Favorite::new(
-                                alias.clone(),
-                                source.clone(),
-                                source_type.clone(),
-                            );
-                            if favorites_store.add(favorite).is_ok() {
-                                if let Err(e) = favorites_store.save() {
-                                    tracing::error!("Failed to save favorites: {}", e);
-                                }
-                                tracing::info!("Added to favorites: {} as {}", source, alias);
-                                state.add_success_notification(format!(
-                                    "⭐ Added '{}' to favorites",
-                                    display_source
-                                ));
-                            } else {
-                                // Alias already exists, try with a suffix
-                                let alias_with_suffix =
-                                    format!("{}-{}", alias, chrono::Utc::now().timestamp() % 1000);
-                                let favorite = crate::config::Favorite::new(
-                                    alias_with_suffix.clone(),
-                                    source.clone(),
-                                    source_type,
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    path = %workspace_path.display(),
+                                    "refusing to favorite: no remote indicator"
                                 );
-                                let _ = favorites_store.add(favorite);
-                                if let Err(e) = favorites_store.save() {
-                                    tracing::error!("Failed to save favorites: {}", e);
-                                }
-                                tracing::info!(
-                                    "Added to favorites: {} as {}",
-                                    source,
-                                    alias_with_suffix
-                                );
-                                state.add_success_notification(format!(
-                                    "⭐ Added '{}' to favorites",
-                                    display_source
+                                state.add_error_notification(format!(
+                                    "★ Can't favorite '{}': {}",
+                                    workspace_name, e
                                 ));
                             }
                         }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5853,6 +5853,20 @@ impl AppState {
             snapshot.mode
         );
 
+        // Remote sources (every star is now remote, plus typed URLs / shorthand)
+        // branch their worktree off the remote's DEFAULT branch (origin/HEAD),
+        // freshly fetched — never a stale local `main` or the cache's checked-out
+        // HEAD. Local-path picks keep the legacy `get_default_branch` flow
+        // (`existing_worktree = None`).
+        let existing_worktree = if snapshot.repo_source.is_remote() {
+            match self.prepare_remote_worktree(session_id, &repo_path, &snapshot).await {
+                Ok(ew) => Some(ew),
+                Err(()) => return, // already notified + cancelled
+            }
+        } else {
+            None
+        };
+
         let result = self
             .create_session_with_logs(
                 &repo_path,
@@ -5864,7 +5878,7 @@ impl AppState {
                 snapshot.agent_type,
                 snapshot.session_model,
                 snapshot.codex_model,
-                None, // existing_worktree — local-only path for now
+                existing_worktree,
             )
             .await;
 
@@ -5884,6 +5898,59 @@ impl AppState {
             Err(e) => {
                 error!("Failed to create session via configure flow: {}", e);
                 self.cancel_new_session();
+            }
+        }
+    }
+
+    /// Build a worktree for a remote/star launch, branched off the remote's
+    /// default branch (`origin/HEAD`) of the freshly-fetched cache. Returns
+    /// `(worktree_path, source_repo_path)` for the `existing_worktree` arg of
+    /// `create_session_with_logs`. On failure: notifies + cancels the
+    /// new-session flow and returns `Err(())`.
+    ///
+    /// Runs on `spawn_blocking` because the `git` CLI calls are synchronous.
+    async fn prepare_remote_worktree(
+        &mut self,
+        session_id: uuid::Uuid,
+        cache_path: &std::path::Path,
+        snapshot: &ConfigureLaunchSnapshot,
+    ) -> Result<(std::path::PathBuf, std::path::PathBuf), ()> {
+        use crate::git::{RemoteRepoManager, WorktreeManager};
+
+        let cache = cache_path.to_path_buf();
+        let branch = snapshot.branch_name.clone();
+        let source = snapshot.repo_source.clone();
+
+        let join = tokio::task::spawn_blocking(
+            move || -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+                let wt_manager =
+                    WorktreeManager::new().map_err(|e| format!("worktree manager init: {e}"))?;
+                let worktree_path = wt_manager
+                    .generate_worktree_path(session_id, &cache, &branch)
+                    .map_err(|e| format!("worktree path: {e}"))?;
+                let remote_manager =
+                    RemoteRepoManager::new().map_err(|e| format!("remote manager init: {e}"))?;
+                remote_manager
+                    .create_worktree_off_remote_default(&cache, &worktree_path, &branch, &source)
+                    .map_err(|e| format!("{e}"))?;
+                Ok((worktree_path, cache))
+            },
+        )
+        .await;
+
+        match join {
+            Ok(Ok(paths)) => Ok(paths),
+            Ok(Err(msg)) => {
+                tracing::error!(error = %msg, "prepare_remote_worktree failed");
+                self.add_error_notification(format!("Could not prepare worktree off main: {msg}"));
+                self.cancel_new_session();
+                Err(())
+            }
+            Err(join_err) => {
+                tracing::error!(error = %join_err, "prepare_remote_worktree task panicked");
+                self.add_error_notification(format!("Worktree task panicked: {join_err}"));
+                self.cancel_new_session();
+                Err(())
             }
         }
     }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5873,14 +5873,20 @@ impl AppState {
         // freshly fetched — never a stale local `main` or the cache's checked-out
         // HEAD. Local-path picks keep the legacy `get_default_branch` flow
         // (`existing_worktree = None`).
-        let existing_worktree = if snapshot.repo_source.is_remote() {
-            match self.prepare_remote_worktree(session_id, &repo_path, &snapshot).await {
-                Ok(ew) => Some(ew),
-                Err(()) => return, // already notified + cancelled
-            }
-        } else {
-            None
-        };
+        //
+        // Gated to Interactive mode: only `create_interactive_session` consumes
+        // `existing_worktree`. Boss mode (`create_boss_session`) ignores it and
+        // builds its own Docker request from `repo_path`, so preparing a worktree
+        // there would orphan it on disk and leave a stray cache branch.
+        let existing_worktree =
+            if snapshot.repo_source.is_remote() && snapshot.mode == SessionMode::Interactive {
+                match self.prepare_remote_worktree(session_id, &repo_path, &snapshot).await {
+                    Ok(ew) => Some(ew),
+                    Err(()) => return, // already notified + cancelled
+                }
+            } else {
+                None
+            };
 
         let result = self
             .create_session_with_logs(

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -92,6 +92,20 @@ pub enum PickRepoOutcome {
     /// Source needs an async clone before advancing. Phase 5 wires the
     /// spinner display; Phase 4 stops here.
     StartClone(RepoSource),
+    /// Surface a transient message to the user (favorite added/removed, or a
+    /// refusal) and stay on the picker. The dispatcher maps `is_error` to an
+    /// error vs. info notification.
+    Notice { message: String, is_error: bool },
+}
+
+/// Result of toggling a favorite — drives the `^F` notification.
+enum FavoriteToggle {
+    /// Newly favorited; carries the stored remote source for display.
+    Added(String),
+    /// Un-favorited; carries the row label for display.
+    Removed(String),
+    /// Refused because the row has no remote repository indicator.
+    Refused(String),
 }
 
 /// Persistent state for the picker. Constructed once per new-session
@@ -537,9 +551,28 @@ pub fn handle_key(state: &mut PickRepoState, key: KeyEvent) -> PickRepoOutcome {
             KeyCode::Char('f' | 'F') => {
                 tracing::debug!("pick_repo: ^F toggle favorite on highlighted row");
                 if let Some(row) = state.highlighted().cloned() {
-                    toggle_favorite(state, &row);
-                    let local_repos = collect_local_repo_paths(state);
-                    state.rebuild_rows(&local_repos);
+                    return match toggle_favorite(state, &row) {
+                        FavoriteToggle::Refused(reason) => PickRepoOutcome::Notice {
+                            message: format!("★ Can't favorite: {reason}"),
+                            is_error: true,
+                        },
+                        FavoriteToggle::Added(display) => {
+                            let local_repos = collect_local_repo_paths(state);
+                            state.rebuild_rows(&local_repos);
+                            PickRepoOutcome::Notice {
+                                message: format!("⭐ Added '{display}' to favorites"),
+                                is_error: false,
+                            }
+                        }
+                        FavoriteToggle::Removed(display) => {
+                            let local_repos = collect_local_repo_paths(state);
+                            state.rebuild_rows(&local_repos);
+                            PickRepoOutcome::Notice {
+                                message: format!("★ Removed '{display}' from favorites"),
+                                is_error: false,
+                            }
+                        }
+                    };
                 }
                 return PickRepoOutcome::Stay;
             }
@@ -636,37 +669,58 @@ fn resolve_outcome(source: RepoSource) -> PickRepoOutcome {
 /// (mutating `state.favorites`) AND the on-disk YAML so the change survives
 /// across TUI restarts.
 ///
-/// Finding #1 sub-issue: refuses to persist when the row's source is
-/// `Filter` — writing `SourceType::LocalPath` with the alias-string as the
-/// path silently corrupts `favorites.yaml`. Pre-fix this only mattered for
-/// recents (which used Filter as a leaky "unknown provenance" carrier);
-/// post-fix the picker always reconstructs a real variant via
-/// `recent_source`, so a Filter source here is genuinely unparseable input
-/// that should not be persisted.
-fn toggle_favorite(state: &mut PickRepoState, row: &PickRepoRow) {
+/// A favorite ALWAYS records a remote indicator. Remote rows store directly;
+/// a `LocalPath` row is resolved to its `origin` remote via
+/// [`favorite_from_local_repo`] (refused if it has none). `SshSession`
+/// (interactive, not a repo) and `Filter` (unparseable text) rows are refused
+/// outright — never persisted.
+fn toggle_favorite(state: &mut PickRepoState, row: &PickRepoRow) -> FavoriteToggle {
     if state.favorites.has_alias(&row.id) {
         state.favorites.remove(&row.id);
-    } else {
-        let (source_str, source_type) = match &row.source {
-            RepoSource::HttpsUrl(u) => (u.clone(), SourceType::HttpsUrl),
-            RepoSource::SshUrl(u) => (u.clone(), SourceType::SshUrl),
-            RepoSource::GithubShorthand { owner, repo } => {
-                (format!("{owner}/{repo}"), SourceType::GithubShorthand)
-            }
-            RepoSource::LocalPath(p) => (p.display().to_string(), SourceType::LocalPath),
-            RepoSource::SshSession(s) => (s.clone(), SourceType::SshUrl),
-            RepoSource::Filter(s) => {
-                tracing::warn!(
-                    alias = %row.id,
-                    text = %s,
-                    "pick_repo: refusing to favorite a Filter row — no real source provenance",
-                );
-                return;
-            }
-        };
-        let fav = Favorite::new(row.id.clone(), source_str, source_type);
-        state.favorites.set(fav);
+        persist_favorites(state);
+        return FavoriteToggle::Removed(row.label.clone());
     }
+
+    let fav = match &row.source {
+        RepoSource::HttpsUrl(u) => Favorite::new(row.id.clone(), u.clone(), SourceType::HttpsUrl),
+        RepoSource::SshUrl(u) => Favorite::new(row.id.clone(), u.clone(), SourceType::SshUrl),
+        RepoSource::GithubShorthand { owner, repo } => Favorite::new(
+            row.id.clone(),
+            format!("{owner}/{repo}"),
+            SourceType::GithubShorthand,
+        ),
+        RepoSource::LocalPath(p) => {
+            match crate::config::favorite_from_local_repo(row.id.clone(), p) {
+                Ok(fav) => fav,
+                Err(e) => {
+                    tracing::warn!(
+                        alias = %row.id,
+                        path = %p.display(),
+                        error = %e,
+                        "pick_repo: refusing to favorite local row — no remote indicator",
+                    );
+                    return FavoriteToggle::Refused(e.to_string());
+                }
+            }
+        }
+        RepoSource::SshSession(s) | RepoSource::Filter(s) => {
+            tracing::warn!(
+                alias = %row.id,
+                text = %s,
+                "pick_repo: refusing to favorite — not a remote repository indicator",
+            );
+            return FavoriteToggle::Refused("not a remote repository".to_string());
+        }
+    };
+
+    let display = fav.source.clone();
+    state.favorites.set(fav);
+    persist_favorites(state);
+    FavoriteToggle::Added(display)
+}
+
+/// Persist the favorites store to disk, logging (but not failing) on error.
+fn persist_favorites(state: &PickRepoState) {
     if let Err(err) = state.favorites.save() {
         tracing::warn!(error = %err, "pick_repo: failed to persist favorites");
     }

--- a/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
+++ b/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
@@ -1,10 +1,14 @@
 // ABOUTME: Persistent storage for repository favorites
-// Stores favorites in ~/.claude/favorites.yaml for quick access to frequently-used repos
+// Stores favorites in ~/.agents-in-a-box/favorites.yaml for quick access to
+// frequently-used repos. A favorite ALWAYS records a remote indicator (an
+// HTTPS/SSH URL or `owner/repo` shorthand) — never a local path. Local-path
+// entries from older versions are rewritten to their `origin` remote (or
+// dropped) by `migrate_local_to_remote`.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Source type for a favorite repository
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -257,11 +261,262 @@ impl FavoritesStore {
     pub fn total_uses(&self) -> u64 {
         self.favorites.iter().map(|f| f.stats.use_count).sum()
     }
+
+    /// Rewrite any legacy `LocalPath` favorites to their `origin` remote
+    /// indicator, dropping the ones whose path has no resolvable remote.
+    ///
+    /// Idempotent: a store that already contains only remote entries returns an
+    /// empty [`MigrationReport`] and is left untouched. The caller is
+    /// responsible for persisting (`save`) when the returned report is
+    /// non-empty.
+    pub fn migrate_local_to_remote(&mut self) -> MigrationReport {
+        let mut report = MigrationReport::default();
+        let mut keep: Vec<Favorite> = Vec::with_capacity(self.favorites.len());
+
+        for fav in std::mem::take(&mut self.favorites) {
+            if fav.source_type != SourceType::LocalPath {
+                keep.push(fav);
+                continue;
+            }
+            match favorite_from_local_repo(fav.alias.clone(), Path::new(&fav.source)) {
+                Ok(remote) => {
+                    // Preserve user-facing metadata + stats; only the source
+                    // pointer changes.
+                    let migrated = Favorite {
+                        alias: fav.alias.clone(),
+                        source_type: remote.source_type,
+                        source: remote.source.clone(),
+                        display_name: fav.display_name,
+                        description: fav.description,
+                        tags: fav.tags,
+                        metadata: fav.metadata,
+                        stats: fav.stats,
+                    };
+                    report.migrated.push((fav.alias, remote.source));
+                    keep.push(migrated);
+                }
+                Err(_) => {
+                    report.dropped.push(fav.alias);
+                }
+            }
+        }
+
+        self.favorites = keep;
+        report
+    }
+}
+
+/// Why deriving a remote favorite from a local repo failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeriveFavoriteError {
+    /// The path is not a git repository (or could not be opened).
+    NotAGitRepo,
+    /// The repository has no `origin` remote.
+    NoRemote,
+    /// The remote URL could not be classified as a clonable remote source.
+    Unparseable(String),
+}
+
+impl std::fmt::Display for DeriveFavoriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAGitRepo => write!(f, "not a git repository"),
+            Self::NoRemote => write!(f, "no git remote (origin) found"),
+            Self::Unparseable(url) => write!(f, "unrecognised remote URL: {url}"),
+        }
+    }
+}
+
+/// Summary of a `migrate_local_to_remote` pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MigrationReport {
+    /// `(alias, new_source)` for each local-path favorite rewritten to remote.
+    pub migrated: Vec<(String, String)>,
+    /// Aliases of local-path favorites dropped for having no resolvable remote.
+    pub dropped: Vec<String>,
+}
+
+impl MigrationReport {
+    /// True when nothing was migrated or dropped (store left untouched).
+    pub fn is_empty(&self) -> bool {
+        self.migrated.is_empty() && self.dropped.is_empty()
+    }
+}
+
+/// Derive a remote [`Favorite`] from a local repository path by reading its
+/// `origin` remote. Returns an error (and stores nothing) when the path is not
+/// a git repo, has no `origin`, or whose remote URL can't be classified.
+///
+/// This is the single source of truth for the "a star is always a remote
+/// indicator" rule — both star entry points and the startup migration call it.
+pub fn favorite_from_local_repo(
+    alias: String,
+    local_path: &Path,
+) -> Result<Favorite, DeriveFavoriteError> {
+    let repo = crate::git::RepositoryManager::open(local_path)
+        .map_err(|_| DeriveFavoriteError::NotAGitRepo)?;
+    let url = match repo.get_remote_url() {
+        Ok(Some(url)) if !url.trim().is_empty() => url,
+        _ => return Err(DeriveFavoriteError::NoRemote),
+    };
+    let (source, source_type) =
+        classify_remote_url(&url).ok_or_else(|| DeriveFavoriteError::Unparseable(url.clone()))?;
+    Ok(Favorite::new(alias, source, source_type))
+}
+
+/// Classify an `origin` URL into a `(source_string, SourceType)` pair, or
+/// `None` if it isn't a shareable remote (e.g. a bare local path origin).
+///
+/// GitHub hosts collapse to `owner/repo` shorthand for nicer display; every
+/// other host keeps its full URL. SSH (`git@host:` / `ssh://`) maps to
+/// `SshUrl`, anything else with a scheme maps to `HttpsUrl`.
+fn classify_remote_url(url: &str) -> Option<(String, SourceType)> {
+    use crate::git::RepoSource;
+
+    let is_ssh = url.starts_with("git@") || url.starts_with("ssh://");
+    let source = if is_ssh {
+        RepoSource::SshUrl(url.to_string())
+    } else if url.contains("://") {
+        RepoSource::HttpsUrl(url.to_string())
+    } else {
+        // No scheme and not SSH shorthand → a local/path origin, not shareable.
+        return None;
+    };
+
+    // Prefer GitHub shorthand when the host resolves to github.com.
+    if let Ok(parsed) = source.parse_components() {
+        if parsed.host == "github.com" && !parsed.owner.is_empty() {
+            return Some((
+                format!("{}/{}", parsed.owner, parsed.repo_name),
+                SourceType::GithubShorthand,
+            ));
+        }
+    }
+
+    match source {
+        RepoSource::HttpsUrl(u) => Some((u, SourceType::HttpsUrl)),
+        RepoSource::SshUrl(u) => Some((u, SourceType::SshUrl)),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Create a git repo at `dir` with `origin` pointing at `url`.
+    fn init_repo_with_remote(dir: &Path, url: &str) {
+        let repo = git2::Repository::init(dir).expect("git init");
+        repo.remote("origin", url).expect("add origin");
+    }
+
+    #[test]
+    fn favorite_from_local_repo_github_https_becomes_shorthand() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo_with_remote(tmp.path(), "https://github.com/anthropics/claude-code.git");
+        let fav = favorite_from_local_repo("cc".into(), tmp.path()).unwrap();
+        assert_eq!(fav.source_type, SourceType::GithubShorthand);
+        assert_eq!(fav.source, "anthropics/claude-code");
+    }
+
+    #[test]
+    fn favorite_from_local_repo_github_ssh_becomes_shorthand() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo_with_remote(tmp.path(), "git@github.com:anthropics/claude-code.git");
+        let fav = favorite_from_local_repo("cc".into(), tmp.path()).unwrap();
+        assert_eq!(fav.source_type, SourceType::GithubShorthand);
+        assert_eq!(fav.source, "anthropics/claude-code");
+    }
+
+    #[test]
+    fn favorite_from_local_repo_non_github_keeps_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo_with_remote(tmp.path(), "https://gitlab.com/group/proj.git");
+        let fav = favorite_from_local_repo("p".into(), tmp.path()).unwrap();
+        assert_eq!(fav.source_type, SourceType::HttpsUrl);
+        assert_eq!(fav.source, "https://gitlab.com/group/proj.git");
+    }
+
+    #[test]
+    fn favorite_from_local_repo_no_origin_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        git2::Repository::init(tmp.path()).unwrap(); // repo, but no origin
+        assert!(matches!(
+            favorite_from_local_repo("x".into(), tmp.path()),
+            Err(DeriveFavoriteError::NoRemote)
+        ));
+    }
+
+    #[test]
+    fn favorite_from_local_repo_not_a_repo_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            favorite_from_local_repo("x".into(), tmp.path()),
+            Err(DeriveFavoriteError::NotAGitRepo)
+        ));
+    }
+
+    #[test]
+    fn migrate_noop_when_all_remote() {
+        let mut store = FavoritesStore::default();
+        store
+            .add(Favorite::new(
+                "cc".into(),
+                "anthropics/claude-code".into(),
+                SourceType::GithubShorthand,
+            ))
+            .unwrap();
+        let report = store.migrate_local_to_remote();
+        assert!(report.is_empty());
+        assert_eq!(store.len(), 1);
+        assert_eq!(
+            store.get("cc").unwrap().source_type,
+            SourceType::GithubShorthand
+        );
+    }
+
+    #[test]
+    fn migrate_rewrites_localpath_with_origin() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo_with_remote(tmp.path(), "https://github.com/anthropics/claude-code.git");
+
+        let mut store = FavoritesStore::default();
+        let mut fav = Favorite::new(
+            "cc".into(),
+            tmp.path().display().to_string(),
+            SourceType::LocalPath,
+        );
+        fav.tags = vec!["keep-me".into()];
+        fav.stats.use_count = 7;
+        store.add(fav).unwrap();
+
+        let report = store.migrate_local_to_remote();
+        assert_eq!(report.dropped.len(), 0);
+        assert_eq!(report.migrated.len(), 1);
+
+        let migrated = store.get("cc").unwrap();
+        assert_eq!(migrated.source_type, SourceType::GithubShorthand);
+        assert_eq!(migrated.source, "anthropics/claude-code");
+        // Metadata + stats preserved across the rewrite.
+        assert_eq!(migrated.tags, vec!["keep-me".to_string()]);
+        assert_eq!(migrated.stats.use_count, 7);
+    }
+
+    #[test]
+    fn migrate_drops_localpath_without_remote() {
+        let tmp = tempfile::tempdir().unwrap(); // not a git repo
+        let mut store = FavoritesStore::default();
+        store
+            .add(Favorite::new(
+                "orphan".into(),
+                tmp.path().display().to_string(),
+                SourceType::LocalPath,
+            ))
+            .unwrap();
+        let report = store.migrate_local_to_remote();
+        assert_eq!(report.dropped, vec!["orphan".to_string()]);
+        assert!(store.is_empty());
+    }
 
     #[test]
     fn test_favorite_creation() {

--- a/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
+++ b/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
@@ -194,22 +194,23 @@ impl FavoritesStore {
         })
     }
 
-    /// Write a one-time backup of the current store before the destructive
-    /// local→remote migration overwrites `favorites.yaml`. No-op if a backup
-    /// already exists (idempotent across restarts), so the original is never
-    /// clobbered by a second migration pass.
-    pub fn write_migration_backup(&self) -> Result<(), std::io::Error> {
-        if let Some(path) = Self::migration_backup_path() {
-            if path.exists() {
-                return Ok(());
-            }
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let content = serde_yaml::to_string(self)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-            fs::write(path, content)?;
+    /// Write a one-time backup of the on-disk store before the destructive
+    /// local→remote migration overwrites `favorites.yaml`. Copies the raw file
+    /// (preserving comments/formatting) rather than re-serializing. No-op if a
+    /// backup already exists (idempotent across restarts) or there is nothing
+    /// on disk yet, so the original is never clobbered by a later pass.
+    pub fn write_migration_backup() -> Result<(), std::io::Error> {
+        let (src, dst) = match (Self::storage_path(), Self::migration_backup_path()) {
+            (Some(s), Some(d)) => (s, d),
+            _ => return Ok(()),
+        };
+        if dst.exists() || !src.exists() {
+            return Ok(());
         }
+        if let Some(parent) = dst.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&src, &dst)?;
         Ok(())
     }
 

--- a/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
+++ b/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
@@ -185,6 +185,34 @@ impl FavoritesStore {
         Ok(())
     }
 
+    /// Path of the one-time pre-migration backup (`favorites.yaml.pre-remote-migration.bak`).
+    fn migration_backup_path() -> Option<PathBuf> {
+        Self::storage_path().map(|p| {
+            let mut s = p.into_os_string();
+            s.push(".pre-remote-migration.bak");
+            PathBuf::from(s)
+        })
+    }
+
+    /// Write a one-time backup of the current store before the destructive
+    /// local→remote migration overwrites `favorites.yaml`. No-op if a backup
+    /// already exists (idempotent across restarts), so the original is never
+    /// clobbered by a second migration pass.
+    pub fn write_migration_backup(&self) -> Result<(), std::io::Error> {
+        if let Some(path) = Self::migration_backup_path() {
+            if path.exists() {
+                return Ok(());
+            }
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let content = serde_yaml::to_string(self)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            fs::write(path, content)?;
+        }
+        Ok(())
+    }
+
     /// Get a favorite by alias
     pub fn get(&self, alias: &str) -> Option<&Favorite> {
         self.favorites.iter().find(|f| f.alias == alias)
@@ -365,21 +393,24 @@ pub fn favorite_from_local_repo(
 }
 
 /// Classify an `origin` URL into a `(source_string, SourceType)` pair, or
-/// `None` if it isn't a shareable remote (e.g. a bare local path origin).
+/// `None` if it isn't a shareable remote.
 ///
 /// GitHub hosts collapse to `owner/repo` shorthand for nicer display; every
 /// other host keeps its full URL. SSH (`git@host:` / `ssh://`) maps to
-/// `SshUrl`, anything else with a scheme maps to `HttpsUrl`.
+/// `SshUrl`; `http(s)://` maps to `HttpsUrl`. Anything else — a bare local
+/// path, or a non-shareable scheme such as `file://` — returns `None` so the
+/// caller refuses the favorite.
 fn classify_remote_url(url: &str) -> Option<(String, SourceType)> {
     use crate::git::RepoSource;
 
     let is_ssh = url.starts_with("git@") || url.starts_with("ssh://");
+    let is_https = url.starts_with("http://") || url.starts_with("https://");
     let source = if is_ssh {
         RepoSource::SshUrl(url.to_string())
-    } else if url.contains("://") {
+    } else if is_https {
         RepoSource::HttpsUrl(url.to_string())
     } else {
-        // No scheme and not SSH shorthand → a local/path origin, not shareable.
+        // Bare local path, `file://`, or any other non-shareable scheme.
         return None;
     };
 
@@ -435,6 +466,17 @@ mod tests {
         let fav = favorite_from_local_repo("p".into(), tmp.path()).unwrap();
         assert_eq!(fav.source_type, SourceType::HttpsUrl);
         assert_eq!(fav.source, "https://gitlab.com/group/proj.git");
+    }
+
+    #[test]
+    fn favorite_from_local_repo_file_url_refused() {
+        // A `file://` origin is machine-local, not a shareable remote → refused.
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo_with_remote(tmp.path(), "file:///srv/git/proj.git");
+        assert!(matches!(
+            favorite_from_local_repo("p".into(), tmp.path()),
+            Err(DeriveFavoriteError::Unparseable(_))
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -21,7 +21,10 @@ pub mod session_defaults;
 pub mod ssh_display_names;
 
 pub use container::{ContainerTemplate, ContainerTemplateConfig};
-pub use favorites_store::{Favorite, FavoritesStore, SourceType as FavoriteSourceType};
+pub use favorites_store::{
+    DeriveFavoriteError, Favorite, FavoritesStore, MigrationReport,
+    SourceType as FavoriteSourceType, favorite_from_local_repo,
+};
 pub use mcp::{McpInitStrategy, McpServerConfig};
 pub use mcp_init::{McpInitResult, McpInitializer, apply_mcp_init_result};
 pub use onboarding::OnboardingConfig;

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -402,12 +402,15 @@ impl RemoteRepoManager {
         }
         let _ = Command::new("git").args(["worktree", "prune"]).current_dir(cache_path).output();
 
+        // Use `-B` (force create/reset) on retry: the first `-b` attempt may have
+        // already created `new_branch` before failing at the checkout stage, so a
+        // second `-b` would abort with "already exists".
         let retry = Command::new("git")
             .args([
                 "worktree",
                 "add",
                 "--no-checkout",
-                "-b",
+                "-B",
                 new_branch,
                 wt.as_ref(),
                 start_point,
@@ -445,8 +448,9 @@ impl RemoteRepoManager {
 
     /// Checkout an existing remote branch into a worktree
     ///
-    /// Unlike create_worktree_from_cache which creates a new local branch,
-    /// this creates a local tracking branch for an existing remote branch.
+    /// Unlike `create_worktree_off_remote_default`, which cuts a NEW branch from
+    /// the remote default, this creates a local tracking branch for an existing
+    /// remote branch.
     /// Uses -B flag to handle the case where the branch is already checked
     /// out in the cache (standard clone has default branch checked out).
     /// Returns `Ok(None)` if worktree was created at the provided path,

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -241,177 +241,205 @@ impl RemoteRepoManager {
         Ok(())
     }
 
-    /// Create a worktree from a cached standard clone
+    /// Create a worktree for a NEW branch cut from the remote's **default**
+    /// branch (`origin/HEAD`), after a fresh fetch.
     ///
-    /// For standard clones, refs are in refs/remotes/origin/{branch},
-    /// so we use origin/{base_branch} to create the new branch.
-    pub fn create_worktree_from_cache(
+    /// This is the base-branch policy for sessions launched from a star (a
+    /// remote source): the agent branch (`agents/...`) is always based on the
+    /// freshly-fetched default ref — never a stale local branch and never the
+    /// cache's currently-checked-out HEAD. Handles `main`/`master`/`develop`
+    /// defaults transparently and retries with a filter bypass when transcrypt
+    /// (or any smudge/clean filter) aborts the checkout.
+    pub fn create_worktree_off_remote_default(
         &self,
         cache_path: &Path,
         worktree_path: &Path,
-        branch_name: &str,
-        base_branch: &str,
-    ) -> Result<(), RemoteRepoError> {
-        info!(
-            "Creating worktree at {} for branch {} (base: {})",
-            worktree_path.display(),
-            branch_name,
-            base_branch
-        );
-
-        // Create parent directory for worktree
+        new_branch: &str,
+        source: &RepoSource,
+    ) -> Result<PathBuf, RemoteRepoError> {
         if let Some(parent) = worktree_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Check if the new branch already exists locally
+        // Refresh remote refs so origin/<default> reflects upstream. Defensive:
+        // clone_repo already fetches on cache reuse, but a directly-supplied
+        // cache may be stale. Non-fatal — we can still branch off whatever
+        // origin/<default> currently points at.
+        let _ = Command::new("git")
+            .args(["fetch", "origin", "--prune"])
+            .current_dir(cache_path)
+            .output();
+
+        let default_branch = self.resolve_default_branch(cache_path, source)?;
+        let start_point = format!("origin/{default_branch}");
+        info!(
+            "Creating worktree at {} for new branch '{}' off {}",
+            worktree_path.display(),
+            new_branch,
+            start_point
+        );
+
+        // Guard against an existing local branch of the same name. Agent branch
+        // names are freshly derived, so this should not happen; fail loudly
+        // rather than silently reusing a stale local branch.
         let branch_exists = Command::new("git")
-            .args(["rev-parse", "--verify", branch_name])
+            .args(["rev-parse", "--verify", "--quiet", new_branch])
             .current_dir(cache_path)
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false);
-
-        if !branch_exists {
-            // Standard clone has refs in refs/remotes/origin/{branch}
-            // Use origin/{base_branch} shorthand
-            let base_ref = format!("origin/{}", base_branch);
-
-            // Verify the remote branch exists
-            let ref_check = Command::new("git")
-                .args(["rev-parse", "--verify", &base_ref])
-                .current_dir(cache_path)
-                .output()?;
-
-            if !ref_check.status.success() {
-                // Get list of available remote branches for better error message
-                let branches_output = Command::new("git")
-                    .args(["branch", "-r"])
-                    .current_dir(cache_path)
-                    .output()
-                    .ok();
-                let available = branches_output
-                    .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-                    .unwrap_or_default();
-                let branch_list: Vec<&str> = available
-                    .lines()
-                    .map(|s| s.trim())
-                    .filter(|s| !s.is_empty() && !s.contains("->"))
-                    .collect();
-
-                return Err(RemoteRepoError::InvalidRepo(format!(
-                    "Base branch 'origin/{}' not found. Available branches: {}",
-                    base_branch,
-                    if branch_list.is_empty() {
-                        "(none)".to_string()
-                    } else {
-                        branch_list.join(", ")
-                    }
-                )));
-            }
-
-            // Create new local branch from the remote tracking branch
-            let output = Command::new("git")
-                .args(["branch", branch_name, &base_ref])
-                .current_dir(cache_path)
-                .output()?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                // Branch might already exist, which is okay
-                if !stderr.contains("already exists") {
-                    return Err(RemoteRepoError::InvalidRepo(format!(
-                        "Failed to create branch '{}': {}",
-                        branch_name, stderr
-                    )));
-                }
-            }
+        if branch_exists {
+            return Err(RemoteRepoError::InvalidRepo(format!(
+                "branch '{}' already exists in cache {}",
+                new_branch,
+                cache_path.display()
+            )));
         }
 
-        // Create the worktree - try normal first, fallback to --no-checkout if filters fail
-        let output = Command::new("git")
-            .args([
-                "worktree",
-                "add",
-                worktree_path.to_string_lossy().as_ref(),
-                branch_name,
-            ])
-            .current_dir(cache_path)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-
-            // Check if failure is due to smudge/clean filter (e.g., transcrypt)
-            if stderr.contains("smudge filter") || stderr.contains("clean filter") {
-                warn!(
-                    "Worktree creation failed due to filter issue, retrying with --no-checkout: {}",
-                    stderr
-                );
-
-                // Clean up any partial worktree that might have been created
-                if worktree_path.exists() {
-                    let _ = std::fs::remove_dir_all(worktree_path);
-                }
-
-                // Retry with --no-checkout to skip the problematic filter
-                let retry_output = Command::new("git")
-                    .args([
-                        "worktree",
-                        "add",
-                        "--no-checkout",
-                        worktree_path.to_string_lossy().as_ref(),
-                        branch_name,
-                    ])
-                    .current_dir(cache_path)
-                    .output()?;
-
-                if !retry_output.status.success() {
-                    let retry_stderr = String::from_utf8_lossy(&retry_output.stderr);
-                    return Err(RemoteRepoError::CloneFailed(format!(
-                        "Failed to create worktree (even with --no-checkout): {}",
-                        retry_stderr
-                    )));
-                }
-
-                // Checkout files with filter bypass (transcrypt uses 'crypt' filter)
-                let checkout_output = Command::new("git")
-                    .args([
-                        "-c",
-                        "filter.crypt.smudge=cat",
-                        "-c",
-                        "filter.crypt.clean=cat",
-                        "checkout",
-                        "--force",
-                    ])
-                    .current_dir(worktree_path)
-                    .output()?;
-
-                if !checkout_output.status.success() {
-                    let checkout_stderr = String::from_utf8_lossy(&checkout_output.stderr);
-                    warn!(
-                        "Checkout with filter bypass had issues: {}",
-                        checkout_stderr
-                    );
-                    // Continue anyway - the worktree exists, files just might not be checked out
-                }
-
-                info!(
-                    "Created worktree with filter bypass at: {}",
-                    worktree_path.display()
-                );
-            } else {
-                return Err(RemoteRepoError::CloneFailed(format!(
-                    "Failed to create worktree: {}",
-                    stderr
-                )));
-            }
-        }
-
+        self.worktree_add_new_branch(cache_path, worktree_path, new_branch, &start_point)?;
         info!(
             "Successfully created worktree at: {}",
             worktree_path.display()
         );
+        Ok(worktree_path.to_path_buf())
+    }
+
+    /// Resolve the remote's default branch name (no `origin/` prefix) for a
+    /// cached clone. Order: the cache's `origin/HEAD` symbolic-ref (set by
+    /// `git clone`), then the remote's advertised HEAD (`ls-remote --symref`),
+    /// then a probe of `origin/main` / `origin/master`.
+    fn resolve_default_branch(
+        &self,
+        cache_path: &Path,
+        source: &RepoSource,
+    ) -> Result<String, RemoteRepoError> {
+        // 1. Cache-local origin/HEAD symbolic-ref (offline, reflects the clone).
+        if let Ok(out) = Command::new("git")
+            .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+            .current_dir(cache_path)
+            .output()
+        {
+            if out.status.success() {
+                let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if let Some(branch) = s.strip_prefix("origin/") {
+                    if !branch.is_empty() {
+                        return Ok(branch.to_string());
+                    }
+                }
+            }
+        }
+
+        // 2. Remote-advertised HEAD (authoritative, but needs connectivity).
+        if let Some(branch) = self.get_default_branch_name(source) {
+            if !branch.is_empty() {
+                return Ok(branch);
+            }
+        }
+
+        // 3. Probe the common defaults in the cache.
+        for cand in ["main", "master"] {
+            let ok = Command::new("git")
+                .args([
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    &format!("origin/{cand}"),
+                ])
+                .current_dir(cache_path)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            if ok {
+                return Ok(cand.to_string());
+            }
+        }
+
+        Err(RemoteRepoError::InvalidRepo(format!(
+            "could not resolve default branch (origin/HEAD) in cache {}",
+            cache_path.display()
+        )))
+    }
+
+    /// `git worktree add -b <new_branch> <path> <start_point>` in `cache_path`,
+    /// retrying with `--no-checkout` + filter bypass when a smudge/clean filter
+    /// (e.g. transcrypt) aborts the checkout.
+    fn worktree_add_new_branch(
+        &self,
+        cache_path: &Path,
+        worktree_path: &Path,
+        new_branch: &str,
+        start_point: &str,
+    ) -> Result<(), RemoteRepoError> {
+        let wt = worktree_path.to_string_lossy();
+        let output = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                new_branch,
+                wt.as_ref(),
+                start_point,
+            ])
+            .current_dir(cache_path)
+            .output()?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if !(stderr.contains("smudge filter") || stderr.contains("clean filter")) {
+            return Err(RemoteRepoError::CloneFailed(format!(
+                "Failed to create worktree: {stderr}"
+            )));
+        }
+
+        warn!(
+            "Worktree creation failed due to filter issue, retrying with --no-checkout: {}",
+            stderr
+        );
+        if worktree_path.exists() {
+            let _ = std::fs::remove_dir_all(worktree_path);
+        }
+        let _ = Command::new("git").args(["worktree", "prune"]).current_dir(cache_path).output();
+
+        let retry = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "--no-checkout",
+                "-b",
+                new_branch,
+                wt.as_ref(),
+                start_point,
+            ])
+            .current_dir(cache_path)
+            .output()?;
+        if !retry.status.success() {
+            return Err(RemoteRepoError::CloneFailed(format!(
+                "Failed to create worktree (even with --no-checkout): {}",
+                String::from_utf8_lossy(&retry.stderr)
+            )));
+        }
+
+        // Checkout files with filter bypass (transcrypt uses the 'crypt' filter).
+        let checkout = Command::new("git")
+            .args([
+                "-c",
+                "filter.crypt.smudge=cat",
+                "-c",
+                "filter.crypt.clean=cat",
+                "checkout",
+                "--force",
+            ])
+            .current_dir(worktree_path)
+            .output()?;
+        if !checkout.status.success() {
+            warn!(
+                "Checkout with filter bypass had issues: {}",
+                String::from_utf8_lossy(&checkout.stderr)
+            );
+            // Non-fatal — the worktree exists, files may just not be checked out.
+        }
         Ok(())
     }
 

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -715,7 +715,12 @@ impl WorktreeManager {
         Ok(final_repo_path)
     }
 
-    fn generate_worktree_path(
+    /// Compute the on-disk worktree path (`<base>/by-name/{repo}--{branch}--{uuid8}`)
+    /// without creating anything. Public so the remote/star launch flow can
+    /// generate a path, build the worktree off `origin/<default>` via
+    /// `RemoteRepoManager`, then hand the same path to
+    /// `create_session_with_worktree`.
+    pub fn generate_worktree_path(
         &self,
         session_id: Uuid,
         repository_path: &Path,

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -146,21 +146,35 @@ async fn main() -> Result<()> {
                 let mut favorites = config::FavoritesStore::load();
                 let report = favorites.migrate_local_to_remote();
                 if !report.is_empty() {
-                    if let Err(e) = favorites.save() {
-                        tracing::error!(error = %e, "failed to persist migrated favorites");
+                    // Back up the original (pre-migration) store once before the
+                    // destructive overwrite so dropped favorites are recoverable.
+                    if let Err(e) = config::FavoritesStore::load().write_migration_backup() {
+                        tracing::warn!(error = %e, "failed to back up favorites before migration");
                     }
-                    if !report.migrated.is_empty() {
-                        app_state.state.add_info_notification(format!(
-                            "⭐ Migrated {} favorite(s) to remote",
-                            report.migrated.len()
-                        ));
-                    }
-                    if !report.dropped.is_empty() {
-                        app_state.state.add_error_notification(format!(
-                            "★ Removed {} local-only favorite(s) with no remote: {}",
-                            report.dropped.len(),
-                            report.dropped.join(", ")
-                        ));
+                    match favorites.save() {
+                        Ok(()) => {
+                            // Only claim success once the migrated store is on disk;
+                            // otherwise the migration would silently re-run next launch.
+                            if !report.migrated.is_empty() {
+                                app_state.state.add_info_notification(format!(
+                                    "⭐ Migrated {} favorite(s) to remote",
+                                    report.migrated.len()
+                                ));
+                            }
+                            if !report.dropped.is_empty() {
+                                app_state.state.add_error_notification(format!(
+                                    "★ Removed {} local-only favorite(s) with no remote: {}",
+                                    report.dropped.len(),
+                                    report.dropped.join(", ")
+                                ));
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "failed to persist migrated favorites");
+                            app_state.state.add_error_notification(format!(
+                                "Could not migrate favorites to remote: {e}"
+                            ));
+                        }
                     }
                 }
             }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -146,9 +146,9 @@ async fn main() -> Result<()> {
                 let mut favorites = config::FavoritesStore::load();
                 let report = favorites.migrate_local_to_remote();
                 if !report.is_empty() {
-                    // Back up the original (pre-migration) store once before the
+                    // Back up the original (pre-migration) file once before the
                     // destructive overwrite so dropped favorites are recoverable.
-                    if let Err(e) = config::FavoritesStore::load().write_migration_backup() {
+                    if let Err(e) = config::FavoritesStore::write_migration_backup() {
                         tracing::warn!(error = %e, "failed to back up favorites before migration");
                     }
                     match favorites.save() {

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -136,6 +136,35 @@ async fn main() -> Result<()> {
 
             let mut app_state = App::new();
             app_state.init().await;
+
+            // Migrate legacy local-path favorites to their remote indicator. A
+            // star is always a remote pointer now; local-path entries from
+            // older versions are rewritten to their `origin` remote, or dropped
+            // when there is none. One-time per launch; idempotent once all
+            // entries are remote. Non-fatal — failure just leaves the store as-is.
+            {
+                let mut favorites = config::FavoritesStore::load();
+                let report = favorites.migrate_local_to_remote();
+                if !report.is_empty() {
+                    if let Err(e) = favorites.save() {
+                        tracing::error!(error = %e, "failed to persist migrated favorites");
+                    }
+                    if !report.migrated.is_empty() {
+                        app_state.state.add_info_notification(format!(
+                            "⭐ Migrated {} favorite(s) to remote",
+                            report.migrated.len()
+                        ));
+                    }
+                    if !report.dropped.is_empty() {
+                        app_state.state.add_error_notification(format!(
+                            "★ Removed {} local-only favorite(s) with no remote: {}",
+                            report.dropped.len(),
+                            report.dropped.join(", ")
+                        ));
+                    }
+                }
+            }
+
             let mut layout = LayoutComponent::new();
 
             // Check if first-time setup is needed

--- a/ainb-tui/crates/ainb-core/tests/star_remote_base.rs
+++ b/ainb-tui/crates/ainb-core/tests/star_remote_base.rs
@@ -1,0 +1,179 @@
+// ABOUTME: Integration tests for star → remote-default-branch worktree creation.
+// Drives real `git` against temp repos to prove a session launched from a star
+// branches off the freshly-fetched remote default (origin/HEAD) — even when the
+// cache's local `main` is stale or the repo's default branch is `master`. Also
+// covers the favorites local→remote migration through the public crate API.
+
+use ainb::git::{RemoteRepoManager, RepoSource};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Run `git` in `cwd` with deterministic identity + isolation from any global
+/// config, returning the raw output.
+fn git(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("git runs")
+}
+
+fn git_ok(cwd: &Path, args: &[&str]) {
+    let out = git(cwd, args);
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn rev_parse(cwd: &Path, rev: &str) -> String {
+    let out = git(cwd, &["rev-parse", rev]);
+    assert!(
+        out.status.success(),
+        "rev-parse {rev} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn current_branch(cwd: &Path) -> String {
+    String::from_utf8_lossy(&git(cwd, &["rev-parse", "--abbrev-ref", "HEAD"]).stdout)
+        .trim()
+        .to_string()
+}
+
+fn commit_file(repo: &Path, name: &str, contents: &str) {
+    std::fs::write(repo.join(name), contents).unwrap();
+    git_ok(repo, &["add", name]);
+    git_ok(repo, &["commit", "-m", &format!("add {name}")]);
+}
+
+/// Build a source repo whose default branch is `default_branch`, with one commit.
+fn init_source(tmp: &Path, default_branch: &str) -> PathBuf {
+    let src = tmp.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    git_ok(&src, &["init", "-b", default_branch]);
+    commit_file(&src, "a.txt", "A");
+    src
+}
+
+#[test]
+fn star_session_branches_off_fresh_remote_main_not_stale_local() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = init_source(tmp.path(), "main");
+
+    let cache = tmp.path().join("cache");
+    git_ok(
+        tmp.path(),
+        &["clone", src.to_str().unwrap(), cache.to_str().unwrap()],
+    );
+
+    // Advance the source's main AFTER cloning — the cache's local `main` is now
+    // stale (still at commit A); its origin/main only refreshes on fetch, which
+    // create_worktree_off_remote_default performs.
+    commit_file(&src, "b.txt", "B");
+    let src_tip = rev_parse(&src, "HEAD");
+    let cache_local_main = rev_parse(&cache, "main");
+    assert_ne!(
+        cache_local_main, src_tip,
+        "precondition: cache local main must be stale relative to source"
+    );
+
+    let mgr = RemoteRepoManager::new().unwrap();
+    let wt = tmp.path().join("wt-main");
+    let source = RepoSource::LocalPath(src.clone());
+    let created = mgr
+        .create_worktree_off_remote_default(&cache, &wt, "agents/test", &source)
+        .expect("worktree off remote default");
+    assert_eq!(created, wt);
+
+    // The new agent branch is based on the freshly-fetched origin/main (commit
+    // B), NOT the cache's stale local main (commit A).
+    assert_eq!(
+        rev_parse(&wt, "HEAD"),
+        src_tip,
+        "worktree must be based on fresh origin/main, not stale local main"
+    );
+    assert_eq!(current_branch(&wt), "agents/test");
+}
+
+#[test]
+fn star_session_branches_off_master_when_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = init_source(tmp.path(), "master");
+
+    let cache = tmp.path().join("cache");
+    git_ok(
+        tmp.path(),
+        &["clone", src.to_str().unwrap(), cache.to_str().unwrap()],
+    );
+    let src_tip = rev_parse(&src, "HEAD");
+
+    // The cache has NO local `main` — the old get_default_branch ladder
+    // (local main → local master → current HEAD) is exactly what this replaces.
+    let mgr = RemoteRepoManager::new().unwrap();
+    let wt = tmp.path().join("wt-master");
+    let source = RepoSource::LocalPath(src.clone());
+    mgr.create_worktree_off_remote_default(&cache, &wt, "agents/x", &source)
+        .expect("worktree off remote default (master)");
+
+    assert_eq!(
+        rev_parse(&wt, "HEAD"),
+        src_tip,
+        "worktree must be based on origin/master"
+    );
+    assert_eq!(current_branch(&wt), "agents/x");
+}
+
+#[test]
+fn migration_rewrites_local_with_origin_and_drops_without() {
+    use ainb::config::{Favorite, FavoriteSourceType, FavoritesStore};
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    // A local repo WITH an origin remote → migrates to remote indicator.
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git_ok(&repo, &["init"]);
+    git_ok(
+        &repo,
+        &["remote", "add", "origin", "https://github.com/o/r.git"],
+    );
+
+    // A path that is NOT a git repo → dropped.
+    let orphan = tmp.path().join("not-a-repo");
+    std::fs::create_dir_all(&orphan).unwrap();
+
+    let mut store = FavoritesStore::default();
+    store
+        .add(Favorite::new(
+            "withremote".into(),
+            repo.display().to_string(),
+            FavoriteSourceType::LocalPath,
+        ))
+        .unwrap();
+    store
+        .add(Favorite::new(
+            "orphan".into(),
+            orphan.display().to_string(),
+            FavoriteSourceType::LocalPath,
+        ))
+        .unwrap();
+
+    let report = store.migrate_local_to_remote();
+    assert_eq!(report.migrated.len(), 1);
+    assert_eq!(report.dropped, vec!["orphan".to_string()]);
+
+    let migrated = store.get("withremote").expect("withremote survives");
+    assert_eq!(migrated.source_type, FavoriteSourceType::GithubShorthand);
+    assert_eq!(migrated.source, "o/r");
+    assert!(store.get("orphan").is_none(), "orphan dropped");
+}

--- a/ainb-tui/plans/star-remote-and-main-base.md
+++ b/ainb-tui/plans/star-remote-and-main-base.md
@@ -1,0 +1,367 @@
+# Star = Remote Indicator + New Session Off Remote Default Branch
+
+## Overview
+Make a "star" (Favorite) **always** record a remote repository indicator (never a local
+path), and make sessions launched **from a star** always create their worktree branched
+off the remote's **default branch** (`origin/HEAD`), fetched fresh. Refuse to star a repo
+that has no resolvable `origin` remote. Auto-migrate existing local-path stars to remote
+on startup; drop the ones with no origin (with a notification).
+
+## Current State Analysis
+
+### Star creation — TWO entry points
+1. **`StarSelectedWorkspace`** — `crates/ainb-core/src/app/events.rs:3266-3410` (PRIMARY).
+   Triggered from the home/workspace list. It *already* tries `get_remote_url()` and
+   prefers a remote indicator, **but falls back to `SourceType::LocalPath` in three
+   branches**: (a) remote URL won't parse (`events.rs:3321-3329`), (b) repo has no
+   `origin` (`events.rs:3330-3338`), (c) path isn't a git repo (`events.rs:3339-3347`).
+   These three fallbacks are the bug — they persist local-path stars.
+2. **pick_repo `^F`** — `crates/ainb-core/src/components/new_session/pick_repo.rs:646-673`
+   `toggle_favorite()` (SECONDARY). Persists whatever the highlighted row's source is,
+   including `RepoSource::LocalPath` for `📁` local-scan rows. No `AppState` access, so it
+   can only `tracing::warn!` — it cannot surface a user notification today.
+
+### New-session base branch
+- `create_session_from_configure()` — `state.rs:5708-5889`. Resolves `repo_path`:
+  `LocalPath` → path as-is; remote (`HttpsUrl`/`SshUrl`/`GithubShorthand`) →
+  `clone_remote_for_configure()` into the `~/.agents-in-a-box/repos/...` cache. **Passes
+  `existing_worktree = None` (`state.rs:5867`)** so *everything* funnels through the local
+  worktree flow.
+- `create_interactive_session()` — `state.rs:6297-6384`. With `existing_worktree = None`
+  it takes the "local repo flow" and calls
+  `InteractiveSessionManager::create_session(..., None /*base_branch*/, ...)`
+  (`state.rs:6371-6383`).
+- `session_manager.rs:217-251` `create_session(base_branch: Option<String>)` →
+  `worktree_manager.create_worktree(..., base_branch.as_deref())`.
+- `worktree_manager.rs:88-150` `create_worktree(base_branch: Option<&str>)`; `None` →
+  `get_default_branch(repo)` (`worktree_manager.rs:407-422`) = **local** `main` → **local**
+  `master` → current `HEAD` shorthand → `"main"`. `ensure_branch_exists()`
+  (`worktree_manager.rs:424-445`) cuts the new branch from a **local** ref. This is the
+  wrong base for star (remote) launches: a cached clone's local `main` is never
+  fast-forwarded by `git fetch` (`remote_repo_manager.rs:226-242`), and `master`/`develop`
+  defaults break the assumption.
+
+### Reusable primitives (already exist)
+- `RepositoryManager::open(path).get_remote_url() -> Result<Option<String>>` —
+  `crates/ainb-core/src/git/repository.rs:83-91` (origin URL or `None`).
+- `RemoteRepoManager::get_default_branch_name(source) -> Option<String>` —
+  `remote_repo_manager.rs:152-178` (resolves `origin/HEAD` via `git ls-remote --symref`).
+- `RemoteRepoManager::checkout_existing_branch_worktree(cache, wt, remote_branch)` —
+  `remote_repo_manager.rs:426+` (`git worktree add -B <b> <path> origin/<b>`; collision
+  suffixing + transcrypt `--no-checkout` retry). Good template for the new method.
+- `RemoteRepoManager::clone_repo()` (`:184`) clones standard, reuses cache, and
+  `git fetch --all --prune` on reuse (`:226`) — so `origin/*` is fresh after this call.
+- `create_session_with_worktree()` — `session_manager.rs:353` consumes a pre-built
+  worktree (used by the `existing_worktree = Some(...)` branch at `state.rs:6352-6367`).
+- `create_worktree_from_cache()` (`remote_repo_manager.rs:248`) — **dead code**, never
+  called; will be removed (it creates a *local*-ref-based branch, the wrong semantics).
+
+## Desired End State
+- Starring a repo with an `origin` → stores `HttpsUrl`/`SshUrl`/`GithubShorthand`.
+- Starring a repo with no `origin` (or not a git repo) → **refused** with a notification;
+  nothing written to `favorites.yaml`.
+- A session launched from a star (any remote source) → its agent branch
+  (`agents/...`) is cut from `origin/<default>` of a freshly-fetched cache, regardless of
+  what the cache's local branches point at, and regardless of `main` vs `master` vs
+  `develop`.
+- Local-path picks / recents / typed paths → **unchanged** (`get_default_branch`).
+- Existing `favorites.yaml`: on startup, every `LocalPath` star with an `origin` is
+  rewritten to a remote indicator (alias/stats/tags preserved); originless ones are
+  dropped; a single aggregated notification reports what changed.
+
+### Discriminator
+"Star-launched only" is implemented as **`RepoSource::is_remote()`** (`repo_source.rs:141`).
+Because stars become always-remote, every star launch is `is_remote() == true`. A typed
+`owner/repo` / URL is also remote and gets the same correct behavior — a bonus, not a
+regression. Local-path rows are `is_remote() == false` and keep the old path.
+
+## What We're NOT Doing
+- Not adding a branch/ref field to `Favorite` (star stays a pure source pointer).
+- Not changing base-branch behavior for local-path / recents / typed-path launches.
+- Not adding a base-branch picker to the Configure screen.
+- Not touching Boss/Docker session base-branch logic beyond what flows through the shared
+  path.
+- Not migrating on every `FavoritesStore::load()` (too many call sites + git I/O on
+  render) — one startup pass only.
+
+## Implementation Approach
+Five phases across three waves. Wave 1 builds the two independent primitives (favorites
+remote-derivation/migration; remote-default worktree creation). Wave 2 wires them into the
+two surfaces (session creation; star toggles). Wave 3 hooks startup migration and adds
+integration tests.
+
+---
+
+## Phase 1: Favorites — remote derivation + migration
+<!-- wave: 1 | depends_on: [] | files: [crates/ainb-core/src/config/favorites_store.rs] -->
+
+### Overview
+Add a shared helper that derives a remote `Favorite` from a local repo path, and a
+startup migration that rewrites/drops existing local-path stars.
+
+### Changes Required
+
+#### `crates/ainb-core/src/config/favorites_store.rs`
+1. `pub enum DeriveFavoriteError { NotAGitRepo, NoRemote, Unparseable(String) }`.
+2. `pub fn favorite_from_local_repo(alias: String, local_path: &Path) -> Result<Favorite, DeriveFavoriteError>`:
+   - `RepositoryManager::open(local_path)` → `NotAGitRepo` on err.
+   - `.get_remote_url()` → `Ok(Some(url))` continue; `Ok(None)`/`Err` → `NoRemote`.
+   - Parse `url` into `(source_string, SourceType)`: GitHub host → `GithubShorthand`
+     (`owner/repo`); else `git@`-prefixed → `SshUrl`; else `HttpsUrl`. (Mirror the
+     classification already in `events.rs:3291-3320`, factored here so both star paths and
+     migration share one implementation.)
+   - Return `Favorite::new(alias, source_string, source_type)`.
+3. `pub struct MigrationReport { pub migrated: Vec<(String,String)>, pub dropped: Vec<String> }`
+   (`(alias, new_source)` and `alias`).
+4. `pub fn migrate_local_to_remote(&mut self) -> MigrationReport`:
+   - Iterate favorites; for each `SourceType::LocalPath`: call
+     `favorite_from_local_repo(alias, Path::new(&source))`.
+     - `Ok(remote_fav)` → replace `source`/`source_type` in place (preserve
+       `display_name`/`description`/`tags`/`metadata`/`stats`), record in `migrated`.
+     - `Err(_)` → mark for removal, record alias in `dropped`.
+   - Remove dropped entries. Idempotent: a store with no `LocalPath` entries returns an
+     empty report and is not mutated.
+   - Caller is responsible for `save()` when the report is non-empty.
+
+### Success Criteria
+#### Automated Verification
+- [ ] `cargo build -p ainb-core` succeeds.
+- [ ] `cargo test -p ainb-core favorites_store` passes.
+- [ ] `cargo clippy -p ainb-core -- -D warnings` clean for the changed crate.
+
+#### Manual Verification
+- [ ] N/A (covered by tests).
+
+### Tests (in-module, behavioral)
+- `migrate_noop_when_all_remote` — store with only remote entries → empty report,
+  unchanged.
+- `migrate_drops_localpath_without_origin` — a `LocalPath` to a temp dir that's not a git
+  repo → dropped, removed from store.
+- `favorite_from_local_repo_*` — use a `git init` + `git remote add origin <url>` temp
+  repo (helper) to assert GitHub-shorthand and non-GitHub HTTPS/SSH classification, and
+  `NoRemote`/`NotAGitRepo` errors. (git2 against a temp dir; no network.)
+
+---
+
+## Phase 2: RemoteRepoManager — worktree off origin default
+<!-- wave: 1 | depends_on: [] | files: [crates/ainb-core/src/git/remote_repo_manager.rs] -->
+
+### Overview
+Add a method that cuts a **new** agent branch from the remote's default ref in a cached
+clone, and delete the dead `create_worktree_from_cache`.
+
+### Changes Required
+
+#### `crates/ainb-core/src/git/remote_repo_manager.rs`
+1. `pub fn create_worktree_off_remote_default(&self, cache_path: &Path, worktree_path: &Path, new_branch: &str, source: &RepoSource) -> Result<PathBuf, RemoteRepoError>`:
+   - Resolve default via `self.get_default_branch_name(source)`; fall back to probing
+     `origin/main` then `origin/master` in the cache (`git rev-parse --verify
+     origin/<b>`); final fallback `RemoteRepoError` if none resolves.
+   - `git -C <cache> fetch origin --prune` (defensive; `clone_repo` already fetched on
+     reuse but a directly-supplied cache may be stale).
+   - `git -C <cache> worktree add -b <new_branch> <worktree_path> origin/<default>`.
+   - Reuse the collision + transcrypt `--no-checkout` retry handling already present in
+     `checkout_existing_branch_worktree` (extract a shared private helper rather than
+     copy-paste).
+   - Return the created `worktree_path`.
+2. Delete `create_worktree_from_cache` (`:248`) and its doc references (dead code).
+
+### Success Criteria
+#### Automated Verification
+- [ ] `cargo build -p ainb-core` succeeds.
+- [ ] `cargo test -p ainb-core remote_repo_manager` passes.
+- [ ] `cargo clippy -p ainb-core -- -D warnings` clean.
+
+#### Manual Verification
+- [ ] N/A (covered by Phase 5 integration test).
+
+### Tests
+- Construct a bare-ish fixture: `git init` source with a `master` default + a commit,
+  `clone` into cache, then call `create_worktree_off_remote_default(... "agents/x" ...)`
+  and assert the worktree HEAD's merge-base equals `origin/master` even though there is no
+  local `main`. (Phase 5 owns the full stale-local-main scenario.)
+
+---
+
+## Phase 3: Session creation branches off remote default for remote sources
+<!-- wave: 2 | depends_on: [2] | files: [crates/ainb-core/src/app/state.rs] -->
+
+### Overview
+For remote sources, build the worktree off `origin/<default>` in the cache and pass it as
+`existing_worktree = Some(...)`; local sources keep the current `None` path.
+
+### Changes Required
+
+#### `crates/ainb-core/src/app/state.rs` — `create_session_from_configure` (5708-5889)
+- After `repo_path` resolution, branch on `snapshot.repo_source.is_remote()`:
+  - **Remote**: `repo_path` is the cache. Compute `worktree_path`
+    (`WorktreeManager::generate_worktree_path(session_id, cache, branch_name)` or the
+    existing helper), then
+    `RemoteRepoManager::create_worktree_off_remote_default(cache, worktree_path,
+    &snapshot.branch_name, &snapshot.repo_source)`. Call `create_session_with_logs(...,
+    existing_worktree = Some((worktree_path, cache_path)))` so
+    `create_interactive_session` takes the `existing_worktree = Some` branch
+    (`state.rs:6352`) → `create_session_with_worktree` (no `get_default_branch`).
+  - **Local**: unchanged — `existing_worktree = None` (current behavior).
+- Keep `branch_name` = `snapshot.branch_name` (the `agents/...` agent branch); it is now
+  cut from `origin/<default>` instead of a local ref.
+
+### Success Criteria
+#### Automated Verification
+- [ ] `cargo build -p ainb-core` succeeds.
+- [ ] `cargo clippy -p ainb-core -- -D warnings` clean.
+
+#### Manual Verification
+- [ ] Launch a session from a starred GitHub repo whose default is `master`; new worktree
+  branch's base is `origin/master` (verify `git merge-base HEAD origin/master` == tip).
+- [ ] Launch from a star where the cache's local `main` is intentionally stale; new branch
+  contains the latest `origin/main` commit.
+- [ ] Launch from a local-path pick; behavior unchanged.
+
+### Checkpoints
+- `[CHECKPOINT:human-verify]` after Phase 3+4 land: run the TUI, star a remote repo,
+  create a session, confirm branch base. Resume on "approved".
+
+---
+
+## Phase 4: Star toggles enforce remote-or-refuse
+<!-- wave: 2 | depends_on: [1] | files: [crates/ainb-core/src/app/events.rs, crates/ainb-core/src/components/new_session/pick_repo.rs] -->
+
+### Overview
+Both star entry points must store a remote indicator or refuse with a notification.
+
+### Changes Required
+
+#### `crates/ainb-core/src/app/events.rs` — `StarSelectedWorkspace` (3266-3410)
+- Replace the inline remote-resolution + three `LocalPath` fallbacks with the shared
+  `favorite_from_local_repo(alias, &workspace.path)`:
+  - `Ok(fav)` → toggle as today (dedupe on `fav.source`), success notification.
+  - `Err(NoRemote | NotAGitRepo | Unparseable)` → **do not add**; call
+    `state.add_error_notification("★ Can't favorite '<name>': no git remote (origin) found")`.
+- Remove the local-path dedupe leg (`f.source == local_path_str`) since stars are never
+  local now (keep a one-release tolerance: still allow *removing* a pre-existing local
+  star by alias).
+
+#### `crates/ainb-core/src/components/new_session/pick_repo.rs`
+- `PickRepoOutcome`: add `Notice { message: String, is_error: bool }`.
+- `toggle_favorite`: when the row source is `RepoSource::LocalPath(p)`, call
+  `favorite_from_local_repo(row.id, &p)`; on `Err` return a refusal signal (don't persist);
+  on `Ok` store the derived remote favorite. Remote sources store as today. Return an enum
+  so `handle_key`'s `^F` branch can map it to `PickRepoOutcome::Notice` (error on refusal,
+  info on add/remove) instead of always `Stay`.
+- `handle_key` `^F` branch (`pick_repo.rs:537-545`): on refusal, return
+  `Notice { is_error: true, .. }` and skip `rebuild_rows`; otherwise rebuild + return
+  `Notice { is_error: false, .. }` (or `Stay`).
+
+#### `crates/ainb-core/src/app/events.rs` — `handle_new_session_keys` (1321-1410)
+- In the `match outcome`, add `PickRepoOutcome::Notice { message, is_error }` →
+  `if is_error { state.add_error_notification(message) } else { state.add_info_notification(message) }`,
+  then `None` (stay on picker).
+
+### Success Criteria
+#### Automated Verification
+- [ ] `cargo build -p ainb-core` succeeds.
+- [ ] `cargo test -p ainb-core pick_repo` passes (existing tests + new outcome test).
+- [ ] `cargo clippy -p ainb-core -- -D warnings` clean.
+
+#### Manual Verification
+- [ ] Star a repo with no origin from the home list → red notification, nothing saved.
+- [ ] Star a local repo *with* origin → saved as remote (`favorites.yaml` shows
+  `github_shorthand`/`https_url`/`ssh_url`).
+- [ ] `^F` on a `📁` local row in the picker → same behavior (refuse / derive-remote).
+
+---
+
+## Phase 5: Startup migration hook + integration tests
+<!-- wave: 3 | depends_on: [1, 3, 4] | files: [crates/ainb-core/src/main.rs, crates/ainb-core/tests/star_remote_base.rs] -->
+
+### Overview
+Run the migration once on TUI startup and notify; add end-to-end coverage for the
+stale-local-main scenario.
+
+### Changes Required
+
+#### `crates/ainb-core/src/main.rs` — TUI bootstrap (~137, after `App::new()`)
+- Only in the `Some(("tui", _)) | None` arm (not CLI subcommands, not tests):
+  `let mut store = FavoritesStore::load(); let report = store.migrate_local_to_remote();
+  if !report.is_empty() { store.save()?; /* push notifications into app_state */ }`.
+- Push one info notification summarizing `migrated.len()` rewritten, and one error
+  notification listing `dropped` aliases ("removed N local-only stars without a remote:
+  ...").
+
+#### `crates/ainb-core/tests/star_remote_base.rs` (new)
+- **stale-local-main**: `git init` source (`main`), commit A; clone into a temp "cache";
+  add commit B to source and `git -C cache fetch`; leave cache local `main` at A; call
+  `create_worktree_off_remote_default(cache, wt, "agents/test", source)`; assert the
+  worktree contains commit B (i.e., based on `origin/main`, not stale local `main`).
+- **master-default**: source default `master`; assert worktree base is `origin/master`.
+- **migration**: write a `favorites.yaml` with a `LocalPath` entry pointing at a git repo
+  with origin → `migrate_local_to_remote` rewrites it; a `LocalPath` to a non-repo → drop.
+
+### Success Criteria
+#### Automated Verification
+- [ ] `cargo build -p ainb-core` succeeds.
+- [ ] `cargo test -p ainb-core --test star_remote_base` passes.
+- [ ] `cargo test -p ainb-core` (full) passes.
+- [ ] `cargo clippy -p ainb-core -- -D warnings` clean.
+- [ ] `cargo fmt --check` clean.
+
+#### Manual Verification
+- [ ] Start TUI with a pre-existing local-path star (with origin) in `favorites.yaml` →
+  notification "migrated 1 star to remote", file rewritten.
+- [ ] Start TUI with a local-path star whose path is not a repo → notification "removed",
+  entry gone.
+
+### Checkpoints
+- `[CHECKPOINT:human-verify]` end-to-end smoke in the running TUI. Resume on "approved".
+
+---
+
+## Dependency Analysis
+```
+Wave 1: Phase 1 (favorites_store.rs)        ─┐
+        Phase 2 (remote_repo_manager.rs)    ─┘ parallel, no file overlap
+Wave 2: Phase 3 (state.rs)        depends_on Phase 2 ─┐
+        Phase 4 (events.rs,pick_repo.rs) depends_on Phase 1 ─┘ parallel, no file overlap
+Wave 3: Phase 5 (main.rs, tests/) depends_on Phase 1,3,4
+```
+No file appears in two phases of the same wave.
+
+## Testing Strategy
+- **Behavioral/integration first** (repo philosophy): the `tests/star_remote_base.rs`
+  fixtures drive real `git` against temp repos — they prove the *outcome* (which commit the
+  new branch is based on), not internal wiring.
+- Module unit tests only where cheap and isolating (favorite classification, migration
+  no-op idempotency, `Notice` outcome plumbing).
+- Existing `pick_repo` tests must stay green (the `Notice` variant is additive).
+
+## Migration Notes — does Stevie keep his existing stars?
+- **Remote stars (github_shorthand / https_url / ssh_url): keep working as-is.** No action.
+- **Local-path stars WITH an `origin` remote: auto-migrated on next TUI launch** — rewritten
+  to the remote indicator, alias/stats/tags preserved. No re-star needed.
+- **Local-path stars WITHOUT an origin (or path no longer a git repo): dropped** on next
+  launch with a notification; these must be **re-created** once the repo has a remote.
+- Net: **most existing stars survive automatically; only originless local stars need
+  re-starring.**
+
+## Risks
+- **Cache staleness**: mitigated by the explicit `git fetch origin --prune` in
+  `create_worktree_off_remote_default` (defensive on top of `clone_repo`'s fetch).
+- **Odd/detached `origin/HEAD`**: `get_default_branch_name` returns `None` → fall back to
+  `origin/main`→`origin/master` probe → error with a clear message rather than a wrong base.
+- **Monorepo git scope**: star derivation opens the repo at the workspace/source path; for
+  the monorepo root that resolves the toolkit's own origin — acceptable and matches today's
+  `StarSelectedWorkspace` intent.
+- **Notification plumbing from pick_repo**: solved by the additive `PickRepoOutcome::Notice`
+  variant; no `AppState` reach-in from the pure component.
+- **Two toggle paths drift**: both now call the single `favorite_from_local_repo` helper, so
+  the rule can't diverge.
+
+## References
+- Diagnosis (this session): star = source-only pointer; base resolved by
+  `get_default_branch` local-ref ladder.
+- Locked decisions: refuse-if-no-origin; base = `origin/HEAD` fresh; auto-migrate on load;
+  star-launched only.
+- Key anchors: `favorites_store.rs`, `pick_repo.rs:646`, `events.rs:3266`, `state.rs:5708`,
+  `state.rs:6352`, `worktree_manager.rs:407`, `remote_repo_manager.rs:152,426`,
+  `repository.rs:83`.


### PR DESCRIPTION
## What

A **star** (favorite) now always records a **remote** repository indicator, and a session launched **from a star** always creates its worktree branched off the remote's **default branch** (`origin/HEAD`), freshly fetched.

### Before
- Starring a repo fell back to storing a **local path** in 3 cases (URL unparseable, no `origin`, not a git repo).
- New sessions branched off the local `main`→`master`→current-HEAD ladder — a stale cache local `main` or a `master`/`develop` default produced the wrong base.

### After
- Star derives the remote from `origin`; **refuses** (with a notification) when there is no resolvable remote — no local-path fallback. Enforced at **both** entry points (home-list `Star` + pick-repo `^F`).
- Remote/star sessions branch the agent branch off `origin/<default>` of a freshly-fetched cache (handles `main`/`master`/`develop`). Local-path picks keep prior behaviour.
- Legacy local-path favorites are **auto-migrated** to their remote on startup; originless ones are dropped with a notification.

## Existing stars
| Kind | Outcome |
|------|---------|
| Remote (`owner/repo`, https, ssh) | Work as-is |
| Local-path **with** `origin` | Auto-migrated on next launch (alias/tags/stats preserved) |
| Local-path **without** `origin` | Dropped on next launch (notified) → re-star once it has a remote |

## Key changes
- `config/favorites_store.rs`: `favorite_from_local_repo()` + `migrate_local_to_remote()` + `DeriveFavoriteError`/`MigrationReport`.
- `git/remote_repo_manager.rs`: `create_worktree_off_remote_default()` (resolve `origin/HEAD`, fresh fetch, branch off `origin/<default>`); removed dead `create_worktree_from_cache`.
- `git/worktree_manager.rs`: `generate_worktree_path()` made public.
- `app/state.rs`: `create_session_from_configure` routes remote sources through `prepare_remote_worktree`.
- `app/events.rs` + `components/new_session/pick_repo.rs`: remote-or-refuse on both star paths; `PickRepoOutcome::Notice`.
- `main.rs`: startup migration with notifications.

## Tests
- New `tests/star_remote_base.rs`: stale-local-main, master-default, local→remote migration.
- favorites unit tests 15/15, pick_repo 7/7, integration 3/3.
- `cargo fmt --all --check` ✓, CI-equivalent lib (`--all-features`, skip `docker::`) **795 passed / 0 failed**, tripwire ✓, `cargo-machete` clean.

Plan: `ainb-tui/plans/star-remote-and-main-base.md`.
