### PR TITLE
ci(release): install cross-target std for the pinned toolchain (fix Intel build E0463)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The build runs in ainb-tui, which pins the toolchain via
+      # rust-toolchain.toml (not the `stable` dtolnay installed the target for).
+      # Add the target's std to the *pinned* toolchain so cross-compiling
+      # x86_64-apple-darwin on the ARM runner can find `core` (no-op for native
+      # targets). Runs in ${{ env.WORKING_DIR }} via the job-level default.
+      - name: Add target std to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 


### PR DESCRIPTION
The v1.4.2 Intel cross-compile failed with `error[E0463]: can't find crate for core`. Root cause: the build runs in `ainb-tui` which pins the toolchain via `rust-toolchain.toml` (1.96.0), but `dtolnay/rust-toolchain@stable` added the x86_64-apple-darwin target to *stable*, not the pinned toolchain. Add a `rustup target add` step (runs in ainb-tui via the job default, so it targets the pinned toolchain). No-op for native targets. After merge I'll re-cut v1.4.2.