### PR TITLE
📦 Tank: support Stitch plugin skill subpaths

### DIFF
--- a/toolkit/bootstrap.js
+++ b/toolkit/bootstrap.js
@@ -1481,30 +1481,34 @@ async function handlePackagesStructureCopy(tool, config, overrideHomeDir = null,
                             const skillDir = `"\${HOME}/${config.targetSubdir}/${externalSkillsPath}/${skill.name}"`;
                             scriptLines.push(`# ${skill.name}${skill.purpose ? ' - ' + skill.purpose : ''}`);
                             scriptLines.push(`SKILL_DIR=${skillDir}`);
-                            if (skill['multi-subpath']) {
-                                // Repo bundles multiple sibling skills under <multi-subpath>/.
-                                // Clone repo to a temp dir, then for each subdir under
-                                // <multi-subpath>/ that contains SKILL.md, copy the whole
-                                // subdir into externalSkillsDir/<subdir-name>/ as a flat
-                                // sibling. Idempotent: skip any target that already has
-                                // SKILL.md.
+                            if (skill['multi-subpaths'] || skill['multi-subpath']) {
+                                // Repo bundles multiple sibling skills under one or more subpaths.
+                                // multi-subpaths: array of paths (new format — supports multiple plugin dirs)
+                                // multi-subpath: string (legacy — single path, backward compat)
+                                // Clone repo once, then for each subpath iterate SKILL.md-bearing
+                                // child dirs and copy (overwriting stale) into externalSkillsDir/.
+                                const subpaths = skill['multi-subpaths']
+                                    ? (Array.isArray(skill['multi-subpaths']) ? skill['multi-subpaths'] : [skill['multi-subpaths']])
+                                    : [skill['multi-subpath']];
                                 const extBase = `"\${HOME}/${config.targetSubdir}/${externalSkillsPath}"`;
-                                scriptLines.push(`echo "  Installing ${skill.name} bundle (multi-subpath: ${skill['multi-subpath']})..."`);
+                                const bundleLabel = skill['multi-subpaths']
+                                    ? `multi-subpaths: ${subpaths.join(', ')}`
+                                    : `multi-subpath: ${skill['multi-subpath']}`;
+                                scriptLines.push(`echo "  Installing ${skill.name} bundle (${bundleLabel})..."`);
                                 scriptLines.push(`TMP_CLONE=$(mktemp -d)`);
                                 scriptLines.push(`git clone --depth 1 ${skill.repo} "$TMP_CLONE/repo"`);
                                 scriptLines.push(`mkdir -p ${extBase}`);
-                                scriptLines.push(`for sub in "$TMP_CLONE/repo/${skill['multi-subpath']}"/*/; do`);
-                                scriptLines.push(`  sub_name=$(basename "$sub")`);
-                                scriptLines.push(`  if [ -f "$sub/SKILL.md" ]; then`);
-                                scriptLines.push(`    if [ -f ${extBase}/"$sub_name"/SKILL.md ]; then`);
-                                scriptLines.push(`      echo "    $sub_name already installed (skipping)"`);
-                                scriptLines.push(`    else`);
-                                scriptLines.push(`      mkdir -p ${extBase}/"$sub_name"`);
-                                scriptLines.push(`      cp -R "$sub"/. ${extBase}/"$sub_name"/`);
-                                scriptLines.push(`      echo "    Installed $sub_name"`);
-                                scriptLines.push(`    fi`);
-                                scriptLines.push(`  fi`);
-                                scriptLines.push(`done`);
+                                for (const sp of subpaths) {
+                                    scriptLines.push(`for sub in "$TMP_CLONE/repo/${sp}"/*/; do`);
+                                    scriptLines.push(`  sub_name=$(basename "$sub")`);
+                                    scriptLines.push(`  if [ -f "$sub/SKILL.md" ]; then`);
+                                    scriptLines.push(`    rm -rf ${extBase}/"$sub_name"`);
+                                    scriptLines.push(`    mkdir -p ${extBase}/"$sub_name"`);
+                                    scriptLines.push(`    cp -R "$sub"/. ${extBase}/"$sub_name"/`);
+                                    scriptLines.push(`    echo "    Installed/updated $sub_name"`);
+                                    scriptLines.push(`  fi`);
+                                    scriptLines.push(`done`);
+                                }
                                 scriptLines.push(`rm -rf "$TMP_CLONE"`);
                             } else if (skill.subpath) {
                                 // Repo contains the skill under a subdirectory. Clone to a temp
@@ -2209,8 +2213,9 @@ async function handleVerify(tool, overrideHomeDir) {
     if (agentSkillsApplicable.length > 0) {
         console.log(`${BOLD}agent-skills${RESET} (external git repos → ${externalSkillsPath}/)`);
         for (const skill of agentSkillsApplicable) {
-            if (skill['multi-subpath']) {
+            if (skill['multi-subpaths'] || skill['multi-subpath']) {
                 // Multi-skill bundle: expect sibling dirs in externalSkillsDir.
+                // Handles both multi-subpaths (array) and legacy multi-subpath (string).
                 // Each declared sub-skill name comes from manifest `skills:` list if
                 // present; otherwise we probe for any SKILL.md-bearing siblings.
                 const declaredSubs = Array.isArray(skill.skills)
@@ -2409,7 +2414,9 @@ async function handleVerify(tool, overrideHomeDir) {
             }
         }
     }
-    const agentSkillsForParity = (manifest['agent-skills'] || []).filter(s => !s['catalog-only'] && s.repo && !s['multi-subpath']);
+    // Exclude multi-subpath(s) bundles from the simple single-skill parity check;
+    // their sub-skills are verified by the agent-skills section above.
+    const agentSkillsForParity = (manifest['agent-skills'] || []).filter(s => !s['catalog-only'] && s.repo && !s['multi-subpath'] && !s['multi-subpaths']);
     parityCheck(agentSkillsForParity, '[agent-skill]', (home, cfg, entry) => {
         const ext = cfg.externalSkillsSubpath || 'skills';
         return path.join(home, cfg.targetSubdir, ext, entry.name);

--- a/toolkit/external-dependencies.yaml
+++ b/toolkit/external-dependencies.yaml
@@ -259,24 +259,43 @@ agent-skills:
 
   - name: stitch-skills
     repo: https://github.com/google-labs-code/stitch-skills
-    multi-subpath: skills
+    # multi-subpaths replaces the old single multi-subpath: skills entry.
+    # Upstream now uses a plugin layout with three plugin dirs, each containing
+    # a skills/ subdirectory. multi-subpaths iterates all three paths and
+    # flattens each SKILL.md-bearing child dir into the external skills dir.
+    # Legacy multi-subpath: <string> entries still work for backward compat.
+    multi-subpaths:
+      - plugins/stitch-utilities/skills
+      - plugins/stitch-design/skills
+      - plugins/stitch-build/skills
     applies-to: [claude, codex, copilot, gemini]
     purpose: "Google Stitch design-to-code skills for UI generation, React components, and video walkthroughs"
     multi-skill: true
     skills:
-      - design-md: "Synthesize semantic design systems into DESIGN.md"
-      - enhance-prompt: "Transform vague UI ideas into Stitch-optimized prompts"
+      # plugins/stitch-utilities/skills
+      - design-md: "Synthesize semantic design systems into DESIGN.md files for Stitch"
+      - enhance-prompt: "Transform vague UI ideas into polished Stitch-optimized prompts"
+      - stitch-loop: "Autonomous baton-passing loop for iterative website building with Stitch"
+      - taste-design: "Semantic design system skill for Google Stitch — generates agent-friendly DESIGN.md"
+      # plugins/stitch-design/skills
+      - generate-design: "Generate visual designs from natural-language prompts using Stitch MCP"
+      - manage-design-system: "Manage and update the design system stored in Stitch"
+      - extract-design-md: "Extract DESIGN.md semantic design specification from existing visual designs"
+      - extract-static-html: "Extract clean, self-contained static HTML from Stitch design outputs"
+      - upload-to-stitch: "Upload local assets and components to a Stitch project"
+      - code-to-design: "Convert existing code or components to a visual Stitch design"
+      # plugins/stitch-build/skills
       - react-components: "Convert Stitch designs into modular Vite/React components"
-      - remotion: "Generate walkthrough videos from Stitch projects"
-      - shadcn-ui: "shadcn/ui component integration and best practices"
-      - stitch-design: "Unified Stitch design entry point with prompt enhancement"
-      - stitch-loop: "Autonomous baton-passing loop for iterative website building"
+      - react-native: "Generate React Native components from Stitch designs"
+      - remotion: "Generate walkthrough videos from Stitch projects using Remotion"
+      - shadcn-ui: "shadcn/ui component integration, discovery, and best practices for Stitch builds"
     features:
       - Stitch MCP integration for AI-powered UI generation
       - Design system synthesis from visual designs
-      - React component extraction with AST validation
+      - React and React Native component extraction with AST validation
       - Remotion video walkthrough generation
       - shadcn/ui component discovery and customization
+      - Plugin layout: three plugin dirs (stitch-utilities, stitch-design, stitch-build)
 
   - name: mcporter
     repo: https://github.com/openclaw/mcporter


### PR DESCRIPTION
## Summary
- replace stale Stitch `multi-subpath: skills` manifest entry with current upstream plugin skill dirs via `multi-subpaths`
- add all 14 current Google Stitch skills to manifest expectations
- update bootstrap install/verify logic to support both legacy `multi-subpath` and new `multi-subpaths`, including stale skill refresh

## Test Plan
- `node --check toolkit/bootstrap.js`
- focused manifest/bootstrap smoke checks: 8/8 passed
- `npm test` after installing deps: existing Jest suite still 7 failed / 2 passed; same failure count confirmed with changes stashed, so unrelated pre-existing baseline

## Notes
- branch pushed: `fix/stitch-skills-plugin-subpaths`
- untracked `uv.lock` left untouched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill bundle installation robustness by properly cleaning destination directories before copying, preventing installation conflicts.
  * Enhanced skill integrity verification to recognize and validate all bundle types correctly.

* **Chores**
  * Updated skill dependency configuration to use standardized schema for improved consistency across the toolkit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->