### PR TITLE
feat(tui): base-branch picker in the new-session Configure screen

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1483,11 +1483,23 @@ impl EventHandler {
                     // top-level dirs and misses every modern by-name worktree.
                     // The latter returned empty → collision never detected
                     // (Stevie 2026-05-27: feat/blog re-launch slipped through).
-                    let existing_branches: Vec<String> = WorktreeManager::new()
+                    let mut existing_branches: Vec<String> = WorktreeManager::new()
                         .ok()
                         .and_then(|m| m.list_all_worktrees().ok())
                         .map(|infos| infos.into_iter().map(|(_, i)| i.branch_name).collect())
                         .unwrap_or_default();
+                    // The session list alone can't see the repo's OWN checkout
+                    // (or a manually-added worktree) — `git worktree list` can.
+                    // Without this, a checkout-direct pick of the repo's
+                    // current branch passes the picker guard and dies at
+                    // `git worktree add` (review P1, PR #211).
+                    if let crate::git::repo_source::RepoSource::LocalPath(p) = &source {
+                        for b in crate::git::branch_list::checked_out_branches(p) {
+                            if !existing_branches.contains(&b) {
+                                existing_branches.push(b);
+                            }
+                        }
+                    }
                     let cfg = ConfigureState::from_pick_repo(
                         source.clone(),
                         label,

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -360,6 +360,9 @@ pub enum AppEvent {
     ConfigureLaunch(crate::components::new_session::configure::LaunchSpec),
     ConfigureBack,              // Esc on Configure → return to PickRepo
     ConfigureOpenPresetManager, // ^P stub until Phase 7 polish
+    /// Enter on the Branch row's Source segment → seed the base-branch
+    /// popup from cached refs + kick the background fetch refresh.
+    ConfigureOpenBranchPicker,
 }
 
 /// Translate a `RepoSource` variant into the `(SourceType, source_string)`
@@ -1360,6 +1363,7 @@ impl EventHandler {
                 ConfigureOutcome::BackToPickRepo => Some(AppEvent::ConfigureBack),
                 ConfigureOutcome::Launch(spec) => Some(AppEvent::ConfigureLaunch(spec)),
                 ConfigureOutcome::OpenPresetManager => Some(AppEvent::ConfigureOpenPresetManager),
+                ConfigureOutcome::OpenBranchPicker => Some(AppEvent::ConfigureOpenBranchPicker),
             };
         }
 
@@ -2410,6 +2414,12 @@ impl EventHandler {
             AppEvent::ConfigureOpenPresetManager => {
                 // Phase 7 polish — stub for now.
                 tracing::warn!("ConfigureOpenPresetManager — stub until Phase 7");
+            }
+            AppEvent::ConfigureOpenBranchPicker => {
+                // Seed from cached refs (instant), kick background refresh.
+                // Git stays in the app layer — components/ never touch git2
+                // (finding #9).
+                state.open_branch_picker();
             }
             AppEvent::ShowNotification(message) => {
                 tracing::info!("Event: ShowNotification - {}", message);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2439,6 +2439,19 @@ pub struct AppState {
     /// Present only while a scan is in flight; `tick()` drains it.
     pub skills_load_receiver: Option<mpsc::UnboundedReceiver<crate::models::SkillsData>>,
 
+    /// Background base-branch refresh for the Configure picker. The fetch +
+    /// re-list runs on `spawn_blocking`; the result lands here and is applied
+    /// by `check_branch_refresh_complete` on the next tick. The `u64` is a
+    /// generation guard — results from a closed/reopened picker are dropped.
+    pub branch_refresh_receiver: Option<
+        mpsc::UnboundedReceiver<(
+            u64,
+            Result<Vec<crate::git::branch_list::BranchEntry>, String>,
+        )>,
+    >,
+    /// Current branch-refresh generation (bumped on every picker open).
+    pub branch_refresh_seq: u64,
+
     // Periodic session snapshot tracking
     pub last_snapshot_time: Option<Instant>,
 
@@ -2674,6 +2687,9 @@ struct ConfigureLaunchSnapshot {
     /// Codex model for Codex-agent sessions. Same omit-on-default semantics
     /// as `session_model`. Set only when `agent_type == Codex`.
     codex_model: Option<crate::models::CodexModel>,
+    /// The base-branch popup pick (2026-06). `None` = legacy base policy:
+    /// HEAD for local repos, origin/HEAD for remote/star launches.
+    base: Option<crate::components::new_session::configure::BaseSelection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2853,6 +2869,10 @@ impl Default for AppState {
             // Skills browser state
             skills_state: crate::components::skills::SkillsViewState::default(),
             skills_load_receiver: None,
+
+            // Configure base-branch picker background refresh
+            branch_refresh_receiver: None,
+            branch_refresh_seq: 0,
 
             // Periodic session snapshot tracking
             last_snapshot_time: None,
@@ -3797,6 +3817,150 @@ impl AppState {
         } else {
             false
         }
+    }
+
+    /// Open the Configure screen's base-branch popup: seed entries from
+    /// cached refs (disk-only — instant, offline-safe), then kick a
+    /// background fetch + re-list whose result is applied by
+    /// `check_branch_refresh_complete` on a later tick (interview pick
+    /// 2026-06-03: cached-first, async refresh).
+    pub fn open_branch_picker(&mut self) {
+        use crate::components::new_session::configure::{BranchPickerState, PickerBranchEntry};
+        use crate::git::branch_list::{self, BranchEntry};
+        use crate::git::repo_source::RepoSource;
+
+        let Some(cfg) = self.new_session_state.as_mut().and_then(|ns| ns.configure_state.as_mut())
+        else {
+            return;
+        };
+
+        // Where do cached refs live? The repo itself for local picks; the
+        // clone cache for remote/star sources (when already cloned). A
+        // not-yet-cloned remote has no cached refs — the popup opens empty
+        // with the spinner and the ls-remote refresh fills it.
+        let source = cfg.repo_source.clone();
+        let list_path: Option<std::path::PathBuf> = match &source {
+            RepoSource::LocalPath(p) => Some(p.clone()),
+            RepoSource::HttpsUrl(_)
+            | RepoSource::SshUrl(_)
+            | RepoSource::GithubShorthand { .. } => {
+                crate::git::RemoteRepoManager::new().ok().and_then(|m| {
+                    source
+                        .parse_components()
+                        .ok()
+                        .filter(|parsed| m.is_cached(parsed))
+                        .map(|parsed| m.get_cache_path(&parsed))
+                })
+            }
+            // SshSession / Filter never show the Branch row.
+            _ => None,
+        };
+
+        let existing = cfg.existing_branches.clone();
+        let mark_in_use = |entries: Vec<BranchEntry>| -> Vec<PickerBranchEntry> {
+            entries
+                .into_iter()
+                .map(|e| PickerBranchEntry {
+                    in_use: existing.iter().any(|b| b == &e.short_name),
+                    entry: e,
+                })
+                .collect()
+        };
+
+        let cached = list_path.as_deref().map(branch_list::list_repo_branches).unwrap_or_default();
+        cfg.branch_picker = Some(BranchPickerState::new(mark_in_use(cached), true));
+
+        // Background refresh — generation-guarded so a stale result can't
+        // repopulate a closed/reopened picker.
+        self.branch_refresh_seq += 1;
+        let seq = self.branch_refresh_seq;
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.branch_refresh_receiver = Some(rx);
+        tokio::spawn(async move {
+            let join = tokio::task::spawn_blocking(move || -> Result<Vec<BranchEntry>, String> {
+                match list_path {
+                    Some(p) => Ok(branch_list::fetch_and_list(&p)),
+                    None => {
+                        // Remote source with no cache yet: ls-remote.
+                        let manager =
+                            crate::git::RemoteRepoManager::new().map_err(|e| e.to_string())?;
+                        let remote =
+                            manager.list_remote_branches(&source).map_err(|e| e.to_string())?;
+                        Ok(remote
+                            .into_iter()
+                            .map(|b| BranchEntry {
+                                display: format!("origin/{}", b.name),
+                                short_name: b.name,
+                                is_remote: true,
+                                is_default: b.is_default,
+                            })
+                            .collect())
+                    }
+                }
+            })
+            .await;
+            let payload = match join {
+                Ok(r) => r,
+                Err(join_err) => Err(format!("branch refresh task panicked: {join_err}")),
+            };
+            let _ = tx.send((seq, payload));
+        });
+    }
+
+    /// Poll the background branch refresh. Applies the fresh list to the
+    /// popup (if still open) and stops the spinner. Refresh errors keep the
+    /// cached entries — offline-safe — and surface a non-blocking warning.
+    /// Returns true when state changed this tick.
+    pub fn check_branch_refresh_complete(&mut self) -> bool {
+        use crate::components::new_session::configure::PickerBranchEntry;
+
+        let Some(ref mut receiver) = self.branch_refresh_receiver else {
+            return false;
+        };
+        let (seq, result) = match receiver.try_recv() {
+            Ok(payload) => payload,
+            Err(mpsc::error::TryRecvError::Empty) => return false,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                self.branch_refresh_receiver = None;
+                return false;
+            }
+        };
+        self.branch_refresh_receiver = None;
+        if seq != self.branch_refresh_seq {
+            // A newer picker session superseded this refresh.
+            return false;
+        }
+
+        let mut warn_msg: Option<String> = None;
+        if let Some(cfg) =
+            self.new_session_state.as_mut().and_then(|ns| ns.configure_state.as_mut())
+        {
+            let existing = cfg.existing_branches.clone();
+            if let Some(picker) = cfg.branch_picker.as_mut() {
+                picker.loading = false;
+                match result {
+                    Ok(entries) => {
+                        picker.entries = entries
+                            .into_iter()
+                            .map(|e| PickerBranchEntry {
+                                in_use: existing.iter().any(|b| b == &e.short_name),
+                                entry: e,
+                            })
+                            .collect();
+                        picker.clamp_selection();
+                    }
+                    Err(msg) => {
+                        // Keep the cached list usable; just warn.
+                        warn_msg = Some(msg);
+                    }
+                }
+            }
+        }
+        if let Some(msg) = warn_msg {
+            warn!("branch refresh failed: {msg}");
+            self.add_warning_notification(format!("Branch refresh failed: {msg}"));
+        }
+        true
     }
 
     /// Load Boss mode sessions from Docker containers
@@ -5765,7 +5929,19 @@ impl AppState {
             agent_type,
             session_model,
             codex_model,
+            base: spec.base.clone(),
         };
+
+        // Boss mode builds its own Docker workspace from `repo_path` and
+        // doesn't consume the worktree machinery — a picked base can't be
+        // honored there yet. Be honest about it rather than silently using
+        // the default.
+        if snapshot.base.is_some() && snapshot.mode == SessionMode::Boss {
+            self.add_warning_notification(
+                "Base-branch pick is not applied in Boss mode yet — session uses the default base"
+                    .to_string(),
+            );
+        }
 
         // ONLY check authentication for Boss mode (Docker-based sessions)
         if snapshot.mode == SessionMode::Boss {
@@ -5873,20 +6049,32 @@ impl AppState {
         // `existing_worktree`. Boss mode (`create_boss_session`) ignores it and
         // builds its own Docker request from `repo_path`, so preparing a worktree
         // there would orphan it on disk and leave a stray cache branch.
+        // Checkout-direct picks from the remote flow can land on a suffixed
+        // branch (`feature-x-ab12cd34`) when the branch already has a
+        // worktree — track the branch the worktree actually got.
+        let mut effective_branch = snapshot.branch_name.clone();
         let existing_worktree =
             if snapshot.repo_source.is_remote() && snapshot.mode == SessionMode::Interactive {
                 match self.prepare_remote_worktree(session_id, &repo_path, &snapshot).await {
-                    Ok(ew) => Some(ew),
+                    Ok((worktree_path, source_repo, branch)) => {
+                        effective_branch = branch;
+                        Some((worktree_path, source_repo))
+                    }
                     Err(()) => return, // already notified + cancelled
                 }
             } else {
                 None
             };
 
+        // Local repos: hand the picked base ref (if any) to the worktree
+        // machinery. The display form is revparse-able for both kinds —
+        // `origin/feature-x` (remote pick) or `feature-x` (local pick).
+        let base_start_point = snapshot.base.as_ref().map(|b| b.display.clone());
+
         let result = self
             .create_session_with_logs(
                 &repo_path,
-                &snapshot.branch_name,
+                &effective_branch,
                 session_id,
                 snapshot.skip_permissions,
                 snapshot.mode,
@@ -5895,6 +6083,7 @@ impl AppState {
                 snapshot.session_model,
                 snapshot.codex_model,
                 existing_worktree,
+                base_start_point,
             )
             .await;
 
@@ -5918,9 +6107,14 @@ impl AppState {
         }
     }
 
-    /// Build a worktree for a remote/star launch, branched off the remote's
-    /// default branch (`origin/HEAD`) of the freshly-fetched cache. Returns
-    /// `(worktree_path, source_repo_path)` for the `existing_worktree` arg of
+    /// Build a worktree for a remote/star launch. Base policy:
+    ///   * no pick — NEW branch off the remote's default (`origin/HEAD`),
+    ///     freshly fetched (legacy star policy);
+    ///   * base-off pick — NEW branch off `origin/<picked>`;
+    ///   * checkout pick — the picked branch itself, as a local tracking
+    ///     branch (suffixed when the branch already has a worktree).
+    ///
+    /// Returns `(worktree_path, source_repo_path, effective_branch)` for
     /// `create_session_with_logs`. On failure: notifies + cancels the
     /// new-session flow and returns `Err(())`.
     ///
@@ -5930,15 +6124,17 @@ impl AppState {
         session_id: uuid::Uuid,
         cache_path: &std::path::Path,
         snapshot: &ConfigureLaunchSnapshot,
-    ) -> Result<(std::path::PathBuf, std::path::PathBuf), ()> {
+    ) -> Result<(std::path::PathBuf, std::path::PathBuf, String), ()> {
+        use crate::components::new_session::configure::BaseMode;
         use crate::git::{RemoteRepoManager, WorktreeManager};
 
         let cache = cache_path.to_path_buf();
         let branch = snapshot.branch_name.clone();
         let source = snapshot.repo_source.clone();
+        let base = snapshot.base.clone();
 
         let join = tokio::task::spawn_blocking(
-            move || -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+            move || -> Result<(std::path::PathBuf, std::path::PathBuf, String), String> {
                 let wt_manager =
                     WorktreeManager::new().map_err(|e| format!("worktree manager init: {e}"))?;
                 let worktree_path = wt_manager
@@ -5946,10 +6142,49 @@ impl AppState {
                     .map_err(|e| format!("worktree path: {e}"))?;
                 let remote_manager =
                     RemoteRepoManager::new().map_err(|e| format!("remote manager init: {e}"))?;
-                remote_manager
-                    .create_worktree_off_remote_default(&cache, &worktree_path, &branch, &source)
-                    .map_err(|e| format!("{e}"))?;
-                Ok((worktree_path, cache))
+                match base {
+                    Some(b) if b.mode == BaseMode::Checkout => {
+                        // `clone_repo` already fetched on cache reuse, so
+                        // origin/<branch> is fresh. Suffix-collision handling
+                        // lives inside checkout_existing_branch_worktree.
+                        match remote_manager
+                            .checkout_existing_branch_worktree(
+                                &cache,
+                                &worktree_path,
+                                &b.short_name,
+                            )
+                            .map_err(|e| format!("{e}"))?
+                        {
+                            Some((suffixed_path, suffixed_branch)) => {
+                                Ok((suffixed_path, cache, suffixed_branch))
+                            }
+                            None => Ok((worktree_path, cache, b.short_name.clone())),
+                        }
+                    }
+                    Some(b) => {
+                        remote_manager
+                            .create_worktree_off_remote_branch(
+                                &cache,
+                                &worktree_path,
+                                &branch,
+                                Some(&b.short_name),
+                                &source,
+                            )
+                            .map_err(|e| format!("{e}"))?;
+                        Ok((worktree_path, cache, branch))
+                    }
+                    None => {
+                        remote_manager
+                            .create_worktree_off_remote_default(
+                                &cache,
+                                &worktree_path,
+                                &branch,
+                                &source,
+                            )
+                            .map_err(|e| format!("{e}"))?;
+                        Ok((worktree_path, cache, branch))
+                    }
+                }
             },
         )
         .await;
@@ -6338,6 +6573,7 @@ impl AppState {
         model: Option<crate::models::ClaudeModel>,
         codex_model: Option<crate::models::CodexModel>,
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
+        base_start_point: Option<String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Branch based on session mode
         match mode {
@@ -6351,6 +6587,7 @@ impl AppState {
                     model,
                     codex_model,
                     existing_worktree,
+                    base_start_point,
                 )
                 .await
             }
@@ -6377,6 +6614,9 @@ impl AppState {
     /// * `agent_type` - Type of agent (Claude, Shell, etc.)
     /// * `model` - Claude model to use
     /// * `existing_worktree` - For remote repos: (worktree_path, source_repo_path)
+    /// * `base_start_point` - For local repos: revparse-able ref the new
+    ///   branch is cut from (`origin/feature-x` / `feature-x`); `None` keeps
+    ///   the legacy default-branch policy
     async fn create_interactive_session(
         &mut self,
         repo_path: &std::path::Path,
@@ -6387,6 +6627,7 @@ impl AppState {
         model: Option<crate::models::ClaudeModel>,
         codex_model: Option<crate::models::CodexModel>,
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
+        base_start_point: Option<String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::interactive::InteractiveSessionManager;
 
@@ -6457,7 +6698,7 @@ impl AppState {
                     workspace_name.clone(),
                     repo_path.to_path_buf(),
                     branch_name.to_string(),
-                    None, // base_branch
+                    base_start_point,
                     skip_permissions,
                     agent_type,
                     model,
@@ -8977,6 +9218,11 @@ impl App {
 
         // Check for completed background skills scan
         if self.state.check_skills_load_complete() {
+            self.state.ui_needs_refresh = true;
+        }
+
+        // Check for a completed base-branch refresh (Configure picker)
+        if self.state.check_branch_refresh_complete() {
             self.state.ui_needs_refresh = true;
         }
 

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -32,6 +32,7 @@ use std::collections::HashMap;
 use crate::app::state::TextEditor;
 use crate::config::presets::{PresetManager, RepositoryPreset, SessionMode};
 use crate::config::session_defaults::SessionDefaults;
+use crate::git::branch_list::BranchEntry;
 use crate::git::branch_namer::derive_branch_name;
 use crate::git::repo_source::RepoSource;
 
@@ -78,6 +79,111 @@ impl CustomOverrides {
             agent_model: preset.agent_model.clone(),
             mode: preset.mode,
             skip_all: preset.permissions.skip_all,
+        }
+    }
+}
+
+/// Which segment of the Branch row (`source → worktree`) is targeted when
+/// the row is focused. ←/→ toggles; Enter acts on the targeted segment —
+/// Source opens the base-branch picker popup, Worktree opens the inline
+/// name edit (2026-06 base-picker feature).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchSegment {
+    Source,
+    Worktree,
+}
+
+/// How a picked base ref is applied at launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BaseMode {
+    /// Cut a fresh `agents/xxx` branch off the picked ref (default).
+    BaseOff,
+    /// Check out the picked branch itself in the worktree (local tracking
+    /// branch for remote picks). No generated branch name.
+    Checkout,
+}
+
+/// The user's pick from the base-branch popup. Threaded through `LaunchSpec`
+/// into `create_session_from_configure`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseSelection {
+    /// Display ref — `origin/feature-x` for remote entries, `feature-x` for
+    /// local ones. Doubles as the git start-point (revparse-able).
+    pub display: String,
+    /// Local short name (`feature-x`) — the branch a Checkout selection
+    /// creates / checks out.
+    pub short_name: String,
+    /// True when the pick came from the remote section.
+    pub is_remote: bool,
+    pub mode: BaseMode,
+}
+
+/// One row in the base-branch popup: the git entry plus the live-worktree
+/// collision flag (drives the `⚠ in use` marker and blocks Checkout picks).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PickerBranchEntry {
+    pub entry: BranchEntry,
+    pub in_use: bool,
+}
+
+/// State for the base-branch popup. `None` on `ConfigureState.branch_picker`
+/// when closed. Entries are seeded from cached refs at open (instant) and
+/// replaced in place when the background fetch lands (`loading` spinner).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchPickerState {
+    pub filter: String,
+    pub entries: Vec<PickerBranchEntry>,
+    /// Index into `filtered_indices()` — NOT into `entries`.
+    pub selected: usize,
+    /// True while the background fetch/ls-remote refresh is in flight.
+    pub loading: bool,
+    /// Inline error line (e.g. Checkout pick on an in-use branch).
+    pub error: Option<String>,
+    /// Action applied on Enter; Tab toggles.
+    pub mode: BaseMode,
+}
+
+impl BranchPickerState {
+    #[must_use]
+    pub fn new(entries: Vec<PickerBranchEntry>, loading: bool) -> Self {
+        Self {
+            filter: String::new(),
+            entries,
+            selected: 0,
+            loading,
+            error: None,
+            mode: BaseMode::BaseOff,
+        }
+    }
+
+    /// Indices into `entries` that match the filter (case-insensitive
+    /// substring on the display ref). Empty filter matches everything.
+    #[must_use]
+    pub fn filtered_indices(&self) -> Vec<usize> {
+        let needle = self.filter.to_lowercase();
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| needle.is_empty() || e.entry.display.to_lowercase().contains(&needle))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// The entry currently under the selection cursor, if any.
+    #[must_use]
+    pub fn selected_entry(&self) -> Option<&PickerBranchEntry> {
+        let filtered = self.filtered_indices();
+        filtered.get(self.selected).map(|&i| &self.entries[i])
+    }
+
+    /// Re-clamp `selected` after the entry set or filter changed (also used
+    /// by the app layer when the background refresh replaces `entries`).
+    pub fn clamp_selection(&mut self) {
+        let len = self.filtered_indices().len();
+        if len == 0 {
+            self.selected = 0;
+        } else if self.selected >= len {
+            self.selected = len - 1;
         }
     }
 }
@@ -153,6 +259,13 @@ pub struct ConfigureState {
     /// `derive_branch_name` so collision-disambiguation actually fires
     /// (finding #16).
     pub existing_branches: Vec<String>,
+    /// Which segment of the Branch row Enter acts on (←/→ toggles).
+    pub branch_segment: BranchSegment,
+    /// The user's base-branch pick, when they used the popup. `None` keeps
+    /// the legacy behavior (HEAD for local repos, origin/HEAD for remote).
+    pub base_selection: Option<BaseSelection>,
+    /// Base-branch popup state — `Some` while the popup is open.
+    pub branch_picker: Option<BranchPickerState>,
 }
 
 impl ConfigureState {
@@ -239,6 +352,9 @@ impl ConfigureState {
             presets_cache,
             branch_prefix: branch_prefix.to_string(),
             existing_branches,
+            branch_segment: BranchSegment::Source,
+            base_selection: None,
+            branch_picker: None,
         }
     }
 
@@ -312,13 +428,26 @@ impl ConfigureState {
         }
     }
 
+    /// True when the user picked "checkout the branch itself" in the base
+    /// popup — the worktree lands ON the picked branch, no generated name.
+    #[must_use]
+    pub fn is_checkout(&self) -> bool {
+        self.base_selection.as_ref().is_some_and(|b| b.mode == BaseMode::Checkout)
+    }
+
     /// The branch name that will actually be used for the worktree. Priority:
+    ///   0. checkout-direct pick — the picked branch IS the session branch;
     ///   1. in-progress inline edit buffer (so the collision warning updates
     ///      live as the user types — Stevie 2026-05-27);
     ///   2. committed manual override;
     ///   3. auto-derived random name.
     #[must_use]
     pub fn effective_branch(&self) -> String {
+        if let Some(base) = self.base_selection.as_ref() {
+            if base.mode == BaseMode::Checkout {
+                return base.short_name.clone();
+            }
+        }
         if let Some(ref buf) = self.branch_edit {
             return buf.clone();
         }
@@ -430,6 +559,10 @@ pub enum ConfigureOutcome {
     Launch(LaunchSpec),
     /// `^P` — open the preset manager overlay (stub for Phase 5; Phase 7).
     OpenPresetManager,
+    /// Enter on the Branch row's Source segment — the dispatcher must list
+    /// branches (git stays out of components/ — finding #9), seed
+    /// `branch_picker`, and kick the background refresh.
+    OpenBranchPicker,
 }
 
 /// Launch payload built by the Configure component and threaded all the way
@@ -448,6 +581,9 @@ pub struct LaunchSpec {
     /// Persisted to `session-defaults.per_repo[].last_branch_override` so the
     /// next launch can pre-fill the textarea.
     pub branch_override: Option<String>,
+    /// The base-branch popup pick, when used. `None` = legacy base policy
+    /// (HEAD for local repos, origin/HEAD for remote/star launches).
+    pub base: Option<BaseSelection>,
     pub prompt: Option<String>,
 }
 
@@ -554,6 +690,11 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
     // Modal overlay for save-preset, if open.
     if let Some(ref name_buf) = state.save_preset_modal {
         render_save_preset_modal(f, area, name_buf);
+    }
+
+    // Base-branch popup, if open. Rendered last so it overlays the form.
+    if let Some(ref picker) = state.branch_picker {
+        render_branch_picker_modal(f, area, picker);
     }
 }
 
@@ -900,20 +1041,66 @@ fn render_branch_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused:
         }
         return;
     }
+    // Checkout-direct pick: the picked branch IS the session branch — no
+    // `source → worktree` arrow, no generated name.
+    if state.is_checkout() {
+        let line = Line::from(vec![
+            focus_indicator(focused),
+            label_span("Branch:  "),
+            Span::styled(
+                state.effective_branch(),
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  (checkout)",
+                Style::default().fg(GOLD).add_modifier(Modifier::ITALIC),
+            ),
+            Span::styled(
+                "   [Enter to pick base]",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(line), area);
+        return;
+    }
+
     let worktree = state.effective_branch();
     let collision = state.branch_collision();
 
+    // Segment targeting (2026-06 base picker): when the row is focused the
+    // targeted segment renders underlined; ←/→ toggles, Enter acts on it.
+    let source_targeted = focused && state.branch_segment == BranchSegment::Source;
+    let worktree_targeted = focused && state.branch_segment == BranchSegment::Worktree;
+
+    let mut source_style = Style::default().fg(SOFT_WHITE);
+    if source_targeted {
+        source_style = source_style.add_modifier(Modifier::UNDERLINED | Modifier::BOLD);
+    }
+
     // Branch worktree name renders red when it collides with a live worktree,
     // green otherwise. The collision is only reachable via manual override.
-    let worktree_style = if collision {
+    let mut worktree_style = if collision {
         Style::default().fg(ALERT_RED).add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
     };
+    if worktree_targeted {
+        worktree_style = worktree_style.add_modifier(Modifier::UNDERLINED);
+    }
     let trailing = if collision {
         Span::styled(
             "   \u{26a0} in use",
             Style::default().fg(ALERT_RED).add_modifier(Modifier::BOLD),
+        )
+    } else if source_targeted {
+        Span::styled(
+            "   [Enter to pick base \u{00b7} \u{2192} name]",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        )
+    } else if worktree_targeted {
+        Span::styled(
+            "   [Enter to edit \u{00b7} \u{2190} base]",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
         )
     } else {
         Span::styled(
@@ -924,7 +1111,7 @@ fn render_branch_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused:
     let branch_line = Line::from(vec![
         focus_indicator(focused),
         label_span("Branch:  "),
-        Span::styled(state.branch_source.clone(), Style::default().fg(SOFT_WHITE)),
+        Span::styled(state.branch_source.clone(), source_style),
         Span::styled(" \u{2192} ", Style::default().fg(MUTED_GRAY)),
         Span::styled(worktree, worktree_style),
         trailing,
@@ -1228,6 +1415,165 @@ fn render_save_preset_modal(f: &mut Frame, area: Rect, name_buf: &str) {
     f.render_widget(para, inner);
 }
 
+/// Centered base-branch popup. Filter line, sectioned scrollable list
+/// (remote first, default on top, `⚠ in use` markers), mode-aware footer.
+fn render_branch_picker_modal(f: &mut Frame, area: Rect, picker: &BranchPickerState) {
+    let width = 62.min(area.width.saturating_sub(4));
+    let height = 16.min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let modal = Rect::new(x, y, width, height);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(GOLD))
+        .title(Span::styled(
+            " Pick base branch ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+        .title_alignment(Alignment::Center)
+        .style(Style::default().bg(DARK_BG));
+    let inner = block.inner(modal);
+    f.render_widget(ratatui::widgets::Clear, modal);
+    f.render_widget(block, modal);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Filter line, with the refresh spinner while the background fetch runs.
+    let mut filter_spans = vec![
+        Span::styled("> ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+        Span::styled(picker.filter.clone(), Style::default().fg(SOFT_WHITE)),
+        Span::styled("_", Style::default().fg(MUTED_GRAY)),
+    ];
+    if picker.loading {
+        filter_spans.push(Span::styled(
+            "   \u{27f3} refreshing\u{2026}",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ));
+    }
+    lines.push(Line::from(filter_spans));
+
+    // Error line (e.g. checkout pick on an in-use branch), else spacer.
+    if let Some(ref err) = picker.error {
+        lines.push(Line::from(Span::styled(
+            format!("\u{26a0} {err}"),
+            Style::default().fg(ALERT_RED).add_modifier(Modifier::BOLD),
+        )));
+    } else {
+        lines.push(Line::raw(""));
+    }
+
+    // Build the display list: section headers interleaved with entries.
+    enum Item {
+        Header(&'static str),
+        Entry(usize, usize), // (entries idx, filtered position)
+    }
+    let filtered = picker.filtered_indices();
+    let mut items: Vec<Item> = Vec::new();
+    let mut last_remote: Option<bool> = None;
+    for (pos, &idx) in filtered.iter().enumerate() {
+        let is_remote = picker.entries[idx].entry.is_remote;
+        if last_remote != Some(is_remote) {
+            items.push(Item::Header(if is_remote { "remote" } else { "local" }));
+            last_remote = Some(is_remote);
+        }
+        items.push(Item::Entry(idx, pos));
+    }
+
+    // 2 lines used above + 1 footer line below.
+    let list_height = (inner.height as usize).saturating_sub(3).max(1);
+
+    if items.is_empty() {
+        let msg = if picker.entries.is_empty() && picker.loading {
+            "loading branches\u{2026}"
+        } else {
+            "no branches match"
+        };
+        lines.push(Line::from(Span::styled(
+            format!("  {msg}"),
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        )));
+    } else {
+        // Scroll the window so the selected entry stays visible.
+        let sel_display = items
+            .iter()
+            .position(|i| matches!(i, Item::Entry(_, pos) if *pos == picker.selected))
+            .unwrap_or(0);
+        let start = sel_display.saturating_sub(list_height.saturating_sub(1));
+        for item in items.iter().skip(start).take(list_height) {
+            match item {
+                Item::Header(name) => lines.push(Line::from(Span::styled(
+                    format!("\u{2500}\u{2500} {name} \u{2500}\u{2500}"),
+                    Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+                ))),
+                Item::Entry(idx, pos) => {
+                    let e = &picker.entries[*idx];
+                    let selected = *pos == picker.selected;
+                    let mut spans: Vec<Span<'static>> = Vec::new();
+                    if selected {
+                        spans.push(Span::styled(
+                            "\u{25b8} ",
+                            Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+                        ));
+                    } else {
+                        spans.push(Span::raw("  "));
+                    }
+                    let name_style = if selected {
+                        Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(SOFT_WHITE)
+                    };
+                    spans.push(Span::styled(e.entry.display.clone(), name_style));
+                    if e.entry.is_default {
+                        spans.push(Span::styled(
+                            "  (default)",
+                            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+                        ));
+                    }
+                    if e.in_use {
+                        spans.push(Span::styled(
+                            "  \u{26a0} in use",
+                            Style::default().fg(ALERT_RED).add_modifier(Modifier::BOLD),
+                        ));
+                    }
+                    lines.push(Line::from(spans));
+                }
+            }
+        }
+    }
+
+    // Pad so the footer sits on the last inner line.
+    while (lines.len() as u16) < inner.height.saturating_sub(1) {
+        lines.push(Line::raw(""));
+    }
+
+    // Mode-aware footer: Enter's action follows the Tab-toggled mode.
+    let (enter_action, tab_action) = match picker.mode {
+        BaseMode::BaseOff => ("=New branch off pick  ", "=Checkout mode  "),
+        BaseMode::Checkout => ("=Checkout branch  ", "=Base-off mode  "),
+    };
+    lines.push(Line::from(vec![
+        Span::styled(
+            "Enter",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(enter_action, Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            "Tab",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(tab_action, Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            "Esc",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("=Close", Style::default().fg(MUTED_GRAY)),
+    ]));
+
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
 /// Render-side adapter: parse `ssh://user@host:port` into (user, host, port)
 /// strings for the SSH variant.
 fn parse_ssh_session(url: &str) -> (String, String, String) {
@@ -1267,6 +1613,11 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
         return handle_modal_key(state, key);
     }
 
+    // Base-branch popup interception — mirrors the save-preset modal.
+    if state.branch_picker.is_some() {
+        return handle_branch_picker_key(state, key);
+    }
+
     // Inline branch edit takes priority over the row machinery — every key
     // either commits / cancels the edit or extends the buffer.
     if state.branch_edit.is_some() {
@@ -1303,13 +1654,25 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
             ConfigureOutcome::Stay
         }
         KeyCode::Enter => match state.focused_row {
-            ConfigureRow::Branch => {
-                // Open inline branch edit. Seed buffer from override or auto.
-                let buf =
-                    state.branch_override.clone().unwrap_or_else(|| state.branch_worktree.clone());
-                state.branch_edit = Some(buf);
-                ConfigureOutcome::Stay
-            }
+            ConfigureRow::Branch => match state.branch_segment {
+                // Source segment: open the base-branch picker popup. The
+                // dispatcher lists branches (git stays out of components/).
+                BranchSegment::Source => ConfigureOutcome::OpenBranchPicker,
+                BranchSegment::Worktree => {
+                    // Checkout-direct pick: no generated name to edit — route
+                    // to the picker instead so Enter never dead-ends.
+                    if state.is_checkout() {
+                        return ConfigureOutcome::OpenBranchPicker;
+                    }
+                    // Open inline branch edit. Seed buffer from override or auto.
+                    let buf = state
+                        .branch_override
+                        .clone()
+                        .unwrap_or_else(|| state.branch_worktree.clone());
+                    state.branch_edit = Some(buf);
+                    ConfigureOutcome::Stay
+                }
+            },
             ConfigureRow::Prompt => {
                 // Inside Prompt textarea — Enter = newline. Ctrl+Enter is
                 // the launch shortcut from anywhere.
@@ -1385,17 +1748,22 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
     }
     let preset = state.effective_preset();
     let prompt = state.prompt.to_non_empty_string();
+    // Checkout-direct pick: the session branch IS the picked branch — the
+    // generated `agents/xxx` name (and any manual override) doesn't apply.
+    let branch_worktree = if state.is_checkout() {
+        state.effective_branch()
+    } else {
+        state.branch_override.clone().unwrap_or_else(|| state.branch_worktree.clone())
+    };
     ConfigureOutcome::Launch(LaunchSpec {
         repo_label: state.repo_label.clone(),
         repo_source: state.repo_source.clone(),
         preset_name: preset.name.clone(),
         preset,
-        branch_worktree: state
-            .branch_override
-            .clone()
-            .unwrap_or_else(|| state.branch_worktree.clone()),
+        branch_worktree,
         branch_source: state.branch_source.clone(),
         branch_override: state.branch_override.clone(),
+        base: state.base_selection.clone(),
         prompt,
     })
 }
@@ -1425,8 +1793,18 @@ fn cycle_value_in_focused_row(state: &mut ConfigureState, delta: i32) {
                 cycle_yolo(state);
             }
         }
-        ConfigureRow::Branch
-        | ConfigureRow::Prompt
+        ConfigureRow::Branch => {
+            // ←/→ on the Branch row toggles the targeted segment
+            // (source ⇄ worktree). Checkout mode pins Source — there's no
+            // editable worktree name to target.
+            if !state.is_checkout() {
+                state.branch_segment = match state.branch_segment {
+                    BranchSegment::Source => BranchSegment::Worktree,
+                    BranchSegment::Worktree => BranchSegment::Source,
+                };
+            }
+        }
+        ConfigureRow::Prompt
         | ConfigureRow::Host
         | ConfigureRow::User
         | ConfigureRow::Port
@@ -1604,6 +1982,85 @@ fn handle_branch_edit_key(state: &mut ConfigureState, key: KeyEvent) -> Configur
     }
 }
 
+/// Base-branch popup key handler. Chars/Backspace edit the fuzzy filter,
+/// ↑/↓ move the selection, Tab toggles the action mode (base-off ⇄ checkout),
+/// Enter commits the pick, Esc closes without changes.
+///
+/// `c` from the interview mock was dropped as the checkout shortcut — plain
+/// chars feed the filter, so a bare-letter action key would corrupt typing.
+/// Tab-toggle + Enter keeps per-branch action choice without the conflict.
+fn handle_branch_picker_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome {
+    let picker = state.branch_picker.as_mut().expect("guard checked");
+    match key.code {
+        KeyCode::Esc => {
+            state.branch_picker = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Tab | KeyCode::BackTab => {
+            picker.mode = match picker.mode {
+                BaseMode::BaseOff => BaseMode::Checkout,
+                BaseMode::Checkout => BaseMode::BaseOff,
+            };
+            picker.error = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Up => {
+            picker.selected = picker.selected.saturating_sub(1);
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Down => {
+            let len = picker.filtered_indices().len();
+            if len > 0 && picker.selected + 1 < len {
+                picker.selected += 1;
+            }
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Backspace => {
+            picker.filter.pop();
+            picker.clamp_selection();
+            picker.error = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Enter => {
+            let Some(picked) = picker.selected_entry().cloned() else {
+                return ConfigureOutcome::Stay;
+            };
+            let mode = picker.mode;
+            // Checkout of an in-use branch is a hard `git worktree add`
+            // failure — block here with the inline error (interview pick:
+            // mark + block, never silently degrade to base-off).
+            if mode == BaseMode::Checkout && picked.in_use {
+                picker.error = Some(
+                    "checked out by a live session — base a new branch off it instead".to_string(),
+                );
+                return ConfigureOutcome::Stay;
+            }
+            state.base_selection = Some(BaseSelection {
+                display: picked.entry.display.clone(),
+                short_name: picked.entry.short_name.clone(),
+                is_remote: picked.entry.is_remote,
+                mode,
+            });
+            state.branch_source = picked.entry.display;
+            if state.is_checkout() {
+                // No generated name in checkout mode — drop the stale edit
+                // buffer and pin the segment back on Source.
+                state.branch_edit = None;
+                state.branch_segment = BranchSegment::Source;
+            }
+            state.branch_picker = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            picker.filter.push(c);
+            picker.clamp_selection();
+            picker.error = None;
+            ConfigureOutcome::Stay
+        }
+        _ => ConfigureOutcome::Stay,
+    }
+}
+
 /// Save-preset modal key handler. Backspace removes from the name buffer;
 /// Enter calls `PresetManager::save_preset` and closes the modal; Esc cancels.
 fn handle_modal_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome {
@@ -1694,6 +2151,9 @@ mod tests {
             presets_cache,
             branch_prefix: "agents/".into(),
             existing_branches: Vec::new(),
+            branch_segment: BranchSegment::Source,
+            base_selection: None,
+            branch_picker: None,
         }
     }
 
@@ -1981,6 +2441,146 @@ mod tests {
         cycle_value_in_focused_row(&mut s, 1);
         // First step from SystemDefault → Gpt55 → "gpt-5.5".
         assert_eq!(s.custom_overrides.as_ref().unwrap().agent_model, "gpt-5.5");
+    }
+
+    // --- 2026-06: base-branch picker ---------------------------------------
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn mk_entries() -> Vec<PickerBranchEntry> {
+        let mk = |display: &str, short: &str, remote: bool, default: bool, in_use: bool| {
+            PickerBranchEntry {
+                entry: BranchEntry {
+                    display: display.into(),
+                    short_name: short.into(),
+                    is_remote: remote,
+                    is_default: default,
+                },
+                in_use,
+            }
+        };
+        vec![
+            mk("origin/main", "main", true, true, false),
+            mk("origin/feature-x", "feature-x", true, false, false),
+            mk("origin/fix/login", "fix/login", true, false, true),
+            mk("local-only", "local-only", false, false, false),
+        ]
+    }
+
+    #[test]
+    fn enter_on_source_segment_opens_picker() {
+        let mut s = mk_state();
+        s.focused_row = ConfigureRow::Branch;
+        assert_eq!(s.branch_segment, BranchSegment::Source, "Source is default");
+        let outcome = handle_key(&mut s, key(KeyCode::Enter));
+        assert_eq!(outcome, ConfigureOutcome::OpenBranchPicker);
+    }
+
+    #[test]
+    fn arrows_toggle_segment_and_enter_edits_worktree_name() {
+        let mut s = mk_state();
+        s.focused_row = ConfigureRow::Branch;
+        handle_key(&mut s, key(KeyCode::Right));
+        assert_eq!(s.branch_segment, BranchSegment::Worktree);
+        let outcome = handle_key(&mut s, key(KeyCode::Enter));
+        assert_eq!(outcome, ConfigureOutcome::Stay);
+        assert!(
+            s.branch_edit.is_some(),
+            "Worktree segment Enter = inline edit"
+        );
+    }
+
+    #[test]
+    fn picker_enter_commits_base_off_pick() {
+        let mut s = mk_state();
+        s.branch_picker = Some(BranchPickerState::new(mk_entries(), false));
+        // Move to origin/feature-x and commit.
+        handle_key(&mut s, key(KeyCode::Down));
+        handle_key(&mut s, key(KeyCode::Enter));
+        assert!(s.branch_picker.is_none(), "popup closes on commit");
+        let base = s.base_selection.clone().expect("pick recorded");
+        assert_eq!(base.display, "origin/feature-x");
+        assert_eq!(base.short_name, "feature-x");
+        assert_eq!(base.mode, BaseMode::BaseOff);
+        assert_eq!(s.branch_source, "origin/feature-x", "row shows the pick");
+        // Worktree name still the generated one — base-off keeps it.
+        assert_eq!(s.effective_branch(), s.branch_worktree);
+    }
+
+    #[test]
+    fn picker_tab_toggles_to_checkout_and_picked_branch_becomes_session_branch() {
+        let mut s = mk_state();
+        s.branch_picker = Some(BranchPickerState::new(mk_entries(), false));
+        handle_key(&mut s, key(KeyCode::Down)); // origin/feature-x
+        handle_key(&mut s, key(KeyCode::Tab)); // checkout mode
+        handle_key(&mut s, key(KeyCode::Enter));
+        assert!(s.is_checkout());
+        assert_eq!(s.effective_branch(), "feature-x");
+        // Launch spec carries the pick and uses the picked branch name.
+        s.focused_row = ConfigureRow::Launch;
+        let outcome = launch_outcome(&mut s);
+        let ConfigureOutcome::Launch(spec) = outcome else {
+            panic!("expected launch");
+        };
+        assert_eq!(spec.branch_worktree, "feature-x");
+        assert_eq!(spec.base.unwrap().mode, BaseMode::Checkout);
+    }
+
+    #[test]
+    fn picker_blocks_checkout_of_in_use_branch() {
+        let mut s = mk_state();
+        s.branch_picker = Some(BranchPickerState::new(mk_entries(), false));
+        handle_key(&mut s, key(KeyCode::Down));
+        handle_key(&mut s, key(KeyCode::Down)); // origin/fix/login (in use)
+        handle_key(&mut s, key(KeyCode::Tab)); // checkout mode
+        handle_key(&mut s, key(KeyCode::Enter));
+        let picker = s.branch_picker.as_ref().expect("popup stays open");
+        assert!(picker.error.is_some(), "inline error shown");
+        assert!(s.base_selection.is_none(), "no pick recorded");
+        // Base-off of the same branch is fine — Tab back and commit.
+        handle_key(&mut s, key(KeyCode::Tab));
+        handle_key(&mut s, key(KeyCode::Enter));
+        assert_eq!(s.base_selection.unwrap().mode, BaseMode::BaseOff);
+    }
+
+    #[test]
+    fn picker_filter_narrows_and_esc_closes_without_pick() {
+        let mut s = mk_state();
+        s.branch_picker = Some(BranchPickerState::new(mk_entries(), false));
+        for c in "feat".chars() {
+            handle_key(&mut s, key(KeyCode::Char(c)));
+        }
+        {
+            let picker = s.branch_picker.as_ref().unwrap();
+            assert_eq!(picker.filtered_indices().len(), 1);
+            assert_eq!(
+                picker.selected_entry().unwrap().entry.display,
+                "origin/feature-x"
+            );
+        }
+        handle_key(&mut s, key(KeyCode::Esc));
+        assert!(s.branch_picker.is_none());
+        assert!(s.base_selection.is_none());
+        assert_eq!(s.branch_source, "main", "Esc leaves the source untouched");
+    }
+
+    #[test]
+    fn checkout_pick_pins_segment_and_reroutes_enter_to_picker() {
+        let mut s = mk_state();
+        s.branch_segment = BranchSegment::Worktree;
+        s.branch_picker = Some(BranchPickerState::new(mk_entries(), false));
+        handle_key(&mut s, key(KeyCode::Tab)); // checkout mode
+        handle_key(&mut s, key(KeyCode::Enter)); // pick origin/main
+        assert_eq!(s.branch_segment, BranchSegment::Source, "segment pinned");
+        // ←/→ must not move the segment off Source in checkout mode.
+        s.focused_row = ConfigureRow::Branch;
+        handle_key(&mut s, key(KeyCode::Right));
+        assert_eq!(s.branch_segment, BranchSegment::Source);
+        // Enter re-opens the picker (no generated name to edit).
+        let outcome = handle_key(&mut s, key(KeyCode::Enter));
+        assert_eq!(outcome, ConfigureOutcome::OpenBranchPicker);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -1614,6 +1614,10 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
     }
 
     // Base-branch popup interception — mirrors the save-preset modal.
+    // INVARIANT: the two modals are mutually exclusive (the picker handler
+    // exposes no ^S path and vice versa). If that ever changes, align this
+    // precedence with the render order in `render()` — the picker draws on
+    // top, so it must also win the key race.
     if state.branch_picker.is_some() {
         return handle_branch_picker_key(state, key);
     }

--- a/ainb-tui/crates/ainb-core/src/git/branch_list.rs
+++ b/ainb-tui/crates/ainb-core/src/git/branch_list.rs
@@ -82,6 +82,33 @@ pub fn fetch_and_list(repo_path: &Path) -> Vec<BranchEntry> {
     list_repo_branches(repo_path)
 }
 
+/// Branch short names checked out in ANY worktree of `repo_path` — including
+/// the repo's own main working copy. Parsed from `git worktree list
+/// --porcelain`.
+///
+/// The ainb session list alone can't see the repo's own checkout (or a
+/// manually-added worktree); without this, a checkout-direct pick of the
+/// repo's current branch passes the picker guard and dies at
+/// `git worktree add` with "already used by worktree" (review P1, PR #211).
+#[must_use]
+pub fn checked_out_branches(repo_path: &Path) -> Vec<String> {
+    let Ok(output) = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_path)
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|l| l.strip_prefix("branch refs/heads/"))
+        .map(str::to_string)
+        .collect()
+}
+
 /// Pure assembly: dedup remote-vs-local, tag the default, sort sections.
 /// Split out for testability without a fixture repo.
 fn build_entries(
@@ -202,5 +229,48 @@ mod tests {
     fn list_repo_branches_empty_for_non_repo() {
         let tmp = tempfile::TempDir::new().unwrap();
         assert!(list_repo_branches(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn checked_out_branches_empty_for_non_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(checked_out_branches(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn checked_out_branches_sees_main_checkout_and_added_worktrees() {
+        // Real repo: the main checkout's branch must be reported even with
+        // zero ainb-managed worktrees — that's the review-P1 regression
+        // (checkout-direct pick of the repo's current branch must be
+        // markable as in-use).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir(&repo_path).unwrap();
+        let git = |args: &[&str], cwd: &Path| {
+            let out = Command::new("git").args(args).current_dir(cwd).output().unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"], &repo_path);
+        git(&["config", "user.email", "t@t"], &repo_path);
+        git(&["config", "user.name", "t"], &repo_path);
+        git(&["commit", "--allow-empty", "-m", "init"], &repo_path);
+        git(&["branch", "feature-x"], &repo_path);
+
+        let checked = checked_out_branches(&repo_path);
+        assert_eq!(checked, vec!["main".to_string()], "main checkout reported");
+
+        // A second worktree's branch shows up too.
+        let wt = tmp.path().join("wt");
+        git(
+            &["worktree", "add", wt.to_str().unwrap(), "feature-x"],
+            &repo_path,
+        );
+        let checked = checked_out_branches(&repo_path);
+        assert!(checked.contains(&"main".to_string()));
+        assert!(checked.contains(&"feature-x".to_string()));
     }
 }

--- a/ainb-tui/crates/ainb-core/src/git/branch_list.rs
+++ b/ainb-tui/crates/ainb-core/src/git/branch_list.rs
@@ -1,0 +1,206 @@
+// ABOUTME: Branch enumeration for the new-session base-branch picker.
+//
+// Two entry points:
+//   * `list_repo_branches` — disk-only (git2): local heads + `refs/remotes/
+//     origin/*`. Instant; safe to call on the event thread when the popup
+//     opens (cached-first design — Stevie 2026-06-03 interview).
+//   * `fetch_and_list` — `git fetch origin --prune` then re-list. Slow
+//     (network); callers MUST run it on `spawn_blocking` and apply the result
+//     via the tick-poll channel pattern (see `check_skills_load_complete`).
+//
+// Dedup rule: a remote branch `origin/x` is omitted when a local branch `x`
+// exists — the local entry is the one offered (it's what a checkout would
+// land on). Sections: remote first (default branch at the top), then local.
+
+use std::path::Path;
+use std::process::Command;
+
+use git2::{BranchType, Repository};
+
+/// One selectable row in the base-branch picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchEntry {
+    /// Display ref — `origin/feature-x` for remote entries, `feature-x` for
+    /// local ones. This is also the start-point handed to `git worktree add`.
+    pub display: String,
+    /// Local short name (`feature-x` for both kinds). The branch a
+    /// checkout-direct selection would create / check out.
+    pub short_name: String,
+    /// True for `refs/remotes/origin/*` entries.
+    pub is_remote: bool,
+    /// True for the repo's default branch (origin/HEAD target, or main/master
+    /// fallback). Sorted first within its section.
+    pub is_default: bool,
+}
+
+/// List branches from on-disk refs only (no network). Remote section first
+/// (default branch at the top, then alphabetical), then local branches that
+/// don't shadow a remote entry's dedup. Returns an empty vec for non-repos.
+#[must_use]
+pub fn list_repo_branches(repo_path: &Path) -> Vec<BranchEntry> {
+    let Ok(repo) = Repository::open(repo_path) else {
+        return Vec::new();
+    };
+
+    let default_branch = default_branch_short_name(&repo);
+
+    let mut locals: Vec<String> = Vec::new();
+    if let Ok(branches) = repo.branches(Some(BranchType::Local)) {
+        for (branch, _) in branches.flatten() {
+            if let Ok(Some(name)) = branch.name() {
+                locals.push(name.to_string());
+            }
+        }
+    }
+
+    let mut remotes: Vec<String> = Vec::new();
+    if let Ok(branches) = repo.branches(Some(BranchType::Remote)) {
+        for (branch, _) in branches.flatten() {
+            if let Ok(Some(name)) = branch.name() {
+                // Skip the symbolic `origin/HEAD` pointer — it duplicates the
+                // default branch entry.
+                if name.ends_with("/HEAD") {
+                    continue;
+                }
+                remotes.push(name.to_string());
+            }
+        }
+    }
+
+    build_entries(remotes, locals, default_branch.as_deref())
+}
+
+/// `git fetch origin --prune`, then list. Blocking + network — run on
+/// `spawn_blocking`. Fetch failure is non-fatal (offline-safe): the cached
+/// refs are listed either way.
+#[must_use]
+pub fn fetch_and_list(repo_path: &Path) -> Vec<BranchEntry> {
+    let _ = Command::new("git")
+        .args(["fetch", "origin", "--prune"])
+        .current_dir(repo_path)
+        .output();
+    list_repo_branches(repo_path)
+}
+
+/// Pure assembly: dedup remote-vs-local, tag the default, sort sections.
+/// Split out for testability without a fixture repo.
+fn build_entries(
+    remotes: Vec<String>,
+    locals: Vec<String>,
+    default_branch: Option<&str>,
+) -> Vec<BranchEntry> {
+    let mut entries: Vec<BranchEntry> = Vec::new();
+
+    for remote in remotes {
+        let short = remote.split_once('/').map_or(remote.as_str(), |(_, s)| s);
+        // Dedup: a local branch with the same short name shadows the remote
+        // entry (checkout would land on the local branch anyway).
+        if locals.iter().any(|l| l == short) {
+            continue;
+        }
+        entries.push(BranchEntry {
+            display: remote.clone(),
+            short_name: short.to_string(),
+            is_remote: true,
+            is_default: Some(short) == default_branch,
+        });
+    }
+
+    for local in locals {
+        entries.push(BranchEntry {
+            is_default: Some(local.as_str()) == default_branch,
+            display: local.clone(),
+            short_name: local,
+            is_remote: false,
+        });
+    }
+
+    // Remote section first; default branch tops its section; alphabetical
+    // within. `sort_by` is stable so equal keys keep insertion order.
+    entries.sort_by(|a, b| {
+        b.is_remote
+            .cmp(&a.is_remote)
+            .then(b.is_default.cmp(&a.is_default))
+            .then(a.display.cmp(&b.display))
+    });
+    entries
+}
+
+/// Resolve the default branch's SHORT name (`main`, not `origin/main`).
+/// Ladder: `origin/HEAD` symbolic-ref → local `main` → local `master`.
+fn default_branch_short_name(repo: &Repository) -> Option<String> {
+    if let Ok(reference) = repo.find_reference("refs/remotes/origin/HEAD") {
+        if let Some(target) = reference.symbolic_target() {
+            if let Some(short) = target.strip_prefix("refs/remotes/origin/") {
+                return Some(short.to_string());
+            }
+        }
+    }
+    for cand in ["main", "master"] {
+        if repo.find_branch(cand, BranchType::Local).is_ok() {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(entries: &[BranchEntry]) -> Vec<&str> {
+        entries.iter().map(|e| e.display.as_str()).collect()
+    }
+
+    #[test]
+    fn remote_section_first_default_on_top() {
+        let entries = build_entries(
+            vec![
+                "origin/zeta".into(),
+                "origin/main".into(),
+                "origin/alpha".into(),
+            ],
+            vec!["local-only".into()],
+            Some("main"),
+        );
+        assert_eq!(
+            names(&entries),
+            vec!["origin/main", "origin/alpha", "origin/zeta", "local-only"]
+        );
+        assert!(entries[0].is_default);
+        assert!(!entries[0].short_name.contains('/'));
+        assert_eq!(entries[0].short_name, "main");
+    }
+
+    #[test]
+    fn local_branch_shadows_remote_counterpart() {
+        let entries = build_entries(
+            vec!["origin/feature-x".into(), "origin/main".into()],
+            vec!["feature-x".into()],
+            Some("main"),
+        );
+        // origin/feature-x deduped away; local feature-x remains.
+        assert_eq!(names(&entries), vec!["origin/main", "feature-x"]);
+        assert!(!entries[1].is_remote);
+    }
+
+    #[test]
+    fn default_tag_applies_to_local_when_no_remote() {
+        let entries = build_entries(vec![], vec!["dev".into(), "main".into()], Some("main"));
+        assert_eq!(names(&entries), vec!["main", "dev"]);
+        assert!(entries[0].is_default);
+    }
+
+    #[test]
+    fn nested_branch_names_keep_full_short_name() {
+        let entries = build_entries(vec!["origin/fix/login".into()], vec![], None);
+        assert_eq!(entries[0].short_name, "fix/login");
+        assert_eq!(entries[0].display, "origin/fix/login");
+    }
+
+    #[test]
+    fn list_repo_branches_empty_for_non_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(list_repo_branches(tmp.path()).is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/git/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/git/mod.rs
@@ -1,5 +1,6 @@
 // ABOUTME: Git integration module for workspace detection, worktree management, and git operations
 
+pub mod branch_list;
 pub mod branch_namer;
 pub mod diff_analyzer;
 pub mod operations;
@@ -9,6 +10,7 @@ pub mod repository;
 pub mod workspace_scanner;
 pub mod worktree_manager;
 
+pub use branch_list::BranchEntry;
 pub use remote_repo_manager::{RemoteBranch, RemoteRepoError, RemoteRepoManager};
 pub use repo_source::{ParsedRepo, RepoSource, RepoSourceError};
 pub use repository::RepositoryManager;

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -257,21 +257,42 @@ impl RemoteRepoManager {
         new_branch: &str,
         source: &RepoSource,
     ) -> Result<PathBuf, RemoteRepoError> {
+        // Resolve the default lazily inside the shared impl so the fetch
+        // happens first (origin/HEAD may move).
+        self.create_worktree_off_remote_branch(cache_path, worktree_path, new_branch, None, source)
+    }
+
+    /// Create a worktree for a NEW branch cut from an arbitrary remote branch
+    /// (`origin/<base_branch>`), after a fresh fetch. `base_branch = None`
+    /// resolves the remote's default (the star-launch policy). This is the
+    /// base-branch-picker path (2026-06): the picked entry's short name comes
+    /// straight through as `base_branch`.
+    pub fn create_worktree_off_remote_branch(
+        &self,
+        cache_path: &Path,
+        worktree_path: &Path,
+        new_branch: &str,
+        base_branch: Option<&str>,
+        source: &RepoSource,
+    ) -> Result<PathBuf, RemoteRepoError> {
         if let Some(parent) = worktree_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Refresh remote refs so origin/<default> reflects upstream. Defensive:
+        // Refresh remote refs so origin/<base> reflects upstream. Defensive:
         // clone_repo already fetches on cache reuse, but a directly-supplied
         // cache may be stale. Non-fatal — we can still branch off whatever
-        // origin/<default> currently points at.
+        // origin/<base> currently points at.
         let _ = Command::new("git")
             .args(["fetch", "origin", "--prune"])
             .current_dir(cache_path)
             .output();
 
-        let default_branch = self.resolve_default_branch(cache_path, source)?;
-        let start_point = format!("origin/{default_branch}");
+        let base = match base_branch {
+            Some(b) => b.to_string(),
+            None => self.resolve_default_branch(cache_path, source)?,
+        };
+        let start_point = format!("origin/{base}");
         info!(
             "Creating worktree at {} for new branch '{}' off {}",
             worktree_path.display(),

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -433,13 +433,29 @@ impl WorktreeManager {
             return Ok(());
         }
 
-        // Get the base branch commit
-        let base_branch_ref = repo.find_branch(base_branch, BranchType::Local)?;
-        let base_commit = base_branch_ref.get().peel_to_commit()?;
+        // Resolve the base. Local branch first (legacy path), then any
+        // revparse-able ref — `origin/feature-x`, a tag, or a SHA. The base
+        // picker (2026-06) hands remote-tracking refs straight through here.
+        let base_commit = match repo.find_branch(base_branch, BranchType::Local) {
+            Ok(branch) => branch.get().peel_to_commit()?,
+            Err(_) => repo.revparse_single(base_branch)?.peel_to_commit()?,
+        };
 
         // Create the new branch
-        repo.branch(branch_name, &base_commit, false)?;
+        let mut new_branch = repo.branch(branch_name, &base_commit, false)?;
         info!("Created new branch: {} from {}", branch_name, base_branch);
+
+        // Checkout-direct case: branch created from its own remote-tracking
+        // ref (`feature-x` off `origin/feature-x`) — wire up the upstream so
+        // pull/push work out of the box in the worktree.
+        if base_branch == format!("origin/{branch_name}") {
+            if let Err(e) = new_branch.set_upstream(Some(base_branch)) {
+                warn!(
+                    "Could not set upstream {} for {}: {}",
+                    base_branch, branch_name, e
+                );
+            }
+        }
 
         Ok(())
     }
@@ -873,6 +889,26 @@ mod tests {
 
         let default_branch = manager.get_default_branch(&repo);
         assert!(!default_branch.is_empty());
+    }
+
+    #[test]
+    fn test_ensure_branch_exists_from_revparse_ref() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = create_test_repo(temp_dir.path()).unwrap();
+        let manager = WorktreeManager::with_base_dir(temp_dir.path().to_path_buf()).unwrap();
+
+        // A SHA base exercises the revparse fallback — the same path
+        // remote-tracking refs (`origin/feature-x`) take when the base
+        // picker hands one through.
+        let head_sha = repo.head().unwrap().target().unwrap().to_string();
+        manager.ensure_branch_exists(&repo, "picked-base", &head_sha).unwrap();
+        assert!(repo.find_branch("picked-base", BranchType::Local).is_ok());
+
+        // Unresolvable base must error, not silently fall back.
+        assert!(
+            manager.ensure_branch_exists(&repo, "other", "origin/does-not-exist").is_err(),
+            "unknown base ref must fail loudly"
+        );
     }
 
     #[test]

--- a/ainb-tui/plans/new-session-branch-picker.md
+++ b/ainb-tui/plans/new-session-branch-picker.md
@@ -1,0 +1,103 @@
+# Spec: New-Session Base Branch Picker
+
+**Generated from:** interview (2026-06-03)
+**Version:** 1.0
+
+## Executive Summary
+
+The new-session Configure screen shows `Branch: main → agents/xxxx` where the
+source segment is display-only. This feature makes the source selectable: a
+popup picker listing remote + local branches, with two actions per branch —
+base a fresh `agents/xxx` branch off the pick, or check out the picked branch
+itself in the worktree.
+
+## Flow
+
+```
+┌────────────┐   ┌──────────────────────────┐   ┌─────────────────────────────┐
+│ Configure  │──▶│ Branch row, src focused  │──▶│ Popup: branch list + filter │
+│ screen     │   │ Enter opens picker       │   │ cached refs → async refresh │
+└────────────┘   └──────────────────────────┘   └──────────────┬──────────────┘
+                                                               │
+                                  ┌────────────────────────────┼───────────────┐
+                                  ▼                            ▼               │
+                       Enter = base-off               c = checkout direct      │
+                       worktree add -b agents/xx      worktree add <path> br   │
+                       <path> <picked-ref>            (tracking branch)        │
+                                  │                            │               │
+                                  └────────────┬───────────────┘   Esc = close ┘
+                                               ▼
+                                      session created
+```
+
+## Decisions Made (interview, all axes)
+
+| Axis | Decision | Rationale |
+|------|----------|-----------|
+| Semantics | Dual action: Enter = new `agents/xxx` based off pick; `c` = checkout picked branch itself | Covers fresh-work AND continue-existing-PR cases |
+| Scope | Both local repos and star-launched remote repos | One consistent UX |
+| UI placement | Popup on Branch row source segment, fuzzy filter (like repo picker) | No new Configure row; familiar pattern |
+| List contents | Remote (`origin/*`) + local branches, sectioned, default-first, dedup where local tracks remote | Literal ask = remote; local adds offline value |
+| Collision | Rows show `⚠ in use` (branch checked out in another worktree); `c` on such a row = inline error, stays in picker | Git hard-blocks double checkout; fail visible, no surprise fallback |
+| Fetch timing | Open instantly from cached `refs/remotes/*`; background fetch refreshes list in place with spinner | Offline-safe, no popup hang on slow network |
+
+## Scope
+
+### In Scope
+- Popup branch picker in Configure screen (Branch row source segment)
+- Base-off semantics: `git worktree add -b <agents/xxx> <path> <picked-ref>`
+- Checkout-direct semantics:
+  - remote pick, no local branch: `git worktree add --track -b <name> <path> origin/<name>`
+  - local branch exists, not checked out: `git worktree add <path> <name>`
+- In-use detection from existing worktrees (reuse `existing_branches` machinery)
+- Cached-first listing + async refresh for local repos (`refs/remotes/*` on disk)
+  and remote repos (`list_remote_branches()` already exists, remote_repo_manager.rs:82)
+- Branch row display updates:
+  - base-off: `origin/feature-x → agents/ab12cd34`
+  - checkout: `feature-x (checkout)` — no generated name
+- Worktree-name inline edit unchanged for base-off mode
+
+### Out of Scope
+- Attaching to an existing session that already has the branch (deferred)
+- Branch creation from arbitrary SHAs/tags
+- Multi-remote support (origin only)
+
+## Technical Requirements
+
+### Touched components
+
+| Component | File | Change |
+|-----------|------|--------|
+| Configure state | `crates/ainb-core/src/components/new_session/configure.rs` | `BranchPickerState`, `BaseSelection { ref_name, mode }`, render popup, key handling |
+| Events wiring | `crates/ainb-core/src/app/events.rs` | populate cached entries on popup open; async refresh message; thread `BaseSelection` into session creation |
+| Local git | `crates/ainb-core/src/git/worktree_manager.rs` | worktree-add with explicit start point; checkout-direct variant |
+| Remote git | `crates/ainb-core/src/git/remote_repo_manager.rs` | worktree off picked `origin/<branch>` (generalise `create_worktree_off_remote_default`) |
+| Branch listing | git layer | local: `refs/remotes/*` + local heads via git2 (cached, offline); refresh via fetch/ls-remote |
+
+### Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Picked branch checked out in another worktree, `c` pressed | Inline error in popup, no action |
+| Picked branch checked out elsewhere, Enter pressed | Fine — base-off creates new branch |
+| Checkout-direct of remote branch with no local counterpart | Create local tracking branch in worktree |
+| Checkout-direct where local branch exists and is behind origin | Check out local branch as-is (no auto-ff) — user's branch state preserved |
+| Refresh fails (offline) | Keep cached list, show non-blocking warn, popup stays usable |
+| No remote configured (local-only repo) | Local section only, no spinner |
+| Filter matches nothing | Empty-state line, Esc still closes |
+| Default branch | Always sorted first, marked `(default)` |
+
+## Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Async refresh races popup close | Low | Med | Guard refresh result application on popup-open + repo identity |
+| Checkout-direct branch-name collisions with stale local branches | Med | Low | Pre-check local branch state; in-use markers from worktree list |
+| Big repos: ls-remote slow | Low | Med | Cached-first design; spinner only on the refresh, never blocking |
+
+## Implementation Notes — Priority Order
+
+1. Git layer: branch enumeration (cached + refresh) and worktree-add variants
+2. Configure state + popup render + key handling
+3. Events wiring: open/refresh/selection → session creation (local + remote paths)
+4. Behavioural tests (git layer in temp repos; picker state transitions)

--- a/ainb-tui/plans/new-session-branch-picker.md
+++ b/ainb-tui/plans/new-session-branch-picker.md
@@ -79,6 +79,7 @@ itself in the worktree.
 | Scenario | Expected Behavior |
 |----------|-------------------|
 | Picked branch checked out in another worktree, `c` pressed | Inline error in popup, no action |
+| Picked branch checked out in the repo's OWN working copy (or a manual worktree) | `⚠ in use` via `git worktree list --porcelain`, checkout blocked (review P1, PR #211) |
 | Picked branch checked out elsewhere, Enter pressed | Fine — base-off creates new branch |
 | Checkout-direct of remote branch with no local counterpart | Create local tracking branch in worktree |
 | Checkout-direct where local branch exists and is behind origin | Check out local branch as-is (no auto-ff) — user's branch state preserved |


### PR DESCRIPTION
## Summary

The new-session Branch row showed `main → agents/xxxx` with the source display-only — every session branched off HEAD (local repos) or origin/HEAD (star launches). This adds a base-branch picker:

- **←/→ on the Branch row** targets the source segment; **Enter** opens a popup listing **remote + local branches** (fuzzy filter, sectioned, default-first)
- **Two actions per pick** (Tab toggles, footer shows the live mode):
  - **base-off** (default): cut the generated `agents/xxx` branch off the pick — `git worktree add -b agents/xxx <path> origin/<pick>`
  - **checkout**: the worktree lands on the picked branch itself as a local tracking branch — for continuing existing work
- Branches checked out by a live session render **⚠ in use** and block checkout picks (base-off still allowed)
- Popup opens **instantly from cached refs**; a background `git fetch` refreshes the list in place (spinner, generation-guarded channel, offline-safe)
- Works for local repos **and** star/remote launches (not-yet-cloned remotes list via `ls-remote`)
- Boss mode: honest warning that picks aren't applied there yet

Spec with full decision log: `ainb-tui/plans/new-session-branch-picker.md` (completes the picker deferred in #209).

## Implementation

| Layer | Change |
|---|---|
| `git/branch_list.rs` (new) | disk-only local+remote enumeration + fetch-and-relist |
| `git/worktree_manager.rs` | `ensure_branch_exists` resolves revparse-able bases; upstream wired for checkout picks |
| `git/remote_repo_manager.rs` | star path generalised to `create_worktree_off_remote_branch(origin/<base>)` |
| `configure.rs` | segment-aware Branch row, popup state/render/keys, `LaunchSpec.base` |
| `events.rs` / `state.rs` | `OpenBranchPicker` event, cached-seed + async refresh (tick-polled), base threaded through both creation paths |

## Testing

- 7 new behavioural tests for the picker state machine (open/filter/commit/in-use block/segment pinning)
- 5 unit tests for branch enumeration (dedup, default-first, sections)
- revparse-base test for `ensure_branch_exists` (SHA base + unknown-ref fails loudly)
- CI-mirrored run green: `cargo fmt --check`, lib tests with CI skips (822 passed / 0 failed), `tripwire_inbox_opens_and_renders` passed, `cargo build --workspace` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a base-branch picker popup to the Configure screen for selecting a branch when creating a new session.
  * Branch picker displays both local and remote branches with filtering support and background refresh.
  * Support for two launch modes: creating a new worktree branch from the selected base or checking out the selected branch directly.

* **Tests**
  * Added tests covering branch picker interactions, filtering, selection modes, and in-use branch collision detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->