### PR TITLE
ci(release): cross-compile Intel macOS bottle on ARM runner (macos-13 unavailable)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,9 +186,12 @@ jobs:
             os: macos-latest
             ext: ""
             archive: tar.gz
-          # macOS Intel (native build on the Intel macos-13 runner)
+          # macOS Intel (x86_64) — cross-compiled on the ARM runner. Dedicated
+          # macos-13 Intel runners queue indefinitely in this org, and Apple's
+          # macOS SDK is universal, so `--target x86_64-apple-darwin` on the ARM
+          # runner produces a valid Intel binary.
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             ext: ""
             archive: tar.gz
           # Linux glibc (works on most distributions)


### PR DESCRIPTION
Follow-up to #218. The v1.4.1 release stalled: the `x86_64-apple-darwin` build job sat queued >15min because dedicated macos-13 Intel runners don't allocate in this org. Switch that matrix entry to `macos-latest` and cross-compile (`--target x86_64-apple-darwin`) — Apple's SDK is universal so this yields a valid Intel binary without an Intel runner. After merge I'll cut v1.4.2 (v1.4.1 tag was deleted — it never produced a release).