### PR TITLE
feat(site): click-to-zoom lightbox on all docsite images

### DIFF
--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import starlightImageZoom from 'starlight-image-zoom';
 
 // https://astro.build/config
 export default defineConfig({
@@ -19,6 +20,7 @@ export default defineConfig({
           href: 'https://github.com/stevengonsalvez/agents-in-a-box',
         },
       ],
+      plugins: [starlightImageZoom()],
       customCss: ['./src/styles/tokens.css', './src/styles/crt.css'],
       editLink: {
         baseUrl: 'https://github.com/stevengonsalvez/agents-in-a-box/edit/main/',

--- a/website/site/package-lock.json
+++ b/website/site/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@astrojs/starlight": "^0.39.2",
         "astro": "^6.3.1",
-        "sharp": "^0.34.5"
+        "sharp": "^0.34.5",
+        "starlight-image-zoom": "^0.14.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -5554,6 +5555,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/starlight-image-zoom": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/starlight-image-zoom/-/starlight-image-zoom-0.14.2.tgz",
+      "integrity": "sha512-YBvE724gFMiVjObGtXmfIDi3zAxVBsvGukeRXOiWLNnESFOBZFfO9DpC/reHohrCxFrO+5ot0XR8EimbE0LpsA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx-jsx": "^3.2.0",
+        "rehype-raw": "^7.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.38.0"
       }
     },
     "node_modules/stream-replace-string": {

--- a/website/site/package.json
+++ b/website/site/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.39.2",
     "astro": "^6.3.1",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "starlight-image-zoom": "^0.14.2"
   }
 }


### PR DESCRIPTION
## What

Adds the [`starlight-image-zoom`](https://starlight-image-zoom.netlify.app/) Starlight plugin (v0.14.2, peer-compatible with our Starlight ^0.39) and registers it in `astro.config.mjs`. Every content image on the docsite — architecture SVGs, screenshots, code-review GIFs — now opens in a fullscreen lightbox on click, dismissed with Escape or click-outside. Keyboard-accessible (zoom control button per image).

## Verification

- `npm run build` green, 42 pages
- Built HTML inspected: every content `<img>` wrapped in `starlight-image-zoom-zoomable` (product/architecture 1/1, plugins/overview 2/2, tui/code-review 4/4)
- Click-tested in a real browser against `astro preview`: ecosystem SVG and burndown PNG both pop out fullscreen with caption; Escape closes