### PR TITLE
fix(tui): start all selected sessions on Enter/r, not just the highlighted one

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -51,9 +51,10 @@ pub enum AppEvent {
     RestartSession,
     DeleteSession,
     ResumeSession(String), // Resume a Stopped interactive session (carries trigger key: "Enter" or "r")
-    OpenInEditor,          // Open selected session's workspace in preferred editor
-    OpenQuickShell,        // Open shell in selected workspace/session directory
-    CleanupOrphaned,       // Clean up orphaned containers
+    ResumeSelectedSessions(String), // Resume all multi-selected Stopped interactive sessions (carries trigger key)
+    OpenInEditor,                   // Open selected session's workspace in preferred editor
+    OpenQuickShell,                 // Open shell in selected workspace/session directory
+    CleanupOrphaned,                // Clean up orphaned containers
     SwitchToLogs,
     SwitchToTerminal,
     GoToTop,
@@ -1195,7 +1196,12 @@ impl EventHandler {
                 // Enter on a Running session = attach (mirrors 'a').
                 // Other selection types fall through to None to preserve prior behaviour.
                 use crate::models::{SessionAgentType, SessionMode, SessionStatus};
-                if let Some(session) = state.selected_session() {
+                // Checked rows win over cursor: with a multi-select active,
+                // Enter starts every selected resumable session, not just the
+                // highlighted one.
+                if !state.selected_sessions.is_empty() {
+                    Some(AppEvent::ResumeSelectedSessions("Enter".to_string()))
+                } else if let Some(session) = state.selected_session() {
                     let is_interactive = matches!(session.mode, SessionMode::Interactive)
                         && matches!(
                             session.agent_type,
@@ -1217,7 +1223,11 @@ impl EventHandler {
                 // 'r' resumes a Stopped interactive session; otherwise it falls
                 // back to the existing reauthenticate-credentials shortcut.
                 use crate::models::{SessionAgentType, SessionMode, SessionStatus};
-                if let Some(session) = state.selected_session() {
+                // Checked rows win over cursor: with a multi-select active,
+                // 'r' resumes every selected resumable session.
+                if !state.selected_sessions.is_empty() {
+                    Some(AppEvent::ResumeSelectedSessions("r".to_string()))
+                } else if let Some(session) = state.selected_session() {
                     let is_interactive = matches!(session.mode, SessionMode::Interactive)
                         && matches!(
                             session.agent_type,
@@ -2712,7 +2722,7 @@ impl EventHandler {
                     state.selected_sessions.len() + state.selected_other_tmux_sessions.len();
                 if count > 0 {
                     state.add_success_notification(format!(
-                        "{} session(s) selected — Shift+D to delete",
+                        "{} session(s) selected — Enter to start, Shift+D to delete",
                         count
                     ));
                 }
@@ -2752,6 +2762,34 @@ impl EventHandler {
                         Some(AsyncAction::ResumeSession(session_id, trigger));
                 } else {
                     state.add_warning_notification("No session selected to resume".to_string());
+                }
+            }
+            AppEvent::ResumeSelectedSessions(trigger) => {
+                // Checked rows win over cursor resume: when sessions are
+                // multi-selected, start every resumable one, not just the
+                // highlighted row. Running selections are skipped so we never
+                // kill+recreate a live tmux session.
+                let total_selected = state.selected_sessions.len();
+                let ids = state.selected_resumable_session_ids();
+                if ids.is_empty() {
+                    state.add_warning_notification(format!(
+                        "No stopped interactive sessions among {} selected to resume",
+                        total_selected
+                    ));
+                } else {
+                    tracing::info!(
+                        "[ACTION] Bulk-resuming {} of {} selected session(s) (trigger={})",
+                        ids.len(),
+                        total_selected,
+                        trigger
+                    );
+                    state.add_success_notification(format!(
+                        "Resuming {} selected session(s)...",
+                        ids.len()
+                    ));
+                    state.pending_async_action =
+                        Some(AsyncAction::BulkResumeSessions(ids, trigger));
+                    state.selected_sessions.clear();
                 }
             }
             AppEvent::OpenInEditor => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2720,21 +2720,22 @@ pub enum AsyncAction {
     /// the dispatcher so the async path doesn't re-derive it from
     /// `configure_state` (finding #7).
     CreateSessionFromConfigure(crate::components::new_session::configure::LaunchSpec),
-    DeleteSession(Uuid),           // New - delete session with container cleanup
-    StopSession(Uuid),             // Soft-stop interactive session (kill tmux only)
+    DeleteSession(Uuid),         // New - delete session with container cleanup
+    StopSession(Uuid),           // Soft-stop interactive session (kill tmux only)
     ResumeSession(Uuid, String), // Recreate tmux for a Stopped interactive session; String is the trigger key for audit
-    BulkDeleteSessions(Vec<Uuid>), // Bulk delete multiple sessions
-    RefreshWorkspaces,           // Manual refresh of workspace data
-    FetchContainerLogs(Uuid),    // Fetch container logs for a session
-    AttachToContainer(Uuid),     // Attach to a container session
-    AttachToTmuxSession(Uuid),   // Attach to a tmux session
-    KillContainer(Uuid),         // Kill container for a session
-    AuthSetupOAuth,              // Run OAuth authentication setup
-    AuthSetupApiKey,             // Save API key authentication
-    ReauthenticateCredentials,   // Re-authenticate Claude credentials
-    RestartSession(Uuid),        // Restart a stopped session with new container
-    CleanupOrphaned,             // Clean up orphaned containers without worktrees
-    AttachToOtherTmux(String),   // Attach to a non-agents-in-a-box tmux session by name
+    BulkResumeSessions(Vec<Uuid>, String), // Resume multiple Stopped interactive sessions; String is the trigger key for audit
+    BulkDeleteSessions(Vec<Uuid>),         // Bulk delete multiple sessions
+    RefreshWorkspaces,                     // Manual refresh of workspace data
+    FetchContainerLogs(Uuid),              // Fetch container logs for a session
+    AttachToContainer(Uuid),               // Attach to a container session
+    AttachToTmuxSession(Uuid),             // Attach to a tmux session
+    KillContainer(Uuid),                   // Kill container for a session
+    AuthSetupOAuth,                        // Run OAuth authentication setup
+    AuthSetupApiKey,                       // Save API key authentication
+    ReauthenticateCredentials,             // Re-authenticate Claude credentials
+    RestartSession(Uuid),                  // Restart a stopped session with new container
+    CleanupOrphaned,                       // Clean up orphaned containers without worktrees
+    AttachToOtherTmux(String),             // Attach to a non-agents-in-a-box tmux session by name
     AttachWitr, // Launch `witr -i` (process-causality browser) in a dedicated tmux session and attach full-screen
     KillOtherTmux(String), // Kill a non-agents-in-a-box tmux session by name
     KillOtherTmuxSessions(Vec<String>), // Kill multiple non-agents-in-a-box tmux sessions by name
@@ -4550,6 +4551,33 @@ impl AppState {
         } else if self.is_other_tmux_selected() {
             self.toggle_select_other_tmux_session();
         }
+    }
+
+    /// Of the multi-selected managed sessions, return the IDs that can actually
+    /// be resumed: interactive agent sessions that are currently Stopped.
+    /// Running sessions are excluded so a bulk resume never kills+recreates a
+    /// live tmux session. Order is unspecified (sourced from a HashSet).
+    pub fn selected_resumable_session_ids(&self) -> Vec<Uuid> {
+        use crate::models::{SessionAgentType, SessionMode, SessionStatus};
+        self.selected_sessions
+            .iter()
+            .copied()
+            .filter(|id| {
+                self.find_session(*id)
+                    .map(|s| {
+                        let is_interactive = matches!(s.mode, SessionMode::Interactive)
+                            && matches!(
+                                s.agent_type,
+                                SessionAgentType::Claude
+                                    | SessionAgentType::Codex
+                                    | SessionAgentType::Gemini
+                                    | SessionAgentType::Copilot
+                            );
+                        is_interactive && matches!(s.status, SessionStatus::Stopped)
+                    })
+                    .unwrap_or(false)
+            })
+            .collect()
     }
 
     /// Toggle multi-select for the currently highlighted "Other tmux" session.
@@ -7633,6 +7661,31 @@ impl AppState {
                         error!("Failed to resume session {}: {}", session_id, e);
                         self.add_error_notification(format!("Resume failed: {}", e));
                     }
+                }
+                AsyncAction::BulkResumeSessions(session_ids, trigger) => {
+                    let total = session_ids.len();
+                    let mut resumed = 0;
+                    let mut failed = 0;
+                    for id in session_ids {
+                        if let Err(e) = self.resume_interactive_session(id, trigger.clone()).await {
+                            error!("Failed to resume session {}: {}", id, e);
+                            failed += 1;
+                        } else {
+                            resumed += 1;
+                        }
+                    }
+                    // resume_interactive_session refreshes per-session on success;
+                    // refresh once more so a final all-failed batch still repaints.
+                    self.load_real_workspaces().await;
+                    if failed > 0 {
+                        self.add_warning_notification(format!(
+                            "Resumed {}/{} sessions ({} failed)",
+                            resumed, total, failed
+                        ));
+                    } else {
+                        self.add_success_notification(format!("Resumed {} session(s)", resumed));
+                    }
+                    self.ui_needs_refresh = true;
                 }
                 AsyncAction::BulkDeleteSessions(session_ids) => {
                     let total = session_ids.len();

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -868,4 +868,94 @@ mod tests {
         assert_eq!(AppState::agent_hook_name(SessionAgentType::Shell), None);
         assert_eq!(AppState::agent_hook_name(SessionAgentType::Gemini), None);
     }
+
+    // ---- bulk-resume selection (Enter/r on multi-selected sessions) ----
+
+    fn resumable_session(
+        name: &str,
+        mode: SessionMode,
+        agent: SessionAgentType,
+        status: crate::models::SessionStatus,
+    ) -> crate::models::Session {
+        let mut s = crate::models::Session::new(name.to_string(), "/tmp/ws".to_string());
+        s.mode = mode;
+        s.agent_type = agent;
+        s.status = status;
+        s
+    }
+
+    /// Bulk resume must start every selected *stopped interactive* session and
+    /// exclude everything else — Running interactive (would kill+recreate a live
+    /// tmux), Boss-mode, and non-agent (Shell) sessions. Regression for the bug
+    /// where Enter only resumed the highlighted row.
+    #[test]
+    fn selected_resumable_session_ids_keeps_only_stopped_interactive() {
+        use crate::models::SessionStatus;
+
+        let stopped_claude = resumable_session(
+            "stopped-claude",
+            SessionMode::Interactive,
+            SessionAgentType::Claude,
+            SessionStatus::Stopped,
+        );
+        let stopped_codex = resumable_session(
+            "stopped-codex",
+            SessionMode::Interactive,
+            SessionAgentType::Codex,
+            SessionStatus::Stopped,
+        );
+        let running_claude = resumable_session(
+            "running-claude",
+            SessionMode::Interactive,
+            SessionAgentType::Claude,
+            SessionStatus::Running,
+        );
+        let boss_stopped = resumable_session(
+            "boss-stopped",
+            SessionMode::Boss,
+            SessionAgentType::Claude,
+            SessionStatus::Stopped,
+        );
+        let shell_stopped = resumable_session(
+            "shell-stopped",
+            SessionMode::Interactive,
+            SessionAgentType::Shell,
+            SessionStatus::Stopped,
+        );
+
+        let resumable_ids = [stopped_claude.id, stopped_codex.id];
+        let all_ids = [
+            stopped_claude.id,
+            stopped_codex.id,
+            running_claude.id,
+            boss_stopped.id,
+            shell_stopped.id,
+        ];
+
+        let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
+        ws.add_session(stopped_claude);
+        ws.add_session(stopped_codex);
+        ws.add_session(running_claude);
+        ws.add_session(boss_stopped);
+        ws.add_session(shell_stopped);
+
+        let mut state = AppState::new();
+        state.workspaces.push(ws);
+        // Mark all five as multi-selected.
+        for id in all_ids {
+            state.selected_sessions.insert(id);
+        }
+
+        let mut got = state.selected_resumable_session_ids();
+        got.sort();
+        let mut want = resumable_ids.to_vec();
+        want.sort();
+        assert_eq!(got, want, "only stopped interactive agent sessions resume");
+    }
+
+    #[test]
+    fn selected_resumable_session_ids_empty_when_nothing_selected() {
+        let state = AppState::new();
+        assert!(state.selected_resumable_session_ids().is_empty());
+    }
 }


### PR DESCRIPTION
## Problem

Selecting multiple sessions with **Space** and pressing **Enter** (or `r`) only started the *highlighted* session — every other marked session was ignored.

Root cause: the Enter/`r` key handlers read `selected_session()` / `get_selected_session_id()`, which return the cursor row and ignore the `selected_sessions` multi-select set entirely. Bulk **delete** (`Shift+D`) already honoured the selection, so the resume and delete paths had drifted apart.

## Fix

Mirror the existing bulk-delete pattern for resume:

- **`AppEvent::ResumeSelectedSessions(String)`** — Enter and `r` route here whenever `selected_sessions` is non-empty (checked rows win over the cursor), falling back to the existing single-session behaviour otherwise.
- **`AsyncAction::BulkResumeSessions(Vec<Uuid>, String)`** — loops `resume_interactive_session` over each id and reports a `resumed/failed` tally.
- **`selected_resumable_session_ids()`** — filters the selection to **Stopped interactive agent** sessions only.
- Selection notification now reads `… selected — Enter to start, Shift+D to delete`.

## Safety

The filter **excludes Running sessions**: `resume_interactive_session` kills + recreates the tmux session, so bulk-resuming a live session would destroy it. Boss-mode and Shell sessions are skipped too (not resumable interactive agents).

## Tests

- Added 2 regression tests locking the filter invariant (Running / Boss / Shell excluded; only Stopped interactive resume).
- `cargo build` clean, `cargo clippy` zero errors (pre-existing warning debt only).
- Existing 876 lib tests pass; the 9 `docker::agents_dev_tests` failures are environmental (no Docker daemon), unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-session bulk resume: Select multiple sessions and resume them together using Enter or 'r' key.
  * Smart filtering ensures only stopped interactive sessions are resumed, excluding running or shell sessions.
  * Enhanced notifications report successful resumes and failures with counts.

* **Tests**
  * Added tests validating bulk resume selection behavior and session filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->