### PR TITLE
fix(tui): surface stopped sessions on startup without a manual refresh

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3718,6 +3718,26 @@ impl AppState {
                             }
 
                             self.add_success_notification("Workspaces loaded".to_string());
+
+                            // The fast startup loader (`load_workspaces_async`)
+                            // only surfaces LIVE boss/interactive sessions — it
+                            // skips the stopped-session second-pass that
+                            // `load_real_workspaces` runs (reading sessions.json
+                            // for dead-tmux entries whose worktree still exists).
+                            // Without this, stopped sessions stay hidden until
+                            // the user happens to trigger a full refresh (stop a
+                            // session, delete one, press `f`). Enqueue exactly one
+                            // full refresh so the complete picture (stopped
+                            // sessions included) appears right after first paint.
+                            // Fires once per launch: this branch runs a single
+                            // time (the receiver is cleared above), and
+                            // `load_real_workspaces` doesn't re-arm it — no loop.
+                            // Guard on `None` so a user-queued action is never
+                            // clobbered.
+                            if self.pending_async_action.is_none() {
+                                self.pending_async_action = Some(AsyncAction::RefreshWorkspaces);
+                            }
+
                             return true;
                         }
                         WorkspaceLoadResult::Error(err) => {

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -958,4 +958,50 @@ mod tests {
         let state = AppState::new();
         assert!(state.selected_resumable_session_ids().is_empty());
     }
+
+    // ========================================================================
+    // Startup discovery: the fast loader must hand off to a full refresh so
+    // stopped sessions (which `load_workspaces_async` does not surface) appear
+    // without the user having to manually refresh.
+    // ========================================================================
+
+    #[test]
+    fn initial_background_load_enqueues_full_refresh_for_stopped_sessions() {
+        use crate::app::state::WorkspaceLoadResult;
+
+        let mut state = AppState::new();
+        state.pending_async_action = None;
+
+        // Simulate the startup background load completing.
+        let tx = state.start_background_workspace_loading();
+        tx.send(WorkspaceLoadResult::Success(Vec::new())).expect("send load result");
+
+        let updated = state.check_workspace_loading_complete();
+
+        assert!(updated, "applying the background result reports an update");
+        assert_eq!(
+            state.pending_async_action,
+            Some(AsyncAction::RefreshWorkspaces),
+            "fast startup load must enqueue a full refresh so stopped sessions surface"
+        );
+    }
+
+    #[test]
+    fn initial_background_load_does_not_clobber_a_queued_action() {
+        use crate::app::state::WorkspaceLoadResult;
+
+        let mut state = AppState::new();
+        // A user-queued action is already pending when the load completes.
+        state.pending_async_action = Some(AsyncAction::CleanupOrphaned);
+
+        let tx = state.start_background_workspace_loading();
+        tx.send(WorkspaceLoadResult::Success(Vec::new())).expect("send load result");
+        state.check_workspace_loading_complete();
+
+        assert_eq!(
+            state.pending_async_action,
+            Some(AsyncAction::CleanupOrphaned),
+            "an already-queued action must not be overwritten by the refresh hand-off"
+        );
+    }
 }


### PR DESCRIPTION
## Symptom
On launch, the session list showed only live sessions. **Stopped sessions** (and, on older builds, "Other tmux") only appeared after the user triggered a refresh — e.g. stopping another session, deleting one, or pressing `f`.

## Root cause
Two divergent workspace loaders:

```
STARTUP (App::init → background)          ACTION/REFRESH (stop, f, delete)
   load_workspaces_async()  (state.rs:2489)   load_real_workspaces()  (state.rs:3484)
     • boss + LIVE tmux only                    • boss + interactive
     • ✗ no stopped second-pass                 • ✓ stopped second-pass (4093-4151)
     • result applied verbatim                  • ✓ load_other_tmux_sessions()
       (check_workspace_loading_complete:3632)
```

The fast startup loader exists to avoid blocking on a slow Docker daemon, but it never runs the stopped-session second-pass (which reads `sessions.json` for dead-tmux entries whose worktree still exists). So stopped sessions stayed hidden until a full `load_real_workspaces` ran for some other reason.

## Fix
When the initial background load completes (`check_workspace_loading_complete` success branch), enqueue **exactly one** full `load_real_workspaces` refresh so the complete picture appears right after first paint.

- Fires once per launch (the receiver is cleared when the result is applied; `load_real_workspaces` doesn't re-arm it → no loop).
- Guarded on a `None` pending action so a user-queued action is never clobbered.
- Keeps the fast first paint (live sessions render immediately; stopped backfill follows).

## Tests
- `initial_background_load_enqueues_full_refresh_for_stopped_sessions` — full refresh is enqueued after the fast load.
- `initial_background_load_does_not_clobber_a_queued_action` — guard preserves an already-queued action.
- Full CI lib suite green locally: `cargo nextest run --lib --all-features … --skip docker::` → 883 passed, 37 skipped.

Note: stopped sessions whose worktree dir was deleted are intentionally routed to `/recover-sessions` (state.rs:4111/4119) — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stopped sessions were not visible during application startup. The app now properly displays the complete and accurate session list, including all stopped sessions, after the initial startup process completes.

* **Tests**
  * Added unit tests to verify correct session visibility during app startup and to ensure that any pending operations are properly preserved during workspace loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->