### PR TITLE
fix(tui): parse Claude Code rate-limit resets_at as Unix epoch

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/statusline.rs
@@ -31,7 +31,9 @@ pub const CACHE_SCHEMA_VERSION: u32 = 1;
 pub struct RateWindow {
     /// Used percentage, 0..=100.
     pub pct: u8,
-    /// ISO8601 reset timestamp as reported by Claude Code (passed through).
+    /// Reset instant as an RFC3339 string. Claude Code reports `resets_at`
+    /// as a Unix epoch integer (or, historically, an ISO8601 string);
+    /// [`parse_resets_at`] normalises both forms to RFC3339 for the cache.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resets_at: Option<String>,
 }
@@ -107,8 +109,32 @@ fn rate_window_from_value(value: &serde_json::Value) -> Option<RateWindow> {
         .get("used_percentage")
         .and_then(serde_json::Value::as_f64)
         .map(round_pct)?;
-    let resets_at = value.get("resets_at").and_then(serde_json::Value::as_str).map(str::to_string);
+    let resets_at = value.get("resets_at").and_then(parse_resets_at);
     Some(RateWindow { pct, resets_at })
+}
+
+/// Normalise a `resets_at` value from a Claude Code statusline payload into
+/// an RFC3339 string (the cache's on-disk shape, which the TUI parses via
+/// `live_window::instant_from_iso8601`).
+///
+/// The real payload sends `resets_at` as a **Unix epoch integer** (seconds),
+/// e.g. `1780791600`; earlier/synthetic payloads used an ISO8601 string.
+/// Reading it with `as_str()` alone (the historical behaviour) silently
+/// dropped the integer form, so the reset instant never reached the cache
+/// and the TUI's per-window "↻ <reset>" affordance had nothing to render.
+/// Accept both forms here.
+fn parse_resets_at(value: &serde_json::Value) -> Option<String> {
+    if let Some(s) = value.as_str() {
+        // Already a timestamp string — trust it as-is.
+        return Some(s.to_string());
+    }
+    // Unix epoch seconds, sent as an integer (or, defensively, a float —
+    // filtered to finite values so a stray NaN/∞ can't cast to a bogus
+    // epoch rather than failing cleanly).
+    let epoch = value
+        .as_i64()
+        .or_else(|| value.as_f64().filter(|f| f.is_finite()).map(|f| f as i64))?;
+    chrono::DateTime::from_timestamp(epoch, 0).map(|dt| dt.to_rfc3339())
 }
 
 fn round_pct(p: f64) -> u8 {
@@ -332,6 +358,61 @@ mod tests {
         );
         assert_eq!(cache.seven_day.as_ref().unwrap().pct, 3);
         assert_eq!(cache.today_cost_usd, Some(4.21));
+    }
+
+    #[test]
+    fn parse_payload_accepts_epoch_integer_resets_at() {
+        // The real Claude Code statusline payload sends `resets_at` as a Unix
+        // epoch integer, not an ISO8601 string. Regression guard for the bug
+        // where `as_str()` silently dropped the integer form, leaving the
+        // TUI's per-window "↻ <reset>" affordance with no data to render.
+        let raw = br#"{
+            "rate_limits": {
+                "five_hour": {"used_percentage": 11, "resets_at": 1780791600},
+                "seven_day": {"used_percentage": 7.0, "resets_at": 1781283600}
+            }
+        }"#;
+        let cache = parse_payload(raw).expect("should parse");
+        let fh = cache.five_hour.expect("five_hour present");
+        assert_eq!(fh.pct, 11);
+        let resets = fh.resets_at.expect("resets_at must populate from epoch int");
+        // Stored as RFC3339 and round-trips to the original instant.
+        assert_eq!(
+            chrono::DateTime::parse_from_rfc3339(&resets).unwrap().timestamp(),
+            1780791600
+        );
+        let wk = cache.seven_day.expect("seven_day present");
+        assert_eq!(
+            chrono::DateTime::parse_from_rfc3339(wk.resets_at.as_ref().unwrap())
+                .unwrap()
+                .timestamp(),
+            1781283600
+        );
+    }
+
+    #[test]
+    fn parse_resets_at_handles_int_float_string_and_garbage() {
+        use serde_json::json;
+        // Integer epoch → RFC3339 round-tripping to the same instant.
+        let s = parse_resets_at(&json!(1780791600i64)).expect("int epoch");
+        assert_eq!(
+            chrono::DateTime::parse_from_rfc3339(&s).unwrap().timestamp(),
+            1780791600
+        );
+        // Float epoch (defensive) → truncated to whole seconds.
+        let s = parse_resets_at(&json!(1780791600.9)).expect("float epoch");
+        assert_eq!(
+            chrono::DateTime::parse_from_rfc3339(&s).unwrap().timestamp(),
+            1780791600
+        );
+        // ISO8601 string → passthrough unchanged.
+        assert_eq!(
+            parse_resets_at(&json!("2026-06-07T00:20:00Z")).as_deref(),
+            Some("2026-06-07T00:20:00Z")
+        );
+        // Non-timestamp values → None.
+        assert!(parse_resets_at(&json!(true)).is_none());
+        assert!(parse_resets_at(&json!(null)).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## The bug

PR #224 added a per-window **reset date/time** (`↻ <reset>`) to the top-bar live-quota widget, but it never renders — the `↻` stamp is absent even on latest `main`.

Root cause is **upstream of the rendering**, in the statusline writer. Claude Code's real statusline payload sends `resets_at` as a **Unix epoch integer**:

```json
"rate_limits": {
  "five_hour": { "used_percentage": 11, "resets_at": 1780791600 },
  "seven_day": { "used_percentage": 7.0, "resets_at": 1781283600 }
}
```

…but `rate_window_from_value` read it as a string:

```rust
let resets_at = value.get("resets_at").and_then(serde_json::Value::as_str)...
//                                                  ^^ None for a JSON number
```

`as_str()` returns `None` for a number, so `resets_at` was silently dropped before it reached `live.json` (only `used_percentage` survived). The TUI then has `five_hour_resets_at = None` → nothing to render. #224's tests used synthetic ISO8601 *strings*, so they passed against the same wrong assumption. The pre-#224 `⏱` countdown was dead-on-arrival for the same reason.

```
CC payload                       writer (as_str)        live.json      TUI
resets_at: 1780791600 (number) → as_str() = None  →  (omitted)   →  no ↻
used_percentage: 11            → as_f64() = 11     →  pct: 11     →  ✅
```

## The fix

New `parse_resets_at` accepts **both** forms and normalises to an RFC3339 string (the cache's existing string shape, which the TUI parses via `live_window::instant_from_iso8601`):
- Unix epoch integer (and, defensively, float) → `DateTime::from_timestamp(..).to_rfc3339()`
- ISO8601 string → pass-through

No cache schema change (`resets_at` stays `Option<String>`), so it's backward-compatible with any existing cache. Also corrected the now-stale `RateWindow.resets_at` doc comment ("passed through" → "normalised").

## Verification

Captured a real Claude Code statusline payload (temporarily, then reverted) — confirmed the epoch-integer shape above. The values decode to sensible resets: `1780791600 → Jun 7 01:20`, `1781283600 → Jun 12 18:00`.

## Tests

- `parse_payload_accepts_epoch_integer_resets_at` — full payload with integer epochs round-trips through the cache.
- `parse_resets_at_handles_int_float_string_and_garbage` — int/float epoch → RFC3339, ISO8601 string pass-through, non-timestamps → None.
- Existing ISO8601-string payload tests still pass (44/44 statusline + live_window).

## Follow-up (not in this PR)

To see it end-to-end, the running TUI must be rebuilt from a `main` that includes both #224 (rendering) and this fix (data). Optional: surface the reset in the Claude Code statusline (`statusline.sh` line 2) too — separate enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rate-limit reset time handling to support multiple timestamp formats from API responses, ensuring consistent and reliable tracking of rate-limit window resets.

* **Tests**
  * Added regression tests to verify timestamp parsing works correctly across various formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->