### PR TITLE
fix(tui): seed branch-collision guards from clone cache for remote picks

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3864,19 +3864,11 @@ impl AppState {
         let source = cfg.repo_source.clone();
         let list_path: Option<std::path::PathBuf> = match &source {
             RepoSource::LocalPath(p) => Some(p.clone()),
-            RepoSource::HttpsUrl(_)
-            | RepoSource::SshUrl(_)
-            | RepoSource::GithubShorthand { .. } => {
-                crate::git::RemoteRepoManager::new().ok().and_then(|m| {
-                    source
-                        .parse_components()
-                        .ok()
-                        .filter(|parsed| m.is_cached(parsed))
-                        .map(|parsed| m.get_cache_path(&parsed))
-                })
-            }
-            // SshSession / Filter never show the Branch row.
-            _ => None,
+            // Remote sources resolve to their clone cache when already cloned;
+            // SshSession / Filter never show the Branch row (resolver → None).
+            _ => crate::git::RemoteRepoManager::new()
+                .ok()
+                .and_then(|m| m.cached_source_path(&source)),
         };
 
         let existing = cfg.existing_branches.clone();
@@ -6318,14 +6310,25 @@ impl AppState {
         // add` will accept — the legacy `list_worktrees()` alone missed by-name
         // worktrees (Stevie 2026-05-27: feat/blog re-launch slipped through;
         // review P1, PR #211 added the repo's own checkout; deduped in #232).
-        let repo_path = match &source {
-            crate::git::repo_source::RepoSource::LocalPath(p) => Some(p.as_path()),
-            _ => None,
+        let repo_path: Option<std::path::PathBuf> = match &source {
+            crate::git::repo_source::RepoSource::LocalPath(p) => Some(p.clone()),
+            // Remote/star picks: when the clone cache already exists, its refs
+            // ARE the repo — seed both guards from it so typing an existing
+            // branch warns inline BEFORE launch instead of dying at
+            // `git worktree add -b` (Stevie 2026-06-09: feat/ota on the cached
+            // shotclubhouse pick slipped through and failed only after Launch).
+            // A not-yet-cached remote still starts empty; the base-picker
+            // ls-remote refresh backfills `repo_branch_names` later.
+            _ => crate::git::RemoteRepoManager::new()
+                .ok()
+                .and_then(|m| m.cached_source_path(&source)),
         };
+        let repo_path = repo_path.as_deref();
         let existing_branches = crate::git::branch_list::in_use_branch_names(repo_path);
         // All existing branch names (local heads + remote-tracking) for the
-        // base-off "⚠ exists" guard. Cheap for a local repo; a remote pick
-        // fills this in later when the base picker lists/fetches branches.
+        // base-off "⚠ exists" guard. Cheap for a local repo or a cached
+        // remote; a not-yet-cached remote pick fills this in later when the
+        // base picker lists/fetches branches.
         let repo_branch_names: Vec<String> = repo_path
             .map(|p| {
                 crate::git::branch_list::list_repo_branches(p)

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -74,7 +74,12 @@ impl RemoteRepoManager {
 
     /// Check if a repo is already cached (standard clone with .git subdirectory)
     pub fn is_cached(&self, parsed: &ParsedRepo) -> bool {
-        let cache_path = self.get_cache_path(parsed);
+        Self::cache_path_is_populated(&self.get_cache_path(parsed))
+    }
+
+    /// The one definition of "this cache path holds a usable clone" — shared
+    /// by `is_cached` and `cached_source_path` so the rule can't drift.
+    fn cache_path_is_populated(cache_path: &Path) -> bool {
         cache_path.exists() && cache_path.join(".git").exists()
     }
 
@@ -88,11 +93,11 @@ impl RemoteRepoManager {
         match source {
             RepoSource::HttpsUrl(_)
             | RepoSource::SshUrl(_)
-            | RepoSource::GithubShorthand { .. } => source
-                .parse_components()
-                .ok()
-                .filter(|parsed| self.is_cached(parsed))
-                .map(|parsed| self.get_cache_path(&parsed)),
+            | RepoSource::GithubShorthand { .. } => {
+                let parsed = source.parse_components().ok()?;
+                let cache_path = self.get_cache_path(&parsed);
+                Self::cache_path_is_populated(&cache_path).then_some(cache_path)
+            }
             _ => None,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -78,6 +78,25 @@ impl RemoteRepoManager {
         cache_path.exists() && cache_path.join(".git").exists()
     }
 
+    /// Cache path for a clonable remote source IF it is already cloned.
+    /// `None` for a not-yet-cached remote and for sources that never clone
+    /// (local paths, SSH sessions, filter text). This is the disk location
+    /// whose refs seed the Configure screen's branch-collision guards and
+    /// the base-branch popup — keep every caller on this one resolver so the
+    /// guards and the popup can never disagree about where refs live.
+    pub fn cached_source_path(&self, source: &RepoSource) -> Option<PathBuf> {
+        match source {
+            RepoSource::HttpsUrl(_)
+            | RepoSource::SshUrl(_)
+            | RepoSource::GithubShorthand { .. } => source
+                .parse_components()
+                .ok()
+                .filter(|parsed| self.is_cached(parsed))
+                .map(|parsed| self.get_cache_path(&parsed)),
+            _ => None,
+        }
+    }
+
     /// List remote branches without cloning (uses git ls-remote)
     pub fn list_remote_branches(
         &self,
@@ -1133,6 +1152,39 @@ mod tests {
         let parsed = source.parse_components().unwrap();
 
         assert!(!manager.is_cached(&parsed));
+    }
+
+    #[test]
+    fn cached_source_path_resolves_only_cached_remotes() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = RemoteRepoManager::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+        // Fake a cached clone: `is_cached` checks for `<cache>/.git` on disk.
+        let cached = temp_dir.path().join("github.com").join("owner").join("repo");
+        std::fs::create_dir_all(cached.join(".git")).unwrap();
+
+        // Cached remote → resolves to the clone-cache path. This is the seed
+        // for the Configure screen's branch-collision guards: without it a
+        // remote pick gets empty guard lists and an existing branch name only
+        // fails AFTER Launch, at `git worktree add -b` (the feat/ota repro).
+        let hit = RepoSource::GithubShorthand {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+        assert_eq!(manager.cached_source_path(&hit), Some(cached));
+
+        // Same shape, never cloned → None (guards backfill async instead).
+        let miss = RepoSource::GithubShorthand {
+            owner: "owner".to_string(),
+            repo: "never-cloned".to_string(),
+        };
+        assert_eq!(manager.cached_source_path(&miss), None);
+
+        // Non-clonable sources never resolve, even if a path happens to exist.
+        let local = RepoSource::LocalPath(temp_dir.path().to_path_buf());
+        assert_eq!(manager.cached_source_path(&local), None);
+        let ssh_session = RepoSource::SshSession("ssh://user@host".to_string());
+        assert_eq!(manager.cached_source_path(&ssh_session), None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`advance_pick_repo_to_configure` only resolved a repo path for `LocalPath` sources. A remote/star pick reached the Configure screen with an empty `repo_branch_names` and an `existing_branches` list that missed the clone cache's checkouts. Typing an existing branch name (e.g. `feat/ota` on the cached shotclubhouse pick) showed no inline ⚠ warning and failed only after Launch, at `git worktree add -b`:

```
remote pick → repo_path = None → guard lists EMPTY
type feat/ota → no ⚠ → Launch → "Failed to create worktree: branch already exists"
```

## Fix

- New `RemoteRepoManager::cached_source_path()` — the single resolver from a clonable source to its clone-cache path when already cloned. `None` for not-yet-cached remotes and never-clonable sources (LocalPath / SshSession / Filter).
- `advance_pick_repo_to_configure` seeds both guards from the cache for remote picks, so the live ⚠ warning and the pre-launch block behave identically to local picks.
- `open_branch_picker` deduplicated onto the same resolver (was a copy of the `is_cached → get_cache_path` ladder).
- Not-yet-cached remotes keep async behaviour: guards start empty, base-picker refresh backfills.

## Testing

- New unit test `cached_source_path_resolves_only_cached_remotes` (cached remote → path, never-cloned → None, LocalPath/SshSession → None)
- All 38 configure tests + 79 git module tests pass
- `cargo check` clean (existing warnings on main unchanged)