### PR TITLE
revert: restore webapp-testing skill (keep agent yamls removed)

### DIFF
--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -1883,6 +1883,62 @@ async function handleFullDirectoryCopy(tool, config, overrideHomeDir = null, tar
             const skillsFiles = copyDirectoryRecursive(skillsSource, skillsDest, [], config.templateSubstitutions || {});
             completeProgress(`Copied ${skillsFiles} skill files`);
         }
+
+        // Smart compilation for browser-tools in webapp-testing skill
+        const browserToolsDir = path.join(skillsDest, 'webapp-testing', 'bin');
+        const browserToolsTs = path.join(browserToolsDir, 'browser-tools.ts');
+        const browserToolsBinary = path.join(browserToolsDir, 'browser-tools');
+        const rebuildFlag = process.argv.includes('--rebuild');
+
+        if (fs.existsSync(browserToolsTs)) {
+            // For claude-code-4.5: compile the binary
+            if (tool === 'claude-code-4.5') {
+                let shouldCompile = rebuildFlag;
+
+                if (!fs.existsSync(browserToolsBinary)) {
+                    shouldCompile = true;
+                    showProgress('browser-tools binary missing, compiling');
+                } else if (!rebuildFlag) {
+                    const tsStats = statSync(browserToolsTs);
+                    const binaryStats = statSync(browserToolsBinary);
+                    if (tsStats.mtime > binaryStats.mtime) {
+                        shouldCompile = true;
+                        showProgress('browser-tools.ts is newer, recompiling');
+                    }
+                }
+
+                if (shouldCompile) {
+                    try {
+                        showProgress('Compiling browser-tools binary');
+                        const { execSync } = await import('child_process');
+
+                        // Try Bun first
+                        try {
+                            execSync('which bun', { stdio: 'pipe' });
+                            execSync(
+                                `cd "${browserToolsDir}" && bun install && bun build browser-tools.ts --compile --target bun --outfile browser-tools`,
+                                { stdio: 'pipe' }
+                            );
+                            completeProgress('Compiled browser-tools with Bun');
+                        } catch {
+                            // Fallback to esbuild
+                            try {
+                                execSync('which esbuild', { stdio: 'pipe' });
+                                execSync(
+                                    `cd "${browserToolsDir}" && npm install && esbuild browser-tools.ts --bundle --platform=node --outfile=browser-tools.js`,
+                                    { stdio: 'pipe' }
+                                );
+                                completeProgress('Compiled browser-tools with esbuild (JavaScript output)');
+                            } catch {
+                                completeProgress('Compilation failed, using existing binary if available');
+                            }
+                        }
+                    } catch (error) {
+                        completeProgress(`Compilation error: ${error.message}, using existing binary if available`);
+                    }
+                }
+            }
+        }
     }
 
     // Copy tool-specific files if they exist
@@ -2384,7 +2440,7 @@ async function main() {
     let targetFolder = targetFolderArg ? targetFolderArg.split('=')[1] : null;
     let overrideHomeDir = homeDirArg ? homeDirArg.split('=')[1] : null;
 
-    // Parse --packages=skills/coding-agent,agents/engineering,...
+    // Parse --packages=skills/webapp-testing,agents/engineering,...
     let specifiedPackages = null;
     if (packagesArg) {
         specifiedPackages = packagesArg.split('=')[1].split(',').map(p => p.trim());

--- a/toolkit/catalog.yaml
+++ b/toolkit/catalog.yaml
@@ -107,6 +107,7 @@ components:
     - tui-style-guide
     - ui-ux-pro-max
     - validate
+    - webapp-testing
     - workflow
 
   workflows:

--- a/toolkit/external-dependencies.yaml
+++ b/toolkit/external-dependencies.yaml
@@ -76,6 +76,14 @@ bundled-skills:
       - Verification-code and magic-link extractors
       - Tool-neutral state file under .agents/agentmail/
 
+  - name: webapp-testing
+    path: packages/skills/webapp-testing
+    purpose: "Playwright-based web app testing and browser automation"
+    features:
+      - Browser screenshot capture
+      - UI element interaction
+      - End-to-end testing workflows
+
   - name: crypto-research
     path: packages/skills/crypto-research
     purpose: "Multi-agent cryptocurrency market analysis"

--- a/toolkit/packages/skills/webapp-testing/LICENSE.txt
+++ b/toolkit/packages/skills/webapp-testing/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/toolkit/packages/skills/webapp-testing/SKILL.md
+++ b/toolkit/packages/skills/webapp-testing/SKILL.md
@@ -1,0 +1,533 @@
+---
+name: webapp-testing
+description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+license: Complete terms in LICENSE.txt
+---
+
+# Web Application Testing
+
+To test local web applications, write native Python Playwright scripts.
+
+**Helper Scripts Available**:
+- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
+
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+
+## Browser Tools (Direct Chrome DevTools Control)
+
+The `{{HOME_TOOL_DIR}}/skills/webapp-testing/bin/browser-tools` utility provides lightweight, context-rot-proof browser automation using the Chrome DevTools Protocol directly (no MCP overhead).
+
+**Available Commands**:
+
+```bash
+# Launch browser and get connection details
+/.claude/skills/webapp-testing/bin/browser-tools start [--port PORT] [--headless]
+
+# Navigate to URL
+/.claude/skills/webapp-testing/bin/browser-tools nav <url> [--wait-for {load|networkidle|domcontentloaded}]
+
+# Evaluate JavaScript
+/.claude/skills/webapp-testing/bin/browser-tools eval "<javascript code>"
+
+# Take screenshot
+/.claude/skills/webapp-testing/bin/browser-tools screenshot <output.png> [--full-page] [--selector CSS_SELECTOR]
+
+# Interactive element picker (returns selectors)
+/.claude/skills/webapp-testing/bin/browser-tools pick
+
+# Get console logs
+/.claude/skills/webapp-testing/bin/browser-tools console [--level {log|warn|error|all}]
+
+# Search page content
+/.claude/skills/webapp-testing/bin/browser-tools search "<query>" [--case-sensitive]
+
+# Extract page content (markdown, links, text)
+/.claude/skills/webapp-testing/bin/browser-tools content [--format {markdown|links|text}]
+
+# Get/set cookies
+/.claude/skills/webapp-testing/bin/browser-tools cookies [--set NAME=VALUE] [--domain DOMAIN]
+
+# Inspect element details
+/.claude/skills/webapp-testing/bin/browser-tools inspect <css-selector>
+
+# Terminate browser session
+/.claude/skills/webapp-testing/bin/browser-tools kill
+```
+
+**When to Use Browser-Tools vs Playwright**:
+
+✅ **Use browser-tools when**:
+- Quick inspection/debugging of running apps
+- Need to identify selectors interactively (`pick` command)
+- Extracting page content for analysis
+- Running simple JavaScript snippets
+- Monitoring console logs in real-time
+- Taking quick screenshots without writing scripts
+
+✅ **Use Playwright when**:
+- Complex multi-step automation workflows
+- Need full test assertion framework
+- Handling multi-step forms
+- Database integration (Supabase utilities)
+- Comprehensive test coverage
+- Generating test reports
+
+**Example Workflow**:
+
+```bash
+# 1. Start browser pointed at your app
+/.claude/skills/webapp-testing/bin/browser-tools start --port 9222
+
+# 2. Navigate to the page
+/.claude/skills/webapp-testing/bin/browser-tools nav http://localhost:3000
+
+# 3. Use interactive picker to find selectors
+/.claude/skills/webapp-testing/bin/browser-tools pick
+# Click on elements in the browser, get their selectors
+
+# 4. Inspect specific elements
+/.claude/skills/webapp-testing/bin/browser-tools inspect "button.submit"
+
+# 5. Take screenshot for documentation
+/.claude/skills/webapp-testing/bin/browser-tools screenshot /tmp/page.png --full-page
+
+# 6. Check console for errors
+/.claude/skills/webapp-testing/bin/browser-tools console --level error
+
+# 7. Clean up
+/.claude/skills/webapp-testing/bin/browser-tools kill
+```
+
+**Benefits**:
+- **No MCP overhead**: Direct Chrome DevTools Protocol communication
+- **Context-rot proof**: No dependency on evolving MCP specifications
+- **Interactive picker**: Visual element selection for selector discovery
+- **Lightweight**: Faster than full Playwright for simple tasks
+- **Pre-compiled binary**: Ready to use, no compilation needed (auto-compiled via create-rule.js)
+
+## Decision Tree: Choosing Your Approach
+
+```
+User task → Is it static HTML?
+    ├─ Yes → Read HTML file directly to identify selectors
+    │         ├─ Success → Write Playwright script using selectors
+    │         └─ Fails/Incomplete → Treat as dynamic (below)
+    │
+    └─ No (dynamic webapp) → Is the server already running?
+        ├─ No → Run: python scripts/with_server.py --help
+        │        Then use the helper + write simplified Playwright script
+        │
+        └─ Yes → Reconnaissance-then-action:
+            1. Navigate and wait for networkidle
+            2. Take screenshot or inspect DOM
+            3. Identify selectors from rendered state
+            4. Execute actions with discovered selectors
+```
+
+## Example: Using with_server.py
+
+To start a server, run `--help` first, then use the helper:
+
+**Single server:**
+```bash
+python scripts/with_server.py --server "npm run dev" --port 3000 -- python your_automation.py
+```
+
+**Multiple servers (e.g., backend + frontend):**
+```bash
+python scripts/with_server.py \
+  --server "cd backend && python server.py" --port 8000 \
+  --server "cd frontend && npm run dev" --port 3000 \
+  -- python your_automation.py
+```
+
+To create an automation script, include only Playwright logic (servers are managed automatically):
+```python
+from playwright.sync_api import sync_playwright
+
+APP_PORT = 3000  # Match the port from --port argument
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    page = browser.new_page()
+    page.goto(f'http://localhost:{APP_PORT}') # Server already running and ready
+    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
+    # ... your automation logic
+    browser.close()
+```
+
+## Reconnaissance-Then-Action Pattern
+
+1. **Inspect rendered DOM**:
+   ```python
+   page.screenshot(path='/tmp/inspect.png', full_page=True)
+   content = page.content()
+   page.locator('button').all()
+   ```
+
+2. **Identify selectors** from inspection results
+
+3. **Execute actions** using discovered selectors
+
+## Common Pitfall
+
+❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
+✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
+
+## Best Practices
+
+- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly. 
+- Use `sync_playwright()` for synchronous scripts
+- Always close the browser when done
+- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
+- Add appropriate waits: `page.wait_for_selector()` or `page.wait_for_timeout()`
+
+## Utility Modules
+
+The skill now includes comprehensive utilities for common testing patterns:
+
+### UI Interactions (`utils/ui_interactions.py`)
+
+Handle common UI patterns automatically:
+
+```python
+from utils.ui_interactions import (
+    dismiss_cookie_banner,
+    dismiss_modal,
+    click_with_header_offset,
+    force_click_if_needed,
+    wait_for_no_overlay,
+    wait_for_stable_dom
+)
+
+# Dismiss cookie consent
+dismiss_cookie_banner(page)
+
+# Close welcome modal
+dismiss_modal(page, modal_identifier="Welcome")
+
+# Click button behind fixed header
+click_with_header_offset(page, 'button#submit', header_height=100)
+
+# Try click with force fallback
+force_click_if_needed(page, 'button#action')
+
+# Wait for loading overlays to disappear
+wait_for_no_overlay(page)
+
+# Wait for DOM to stabilize
+wait_for_stable_dom(page)
+```
+
+### Smart Form Filling (`utils/form_helpers.py`)
+
+Intelligently handle form variations:
+
+```python
+from utils.form_helpers import (
+    SmartFormFiller,
+    handle_multi_step_form,
+    auto_fill_form
+)
+
+# Works with both "Full Name" and "First/Last Name" fields
+filler = SmartFormFiller()
+filler.fill_name_field(page, "Jane Doe")
+filler.fill_email_field(page, "jane@example.com")
+filler.fill_password_fields(page, "SecurePass123!")
+filler.fill_phone_field(page, "+447700900123")
+filler.fill_date_field(page, "1990-01-15", field_hint="birth")
+
+# Auto-fill entire form
+results = auto_fill_form(page, {
+    'email': 'test@example.com',
+    'password': 'Pass123!',
+    'full_name': 'Test User',
+    'phone': '+447700900123',
+    'date_of_birth': '1990-01-15'
+})
+
+# Handle multi-step forms
+steps = [
+    {'fields': {'email': 'test@example.com', 'password': 'Pass123!'}, 'checkbox': True},
+    {'fields': {'full_name': 'Test User', 'date_of_birth': '1990-01-15'}},
+    {'complete': True}
+]
+handle_multi_step_form(page, steps)
+```
+
+### Supabase Testing (`utils/supabase.py`)
+
+Database operations for Supabase-based apps:
+
+```python
+from utils.supabase import SupabaseTestClient, quick_cleanup
+
+# Initialize client
+client = SupabaseTestClient(
+    url="https://project.supabase.co",
+    service_key="your-service-role-key",
+    db_password="your-db-password"
+)
+
+# Create test user
+user_id = client.create_user("test@example.com", "password123")
+
+# Create invite code
+client.create_invite_code("TEST2024", code_type="general")
+
+# Bypass email verification
+client.confirm_email(user_id)
+
+# Cleanup after test
+client.cleanup_related_records(user_id)
+client.delete_user(user_id)
+
+# Quick cleanup helper
+quick_cleanup("test@example.com", "db_password", "https://project.supabase.co")
+```
+
+### Advanced Wait Strategies (`utils/wait_strategies.py`)
+
+Better alternatives to simple sleep():
+
+```python
+from utils.wait_strategies import (
+    wait_for_api_call,
+    wait_for_element_stable,
+    smart_navigation_wait,
+    combined_wait
+)
+
+# Wait for specific API response
+response = wait_for_api_call(page, '**/api/profile**')
+
+# Wait for element to stop moving
+wait_for_element_stable(page, '.dropdown-menu', stability_ms=1000)
+
+# Smart navigation with URL check
+page.click('button#login')
+smart_navigation_wait(page, expected_url_pattern='**/dashboard**')
+
+# Comprehensive wait (network + DOM + overlays)
+combined_wait(page)
+```
+
+### Smart Selectors (`utils/smart_selectors.py`) ⭐ NEW
+
+Automatically try multiple selector strategies to find elements, reducing test brittleness:
+
+```python
+from utils.smart_selectors import SelectorStrategies
+
+# Find and fill email field (tries 7 different selector strategies)
+success = SelectorStrategies.smart_fill(page, 'email', 'test@example.com')
+# Output: ✓ Found field via placeholder: input[placeholder*="email" i]
+#         ✓ Filled 'email' with value
+
+# Find and click button (tries 8 different strategies)
+success = SelectorStrategies.smart_click(page, 'Sign In')
+# Output: ✓ Found button via case-insensitive text: button:text-matches("Sign In", "i")
+#         ✓ Clicked 'Sign In' button
+
+# Manual control - find input field selector
+selector = SelectorStrategies.find_input_field(page, 'password')
+if selector:
+    page.fill(selector, 'my-password')
+
+# Manual control - find button selector
+selector = SelectorStrategies.find_button(page, 'Submit')
+if selector:
+    page.click(selector)
+
+# Try custom selectors with fallback
+selectors = ['button#submit', 'button.submit-btn', 'input[type="submit"]']
+selector = SelectorStrategies.find_any_element(page, selectors)
+```
+
+**Selector Strategies Tried (in order):**
+
+For input fields:
+1. Test IDs: `[data-testid*="email"]`
+2. ARIA labels: `input[aria-label*="email"]`
+3. Placeholder: `input[placeholder*="email"]`
+4. Name attribute: `input[name*="email"]`
+5. Type attribute: `input[type="email"]`
+6. ID exact: `#email`
+7. ID partial: `input[id*="email"]`
+
+For buttons:
+1. Test IDs: `[data-testid*="sign-in"]`
+2. Name attribute: `button[name*="Sign In"]`
+3. Exact text: `button:has-text("Sign In")`
+4. Case-insensitive: `button:text-matches("Sign In", "i")`
+5. Link as button: `a:has-text("Sign In")`
+6. Submit input: `input[type="submit"][value*="Sign In"]`
+7. Role button: `[role="button"]:has-text("Sign In")`
+
+**When to use:**
+- ✅ Forms where HTML structure changes frequently
+- ✅ Third-party components with unpredictable selectors
+- ✅ Multi-application test suites
+- ❌ Performance-critical tests (adds 5s timeout per strategy)
+
+**Performance:**
+- Timeout per strategy: 5 seconds (configurable)
+- Max timeout: 10 seconds across all strategies
+- Typical: First strategy works (1-2 seconds)
+
+### Browser Configuration (`utils/browser_config.py`) ⭐ NEW
+
+Auto-configure browser context for testing environments:
+
+```python
+from utils.browser_config import BrowserConfig
+
+# Auto-detect CSP bypass for localhost
+context = BrowserConfig.create_test_context(
+    browser,
+    'http://localhost:3000'
+)
+# Output:
+# ============================================================
+#   Browser Context Configuration
+# ============================================================
+#   Base URL: http://localhost:3000
+#   🔓 CSP bypass: ENABLED (testing on localhost)
+#   ⚠️  HTTPS errors: IGNORED (self-signed certs OK)
+#   📐 Viewport: 1280x720
+# ============================================================
+
+# Production testing (no CSP bypass)
+context = BrowserConfig.create_test_context(
+    browser,
+    'https://production.example.com'
+)
+# Output: 🔒 CSP bypass: DISABLED (production mode)
+
+# Mobile device emulation
+context = BrowserConfig.create_mobile_context(
+    browser,
+    device='iPhone 12',
+    base_url='http://localhost:3000'
+)
+# Output: 📱 Mobile context: iPhone 12
+#         Viewport: {'width': 390, 'height': 844}
+#         🔓 CSP bypass: ENABLED
+
+# Manual override
+context = BrowserConfig.create_test_context(
+    browser,
+    'http://localhost:3000',
+    bypass_csp=False,  # Force disable even for localhost
+    record_video=True,  # Record test session
+    extra_http_headers={'Authorization': 'Bearer token'}
+)
+```
+
+**Features:**
+- **Auto CSP detection**: Enables bypass for localhost, disables for production
+- **Self-signed certs**: Ignores HTTPS errors by default
+- **Consistent viewport**: 1280x720 default for reproducible tests
+- **Mobile emulation**: Built-in device profiles
+- **Video recording**: Optional session recording
+- **Verbose logging**: See exactly what's configured
+
+**When to use:**
+- ✅ Every test (replaces manual `browser.new_context()`)
+- ✅ Testing on localhost with CSP restrictions
+- ✅ Mobile-responsive testing
+- ✅ Need consistent browser configuration across tests
+
+### CSP Monitoring (`utils/ui_interactions.py`) ⭐ NEW
+
+Auto-detect and suggest fixes for Content Security Policy violations:
+
+```python
+from utils.ui_interactions import setup_page_with_csp_handling
+from utils.browser_config import BrowserConfig
+
+context = BrowserConfig.create_test_context(browser, 'http://localhost:7160')
+page = context.new_page()
+
+# Enable CSP violation monitoring
+setup_page_with_csp_handling(page)
+
+page.goto('http://localhost:7160')
+
+# If CSP violation occurs, you'll see:
+# ======================================================================
+# ⚠️  CSP VIOLATION DETECTED
+# ======================================================================
+# Message: Refused to execute inline script because it violates...
+#
+# 💡 SUGGESTION:
+#    For localhost testing, use:
+#
+#    from utils.browser_config import BrowserConfig
+#    context = BrowserConfig.create_test_context(
+#        browser, 'http://localhost:3000'
+#    )
+#    # Auto-enables CSP bypass for localhost
+#
+#    Or manually:
+#    context = browser.new_context(bypass_csp=True)
+# ======================================================================
+```
+
+**When to use:**
+- ✅ Debugging why tests fail on localhost
+- ✅ Identifying CSP configuration issues
+- ✅ Verifying CSP bypass is working
+- ❌ Production testing (CSP should be enforced)
+
+## Complete Examples
+
+### Multi-Step Registration
+
+See `examples/multi_step_registration.py` for a complete example showing:
+- Database setup (invite codes)
+- Cookie banner dismissal
+- Multi-step form automation
+- Email verification bypass
+- Login flow
+- Dashboard verification
+- Cleanup
+
+Run it:
+```bash
+python examples/multi_step_registration.py
+```
+
+## Using the Webapp-Testing Subagent
+
+A specialized subagent is available for testing automation. Use it to keep your main conversation focused on development:
+
+```
+You: "Use webapp-testing agent to register test@example.com and verify the parent role switch works"
+
+Main Agent: [Launches webapp-testing subagent]
+
+Webapp-Testing Agent: [Runs complete automation, returns results]
+```
+
+**Benefits:**
+- Keeps main context clean
+- Specialized for Playwright automation
+- Access to all skill utilities
+- Automatic screenshot capture
+- Clear result reporting
+
+## Reference Files
+
+- **examples/** - Examples showing common patterns:
+  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
+  - `static_html_automation.py` - Using file:// URLs for local HTML
+  - `console_logging.py` - Capturing console logs during automation
+  - `multi_step_registration.py` - Complete registration flow example (NEW)
+
+- **utils/** - Reusable utility modules (NEW):
+  - `ui_interactions.py` - Cookie banners, modals, overlays, stable waits
+  - `form_helpers.py` - Smart form filling, multi-step automation
+  - `supabase.py` - Database operations for Supabase apps
+  - `wait_strategies.py` - Advanced waiting patterns

--- a/toolkit/packages/skills/webapp-testing/bin/.gitignore
+++ b/toolkit/packages/skills/webapp-testing/bin/.gitignore
@@ -1,0 +1,12 @@
+# Dependencies
+node_modules/
+
+# Build artifacts
+*.bun-build
+.*.bun-build
+bun.lockb
+bun.lock
+
+# Logs
+logs/
+*.log

--- a/toolkit/packages/skills/webapp-testing/bin/browser-tools.ts
+++ b/toolkit/packages/skills/webapp-testing/bin/browser-tools.ts
@@ -1,0 +1,1033 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Minimal Chrome DevTools helpers inspired by Mario Zechner's
+ * "What if you don't need MCP?" article.
+ *
+ * Keeps everything in one TypeScript CLI so agents (or humans) can drive Chrome
+ * directly via the DevTools protocol without pulling in a large MCP server.
+ */
+import { Command } from 'commander';
+import { execSync, spawn } from 'node:child_process';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { inspect } from 'node:util';
+import puppeteer from 'puppeteer-core';
+
+/** Utility type so TypeScript knows the async function constructor */
+type AsyncFunctionCtor = new (...args: string[]) => (...fnArgs: unknown[]) => Promise<unknown>;
+
+/**
+ * Convert Playwright-style selectors to native JavaScript equivalents.
+ * Playwright has custom pseudo-selectors like :has-text() that don't work
+ * with native document.querySelector().
+ *
+ * This function transforms code containing these selectors to use
+ * Array.from().find() patterns instead.
+ */
+function convertPlaywrightSelectorsToNative(code: string): string {
+  // Pattern: selector:has-text("text") or selector:has-text('text')
+  // Example: button:has-text("Accept") -> Array.from(document.querySelectorAll('button')).find(el => el.textContent?.includes('Accept'))
+  const hasTextPattern = /(['"`])([^'"`]*):has-text\((['"])([^'"]*)\3\)\1/g;
+
+  let result = code;
+
+  // Replace :has-text() patterns in querySelector calls
+  result = result.replace(
+    /document\.querySelector\s*\(\s*(['"`])([^'"`]*):has-text\((['"])([^'"]*)\3\)([^'"`]*)\1\s*\)/g,
+    (_, quote, baseSelector, _textQuote, textContent, restSelector) => {
+      const fullBase = baseSelector + (restSelector || '');
+      // If there's a base selector, use it; otherwise search all elements
+      const selectorPart = fullBase.trim() || '*';
+      return `Array.from(document.querySelectorAll('${selectorPart}')).find(el => el.textContent?.includes('${textContent}'))`;
+    }
+  );
+
+  // Also handle querySelectorAll with :has-text()
+  result = result.replace(
+    /document\.querySelectorAll\s*\(\s*(['"`])([^'"`]*):has-text\((['"])([^'"]*)\3\)([^'"`]*)\1\s*\)/g,
+    (_, quote, baseSelector, _textQuote, textContent, restSelector) => {
+      const fullBase = baseSelector + (restSelector || '');
+      const selectorPart = fullBase.trim() || '*';
+      return `Array.from(document.querySelectorAll('${selectorPart}')).filter(el => el.textContent?.includes('${textContent}'))`;
+    }
+  );
+
+  // Handle standalone selectors in quotes that contain :has-text (for cases where the selector is passed to other functions)
+  // Pattern: 'button:has-text("Accept")' -> warn and suggest alternative
+  if (result.includes(':has-text(') && !result.includes('Array.from')) {
+    // If there are still :has-text patterns, it's probably a standalone selector string
+    // We can't automatically convert these without knowing the context
+    console.warn('Warning: :has-text() is a Playwright-specific selector and may not work with native querySelector.');
+    console.warn('Consider using: Array.from(document.querySelectorAll("selector")).find(el => el.textContent?.includes("text"))');
+  }
+
+  return result;
+}
+
+const DEFAULT_PORT = 9222;
+const DEFAULT_PROFILE_DIR = path.join(os.homedir(), '.cache', 'scraping');
+const DEFAULT_CHROME_BIN = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+function browserURL(port: number): string {
+  return `http://localhost:${port}`;
+}
+
+async function connectBrowser(port: number) {
+  return puppeteer.connect({ browserURL: browserURL(port), defaultViewport: null });
+}
+
+async function getActivePage(port: number) {
+  const browser = await connectBrowser(port);
+  const pages = await browser.pages();
+  const page = pages.at(-1);
+  if (!page) {
+    await browser.disconnect();
+    throw new Error('No active tab found');
+  }
+  return { browser, page };
+}
+
+const program = new Command();
+program
+  .name('browser-tools')
+  .description('Lightweight Chrome DevTools helpers (no MCP required).')
+  .configureHelp({ sortSubcommands: true })
+  .showSuggestionAfterError();
+
+program
+  .command('start')
+  .description('Launch Chrome with remote debugging enabled.')
+  .option('-p, --port <number>', 'Remote debugging port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('--profile', 'Copy your default Chrome profile before launch.', false)
+  .option('--profile-dir <path>', 'Directory for the temporary Chrome profile.', DEFAULT_PROFILE_DIR)
+  .option('--chrome-path <path>', 'Path to the Chrome binary.', DEFAULT_CHROME_BIN)
+  .option('--kill-existing', 'Stop any running Google Chrome before launch (default: false).', false)
+  .action(async (options) => {
+    const { port, profile, profileDir, chromePath, killExisting } = options as {
+      port: number;
+      profile: boolean;
+      profileDir: string;
+      chromePath: string;
+      killExisting: boolean;
+    };
+
+    if (killExisting) {
+      try {
+        execSync("killall 'Google Chrome'", { stdio: 'ignore' });
+      } catch {
+        // ignore missing processes
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    execSync(`mkdir -p "${profileDir}"`);
+    if (profile) {
+      const source = `${path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome')}/`;
+      execSync(`rsync -a --delete "${source}" "${profileDir}/"`, { stdio: 'ignore' });
+    }
+
+    spawn(chromePath, [`--remote-debugging-port=${port}`, `--user-data-dir=${profileDir}`, '--no-first-run', '--disable-popup-blocking'], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+
+    let connected = false;
+    for (let attempt = 0; attempt < 30; attempt++) {
+      try {
+        const browser = await connectBrowser(port);
+        await browser.disconnect();
+        connected = true;
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+
+    if (!connected) {
+      console.error(`✗ Failed to start Chrome on port ${port}`);
+      process.exit(1);
+    }
+    console.log(`✓ Chrome listening on http://localhost:${port}${profile ? ' (profile copied)' : ''}`);
+  });
+
+program
+  .command('nav <url>')
+  .description('Navigate the current tab or open a new tab.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('--new', 'Open in a new tab.', false)
+  .action(async (url: string, options) => {
+    const port = options.port as number;
+    const browser = await connectBrowser(port);
+    try {
+      if (options.new) {
+        const page = await browser.newPage();
+        await page.goto(url, { waitUntil: 'domcontentloaded' });
+        console.log('✓ Opened in new tab:', url);
+      } else {
+        const pages = await browser.pages();
+        const page = pages.at(-1);
+        if (!page) {
+          throw new Error('No active tab found');
+        }
+        await page.goto(url, { waitUntil: 'domcontentloaded' });
+        console.log('✓ Navigated current tab to:', url);
+      }
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('eval <code...>')
+  .description('Evaluate JavaScript in the active page context.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('--pretty-print', 'Format array/object results with indentation.', false)
+  .action(async (code: string[], options) => {
+    // Join code and convert any Playwright-specific selectors to native JS
+    const snippet = convertPlaywrightSelectorsToNative(code.join(' '));
+    const port = options.port as number;
+    const pretty = Boolean(options.prettyPrint);
+    const useColor = process.stdout.isTTY;
+
+    const printPretty = (value: unknown) => {
+      console.log(
+        inspect(value, {
+          depth: 6,
+          colors: useColor,
+          maxArrayLength: 50,
+          breakLength: 80,
+          compact: false,
+        }),
+      );
+    };
+
+    const { browser, page } = await getActivePage(port);
+    try {
+      const result = await page.evaluate((body) => {
+        const ASYNC_FN = Object.getPrototypeOf(async () => {}).constructor as AsyncFunctionCtor;
+        return new ASYNC_FN(`return (${body})`)();
+      }, snippet);
+
+      if (pretty) {
+        printPretty(result);
+      } else if (Array.isArray(result)) {
+        result.forEach((entry, index) => {
+          if (index > 0) {
+            console.log('');
+          }
+          Object.entries(entry).forEach(([key, value]) => {
+            console.log(`${key}: ${value}`);
+          });
+        });
+      } else if (typeof result === 'object' && result !== null) {
+        Object.entries(result).forEach(([key, value]) => {
+          console.log(`${key}: ${value}`);
+        });
+      } else {
+        console.log(result);
+      }
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('screenshot')
+  .description('Capture the current viewport and print the temp PNG path.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .action(async (options) => {
+    const port = options.port as number;
+    const { browser, page } = await getActivePage(port);
+    try {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const filePath = path.join(os.tmpdir(), `screenshot-${timestamp}.png`);
+      await page.screenshot({ path: filePath });
+      console.log(filePath);
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('pick <message...>')
+  .description('Interactive DOM picker that prints metadata for clicked elements.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .action(async (messageParts: string[], options) => {
+    const message = messageParts.join(' ');
+    const port = options.port as number;
+    const { browser, page } = await getActivePage(port);
+    try {
+      await page.evaluate(() => {
+        const scope = globalThis as typeof globalThis & {
+          pickOverlayInjected?: boolean;
+          pick?: (prompt: string) => Promise<unknown>;
+        };
+        if (scope.pickOverlayInjected) {
+          return;
+        }
+        scope.pickOverlayInjected = true;
+        scope.pick = async (prompt: string) =>
+          new Promise((resolve) => {
+            const selections: unknown[] = [];
+            const selectedElements = new Set<HTMLElement>();
+
+            const overlay = document.createElement('div');
+            overlay.style.cssText =
+              'position:fixed;top:0;left:0;width:100%;height:100%;z-index:2147483647;pointer-events:none';
+
+            const highlight = document.createElement('div');
+            highlight.style.cssText =
+              'position:absolute;border:2px solid #3b82f6;background:rgba(59,130,246,0.1);transition:all 0.05s ease';
+            overlay.appendChild(highlight);
+
+            const banner = document.createElement('div');
+            banner.style.cssText =
+              'position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#1f2937;color:#fff;padding:12px 24px;border-radius:8px;font:14px system-ui;box-shadow:0 4px 12px rgba(0,0,0,0.3);pointer-events:auto;z-index:2147483647';
+
+            const updateBanner = () => {
+              banner.textContent = `${prompt} (${selections.length} selected, Cmd/Ctrl+click to add, Enter to finish, ESC to cancel)`;
+            };
+
+            const cleanup = () => {
+              document.removeEventListener('mousemove', onMove, true);
+              document.removeEventListener('click', onClick, true);
+              document.removeEventListener('keydown', onKey, true);
+              overlay.remove();
+              banner.remove();
+              selectedElements.forEach((el) => {
+                el.style.outline = '';
+              });
+            };
+
+            const serialize = (el: HTMLElement) => {
+              const parents: string[] = [];
+              let current = el.parentElement;
+              while (current && current !== document.body) {
+                const id = current.id ? `#${current.id}` : '';
+                const cls = current.className ? `.${current.className.trim().split(/\s+/).join('.')}` : '';
+                parents.push(`${current.tagName.toLowerCase()}${id}${cls}`);
+                current = current.parentElement;
+              }
+              return {
+                tag: el.tagName.toLowerCase(),
+                id: el.id || null,
+                class: el.className || null,
+                text: el.textContent?.trim()?.slice(0, 200) || null,
+                html: el.outerHTML.slice(0, 500),
+                parents: parents.join(' > '),
+              };
+            };
+
+            const onMove = (event: MouseEvent) => {
+              const node = document.elementFromPoint(event.clientX, event.clientY) as HTMLElement | null;
+              if (!node || overlay.contains(node) || banner.contains(node)) return;
+              const rect = node.getBoundingClientRect();
+              highlight.style.cssText = `position:absolute;border:2px solid #3b82f6;background:rgba(59,130,246,0.1);top:${rect.top}px;left:${rect.left}px;width:${rect.width}px;height:${rect.height}px`;
+            };
+            const onClick = (event: MouseEvent) => {
+              if (banner.contains(event.target as Node)) return;
+              event.preventDefault();
+              event.stopPropagation();
+              const node = document.elementFromPoint(event.clientX, event.clientY) as HTMLElement | null;
+              if (!node || overlay.contains(node) || banner.contains(node)) return;
+
+              if (event.metaKey || event.ctrlKey) {
+                if (!selectedElements.has(node)) {
+                  selectedElements.add(node);
+                  node.style.outline = '3px solid #10b981';
+                  selections.push(serialize(node));
+                  updateBanner();
+                }
+              } else {
+                cleanup();
+                const info = serialize(node);
+                resolve(selections.length > 0 ? selections : info);
+              }
+            };
+
+            const onKey = (event: KeyboardEvent) => {
+              if (event.key === 'Escape') {
+                cleanup();
+                resolve(null);
+              } else if (event.key === 'Enter' && selections.length > 0) {
+                cleanup();
+                resolve(selections);
+              }
+            };
+
+            document.addEventListener('mousemove', onMove, true);
+            document.addEventListener('click', onClick, true);
+            document.addEventListener('keydown', onKey, true);
+
+            document.body.append(overlay, banner);
+            updateBanner();
+          });
+      });
+
+      const result = await page.evaluate((msg) => {
+        const pickFn = (window as Window & { pick?: (message: string) => Promise<unknown> }).pick;
+        if (!pickFn) {
+          return null;
+        }
+        return pickFn(msg);
+      }, message);
+
+      if (Array.isArray(result)) {
+        result.forEach((entry, index) => {
+          if (index > 0) {
+            console.log('');
+          }
+          Object.entries(entry).forEach(([key, value]) => {
+            console.log(`${key}: ${value}`);
+          });
+        });
+      } else if (result && typeof result === 'object') {
+        Object.entries(result).forEach(([key, value]) => {
+          console.log(`${key}: ${value}`);
+        });
+      } else {
+        console.log(result);
+      }
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('console')
+  .description('Capture and display console logs from the active tab.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('--types <list>', 'Comma-separated log types to show (e.g., log,error,warn). Default: all types')
+  .option('--follow', 'Continuous monitoring mode (like tail -f)', false)
+  .option('--timeout <seconds>', 'Capture duration in seconds (default: 5 for one-shot, infinite for --follow)', (value) => Number.parseInt(value, 10))
+  .option('--color', 'Force color output')
+  .option('--no-color', 'Disable color output')
+  .option('--no-serialize', 'Disable object serialization (show raw text only)', false)
+  .action(async (options) => {
+    const port = options.port as number;
+    const follow = options.follow as boolean;
+    const timeout = options.timeout as number | undefined;
+    const typesFilter = options.types as string | undefined;
+    const noSerialize = options.noSerialize as boolean;
+    const serialize = !noSerialize;
+
+    // Track explicit color flags by looking at argv to avoid Commander defaults overriding TTY detection.
+    const argv = process.argv.slice(2);
+    const colorFlag = argv.includes('--color') ? true : argv.includes('--no-color') ? false : undefined;
+
+    // Determine if we should use colors: explicit flag or TTY auto-detection
+    const useColor = colorFlag ?? process.stdout.isTTY;
+
+    // Parse types filter
+    const normalizeType = (value: string) => {
+      const lower = value.toLowerCase();
+      if (lower === 'warning') return 'warn';
+      return lower;
+    };
+
+    const allowedTypes = typesFilter
+      ? new Set(typesFilter.split(',').map((t) => normalizeType(t.trim())))
+      : null; // null means show all types
+
+    // Color functions (no-op if colors disabled)
+    const colorize = (text: string, colorCode: string) => (useColor ? `\x1b[${colorCode}m${text}\x1b[0m` : text);
+    const red = (text: string) => colorize(text, '31');
+    const yellow = (text: string) => colorize(text, '33');
+    const cyan = (text: string) => colorize(text, '36');
+    const gray = (text: string) => colorize(text, '90');
+    const white = (text: string) => text;
+
+    const typeColors: Record<string, (text: string) => string> = {
+      error: red,
+      warn: yellow,
+      warning: yellow,
+      info: cyan,
+      debug: gray,
+      log: white,
+      pageerror: red,
+    };
+
+    // Helper function definitions (outside try/catch as they don't need error handling)
+    const formatTimestamp = () => {
+      const now = new Date();
+      return now.toTimeString().split(' ')[0] + '.' + now.getMilliseconds().toString().padStart(3, '0');
+    };
+
+    // Serialize value in Node.js util.inspect style with depth limit
+    const formatValue = (value: any, depth = 0, maxDepth = 10): string => {
+      if (depth > maxDepth) {
+        return '[Object]';
+      }
+
+      if (value === null) return 'null';
+      if (value === undefined) return 'undefined';
+      if (typeof value === 'string') return `'${value}'`;
+      if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+      if (typeof value === 'function') return '[Function]';
+
+      if (Array.isArray(value)) {
+        const items = value.map((v) => formatValue(v, depth + 1, maxDepth));
+        return `[ ${items.join(', ')} ]`;
+      }
+
+      if (typeof value === 'object') {
+        const entries = Object.entries(value).map(([k, v]) => `${k}: ${formatValue(v, depth + 1, maxDepth)}`);
+        return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}';
+      }
+
+      return String(value);
+    };
+
+    // Serialize console message arguments
+    const serializeArgs = async (msg: any): Promise<string> => {
+      try {
+        const args = msg.args();
+        const values = await Promise.all(
+          args.map(async (arg: any) => {
+            try {
+              const value = await arg.jsonValue();
+              return formatValue(value);
+            } catch (error) {
+              const errorMsg = error instanceof Error ? error.message : String(error);
+              if (errorMsg.includes('circular')) return '[Circular]';
+              if (errorMsg.includes('reference chain')) return '[DeepObject]';
+              return '[Unserializable]';
+            }
+          })
+        );
+        return values.join(' ');
+      } catch {
+        // Fallback to text representation
+        return msg.text();
+      }
+    };
+
+    const formatMessage = (type: string, text: string, location?: { url?: string; lineNumber?: number }) => {
+      const color = typeColors[type] || white;
+      const timestamp = formatTimestamp();
+      const loc = location?.url && location?.lineNumber ? ` ${location.url}:${location.lineNumber}` : '';
+      return color(`[${type.toUpperCase()}] ${timestamp} ${text}${loc}`);
+    };
+
+    // Execution code (needs try/catch for error handling)
+    const { browser, page } = await getActivePage(port);
+
+    try {
+      // Set up console listener
+      page.on('console', async (msg) => {
+        const type = normalizeType(msg.type());
+        if (allowedTypes && !allowedTypes.has(type)) {
+          return; // Filter out unwanted types
+        }
+
+        const text = serialize ? await serializeArgs(msg) : msg.text();
+        console.log(formatMessage(type, text, msg.location()));
+      });
+
+      // Set up page error listener
+      page.on('pageerror', (error) => {
+        if (allowedTypes && !allowedTypes.has('pageerror') && !allowedTypes.has('error')) {
+          return;
+        }
+        console.log(formatMessage('pageerror', error.message));
+      });
+
+      if (follow) {
+        // Continuous monitoring mode
+        console.log(gray('Monitoring console logs (Ctrl+C to stop)...'));
+        const waitForExit = () =>
+          new Promise<void>((resolve) => {
+            const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+            const onSignal = () => {
+              cleanup();
+              resolve();
+            };
+            const onBeforeExit = () => {
+              cleanup();
+              resolve();
+            };
+            const cleanup = () => {
+              signals.forEach((signal) => process.off(signal, onSignal));
+              process.off('beforeExit', onBeforeExit);
+            };
+            signals.forEach((signal) => process.on(signal, onSignal));
+            process.on('beforeExit', onBeforeExit);
+          });
+
+        await waitForExit();
+      } else {
+        // One-shot mode with timeout
+        const duration = timeout ?? 5;
+        console.log(gray(`Capturing console logs for ${duration} seconds...`));
+        await new Promise((resolve) => setTimeout(resolve, duration * 1000));
+      }
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('search <query...>')
+  .description('Google search with optional readable content extraction.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('-n, --count <number>', 'Number of results to return (default: 5, max: 50)', (value) => Number.parseInt(value, 10), 5)
+  .option('--content', 'Fetch readable content for each result (slower).', false)
+  .option('--timeout <seconds>', 'Per-navigation timeout in seconds (default: 10).', (value) => Number.parseInt(value, 10), 10)
+  .action(async (queryWords: string[], options) => {
+    const port = options.port as number;
+    const count = Math.max(1, Math.min(options.count as number, 50));
+    const fetchContent = Boolean(options.content);
+    const timeoutMs = Math.max(3, (options.timeout as number) ?? 10) * 1000;
+    const query = queryWords.join(' ');
+
+    const { browser, page } = await getActivePage(port);
+    try {
+      const results: { title: string; link: string; snippet: string; content?: string }[] = [];
+      let start = 0;
+      while (results.length < count) {
+        const searchUrl = `https://www.google.com/search?q=${encodeURIComponent(query)}&start=${start}`;
+        await page.goto(searchUrl, { waitUntil: 'domcontentloaded', timeout: timeoutMs }).catch(() => {});
+        await page.waitForSelector('div.MjjYud', { timeout: 3000 }).catch(() => {});
+
+        const pageResults = await page.evaluate(() => {
+          const items: { title: string; link: string; snippet: string }[] = [];
+          document.querySelectorAll('div.MjjYud').forEach((result) => {
+            const titleEl = result.querySelector('h3');
+            const linkEl = result.querySelector('a');
+            const snippetEl = result.querySelector('div.VwiC3b, div[data-sncf]');
+            const link = linkEl?.getAttribute('href') ?? '';
+            if (titleEl && linkEl && link && !link.startsWith('https://www.google.com')) {
+              items.push({
+                title: titleEl.textContent?.trim() ?? '',
+                link,
+                snippet: snippetEl?.textContent?.trim() ?? '',
+              });
+            }
+          });
+          return items;
+        });
+
+        for (const r of pageResults) {
+          if (results.length >= count) break;
+          if (!results.some((existing) => existing.link === r.link)) {
+            results.push(r);
+          }
+        }
+
+        if (pageResults.length === 0 || start >= 90) {
+          break;
+        }
+        start += 10;
+      }
+
+      if (fetchContent) {
+        for (const result of results) {
+          try {
+            await page.goto(result.link, { waitUntil: 'networkidle2', timeout: timeoutMs }).catch(() => {});
+            const article = await extractReadableContent(page);
+            result.content = article.content ?? '(No readable content)';
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            result.content = `(Error fetching content: ${message})`;
+          }
+        }
+      }
+
+      results.forEach((r, index) => {
+        console.log(`--- Result ${index + 1} ---`);
+        console.log(`Title: ${r.title}`);
+        console.log(`Link: ${r.link}`);
+        if (r.snippet) {
+          console.log(`Snippet: ${r.snippet}`);
+        }
+        if (r.content) {
+          console.log(`Content:\n${r.content}`);
+        }
+        console.log('');
+      });
+
+      if (results.length === 0) {
+        console.log('No results found.');
+      }
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('content <url>')
+  .description('Extract readable content from a URL as markdown-like text.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .option('--timeout <seconds>', 'Navigation timeout in seconds (default: 10).', (value) => Number.parseInt(value, 10), 10)
+  .action(async (url: string, options) => {
+    const port = options.port as number;
+    const timeoutMs = Math.max(3, (options.timeout as number) ?? 10) * 1000;
+    const { browser, page } = await getActivePage(port);
+    try {
+      await page.goto(url, { waitUntil: 'networkidle2', timeout: timeoutMs }).catch(() => {});
+      const article = await extractReadableContent(page);
+      console.log(`URL: ${article.url}`);
+      if (article.title) {
+        console.log(`Title: ${article.title}`);
+      }
+      console.log('');
+      console.log(article.content ?? '(No readable content)');
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('cookies')
+  .description('Dump cookies from the active tab as JSON.')
+  .option('--port <number>', 'Debugger port (default: 9222)', (value) => Number.parseInt(value, 10), DEFAULT_PORT)
+  .action(async (options) => {
+    const port = options.port as number;
+    const { browser, page } = await getActivePage(port);
+    try {
+      const cookies = await page.cookies();
+      console.log(JSON.stringify(cookies, null, 2));
+    } finally {
+      await browser.disconnect();
+    }
+  });
+
+program
+  .command('inspect')
+  .description('List Chrome processes launched with --remote-debugging-port and show their open tabs.')
+  .option('--ports <list>', 'Comma-separated list of ports to include.', parseNumberListArg)
+  .option('--pids <list>', 'Comma-separated list of PIDs to include.', parseNumberListArg)
+  .option('--json', 'Emit machine-readable JSON output.', false)
+  .action(async (options) => {
+    const ports = (options.ports as number[] | undefined)?.filter((entry) => Number.isFinite(entry) && entry > 0);
+    const pids = (options.pids as number[] | undefined)?.filter((entry) => Number.isFinite(entry) && entry > 0);
+    const sessions = await describeChromeSessions({
+      ports,
+      pids,
+      includeAll: !ports?.length && !pids?.length,
+    });
+    if (options.json) {
+      console.log(JSON.stringify(sessions, null, 2));
+      return;
+    }
+    if (sessions.length === 0) {
+      console.log('No Chrome instances with DevTools ports found.');
+      return;
+    }
+    sessions.forEach((session, index) => {
+      if (index > 0) {
+        console.log('');
+      }
+      const transport = session.port !== undefined ? `port ${session.port}` : session.usesPipe ? 'debugging pipe' : 'unknown transport';
+      const header = [`Chrome PID ${session.pid}`, `(${transport})`];
+      if (session.version?.Browser) {
+        header.push(`- ${session.version.Browser}`);
+      }
+      console.log(header.join(' '));
+      if (session.tabs.length === 0) {
+        console.log('  (no tabs reported)');
+        return;
+      }
+      session.tabs.forEach((tab, idx) => {
+        const title = tab.title || '(untitled)';
+        const url = tab.url || '(no url)';
+        console.log(`  Tab ${idx + 1}: ${title}`);
+        console.log(`           ${url}`);
+      });
+    });
+  });
+
+program
+  .command('kill')
+  .description('Terminate Chrome instances that have DevTools ports open.')
+  .option('--ports <list>', 'Comma-separated list of ports to target.', parseNumberListArg)
+  .option('--pids <list>', 'Comma-separated list of PIDs to target.', parseNumberListArg)
+  .option('--all', 'Kill every matching Chrome instance.', false)
+  .option('--force', 'Skip the confirmation prompt.', false)
+  .action(async (options) => {
+    const ports = (options.ports as number[] | undefined)?.filter((entry) => Number.isFinite(entry) && entry > 0);
+    const pids = (options.pids as number[] | undefined)?.filter((entry) => Number.isFinite(entry) && entry > 0);
+    const killAll = Boolean(options.all);
+    if (!killAll && (!ports?.length && !pids?.length)) {
+      console.error('Specify --all, --ports <list>, or --pids <list> to select targets.');
+      process.exit(1);
+    }
+    const sessions = await describeChromeSessions({ ports, pids, includeAll: killAll });
+    if (sessions.length === 0) {
+      console.log('No matching Chrome instances found.');
+      return;
+    }
+    if (!options.force) {
+      console.log('About to terminate the following Chrome sessions:');
+      sessions.forEach((session) => {
+        const transport = session.port !== undefined ? `port ${session.port}` : session.usesPipe ? 'debugging pipe' : 'unknown transport';
+        console.log(`  PID ${session.pid} (${transport})`);
+      });
+      const rl = readline.createInterface({ input, output });
+      const answer = (await rl.question('Proceed? [y/N] ')).trim().toLowerCase();
+      rl.close();
+      if (answer !== 'y' && answer !== 'yes') {
+        console.log('Aborted.');
+        return;
+      }
+    }
+    const failures: { pid: number; error: string }[] = [];
+    sessions.forEach((session) => {
+      try {
+        process.kill(session.pid);
+        const transport = session.port !== undefined ? `port ${session.port}` : session.usesPipe ? 'debugging pipe' : 'unknown transport';
+        console.log(`✓ Killed Chrome PID ${session.pid} (${transport})`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`✗ Failed to kill PID ${session.pid}: ${message}`);
+        failures.push({ pid: session.pid, error: message });
+      }
+    });
+    if (failures.length > 0) {
+      process.exitCode = 1;
+    }
+  });
+
+interface ChromeProcessInfo {
+  pid: number;
+  port?: number;
+  usesPipe: boolean;
+  command: string;
+}
+
+interface ChromeTabInfo {
+  id?: string;
+  title?: string;
+  url?: string;
+  type?: string;
+}
+
+interface ChromeSessionDescription extends ChromeProcessInfo {
+  version?: Record<string, string>;
+  tabs: ChromeTabInfo[];
+}
+
+async function ensureReadability(page: any) {
+  try {
+    await page.setBypassCSP?.(true);
+  } catch {
+    // ignore
+  }
+  const scripts = [
+    'https://unpkg.com/@mozilla/readability@0.4.4/Readability.js',
+    'https://unpkg.com/turndown@7.1.2/dist/turndown.js',
+    'https://unpkg.com/turndown-plugin-gfm@1.0.2/dist/turndown-plugin-gfm.js',
+  ];
+  for (const src of scripts) {
+    try {
+      const alreadyLoaded = await page.evaluate((url) => {
+        return Boolean(document.querySelector(`script[src="${url}"]`));
+      }, src);
+      if (!alreadyLoaded) {
+        await page.addScriptTag({ url: src });
+      }
+    } catch {
+      // best-effort; continue
+    }
+  }
+}
+
+async function extractReadableContent(page: any): Promise<{ title?: string; content?: string; url: string }> {
+  await ensureReadability(page);
+  const result = await page.evaluate(() => {
+    const asMarkdown = (html: string | null | undefined) => {
+      if (!html) return '';
+      const TurndownService = (window as any).TurndownService;
+      const turndownPluginGfm = (window as any).turndownPluginGfm;
+      if (!TurndownService) {
+        return '';
+      }
+      const turndown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
+      if (turndownPluginGfm?.gfm) {
+        turndown.use(turndownPluginGfm.gfm);
+      }
+      return turndown
+        .turndown(html)
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+    };
+
+    const fallbackText = () => {
+      const main =
+        document.querySelector('main, article, [role="main"], .content, #content') || document.body || document.documentElement;
+      return main?.textContent?.trim() ?? '';
+    };
+
+    let title = document.title;
+    let content = '';
+
+    try {
+      const Readability = (window as any).Readability;
+      if (Readability) {
+        const clone = document.cloneNode(true) as Document;
+        const article = new Readability(clone).parse();
+        title = article?.title || title;
+        content = asMarkdown(article?.content) || article?.textContent || '';
+      }
+    } catch {
+      // ignore readability failures
+    }
+
+    if (!content) {
+      content = fallbackText();
+    }
+
+    content = content?.trim().slice(0, 8000);
+
+    return { title, content, url: location.href };
+  });
+  return result;
+}
+
+function parseNumberListArg(value: string): number[] {
+  return parseNumberList(value) ?? [];
+}
+
+function parseNumberList(inputValue: string | undefined): number[] | undefined {
+  if (!inputValue) {
+    return undefined;
+  }
+  const parsed = inputValue
+    .split(',')
+    .map((entry) => Number.parseInt(entry.trim(), 10))
+    .filter((value) => Number.isFinite(value));
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+async function describeChromeSessions(options: {
+  ports?: number[];
+  pids?: number[];
+  includeAll?: boolean;
+}): Promise<ChromeSessionDescription[]> {
+  const { ports, pids, includeAll } = options;
+  const processes = await listDevtoolsChromes();
+  const portSet = new Set(ports ?? []);
+  const pidSet = new Set(pids ?? []);
+  const candidates = processes.filter((proc) => {
+    if (includeAll) {
+      return true;
+    }
+    if (portSet.size > 0 && proc.port !== undefined && portSet.has(proc.port)) {
+      return true;
+    }
+    if (pidSet.size > 0 && pidSet.has(proc.pid)) {
+      return true;
+    }
+    return false;
+  });
+  const results: ChromeSessionDescription[] = [];
+  for (const proc of candidates) {
+    let version: Record<string, string> | undefined;
+    let filteredTabs: ChromeTabInfo[] = [];
+    if (proc.port !== undefined) {
+      const [versionResp, tabs] = await Promise.all([
+        fetchJson(`http://localhost:${proc.port}/json/version`).catch(() => undefined),
+        fetchJson(`http://localhost:${proc.port}/json/list`).catch(() => []),
+      ]);
+      version = versionResp as Record<string, string> | undefined;
+      filteredTabs = Array.isArray(tabs)
+        ? (tabs as ChromeTabInfo[]).filter((tab) => {
+            const type = tab.type?.toLowerCase() ?? '';
+            if (type && type !== 'page' && type !== 'app') {
+              if (!tab.url || tab.url.startsWith('devtools://') || tab.url.startsWith('chrome-extension://')) {
+                return false;
+              }
+            }
+            if (!tab.url || tab.url.trim().length === 0) {
+              return false;
+            }
+            return true;
+          })
+        : [];
+    }
+    results.push({
+      ...proc,
+      version,
+      tabs: filteredTabs,
+    });
+  }
+  return results;
+}
+
+async function listDevtoolsChromes(): Promise<ChromeProcessInfo[]> {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+    console.warn('Chrome inspection is only supported on macOS and Linux for now.');
+    return [];
+  }
+  let output = '';
+  try {
+    output = execSync('ps -ax -o pid=,command=', { encoding: 'utf8' });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to enumerate processes: ${message}`);
+  }
+  const processes: ChromeProcessInfo[] = [];
+  output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const match = line.match(/^(\d+)\s+(.+)$/);
+      if (!match) {
+        return;
+      }
+      const pid = Number.parseInt(match[1], 10);
+      const command = match[2];
+      if (!Number.isFinite(pid) || pid <= 0) {
+        return;
+      }
+      if (!/chrome/i.test(command) || (!/--remote-debugging-port/.test(command) && !/--remote-debugging-pipe/.test(command))) {
+        return;
+      }
+      const portMatch = command.match(/--remote-debugging-port(?:=|\s+)(\d+)/);
+      if (portMatch) {
+        const port = Number.parseInt(portMatch[1], 10);
+        if (!Number.isFinite(port)) {
+          return;
+        }
+        processes.push({ pid, port, usesPipe: false, command });
+        return;
+      }
+      if (/--remote-debugging-pipe/.test(command)) {
+        processes.push({ pid, usesPipe: true, command });
+      }
+    });
+  return processes;
+}
+
+function fetchJson(url: string, timeoutMs = 2000): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const request = http.get(url, { timeout: timeoutMs }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        if ((response.statusCode ?? 500) >= 400) {
+          reject(new Error(`HTTP ${response.statusCode} for ${url}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          resolve(undefined);
+        }
+      });
+    });
+    request.on('timeout', () => {
+      request.destroy(new Error(`Request to ${url} timed out`));
+    });
+    request.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+program.parseAsync(process.argv);

--- a/toolkit/packages/skills/webapp-testing/bin/package.json
+++ b/toolkit/packages/skills/webapp-testing/bin/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "commander": "^12.1.0",
+    "puppeteer-core": "^23.6.0"
+  }
+}

--- a/toolkit/packages/skills/webapp-testing/examples/console_logging.py
+++ b/toolkit/packages/skills/webapp-testing/examples/console_logging.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Capturing console logs during browser automation
+
+url = 'http://localhost:5173'  # Replace with your URL
+
+console_logs = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Set up console log capture
+    def handle_console_message(msg):
+        console_logs.append(f"[{msg.type}] {msg.text}")
+        print(f"Console: [{msg.type}] {msg.text}")
+
+    page.on("console", handle_console_message)
+
+    # Navigate to page
+    page.goto(url)
+    page.wait_for_load_state('networkidle')
+
+    # Interact with the page (triggers console logs)
+    page.click('text=Dashboard')
+    page.wait_for_timeout(1000)
+
+    browser.close()
+
+# Save console logs to file
+with open('/mnt/user-data/outputs/console.log', 'w') as f:
+    f.write('\n'.join(console_logs))
+
+print(f"\nCaptured {len(console_logs)} console messages")
+print(f"Logs saved to: /mnt/user-data/outputs/console.log")

--- a/toolkit/packages/skills/webapp-testing/examples/element_discovery.py
+++ b/toolkit/packages/skills/webapp-testing/examples/element_discovery.py
@@ -1,0 +1,40 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Discovering buttons and other elements on a page
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    # Navigate to page and wait for it to fully load
+    page.goto('http://localhost:3000')  # Replace with your app URL
+    page.wait_for_load_state('networkidle')
+
+    # Discover all buttons on the page
+    buttons = page.locator('button').all()
+    print(f"Found {len(buttons)} buttons:")
+    for i, button in enumerate(buttons):
+        text = button.inner_text() if button.is_visible() else "[hidden]"
+        print(f"  [{i}] {text}")
+
+    # Discover links
+    links = page.locator('a[href]').all()
+    print(f"\nFound {len(links)} links:")
+    for link in links[:5]:  # Show first 5
+        text = link.inner_text().strip()
+        href = link.get_attribute('href')
+        print(f"  - {text} -> {href}")
+
+    # Discover input fields
+    inputs = page.locator('input, textarea, select').all()
+    print(f"\nFound {len(inputs)} input fields:")
+    for input_elem in inputs:
+        name = input_elem.get_attribute('name') or input_elem.get_attribute('id') or "[unnamed]"
+        input_type = input_elem.get_attribute('type') or 'text'
+        print(f"  - {name} ({input_type})")
+
+    # Take screenshot for visual reference
+    page.screenshot(path='/tmp/page_discovery.png', full_page=True)
+    print("\nScreenshot saved to /tmp/page_discovery.png")
+
+    browser.close()

--- a/toolkit/packages/skills/webapp-testing/examples/multi_step_registration.py
+++ b/toolkit/packages/skills/webapp-testing/examples/multi_step_registration.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+Multi-Step Registration Example
+
+Demonstrates complete registration flow using all webapp-testing utilities:
+- UI interactions (cookie banners, modals)
+- Smart form filling (handles field variations)
+- Database operations (invite codes, email verification)
+- Advanced wait strategies
+
+This example is based on a real-world React/Supabase app with 3-step registration.
+"""
+
+import sys
+import os
+from playwright.sync_api import sync_playwright
+import time
+
+# Add utils to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from utils.ui_interactions import dismiss_cookie_banner, dismiss_modal
+from utils.form_helpers import SmartFormFiller, handle_multi_step_form
+from utils.supabase import SupabaseTestClient
+from utils.wait_strategies import combined_wait, smart_navigation_wait
+
+
+def register_user_complete_flow():
+    """
+    Complete multi-step registration with database setup and verification.
+
+    Flow:
+    1. Create invite code in database
+    2. Navigate to registration page
+    3. Fill multi-step form (Code → Credentials → Personal Info → Avatar)
+    4. Verify email via database
+    5. Login
+    6. Verify dashboard access
+    7. Cleanup (optional)
+    """
+
+    # Configuration - adjust for your app
+    APP_URL = "http://localhost:3000"
+    REGISTER_URL = f"{APP_URL}/register"
+
+    # Database config (adjust for your project)
+    DB_PASSWORD = "your-db-password"
+    SUPABASE_URL = "https://project.supabase.co"
+    SERVICE_KEY = "your-service-role-key"
+
+    # Test user data
+    TEST_EMAIL = "test.user@example.com"
+    TEST_PASSWORD = "TestPass123!"
+    FULL_NAME = "Test User"
+    PHONE = "+447700900123"
+    DATE_OF_BIRTH = "1990-01-15"
+    INVITE_CODE = "TEST2024"
+
+    print("\n" + "="*60)
+    print("MULTI-STEP REGISTRATION AUTOMATION")
+    print("="*60)
+
+    # Step 1: Setup database
+    print("\n[1/8] Setting up database...")
+    db_client = SupabaseTestClient(
+        url=SUPABASE_URL,
+        service_key=SERVICE_KEY,
+        db_password=DB_PASSWORD
+    )
+
+    # Create invite code
+    if db_client.create_invite_code(INVITE_CODE, code_type="general"):
+        print(f"    ✓ Created invite code: {INVITE_CODE}")
+    else:
+        print(f"    ⚠️  Invite code may already exist")
+
+    # Clean up any existing test user
+    existing_user = db_client.find_user_by_email(TEST_EMAIL)
+    if existing_user:
+        print(f"    Cleaning up existing user...")
+        db_client.cleanup_related_records(existing_user)
+        db_client.delete_user(existing_user)
+
+    # Step 2: Start browser automation
+    print("\n[2/8] Starting browser automation...")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        page = browser.new_page(viewport={'width': 1400, 'height': 1000})
+
+        try:
+            # Step 3: Navigate to registration
+            print("\n[3/8] Navigating to registration page...")
+            page.goto(REGISTER_URL, wait_until='networkidle')
+            smart_navigation_wait(page)  # Use smart wait instead of time.sleep(2)
+
+            # Handle cookie banner
+            if dismiss_cookie_banner(page):
+                print("    ✓ Dismissed cookie banner")
+
+            page.screenshot(path='/tmp/reg_step1_start.png', full_page=True)
+            print("    ✓ Screenshot: /tmp/reg_step1_start.png")
+
+            # Step 4: Fill multi-step form
+            print("\n[4/8] Filling multi-step registration form...")
+
+            # Define form steps
+            steps = [
+                {
+                    'name': 'Invite Code',
+                    'fields': {'invite_code': INVITE_CODE},
+                    'custom_fill': lambda: page.locator('input').first.fill(INVITE_CODE),
+                    'custom_submit': lambda: page.locator('input').first.press('Enter'),
+                },
+                {
+                    'name': 'Credentials',
+                    'fields': {
+                        'email': TEST_EMAIL,
+                        'password': TEST_PASSWORD,
+                    },
+                    'checkbox': True,  # Terms of service
+                },
+                {
+                    'name': 'Personal Info',
+                    'fields': {
+                        'full_name': FULL_NAME,
+                        'date_of_birth': DATE_OF_BIRTH,
+                        'phone': PHONE,
+                    },
+                },
+                {
+                    'name': 'Avatar Selection',
+                    'complete': True,  # Final step with COMPLETE button
+                }
+            ]
+
+            # Process each step
+            filler = SmartFormFiller()
+
+            for i, step in enumerate(steps):
+                print(f"\n    Step {i+1}/4: {step['name']}")
+
+                # Custom filling logic for first step (invite code)
+                if 'custom_fill' in step:
+                    step['custom_fill']()
+                    combined_wait(page, timeout=2000)  # Brief wait for UI update
+
+                    if 'custom_submit' in step:
+                        step['custom_submit']()
+                    else:
+                        page.locator('button:has-text("CONTINUE")').first.click()
+
+                    # Wait for navigation/API response
+                    combined_wait(page, timeout=5000)
+                    smart_navigation_wait(page)
+
+                # Standard form filling for other steps
+                elif 'fields' in step:
+                    if 'email' in step['fields']:
+                        filler.fill_email_field(page, step['fields']['email'])
+                        print("      ✓ Email")
+
+                    if 'password' in step['fields']:
+                        filler.fill_password_fields(page, step['fields']['password'])
+                        print("      ✓ Password")
+
+                    if 'full_name' in step['fields']:
+                        filler.fill_name_field(page, step['fields']['full_name'])
+                        print("      ✓ Full Name")
+
+                    if 'date_of_birth' in step['fields']:
+                        filler.fill_date_field(page, step['fields']['date_of_birth'], field_hint='birth')
+                        print("      ✓ Date of Birth")
+
+                    if 'phone' in step['fields']:
+                        filler.fill_phone_field(page, step['fields']['phone'])
+                        print("      ✓ Phone")
+
+                    # Check terms checkbox if needed
+                    if step.get('checkbox'):
+                        page.locator('input[type="checkbox"]').first.check()
+                        print("      ✓ Terms accepted")
+
+                    combined_wait(page, timeout=1000)  # Brief wait for form validation
+
+                    # Click continue
+                    page.locator('button:has-text("CONTINUE")').first.click()
+                    combined_wait(page, timeout=5000)  # Wait for step transition
+                    smart_navigation_wait(page)
+
+                # Final step - click COMPLETE
+                elif step.get('complete'):
+                    complete_btn = page.locator('button:has-text("COMPLETE")').first
+                    complete_btn.click()
+                    print("      ✓ Clicked COMPLETE")
+
+                    # Wait for registration to complete (may involve API calls)
+                    combined_wait(page, timeout=10000)
+                    smart_navigation_wait(page)
+
+                # Screenshot after each step
+                page.screenshot(path=f'/tmp/reg_step{i+1}_complete.png', full_page=True)
+                print(f"      ✓ Screenshot: /tmp/reg_step{i+1}_complete.png")
+
+            print("\n    ✓ Multi-step form completed!")
+
+            # Step 5: Handle post-registration
+            print("\n[5/8] Handling post-registration...")
+
+            # Dismiss welcome modal if present
+            if dismiss_modal(page, modal_identifier="Welcome"):
+                print("    ✓ Dismissed welcome modal")
+
+            current_url = page.url
+            print(f"    Current URL: {current_url}")
+
+            # Step 6: Verify email via database
+            print("\n[6/8] Verifying email via database...")
+            combined_wait(page, timeout=2000)  # Brief wait for user to be created in DB
+
+            user_id = db_client.find_user_by_email(TEST_EMAIL)
+            if user_id:
+                print(f"    ✓ Found user: {user_id}")
+
+                if db_client.confirm_email(user_id):
+                    print("    ✓ Email verified in database")
+                else:
+                    print("    ⚠️  Could not verify email")
+            else:
+                print("    ⚠️  User not found in database")
+
+            # Step 7: Login (if not already logged in)
+            print("\n[7/8] Logging in...")
+
+            if 'login' in current_url.lower():
+                print("    Needs login...")
+
+                filler.fill_email_field(page, TEST_EMAIL)
+                filler.fill_password_fields(page, TEST_PASSWORD, confirm=False)
+                combined_wait(page, timeout=1000)
+
+                page.locator('button[type="submit"]').first.click()
+                combined_wait(page, timeout=8000)  # Wait for login API
+                smart_navigation_wait(page)
+
+                print("    ✓ Logged in")
+            else:
+                print("    ✓ Already logged in")
+
+            # Step 8: Verify dashboard access
+            print("\n[8/8] Verifying dashboard access...")
+
+            # Navigate to dashboard/perform if not already there
+            if 'perform' not in page.url.lower() and 'dashboard' not in page.url.lower():
+                page.goto(f"{APP_URL}/perform", wait_until='networkidle')
+                smart_navigation_wait(page)
+
+            page.screenshot(path='/tmp/reg_final_dashboard.png', full_page=True)
+            print("    ✓ Screenshot: /tmp/reg_final_dashboard.png")
+
+            # Check if we're on the dashboard
+            if 'perform' in page.url.lower() or 'dashboard' in page.url.lower():
+                print("    ✓ Successfully reached dashboard!")
+            else:
+                print(f"    ⚠️  Unexpected URL: {page.url}")
+
+            print("\n" + "="*60)
+            print("REGISTRATION COMPLETE!")
+            print("="*60)
+            print(f"\nUser: {TEST_EMAIL}")
+            print(f"Password: {TEST_PASSWORD}")
+            print(f"User ID: {user_id}")
+            print(f"\nScreenshots saved to /tmp/reg_step*.png")
+            print("="*60)
+
+            # Keep browser open for inspection
+            print("\nKeeping browser open for 30 seconds...")
+            time.sleep(30)
+
+        except Exception as e:
+            print(f"\n❌ Error: {e}")
+            import traceback
+            traceback.print_exc()
+            page.screenshot(path='/tmp/reg_error.png', full_page=True)
+            print("    Error screenshot: /tmp/reg_error.png")
+
+        finally:
+            browser.close()
+
+            # Optional cleanup
+            print("\n" + "="*60)
+            print("Cleanup")
+            print("="*60)
+
+            cleanup = input("\nDelete test user? (y/N): ").strip().lower()
+            if cleanup == 'y' and user_id:
+                print("Cleaning up...")
+                db_client.cleanup_related_records(user_id)
+                db_client.delete_user(user_id)
+                print("✓ Test user deleted")
+            else:
+                print("Test user kept for manual testing")
+
+
+if __name__ == '__main__':
+    print("\nMulti-Step Registration Automation Example")
+    print("=" * 60)
+    print("\nBefore running:")
+    print("1. Update configuration variables at the top of the script")
+    print("2. Ensure your app is running (e.g., npm run dev)")
+    print("3. Have database credentials ready")
+    print("\n" + "=" * 60)
+
+    proceed = input("\nProceed with registration? (y/N): ").strip().lower()
+
+    if proceed == 'y':
+        register_user_complete_flow()
+    else:
+        print("\nCancelled.")

--- a/toolkit/packages/skills/webapp-testing/examples/static_html_automation.py
+++ b/toolkit/packages/skills/webapp-testing/examples/static_html_automation.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import sync_playwright
+import os
+
+# Example: Automating interaction with static HTML files using file:// URLs
+
+html_file_path = os.path.abspath('path/to/your/file.html')
+file_url = f'file://{html_file_path}'
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Navigate to local HTML file
+    page.goto(file_url)
+
+    # Take screenshot
+    page.screenshot(path='/mnt/user-data/outputs/static_page.png', full_page=True)
+
+    # Interact with elements
+    page.click('text=Click Me')
+    page.fill('#name', 'John Doe')
+    page.fill('#email', 'john@example.com')
+
+    # Submit form
+    page.click('button[type="submit"]')
+    page.wait_for_timeout(500)
+
+    # Take final screenshot
+    page.screenshot(path='/mnt/user-data/outputs/after_submit.png', full_page=True)
+
+    browser.close()
+
+print("Static HTML automation completed!")

--- a/toolkit/packages/skills/webapp-testing/scripts/with_server.py
+++ b/toolkit/packages/skills/webapp-testing/scripts/with_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Start one or more servers, wait for them to be ready, run a command, then clean up.
+
+Usage:
+    # Single server
+    python scripts/with_server.py --server "npm run dev" --port 5173 -- python automation.py
+    python scripts/with_server.py --server "npm start" --port 3000 -- python test.py
+
+    # Multiple servers
+    python scripts/with_server.py \
+      --server "cd backend && python server.py" --port 3000 \
+      --server "cd frontend && npm run dev" --port 5173 \
+      -- python test.py
+"""
+
+import subprocess
+import socket
+import time
+import sys
+import argparse
+
+def is_server_ready(port, timeout=30):
+    """Wait for server to be ready by polling the port."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection(('localhost', port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run command with one or more servers')
+    parser.add_argument('--server', action='append', dest='servers', required=True, help='Server command (can be repeated)')
+    parser.add_argument('--port', action='append', dest='ports', type=int, required=True, help='Port for each server (must match --server count)')
+    parser.add_argument('--timeout', type=int, default=30, help='Timeout in seconds per server (default: 30)')
+    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to run after server(s) ready')
+
+    args = parser.parse_args()
+
+    # Remove the '--' separator if present
+    if args.command and args.command[0] == '--':
+        args.command = args.command[1:]
+
+    if not args.command:
+        print("Error: No command specified to run")
+        sys.exit(1)
+
+    # Parse server configurations
+    if len(args.servers) != len(args.ports):
+        print("Error: Number of --server and --port arguments must match")
+        sys.exit(1)
+
+    servers = []
+    for cmd, port in zip(args.servers, args.ports):
+        servers.append({'cmd': cmd, 'port': port})
+
+    server_processes = []
+
+    try:
+        # Start all servers
+        for i, server in enumerate(servers):
+            print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
+
+            # Use shell=True to support commands with cd and &&
+            process = subprocess.Popen(
+                server['cmd'],
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            server_processes.append(process)
+
+            # Wait for this server to be ready
+            print(f"Waiting for server on port {server['port']}...")
+            if not is_server_ready(server['port'], timeout=args.timeout):
+                raise RuntimeError(f"Server failed to start on port {server['port']} within {args.timeout}s")
+
+            print(f"Server ready on port {server['port']}")
+
+        print(f"\nAll {len(servers)} server(s) ready")
+
+        # Run the command
+        print(f"Running: {' '.join(args.command)}\n")
+        result = subprocess.run(args.command)
+        sys.exit(result.returncode)
+
+    finally:
+        # Clean up all servers
+        print(f"\nStopping {len(server_processes)} server(s)...")
+        for i, process in enumerate(server_processes):
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            print(f"Server {i+1} stopped")
+        print("All servers stopped")
+
+
+if __name__ == '__main__':
+    main()

--- a/toolkit/packages/skills/webapp-testing/utils/browser_config.py
+++ b/toolkit/packages/skills/webapp-testing/utils/browser_config.py
@@ -1,0 +1,217 @@
+"""
+Smart Browser Configuration for Testing
+
+Automatically configures browser context with appropriate settings
+based on the testing environment (localhost vs production).
+
+Usage:
+    from utils.browser_config import BrowserConfig
+
+    context = BrowserConfig.create_test_context(
+        browser,
+        'http://localhost:3000'
+    )
+"""
+
+from typing import Optional, Dict
+from playwright.sync_api import Browser, BrowserContext
+from urllib.parse import urlparse
+
+
+class BrowserConfig:
+    """Smart browser configuration for testing environments"""
+
+    @staticmethod
+    def is_localhost_url(url: str) -> bool:
+        """
+        Check if URL is localhost or local development environment.
+
+        Args:
+            url: URL to check
+
+        Returns:
+            True if localhost/127.0.0.1, False otherwise
+
+        Examples:
+            >>> BrowserConfig.is_localhost_url('http://localhost:3000')
+            True
+            >>> BrowserConfig.is_localhost_url('http://127.0.0.1:8080')
+            True
+            >>> BrowserConfig.is_localhost_url('https://production.com')
+            False
+        """
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname or parsed.netloc
+
+            localhost_patterns = [
+                'localhost',
+                '127.0.0.1',
+                '0.0.0.0',
+                '::1',  # IPv6 localhost
+            ]
+
+            return any(pattern in hostname.lower() for pattern in localhost_patterns)
+        except Exception:
+            return False
+
+    @staticmethod
+    def create_test_context(
+        browser: Browser,
+        base_url: str = 'http://localhost',
+        bypass_csp: Optional[bool] = None,
+        ignore_https_errors: bool = True,
+        extra_http_headers: Optional[Dict[str, str]] = None,
+        viewport: Optional[Dict[str, int]] = None,
+        record_video: bool = False,
+        verbose: bool = True
+    ) -> BrowserContext:
+        """
+        Create browser context optimized for testing.
+
+        Auto-detects CSP bypass need:
+        - If base_url contains 'localhost' or '127.0.0.1' → bypass_csp=True
+        - Otherwise → bypass_csp=False
+
+        Args:
+            browser: Playwright browser instance
+            base_url: Base URL of application under test
+            bypass_csp: Override auto-detection (None = auto-detect)
+            ignore_https_errors: Ignore HTTPS errors (self-signed certs)
+            extra_http_headers: Additional HTTP headers to send
+            viewport: Custom viewport size (default: 1280x720)
+            record_video: Record video of test session
+            verbose: Print configuration choices
+
+        Returns:
+            Configured browser context
+
+        Example:
+            # Auto-detect CSP bypass for localhost
+            context = BrowserConfig.create_test_context(
+                browser,
+                'http://localhost:7160'
+            )
+            # Output: 🔓 CSP bypass enabled (testing on localhost)
+
+            # Manually override for production testing
+            context = BrowserConfig.create_test_context(
+                browser,
+                'https://production.com',
+                bypass_csp=False
+            )
+        """
+        # Auto-detect CSP bypass if not specified
+        if bypass_csp is None:
+            bypass_csp = BrowserConfig.is_localhost_url(base_url)
+
+        # Default viewport for consistent testing
+        if viewport is None:
+            viewport = {'width': 1280, 'height': 720}
+
+        # Build context options
+        context_options = {
+            'bypass_csp': bypass_csp,
+            'ignore_https_errors': ignore_https_errors,
+            'viewport': viewport,
+        }
+
+        # Add extra headers if provided
+        if extra_http_headers:
+            context_options['extra_http_headers'] = extra_http_headers
+
+        # Add video recording if requested
+        if record_video:
+            context_options['record_video_dir'] = '/tmp/playwright-videos'
+
+        # Create context
+        context = browser.new_context(**context_options)
+
+        # Print configuration for visibility
+        if verbose:
+            print("\n" + "=" * 60)
+            print("  Browser Context Configuration")
+            print("=" * 60)
+            print(f"  Base URL: {base_url}")
+
+            if bypass_csp:
+                print("  🔓 CSP bypass: ENABLED (testing on localhost)")
+            else:
+                print("  🔒 CSP bypass: DISABLED (production mode)")
+
+            if ignore_https_errors:
+                print("  ⚠️  HTTPS errors: IGNORED (self-signed certs OK)")
+
+            print(f"  📐 Viewport: {viewport['width']}x{viewport['height']}")
+
+            if extra_http_headers:
+                print(f"  📨 Extra headers: {len(extra_http_headers)} header(s)")
+
+            if record_video:
+                print("  🎥 Video recording: ENABLED")
+
+            print("=" * 60 + "\n")
+
+        return context
+
+    @staticmethod
+    def create_mobile_context(
+        browser: Browser,
+        device: str = 'iPhone 12',
+        base_url: str = 'http://localhost',
+        bypass_csp: Optional[bool] = None,
+        verbose: bool = True
+    ) -> BrowserContext:
+        """
+        Create mobile browser context with device emulation.
+
+        Args:
+            browser: Playwright browser instance
+            device: Device to emulate (e.g., 'iPhone 12', 'Pixel 5')
+            base_url: Base URL of application under test
+            bypass_csp: Override auto-detection
+            verbose: Print configuration
+
+        Returns:
+            Mobile browser context
+
+        Example:
+            context = BrowserConfig.create_mobile_context(
+                browser,
+                device='iPhone 12',
+                base_url='http://localhost:3000'
+            )
+        """
+        from playwright.sync_api import devices
+
+        # Get device descriptor
+        if device not in devices:
+            available = ', '.join(list(devices.keys())[:5])
+            raise ValueError(
+                f"Unknown device: {device}. "
+                f"Available: {available}, ..."
+            )
+
+        device_descriptor = devices[device]
+
+        # Auto-detect CSP bypass
+        if bypass_csp is None:
+            bypass_csp = BrowserConfig.is_localhost_url(base_url)
+
+        # Merge with our defaults
+        context_options = {
+            **device_descriptor,
+            'bypass_csp': bypass_csp,
+            'ignore_https_errors': True,
+        }
+
+        context = browser.new_context(**context_options)
+
+        if verbose:
+            print(f"\n📱 Mobile context: {device}")
+            print(f"   Viewport: {device_descriptor['viewport']}")
+            if bypass_csp:
+                print(f"   🔓 CSP bypass: ENABLED")
+            print()
+
+        return context

--- a/toolkit/packages/skills/webapp-testing/utils/form_helpers.py
+++ b/toolkit/packages/skills/webapp-testing/utils/form_helpers.py
@@ -1,0 +1,463 @@
+"""
+Smart Form Filling Helpers
+
+Handles common form patterns across web applications:
+- Multi-step forms with validation
+- Dynamic field variations (full name vs first/last name)
+- Retry strategies for flaky selectors
+- Intelligent field detection
+"""
+
+from playwright.sync_api import Page
+from typing import Dict, List, Any, Optional
+import time
+
+
+class SmartFormFiller:
+    """
+    Intelligent form filling that handles variations in field structures.
+
+    Example:
+        ```python
+        filler = SmartFormFiller()
+        filler.fill_name_field(page, "John Doe")  # Tries full name or first/last
+        filler.fill_email_field(page, "test@example.com")
+        filler.fill_password_fields(page, "SecurePass123!")
+        ```
+    """
+
+    @staticmethod
+    def fill_name_field(page: Page, full_name: str, timeout: int = 5000) -> bool:
+        """
+        Fill name field(s) - handles both single "Full Name" and separate "First/Last Name" fields.
+
+        Args:
+            page: Playwright Page object
+            full_name: Full name as string (e.g., "John Doe")
+            timeout: Maximum time to wait for fields (milliseconds)
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            ```python
+            # Works with both field structures:
+            # - Single field: "Full Name"
+            # - Separate fields: "First Name" and "Last Name"
+            fill_name_field(page, "Jane Smith")
+            ```
+        """
+        # Strategy 1: Try single "Full Name" field
+        full_name_selectors = [
+            'input[name*="full" i][name*="name" i]',
+            'input[placeholder*="full name" i]',
+            'input[placeholder*="name" i]',
+            'input[id*="fullname" i]',
+            'input[id*="full-name" i]',
+        ]
+
+        for selector in full_name_selectors:
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(full_name)
+                    return True
+            except:
+                continue
+
+        # Strategy 2: Try separate First/Last Name fields
+        parts = full_name.split(' ', 1)
+        first_name = parts[0] if parts else full_name
+        last_name = parts[1] if len(parts) > 1 else ''
+
+        first_name_selectors = [
+            'input[name*="first" i][name*="name" i]',
+            'input[placeholder*="first name" i]',
+            'input[id*="firstname" i]',
+            'input[id*="first-name" i]',
+        ]
+
+        last_name_selectors = [
+            'input[name*="last" i][name*="name" i]',
+            'input[placeholder*="last name" i]',
+            'input[id*="lastname" i]',
+            'input[id*="last-name" i]',
+        ]
+
+        first_filled = False
+        last_filled = False
+
+        # Fill first name
+        for selector in first_name_selectors:
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(first_name)
+                    first_filled = True
+                    break
+            except:
+                continue
+
+        # Fill last name
+        for selector in last_name_selectors:
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(last_name)
+                    last_filled = True
+                    break
+            except:
+                continue
+
+        return first_filled or last_filled
+
+    @staticmethod
+    def fill_email_field(page: Page, email: str, timeout: int = 5000) -> bool:
+        """
+        Fill email field with multiple selector strategies.
+
+        Args:
+            page: Playwright Page object
+            email: Email address
+            timeout: Maximum time to wait for field (milliseconds)
+
+        Returns:
+            True if successful, False otherwise
+        """
+        email_selectors = [
+            'input[type="email"]',
+            'input[name="email" i]',
+            'input[placeholder*="email" i]',
+            'input[id*="email" i]',
+            'input[autocomplete="email"]',
+        ]
+
+        for selector in email_selectors:
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(email)
+                    return True
+            except:
+                continue
+
+        return False
+
+    @staticmethod
+    def fill_password_fields(page: Page, password: str, confirm: bool = True, timeout: int = 5000) -> bool:
+        """
+        Fill password field(s) - handles both single password and password + confirm.
+
+        Args:
+            page: Playwright Page object
+            password: Password string
+            confirm: Whether to also fill confirmation field (default True)
+            timeout: Maximum time to wait for fields (milliseconds)
+
+        Returns:
+            True if successful, False otherwise
+        """
+        password_fields = page.locator('input[type="password"]').all()
+
+        if not password_fields:
+            return False
+
+        # Fill first password field
+        try:
+            password_fields[0].fill(password)
+        except:
+            return False
+
+        # Fill confirmation field if requested and exists
+        if confirm and len(password_fields) > 1:
+            try:
+                password_fields[1].fill(password)
+            except:
+                pass
+
+        return True
+
+    @staticmethod
+    def fill_phone_field(page: Page, phone: str, timeout: int = 5000) -> bool:
+        """
+        Fill phone number field with multiple selector strategies.
+
+        Args:
+            page: Playwright Page object
+            phone: Phone number string
+            timeout: Maximum time to wait for field (milliseconds)
+
+        Returns:
+            True if successful, False otherwise
+        """
+        phone_selectors = [
+            'input[type="tel"]',
+            'input[name*="phone" i]',
+            'input[placeholder*="phone" i]',
+            'input[id*="phone" i]',
+            'input[autocomplete="tel"]',
+        ]
+
+        for selector in phone_selectors:
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(phone)
+                    return True
+            except:
+                continue
+
+        return False
+
+    @staticmethod
+    def fill_date_field(page: Page, date_value: str, field_hint: str = None, timeout: int = 5000) -> bool:
+        """
+        Fill date field (handles both date input and text input).
+
+        Args:
+            page: Playwright Page object
+            date_value: Date as string (format: YYYY-MM-DD for date inputs)
+            field_hint: Optional hint about field (e.g., "birth", "start", "end")
+            timeout: Maximum time to wait for field (milliseconds)
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            ```python
+            fill_date_field(page, "1990-01-15", field_hint="birth")
+            ```
+        """
+        # Build selectors based on hint
+        date_selectors = ['input[type="date"]']
+
+        if field_hint:
+            date_selectors.extend([
+                f'input[name*="{field_hint}" i]',
+                f'input[placeholder*="{field_hint}" i]',
+                f'input[id*="{field_hint}" i]',
+            ])
+
+        for selector in date_selectors:
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(date_value)
+                    return True
+            except:
+                continue
+
+        return False
+
+
+def fill_with_retry(page: Page, selectors: List[str], value: str, max_attempts: int = 3) -> bool:
+    """
+    Try multiple selectors with retry logic.
+
+    Args:
+        page: Playwright Page object
+        selectors: List of CSS selectors to try
+        value: Value to fill
+        max_attempts: Maximum retry attempts per selector
+
+    Returns:
+        True if any selector succeeded, False otherwise
+
+    Example:
+        ```python
+        selectors = ['input#email', 'input[name="email"]', 'input[type="email"]']
+        fill_with_retry(page, selectors, 'test@example.com')
+        ```
+    """
+    for selector in selectors:
+        for attempt in range(max_attempts):
+            try:
+                field = page.locator(selector).first
+                if field.is_visible(timeout=1000):
+                    field.fill(value)
+                    time.sleep(0.3)
+                    # Verify value was set
+                    if field.input_value() == value:
+                        return True
+            except:
+                if attempt < max_attempts - 1:
+                    time.sleep(0.5)
+                continue
+
+    return False
+
+
+def handle_multi_step_form(page: Page, steps: List[Dict[str, Any]], continue_button_text: str = "CONTINUE") -> bool:
+    """
+    Automate multi-step form completion.
+
+    Args:
+        page: Playwright Page object
+        steps: List of step configurations, each with fields and actions
+        continue_button_text: Text of button to advance steps
+
+    Returns:
+        True if all steps completed successfully, False otherwise
+
+    Example:
+        ```python
+        steps = [
+            {
+                'fields': {'email': 'test@example.com', 'password': 'Pass123!'},
+                'checkbox': 'terms',  # Optional checkbox to check
+                'wait_after': 2,  # Optional wait time after step
+            },
+            {
+                'fields': {'full_name': 'John Doe', 'date_of_birth': '1990-01-15'},
+            },
+            {
+                'complete': True,  # Final step, click complete/finish button
+            }
+        ]
+        handle_multi_step_form(page, steps)
+        ```
+    """
+    filler = SmartFormFiller()
+
+    for i, step in enumerate(steps):
+        print(f"  Processing step {i+1}/{len(steps)}...")
+
+        # Fill fields in this step
+        if 'fields' in step:
+            for field_type, value in step['fields'].items():
+                if field_type == 'email':
+                    filler.fill_email_field(page, value)
+                elif field_type == 'password':
+                    filler.fill_password_fields(page, value)
+                elif field_type == 'full_name':
+                    filler.fill_name_field(page, value)
+                elif field_type == 'phone':
+                    filler.fill_phone_field(page, value)
+                elif field_type.startswith('date'):
+                    hint = field_type.replace('date_', '').replace('_', ' ')
+                    filler.fill_date_field(page, value, field_hint=hint)
+                else:
+                    # Generic field - try to find and fill
+                    print(f"    Warning: Unknown field type '{field_type}'")
+
+        # Check checkbox if specified
+        if 'checkbox' in step:
+            try:
+                checkbox = page.locator('input[type="checkbox"]').first
+                checkbox.check()
+            except:
+                print(f"    Warning: Could not check checkbox")
+
+        # Wait if specified
+        if 'wait_after' in step:
+            time.sleep(step['wait_after'])
+        else:
+            time.sleep(1)
+
+        # Click continue/submit button
+        if i < len(steps) - 1:  # Not the last step
+            button_selectors = [
+                f'button:has-text("{continue_button_text}")',
+                'button[type="submit"]',
+                'button:has-text("Next")',
+                'button:has-text("Continue")',
+            ]
+
+            clicked = False
+            for selector in button_selectors:
+                try:
+                    button = page.locator(selector).first
+                    if button.is_visible(timeout=2000):
+                        button.click()
+                        clicked = True
+                        break
+                except:
+                    continue
+
+            if not clicked:
+                print(f"    Warning: Could not find continue button for step {i+1}")
+                return False
+
+            # Wait for next step to load
+            page.wait_for_load_state('networkidle')
+            time.sleep(2)
+
+        else:  # Last step
+            if step.get('complete', False):
+                complete_selectors = [
+                    'button:has-text("COMPLETE")',
+                    'button:has-text("Complete")',
+                    'button:has-text("FINISH")',
+                    'button:has-text("Finish")',
+                    'button:has-text("SUBMIT")',
+                    'button:has-text("Submit")',
+                    'button[type="submit"]',
+                ]
+
+                for selector in complete_selectors:
+                    try:
+                        button = page.locator(selector).first
+                        if button.is_visible(timeout=2000):
+                            button.click()
+                            page.wait_for_load_state('networkidle')
+                            time.sleep(3)
+                            return True
+                    except:
+                        continue
+
+                print("    Warning: Could not find completion button")
+                return False
+
+    return True
+
+
+def auto_fill_form(page: Page, field_mapping: Dict[str, str]) -> Dict[str, bool]:
+    """
+    Automatically fill a form based on field mapping.
+
+    Intelligently detects field types and uses appropriate filling strategies.
+
+    Args:
+        page: Playwright Page object
+        field_mapping: Dictionary mapping field types to values
+
+    Returns:
+        Dictionary with results for each field (True = filled, False = failed)
+
+    Example:
+        ```python
+        results = auto_fill_form(page, {
+            'email': 'test@example.com',
+            'password': 'SecurePass123!',
+            'full_name': 'Jane Doe',
+            'phone': '+447700900123',
+            'date_of_birth': '1990-01-15',
+        })
+        print(f"Email filled: {results['email']}")
+        ```
+    """
+    filler = SmartFormFiller()
+    results = {}
+
+    for field_type, value in field_mapping.items():
+        if field_type == 'email':
+            results[field_type] = filler.fill_email_field(page, value)
+        elif field_type == 'password':
+            results[field_type] = filler.fill_password_fields(page, value)
+        elif 'name' in field_type.lower():
+            results[field_type] = filler.fill_name_field(page, value)
+        elif 'phone' in field_type.lower():
+            results[field_type] = filler.fill_phone_field(page, value)
+        elif 'date' in field_type.lower():
+            hint = field_type.replace('date_of_', '').replace('_', ' ')
+            results[field_type] = filler.fill_date_field(page, value, field_hint=hint)
+        else:
+            # Try generic fill
+            try:
+                field = page.locator(f'input[name="{field_type}"]').first
+                field.fill(value)
+                results[field_type] = True
+            except:
+                results[field_type] = False
+
+    return results

--- a/toolkit/packages/skills/webapp-testing/utils/smart_selectors.py
+++ b/toolkit/packages/skills/webapp-testing/utils/smart_selectors.py
@@ -1,0 +1,306 @@
+"""
+Smart Selector Strategies for Robust Web Testing
+
+Automatically tries multiple selector strategies to find elements,
+reducing test brittleness when HTML structure changes.
+
+Usage:
+    from utils.smart_selectors import SelectorStrategies
+
+    # Find and fill email field
+    SelectorStrategies.smart_fill(page, 'email', 'test@example.com')
+
+    # Find and click button
+    SelectorStrategies.smart_click(page, 'Sign In')
+"""
+
+from typing import Optional, List
+from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError
+
+
+class SelectorStrategies:
+    """Multiple strategies for finding common elements"""
+
+    # Reduced timeouts for faster failure (5s per strategy instead of default 30s)
+    DEFAULT_TIMEOUT = 5000  # 5 seconds per strategy attempt
+    MAX_TOTAL_TIMEOUT = 10000  # 10 seconds max across all strategies
+
+    @staticmethod
+    def find_input_field(
+        page: Page,
+        field_type: str,
+        timeout: int = DEFAULT_TIMEOUT,
+        verbose: bool = True
+    ) -> Optional[str]:
+        """
+        Find input field using multiple strategies in order of reliability.
+
+        Strategies (in order):
+        1. Test IDs: [data-testid*="field_type"]
+        2. ARIA labels: input[aria-label*="field_type" i]
+        3. Placeholder: input[placeholder*="field_type" i]
+        4. Name attribute: input[name*="field_type" i]
+        5. Type attribute: input[type="field_type"]
+        6. ID attribute: #field_type, input[id*="field_type" i]
+
+        Args:
+            page: Playwright Page object
+            field_type: Type of field to find (e.g., 'email', 'password')
+            timeout: Timeout per strategy in milliseconds (default: 5000)
+            verbose: Print which strategy succeeded (default: True)
+
+        Returns:
+            Selector string that worked, or None if not found
+
+        Example:
+            selector = SelectorStrategies.find_input_field(page, 'email')
+            if selector:
+                page.fill(selector, 'test@example.com')
+        """
+        strategies = [
+            # Strategy 1: Test IDs (most reliable)
+            (f'[data-testid*="{field_type}" i]', 'data-testid'),
+
+            # Strategy 2: ARIA labels (accessibility best practice)
+            (f'input[aria-label*="{field_type}" i]', 'aria-label'),
+
+            # Strategy 3: Placeholder text
+            (f'input[placeholder*="{field_type}" i]', 'placeholder'),
+
+            # Strategy 4: Name attribute
+            (f'input[name*="{field_type}" i]', 'name attribute'),
+
+            # Strategy 5: Type attribute (works for email, password, text)
+            (f'input[type="{field_type}"]', 'type attribute'),
+
+            # Strategy 6: ID attribute (exact match)
+            (f'#{field_type}', 'id (exact)'),
+
+            # Strategy 7: ID attribute (partial match)
+            (f'input[id*="{field_type}" i]', 'id (partial)'),
+        ]
+
+        for selector, strategy_name in strategies:
+            try:
+                locator = page.locator(selector).first
+                if locator.is_visible(timeout=timeout):
+                    if verbose:
+                        print(f"✓ Found field via {strategy_name}: {selector}")
+                    return selector
+            except PlaywrightTimeoutError:
+                continue
+            except Exception:
+                # Catch other errors (element not found, etc.)
+                continue
+
+        if verbose:
+            print(f"✗ Could not find field for '{field_type}' using any strategy")
+        return None
+
+    @staticmethod
+    def find_button(
+        page: Page,
+        button_text: str,
+        timeout: int = DEFAULT_TIMEOUT,
+        verbose: bool = True
+    ) -> Optional[str]:
+        """
+        Find button by text using multiple strategies.
+
+        Strategies:
+        1. Test ID: [data-testid*="button-text"]
+        2. Role with name: button[name="button_text"]
+        3. Exact text: button:has-text("Button Text")
+        4. Partial text (case-insensitive): button:text-matches("button text", "i")
+        5. Link as button: a:has-text("Button Text")
+        6. Input submit: input[type="submit"][value*="button text" i]
+
+        Args:
+            page: Playwright Page object
+            button_text: Text on the button
+            timeout: Timeout per strategy in milliseconds
+            verbose: Print which strategy succeeded
+
+        Returns:
+            Selector string that worked, or None if not found
+
+        Example:
+            selector = SelectorStrategies.find_button(page, 'Sign In')
+            if selector:
+                page.click(selector)
+        """
+        # Normalize button text for test-id matching
+        test_id = button_text.lower().replace(' ', '-')
+
+        strategies = [
+            # Strategy 1: Test IDs
+            (f'[data-testid*="{test_id}" i]', 'data-testid'),
+
+            # Strategy 2: Button with name attribute
+            (f'button[name*="{button_text}" i]', 'button name'),
+
+            # Strategy 3: Exact text match
+            (f'button:has-text("{button_text}")', 'exact text'),
+
+            # Strategy 4: Case-insensitive text match
+            (f'button:text-matches("{button_text}", "i")', 'case-insensitive text'),
+
+            # Strategy 5: Link styled as button
+            (f'a:has-text("{button_text}")', 'link (exact text)'),
+
+            # Strategy 6: Link case-insensitive
+            (f'a:text-matches("{button_text}", "i")', 'link (case-insensitive)'),
+
+            # Strategy 7: Input submit button
+            (f'input[type="submit"][value*="{button_text}" i]', 'submit input'),
+
+            # Strategy 8: Any clickable element with text
+            (f'[role="button"]:has-text("{button_text}")', 'role=button'),
+        ]
+
+        for selector, strategy_name in strategies:
+            try:
+                locator = page.locator(selector).first
+                if locator.is_visible(timeout=timeout):
+                    if verbose:
+                        print(f"✓ Found button via {strategy_name}: {selector}")
+                    return selector
+            except PlaywrightTimeoutError:
+                continue
+            except Exception:
+                continue
+
+        if verbose:
+            print(f"✗ Could not find button '{button_text}' using any strategy")
+        return None
+
+    @staticmethod
+    def smart_fill(
+        page: Page,
+        field_type: str,
+        value: str,
+        timeout: int = MAX_TOTAL_TIMEOUT,
+        verbose: bool = True
+    ) -> bool:
+        """
+        Find and fill a field automatically using smart selector strategies.
+
+        Args:
+            page: Playwright Page object
+            field_type: Type of field (e.g., 'email', 'password', 'username')
+            value: Value to fill
+            timeout: Max timeout across all strategies
+            verbose: Print progress messages
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            success = SelectorStrategies.smart_fill(page, 'email', 'test@example.com')
+            if not success:
+                print("Failed to fill email field")
+        """
+        selector = SelectorStrategies.find_input_field(
+            page, field_type, timeout=timeout // 2, verbose=verbose
+        )
+
+        if selector:
+            try:
+                page.fill(selector, value)
+                if verbose:
+                    print(f"✓ Filled '{field_type}' with value")
+                return True
+            except Exception as e:
+                if verbose:
+                    print(f"✗ Found field but failed to fill: {e}")
+                return False
+
+        return False
+
+    @staticmethod
+    def smart_click(
+        page: Page,
+        button_text: str,
+        timeout: int = MAX_TOTAL_TIMEOUT,
+        verbose: bool = True
+    ) -> bool:
+        """
+        Find and click a button automatically using smart selector strategies.
+
+        Args:
+            page: Playwright Page object
+            button_text: Text on the button to click
+            timeout: Max timeout across all strategies
+            verbose: Print progress messages
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            success = SelectorStrategies.smart_click(page, 'Sign In')
+            if not success:
+                print("Failed to click Sign In button")
+        """
+        selector = SelectorStrategies.find_button(
+            page, button_text, timeout=timeout // 2, verbose=verbose
+        )
+
+        if selector:
+            try:
+                page.click(selector)
+                if verbose:
+                    print(f"✓ Clicked '{button_text}' button")
+                return True
+            except Exception as e:
+                if verbose:
+                    print(f"✗ Found button but failed to click: {e}")
+                return False
+
+        return False
+
+    @staticmethod
+    def find_any_element(
+        page: Page,
+        selectors: List[str],
+        timeout: int = DEFAULT_TIMEOUT,
+        verbose: bool = True
+    ) -> Optional[str]:
+        """
+        Try multiple custom selectors and return the first one that works.
+
+        Useful when you have specific selectors to try but want fallback logic.
+
+        Args:
+            page: Playwright Page object
+            selectors: List of CSS selectors to try
+            timeout: Timeout per selector
+            verbose: Print which selector worked
+
+        Returns:
+            First selector that found a visible element, or None
+
+        Example:
+            selectors = [
+                'button#submit',
+                'button.submit-btn',
+                'input[type="submit"]'
+            ]
+            selector = SelectorStrategies.find_any_element(page, selectors)
+            if selector:
+                page.click(selector)
+        """
+        for selector in selectors:
+            try:
+                locator = page.locator(selector).first
+                if locator.is_visible(timeout=timeout):
+                    if verbose:
+                        print(f"✓ Found element: {selector}")
+                    return selector
+            except PlaywrightTimeoutError:
+                continue
+            except Exception:
+                continue
+
+        if verbose:
+            print(f"✗ Could not find element using any of {len(selectors)} selectors")
+        return None

--- a/toolkit/packages/skills/webapp-testing/utils/supabase.py
+++ b/toolkit/packages/skills/webapp-testing/utils/supabase.py
@@ -1,0 +1,353 @@
+"""
+Supabase Test Utilities
+
+Generic database helpers for testing with Supabase.
+Supports user management, email verification, and test data cleanup.
+"""
+
+import subprocess
+import json
+from typing import Dict, List, Optional, Any
+
+
+class SupabaseTestClient:
+    """
+    Generic Supabase test client for database operations during testing.
+
+    Example:
+        ```python
+        client = SupabaseTestClient(
+            url="https://project.supabase.co",
+            service_key="your-service-role-key",
+            db_password="your-db-password"
+        )
+
+        # Create test user
+        user_id = client.create_user("test@example.com", "password123")
+
+        # Verify email (bypass email sending)
+        client.confirm_email(user_id)
+
+        # Cleanup after test
+        client.delete_user(user_id)
+        ```
+    """
+
+    def __init__(self, url: str, service_key: str, db_password: str = None, db_host: str = None):
+        """
+        Initialize Supabase test client.
+
+        Args:
+            url: Supabase project URL (e.g., "https://project.supabase.co")
+            service_key: Service role key for admin operations
+            db_password: Database password for direct SQL operations
+            db_host: Database host (if different from default)
+        """
+        self.url = url.rstrip('/')
+        self.service_key = service_key
+        self.db_password = db_password
+
+        # Extract DB host from URL if not provided
+        if not db_host:
+            # Convert https://abc123.supabase.co to db.abc123.supabase.co
+            project_ref = url.split('//')[1].split('.')[0]
+            self.db_host = f"db.{project_ref}.supabase.co"
+        else:
+            self.db_host = db_host
+
+    def _run_sql(self, sql: str) -> Dict[str, Any]:
+        """
+        Execute SQL directly against the database.
+
+        Args:
+            sql: SQL query to execute
+
+        Returns:
+            Dictionary with 'success', 'output', 'error' keys
+        """
+        if not self.db_password:
+            return {'success': False, 'error': 'Database password not provided'}
+
+        try:
+            result = subprocess.run(
+                [
+                    'psql',
+                    '-h', self.db_host,
+                    '-p', '5432',
+                    '-U', 'postgres',
+                    '-c', sql,
+                    '-t',  # Tuples only
+                    '-A',  # Unaligned output
+                ],
+                env={'PGPASSWORD': self.db_password},
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            return {
+                'success': result.returncode == 0,
+                'output': result.stdout.strip(),
+                'error': result.stderr.strip() if result.returncode != 0 else None
+            }
+        except Exception as e:
+            return {'success': False, 'error': str(e)}
+
+    def create_user(self, email: str, password: str, metadata: Dict = None) -> Optional[str]:
+        """
+        Create a test user via Auth Admin API.
+
+        Args:
+            email: User email
+            password: User password
+            metadata: Optional user metadata
+
+        Returns:
+            User ID if successful, None otherwise
+
+        Example:
+            ```python
+            user_id = client.create_user(
+                "test@example.com",
+                "SecurePass123!",
+                metadata={"full_name": "Test User"}
+            )
+            ```
+        """
+        import requests
+
+        payload = {
+            'email': email,
+            'password': password,
+            'email_confirm': True
+        }
+
+        if metadata:
+            payload['user_metadata'] = metadata
+
+        try:
+            response = requests.post(
+                f"{self.url}/auth/v1/admin/users",
+                headers={
+                    'Authorization': f'Bearer {self.service_key}',
+                    'apikey': self.service_key,
+                    'Content-Type': 'application/json'
+                },
+                json=payload,
+                timeout=10
+            )
+
+            if response.ok:
+                return response.json().get('id')
+            else:
+                print(f"Error creating user: {response.text}")
+                return None
+        except Exception as e:
+            print(f"Exception creating user: {e}")
+            return None
+
+    def confirm_email(self, user_id: str = None, email: str = None) -> bool:
+        """
+        Confirm user email (bypass email verification for testing).
+
+        Args:
+            user_id: User ID (if known)
+            email: User email (alternative to user_id)
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            ```python
+            # By user ID
+            client.confirm_email(user_id="abc-123")
+
+            # Or by email
+            client.confirm_email(email="test@example.com")
+            ```
+        """
+        if user_id:
+            sql = f"UPDATE auth.users SET email_confirmed_at = NOW() WHERE id = '{user_id}';"
+        elif email:
+            sql = f"UPDATE auth.users SET email_confirmed_at = NOW() WHERE email = '{email}';"
+        else:
+            return False
+
+        result = self._run_sql(sql)
+        return result['success']
+
+    def delete_user(self, user_id: str = None, email: str = None) -> bool:
+        """
+        Delete a test user and related data.
+
+        Args:
+            user_id: User ID
+            email: User email (alternative to user_id)
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            ```python
+            client.delete_user(email="test@example.com")
+            ```
+        """
+        # Get user ID if email provided
+        if email and not user_id:
+            result = self._run_sql(f"SELECT id FROM auth.users WHERE email = '{email}';")
+            if result['success'] and result['output']:
+                user_id = result['output'].strip()
+            else:
+                return False
+
+        if not user_id:
+            return False
+
+        # Delete from profiles first (foreign key)
+        self._run_sql(f"DELETE FROM public.profiles WHERE id = '{user_id}';")
+
+        # Delete from auth.users
+        result = self._run_sql(f"DELETE FROM auth.users WHERE id = '{user_id}';")
+
+        return result['success']
+
+    def cleanup_related_records(self, user_id: str, tables: List[str] = None) -> Dict[str, bool]:
+        """
+        Clean up user-related records from multiple tables.
+
+        Args:
+            user_id: User ID
+            tables: List of tables to clean (defaults to common tables)
+
+        Returns:
+            Dictionary mapping table names to cleanup success status
+
+        Example:
+            ```python
+            results = client.cleanup_related_records(
+                user_id="abc-123",
+                tables=["profiles", "team_members", "coach_verification_requests"]
+            )
+            ```
+        """
+        if not tables:
+            tables = [
+                'pending_profiles',
+                'coach_verification_requests',
+                'team_members',
+                'team_join_requests',
+                'profiles'
+            ]
+
+        results = {}
+
+        for table in tables:
+            # Try both user_id and id columns
+            sql = f"DELETE FROM public.{table} WHERE user_id = '{user_id}' OR id = '{user_id}';"
+            result = self._run_sql(sql)
+            results[table] = result['success']
+
+        return results
+
+    def create_invite_code(self, code: str, code_type: str = 'general', max_uses: int = 999) -> bool:
+        """
+        Create an invite code for testing.
+
+        Args:
+            code: Invite code string
+            code_type: Type of code (e.g., 'general', 'team_join')
+            max_uses: Maximum number of uses
+
+        Returns:
+            True if successful, False otherwise
+
+        Example:
+            ```python
+            client.create_invite_code("TEST2024", code_type="general")
+            ```
+        """
+        sql = f"""
+        INSERT INTO public.invite_codes (code, code_type, is_valid, max_uses, expires_at)
+        VALUES ('{code}', '{code_type}', true, {max_uses}, NOW() + INTERVAL '30 days')
+        ON CONFLICT (code) DO UPDATE SET is_valid=true, max_uses={max_uses}, use_count=0;
+        """
+
+        result = self._run_sql(sql)
+        return result['success']
+
+    def find_user_by_email(self, email: str) -> Optional[str]:
+        """
+        Find user ID by email address.
+
+        Args:
+            email: User email
+
+        Returns:
+            User ID if found, None otherwise
+        """
+        sql = f"SELECT id FROM auth.users WHERE email = '{email}';"
+        result = self._run_sql(sql)
+
+        if result['success'] and result['output']:
+            return result['output'].strip()
+        return None
+
+    def get_user_privileges(self, user_id: str) -> Optional[List[str]]:
+        """
+        Get user's privilege array.
+
+        Args:
+            user_id: User ID
+
+        Returns:
+            List of privileges if found, None otherwise
+        """
+        sql = f"SELECT privileges FROM public.profiles WHERE id = '{user_id}';"
+        result = self._run_sql(sql)
+
+        if result['success'] and result['output']:
+            # Parse PostgreSQL array format
+            privileges_str = result['output'].strip('{}')
+            return [p.strip() for p in privileges_str.split(',')]
+        return None
+
+
+def quick_cleanup(email: str, db_password: str, project_url: str) -> bool:
+    """
+    Quick cleanup helper - delete user and all related data.
+
+    Args:
+        email: User email to delete
+        db_password: Database password
+        project_url: Supabase project URL
+
+    Returns:
+        True if successful, False otherwise
+
+    Example:
+        ```python
+        from utils.supabase import quick_cleanup
+
+        # Clean up test user
+        quick_cleanup(
+            "test@example.com",
+            "db_password",
+            "https://project.supabase.co"
+        )
+        ```
+    """
+    client = SupabaseTestClient(
+        url=project_url,
+        service_key="",  # Not needed for SQL operations
+        db_password=db_password
+    )
+
+    user_id = client.find_user_by_email(email)
+    if not user_id:
+        return True  # Already deleted
+
+    # Clean up all related tables
+    client.cleanup_related_records(user_id)
+
+    # Delete user
+    return client.delete_user(user_id)

--- a/toolkit/packages/skills/webapp-testing/utils/ui_interactions.py
+++ b/toolkit/packages/skills/webapp-testing/utils/ui_interactions.py
@@ -1,0 +1,454 @@
+"""
+UI Interaction Helpers for Web Automation
+
+Common UI patterns that appear across many web applications:
+- Cookie consent banners
+- Modal dialogs
+- Loading overlays
+- Welcome tours/onboarding
+- Fixed headers blocking clicks
+"""
+
+from playwright.sync_api import Page
+import time
+
+
+def dismiss_cookie_banner(page: Page, timeout: int = 3000) -> bool:
+    """
+    Detect and dismiss cookie consent banners.
+
+    Tries common patterns:
+    - "Accept" / "Accept All" / "OK" buttons
+    - "I Agree" / "Got it" buttons
+    - Cookie banner containers
+
+    Args:
+        page: Playwright Page object
+        timeout: Maximum time to wait for banner (milliseconds)
+
+    Returns:
+        True if banner was found and dismissed, False otherwise
+
+    Example:
+        ```python
+        page.goto('https://example.com')
+        if dismiss_cookie_banner(page):
+            print("Cookie banner dismissed")
+        ```
+    """
+    cookie_button_selectors = [
+        'button:has-text("Accept")',
+        'button:has-text("Accept All")',
+        'button:has-text("Accept all")',
+        'button:has-text("I Agree")',
+        'button:has-text("I agree")',
+        'button:has-text("OK")',
+        'button:has-text("Got it")',
+        'button:has-text("Allow")',
+        'button:has-text("Allow all")',
+        '[data-testid="cookie-accept"]',
+        '[data-testid="accept-cookies"]',
+        '[id*="cookie-accept" i]',
+        '[id*="accept-cookie" i]',
+        '[class*="cookie-accept" i]',
+    ]
+
+    for selector in cookie_button_selectors:
+        try:
+            button = page.locator(selector).first
+            if button.is_visible(timeout=timeout):
+                button.click()
+                time.sleep(0.5)  # Brief wait for banner to disappear
+                return True
+        except:
+            continue
+
+    return False
+
+
+def dismiss_modal(page: Page, modal_identifier: str = None, timeout: int = 2000) -> bool:
+    """
+    Close modal dialogs with multiple fallback strategies.
+
+    Strategies:
+    1. If identifier provided, close that specific modal
+    2. Click close button (X, Close, Cancel, etc.)
+    3. Press Escape key
+    4. Click backdrop/overlay
+
+    Args:
+        page: Playwright Page object
+        modal_identifier: Optional - specific text in modal to identify it
+        timeout: Maximum time to wait for modal (milliseconds)
+
+    Returns:
+        True if modal was found and closed, False otherwise
+
+    Example:
+        ```python
+        # Close any modal
+        dismiss_modal(page)
+
+        # Close specific "Welcome" modal
+        dismiss_modal(page, modal_identifier="Welcome")
+        ```
+    """
+    # If specific modal identifier provided, wait for it first
+    if modal_identifier:
+        try:
+            modal = page.locator(f'[role="dialog"]:has-text("{modal_identifier}"), dialog:has-text("{modal_identifier}")').first
+            if not modal.is_visible(timeout=timeout):
+                return False
+        except:
+            return False
+
+    # Strategy 1: Click close button
+    close_button_selectors = [
+        'button:has-text("Close")',
+        'button:has-text("×")',
+        'button:has-text("X")',
+        'button:has-text("Cancel")',
+        'button:has-text("GOT IT")',
+        'button:has-text("Got it")',
+        'button:has-text("OK")',
+        'button:has-text("Dismiss")',
+        '[aria-label="Close"]',
+        '[aria-label="close"]',
+        '[data-testid="close-modal"]',
+        '[class*="close" i]',
+        '[class*="dismiss" i]',
+    ]
+
+    for selector in close_button_selectors:
+        try:
+            button = page.locator(selector).first
+            if button.is_visible(timeout=500):
+                button.click()
+                time.sleep(0.5)
+                return True
+        except:
+            continue
+
+    # Strategy 2: Press Escape key
+    try:
+        page.keyboard.press('Escape')
+        time.sleep(0.5)
+        # Check if modal is gone
+        modals = page.locator('[role="dialog"], dialog').all()
+        if all(not m.is_visible() for m in modals):
+            return True
+    except:
+        pass
+
+    # Strategy 3: Click backdrop (if exists and clickable)
+    try:
+        backdrop = page.locator('[class*="backdrop" i], [class*="overlay" i]').first
+        if backdrop.is_visible(timeout=500):
+            backdrop.click(position={'x': 10, 'y': 10})  # Click corner, not center
+            time.sleep(0.5)
+            return True
+    except:
+        pass
+
+    return False
+
+
+def click_with_header_offset(page: Page, selector: str, header_height: int = 80, force: bool = False):
+    """
+    Click an element while accounting for fixed headers that might block it.
+
+    Scrolls the element into view with an offset to avoid fixed headers,
+    then clicks it.
+
+    Args:
+        page: Playwright Page object
+        selector: CSS selector for the element to click
+        header_height: Height of fixed header in pixels (default 80)
+        force: Whether to use force click if normal click fails
+
+    Example:
+        ```python
+        # Click button that might be behind a fixed header
+        click_with_header_offset(page, 'button#submit', header_height=100)
+        ```
+    """
+    element = page.locator(selector).first
+
+    # Scroll element into view with offset
+    element.evaluate(f'el => el.scrollIntoView({{ block: "center", inline: "nearest" }})')
+    page.evaluate(f'window.scrollBy(0, -{header_height})')
+    time.sleep(0.3)  # Brief wait for scroll to complete
+
+    try:
+        element.click()
+    except Exception as e:
+        if force:
+            element.click(force=True)
+        else:
+            raise e
+
+
+def force_click_if_needed(page: Page, selector: str, timeout: int = 5000) -> bool:
+    """
+    Try normal click first, use force click if it fails (e.g., due to overlays).
+
+    Args:
+        page: Playwright Page object
+        selector: CSS selector for the element to click
+        timeout: Maximum time to wait for element (milliseconds)
+
+    Returns:
+        True if click succeeded (normal or forced), False otherwise
+
+    Example:
+        ```python
+        # Try to click, handling potential overlays
+        if force_click_if_needed(page, 'button#submit'):
+            print("Button clicked successfully")
+        ```
+    """
+    try:
+        element = page.locator(selector).first
+        if not element.is_visible(timeout=timeout):
+            return False
+
+        # Try normal click first
+        try:
+            element.click(timeout=timeout)
+            return True
+        except:
+            # Fall back to force click
+            element.click(force=True)
+            return True
+    except:
+        return False
+
+
+def wait_for_no_overlay(page: Page, max_wait_seconds: int = 10) -> bool:
+    """
+    Wait for loading overlays/spinners to disappear.
+
+    Looks for common loading overlay patterns and waits until they're gone.
+
+    Args:
+        page: Playwright Page object
+        max_wait_seconds: Maximum time to wait (seconds)
+
+    Returns:
+        True if overlays disappeared, False if timeout
+
+    Example:
+        ```python
+        page.click('button#submit')
+        wait_for_no_overlay(page)  # Wait for loading to complete
+        ```
+    """
+    overlay_selectors = [
+        '[class*="loading" i]',
+        '[class*="spinner" i]',
+        '[class*="overlay" i]',
+        '[class*="backdrop" i]',
+        '[data-loading="true"]',
+        '[aria-busy="true"]',
+        '.loader',
+        '.loading',
+        '#loading',
+    ]
+
+    start_time = time.time()
+
+    while time.time() - start_time < max_wait_seconds:
+        all_hidden = True
+
+        for selector in overlay_selectors:
+            try:
+                overlays = page.locator(selector).all()
+                for overlay in overlays:
+                    if overlay.is_visible():
+                        all_hidden = False
+                        break
+            except:
+                continue
+
+            if not all_hidden:
+                break
+
+        if all_hidden:
+            return True
+
+        time.sleep(0.5)
+
+    return False
+
+
+def handle_welcome_tour(page: Page, skip_button_text: str = "Skip") -> bool:
+    """
+    Automatically skip onboarding tours or welcome wizards.
+
+    Looks for and clicks "Skip", "Skip Tour", "Close", "Maybe Later" buttons.
+
+    Args:
+        page: Playwright Page object
+        skip_button_text: Text to look for in skip buttons (default "Skip")
+
+    Returns:
+        True if tour was skipped, False if no tour found
+
+    Example:
+        ```python
+        page.goto('https://app.example.com')
+        handle_welcome_tour(page)  # Skip any onboarding tour
+        ```
+    """
+    skip_selectors = [
+        f'button:has-text("{skip_button_text}")',
+        'button:has-text("Skip Tour")',
+        'button:has-text("Maybe Later")',
+        'button:has-text("No Thanks")',
+        'button:has-text("Close Tour")',
+        '[data-testid="skip-tour"]',
+        '[data-testid="close-tour"]',
+        '[aria-label="Skip tour"]',
+        '[aria-label="Close tour"]',
+    ]
+
+    for selector in skip_selectors:
+        try:
+            button = page.locator(selector).first
+            if button.is_visible(timeout=2000):
+                button.click()
+                time.sleep(0.5)
+                return True
+        except:
+            continue
+
+    return False
+
+
+def wait_for_stable_dom(page: Page, stability_duration_ms: int = 1000, max_wait_seconds: int = 10) -> bool:
+    """
+    Wait for the DOM to stop changing (useful for dynamic content loading).
+
+    Monitors for DOM mutations and waits until no changes occur for the specified duration.
+
+    Args:
+        page: Playwright Page object
+        stability_duration_ms: Duration of no changes to consider stable (milliseconds)
+        max_wait_seconds: Maximum time to wait (seconds)
+
+    Returns:
+        True if DOM stabilized, False if timeout
+
+    Example:
+        ```python
+        page.goto('https://app.example.com')
+        wait_for_stable_dom(page)  # Wait for all dynamic content to load
+        ```
+    """
+    # Inject mutation observer script
+    script = f"""
+    new Promise((resolve) => {{
+        let lastMutation = Date.now();
+        const observer = new MutationObserver(() => {{
+            lastMutation = Date.now();
+        }});
+
+        observer.observe(document.body, {{
+            childList: true,
+            subtree: true,
+            attributes: true
+        }});
+
+        const checkStability = () => {{
+            if (Date.now() - lastMutation >= {stability_duration_ms}) {{
+                observer.disconnect();
+                resolve(true);
+            }} else if (Date.now() - lastMutation > {max_wait_seconds * 1000}) {{
+                observer.disconnect();
+                resolve(false);
+            }} else {{
+                setTimeout(checkStability, 100);
+            }}
+        }};
+
+        setTimeout(checkStability, {stability_duration_ms});
+    }})
+    """
+
+    try:
+        result = page.evaluate(script)
+        return result
+    except:
+        return False
+
+
+def setup_page_with_csp_handling(page):
+    """
+    Set up page with automatic CSP error detection and helpful suggestions.
+
+    Monitors console for CSP violations and suggests fixes.
+    Call this once per page before navigation.
+
+    Args:
+        page: Playwright Page object
+
+    Example:
+        setup_page_with_csp_handling(page)
+        page.goto('http://localhost:7160')
+        # If CSP violation occurs:
+        # Output: ⚠️  CSP Violation detected: [error message]
+        #         💡 Suggestion: Use BrowserConfig.create_test_context() with auto CSP bypass
+
+    Usage with BrowserConfig:
+        from utils.browser_config import BrowserConfig
+
+        context = BrowserConfig.create_test_context(browser, 'http://localhost:3000')
+        page = context.new_page()
+        setup_page_with_csp_handling(page)
+    """
+    csp_violations = []
+
+    def handle_console(msg):
+        """Handler for console messages that detects CSP violations"""
+        text = msg.text.lower()
+
+        # Detect various CSP-related errors
+        csp_keywords = [
+            'content security policy',
+            'csp',
+            'refused to execute inline script',
+            'refused to load',
+            'blocked by content security policy',
+        ]
+
+        if any(keyword in text for keyword in csp_keywords):
+            # Avoid duplicate messages
+            if msg.text not in csp_violations:
+                csp_violations.append(msg.text)
+                print("\n" + "=" * 70)
+                print("⚠️  CSP VIOLATION DETECTED")
+                print("=" * 70)
+                print(f"Message: {msg.text[:200]}")
+                print("\n💡 SUGGESTION:")
+                print("   For localhost testing, use:")
+                print("   ")
+                print("   from utils.browser_config import BrowserConfig")
+                print("   context = BrowserConfig.create_test_context(")
+                print("       browser, 'http://localhost:3000'")
+                print("   )")
+                print("   # Auto-enables CSP bypass for localhost")
+                print("\n   Or manually:")
+                print("   context = browser.new_context(bypass_csp=True)")
+                print("=" * 70 + "\n")
+
+    # Attach console listener
+    page.on('console', handle_console)
+
+    # Also monitor for page errors related to CSP
+    def handle_page_error(error):
+        """Handler for page errors"""
+        error_text = str(error).lower()
+        if 'content security policy' in error_text or 'csp' in error_text:
+            print(f"\n⚠️  Page Error (CSP-related): {error}\n")
+
+    page.on('pageerror', handle_page_error)

--- a/toolkit/packages/skills/webapp-testing/utils/wait_strategies.py
+++ b/toolkit/packages/skills/webapp-testing/utils/wait_strategies.py
@@ -1,0 +1,312 @@
+"""
+Advanced Wait Strategies for Reliable Web Automation
+
+Better alternatives to simple sleep() or networkidle for dynamic web applications.
+"""
+
+from playwright.sync_api import Page
+import time
+from typing import Callable, Optional, Any
+
+
+def wait_for_api_call(page: Page, url_pattern: str, timeout_seconds: int = 10) -> Optional[Any]:
+    """
+    Wait for a specific API call to complete and return its response.
+
+    Args:
+        page: Playwright Page object
+        url_pattern: URL pattern to match (can include wildcards)
+        timeout_seconds: Maximum time to wait
+
+    Returns:
+        Response data if call completed, None if timeout
+
+    Example:
+        ```python
+        # Wait for user profile API call
+        response = wait_for_api_call(page, '**/api/profile**')
+        if response:
+            print(f"Profile loaded: {response}")
+        ```
+    """
+    response_data = {'data': None, 'completed': False}
+
+    def handle_response(response):
+        if url_pattern.replace('**', '') in response.url:
+            try:
+                response_data['data'] = response.json()
+                response_data['completed'] = True
+            except:
+                response_data['completed'] = True
+
+    page.on('response', handle_response)
+
+    start_time = time.time()
+    while not response_data['completed'] and (time.time() - start_time) < timeout_seconds:
+        time.sleep(0.1)
+
+    page.remove_listener('response', handle_response)
+
+    return response_data['data']
+
+
+def wait_for_element_stable(page: Page, selector: str, stability_ms: int = 1000, timeout_seconds: int = 10) -> bool:
+    """
+    Wait for an element's position to stabilize (stop moving/changing).
+
+    Useful for elements that animate or shift due to dynamic content loading.
+
+    Args:
+        page: Playwright Page object
+        selector: CSS selector for the element
+        stability_ms: Duration element must remain stable (milliseconds)
+        timeout_seconds: Maximum time to wait
+
+    Returns:
+        True if element stabilized, False if timeout
+
+    Example:
+        ```python
+        # Wait for dropdown menu to finish animating
+        wait_for_element_stable(page, '.dropdown-menu', stability_ms=500)
+        ```
+    """
+    try:
+        element = page.locator(selector).first
+
+        script = f"""
+        (element, stabilityMs) => {{
+            return new Promise((resolve) => {{
+                let lastRect = element.getBoundingClientRect();
+                let lastChange = Date.now();
+
+                const checkStability = () => {{
+                    const currentRect = element.getBoundingClientRect();
+
+                    if (currentRect.top !== lastRect.top ||
+                        currentRect.left !== lastRect.left ||
+                        currentRect.width !== lastRect.width ||
+                        currentRect.height !== lastRect.height) {{
+                        lastChange = Date.now();
+                        lastRect = currentRect;
+                    }}
+
+                    if (Date.now() - lastChange >= stabilityMs) {{
+                        resolve(true);
+                    }} else if (Date.now() - lastChange < {timeout_seconds * 1000}) {{
+                        setTimeout(checkStability, 50);
+                    }} else {{
+                        resolve(false);
+                    }}
+                }};
+
+                setTimeout(checkStability, stabilityMs);
+            }});
+        }}
+        """
+
+        result = element.evaluate(script, stability_ms)
+        return result
+    except:
+        return False
+
+
+def wait_with_retry(page: Page, condition_fn: Callable[[], bool], max_retries: int = 5, backoff_seconds: float = 0.5) -> bool:
+    """
+    Wait for a condition with exponential backoff retry.
+
+    Args:
+        page: Playwright Page object
+        condition_fn: Function that returns True when condition is met
+        max_retries: Maximum number of retry attempts
+        backoff_seconds: Initial backoff duration (doubles each retry)
+
+    Returns:
+        True if condition met, False if all retries exhausted
+
+    Example:
+        ```python
+        # Wait for specific element to appear with retry
+        def check_dashboard():
+            return page.locator('#dashboard').is_visible()
+
+        if wait_with_retry(page, check_dashboard):
+            print("Dashboard loaded!")
+        ```
+    """
+    wait_time = backoff_seconds
+
+    for attempt in range(max_retries):
+        try:
+            if condition_fn():
+                return True
+        except:
+            pass
+
+        if attempt < max_retries - 1:
+            time.sleep(wait_time)
+            wait_time *= 2  # Exponential backoff
+
+    return False
+
+
+def smart_navigation_wait(page: Page, expected_url_pattern: str = None, timeout_seconds: int = 10) -> bool:
+    """
+    Comprehensive wait strategy after navigation/interaction.
+
+    Combines multiple strategies:
+    1. Network idle
+    2. DOM stability
+    3. URL pattern match (if provided)
+
+    Args:
+        page: Playwright Page object
+        expected_url_pattern: Optional URL pattern to wait for
+        timeout_seconds: Maximum time to wait
+
+    Returns:
+        True if all conditions met, False if timeout
+
+    Example:
+        ```python
+        page.click('button#login')
+        smart_navigation_wait(page, expected_url_pattern='**/dashboard**')
+        ```
+    """
+    start_time = time.time()
+
+    # Step 1: Wait for network idle
+    try:
+        page.wait_for_load_state('networkidle', timeout=timeout_seconds * 1000)
+    except:
+        pass
+
+    # Step 2: Check URL if pattern provided
+    if expected_url_pattern:
+        while (time.time() - start_time) < timeout_seconds:
+            current_url = page.url
+            pattern = expected_url_pattern.replace('**', '')
+            if pattern in current_url:
+                break
+            time.sleep(0.5)
+        else:
+            return False
+
+    # Step 3: Brief wait for DOM stability
+    time.sleep(1)
+
+    return True
+
+
+def wait_for_data_load(page: Page, data_attribute: str = 'data-loaded', timeout_seconds: int = 10) -> bool:
+    """
+    Wait for data-loading attribute to indicate completion.
+
+    Args:
+        page: Playwright Page object
+        data_attribute: Data attribute to check (e.g., 'data-loaded')
+        timeout_seconds: Maximum time to wait
+
+    Returns:
+        True if data loaded, False if timeout
+
+    Example:
+        ```python
+        # Wait for element with data-loaded="true"
+        wait_for_data_load(page, data_attribute='data-loaded')
+        ```
+    """
+    start_time = time.time()
+
+    while (time.time() - start_time) < timeout_seconds:
+        try:
+            elements = page.locator(f'[{data_attribute}="true"]').all()
+            if elements:
+                return True
+        except:
+            pass
+
+        time.sleep(0.3)
+
+    return False
+
+
+def wait_until_no_element(page: Page, selector: str, timeout_seconds: int = 10) -> bool:
+    """
+    Wait until an element is no longer visible (e.g., loading spinner disappears).
+
+    Args:
+        page: Playwright Page object
+        selector: CSS selector for the element
+        timeout_seconds: Maximum time to wait
+
+    Returns:
+        True if element disappeared, False if still visible after timeout
+
+    Example:
+        ```python
+        # Wait for loading spinner to disappear
+        wait_until_no_element(page, '.loading-spinner')
+        ```
+    """
+    start_time = time.time()
+
+    while (time.time() - start_time) < timeout_seconds:
+        try:
+            element = page.locator(selector).first
+            if not element.is_visible(timeout=500):
+                return True
+        except:
+            return True  # Element not found = disappeared
+
+        time.sleep(0.3)
+
+    return False
+
+
+def combined_wait(page: Page, timeout_seconds: int = 10) -> bool:
+    """
+    Comprehensive wait combining multiple strategies for maximum reliability.
+
+    Uses:
+    1. Network idle
+    2. No visible loading indicators
+    3. DOM stability
+    4. Brief settling time
+
+    Args:
+        page: Playwright Page object
+        timeout_seconds: Maximum time to wait
+
+    Returns:
+        True if all conditions met, False if timeout
+
+    Example:
+        ```python
+        page.click('button#submit')
+        combined_wait(page)  # Wait for everything to settle
+        ```
+    """
+    start_time = time.time()
+
+    # Network idle
+    try:
+        page.wait_for_load_state('networkidle', timeout=timeout_seconds * 1000)
+    except:
+        pass
+
+    # Wait for common loading indicators to disappear
+    loading_selectors = [
+        '.loading',
+        '.spinner',
+        '[data-loading="true"]',
+        '[aria-busy="true"]',
+    ]
+
+    for selector in loading_selectors:
+        wait_until_no_element(page, selector, timeout_seconds=3)
+
+    # Final settling time
+    time.sleep(1)
+
+    return (time.time() - start_time) < timeout_seconds


### PR DESCRIPTION
Restores the webapp-testing **skill** that was removed in #221, per request — the duplicated webapp-testing.yaml **agent** files stay deleted.

- Re-adds `packages/skills/webapp-testing/` (SKILL.md, examples, utils, `bin/browser-tools` + .ts).
- Re-adds the `bundled-skills` manifest entry and regenerates `catalog.yaml`.
- Restores the `bootstrap.js` browser-tools compile step (skill machinery).
- Home `~/.claude/skills/webapp-testing` restored too.