### PR TITLE
docs: ecosystem architecture SVG in docsite + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,10 @@ The `/reflect` skill captures learnings. The `/research` and `/prime` skills ret
 
 ## Architecture
 
+<p align="center">
+  <img src="docs/assets/diagrams/ecosystem-architecture.svg" alt="agents-in-a-box ecosystem architecture — ainb TUI Rust workspace, JSON-RPC plugin host, fleet orchestration, portable toolkit deploying to 9+ tool homes, reflect GraphRAG memory, and the on-disk state that ties them together" width="900">
+</p>
+
 ```
 agents-in-a-box/
 │

--- a/docs/assets/diagrams/ecosystem-architecture.svg
+++ b/docs/assets/diagrams/ecosystem-architecture.svg
@@ -195,7 +195,7 @@
   <path d="M 190,820 V 914" fill="none" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
   <rect x="151" y="843" width="78" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
   <text x="190" y="852" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">write JSONL</text>
-  <path d="M 250,920 V 898 H 628 V 770 A 8 8 0 0 0 628,754 V 568 A 8 8 0 0 0 628,552 V 330 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 250,920 V 898 H 628 V 568 A 8 8 0 0 0 628,552 V 330 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
   <rect x="552" y="473.5" width="151" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
   <text x="628" y="482" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">plugins read transcripts</text>
   <path d="M 290,920 V 905 H 752 A 8 8 0 0 1 768,905 H 1160 V 578 H 1194" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>

--- a/docs/assets/diagrams/ecosystem-architecture.svg
+++ b/docs/assets/diagrams/ecosystem-architecture.svg
@@ -1,0 +1,225 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1720 1150" width="1720" height="1150">
+  <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif; }</style>
+  <defs>
+    <marker id="arr" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" fill="#5A554E"/></marker>
+    <marker id="arrClay" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" fill="#D97757"/></marker>
+    <marker id="arrOlive" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" fill="#788C5D"/></marker>
+    <filter id="soft" x="-10%" y="-10%" width="120%" height="130%"><feDropShadow dx="0" dy="1.5" stdDeviation="3" flood-color="#141413" flood-opacity="0.07"/></filter>
+  </defs>
+  <rect width="1720" height="1150" fill="#FAF9F5"/>
+  <text x="40" y="46" fill="#141413" font-size="27" font-weight="800">agents-in-a-box</text>
+  <rect x="40" y="56" width="252" height="4" rx="2" fill="#D97757"/>
+  <text x="312" y="46" fill="#6B655B" font-size="16">Ecosystem architecture - TUI orchestrator, plugin host, fleet control, portable toolkit, GraphRAG memory</text>
+  <rect x="40" y="100" width="560" height="540" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="64" y="132" fill="#141413" font-size="16.5" font-weight="700">1 - ainb TUI - Rust workspace (11 crates)</text>
+  <text x="64" y="151" fill="#6B655B" font-size="11.5">terminal UI + CLI, single binary, tmux-persistent sessions</text>
+  <rect x="64" y="170" width="512" height="92" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="320.0" y="203" text-anchor="middle" fill="#141413" font-size="15" font-weight="700">ainb-core</text>
+  <text x="320.0" y="224" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">TUI: home - sessions - usage - inbox - code review</text>
+  <text x="320.0" y="242" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">CLI: run - list - attach - usage - plugin - fleet - doctor</text>
+  <path d="M 140,262 V 296" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 320,262 V 296" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 500,262 V 296" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="64" y="300" width="152" height="84" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="140.0" y="329" text-anchor="middle" fill="#141413" font-size="13" font-weight="700">Docker</text>
+  <text x="140.0" y="348" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Bollard API</text>
+  <text x="140.0" y="364" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">per-session env</text>
+  <rect x="244" y="300" width="152" height="84" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="320.0" y="329" text-anchor="middle" fill="#141413" font-size="13" font-weight="700">Git worktrees</text>
+  <text x="320.0" y="348" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">branch-per-</text>
+  <text x="320.0" y="364" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">session isolation</text>
+  <rect x="424" y="300" width="152" height="84" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="500.0" y="329" text-anchor="middle" fill="#141413" font-size="13" font-weight="700">tmux</text>
+  <text x="500.0" y="348" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">PTY attach</text>
+  <text x="500.0" y="364" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">send-keys</text>
+  <path d="M 140,384 V 410" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 320,384 V 410" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 500,384 V 410" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="64" y="414" width="512" height="66" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="320.0" y="442" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">Provider adapters</text>
+  <text x="320.0" y="462" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">claude - codex - gemini - copilot (Provider trait)</text>
+  <rect x="64" y="508" width="512" height="56" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="320.0" y="531" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.agents-in-a-box/</text>
+  <text x="320.0" y="549" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">config.toml - favorites.yaml - presets - plugin root</text>
+  <text x="320" y="606" text-anchor="middle" fill="#6B655B" font-size="11.5">crates: core + plugin-protocol / runtime / sdk-rust / testkit / cts-v2 / types + 4 plugin binaries</text>
+  <rect x="660" y="100" width="480" height="350" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="684" y="132" fill="#141413" font-size="16.5" font-weight="700">2 - Plugin host - subprocess runtime</text>
+  <text x="684" y="151" fill="#6B655B" font-size="11.5">manifest v2 discovery from ~/.agents-in-a-box/plugins/</text>
+  <rect x="684" y="156" width="432" height="62" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="900.0" y="182" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">ainb-plugin-runtime</text>
+  <text x="900.0" y="202" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">spawn - lifecycle FSM - snapshot/action bus - render frames</text>
+  <path d="M 900,218 V 268" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="824" y="239" width="152" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="900" y="248" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">JSON-RPC 2.0 over stdio</text>
+  <rect x="684" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="733.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">burndown</text>
+  <text x="733.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">usage + cost</text>
+  <text x="733.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">analytics</text>
+  <rect x="795" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="844.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">session-reader</text>
+  <text x="844.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">JSONL parse</text>
+  <text x="844.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">SQLite cache</text>
+  <rect x="906" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="955.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">notifyd</text>
+  <text x="955.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">notifications</text>
+  <text x="955.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">inbox feed</text>
+  <rect x="1017" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1066.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">witr</text>
+  <text x="1066.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">process</text>
+  <text x="1066.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">causality</text>
+  <rect x="684" y="386" width="432" height="44" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="900.0" y="411" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="600">SDK + conformance: protocol - sdk-rust - testkit - cts-v2 (14 axes)</text>
+  <rect x="1200" y="100" width="480" height="350" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="1224" y="132" fill="#141413" font-size="16.5" font-weight="700">3 - Toolkit - write once, deploy to 9+ tools</text>
+  <text x="1224" y="151" fill="#6B655B" font-size="11.5">toolkit/ in the ai-coder-rules monorepo</text>
+  <rect x="1224" y="156" width="432" height="64" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1440.0" y="183" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">toolkit/packages/</text>
+  <text x="1440.0" y="203" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">91 skills - 37 agents - 22 hooks - workflows - knowledge</text>
+  <path d="M 1340,220 V 248" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="1224" y="252" width="300" height="70" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1374" y="276" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">bootstrap.js</text>
+  <text x="1374" y="294" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">TOOL_DIR templating</text>
+  <text x="1374" y="310" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">external-dependencies.yaml</text>
+  <path d="M 1340,322 V 342" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="1355" y="323" width="47" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="1378" y="332" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">deploy</text>
+  <rect x="1224" y="346" width="432" height="70" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1440.0" y="368" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">Tool homes (9+)</text>
+  <text x="1440.0" y="388" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">~/.claude - ~/.codex - ~/.copilot - ~/.gemini</text>
+  <text x="1440.0" y="404" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">hermes - nanoclaw - cursor - amazon q - ...</text>
+  <path d="M 1580,342 V 224" fill="none" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
+  <rect x="1531" y="277.5" width="98" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="1580" y="286" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">/sync-learnings</text>
+  <rect x="660" y="500" width="480" height="310" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="684" y="532" fill="#141413" font-size="16.5" font-weight="700">4 - Fleet orchestration - ainb fleet</text>
+  <text x="684" y="551" fill="#6B655B" font-size="11.5">drive every agent session on the host</text>
+  <rect x="684" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="731.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">discover</text>
+  <text x="731.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">ainb - peers</text>
+  <text x="731.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">db - bg jobs</text>
+  <path d="M 778,600 H 798" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="798" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="845.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">merge</text>
+  <text x="845.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">dedup</text>
+  <text x="845.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">by cwd</text>
+  <path d="M 892,600 H 912" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="912" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="959.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">read</text>
+  <text x="959.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">JSONL tail -</text>
+  <text x="959.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">pane - needs</text>
+  <path d="M 1006,600 H 1026" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="1026" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1073.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">send</text>
+  <text x="1073.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">broker first,</text>
+  <text x="1073.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">tmux fallback</text>
+  <rect x="684" y="668" width="436" height="44" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="902.0" y="693" text-anchor="middle" fill="#141413" font-size="12" font-weight="600">verbs: standup - broadcast - sequence - needs - daemon</text>
+  <rect x="684" y="736" width="436" height="54" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="902.0" y="758" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">claude-peers broker - HTTP :7899</text>
+  <text x="902.0" y="776" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">register - heartbeat - send-message - poll</text>
+  <rect x="1200" y="500" width="480" height="310" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="1224" y="532" fill="#141413" font-size="16.5" font-weight="700">5 - reflect - GraphRAG memory</text>
+  <text x="1224" y="551" fill="#6B655B" font-size="11.5">correct once, never again - cross-tool learnings</text>
+  <rect x="1224" y="556" width="432" height="60" rx="10" fill="#C9D2B8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1440.0" y="581" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">plugins/reflect (Claude plugin)</text>
+  <text x="1440.0" y="601" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">PreCompact drain - SessionStart recall - /reflect skills</text>
+  <path d="M 1400,616 V 644" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
+  <rect x="1413" y="625" width="47" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="1436" y="634" text-anchor="middle" fill="#788C5D" font-size="11" font-weight="600">ingest</text>
+  <rect x="1224" y="648" width="340" height="60" rx="10" fill="#C9D2B8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1394.0" y="674" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">reflect-kb CLI (python)</text>
+  <text x="1394.0" y="693" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">nano-graphrag - nano-vectordb - sidecars</text>
+  <path d="M 1400,708 V 736" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
+  <rect x="1400" y="717" width="96" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="1448" y="726" text-anchor="middle" fill="#788C5D" font-size="11" font-weight="600">index - search</text>
+  <rect x="1224" y="740" width="432" height="54" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1440.0" y="762" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.claude/global-learnings/</text>
+  <text x="1440.0" y="780" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">documents/*.md - *.entities.yaml - graph cache</text>
+  <path d="M 1610,740 V 620" fill="none" stroke="#788C5D" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arrOlive)"/>
+  <rect x="1587" y="675.5" width="45" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="1610" y="684" text-anchor="middle" fill="#788C5D" font-size="10.5" font-weight="600">recall</text>
+  <rect x="40" y="690" width="560" height="130" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="64" y="722" fill="#141413" font-size="16.5" font-weight="700">Live agent sessions</text>
+  <text x="64" y="741" fill="#6B655B" font-size="11.5">tmux panes - Docker containers - git worktrees</text>
+  <rect x="64" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="122.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">claude</text>
+  <text x="122.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Claude Code</text>
+  <rect x="198" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="256.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">codex</text>
+  <text x="256.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Codex CLI</text>
+  <rect x="332" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="390.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">gemini</text>
+  <text x="390.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Gemini CLI</text>
+  <rect x="466" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="524.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">copilot</text>
+  <text x="524.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Copilot CLI</text>
+  <rect x="40" y="870" width="1100" height="150" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="64" y="902" fill="#141413" font-size="16.5" font-weight="700">Data on disk</text>
+  <rect x="64" y="920" width="250" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="189.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.claude/projects/</text>
+  <text x="189.0" y="963" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">**/*.jsonl transcripts</text>
+  <text x="189.0" y="980" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">turns - usage - stop_reason</text>
+  <rect x="334" y="920" width="230" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="449.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.codex/sessions/</text>
+  <text x="449.0" y="963" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">rollout-*.jsonl</text>
+  <text x="449.0" y="980" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">written by codex CLI</text>
+  <rect x="584" y="920" width="220" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="694.0" y="953" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.claude-peers.db</text>
+  <text x="694.0" y="971" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">peer registry (SQLite)</text>
+  <rect x="824" y="920" width="292" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="970.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.agents-in-a-box/plugins/</text>
+  <text x="970.0" y="963" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">manifests + plugin binaries</text>
+  <text x="970.0" y="980" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">discovered by plugin runtime</text>
+  <rect x="1200" y="870" width="480" height="150" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
+  <text x="1224" y="902" fill="#141413" font-size="16.5" font-weight="700">6 - Distribution + docs</text>
+  <rect x="1224" y="920" width="130" height="76" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1289.0" y="953" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">Homebrew</text>
+  <text x="1289.0" y="972" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">tap -> ainb</text>
+  <rect x="1370" y="920" width="130" height="76" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1435.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">docs/ tree</text>
+  <text x="1435.0" y="963" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">tui - toolkit -</text>
+  <text x="1435.0" y="980" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">plugins - kb</text>
+  <rect x="1516" y="920" width="140" height="76" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
+  <text x="1586.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">Starlight site</text>
+  <text x="1586.0" y="963" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">website/site -></text>
+  <text x="1586.0" y="980" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">GitHub Pages</text>
+  <path d="M 600,210 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="594" y="187.5" width="69" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="628" y="196" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">spawn host</text>
+  <path d="M 600,560 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="591" y="537.5" width="75" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="628" y="546" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">fleet verbs</text>
+  <path d="M 320,640 V 684" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="272" y="658" width="96" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="320" y="667" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">spawn - attach</text>
+  <path d="M 190,820 V 914" fill="none" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
+  <rect x="151" y="843" width="78" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="190" y="852" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">write JSONL</text>
+  <path d="M 250,920 V 898 H 628 V 770 A 8 8 0 0 0 628,754 V 568 A 8 8 0 0 0 628,552 V 330 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="552" y="473.5" width="151" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="628" y="482" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">plugins read transcripts</text>
+  <path d="M 290,920 V 905 H 752 A 8 8 0 0 1 768,905 H 1160 V 578 H 1194" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
+  <rect x="877" y="892.5" width="216" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="985" y="901" text-anchor="middle" fill="#788C5D" font-size="10.5" font-weight="600">harvest transcripts -> ingest queue</text>
+  <path d="M 760,790 V 914" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <rect x="717" y="836.5" width="86" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="760" y="845" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">peer registry</text>
+  <path d="M 684,762 H 644 A 8 8 0 0 0 628,762 H 606" fill="none" stroke="#D97757" stroke-width="2" marker-end="url(#arrClay)"/>
+  <rect x="596" y="739.5" width="92" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
+  <text x="642" y="748" text-anchor="middle" fill="#D97757" font-size="10.5" font-weight="600">deliver prompt</text>
+  <rect x="40" y="1050" width="660" height="64" rx="10" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.2"/>
+  <text x="60" y="1075" fill="#141413" font-size="12.5" font-weight="700">Legend</text>
+  <line x1="130" y1="1071" x2="166" y2="1071" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="174" y="1075" fill="#6B655B" font-size="11.5">data / control flow</text>
+  <line x1="130" y1="1097" x2="166" y2="1097" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
+  <text x="174" y="1101" fill="#6B655B" font-size="11.5">write / feedback</text>
+  <line x1="330" y1="1071" x2="366" y2="1071" stroke="#D97757" stroke-width="2" marker-end="url(#arrClay)"/>
+  <text x="374" y="1075" fill="#6B655B" font-size="11.5">fleet prompt delivery</text>
+  <line x1="330" y1="1097" x2="366" y2="1097" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
+  <text x="374" y="1101" fill="#6B655B" font-size="11.5">learning loop (reflect)</text>
+  <rect x="530" y="1062" width="14" height="14" rx="4" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.2"/>
+  <text x="552" y="1073" fill="#6B655B" font-size="11.5">active component</text>
+  <rect x="530" y="1088" width="14" height="14" rx="4" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.2"/>
+  <text x="552" y="1099" fill="#6B655B" font-size="11.5">storage / state</text>
+  <text x="1680" y="1100" text-anchor="end" fill="#6B655B" font-size="11">ai-coder-rules monorepo - ainb-tui v1.5 - toolkit - reflect-kb</text>
+</svg>

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -8,6 +8,14 @@ How the four components of agents-in-a-box fit together.
 
 ---
 
+## Ecosystem map
+
+![agents-in-a-box ecosystem architecture — ainb TUI Rust workspace, JSON-RPC plugin host, fleet orchestration, portable toolkit deploying to 9+ tool homes, reflect GraphRAG memory, and the on-disk state that ties them together](../assets/diagrams/ecosystem-architecture.svg)
+
+Solid arrows are data/control flow, dashed arrows are writes and feedback, clay is fleet prompt delivery, and olive is the learning loop. The small hops where lines cross are jump-overs — the lines do not connect.
+
+---
+
 ## Box diagram
 
 ```


### PR DESCRIPTION
## What

- Adds `docs/assets/diagrams/ecosystem-architecture.svg` — hand-authored, fully editable SVG (no external assets, Claude brand palette) mapping the whole agents-in-a-box ecosystem: ainb TUI workspace (11 crates), JSON-RPC plugin host, fleet orchestration, toolkit bootstrap to 9+ tool homes, reflect GraphRAG memory, distribution/docs, and shared on-disk state.
- Embeds it in `docs/product/architecture.md` (whole-system architecture page, new **Ecosystem map** section above the existing box diagram).
- Embeds it in the README `## Architecture` section above the directory tree.

## Why

The architecture section had only ASCII diagrams; this gives the docsite and README a single visual ecosystem map. Kept as SVG (not PNG) so it stays editable.

## Notes

- Follows the existing `docs/assets/diagrams/*.svg` + relative-markdown-image convention already used by plugin docs, so the Starlight site picks it up with no config changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ecosystem architecture diagrams to README and architecture documentation, providing visual representation of system components and their relationships.
  * Included comprehensive visual legend explaining diagram elements: arrow types, color coding, shapes, and connection notation for improved architecture clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->