### PR TITLE
fix(tui): handle new-session onto an already-checked-out branch

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1472,7 +1472,6 @@ impl EventHandler {
                     use crate::components::new_session::configure::ConfigureState;
                     use crate::config::session_defaults::SessionDefaults;
                     use crate::git::repo_source::head_branch;
-                    use crate::git::worktree_manager::WorktreeManager;
                     if let Some(pick) =
                         state.new_session_state.as_ref().and_then(|ns| ns.pick_repo_state.as_ref())
                     {
@@ -1488,29 +1487,18 @@ impl EventHandler {
                         _ => None,
                     };
                     let branch_prefix = state.app_config.workspace_defaults.branch_prefix.clone();
-                    // Use `list_all_worktrees` (scans by-session symlinks →
-                    // real git branch via head.shorthand()), NOT
-                    // `list_worktrees` which only finds legacy UUID-named
-                    // top-level dirs and misses every modern by-name worktree.
-                    // The latter returned empty → collision never detected
-                    // (Stevie 2026-05-27: feat/blog re-launch slipped through).
-                    let mut existing_branches: Vec<String> = WorktreeManager::new()
-                        .ok()
-                        .and_then(|m| m.list_all_worktrees().ok())
-                        .map(|infos| infos.into_iter().map(|(_, i)| i.branch_name).collect())
-                        .unwrap_or_default();
-                    // The session list alone can't see the repo's OWN checkout
-                    // (or a manually-added worktree) — `git worktree list` can.
-                    // Without this, a checkout-direct pick of the repo's
-                    // current branch passes the picker guard and dies at
-                    // `git worktree add` (review P1, PR #211).
-                    if let crate::git::repo_source::RepoSource::LocalPath(p) = &source {
-                        for b in crate::git::branch_list::checked_out_branches(p) {
-                            if !existing_branches.contains(&b) {
-                                existing_branches.push(b);
-                            }
-                        }
-                    }
+                    // Every branch already checked out in any worktree (ainb's
+                    // by-session worktrees + the repo's own checkout + manual
+                    // worktrees). Single source of truth so the collision guard
+                    // matches what `git worktree add` will accept — the legacy
+                    // `list_worktrees()` alone missed by-name worktrees
+                    // (Stevie 2026-05-27: feat/blog re-launch slipped through;
+                    // review P1, PR #211 added the repo's own checkout).
+                    let repo_path = match &source {
+                        crate::git::repo_source::RepoSource::LocalPath(p) => Some(p.as_path()),
+                        _ => None,
+                    };
+                    let existing_branches = crate::git::branch_list::in_use_branch_names(repo_path);
                     let cfg = ConfigureState::from_pick_repo(
                         source.clone(),
                         label,

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5863,6 +5863,11 @@ impl AppState {
     }
 
     pub fn cancel_new_session(&mut self) {
+        // INVARIANT: must NOT clear `self.notifications`. Callers post an error
+        // toast immediately before cancelling (e.g. the worktree-create failure
+        // arm in `create_session_from_configure`) and rely on it surviving the
+        // teardown — clearing here would re-introduce the silent-flash bug
+        // (Stevie 2026-06-06).
         self.new_session_state = None;
         // Return to whichever screen the user opened new-session from
         // (Home / Sessions / …). Falls back to SESSION_LIST if no
@@ -6102,6 +6107,13 @@ impl AppState {
             }
             Err(e) => {
                 error!("Failed to create session via configure flow: {}", e);
+                // Surface the real failure (e.g. "branch already used by
+                // worktree", "worktree already exists", invalid name) BEFORE
+                // tearing down the modal. Without this the error only hit the
+                // log and the modal closed silently — the user saw a flash and
+                // never learned why (Stevie 2026-06-06). cancel_new_session()
+                // leaves self.notifications intact, so the 5s toast survives.
+                self.add_error_notification(format!("Could not create session: {e}"));
                 self.cancel_new_session();
             }
         }
@@ -8194,12 +8206,14 @@ impl AppState {
                         .unwrap_or_else(|| workspace.path.display().to_string());
                     let branch_source = crate::git::repo_source::head_branch(&workspace.path);
                     let branch_prefix = self.app_config.workspace_defaults.branch_prefix.clone();
-                    let existing_branches: Vec<String> =
-                        crate::git::worktree_manager::WorktreeManager::new()
-                            .ok()
-                            .and_then(|m| m.list_worktrees().ok())
-                            .map(|infos| infos.into_iter().map(|i| i.branch_name).collect())
-                            .unwrap_or_default();
+                    // Same complete in-use list the repo-picker path uses. The
+                    // legacy `list_worktrees()` here only saw legacy UUID dirs
+                    // and missed every by-name worktree, so a re-launch onto an
+                    // already-checked-out branch slipped the collision guard and
+                    // died at `git worktree add` (Stevie 2026-06-06: feat/ota).
+                    let existing_branches = crate::git::branch_list::in_use_branch_names(Some(
+                        workspace.path.as_path(),
+                    ));
                     let configure_state = ConfigureState::from_pick_repo(
                         repo_source,
                         repo_label,

--- a/ainb-tui/crates/ainb-core/src/git/branch_list.rs
+++ b/ainb-tui/crates/ainb-core/src/git/branch_list.rs
@@ -129,9 +129,15 @@ pub fn checked_out_branches(repo_path: &Path) -> Vec<String> {
 /// checkout + manual worktrees from the guard.
 #[must_use]
 pub fn in_use_branch_names(repo_path: Option<&Path>) -> Vec<String> {
+    use std::collections::HashSet;
+
     use super::worktree_manager::WorktreeManager;
 
-    let mut names: Vec<String> = WorktreeManager::new()
+    // A set: the only consumers (`branch_collision`, the picker `in_use`
+    // mark, `derive_branch_name`'s collision-avoidance) do membership checks,
+    // never ordered display — so dedup is free and `main`/`master` appearing
+    // across many sessions collapses to one entry.
+    let mut names: HashSet<String> = WorktreeManager::new()
         .ok()
         .and_then(|m| m.list_all_worktrees().ok())
         .map(|infos| infos.into_iter().map(|(_, i)| i.branch_name).collect())
@@ -139,13 +145,11 @@ pub fn in_use_branch_names(repo_path: Option<&Path>) -> Vec<String> {
 
     if let Some(path) = repo_path {
         for b in checked_out_branches(path) {
-            if !names.contains(&b) {
-                names.push(b);
-            }
+            names.insert(b);
         }
     }
 
-    names
+    names.into_iter().collect()
 }
 
 /// Pure assembly: dedup remote-vs-local, tag the default, sort sections.

--- a/ainb-tui/crates/ainb-core/src/git/branch_list.rs
+++ b/ainb-tui/crates/ainb-core/src/git/branch_list.rs
@@ -109,6 +109,45 @@ pub fn checked_out_branches(repo_path: &Path) -> Vec<String> {
         .collect()
 }
 
+/// Every branch short name that would make `git worktree add` fail because it
+/// is already checked out somewhere. Two sources, deduped:
+///   1. `list_all_worktrees()` — branches in ainb's own by-session worktrees
+///      (scans the by-session symlinks → real git branch), across ALL repos.
+///   2. `checked_out_branches(repo_path)` — the repo's own main checkout plus
+///      any manually-added worktree, which the ainb session list can't see.
+///
+/// This is the single source of truth for the Configure screen's collision
+/// guard (the inline "⚠ in use" marker + the pre-launch block). Both the
+/// repo-picker entry and the restart entry MUST build `existing_branches` from
+/// here — using the legacy `list_worktrees()` alone silently misses every
+/// modern by-name worktree, so an in-use branch slips the guard and dies at
+/// `git worktree add` (Stevie 2026-06-06: feat/ota re-launch slipped through).
+///
+/// `repo_path` is `None` ONLY for non-local sources (e.g. an SSH session),
+/// which have no local checkout to scan. For any `LocalPath` repo pass
+/// `Some(path)` — passing `None` there would silently drop the repo's own
+/// checkout + manual worktrees from the guard.
+#[must_use]
+pub fn in_use_branch_names(repo_path: Option<&Path>) -> Vec<String> {
+    use super::worktree_manager::WorktreeManager;
+
+    let mut names: Vec<String> = WorktreeManager::new()
+        .ok()
+        .and_then(|m| m.list_all_worktrees().ok())
+        .map(|infos| infos.into_iter().map(|(_, i)| i.branch_name).collect())
+        .unwrap_or_default();
+
+    if let Some(path) = repo_path {
+        for b in checked_out_branches(path) {
+            if !names.contains(&b) {
+                names.push(b);
+            }
+        }
+    }
+
+    names
+}
+
 /// Pure assembly: dedup remote-vs-local, tag the default, sort sections.
 /// Split out for testability without a fixture repo.
 fn build_entries(
@@ -272,5 +311,53 @@ mod tests {
         let checked = checked_out_branches(&repo_path);
         assert!(checked.contains(&"main".to_string()));
         assert!(checked.contains(&"feature-x".to_string()));
+    }
+
+    #[test]
+    fn in_use_branch_names_includes_repo_checkout_branches() {
+        // The collision guard's source of truth must include the repo's own
+        // checked-out branches (main + any added worktree). The global
+        // by-session worktree list is merged in too, so assert superset rather
+        // than equality to stay independent of the host's ainb state
+        // (Stevie 2026-06-06: feat/ota slipped a guard built from the legacy
+        // list_worktrees() alone).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir(&repo_path).unwrap();
+        let git = |args: &[&str], cwd: &Path| {
+            let out = Command::new("git").args(args).current_dir(cwd).output().unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"], &repo_path);
+        git(&["config", "user.email", "t@t"], &repo_path);
+        git(&["config", "user.name", "t"], &repo_path);
+        git(&["commit", "--allow-empty", "-m", "init"], &repo_path);
+        git(&["branch", "feature-x"], &repo_path);
+        let wt = tmp.path().join("wt");
+        git(
+            &["worktree", "add", wt.to_str().unwrap(), "feature-x"],
+            &repo_path,
+        );
+
+        let names = in_use_branch_names(Some(&repo_path));
+        assert!(names.contains(&"main".to_string()), "repo checkout in list");
+        assert!(
+            names.contains(&"feature-x".to_string()),
+            "added worktree branch in list"
+        );
+    }
+
+    #[test]
+    fn in_use_branch_names_none_skips_repo_scan() {
+        // The SSH/non-local path: no `repo_path`, so the helper returns only
+        // the global by-session worktree list and must NOT attempt a
+        // `git worktree list` against any path. Host-independent: we only
+        // assert it returns without panicking (the `if let Some` arm is
+        // skipped entirely).
+        let _ = in_use_branch_names(None);
     }
 }


### PR DESCRIPTION
## Problem

Creating a worktree for a branch that is **already checked out elsewhere** (e.g. re-launching `feat/ota`) failed only **after** pressing Launch:

- `git worktree add` errored (branch already used by a worktree).
- The `create_session_from_configure` `Err` arm logged the error and silently called `cancel_new_session()` — **no notification**. The user saw the modal flash shut and never learned why.
- The pre-launch collision guard (`branch_collision()`) should have caught this at selection time, but the **restart entry** built `existing_branches` from the legacy `list_worktrees()` (legacy UUID dirs only — misses every modern by-name worktree), so in-use branches slipped through.

## Fix

```
press Launch ─▶ branch_collision()? ─no─▶ git worktree add ─fail─▶ Err(e)
                  │ (now complete list)        │                     │
                 yes                           ▼                     ▼
                  └─ block + "⚠ in use"   (caught earlier)   add_error_notification(e)
                     at selection time                       + cancel  → 5s toast
```

1. **`branch_list::in_use_branch_names(repo_path)`** — new single source of truth for the collision guard: `list_all_worktrees()` (ainb by-session worktrees) **+** the repo's own checkout / manual worktrees via `checked_out_branches()`, deduped. Both the **repo-picker** entry (`events.rs`) and the **restart** entry (`state.rs`) now build `existing_branches` from it. The restart path previously used the weak `list_worktrees()`, which is why the guard missed in-use branches.
2. **Surface the real error** — the `Err` arm now posts `add_error_notification(...)` (a 5s toast) **before** `cancel_new_session()`, which intentionally preserves `self.notifications`. An invariant comment was added to `cancel_new_session` to protect this.

Now an in-use branch is flagged inline (`⚠ in use`) and Launch is blocked at the Branch row; anything that still slips through is shown, not flashed.

## Tests

- `in_use_branch_names_includes_repo_checkout_branches` — fixture repo + added worktree; asserts the helper reports `main` + the worktree branch (superset, host-independent).
- `in_use_branch_names_none_skips_repo_scan` — exercises the SSH/`None` arm.
- All 9 `branch_list` tests + the existing collision-guard tests pass.

## Verification

- `cargo build` green (only pre-existing dead-code warnings).
- `cargo test -p ainb --lib branch_list` — 9/9 pass.
- `cargo fmt` clean; no drift into untouched files.
- Rebased onto current `main`; no conflicts.