### PR TITLE
fix(tui): onboarding right-arrow on every step + simpler session starter

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1647,7 +1647,7 @@ impl EventHandler {
                 }
                 OnboardingStep::DependencyCheck => {
                     match key_event.code {
-                        KeyCode::Enter => {
+                        KeyCode::Enter | KeyCode::Right => {
                             // If deps not checked yet, check them; otherwise advance
                             if onboarding_state.dependency_status.is_none() {
                                 Some(AppEvent::OnboardingCheckDeps)
@@ -1667,7 +1667,7 @@ impl EventHandler {
                     }
                 }
                 OnboardingStep::Authentication => match key_event.code {
-                    KeyCode::Enter => Some(AppEvent::OnboardingNext),
+                    KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingNext),
                     KeyCode::Esc => Some(AppEvent::OnboardingCancel),
                     KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
                         Some(AppEvent::OnboardingBack)
@@ -1676,7 +1676,7 @@ impl EventHandler {
                     _ => None,
                 },
                 OnboardingStep::EditorSelection => match key_event.code {
-                    KeyCode::Enter => Some(AppEvent::OnboardingNext),
+                    KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingNext),
                     KeyCode::Esc => Some(AppEvent::OnboardingCancel),
                     KeyCode::Left | KeyCode::Backspace => Some(AppEvent::OnboardingBack),
                     KeyCode::Up => Some(AppEvent::OnboardingEditorUp),
@@ -1686,7 +1686,7 @@ impl EventHandler {
                     _ => None,
                 },
                 OnboardingStep::Summary => match key_event.code {
-                    KeyCode::Enter => Some(AppEvent::OnboardingFinish),
+                    KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingFinish),
                     KeyCode::Esc => Some(AppEvent::OnboardingCancel),
                     KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
                         Some(AppEvent::OnboardingBack)

--- a/ainb-tui/crates/ainb-core/src/components/welcome_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/welcome_panel.rs
@@ -22,65 +22,26 @@ const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 const ACCENT_CYAN: Color = Color::Rgb(80, 200, 220);
 
 /// Default markdown content for the welcome panel
-pub const DEFAULT_WELCOME_CONTENT: &str = r#"# Welcome to AINB
+pub const DEFAULT_WELCOME_CONTENT: &str = r#"# Agents in a Box
 
-**AI-powered development environment manager** for Claude Code agents
-running in isolated git worktrees.
-
----
-
-## Quick Start
-
-1. **Select an Agent** `[a]` - Configure your Claude instance
-2. **Browse Catalog** `[c]` - Find project templates
-3. **Launch Sessions** `[s]` - Start working in isolated worktrees
-
-Press **Enter** to activate selection, **↑↓** to navigate the sidebar.
+You're on the **Sessions** screen. Start an agent session, or open Setup.
 
 ---
 
-## Architecture
+## Start here
 
-```
-┌─────────────┐         ┌──────────────┐
-│    AINB     │────────▶│   Worktree   │
-│     TUI     │         │   + tmux     │
-└─────────────┘         └──────────────┘
-       │                       │
-       ▼                       ▼
-┌─────────────┐         ┌──────────────┐
-│   Config    │         │    Claude    │
-│   Presets   │         │     Code     │
-└─────────────┘         └──────────────┘
-```
+- `n`         **New session** — pick a repo and launch an agent
+- `Enter`     Open / attach the selected session
+- `1`–`9`     Jump straight to a session by number
+- `?`         Help — every key for this screen
+- `q`         Quit
 
-Each session runs in an **isolated git worktree** with its own:
-- Branch for changes
-- tmux session for terminal access
-- Claude Code instance
+Each session runs in its own git worktree + tmux + agent, fully isolated.
 
 ---
 
-## Key Features
-
-- **Multi-Agent Support** - Run multiple Claude sessions in parallel
-- **Git Worktrees** - Each session gets its own branch
-- **tmux Integration** - Full terminal access to sessions
-- **Session Management** - Start, stop, attach, and monitor
-
----
-
-## Tips
-
-💡 **Tip:** Press `?` anytime for context-sensitive help
-
-💡 **Tip:** Use `s` to jump directly to Sessions
-
-💡 **Tip:** Each worktree is completely isolated - experiment freely!
-
----
-
-*Press Tab to switch focus • ↑↓ to scroll • q to quit*
+💡 Re-run first-time setup any time from the setup menu (`Esc` from the wizard
+returns you here). Press `?` for the full keymap.
 "#;
 
 /// Welcome panel state with scroll position

--- a/ainb-tui/crates/ainb-core/src/components/welcome_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/welcome_panel.rs
@@ -40,8 +40,7 @@ Each session runs in its own git worktree + tmux + agent, fully isolated.
 
 ---
 
-💡 Re-run first-time setup any time from the setup menu (`Esc` from the wizard
-returns you here). Press `?` for the full keymap.
+💡 `Esc` in the setup wizard returns here. Press `?` for the full keymap.
 "#;
 
 /// Welcome panel state with scroll position


### PR DESCRIPTION
## What

Two first-run UX fixes from feedback on the v1.4.2 onboarding wizard:

1. **Right arrow now advances every wizard step.** It was only bound on Welcome — on Dependencies/Authentication/EditorSelection/Summary, `→` was unbound, so the wizard looked frozen to `→` after the first screen ("the right arrow does not work"). Now `Enter | Right` advance on all steps.
2. **Simpler session-screen starter.** Replaced the stale getting-started panel (Select-an-Agent `[a]` / Browse-Catalog `[c]` bindings, ASCII architecture diagram, long feature list) with an accurate short quick-start: `n` new session, `Enter` open/attach, `1`–`9` jump, `?` help, `q` quit.

## Verified live (tmux, isolated HOME → forces onboarding)

- `→` on Welcome → Dependencies → Git Directories all advance (previously stuck after Welcome).
- `Esc` exits the wizard to the home/sessions screen (the menu) — already worked, no change needed.
- New starter content renders on the home screen.

Build + fmt clean; onboarding unit tests pass (21).

## Note (separate decision)

The user asked for `s` to "start a session", but `s` currently **stars a workspace**; `n` is new-session. The starter uses the accurate `n`. Rebinding `s`→sessions and refreshing the home sidebar (`Agents [a]`/`Catalog [c]`, still showing `v2.0.0`) are follow-ups pending a keybinding decision.