### PR TITLE
fix(tui): show pre-launch waiters — drop the attention-marker app-start floor

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2453,15 +2453,11 @@ pub struct AppState {
     pub workspace_load_receiver: Option<mpsc::UnboundedReceiver<WorkspaceLoadResult>>,
 
     /// Per-session "cleared up to" timestamp (epoch ms). A hook event
-    /// only marks a session if its `ts` is newer than this. Bumped to
-    /// "now" while the user is attached, so re-marking only happens for
-    /// activity that arrives after they look away. Defaults to
-    /// [`AppState::app_started_ms`] for sessions never attached.
+    /// only marks a session if its `ts` is newer than this. Defaults to
+    /// `0` (any event in the lookback window can mark); bumped to "now"
+    /// while the user is attached, so re-marking only happens for
+    /// activity that arrives after they look away.
     pub attention_baseline: HashMap<Uuid, i64>,
-    /// Epoch ms captured at app start. Floors the attention query so
-    /// pre-existing notification history never lights up markers on
-    /// launch.
-    pub app_started_ms: i64,
 }
 
 /// Result of background workspace loading
@@ -2872,7 +2868,6 @@ impl Default for AppState {
 
             // Per-session attention markers, driven by ainb-hooks events.
             attention_baseline: HashMap::new(),
-            app_started_ms: chrono::Utc::now().timestamp_millis(),
         }
     }
 }
@@ -8240,11 +8235,18 @@ impl AppState {
     /// (~5s), and keeps the daemon as the DB's sole long-lived owner.
     /// The `exists()` guard avoids `Store::open` creating an empty DB on
     /// machines where notifications were never set up.
+    ///
+    /// The window is purely time-based (`now − LOOKBACK`), **not** floored
+    /// at app start — so opening ainb immediately surfaces sessions that
+    /// were already waiting before launch. Stale `[✓]` turns don't pile up
+    /// because the `Finished` marker self-retires on its own short TTL (see
+    /// [`Self::attention_for_session`]); only genuinely-pending `[?]` / `[!]`
+    /// from the window survive.
     fn recent_attention_events(
         &self,
         now_ms: i64,
     ) -> Option<Vec<ainb_plugin_notifyd::NotificationRecord>> {
-        // Ignore events older than this regardless of when the app started.
+        // Only events within this rolling window can mark a session.
         const LOOKBACK_MS: i64 = 6 * 60 * 60 * 1000;
         // Bounds query cost; ample for any realistic active fleet.
         const QUERY_LIMIT: u32 = 500;
@@ -8254,7 +8256,7 @@ impl AppState {
             return None;
         }
         let store = ainb_plugin_notifyd::Store::open(&db).ok()?;
-        let floor = (now_ms - LOOKBACK_MS).max(self.app_started_ms);
+        let floor = now_ms - LOOKBACK_MS;
         match store.recent_since(floor, QUERY_LIMIT) {
             Ok(rows) => Some(rows),
             Err(e) => {
@@ -8282,8 +8284,10 @@ impl AppState {
                     continue;
                 }
                 let generating = matches!(s.status, crate::models::SessionStatus::Running);
-                let baseline =
-                    self.attention_baseline.get(&s.id).copied().unwrap_or(self.app_started_ms);
+                // Default 0: with no per-session clear point yet, any event in
+                // the lookback window can mark — so pre-launch waiters show up.
+                // Attaching advances this to "now" (see below).
+                let baseline = self.attention_baseline.get(&s.id).copied().unwrap_or(0);
                 let kind = Self::attention_for_session(
                     &s.workspace_path,
                     Self::agent_hook_name(s.agent_type),

--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -55,7 +55,7 @@ While a session is **actively generating**, the marker is suppressed (the busy s
 
 **Does it clear when I answer?** Yes — answering a session (typing a prompt, or approving a permission) makes the agent start responding, and the marker clears on the next ~5 s refresh once it does. It clears via *the agent resuming*, not the keystroke itself, so there's a ≤5 s window between hitting enter and the marker disappearing. **Attaching** to a session clears it immediately and advances a per-session baseline to "now", so it won't re-mark until *new* activity arrives after you look away.
 
-Markers are matched to sessions by **working directory + agent**: each hook event carries the `cwd` it fired in, joined to the ainb session whose `workspace_path` matches (trailing-slash tolerant). Events older than the app's start are ignored, so pre-existing history never lights up markers on launch.
+Markers are matched to sessions by **working directory + agent**: each hook event carries the `cwd` it fired in, joined to the ainb session whose `workspace_path` matches (trailing-slash tolerant). Only events within a rolling **6-hour window** count — so opening ainb immediately surfaces sessions that were already waiting before you launched it (the `[✓]` TTL keeps long-finished turns from piling up, so only genuinely-pending `[?]` / `[!]` survive).
 
 ## Host resources it touches
 


### PR DESCRIPTION
Follow-up to #206. Validating "I see no markers" turned up the cause: the marker query floored events at **app-start**, so a freshly-opened ainb shows nothing — every session that was waiting *before* you launched is hidden, and markers only appear as sessions act while the TUI is already open. That's backwards: you open ainb precisely to see who already needs you.

(Confirmed on a live machine: `notifications.db` had a `Notification` for `shotclubhouse--ops-2` at 13:03, but the TUI launched ~14:17 → floored out → blank, even on a binary that has #206.)

## Change
- `recent_attention_events`: window is now purely time-based (`now − 6h`), no `.max(app_started_ms)`.
- per-session baseline defaults to `0` (any event in the window can mark) instead of app-start.
- removed the now-unused `app_started_ms` field.

Stale `[✓]` still can't pile up — the `Finished` marker self-retires on its existing 5-minute TTL — so on launch only genuinely-pending `[?]` / `[!]` from the last 6h survive. Attaching still advances the baseline to "now".

## Tests
10 attention matrix tests pass (the pure `attention_for_session` is unchanged — this only touches the query window + baseline default). `cargo build` + `fmt --check` clean; clippy clean on changed code. Doc (`inbox-notifications.md`) updated to describe the 6h window.