### PR TITLE
feat(fleet): tmux-first transport toggle (AINB_FLEET_TRANSPORT)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/fleet/read/needs.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/needs.rs
@@ -168,11 +168,15 @@ pub fn classify(input: ClassifyInput) -> Option<NeedsRow> {
     None
 }
 
+/// Advisory hint for the answer-routing channel. Mirrors the default
+/// `tmux-first` send transport: prefer a live tmux pane, fall back to a broker
+/// peer only when there is no tmux session. (Actual delivery is governed by
+/// `AINB_FLEET_TRANSPORT` in the send path.)
 fn derive_route_hint(session: &Session) -> RouteHint {
-    if session.peer_id.is_some() {
-        RouteHint::Broker
-    } else if session.tmux_session.is_some() {
+    if session.tmux_session.is_some() {
         RouteHint::Tmux
+    } else if session.peer_id.is_some() {
+        RouteHint::Broker
     } else {
         RouteHint::None
     }
@@ -202,16 +206,19 @@ mod tests {
     }
 
     #[test]
-    fn route_hint_prefers_broker() {
+    fn route_hint_prefers_tmux() {
+        // A live tmux pane wins even when a broker peer is also registered.
         let mut s = mk_session("/x");
         s.peer_id = Some("p".to_string());
-        assert!(matches!(derive_route_hint(&s), RouteHint::Broker));
+        assert!(matches!(derive_route_hint(&s), RouteHint::Tmux));
     }
 
     #[test]
-    fn route_hint_tmux_fallback() {
-        let s = mk_session("/x");
-        assert!(matches!(derive_route_hint(&s), RouteHint::Tmux));
+    fn route_hint_broker_when_no_tmux() {
+        let mut s = mk_session("/x");
+        s.tmux_session = None;
+        s.peer_id = Some("p".to_string());
+        assert!(matches!(derive_route_hint(&s), RouteHint::Broker));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/send/route.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/send/route.rs
@@ -1,41 +1,126 @@
-// ABOUTME: Send-routing — peers-first, tmux fallback.
+// ABOUTME: Send-routing — transport-configurable; tmux-first by default, broker optional.
 
 use anyhow::Result;
 
 use crate::fleet::send::{broker_health, broker_send, tmux_send, tmux_session_exists};
 use crate::fleet::types::{SendOutcome, Session};
 
-const POPA_PEER_ID_ENV: &str = "AINB_FLEET_PEER_ID";
-const POPA_PEER_ID_DEFAULT: &str = "ainb-fleet-cp";
+const PEER_ID_ENV: &str = "AINB_FLEET_PEER_ID";
+const PEER_ID_DEFAULT: &str = "ainb-fleet-cp";
+const TRANSPORT_ENV: &str = "AINB_FLEET_TRANSPORT";
 
-fn from_peer_id() -> String {
-    std::env::var(POPA_PEER_ID_ENV).unwrap_or_else(|_| POPA_PEER_ID_DEFAULT.to_string())
+/// Which channel to prefer when sending to a session.
+///
+/// The claude-peers broker has proven flaky, so tmux send-keys is the default
+/// primary path; the broker is opt-in or a fallback. Selected via
+/// `AINB_FLEET_TRANSPORT`:
+///
+/// | value | behaviour |
+/// |---|---|
+/// | unset / `tmux` / `tmux-first` | tmux send-keys first, broker fallback (default) |
+/// | `tmux-only` | tmux send-keys only, never touch the broker |
+/// | `peers` / `broker` / `peers-first` | legacy: broker first, tmux fallback |
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Transport {
+    TmuxFirst,
+    TmuxOnly,
+    PeersFirst,
 }
 
-pub async fn send(session: &Session, text: &str) -> Result<SendOutcome> {
-    if let Some(peer_id) = session.peer_id.as_deref() {
-        if broker_health().await {
-            match broker_send(&from_peer_id(), peer_id, text).await {
-                Ok(res) if res.ok => {
-                    return Ok(SendOutcome::Broker {
-                        peer_id: peer_id.to_string(),
-                    });
-                }
-                Ok(_) | Err(_) => { /* fall through to tmux fallback */ }
+fn parse_transport(raw: Option<&str>) -> Transport {
+    match raw.map(str::trim) {
+        Some("peers" | "broker" | "peers-first") => Transport::PeersFirst,
+        Some("tmux-only") => Transport::TmuxOnly,
+        // default (unset, "tmux", "tmux-first", or anything unrecognised): tmux-first
+        _ => Transport::TmuxFirst,
+    }
+}
+
+fn transport() -> Transport {
+    parse_transport(std::env::var(TRANSPORT_ENV).ok().as_deref())
+}
+
+fn from_peer_id() -> String {
+    std::env::var(PEER_ID_ENV).unwrap_or_else(|_| PEER_ID_DEFAULT.to_string())
+}
+
+/// Try a tmux send-keys delivery. `None` if the session has no live tmux pane
+/// or the keystrokes could not be written.
+async fn try_tmux(session: &Session, text: &str) -> Option<SendOutcome> {
+    let name = session.tmux_session.as_deref()?;
+    if tmux_session_exists(name).await && tmux_send(name, text).await.is_ok() {
+        return Some(SendOutcome::Tmux {
+            tmux_session: name.to_string(),
+        });
+    }
+    None
+}
+
+/// Try a broker (claude-peers) delivery. `None` if the session has no peer id,
+/// the broker is unhealthy, or the broker rejected the message.
+async fn try_broker(session: &Session, text: &str) -> Option<SendOutcome> {
+    let peer_id = session.peer_id.as_deref()?;
+    if broker_health().await {
+        if let Ok(res) = broker_send(&from_peer_id(), peer_id, text).await {
+            if res.ok {
+                return Some(SendOutcome::Broker {
+                    peer_id: peer_id.to_string(),
+                });
             }
         }
     }
+    None
+}
 
-    if let Some(name) = session.tmux_session.as_deref() {
-        if tmux_session_exists(name).await {
-            tmux_send(name, text).await?;
-            return Ok(SendOutcome::Tmux {
-                tmux_session: name.to_string(),
-            });
-        }
+pub async fn send(session: &Session, text: &str) -> Result<SendOutcome> {
+    let mode = transport();
+    let outcome = match mode {
+        Transport::TmuxFirst => match try_tmux(session, text).await {
+            Some(o) => Some(o),
+            None => try_broker(session, text).await,
+        },
+        Transport::TmuxOnly => try_tmux(session, text).await,
+        Transport::PeersFirst => match try_broker(session, text).await {
+            Some(o) => Some(o),
+            None => try_tmux(session, text).await,
+        },
+    };
+
+    Ok(outcome.unwrap_or_else(|| SendOutcome::Failed {
+        reason: match mode {
+            Transport::TmuxOnly => {
+                "no live tmux session found (transport=tmux-only)".to_string()
+            }
+            _ => "no live tmux session and no reachable broker peer".to_string(),
+        },
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Transport, parse_transport};
+
+    #[test]
+    fn defaults_to_tmux_first() {
+        assert_eq!(parse_transport(None), Transport::TmuxFirst);
+        assert_eq!(parse_transport(Some("tmux")), Transport::TmuxFirst);
+        assert_eq!(parse_transport(Some("tmux-first")), Transport::TmuxFirst);
+        assert_eq!(parse_transport(Some(" tmux ")), Transport::TmuxFirst);
+        // unrecognised values fail safe to the tmux-first default
+        assert_eq!(parse_transport(Some("garbage")), Transport::TmuxFirst);
+        assert_eq!(parse_transport(Some("")), Transport::TmuxFirst);
     }
 
-    Ok(SendOutcome::Failed {
-        reason: "no peer registered and no tmux session found".to_string(),
-    })
+    #[test]
+    fn tmux_only_opts_out_of_broker() {
+        assert_eq!(parse_transport(Some("tmux-only")), Transport::TmuxOnly);
+    }
+
+    #[test]
+    fn peers_values_select_legacy_broker_first() {
+        assert_eq!(parse_transport(Some("peers")), Transport::PeersFirst);
+        assert_eq!(parse_transport(Some("broker")), Transport::PeersFirst);
+        assert_eq!(parse_transport(Some("peers-first")), Transport::PeersFirst);
+        assert_eq!(parse_transport(Some(" peers ")), Transport::PeersFirst);
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/send/route.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/send/route.rs
@@ -88,9 +88,7 @@ pub async fn send(session: &Session, text: &str) -> Result<SendOutcome> {
 
     Ok(outcome.unwrap_or_else(|| SendOutcome::Failed {
         reason: match mode {
-            Transport::TmuxOnly => {
-                "no live tmux session found (transport=tmux-only)".to_string()
-            }
+            Transport::TmuxOnly => "no live tmux session found (transport=tmux-only)".to_string(),
             _ => "no live tmux session and no reachable broker peer".to_string(),
         },
     }))

--- a/plugins/ainb-fleet/README.md
+++ b/plugins/ainb-fleet/README.md
@@ -1,0 +1,248 @@
+# ainb-fleet
+
+**A control plane for every coding-agent session running on your machine.**
+
+`ainb-fleet` lets one agent (or you) see and drive a whole fleet of interactive
+CLI coding agents — Claude Code, Codex, Gemini, Copilot, or anything else that
+runs in a terminal — from a single place. It enumerates every live session,
+tells you which ones are blocked waiting on you, fans a prompt out to many at
+once, runs ordered multi-step sequences, and auto-recovers sessions that hit
+transient API errors.
+
+It is **agent-agnostic by design**: it talks to sessions over the terminal
+itself (tmux), so it does not care which agent is running in the pane.
+
+```
+                         ┌─────────────────────────────┐
+                         │        ainb fleet           │
+                         │  standup · needs · broadcast │
+                         │  sequence · daemon           │
+                         └──────────────┬──────────────┘
+              read (capture-pane + JSONL)│ write (send-keys)
+        ┌───────────────┬───────────────┼───────────────┬──────────────┐
+        ▼               ▼               ▼               ▼              ▼
+   ┌─────────┐    ┌─────────┐     ┌─────────┐     ┌─────────┐    ┌─────────┐
+   │ Claude  │    │ Codex   │     │ Gemini  │     │ Copilot │    │ any CLI │
+   │ (tmux)  │    │ (tmux)  │     │ (tmux)  │     │ (tmux)  │    │ (tmux)  │
+   └─────────┘    └─────────┘     └─────────┘     └─────────┘    └─────────┘
+```
+
+---
+
+## Why "over PTY"?
+
+Most agent-orchestration tools require a special protocol on both ends (the
+agent must speak it, you must adopt it). `ainb-fleet` takes the opposite bet:
+**the terminal is the universal interface.** Every interactive coding agent
+already reads keystrokes and prints to a pane. So the fleet:
+
+- **Writes** with `tmux send-keys -l` — literal keystrokes into the target pane,
+  exactly what a human would type. Works for any agent, any prompt, no
+  injection risk.
+- **Reads** with `tmux capture-pane` (including scrollback) — to see what the
+  agent printed, detect API errors, and read its current state.
+- **Reads, precisely,** the session's JSONL transcript when available — to pull
+  structured signals (a fired `AskUserQuestion`, an assistant turn that ended
+  with no follow-up) that a screen-scrape can't reliably give you.
+
+Because the transport is the terminal, **the same commands orchestrate Claude,
+Codex, Gemini, Copilot, and any future agent** without per-agent integration.
+
+### Cross-agent capability matrix
+
+| Capability | Claude | Codex | Gemini | Copilot | Any PTY agent |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Send a prompt (`send-keys`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Read pane / detect API errors (`capture-pane`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Broadcast / sequence / auto-continue daemon | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Precise ASK / IDLE signal from JSONL | ✓ | pane¹ | pane¹ | pane¹ | pane¹ |
+| Resume a stopped session | ✓² | fresh | fresh | fresh | fresh |
+
+¹ Agents without a Claude-style JSONL transcript fall back to pane-text
+heuristics for ASK/IDLE; ERR (pane) and WAIT (summary) work for all.
+² Claude resumes via `--resume <jsonl path>`; other agents start a fresh session.
+
+---
+
+## The verbs
+
+| Sub-skill | What it does |
+|---|---|
+| [`/ainb-fleet:standup`](skills/standup/SKILL.md) | List every session — merged across ainb · peers · bg jobs |
+| [`/ainb-fleet:needs`](skills/needs/SKILL.md) | Show sessions blocked on you (ASK / ERR / IDLE / WAIT) |
+| [`/ainb-fleet:broadcast`](skills/broadcast/SKILL.md) | Send one prompt to many selected sessions |
+| [`/ainb-fleet:sequence`](skills/sequence/SKILL.md) | Ordered multi-step prompts, ack-gated between steps |
+| [`/ainb-fleet:daemon`](skills/daemon/SKILL.md) | Background watcher that auto-continues API errors |
+| [`/ainb-fleet:fleet-needs`](skills/fleet-needs/SKILL.md) | Workflow-backed Jarvis HUD over `needs` |
+
+All verbs are also raw CLI subcommands of the `ainb` binary:
+
+```bash
+ainb fleet standup                     # text table (--format json for piping)
+ainb fleet needs                       # Jarvis HUD of blocked sessions
+ainb fleet broadcast "/clear" --all    # fan-out (needs an explicit target flag)
+ainb fleet sequence "step1" "step2" --all
+ainb fleet daemon --verbose            # unattended API-error recovery
+```
+
+---
+
+## Transport — tmux-first, broker optional
+
+Writes go out over **tmux send-keys by default.** A session-to-session message
+broker (claude-peers) is supported as an opt-in fallback. Pick the channel with
+`AINB_FLEET_TRANSPORT`:
+
+```
+            ┌──────────────┐  tmux send-keys -l   ┌───────────┐
+  send ────▶│ live tmux     │────────────────────▶│ delivered │
+            │ pane?         │                      └───────────┘
+            └──────┬───────┘
+                   │ no pane (or transport=peers)
+                   ▼
+            ┌──────────────┐  broker /send-message ┌───────────┐
+            │ peer + broker │─────────────────────▶│ delivered │
+            │  healthy?     │                       └───────────┘
+            └──────────────┘
+```
+
+| `AINB_FLEET_TRANSPORT` | behaviour |
+|---|---|
+| unset / `tmux` / `tmux-first` | tmux send-keys first, broker fallback (**default**) |
+| `tmux-only` | tmux send-keys only — never touch the broker |
+| `peers` / `broker` | legacy broker-first, tmux fallback |
+
+Verify any write landed the way you read everything else — straight from the pane:
+
+```bash
+tmux capture-pane -t "<session>" -p -S -40 | grep -F "<text>" && echo "✓"
+```
+
+---
+
+## How signals are read
+
+The `needs` verb classifies each session into one of four signal kinds. Reads
+are layered — JSONL where it's authoritative, the pane where it isn't:
+
+```
+signal   primary source        fallback
+─────    ──────────────        ────────────────────────
+ASK   ─▶ JSONL (tool_use)      —
+IDLE  ─▶ JSONL (turn-end)      —
+ERR   ─▶ tmux pane (80 ln)     JSONL newest 40 rows (on pane miss)
+WAIT  ─▶ peers summary         —
+```
+
+Priority when more than one fires: **ASK > ERR > IDLE > WAIT.**
+
+---
+
+## Token efficiency
+
+The fleet is built to be cheap to run, even across a large host:
+
+- **The whole Rust read/classify path is LLM-free.** Discovery, pane capture,
+  JSONL parsing and signal classification run as plain code and emit compact
+  JSON with short snippets — zero model tokens.
+- **Enrichment is batched, not fanned out.** When sessions get an AI-drafted
+  "suggested answer", the work is done in **one** pass over all blocked cards,
+  not one subagent per session.
+
+```
+                blocked cards
+                     │
+        ≤ 6 ─────────┼───────── > 6
+         │                       │
+   draft inline             one batched
+   (0 subagents)            subagent call
+         └───────────┬───────────┘
+                     ▼
+            enrich-cache (sha(ctx))
+        unchanged card  ─▶  reused, 0 tokens
+```
+
+- **Hybrid locus.** Small fleets draft suggestions inline (no subagent spawned);
+  large fleets isolate the work into a single batched subagent. Cutoff is
+  `AINB_FLEET_ENRICH_INLINE_MAX` (default `6`).
+- **Content-hash cache.** Each enrichment is cached by a hash of its exact input
+  context (`~/.agents-in-a-box/fleet/enrich-cache.json`). A session that hasn't
+  advanced is never re-enriched — its card renders for free. The cache
+  self-invalidates the instant the context changes; eviction is LRU.
+- **Instant 0-token mode.** `--no-enrich` (or `AINB_FLEET_ENRICH=0`) renders the
+  HUD straight from the Rust JSON with no model calls at all.
+
+---
+
+## Install
+
+`ainb-fleet` ships as a plugin in the agents-in-a-box marketplace and is backed
+by the `ainb` Rust binary.
+
+```bash
+# the fleet verbs live in the ainb binary
+ainb fleet --help
+
+# the LLM-facing skills are deployed with the plugin; invoke from a session:
+/ainb-fleet:standup
+/ainb-fleet:needs
+```
+
+---
+
+## Discovery sources
+
+Sessions are merged + deduped by `cwd` across three sources:
+
+- **ainb** — every session spawned via `ainb run`
+- **peers** — sessions registered with the claude-peers broker (read directly
+  from its sqlite, so discovery survives a down broker)
+- **jobs** — background-session dirs under `~/.claude/jobs/`
+
+A session present in two sources collapses into one record with
+`sources: ["ainb", "peers"]`.
+
+---
+
+## Environment variables
+
+| var | default | use |
+|---|---|---|
+| `AINB_FLEET_TRANSPORT` | `tmux-first` | write channel: `tmux` / `tmux-only` / `peers` |
+| `AINB_FLEET_ENRICH` | `1` | set `0` to disable enrichment globally (= `--no-enrich`) |
+| `AINB_FLEET_ENRICH_INLINE_MAX` | `6` | blocked-card count: inline below, one batched agent above |
+| `AINB_FLEET_IDLE_MIN` | `5` | minutes before an idle session is surfaced |
+| `AINB_FLEET_PEER_ID` | `ainb-fleet-cp` | from-id used when a write falls back to the broker |
+| `AINB_FLEET_JOBS_DIR` | `~/.claude/jobs` | background-job scan root |
+| `AINB_BIN` | `ainb` | override the binary the discover layer shells to (tests) |
+| `CLAUDE_PEERS_DB` | `~/.claude-peers.db` | broker sqlite path (discovery) |
+| `CLAUDE_PEERS_PORT` | `7899` | broker HTTP port (fallback writes only) |
+
+---
+
+## Roadmap
+
+**Now (landing)**
+
+- [x] tmux-first transport with `AINB_FLEET_TRANSPORT` toggle
+- [ ] Batched enrichment — collapse per-session subagents into ≤1 call
+- [ ] Hybrid inline / batched enrich locus by fleet size
+- [ ] Content-hash enrich cache (`sha(ctx)`, LRU, no TTL)
+- [ ] JSONL fallback for ERR detection on pane miss
+- [ ] Unified enrich path across `needs` and `standup`
+- [ ] `--no-enrich` instant 0-token HUD
+
+**Next**
+
+- [ ] Per-session retry cap + backoff in the daemon
+- [ ] Filter / cwd targeting for `sequence` (currently `--all` only)
+- [ ] Answer-routing dedupe (a just-answered session shouldn't reappear once)
+- [ ] Richer non-Claude JSONL adapters (Codex / Gemini transcript shapes)
+
+---
+
+## See also
+
+- `ainb list` — lifecycle-only session list (no peer/jobs enrichment)
+- `ainb attach <workspace>` — drop into a session's tmux
+- `ainb kill <workspace>` — terminate a single session by exact name

--- a/plugins/ainb-fleet/skills/ainb-fleet/SKILL.md
+++ b/plugins/ainb-fleet/skills/ainb-fleet/SKILL.md
@@ -37,7 +37,7 @@ sub-skill with focused docs.
 ## Architecture (1-line)
 
 ```
-discover (ainb + peers + jobs)  ──▶  state read  ──▶  send (peers-first, tmux fallback)
+discover (ainb + peers + jobs)  ──▶  state read  ──▶  send (tmux-first, broker fallback)
 ```
 
 ## Global flag
@@ -45,10 +45,43 @@ discover (ainb + peers + jobs)  ──▶  state read  ──▶  send (peers-fi
 `--format json|text|csv|markdown` (default `text`). Prefer `--format json`
 when an LLM is the consumer.
 
+## Transport — tmux is primary
+
+Writes (broadcast / sequence / daemon / answer-routing) go out over **tmux
+send-keys by default**. The claude-peers broker is opt-in / fallback only,
+because in practice it has proven flaky (silent delivery gaps). The primitives
+the fleet uses are exactly: `tmux send-keys -l` (write), `tmux capture-pane -p
+-S -<n>` (read, incl. scrollback), and the session JSONL transcript
+(`~/.claude/projects/<cwd-slug>/<sid>.jsonl`) as ground-truth read.
+
+Select the write channel with `AINB_FLEET_TRANSPORT`:
+
+| value | behaviour |
+|---|---|
+| unset / `tmux` / `tmux-first` | tmux send-keys first, broker fallback (**default**) |
+| `tmux-only` | tmux send-keys only — never touch the broker |
+| `peers` / `broker` / `peers-first` | legacy: broker first, tmux fallback |
+
+```
+            ┌──────────────┐  tmux send-keys -l   ┌─────────────┐
+  send ────▶│ tmux pane?   │─────────────────────▶│  delivered  │
+            └──────┬───────┘                       └─────────────┘
+                   │ no live pane (or peers-first)
+                   ▼
+            ┌──────────────┐  broker /send-message ┌─────────────┐
+            │ peer + broker│──────────────────────▶│  delivered  │
+            │   healthy?   │                        └─────────────┘
+            └──────────────┘
+```
+
 ## Discovery sources
 
+Discovery is independent of the write transport — peers are still *read* for
+visibility (PID, `summary`, `WAITING:` markers) even when writes go via tmux.
+
 - **ainb** — every session ainb has spawned via `ainb run`
-- **peers** — sessions registered with the claude-peers broker (`~/.claude-peers.db`)
+- **peers** — sessions registered with the claude-peers broker (`~/.claude-peers.db`),
+  read directly from its sqlite (no HTTP), so discovery survives a down broker
 - **jobs** — bg-session dirs under `~/.claude/jobs/`
 
 Merged + deduped by `cwd` so the same session in two sources collapses
@@ -59,10 +92,11 @@ into one record with `sources: ["ainb", "peers"]`.
 | var | default | use |
 |---|---|---|
 | `AINB_BIN` | `ainb` | override binary the discover layer shells to (tests) |
-| `AINB_FLEET_PEER_ID` | `ainb-fleet-cp` | peer id the daemon registers as |
+| `AINB_FLEET_TRANSPORT` | `tmux-first` | write channel: `tmux` / `tmux-only` / `peers` |
+| `AINB_FLEET_PEER_ID` | `ainb-fleet-cp` | from-id used when a write does fall back to the broker |
 | `AINB_FLEET_JOBS_DIR` | `~/.claude/jobs` | bg-job scan root |
-| `CLAUDE_PEERS_DB` | `~/.claude-peers.db` | broker sqlite path |
-| `CLAUDE_PEERS_PORT` | `7899` | broker HTTP port |
+| `CLAUDE_PEERS_DB` | `~/.claude-peers.db` | broker sqlite path (discovery) |
+| `CLAUDE_PEERS_PORT` | `7899` | broker HTTP port (fallback writes only) |
 
 ## See also
 

--- a/plugins/ainb-fleet/skills/broadcast/SKILL.md
+++ b/plugins/ainb-fleet/skills/broadcast/SKILL.md
@@ -4,9 +4,10 @@ description: |
   Fan out a single prompt to selected claude sessions across the fleet.
   Use when you need to apply the same instruction (e.g. `/clear`,
   `git pull`, `remote-control disconnect`) to many sessions at once.
-  Routing: peers-first (broker HTTP) when peer registered, tmux send-keys
-  fallback otherwise. Refuses to run without an explicit targeting flag
-  (--all, --filter <regex>, or --cwd <substring>) — no implicit fan-out.
+  Routing: tmux send-keys by default (the broker is an opt-in fallback,
+  toggled via AINB_FLEET_TRANSPORT). Refuses to run without an explicit
+  targeting flag (--all, --filter <regex>, or --cwd <substring>) — no
+  implicit fan-out.
 version: "0.1.0"
 user-invocable: true
 triggers:
@@ -47,22 +48,30 @@ accidental fan-out.
 
 ```
 ainb fleet broadcast — sent to N target(s)
-  ✓ <name> via broker peer <peer_id>
   ✓ <name> via tmux <tmux_session>
+  ✓ <name> via broker peer <peer_id>
   ✗ <name>: <reason>
 ```
 
-`✓ via broker` = sent through claude-peers HTTP (clean, structured).
 `✓ via tmux` = sent via `tmux send-keys -l` (literal mode, works for any
-tmux pane regardless of peer state).
+tmux pane regardless of peer state) — this is the default path.
+`✓ via broker` = sent through claude-peers HTTP — only seen when a target
+has no live tmux pane (or `AINB_FLEET_TRANSPORT=peers` is set).
 
 ## Routing rule
 
-For each target:
+Controlled by `AINB_FLEET_TRANSPORT` (default `tmux-first`). For each target:
 
-1. If session has `peer_id` and broker is healthy → POST `/send-message` to broker.
-2. Else if session has `tmux_session` and tmux says it exists → `tmux send-keys -l`.
-3. Else → `Failed { reason: "no peer registered and no tmux session found" }`.
+**Default (`tmux-first`):**
+
+1. If session has `tmux_session` and tmux says it exists → `tmux send-keys -l`.
+2. Else if session has `peer_id` and broker is healthy → POST `/send-message` to broker.
+3. Else → `Failed { reason: "no live tmux session and no reachable broker peer" }`.
+
+**`tmux-only`:** step 1 only; never touches the broker. Failure reason notes
+`(transport=tmux-only)`.
+
+**`peers` / `broker` (legacy):** the old order — broker first, tmux fallback.
 
 ## Common flows
 

--- a/plugins/ainb-fleet/skills/daemon/SKILL.md
+++ b/plugins/ainb-fleet/skills/daemon/SKILL.md
@@ -21,8 +21,10 @@ allowed-tools:
 
 # ainb fleet:daemon
 
-Background watcher. Registers as peer `ainb-fleet-cp`. Auto-continues
-sessions hitting API errors.
+Background watcher. Reads each session's tmux pane (`capture-pane`) and
+auto-continues sessions hitting API errors via `tmux send-keys`. It does
+**not** register as a peer — it is purely tmux-driven (broker health is
+checked only to print an informational line).
 
 ## Run
 
@@ -44,7 +46,7 @@ nohup ainb fleet daemon --verbose > ~/.ainb-fleet.log 2>&1 &
 3. Run the API-error regex set over the buffer.
 4. If a match fires AND the (session_id, pattern, snippet-tail) dedupe
    key hasn't been seen yet → send `continue` to that session via the
-   standard route (peers-first, tmux fallback).
+   standard route (tmux-first by default — see `AINB_FLEET_TRANSPORT`).
 
 ## Detected error patterns
 
@@ -90,15 +92,23 @@ pkill -INT -f "ainb fleet daemon"
 kill <pid>
 ```
 
-The daemon's SIGINT handler unregisters from the broker before exit, so
-peers won't see a stale `ainb-fleet-cp` entry.
+The daemon holds no broker registration, so there is no stale peer entry to
+clean up on exit — `Ctrl-C` / `kill` is enough.
 
 ## Observe what the daemon is doing
 
-With `--verbose`, every detection prints:
+On start the daemon prints whether the broker is reachable (informational
+only — writes go via tmux regardless):
 
 ```
 [fleet/daemon] broker healthy at 127.0.0.1:7899
+   # or, when the broker is down:
+[fleet/daemon] broker not reachable — operating in tmux-only mode
+```
+
+With `--verbose`, every detection also prints:
+
+```
 [fleet/daemon] auto-continue -> <tmux_session> (<pattern>)
 ```
 
@@ -114,5 +124,6 @@ tail -F ~/.ainb-fleet.log
   reading the error, racing your investigation.
 - On a fleet doing batch work that explicitly throws errors as control
   flow — the daemon will misinterpret intentional errors.
-- When the broker is down AND every session is tmux-only — the daemon
-  still works via tmux fallback but loses peer-aware routing.
+- On a session with no live tmux pane (bg job, dead tmux) — there is
+  nothing to send-keys to; under the default `tmux-first` it can only
+  reach such a session if it still has a healthy broker peer.

--- a/plugins/ainb-fleet/skills/fleet-needs/SKILL.md
+++ b/plugins/ainb-fleet/skills/fleet-needs/SKILL.md
@@ -41,6 +41,9 @@ SESSION (this skill) ──Workflow({name:'ainb-fleet:hangar', args:{verb:'needs
 | Fallback writes | peers/broker via `ainb fleet broadcast` | only when no tmux_session known; broker has a known delivery gap |
 
 All write routing below uses tmux first. Broker is a last resort, not the default.
+This matches the binary's default `AINB_FLEET_TRANSPORT=tmux-first`; set
+`tmux-only` to disable the broker fallback entirely, or `peers` to restore the
+legacy broker-first order.
 
 ## Step 0 — gate check (fallback if workflows off)
 

--- a/plugins/ainb-fleet/skills/needs/SKILL.md
+++ b/plugins/ainb-fleet/skills/needs/SKILL.md
@@ -74,7 +74,7 @@ Each row in the output array:
     "marker": "WAITING:",
     "text": "…the post-marker text…"
   },
-  "route_hint": "broker" | "tmux" | "none"
+  "route_hint": "tmux" | "broker" | "none"   // advisory; send is tmux-first
 }
 ```
 
@@ -128,15 +128,26 @@ options so the user can click rather than type.
 
 ## Route the answers back
 
-Once Stevie answers each, route via the existing send-route:
+Writes are **tmux-first**. Prefer driving the target pane directly — it lands
+reliably and is verifiable with `capture-pane`:
+
+```bash
+# default, most reliable: write keystrokes straight to the pane
+tmux send-keys -t "<tmux_session>" -l "<answer>"
+tmux send-keys -t "<tmux_session>" Enter
+# verify it landed
+tmux capture-pane -t "<tmux_session>" -p -S -40 | grep -F "<answer>" && echo "✓"
+```
+
+Or go through the verb, which honours `AINB_FLEET_TRANSPORT` (tmux-first):
 
 ```bash
 ainb fleet broadcast "<answer>" --filter "<exact tmux_session>"
 ```
 
-`route_hint` tells you what'll happen:
-- `broker` — clean send through claude-peers HTTP
-- `tmux` — `tmux send-keys -l` literal mode (works for any tmux pane)
+`route_hint` is advisory — it mirrors the default tmux-first order:
+- `tmux` — a live tmux pane exists → `tmux send-keys -l` (the normal case)
+- `broker` — no tmux pane, but a healthy broker peer → claude-peers HTTP fallback
 - `none` — bg job or no targets; can't auto-route; tell user manually
 
 ## Composition example

--- a/plugins/ainb-fleet/skills/standup/SKILL.md
+++ b/plugins/ainb-fleet/skills/standup/SKILL.md
@@ -3,9 +3,10 @@ name: ainb-fleet:standup
 description: |
   Show fleet status — every claude session running on the host, merged
   across ainb + claude-peers broker + background jobs. Use when you need
-  to enumerate sessions before composing an action, see which sessions
-  have a peer registered (broker-routable) vs tmux-only, check the
-  `summary` of each session, or pipe the list into jq for filtering.
+  to enumerate sessions before composing an action, check the `summary`
+  of each session, or pipe the list into jq for filtering. (Writes go
+  via tmux by default; a `peer_id` is just an extra discovery signal /
+  fallback channel, not a routing requirement.)
   Default output: text table. Pass --format json for LLM consumption.
 version: "0.1.0"
 user-invocable: true
@@ -58,7 +59,12 @@ ainb fleet --format json standup | jq -r '.[].tmux_session // .workspace_name'
 ainb fleet --format json standup | jq '.[] | select(.cwd | contains("shotclubhouse"))'
 ```
 
-**Only sessions with peer registration (broker-routable):**
+**Sessions reachable by the default tmux transport:**
+```bash
+ainb fleet --format json standup | jq '.[] | select(.tmux_session != null)'
+```
+
+**Sessions with a broker peer (fallback-routable):**
 ```bash
 ainb fleet --format json standup | jq '.[] | select(.peer_id != null)'
 ```

--- a/plugins/ainb-fleet/workflows/hangar.js
+++ b/plugins/ainb-fleet/workflows/hangar.js
@@ -288,7 +288,7 @@ async function runStandup(opts) {
       activity: (e && e.activity) || (s.summary || '').slice(0, 60) || 'unknown',
       state: (e && e.state) || 'idle',
       stale: (e && e.stale) || '?',
-      routable: s.peer_id ? 'broker' : (s.tmux_session ? 'tmux' : 'none'),
+      routable: s.tmux_session ? 'tmux' : (s.peer_id ? 'broker' : 'none'),
     })
   }
 


### PR DESCRIPTION
## Why

The claude-peers broker has proven flaky (silent delivery gaps). Rather than rip peers out, this makes **tmux the primary transport** and keeps the broker as an opt-in fallback, controlled by a single env toggle.

## What

`fleet::send::route::send()` now branches on `AINB_FLEET_TRANSPORT`:

| value | behaviour |
|---|---|
| unset / `tmux` / `tmux-first` | tmux send-keys first, broker fallback (**new default**) |
| `tmux-only` | tmux send-keys only — never touch the broker |
| `peers` / `broker` / `peers-first` | legacy: broker first, tmux fallback |

This one flip covers `broadcast`, `sequence`, and `daemon` (all route through `send()`).

- `derive_route_hint` (needs) and the hangar `standup` `routable` render now mirror the tmux-first order, so the `needs` JSON / HUD agree with actual delivery.
- Peers **discovery** is unchanged — still read for `summary` / `WAITING:` / pid visibility; only the **write** order flips.
- Unit tests added for transport parsing (fail-safe to tmux-first on unknown values) and route-hint selection.

## Docs

All 6 ainb-fleet skills reframed around tmux-first + the toggle. Also corrected the `daemon` skill's inaccurate peer-registration claims — it never registered a peer; it's purely `capture-pane` reads + `send-keys` writes.

## Tests

- `cargo test -p ainb --lib fleet::send::route` → 3 passed
- `cargo test -p ainb --lib fleet::read::needs` → 6 passed
- `node --test` (hangar workflow) → 16 passed

## Out of scope

Default flips from peers-first → tmux-first; set `AINB_FLEET_TRANSPORT=peers` to restore the old behaviour. Broker code is untouched and remains the fallback.