### PR TITLE
feat(session-reader): incremental refresh by default, hard refresh on demand

### DIFF
--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -157,3 +157,14 @@ show_git_status = true
 #
 # Load everything EXCEPT these (denylist). Ignored when `enabled` is set.
 # disabled = ["burndown"]
+
+# ── Session-reader plugin ─────────────────────────────────────────────
+# The session-reader plugin (usage analytics data backend) refreshes
+# incrementally: files modified within the trailing window below are
+# re-aggregated on each refresh; older history is served from a
+# persisted rollup. A hard refresh (Shift+R in the Analytics screen,
+# or `ainb usage --hard`) rebuilds everything from source.
+#
+# [session_reader]
+# Trailing recent-window size in days (default 30, minimum 1).
+# incremental_window_days = 30

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -680,8 +680,41 @@ async fn dispatch_inner(
     // canonical encoding is asserted byte-for-byte by
     // `refresh_request_hard_wire_bytes_are_pinned` in
     // ainb-plugin-types-sessions — change one, that test fails.
+    // (The exact-token argv scan cannot fire on malformed invocations:
+    // clap validates the full `usage` surface in the registry hook
+    // before dispatch_inner runs, so a typo'd command errors out
+    // before any publish.)
     if argv.iter().any(|a| a == "--hard") {
         const HARD_REFRESH_MSGPACK: [u8; 7] = [0x81, 0xA4, b'h', b'a', b'r', b'd', 0xC3];
+        // Publishing to a topic with no subscriber yet is a silent
+        // no-op — racing session-reader's on_init subscribe would
+        // silently downgrade --hard to a normal refresh. Wait (bounded)
+        // for both subscribers to finish init: session-reader
+        // subscribes to refresh_request during on_init, and burndown
+        // must observe the hard request to drop its stale snapshot so
+        // the retry loop below can only be satisfied by post-rebuild
+        // data.
+        let session_reader = PluginId::from("session-reader");
+        let subscribe_deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            use ainb_plugin_runtime::LifecycleState;
+            let sr = handle.lifecycle_state(&session_reader);
+            let bd = handle.lifecycle_state(&burndown);
+            if matches!(sr, Some(LifecycleState::Running))
+                && matches!(bd, Some(LifecycleState::Running))
+            {
+                break;
+            }
+            if std::time::Instant::now() >= subscribe_deadline {
+                eprintln!(
+                    "warning: --hard requested but plugins not running yet \
+                     (session-reader: {sr:?}, burndown: {bd:?}); the hard \
+                     refresh may be downgraded to a normal one"
+                );
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
         handle.publish_snapshot(
             "sessions.refresh_request",
             bytes::Bytes::from_static(&HARD_REFRESH_MSGPACK),

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -667,6 +667,30 @@ async fn dispatch_inner(
         );
     }
 
+    // `--hard`: tell session-reader to wipe its caches and rebuild
+    // from source before we poll for data. This is the ONE place the
+    // CLI publishes a refresh itself — the normal path relies on
+    // burndown's on_init publish (re-publishing incrementals here
+    // would queue redundant rescans and starve cli_dispatch).
+    //
+    // The payload is the msgpack encoding of the wire type
+    // `ainb_plugin_types_sessions::RefreshRequest { hard: true }`
+    // (`to_vec_named`: fixmap{ "hard": true }). Hand-pinned bytes so
+    // the host CLI stays decoupled from the plugin codec crates; the
+    // canonical encoding is asserted byte-for-byte by
+    // `refresh_request_hard_wire_bytes_are_pinned` in
+    // ainb-plugin-types-sessions — change one, that test fails.
+    if argv.iter().any(|a| a == "--hard") {
+        const HARD_REFRESH_MSGPACK: [u8; 7] = [0x81, 0xA4, b'h', b'a', b'r', b'd', 0xC3];
+        handle.publish_snapshot(
+            "sessions.refresh_request",
+            bytes::Bytes::from_static(&HARD_REFRESH_MSGPACK),
+        );
+        if trace {
+            eprintln!("[usage-cli] --hard: published hard refresh_request");
+        }
+    }
+
     // Retry contract: burndown reports `exit_code = 1` + empty stdout +
     // a stderr containing this exact byte sequence when `self.data` is
     // None. Any *other* exit/stdout/stderr shape (including a real

--- a/ainb-tui/crates/ainb-core/src/cli/usage.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/usage.rs
@@ -125,6 +125,12 @@ pub struct UsageReportArgs {
     /// Bypass the persistent usage cache and force a full re-parse.
     #[arg(long)]
     pub no_cache: bool,
+    /// Hard refresh: wipe the parse cache and stable rollup, then
+    /// rebuild everything from source before reporting. CPU-heavy on
+    /// large histories; the flag itself is the explicit opt-in (no
+    /// interactive prompt, safe for pipes/scripts).
+    #[arg(long)]
+    pub hard: bool,
     // ---- Cross-filter knobs (mirrors of the TUI dashboard pivot) ----
     // All four are repeatable; multiple values for the same filter
     // are OR-combined, and different filters AND together. They layer

--- a/ainb-tui/crates/ainb-core/tests/tripwire_burndown_hard_refresh_confirm.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_burndown_hard_refresh_confirm.rs
@@ -1,0 +1,260 @@
+//! Tripwire: the hard-refresh confirm journey end-to-end.
+//!
+//! `R` on the analytics screen must raise the ⚠ confirm overlay —
+//! NOT fire a rebuild; `n` must dismiss it with the prior data still
+//! on screen; `R` → `y` must dismiss the overlay, publish the hard
+//! refresh, and the dashboard must come back with data after the
+//! rebuild republishes. Asserting the full key→JSON-RPC→plugin→render
+//! pipe, same shape as `tripwire_burndown_keys.rs`:
+//!
+//!   tmux send-keys → host forwards key → Burndown::handle_key →
+//!     confirm_hard state → render overlay → (y) hard refresh_request
+//!     → session-reader wipes caches + rebuilds → usage_data republish.
+//!
+//! Runs against the deterministic `tripwire_keys` fixture (isolated
+//! HOME, pinned AINB_NOW). Skips gracefully when `tmux` or the staged
+//! `dist/plugins` binaries are unavailable — mirroring the gates on
+//! `tripwire_burndown_keys.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Walk up from the ainb binary looking for the `dist/plugins/`
+/// staging dir produced by `scripts/build-plugins.sh`. Returns `None`
+/// if absent so the test can skip rather than fail in fresh checkouts.
+fn plugins_staged() -> Option<PathBuf> {
+    let bin = ainb_bin();
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate.join("session-reader").join("session-reader").exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("tripwire_keys")
+}
+
+fn fixture_now() -> String {
+    fs::read_to_string(fixture_root().join("FIXTURE_NOW.txt"))
+        .expect("FIXTURE_NOW.txt present")
+        .trim()
+        .to_string()
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("mkdir dst");
+    for entry in fs::read_dir(src).expect("read_dir src") {
+        let entry = entry.expect("dir entry");
+        let ty = entry.file_type().expect("file_type");
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&from, &to);
+        } else if ty.is_file() {
+            fs::copy(&from, &to).expect("copy file");
+        }
+    }
+}
+
+fn seed_fixture_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    let fixture = fixture_root();
+    let claude_src = fixture.join("claude").join("projects");
+    if claude_src.is_dir() {
+        copy_dir_all(&claude_src, &home.join(".claude").join("projects"));
+    }
+    let codex_src = fixture.join("codex").join("sessions");
+    if codex_src.is_dir() {
+        copy_dir_all(&codex_src, &home.join(".codex").join("sessions"));
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+fn kill_session(session: &str) {
+    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
+}
+
+/// The overlay's distinctive copy — present iff the confirm is up.
+const OVERLAY_MARKER: &str = "Re-parses ALL session history";
+
+fn has_data(cap: &str) -> bool {
+    cap.contains("Usage Analytics")
+        && cap.contains('$')
+        && cap.chars().any(|ch| ch.is_ascii_digit())
+}
+
+#[test]
+fn hard_refresh_requires_confirm_and_survives_cancel() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!(
+            "SKIP: dist/plugins/{{burndown,session-reader}} not staged — \
+             run `scripts/build-plugins.sh` first"
+        );
+        return;
+    };
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_fixture_home(home_tmp.path());
+
+    let session = format!("tripwire-hardrefresh-{}", std::process::id());
+    let ainb = ainb_bin();
+
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "200", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    let cmd = format!(
+        "HOME={} AINB_PLUGIN_ROOT={} AINB_NOW={} exec {} tui",
+        home_tmp.path().display(),
+        plugin_root.display(),
+        fixture_now(),
+        ainb.display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux send launch cmd");
+
+    let home_deadline = Instant::now() + Duration::from_secs(45);
+    if poll_capture(&session, home_deadline, |c| {
+        c.contains("Stats") && c.contains("[i]")
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
+    }
+
+    // Enter analytics, wait for real data.
+    send_key(&session, "i");
+    let data_deadline = Instant::now() + Duration::from_secs(45);
+    if poll_capture(&session, data_deadline, |c| {
+        has_data(c) && !c.contains("Waiting for session-reader plugin")
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("burndown never rendered data; last:\n---\n{last}\n---");
+    }
+
+    // R must raise the confirm overlay — and must NOT have fired a
+    // rebuild (the prior data is still behind the modal).
+    send_key(&session, "R");
+    let overlay = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
+        c.contains(OVERLAY_MARKER)
+    });
+    if overlay.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("R did not raise the hard-refresh confirm overlay; last:\n---\n{last}\n---");
+    }
+
+    // n cancels: overlay gone, data intact, nothing rebuilt.
+    send_key(&session, "n");
+    let cancelled = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
+        !c.contains(OVERLAY_MARKER) && has_data(c)
+    });
+    if cancelled.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("cancel did not dismiss overlay with data intact; last:\n---\n{last}\n---");
+    }
+
+    // R → y confirms: overlay drops, the hard rebuild runs, and the
+    // dashboard must come back with data once the rebuild republishes.
+    // (The fixture tree is tiny so the rebuild completes in seconds.)
+    send_key(&session, "R");
+    if poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
+        c.contains(OVERLAY_MARKER)
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("second R did not raise the overlay; last:\n---\n{last}\n---");
+    }
+    send_key(&session, "y");
+    let rebuilt = poll_capture(&session, Instant::now() + Duration::from_secs(45), |c| {
+        !c.contains(OVERLAY_MARKER) && has_data(c)
+    });
+    if rebuilt.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("hard refresh did not republish data; last:\n---\n{last}\n---");
+    }
+
+    kill_session(&session);
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -123,6 +123,12 @@ pub struct UsageReportArgs {
     /// Bypass the persistent usage cache and force a full re-parse.
     #[arg(long)]
     pub no_cache: bool,
+    /// Hard refresh: wipe the parse cache and stable rollup, then
+    /// rebuild everything from source before reporting. CPU-heavy on
+    /// large histories; the flag itself is the explicit opt-in (no
+    /// interactive prompt, safe for pipes/scripts).
+    #[arg(long)]
+    pub hard: bool,
     // ---- Cross-filter knobs (mirrors of the TUI dashboard pivot) ----
     // All four are repeatable; multiple values for the same filter
     // are OR-combined, and different filters AND together. They layer
@@ -1807,6 +1813,26 @@ fn plan_show_args_for_plan(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `--hard` must parse on the report surface (both this mirror and
+    /// the host's `cli/usage.rs` carry the flag; the host publishes the
+    /// hard refresh before dispatching) and default to off.
+    #[test]
+    fn hard_flag_parses_and_defaults_off() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Probe {
+            #[command(flatten)]
+            args: UsageReportArgs,
+        }
+
+        let probe = Probe::parse_from(["usage", "--hard"]);
+        assert!(probe.args.hard);
+
+        let probe = Probe::parse_from(["usage"]);
+        assert!(!probe.args.hard);
+    }
 
     #[test]
     fn csv_cell_escapes_formula_starts() {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -13,7 +13,7 @@ use ainb_plugin_sdk::{
     Result, SdkError, WireBuffer,
 };
 use ainb_plugin_types_sessions::{
-    ScanProgressEvent, UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
+    RefreshRequest, ScanProgressEvent, UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
 };
 use async_trait::async_trait;
 use ratatui::buffer::Buffer as RBuffer;
@@ -203,16 +203,42 @@ impl Plugin for BurndownPlugin {
     /// Generation is bumped only when the dispatch matched a binding,
     /// so unmapped keys won't trigger an avoidable re-render.
     async fn handle_key(&mut self, host: &HostClient, params: HandleKeyParams) -> Result<()> {
+        // Hard-refresh confirm overlay is modal: while it's up, every
+        // key resolves it. Dispatched before everything else so the
+        // confirm `y` can never collide with the zoom-yank `y` below.
+        if self.ui.confirm_hard {
+            self.ui.confirm_hard = false;
+            if matches!(params.key.code, KeyCode::Char { ch: 'y' | 'Y' }) {
+                let payload = rmp_serde::to_vec_named(&RefreshRequest { hard: true })
+                    .map(bytes::Bytes::from)
+                    .unwrap_or_default();
+                let _ = host.snapshot_publish("sessions.refresh_request", payload).await;
+            }
+            // Any other key cancels: prior data stays on screen,
+            // nothing is published. (`Esc` is host-reserved and pops
+            // the screen before reaching us, hence `n`/anything.)
+            self.generation = self.generation.wrapping_add(1);
+            return Ok(());
+        }
+
         // Refresh + flush-cache are the two bindings that need the
         // host. Everything else mutates `self.ui` only, so it lives in
         // the pure helper below for testability.
         let handled = match params.key.code {
-            KeyCode::Char { ch: 'r' | 'R' } => {
-                // Ask session-reader to re-publish from scratch. Best
-                // effort — failure is silently dropped, the existing
-                // snapshot stays on screen.
+            KeyCode::Char { ch: 'r' } => {
+                // Ask session-reader to re-publish. Empty payload =
+                // incremental refresh (the cheap path). Best effort —
+                // failure is silently dropped, the existing snapshot
+                // stays on screen.
                 let _ =
                     host.snapshot_publish("sessions.refresh_request", bytes::Bytes::new()).await;
+                true
+            }
+            KeyCode::Char { ch: 'R' } => {
+                // Hard refresh re-parses ALL history from source —
+                // CPU-heavy, so it's gated behind the ⚠ confirm
+                // overlay. Nothing publishes until `y`.
+                self.ui.confirm_hard = true;
                 true
             }
             KeyCode::Char { ch: 'F' } => {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -148,6 +148,13 @@ impl Plugin for BurndownPlugin {
         // walking the per-provider dirs on a cold cache. Failure is
         // non-fatal — the legacy ⏳ Waiting spinner remains.
         let _ = host.snapshot_subscribe("sessions.scan_progress").await;
+        // Subscribe to refresh requests so a HARD refresh (from our own
+        // R-confirm or the CLI --hard) drops the in-memory snapshot:
+        // the dashboard falls back to the scanning skeleton, and the
+        // CLI dispatch retry loop can only be satisfied by data
+        // published AFTER the rebuild — never by the pre-wipe snapshot
+        // the user just declared distrusted.
+        let _ = host.snapshot_subscribe("sessions.refresh_request").await;
 
         // Trigger a fresh publish. Eager-spawned session-reader runs
         // its first publish during its own `on_init`, which races
@@ -171,6 +178,28 @@ impl Plugin for BurndownPlugin {
             }
             "sessions.scan_progress" => {
                 self.ingest_scan_progress(host, &params.payload).await;
+            }
+            "sessions.refresh_request" => {
+                // Empty payload = incremental ping (our own r key, the
+                // FS watcher) — nothing to do. Only a hard refresh
+                // invalidates what is on screen.
+                let hard = !params.payload.is_empty()
+                    && rmp_serde::from_slice::<RefreshRequest>(&params.payload)
+                        .map(|req| req.hard)
+                        .unwrap_or(false);
+                if hard {
+                    self.data = None;
+                    self.pending = None;
+                    self.ui.data = None;
+                    self.ui.cached_filtered = None;
+                    self.filter_cache = None;
+                    self.generation = self.generation.wrapping_add(1);
+                    let _ = host
+                        .log_info(
+                            "burndown: hard refresh observed — dropped snapshot, awaiting rebuild",
+                        )
+                        .await;
+                }
             }
             _ => {}
         }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -1104,16 +1104,25 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
 /// so it never fires from a single keypress. `Esc` is host-reserved
 /// (pops the screen), so cancel rides `n` / any other key.
 fn render_hard_refresh_confirm(buf: &mut Buffer, area: Rect) {
-    let w = 56.min(area.width.saturating_sub(2)).max(20);
-    let h = 7.min(area.height.saturating_sub(2)).max(5);
+    // Below this the overlay copy is unreadable anyway, and a rect
+    // wider/taller than the buffer would panic ratatui's
+    // Buffer::get_mut. The key handling still works without the
+    // overlay (y confirms / anything cancels) — degraded, not broken.
+    if area.width < 20 || area.height < 5 {
+        return;
+    }
+    let w = 56.min(area.width.saturating_sub(2));
+    let h = 7.min(area.height.saturating_sub(2));
     let x = area.x + (area.width.saturating_sub(w)) / 2;
     let y = area.y + (area.height.saturating_sub(h)) / 2;
+    // Belt-and-braces: never paint outside the buffer.
     let rect = Rect {
         x,
         y,
         width: w,
         height: h,
-    };
+    }
+    .intersection(area);
 
     ratatui::widgets::Widget::render(Clear, rect, buf);
     let block = Block::default()
@@ -5009,6 +5018,28 @@ mod cross_filter_tests {
             !flat.contains("Re-parses ALL session history"),
             "overlay leaked into normal render"
         );
+    }
+
+    /// Regression (review MAJOR-3): the confirm overlay must never
+    /// panic on tiny viewports — ratatui's Buffer panics on
+    /// out-of-bounds writes, and a render panic kills the plugin.
+    #[test]
+    fn hard_refresh_confirm_overlay_survives_tiny_viewports() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut state = UsageViewState::default();
+        state.confirm_hard = true;
+
+        for (w, h) in [(1u16, 1u16), (5, 3), (12, 4), (19, 5), (21, 4), (25, 6)] {
+            let backend = TestBackend::new(w, h);
+            let mut terminal = Terminal::new(backend).expect("test backend");
+            terminal
+                .draw(|frame| {
+                    let area = frame.size();
+                    render(frame.buffer_mut(), area, &state);
+                })
+                .unwrap_or_else(|e| panic!("render panicked at {w}x{h}: {e}"));
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -4,10 +4,10 @@
 use chrono::{Datelike, Local, NaiveDate};
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Gauge, Paragraph, Row, Table, Tabs},
+    widgets::{Block, BorderType, Borders, Clear, Gauge, Paragraph, Row, Table, Tabs},
 };
 
 use ainb_plugin_types_sessions::ScanProgressEvent;
@@ -373,6 +373,11 @@ pub struct UsageViewState {
     /// after a successful `y` clipboard copy. Cleared on the next
     /// handled key so it flashes briefly then disappears.
     pub copy_flash: Option<String>,
+    /// `R` pressed: the ⚠ hard-refresh confirm overlay is up. `y`
+    /// publishes the hard refresh; any other key cancels. Gated
+    /// behind a confirm because a hard refresh re-parses ALL session
+    /// history from source — the CPU-heavy path.
+    pub confirm_hard: bool,
 }
 
 /// Per-column width step applied by `<` / `>` in the zoom table.
@@ -410,6 +415,7 @@ impl Default for UsageViewState {
             zoom_col_deltas: Vec::new(),
             zoom_cols_panel: None,
             copy_flash: None,
+            confirm_hard: false,
         }
     }
 }
@@ -1085,6 +1091,65 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     }
 
     render_help_bar(buf, layout[help_idx], state);
+
+    // Drawn last so it overlays whatever the dashboard painted.
+    if state.confirm_hard {
+        render_hard_refresh_confirm(buf, area);
+    }
+}
+
+/// Centered ⚠ confirm overlay for the hard refresh (`R`). A hard
+/// refresh wipes the parse cache + stable rollup and re-parses ALL
+/// session history from source — CPU-heavy on large `$HOME` datasets —
+/// so it never fires from a single keypress. `Esc` is host-reserved
+/// (pops the screen), so cancel rides `n` / any other key.
+fn render_hard_refresh_confirm(buf: &mut Buffer, area: Rect) {
+    let w = 56.min(area.width.saturating_sub(2)).max(20);
+    let h = 7.min(area.height.saturating_sub(2)).max(5);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let rect = Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    };
+
+    ratatui::widgets::Widget::render(Clear, rect, buf);
+    let block = Block::default()
+        .title(Span::styled(
+            " ⚠ Hard refresh ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(PANEL_BG));
+    let inner = block.inner(rect);
+    ratatui::widgets::Widget::render(block, rect, buf);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            "Re-parses ALL session history from source.",
+            Style::default().fg(SOFT_WHITE),
+        )),
+        Line::from(Span::styled(
+            "High CPU for a while on large histories.",
+            Style::default().fg(MUTED_GRAY),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("y", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" rebuild everything   ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("n", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
+        ]),
+    ];
+    ratatui::widgets::Widget::render(
+        Paragraph::new(lines).alignment(Alignment::Center),
+        inner,
+        buf,
+    );
 }
 
 /// Render a slim one-row scan-progress banner above the dashboard. Different
@@ -4384,8 +4449,10 @@ fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     spans.extend_from_slice(&[
         Span::styled("j/k", Style::default().fg(GOLD)),
         Span::styled(" scroll  ", Style::default().fg(MUTED_GRAY)),
-        Span::styled("r/R", Style::default().fg(GOLD)),
+        Span::styled("r", Style::default().fg(GOLD)),
         Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("R", Style::default().fg(GOLD)),
+        Span::styled(" hard refresh  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("F", Style::default().fg(GOLD)),
         Span::styled(" flush cache  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("Esc", Style::default().fg(GOLD)),
@@ -4885,6 +4952,63 @@ mod cross_filter_tests {
             .collect();
         assert!(flat.contains("By Branch"), "panel title missing: {flat}");
         assert!(flat.contains("main"), "branch label missing: {flat}");
+    }
+
+    /// The ⚠ hard-refresh confirm overlay must paint over the
+    /// dashboard when `confirm_hard` is set, with the warning copy and
+    /// both key affordances visible — and stay invisible when unset.
+    #[test]
+    fn hard_refresh_confirm_overlay_renders_when_pending() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut state = UsageViewState::default();
+        state.data = Some(std::sync::Arc::new(fixture()));
+        state.confirm_hard = true;
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("test backend");
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                render(frame.buffer_mut(), area, &state);
+            })
+            .expect("render with confirm overlay must not panic");
+
+        let buffer = terminal.backend().buffer();
+        let flat: String = (0..buffer.area().height)
+            .flat_map(|y| (0..buffer.area().width).map(move |x| (x, y)))
+            .map(|(x, y)| buffer.get(x, y).symbol().to_string())
+            .collect();
+        assert!(
+            flat.contains("Hard refresh"),
+            "overlay title missing: {flat}"
+        );
+        assert!(
+            flat.contains("Re-parses ALL session history"),
+            "warning copy missing"
+        );
+        assert!(flat.contains("rebuild everything"), "y affordance missing");
+        assert!(flat.contains("cancel"), "n affordance missing");
+
+        // And without the flag the overlay must not paint.
+        state.confirm_hard = false;
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("test backend");
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                render(frame.buffer_mut(), area, &state);
+            })
+            .expect("render without overlay must not panic");
+        let buffer = terminal.backend().buffer();
+        let flat: String = (0..buffer.area().height)
+            .flat_map(|y| (0..buffer.area().width).map(move |x| (x, y)))
+            .map(|(x, y)| buffer.get(x, y).symbol().to_string())
+            .collect();
+        assert!(
+            !flat.contains("Re-parses ALL session history"),
+            "overlay leaked into normal render"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 rmp-serde = "1.3"
+toml = { workspace = true }
 bytes = { version = "1.6", features = ["serde"] }
 tracing = { workspace = true }
 
@@ -42,7 +43,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-toml = { workspace = true }
 ainb-plugin-protocol = { path = "../ainb-plugin-protocol" }
 
 [[test]]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -228,8 +228,17 @@ impl UsageCache {
     /// next scan re-parses every file from source and the incremental
     /// path sees no stable aggregate (cold start).
     pub fn clear(&mut self) -> Result<(), CacheError> {
-        self.conn.execute("DELETE FROM file_cache", [])?;
-        self.conn.execute("DELETE FROM stable_aggregate", [])?;
+        // One transaction + busy retry: under cross-process contention a
+        // partial wipe (file_cache gone, rollup still present) must
+        // never become visible to the other instance.
+        with_busy_retry(|| {
+            self.conn.execute_batch(
+                "BEGIN IMMEDIATE;
+                 DELETE FROM file_cache;
+                 DELETE FROM stable_aggregate;
+                 COMMIT;",
+            )
+        })?;
         // VACUUM is a tidiness operation; failure here doesn't matter.
         if let Err(err) = self.conn.execute("VACUUM", []) {
             tracing::warn!("session-reader cache VACUUM after clear failed: {err}");
@@ -316,7 +325,11 @@ impl UsageCache {
             )?;
         }
 
-        if version != SCHEMA_VERSION {
+        // Only stamp UP. A db written by a NEWER build (two ainb
+        // versions sharing one usage.sqlite) must keep its higher
+        // version: stamping it down would make the newer binary re-run
+        // its migrations against an already-migrated schema.
+        if version < SCHEMA_VERSION {
             conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
         }
         Ok(())
@@ -558,6 +571,26 @@ mod tests {
             cache.load_stable().expect("load").is_none(),
             "clear() wipes the stable aggregate"
         );
+    }
+
+    #[test]
+    fn newer_schema_version_is_never_stamped_down() {
+        // Two ainb versions share one usage.sqlite. A db written by a
+        // NEWER build must keep its higher user_version: stamping it
+        // down would make the newer binary re-run its migrations
+        // against an already-migrated schema.
+        let dir = TempDir::new().expect("tempdir");
+        let db = dir.path().join("usage.sqlite");
+        {
+            let cache = UsageCache::open(&db).expect("open v2");
+            cache.conn.pragma_update(None, "user_version", 99).expect("fake v99");
+        }
+        let cache = UsageCache::open(&db).expect("reopen");
+        let version: i64 = cache
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("pragma");
+        assert_eq!(version, 99, "future schema version preserved");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -39,12 +39,43 @@
 #![allow(clippy::cast_possible_wrap)]
 
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ainb_plugin_types_sessions::ProviderCall;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 
 use crate::fnv::fnv1a_64;
+
+/// How long a writer waits for a competing writer/checkpoint before SQLite
+/// returns `SQLITE_BUSY`. Two ainb instances share one `usage.sqlite`, so an
+/// overlapping scan's write would otherwise collide instantly and the caller
+/// falls back to a cache-less (re-parsing) scan — doubling CPU. 5s comfortably
+/// covers a scan's write burst.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Retry a SQLite op when it fails with `BUSY`/`LOCKED`. `busy_timeout` already
+/// blocks for [`BUSY_TIMEOUT`] per attempt; this is a small bounded backstop
+/// for the rare case it still surfaces (e.g. a WAL checkpoint stall under two
+/// concurrent writers). Bounded so a genuinely wedged DB still surfaces an error.
+fn with_busy_retry<T>(mut op: impl FnMut() -> rusqlite::Result<T>) -> rusqlite::Result<T> {
+    use rusqlite::ffi::ErrorCode;
+    let mut attempt: u32 = 0;
+    loop {
+        let result = op();
+        if let Err(rusqlite::Error::SqliteFailure(err, _)) = &result {
+            if matches!(
+                err.code,
+                ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked
+            ) && attempt < 3
+            {
+                attempt += 1;
+                std::thread::sleep(Duration::from_millis(50 * u64::from(attempt)));
+                continue;
+            }
+        }
+        return result;
+    }
+}
 
 /// Current on-disk schema version. Bumping this triggers the v0→vN
 /// migration block in [`UsageCache::migrate`].
@@ -97,6 +128,10 @@ impl UsageCache {
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         conn.pragma_update(None, "temp_store", "MEMORY")?;
+        // Block (up to BUSY_TIMEOUT) instead of erroring when another instance
+        // holds the write lock, so concurrent scans serialize rather than
+        // dropping to a cache-less reparse.
+        conn.busy_timeout(BUSY_TIMEOUT)?;
         Self::migrate(&conn)?;
         Ok(Self { conn })
     }
@@ -112,20 +147,21 @@ impl UsageCache {
         mtime: u64,
         size: u64,
     ) -> Result<Option<Vec<ProviderCall>>, CacheError> {
-        let row: Option<(i64, i64, Vec<u8>)> = self
-            .conn
-            .query_row(
-                "SELECT mtime, size, parsed FROM file_cache WHERE path = ?1",
-                params![path],
-                |row| {
-                    Ok((
-                        row.get::<_, i64>(0)?,
-                        row.get::<_, i64>(1)?,
-                        row.get::<_, Vec<u8>>(2)?,
-                    ))
-                },
-            )
-            .optional()?;
+        let row: Option<(i64, i64, Vec<u8>)> = with_busy_retry(|| {
+            self.conn
+                .query_row(
+                    "SELECT mtime, size, parsed FROM file_cache WHERE path = ?1",
+                    params![path],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                        ))
+                    },
+                )
+                .optional()
+        })?;
 
         let Some((stored_mtime, stored_size, blob)) = row else {
             return Ok(None);
@@ -158,24 +194,26 @@ impl UsageCache {
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
-        self.conn.execute(
-            "INSERT INTO file_cache (path, mtime, size, fingerprint, parsed, cached_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(path) DO UPDATE SET
-                mtime       = excluded.mtime,
-                size        = excluded.size,
-                fingerprint = excluded.fingerprint,
-                parsed      = excluded.parsed,
-                cached_at   = excluded.cached_at",
-            params![
-                path,
-                i64::try_from(mtime).unwrap_or(i64::MAX),
-                i64::try_from(size).unwrap_or(i64::MAX),
-                i64::from_ne_bytes(fingerprint.to_ne_bytes()),
-                blob,
-                cached_at,
-            ],
-        )?;
+        with_busy_retry(|| {
+            self.conn.execute(
+                "INSERT INTO file_cache (path, mtime, size, fingerprint, parsed, cached_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(path) DO UPDATE SET
+                    mtime       = excluded.mtime,
+                    size        = excluded.size,
+                    fingerprint = excluded.fingerprint,
+                    parsed      = excluded.parsed,
+                    cached_at   = excluded.cached_at",
+                params![
+                    path,
+                    i64::try_from(mtime).unwrap_or(i64::MAX),
+                    i64::try_from(size).unwrap_or(i64::MAX),
+                    i64::from_ne_bytes(fingerprint.to_ne_bytes()),
+                    blob,
+                    cached_at,
+                ],
+            )
+        })?;
         Ok(())
     }
 
@@ -421,6 +459,43 @@ mod tests {
         // Original (mtime=1, size=1) row is gone.
         let stale = cache.lookup("/tmp/a.jsonl", 1, 1).expect("lookup");
         assert!(stale.is_none());
+    }
+
+    #[test]
+    fn concurrent_writers_serialize_without_busy_error() {
+        // Two ainb instances share one usage.sqlite. With WAL + busy_timeout,
+        // overlapping writers must serialize instead of erroring SQLITE_BUSY
+        // (which would drop the scan to a cache-less reparse). Without the
+        // busy_timeout pragma this test flakes/panics under contention.
+        use std::sync::Arc;
+        let dir = TempDir::new().expect("tempdir");
+        let db = Arc::new(dir.path().join("usage.sqlite"));
+        // Seed the DB so both threads open an existing WAL file.
+        drop(UsageCache::open(&db).expect("seed open"));
+
+        let handles: Vec<_> = (0..2u64)
+            .map(|t| {
+                let db = Arc::clone(&db);
+                std::thread::spawn(move || {
+                    let mut cache = UsageCache::open(&db).expect("open under contention");
+                    for i in 0..200u64 {
+                        let path = format!("/tmp/t{t}-{i}.jsonl");
+                        cache
+                            .insert(&path, i, i, i, &[fake_call(i)])
+                            .expect("insert under contention");
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("writer thread");
+        }
+
+        // Both writers' rows landed.
+        let cache = UsageCache::open(&db).expect("reopen");
+        assert!(cache.lookup("/tmp/t0-199.jsonl", 199, 199).expect("lookup").is_some());
+        assert!(cache.lookup("/tmp/t1-199.jsonl", 199, 199).expect("lookup").is_some());
     }
 
     // `default_db_path` reads `AINB_HOME` / `XDG_DATA_HOME` / `HOME`

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -239,7 +239,6 @@ impl UsageCache {
 
     /// Persist the stable (older-than-watermark) aggregate. Single-row
     /// upsert; the previous rollup is replaced atomically.
-    #[allow(dead_code)] // wired in by scan_incremental (P4)
     pub fn store_stable(
         &mut self,
         stable: &crate::scanner::StableAggregate,
@@ -260,7 +259,6 @@ impl UsageCache {
     /// A decode failure (blob written by an incompatible build) is
     /// treated as absence — the caller rebuilds from the per-file
     /// cache, which self-heals the row on the next `store_stable`.
-    #[allow(dead_code)] // wired in by scan_incremental (P4)
     pub fn load_stable(&self) -> Result<Option<crate::scanner::StableAggregate>, CacheError> {
         let row: Option<Vec<u8>> = with_busy_retry(|| {
             self.conn

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -79,7 +79,10 @@ fn with_busy_retry<T>(mut op: impl FnMut() -> rusqlite::Result<T>) -> rusqlite::
 
 /// Current on-disk schema version. Bumping this triggers the v0→vN
 /// migration block in [`UsageCache::migrate`].
-pub const SCHEMA_VERSION: i64 = 1;
+///
+/// v2: adds the single-row `stable_aggregate` table holding the
+/// bincode'd incremental-refresh rollup. Additive over v1.
+pub const SCHEMA_VERSION: i64 = 2;
 
 /// Cache error surface.
 #[derive(Debug, thiserror::Error)]
@@ -217,10 +220,16 @@ impl UsageCache {
         Ok(())
     }
 
-    /// Drop every cached row. Schema row (PRAGMA user_version) is
-    /// preserved so re-opens don't trigger another migration.
+    /// Drop every cached row — the per-file parse cache AND the stable
+    /// aggregate. Schema row (PRAGMA user_version) is preserved so
+    /// re-opens don't trigger another migration.
+    ///
+    /// This is the hard-refresh / flush primitive: after a clear, the
+    /// next scan re-parses every file from source and the incremental
+    /// path sees no stable aggregate (cold start).
     pub fn clear(&mut self) -> Result<(), CacheError> {
         self.conn.execute("DELETE FROM file_cache", [])?;
+        self.conn.execute("DELETE FROM stable_aggregate", [])?;
         // VACUUM is a tidiness operation; failure here doesn't matter.
         if let Err(err) = self.conn.execute("VACUUM", []) {
             tracing::warn!("session-reader cache VACUUM after clear failed: {err}");
@@ -228,9 +237,57 @@ impl UsageCache {
         Ok(())
     }
 
-    /// Apply v0→v1 schema migration using `PRAGMA user_version`.
-    /// Future bumps append additional `if version < N` blocks before
-    /// the final `pragma_update`.
+    /// Persist the stable (older-than-watermark) aggregate. Single-row
+    /// upsert; the previous rollup is replaced atomically.
+    #[allow(dead_code)] // wired in by scan_incremental (P4)
+    pub fn store_stable(
+        &mut self,
+        stable: &crate::scanner::StableAggregate,
+    ) -> Result<(), CacheError> {
+        let blob = bincode::serialize(stable)?;
+        with_busy_retry(|| {
+            self.conn.execute(
+                "INSERT INTO stable_aggregate (id, blob) VALUES (1, ?1)
+                 ON CONFLICT(id) DO UPDATE SET blob = excluded.blob",
+                params![blob],
+            )
+        })?;
+        Ok(())
+    }
+
+    /// Load the persisted stable aggregate, if any.
+    ///
+    /// A decode failure (blob written by an incompatible build) is
+    /// treated as absence — the caller rebuilds from the per-file
+    /// cache, which self-heals the row on the next `store_stable`.
+    #[allow(dead_code)] // wired in by scan_incremental (P4)
+    pub fn load_stable(&self) -> Result<Option<crate::scanner::StableAggregate>, CacheError> {
+        let row: Option<Vec<u8>> = with_busy_retry(|| {
+            self.conn
+                .query_row(
+                    "SELECT blob FROM stable_aggregate WHERE id = 1",
+                    [],
+                    |row| row.get::<_, Vec<u8>>(0),
+                )
+                .optional()
+        })?;
+        let Some(blob) = row else {
+            return Ok(None);
+        };
+        match bincode::deserialize(&blob) {
+            Ok(stable) => Ok(Some(stable)),
+            Err(err) => {
+                tracing::warn!(
+                    "session-reader cache: stable aggregate decode failed ({err}); rebuilding"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Apply schema migrations using `PRAGMA user_version`. Each bump
+    /// appends an additional `if version < N` block before the final
+    /// `pragma_update`.
     fn migrate(conn: &Connection) -> Result<(), CacheError> {
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0)).unwrap_or(0);
 
@@ -245,6 +302,19 @@ impl UsageCache {
                      cached_at   INTEGER NOT NULL
                  );
                  CREATE INDEX IF NOT EXISTS idx_mtime ON file_cache(mtime);",
+            )?;
+        }
+
+        // v1→v2: single-row home for the bincode'd StableAggregate
+        // (incremental refresh rollup). Additive — `file_cache` rows
+        // survive, so the upgrade costs one stable rebuild, not a full
+        // re-parse.
+        if version < 2 {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS stable_aggregate (
+                     id   INTEGER PRIMARY KEY CHECK (id = 1),
+                     blob BLOB    NOT NULL
+                 );",
             )?;
         }
 
@@ -390,13 +460,122 @@ mod tests {
     }
 
     #[test]
-    fn migrate_sets_user_version_to_one() {
+    fn migrate_sets_user_version_to_current() {
         let (_dir, cache) = open_in_tmp();
         let version: i64 = cache
             .conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("pragma");
         assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn v1_db_migrates_to_v2_preserving_file_cache() {
+        // Hand-build a v1-schema DB (file_cache only, user_version=1)
+        // with one row, then open through UsageCache and assert the
+        // migration is additive: the parse row survives, the version
+        // bumps, and the stable_aggregate table exists (empty).
+        let dir = TempDir::new().expect("tempdir");
+        let db = dir.path().join("usage.sqlite");
+        {
+            let conn = Connection::open(&db).expect("raw open");
+            conn.execute_batch(
+                "CREATE TABLE file_cache (
+                     path        TEXT    PRIMARY KEY,
+                     mtime       INTEGER NOT NULL,
+                     size        INTEGER NOT NULL,
+                     fingerprint INTEGER NOT NULL,
+                     parsed      BLOB    NOT NULL,
+                     cached_at   INTEGER NOT NULL
+                 );
+                 CREATE INDEX idx_mtime ON file_cache(mtime);
+                 PRAGMA user_version = 1;",
+            )
+            .expect("create v1 schema");
+            let blob = bincode::serialize(&vec![fake_call(7)]).expect("blob");
+            conn.execute(
+                "INSERT INTO file_cache (path, mtime, size, fingerprint, parsed, cached_at)
+                 VALUES ('/tmp/v1.jsonl', 5, 6, 0, ?1, 0)",
+                params![blob],
+            )
+            .expect("seed v1 row");
+        }
+
+        let cache = UsageCache::open(&db).expect("open migrates");
+        let version: i64 = cache
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("pragma");
+        assert_eq!(version, 2, "v1 db migrated to v2");
+
+        let hit = cache.lookup("/tmp/v1.jsonl", 5, 6).expect("lookup").expect("hit");
+        assert_eq!(hit[0].id, 7, "pre-migration parse row survives");
+
+        assert!(
+            cache.load_stable().expect("load").is_none(),
+            "fresh v2 upgrade has no stable aggregate yet"
+        );
+    }
+
+    #[test]
+    fn stable_aggregate_roundtrips() {
+        let (_dir, mut cache) = open_in_tmp();
+        let stable = crate::scanner::StableAggregate {
+            watermark_nanos: 1_234_567,
+            folded: vec![
+                ("/tmp/a.jsonl".into(), 42, 100),
+                ("/tmp/b.jsonl".into(), 43, 7),
+            ],
+            state: crate::scanner::fold(vec![fake_call(1), fake_call(2)]),
+        };
+        cache.store_stable(&stable).expect("store");
+        let back = cache.load_stable().expect("load").expect("present");
+        assert_eq!(back.watermark_nanos, stable.watermark_nanos);
+        assert_eq!(back.folded, stable.folded);
+        assert_eq!(back.state.calls.len(), 2);
+
+        // Upsert replaces, not appends.
+        let stable2 = crate::scanner::StableAggregate {
+            watermark_nanos: 99,
+            folded: Vec::new(),
+            state: crate::scanner::fold(Vec::new()),
+        };
+        cache.store_stable(&stable2).expect("store 2");
+        let back2 = cache.load_stable().expect("load 2").expect("present");
+        assert_eq!(back2.watermark_nanos, 99);
+        assert!(back2.folded.is_empty());
+    }
+
+    #[test]
+    fn clear_drops_stable_aggregate_too() {
+        let (_dir, mut cache) = open_in_tmp();
+        let stable = crate::scanner::StableAggregate {
+            watermark_nanos: 1,
+            folded: vec![("/tmp/a.jsonl".into(), 1, 1)],
+            state: crate::scanner::fold(vec![fake_call(1)]),
+        };
+        cache.store_stable(&stable).expect("store");
+        cache.clear().expect("clear");
+        assert!(
+            cache.load_stable().expect("load").is_none(),
+            "clear() wipes the stable aggregate"
+        );
+    }
+
+    #[test]
+    fn corrupt_stable_blob_reads_as_absent() {
+        let (_dir, mut cache) = open_in_tmp();
+        cache
+            .conn
+            .execute(
+                "INSERT INTO stable_aggregate (id, blob) VALUES (1, X'DEADBEEF')",
+                [],
+            )
+            .expect("plant corrupt blob");
+        assert!(
+            cache.load_stable().expect("load must not error").is_none(),
+            "undecodable stable blob degrades to None (forces rebuild)"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
@@ -1,0 +1,160 @@
+//! Plugin-side config: the `[session_reader]` table of
+//! `~/.agents-in-a-box/config.toml`.
+//!
+//! Read-only — the host owns the file; this plugin only consumes its
+//! own table (mirroring the burndown plugin's disk-read pattern, since
+//! `PluginInitParams` carries no config channel). Any read or parse
+//! failure falls back to defaults: config must never break a scan.
+//!
+//! ```toml
+//! [session_reader]
+//! incremental_window_days = 30
+//! ```
+
+// Consumed by the incremental scan path (`scan_incremental`, P4) and
+// cold-start seeding (P8) on this branch; until those land the module
+// is exercised only by its tests.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Default trailing window (days) for the incremental refresh: files
+/// whose mtime is older than `now - window` are served from the
+/// persisted stable aggregate instead of being re-aggregated.
+pub const DEFAULT_INCREMENTAL_WINDOW_DAYS: u32 = 30;
+
+/// Parsed `[session_reader]` table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct SessionReaderConfig {
+    /// Trailing recent-window size in days. `0` is clamped to `1` so a
+    /// misconfigured zero window cannot disable recency entirely.
+    pub incremental_window_days: u32,
+}
+
+impl Default for SessionReaderConfig {
+    fn default() -> Self {
+        Self {
+            incremental_window_days: DEFAULT_INCREMENTAL_WINDOW_DAYS,
+        }
+    }
+}
+
+impl SessionReaderConfig {
+    /// The effective window, clamped to at least one day.
+    #[must_use]
+    pub fn window_days(self) -> u32 {
+        self.incremental_window_days.max(1)
+    }
+}
+
+/// Load from the default host config path. Missing file, unreadable
+/// file, unparseable TOML, or a malformed `[session_reader]` table all
+/// degrade to [`SessionReaderConfig::default`] (with a warn log).
+#[must_use]
+pub fn load() -> SessionReaderConfig {
+    match default_config_path() {
+        Some(path) => load_from(&path),
+        None => SessionReaderConfig::default(),
+    }
+}
+
+/// Load from an explicit path (testable entry point).
+#[must_use]
+pub fn load_from(path: &Path) -> SessionReaderConfig {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return SessionReaderConfig::default();
+    };
+    let root: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!("session-reader: config parse failed ({err}); using defaults");
+            return SessionReaderConfig::default();
+        }
+    };
+    match root.get("session_reader").cloned() {
+        Some(table) => table.try_into().unwrap_or_else(|err| {
+            tracing::warn!(
+                "session-reader: [session_reader] table malformed ({err}); using defaults"
+            );
+            SessionReaderConfig::default()
+        }),
+        None => SessionReaderConfig::default(),
+    }
+}
+
+/// `~/.agents-in-a-box/config.toml`, resolved via `$HOME`.
+fn default_config_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".agents-in-a-box").join("config.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_config(dir: &TempDir, body: &str) -> PathBuf {
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, body).expect("write config");
+        path
+    }
+
+    #[test]
+    fn present_value_is_read() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "[session_reader]\nincremental_window_days = 7\n");
+        assert_eq!(load_from(&path).incremental_window_days, 7);
+    }
+
+    #[test]
+    fn missing_file_defaults() {
+        let dir = TempDir::new().unwrap();
+        let cfg = load_from(&dir.path().join("nope.toml"));
+        assert_eq!(cfg, SessionReaderConfig::default());
+        assert_eq!(cfg.incremental_window_days, DEFAULT_INCREMENTAL_WINDOW_DAYS);
+    }
+
+    #[test]
+    fn missing_table_defaults() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "[usage]\nplan = \"max\"\n");
+        assert_eq!(load_from(&path), SessionReaderConfig::default());
+    }
+
+    #[test]
+    fn garbage_toml_defaults() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "not toml at {{{ all");
+        assert_eq!(load_from(&path), SessionReaderConfig::default());
+    }
+
+    #[test]
+    fn malformed_table_defaults() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            "[session_reader]\nincremental_window_days = \"soon\"\n",
+        );
+        assert_eq!(load_from(&path), SessionReaderConfig::default());
+    }
+
+    #[test]
+    fn unknown_keys_are_tolerated() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            "[session_reader]\nincremental_window_days = 14\nfuture_knob = true\n",
+        );
+        assert_eq!(load_from(&path).incremental_window_days, 14);
+    }
+
+    #[test]
+    fn zero_window_clamps_to_one_day() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "[session_reader]\nincremental_window_days = 0\n");
+        assert_eq!(load_from(&path).window_days(), 1);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
@@ -11,11 +11,6 @@
 //! incremental_window_days = 30
 //! ```
 
-// Consumed by the incremental scan path (`scan_incremental`, P4) and
-// cold-start seeding (P8) on this branch; until those land the module
-// is exercised only by its tests.
-#![allow(dead_code)]
-
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
@@ -38,10 +38,12 @@ impl Default for SessionReaderConfig {
 }
 
 impl SessionReaderConfig {
-    /// The effective window, clamped to at least one day.
+    /// The effective window, clamped to [1, 36500] days (a zero window
+    /// cannot disable recency; an absurd one cannot overflow the
+    /// nanosecond watermark arithmetic).
     #[must_use]
     pub fn window_days(self) -> u32 {
-        self.incremental_window_days.max(1)
+        self.incremental_window_days.clamp(1, 36_500)
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
@@ -15,6 +15,7 @@ use ainb_plugin_sdk::{SdkError, Server};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod cache;
+mod config;
 mod fnv;
 mod parsers;
 mod plugin;

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/claude.rs
@@ -52,7 +52,9 @@ struct ClaudeUsage {
 pub fn parse_dir(projects_root: &Path) -> Vec<ProviderCall> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        parse_dir_cached(projects_root, &mut None)
+        let mut cache = None;
+        let mut ctx = crate::scanner::ScanCtx::full(&mut cache);
+        parse_dir_cached(projects_root, &mut ctx)
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -66,10 +68,10 @@ pub fn parse_dir(projects_root: &Path) -> Vec<ProviderCall> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_dir_cached(
     projects_root: &Path,
-    cache: &mut Option<crate::cache::UsageCache>,
+    ctx: &mut crate::scanner::ScanCtx<'_>,
 ) -> Vec<ProviderCall> {
     let mut reporter = crate::scanner::ProgressReporter::noop();
-    parse_dir_cached_with_progress(projects_root, cache, &mut reporter)
+    parse_dir_cached_with_progress(projects_root, ctx, &mut reporter)
 }
 
 /// Cache + progress-aware walk. Drives `reporter.note_file` once per
@@ -78,7 +80,7 @@ pub fn parse_dir_cached(
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_dir_cached_with_progress(
     projects_root: &Path,
-    cache: &mut Option<crate::cache::UsageCache>,
+    ctx: &mut crate::scanner::ScanCtx<'_>,
     reporter: &mut crate::scanner::ProgressReporter,
 ) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
@@ -114,7 +116,7 @@ pub fn parse_dir_cached_with_progress(
             let project_path_str = project_path.to_string_lossy().into_owned();
             let project_owned = project.clone();
             reporter.note_file(&project_owned);
-            let file_calls = super::read_file_cached(&path, cache, |content| {
+            let file_calls = super::read_file_cached(&path, ctx, |content| {
                 parse_source(&path_str, &project_owned, &project_path_str, content)
             });
             calls.extend(file_calls);

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/codex.rs
@@ -62,7 +62,9 @@ struct CodexTokenUsage {
 pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        parse_dir_cached(sessions_root, &mut None)
+        let mut cache = None;
+        let mut ctx = crate::scanner::ScanCtx::full(&mut cache);
+        parse_dir_cached(sessions_root, &mut ctx)
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -77,10 +79,10 @@ pub fn parse_dir(sessions_root: &Path) -> Vec<ProviderCall> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_dir_cached(
     sessions_root: &Path,
-    cache: &mut Option<crate::cache::UsageCache>,
+    ctx: &mut crate::scanner::ScanCtx<'_>,
 ) -> Vec<ProviderCall> {
     let mut reporter = crate::scanner::ProgressReporter::noop();
-    parse_dir_cached_with_progress(sessions_root, cache, &mut reporter)
+    parse_dir_cached_with_progress(sessions_root, ctx, &mut reporter)
 }
 
 /// Cache + progress-aware walk. Drives `reporter.note_file` once per
@@ -90,7 +92,7 @@ pub fn parse_dir_cached(
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_dir_cached_with_progress(
     sessions_root: &Path,
-    cache: &mut Option<crate::cache::UsageCache>,
+    ctx: &mut crate::scanner::ScanCtx<'_>,
     reporter: &mut crate::scanner::ProgressReporter,
 ) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
@@ -146,7 +148,7 @@ pub fn parse_dir_cached_with_progress(
                     }
                     let path_str = path.to_string_lossy().into_owned();
                     reporter.note_file(&day_label);
-                    let file_calls = super::read_file_cached(&path, cache, |content| {
+                    let file_calls = super::read_file_cached(&path, ctx, |content| {
                         if !is_valid_codex_session(content) {
                             return Vec::new();
                         }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
@@ -38,14 +38,19 @@ pub(crate) fn stat_for_cache(path: &std::path::Path) -> Option<(u64, u64)> {
     Some((mtime, meta.len()))
 }
 
-/// Cache-aware read-and-parse for one provider session file.
+/// Cache- and watermark-aware read-and-parse for one provider session
+/// file, routed through the scan context.
 ///
 /// 1. `stat(path)` → `(mtime, size)`.
-/// 2. If a cache is supplied and `lookup(path, mtime, size)` hits, return
-///    the cached `Vec<ProviderCall>` with no filesystem read.
-/// 3. Otherwise read the file, call `parse(&content)`, hash the bytes
-///    with FNV-1a 64, and persist `(mtime, size, fingerprint, parsed)`
-///    via `cache.insert`.
+/// 2. When the context has a watermark and `mtime` predates it, the
+///    file is *stable*: its fingerprint is recorded and — under
+///    `StablePolicy::Skip` — the file is neither read nor looked up
+///    (its calls already ride the persisted stable aggregate). Under
+///    `Collect` it takes the cached-read path and its calls route to
+///    `ctx.stable_calls` instead of the return value.
+/// 3. Recent files (or any file in a full scan): if the cache hits on
+///    `(path, mtime, size)`, return the cached calls with no
+///    filesystem read; otherwise read, `parse`, and persist.
 ///
 /// Any cache I/O / SQL failure is logged at `warn` and the call falls
 /// through to a fresh parse — the cache is never allowed to break the
@@ -53,18 +58,57 @@ pub(crate) fn stat_for_cache(path: &std::path::Path) -> Option<(u64, u64)> {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn read_file_cached<F>(
     path: &std::path::Path,
-    cache: &mut Option<crate::cache::UsageCache>,
+    ctx: &mut crate::scanner::ScanCtx<'_>,
     parse: F,
 ) -> Vec<ainb_plugin_types_sessions::ProviderCall>
 where
     F: FnOnce(&str) -> Vec<ainb_plugin_types_sessions::ProviderCall>,
 {
+    use crate::scanner::StablePolicy;
+
     let path_str = path.to_string_lossy().into_owned();
     let stat = stat_for_cache(path);
+    ctx.counters.files_statted = ctx.counters.files_statted.saturating_add(1);
 
-    if let (Some(cache_ref), Some((mtime, size))) = (cache.as_ref(), stat) {
-        match cache_ref.lookup(&path_str, mtime, size) {
-            Ok(Some(hit)) => return hit,
+    if let (Some(watermark), Some((mtime, size))) = (ctx.watermark_nanos, stat) {
+        if mtime < watermark {
+            ctx.stable_present.push((path_str.clone(), mtime, size));
+            match ctx.stable_policy {
+                StablePolicy::Skip => {
+                    ctx.counters.stable_skipped = ctx.counters.stable_skipped.saturating_add(1);
+                    return Vec::new();
+                }
+                StablePolicy::Collect => {
+                    let calls = read_one_cached(path, &path_str, stat, ctx, parse);
+                    ctx.stable_calls.extend(calls);
+                    return Vec::new();
+                }
+            }
+        }
+    }
+
+    read_one_cached(path, &path_str, stat, ctx, parse)
+}
+
+/// The cached read-parse-insert core shared by the recent and
+/// stable-collect routes.
+#[cfg(not(target_arch = "wasm32"))]
+fn read_one_cached<F>(
+    path: &std::path::Path,
+    path_str: &str,
+    stat: Option<(u64, u64)>,
+    ctx: &mut crate::scanner::ScanCtx<'_>,
+    parse: F,
+) -> Vec<ainb_plugin_types_sessions::ProviderCall>
+where
+    F: FnOnce(&str) -> Vec<ainb_plugin_types_sessions::ProviderCall>,
+{
+    if let (Some(cache_ref), Some((mtime, size))) = (ctx.cache.as_ref(), stat) {
+        match cache_ref.lookup(path_str, mtime, size) {
+            Ok(Some(hit)) => {
+                ctx.counters.cache_hits = ctx.counters.cache_hits.saturating_add(1);
+                return hit;
+            }
             Ok(None) => {}
             Err(err) => {
                 tracing::warn!(
@@ -90,10 +134,11 @@ where
     };
 
     let calls = parse(&content);
+    ctx.counters.parsed = ctx.counters.parsed.saturating_add(1);
 
-    if let (Some(cache_ref), Some((mtime, size))) = (cache.as_mut(), stat) {
+    if let (Some(cache_ref), Some((mtime, size))) = (ctx.cache.as_mut(), stat) {
         let fingerprint = crate::cache::fingerprint(content.as_bytes());
-        if let Err(err) = cache_ref.insert(&path_str, mtime, size, fingerprint, &calls) {
+        if let Err(err) = cache_ref.insert(path_str, mtime, size, fingerprint, &calls) {
             tracing::warn!(
                 path = %path.display(),
                 error = %err,

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
@@ -135,6 +135,12 @@ where
 
     let calls = parse(&content);
     ctx.counters.parsed = ctx.counters.parsed.saturating_add(1);
+    // Pace the expensive op: a sub-millisecond breather per parsed
+    // file keeps a cold/hard scan from pegging a core flat-out while
+    // costing a warm refresh (0–2 parses) nothing. The crate forbids
+    // unsafe code, so macOS thread-QoS FFI isn't available — this
+    // duty-cycle yield is the portable softening.
+    std::thread::sleep(std::time::Duration::from_micros(500));
 
     if let (Some(cache_ref), Some((mtime, size))) = (ctx.cache.as_mut(), stat) {
         let fingerprint = crate::cache::fingerprint(content.as_bytes());

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -16,11 +16,39 @@
 use ainb_plugin_sdk::{
     HandleEventParams, HostClient, Plugin, RenderParams, Result, SdkError, WireBuffer,
 };
-use ainb_plugin_types_sessions::{ScanProgressEvent, UsageData, UsageDataEvent, WIRE_VERSION};
+use ainb_plugin_types_sessions::{
+    RefreshRequest, ScanProgressEvent, UsageData, UsageDataEvent, WIRE_VERSION,
+};
 use async_trait::async_trait;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::scanner::{self, ProviderRoots};
+
+/// Nanoseconds per day, for the incremental watermark arithmetic.
+#[cfg(not(target_arch = "wasm32"))]
+const NANOS_PER_DAY: u64 = 86_400_000_000_000;
+
+/// Decode the `sessions.refresh_request` payload. The topic was
+/// historically a bare ping, so an empty payload — what the host FS
+/// watcher and burndown's `r` key still send — decodes to the default
+/// (incremental). A malformed payload also degrades to incremental
+/// with a warn: a bad publisher must never block refreshes, and
+/// incremental is the safe (cheap) direction to fail in.
+fn decode_refresh_request(payload: &[u8]) -> RefreshRequest {
+    if payload.is_empty() {
+        return RefreshRequest::default();
+    }
+    match rmp_serde::from_slice(payload) {
+        Ok(req) => req,
+        Err(err) => {
+            tracing::warn!(
+                "session-reader: refresh_request payload undecodable ({err}); \
+                treating as incremental"
+            );
+            RefreshRequest::default()
+        }
+    }
+}
 
 /// Per-chunk msgpack byte budget. Each chunk's encoded msgpack stays
 /// below this size so the post-base64 + JSON-envelope frame fits
@@ -75,6 +103,15 @@ mod manifest_text {
 pub struct SessionReader {
     last_event: Option<UsageDataEvent>,
     roots: ProviderRoots,
+    /// Trailing recent-window size (days) from `[session_reader]`
+    /// config; bounds the incremental watermark.
+    #[cfg(not(target_arch = "wasm32"))]
+    window_days: u32,
+    /// In-memory copy of the persisted stable rollup so steady-state
+    /// refreshes don't re-deserialize the blob; loaded from the cache
+    /// on the first refresh, replaced whenever a rebuild runs.
+    #[cfg(not(target_arch = "wasm32"))]
+    stable: Option<scanner::StableAggregate>,
     #[cfg(not(target_arch = "wasm32"))]
     cache: Option<crate::cache::UsageCache>,
     /// Set to `true` once we've attempted (and possibly failed) to open
@@ -91,6 +128,10 @@ impl SessionReader {
             last_event: None,
             roots: ProviderRoots::defaults(),
             #[cfg(not(target_arch = "wasm32"))]
+            window_days: crate::config::load().window_days(),
+            #[cfg(not(target_arch = "wasm32"))]
+            stable: None,
+            #[cfg(not(target_arch = "wasm32"))]
             cache: None,
             #[cfg(not(target_arch = "wasm32"))]
             cache_init: false,
@@ -104,6 +145,10 @@ impl SessionReader {
         Self {
             last_event: None,
             roots,
+            #[cfg(not(target_arch = "wasm32"))]
+            window_days: crate::config::DEFAULT_INCREMENTAL_WINDOW_DAYS,
+            #[cfg(not(target_arch = "wasm32"))]
+            stable: None,
             #[cfg(not(target_arch = "wasm32"))]
             cache: None,
             #[cfg(not(target_arch = "wasm32"))]
@@ -125,6 +170,10 @@ impl SessionReader {
     /// regardless of how broken the previous cache was.
     #[cfg(not(target_arch = "wasm32"))]
     async fn flush_cache(&mut self, host: &HostClient) {
+        // The persisted stable rollup dies with the cache (clear()
+        // wipes both tables); the in-memory copy must die with it or
+        // the next refresh would resurrect stale history.
+        self.stable = None;
         self.ensure_cache();
         if let Some(cache) = self.cache.as_mut() {
             match cache.clear() {
@@ -251,8 +300,19 @@ impl SessionReader {
     #[cfg(not(target_arch = "wasm32"))]
     async fn scan_streaming(&mut self, host: &HostClient) -> ainb_plugin_types_sessions::UsageData {
         self.ensure_cache();
+        // First refresh of this process: hydrate the in-memory stable
+        // rollup from the cache (absent on cold start / after flush —
+        // the scan below then runs the one-time seeding rebuild).
+        if self.stable.is_none() {
+            if let Some(cache) = self.cache.as_ref() {
+                self.stable = cache.load_stable().unwrap_or_default();
+            }
+        }
+        let cold_start = self.stable.is_none();
         let roots = self.roots.clone();
         let cache = self.cache.take();
+        let stored = self.stable.take();
+        let window_days = self.window_days;
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ScanProgressEvent>();
 
@@ -264,9 +324,54 @@ impl SessionReader {
                 // we hold `rx` until `scan_handle` resolves).
                 let _ = tx.send(evt);
             });
-            let data = scanner::scan_with_cache_and_progress(&roots, &mut cache_opt, &mut reporter);
-            (data, cache_opt)
+            if cache_opt.is_some() {
+                // Incremental path: stable rollup + recent re-aggregate.
+                let watermark = now_ns().saturating_sub(u64::from(window_days) * NANOS_PER_DAY);
+                let outcome = scanner::scan_incremental(
+                    &roots,
+                    &mut cache_opt,
+                    stored,
+                    watermark,
+                    &mut reporter,
+                );
+                if outcome.stable_rebuilt {
+                    if let Some(cache) = cache_opt.as_mut() {
+                        if let Err(err) = cache.store_stable(&outcome.stable) {
+                            tracing::warn!(
+                                "session-reader: stable rollup persist failed ({err}); \
+                                next refresh rebuilds again"
+                            );
+                        }
+                    }
+                }
+                let c = outcome.counters;
+                tracing::info!(
+                    files_statted = c.files_statted,
+                    parsed = c.parsed,
+                    cache_hits = c.cache_hits,
+                    stable_skipped = c.stable_skipped,
+                    stable_reused = c.stable_reused,
+                    stable_rebuilt = outcome.stable_rebuilt,
+                    "session-reader: incremental refresh"
+                );
+                (outcome.data, Some(outcome.stable), cache_opt)
+            } else {
+                // No cache (path unresolved / open failed): nowhere to
+                // persist a rollup, so run the legacy full scan.
+                let data =
+                    scanner::scan_with_cache_and_progress(&roots, &mut cache_opt, &mut reporter);
+                (data, None, cache_opt)
+            }
         });
+
+        if cold_start {
+            let _ = host
+                .log_info(
+                    "session-reader: no stable rollup found — building full usage history \
+                    (one-time, heavier than a normal refresh)",
+                )
+                .await;
+        }
 
         // Drain progress events. `rx.recv()` returns `None` once the
         // scan task drops its `Sender` (i.e. when the closure +
@@ -293,8 +398,9 @@ impl SessionReader {
         }
 
         match scan_handle.await {
-            Ok((data, cache_opt)) => {
+            Ok((data, stable_out, cache_opt)) => {
                 self.cache = cache_opt;
+                self.stable = stable_out;
                 data
             }
             Err(err) => {
@@ -617,11 +723,25 @@ impl Plugin for SessionReader {
 
     async fn handle_event(&mut self, host: &HostClient, params: HandleEventParams) -> Result<()> {
         if params.topic == TOPIC_REFRESH_REQUEST {
-            tracing::info!("session-reader: refresh requested — rescanning");
+            let req = decode_refresh_request(&params.payload);
+            if req.hard {
+                // Hard refresh: distrust every cache layer. Wipe the
+                // parse cache + stable rollup, then rescan — the cold
+                // incremental path re-parses everything from source
+                // and seeds a fresh rollup.
+                tracing::info!(
+                    "session-reader: HARD refresh requested — wiping caches, rebuilding from source"
+                );
+                #[cfg(not(target_arch = "wasm32"))]
+                self.flush_cache(host).await;
+            } else {
+                tracing::info!("session-reader: refresh requested — incremental rescan");
+            }
             return self.publish(host).await;
         }
         if params.topic == TOPIC_FLUSH_CACHE_REQUEST {
             tracing::info!("session-reader: flush_cache requested — wiping cache + rescanning");
+            #[cfg(not(target_arch = "wasm32"))]
             self.flush_cache(host).await;
             return self.publish(host).await;
         }
@@ -640,6 +760,37 @@ fn now_ns() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn refresh_request_empty_payload_is_incremental() {
+        // The host FS watcher and burndown's `r` key publish bare
+        // pings (empty payload) — back-compat demands incremental.
+        let req = decode_refresh_request(&[]);
+        assert!(!req.hard);
+    }
+
+    #[test]
+    fn refresh_request_empty_map_is_incremental() {
+        // msgpack fixmap-0 (a publisher encoding `{}`) — `hard`
+        // defaults off via #[serde(default)].
+        let req = decode_refresh_request(&[0x80]);
+        assert!(!req.hard);
+    }
+
+    #[test]
+    fn refresh_request_hard_roundtrips() {
+        let bytes = rmp_serde::to_vec_named(&RefreshRequest { hard: true }).expect("encode");
+        let req = decode_refresh_request(&bytes);
+        assert!(req.hard);
+    }
+
+    #[test]
+    fn refresh_request_garbage_degrades_to_incremental() {
+        // A broken publisher must never block refreshes; failing in
+        // the cheap (incremental) direction is the safe default.
+        let req = decode_refresh_request(&[0xC1, 0xFF, 0x00]);
+        assert!(!req.hard);
+    }
 
     #[test]
     fn manifest_toml_parses_as_abi_v2() {

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -100,7 +100,8 @@ pub(crate) fn run_blocking_scan(
     let cold_start = stored.is_none();
 
     if cache_opt.is_some() {
-        let watermark = now_ns().saturating_sub(u64::from(window_days) * NANOS_PER_DAY);
+        let watermark =
+            now_ns().saturating_sub(u64::from(window_days).saturating_mul(NANOS_PER_DAY));
         let outcome = scanner::scan_incremental(roots, &mut cache_opt, stored, watermark, reporter);
         if outcome.stable_rebuilt {
             if let Some(cache) = cache_opt.as_mut() {
@@ -279,6 +280,15 @@ impl SessionReader {
         self.cache = None;
         self.cache_init = false;
         if let Some(path) = crate::cache::default_db_path() {
+            // Take the WAL/SHM siblings with the db: SQLite can
+            // recover a leftover -wal into a freshly created database,
+            // silently resurrecting rows this flush just promised were
+            // gone.
+            for suffix in ["-wal", "-shm"] {
+                let mut sibling = path.as_os_str().to_owned();
+                sibling.push(suffix);
+                let _ = std::fs::remove_file(std::path::Path::new(&sibling));
+            }
             match std::fs::remove_file(&path) {
                 Ok(()) => {
                     let _ = host
@@ -459,9 +469,18 @@ impl SessionReader {
                 outcome.data
             }
             Err(err) => {
+                // The panicked closure took ownership of the cache and
+                // stable rollup with it — both are gone. Re-arm
+                // ensure_cache (cache_init is already true, so without
+                // this reset it would no-op forever and every future
+                // refresh would silently take the cache-less FULL-scan
+                // path — the exact CPU regression this plugin exists
+                // to prevent).
+                self.cache_init = false;
                 let _ = host
                     .log_info(format!(
                         "session-reader: scan task join error: {err}; \
+                        cache handle lost with the panicked task — reopening, \
                         falling back to in-line scan"
                     ))
                     .await;

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -50,6 +50,89 @@ fn decode_refresh_request(payload: &[u8]) -> RefreshRequest {
     }
 }
 
+/// Everything one refresh's blocking scan produced — the glue between
+/// the async plugin and the scanner, factored out so the "cache
+/// present → incremental, else legacy full scan" decision is directly
+/// testable without a `HostClient`.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct BlockingScanOutcome {
+    pub(crate) data: ainb_plugin_types_sessions::UsageData,
+    /// The (reused or rebuilt) stable rollup to keep in memory for the
+    /// next refresh. `None` on the cache-less full-scan path.
+    pub(crate) stable: Option<scanner::StableAggregate>,
+    /// Cache handle returned to the plugin for reuse.
+    pub(crate) cache: Option<crate::cache::UsageCache>,
+    /// Scan instrumentation — `Some` iff the incremental path ran.
+    pub(crate) counters: Option<scanner::ScanCounters>,
+    pub(crate) stable_rebuilt: bool,
+    /// `true` when no stable rollup existed in memory or on disk —
+    /// this refresh was the one-time seeding scan.
+    pub(crate) cold_start: bool,
+}
+
+/// The blocking half of a refresh: decide incremental-vs-full, run the
+/// scan, persist the rollup on rebuild.
+///
+/// - `stored` is the caller's in-memory rollup; when `None` (process
+///   restart, first refresh) the persisted rollup is hydrated from the
+///   cache before deciding cold start.
+/// - With a cache: run [`scanner::scan_incremental`] against
+///   `now - window_days` and persist the rollup whenever it was
+///   rebuilt.
+/// - Without a cache (path unresolved / open failed): nowhere to
+///   persist a rollup, so run the legacy full scan.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn run_blocking_scan(
+    roots: &ProviderRoots,
+    cache: Option<crate::cache::UsageCache>,
+    stored: Option<scanner::StableAggregate>,
+    window_days: u32,
+    reporter: &mut scanner::ProgressReporter,
+) -> BlockingScanOutcome {
+    let mut cache_opt = cache;
+
+    // Hydrate from the persisted rollup when memory is empty — this is
+    // what makes a plugin restart skip the seeding scan.
+    let stored = match stored {
+        Some(s) => Some(s),
+        None => cache_opt.as_ref().and_then(|c| c.load_stable().unwrap_or_default()),
+    };
+    let cold_start = stored.is_none();
+
+    if cache_opt.is_some() {
+        let watermark = now_ns().saturating_sub(u64::from(window_days) * NANOS_PER_DAY);
+        let outcome = scanner::scan_incremental(roots, &mut cache_opt, stored, watermark, reporter);
+        if outcome.stable_rebuilt {
+            if let Some(cache) = cache_opt.as_mut() {
+                if let Err(err) = cache.store_stable(&outcome.stable) {
+                    tracing::warn!(
+                        "session-reader: stable rollup persist failed ({err}); \
+                        next refresh rebuilds again"
+                    );
+                }
+            }
+        }
+        BlockingScanOutcome {
+            data: outcome.data,
+            stable: Some(outcome.stable),
+            cache: cache_opt,
+            counters: Some(outcome.counters),
+            stable_rebuilt: outcome.stable_rebuilt,
+            cold_start,
+        }
+    } else {
+        let data = scanner::scan_with_cache_and_progress(roots, &mut cache_opt, reporter);
+        BlockingScanOutcome {
+            data,
+            stable: None,
+            cache: cache_opt,
+            counters: None,
+            stable_rebuilt: false,
+            cold_start,
+        }
+    }
+}
+
 /// Per-chunk msgpack byte budget. Each chunk's encoded msgpack stays
 /// below this size so the post-base64 + JSON-envelope frame fits
 /// comfortably under the host framer's 16 MiB body cap (base64
@@ -300,15 +383,6 @@ impl SessionReader {
     #[cfg(not(target_arch = "wasm32"))]
     async fn scan_streaming(&mut self, host: &HostClient) -> ainb_plugin_types_sessions::UsageData {
         self.ensure_cache();
-        // First refresh of this process: hydrate the in-memory stable
-        // rollup from the cache (absent on cold start / after flush —
-        // the scan below then runs the one-time seeding rebuild).
-        if self.stable.is_none() {
-            if let Some(cache) = self.cache.as_ref() {
-                self.stable = cache.load_stable().unwrap_or_default();
-            }
-        }
-        let cold_start = self.stable.is_none();
         let roots = self.roots.clone();
         let cache = self.cache.take();
         let stored = self.stable.take();
@@ -317,61 +391,14 @@ impl SessionReader {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ScanProgressEvent>();
 
         let scan_handle = tokio::task::spawn_blocking(move || {
-            let mut cache_opt = cache;
             let mut reporter = scanner::ProgressReporter::new(move |evt| {
                 // Send is unbounded + non-blocking; failures only happen
                 // when the receiver has been dropped (impossible here —
                 // we hold `rx` until `scan_handle` resolves).
                 let _ = tx.send(evt);
             });
-            if cache_opt.is_some() {
-                // Incremental path: stable rollup + recent re-aggregate.
-                let watermark = now_ns().saturating_sub(u64::from(window_days) * NANOS_PER_DAY);
-                let outcome = scanner::scan_incremental(
-                    &roots,
-                    &mut cache_opt,
-                    stored,
-                    watermark,
-                    &mut reporter,
-                );
-                if outcome.stable_rebuilt {
-                    if let Some(cache) = cache_opt.as_mut() {
-                        if let Err(err) = cache.store_stable(&outcome.stable) {
-                            tracing::warn!(
-                                "session-reader: stable rollup persist failed ({err}); \
-                                next refresh rebuilds again"
-                            );
-                        }
-                    }
-                }
-                let c = outcome.counters;
-                tracing::info!(
-                    files_statted = c.files_statted,
-                    parsed = c.parsed,
-                    cache_hits = c.cache_hits,
-                    stable_skipped = c.stable_skipped,
-                    stable_reused = c.stable_reused,
-                    stable_rebuilt = outcome.stable_rebuilt,
-                    "session-reader: incremental refresh"
-                );
-                (outcome.data, Some(outcome.stable), cache_opt)
-            } else {
-                // No cache (path unresolved / open failed): nowhere to
-                // persist a rollup, so run the legacy full scan.
-                let data =
-                    scanner::scan_with_cache_and_progress(&roots, &mut cache_opt, &mut reporter);
-                (data, None, cache_opt)
-            }
+            run_blocking_scan(&roots, cache, stored, window_days, &mut reporter)
         });
-
-        if cold_start {
-            let _ = host
-                .log_info(
-                    "session-reader: no stable rollup found — building full usage history \
-                    (one-time, heavier than a normal refresh)",
-                )
-                .await;
-        }
 
         // Drain progress events. `rx.recv()` returns `None` once the
         // scan task drops its `Sender` (i.e. when the closure +
@@ -398,10 +425,38 @@ impl SessionReader {
         }
 
         match scan_handle.await {
-            Ok((data, stable_out, cache_opt)) => {
-                self.cache = cache_opt;
-                self.stable = stable_out;
-                data
+            Ok(outcome) => {
+                self.cache = outcome.cache;
+                self.stable = outcome.stable;
+                if outcome.cold_start {
+                    let _ = host
+                        .log_info(
+                            "session-reader: no stable rollup found — built full usage \
+                            history (one-time, heavier than a normal refresh)",
+                        )
+                        .await;
+                }
+                // Host-visible counter line — the soak/observability
+                // contract. The plugin subprocess has no tracing
+                // subscriber of its own, so host.log() is the only
+                // sink that reliably lands in the host JSONL
+                // (~/.agents-in-a-box/logs/). scripts/soak-session-reader.sh
+                // greps for exactly this shape.
+                if let Some(c) = outcome.counters {
+                    let _ = host
+                        .log_info(format!(
+                            "session-reader: incremental refresh statted={} parsed={} \
+                            cache_hits={} stable_skipped={} stable_reused={} rebuilt={}",
+                            c.files_statted,
+                            c.parsed,
+                            c.cache_hits,
+                            c.stable_skipped,
+                            c.stable_reused,
+                            outcome.stable_rebuilt,
+                        ))
+                        .await;
+                }
+                outcome.data
             }
             Err(err) => {
                 let _ = host
@@ -760,6 +815,112 @@ fn now_ns() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── run_blocking_scan glue (plugin-level counter assertions) ────
+    //
+    // The scanner-level tests prove scan_incremental's behavior; these
+    // prove the PLUGIN's decision layer: cache present → incremental
+    // (counters populated, rollup persisted, restart rehydrates),
+    // cache absent → legacy full scan. Same oracle: byte-identity with
+    // a cache-less full scan of the same tree.
+
+    fn glue_claude_line(ts: &str, session: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","timestamp":"{ts}","sessionId":"{session}","cwd":"/tmp/proj","gitBranch":"main","message":{{"model":"claude-3-5-sonnet","content":[{{"type":"text","text":"hi"}}],"usage":{{"input_tokens":10,"output_tokens":20}}}}}}"#
+        )
+    }
+
+    fn glue_fixture() -> (tempfile::TempDir, ProviderRoots, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tree tempdir");
+        let claude_root = tmp.path().join("claude/projects/proj-a");
+        std::fs::create_dir_all(&claude_root).expect("mkdir");
+        std::fs::write(
+            claude_root.join("one.jsonl"),
+            glue_claude_line("2026-05-01T10:00:00Z", "s1"),
+        )
+        .expect("write");
+        std::fs::write(
+            claude_root.join("two.jsonl"),
+            glue_claude_line("2026-06-01T10:00:00Z", "s2"),
+        )
+        .expect("write");
+        let roots = ProviderRoots {
+            claude_projects: Some(tmp.path().join("claude/projects")),
+            ..ProviderRoots::default()
+        };
+        let cache_dir = tempfile::tempdir().expect("cache tempdir");
+        // Let the filesystem clock tick past the writes so a
+        // `window_days = 0` watermark (now) puts both files on the
+        // stable side.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        (tmp, roots, cache_dir)
+    }
+
+    fn open_cache(dir: &tempfile::TempDir) -> Option<crate::cache::UsageCache> {
+        Some(crate::cache::UsageCache::open(&dir.path().join("usage.sqlite")).expect("cache"))
+    }
+
+    fn encode(data: &UsageData) -> Vec<u8> {
+        rmp_serde::to_vec_named(data).expect("encode")
+    }
+
+    #[test]
+    fn glue_runs_incremental_persists_rollup_and_rehydrates_on_restart() {
+        let (_tree, roots, cache_dir) = glue_fixture();
+        let oracle = encode(&scanner::scan(&roots));
+        let mut reporter = scanner::ProgressReporter::noop();
+
+        // First refresh: cold start seeds + persists the rollup.
+        let first = run_blocking_scan(&roots, open_cache(&cache_dir), None, 0, &mut reporter);
+        assert!(first.cold_start, "no rollup anywhere yet");
+        assert!(first.stable_rebuilt);
+        let c = first.counters.expect("incremental path ran");
+        assert_eq!(c.parsed, 2, "seed scan parses both files");
+        assert_eq!(encode(&first.data), oracle, "matches full-scan oracle");
+        assert!(
+            first.cache.expect("cache returned").load_stable().expect("load").is_some(),
+            "rollup persisted for the next process"
+        );
+
+        // Simulated plugin restart: in-memory rollup gone (stored =
+        // None), fresh cache handle on the same file. The glue must
+        // rehydrate from disk and reuse — zero parses.
+        let second = run_blocking_scan(&roots, open_cache(&cache_dir), None, 0, &mut reporter);
+        assert!(!second.cold_start, "rollup rehydrated from the cache");
+        assert!(!second.stable_rebuilt);
+        let c = second.counters.expect("incremental path ran");
+        assert_eq!(
+            c.parsed, 0,
+            "no-change refresh after restart parses ZERO files"
+        );
+        assert!(c.stable_reused);
+        assert_eq!(c.stable_skipped, 2, "both stable files skipped outright");
+        assert_eq!(
+            encode(&second.data),
+            oracle,
+            "still byte-identical to the oracle"
+        );
+    }
+
+    #[test]
+    fn glue_falls_back_to_full_scan_without_cache() {
+        let (_tree, roots, _cache_dir) = glue_fixture();
+        let oracle = encode(&scanner::scan(&roots));
+        let mut reporter = scanner::ProgressReporter::noop();
+
+        let out = run_blocking_scan(&roots, None, None, 0, &mut reporter);
+        assert!(
+            out.counters.is_none(),
+            "cache-less refresh takes the legacy full path"
+        );
+        assert!(out.stable.is_none(), "nothing to persist a rollup into");
+        assert!(!out.stable_rebuilt);
+        assert_eq!(
+            encode(&out.data),
+            oracle,
+            "full path matches the oracle trivially"
+        );
+    }
 
     #[test]
     fn refresh_request_empty_payload_is_incremental() {

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -987,7 +987,7 @@ fn nanos_to_usd(nanos: i64) -> f64 {
 /// [`merge`]'s `cost_usd` arm: any `Some` survives, two `Some`s add.
 fn add_cost_nanos(into: &mut Option<i64>, from: Option<i64>) {
     *into = match (*into, from) {
-        (Some(a), Some(b)) => Some(a + b),
+        (Some(a), Some(b)) => Some(a.saturating_add(b)),
         (Some(a), None) => Some(a),
         (None, Some(b)) => Some(b),
         (None, None) => None,
@@ -1011,12 +1011,18 @@ fn call_bucket(call: &ProviderCall) -> TokenBucket {
 }
 
 fn merge(into: &mut TokenBucket, from: &TokenBucket) {
-    into.input_tokens += from.input_tokens;
-    into.cache_creation_tokens += from.cache_creation_tokens;
-    into.cache_read_tokens += from.cache_read_tokens;
-    into.output_tokens += from.output_tokens;
-    into.reasoning_tokens += from.reasoning_tokens;
-    into.call_count += from.call_count;
+    // Saturating sums: token counts come straight from on-disk JSONL
+    // (corruptible / hostile), and a debug-build overflow panic inside
+    // the blocking scan task would cost the plugin its cache handle.
+    // Unsigned saturating addition stays associative, so the
+    // byte-identity merge contract is unaffected.
+    into.input_tokens = into.input_tokens.saturating_add(from.input_tokens);
+    into.cache_creation_tokens =
+        into.cache_creation_tokens.saturating_add(from.cache_creation_tokens);
+    into.cache_read_tokens = into.cache_read_tokens.saturating_add(from.cache_read_tokens);
+    into.output_tokens = into.output_tokens.saturating_add(from.output_tokens);
+    into.reasoning_tokens = into.reasoning_tokens.saturating_add(from.reasoning_tokens);
+    into.call_count = into.call_count.saturating_add(from.call_count);
     into.cost_usd = match (into.cost_usd, from.cost_usd) {
         (Some(a), Some(b)) => Some(a + b),
         (Some(a), None) => Some(a),

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -584,6 +584,27 @@ pub(crate) fn emit(state: AggState) -> UsageData {
     }
 }
 
+/// Persisted stable (older-than-watermark) aggregate: the fold state
+/// of every file whose mtime predates the watermark, plus the exact
+/// fingerprint set it was built from.
+///
+/// Validity contract: the stored state is reusable on a refresh iff
+/// the walk's stable file set — every `(path, mtime, size)` older than
+/// the watermark — equals `folded` exactly. Any aged-in, deleted, or
+/// touched file breaks equality and forces a rebuild, which is what
+/// makes an edited-then-aged or appended file impossible to
+/// double-count.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct StableAggregate {
+    /// `now - incremental_window_days` (Unix nanos) at build time.
+    /// Bookkeeping only — validity is decided by `folded` equality.
+    pub(crate) watermark_nanos: u64,
+    /// Sorted `(path, mtime_nanos, size)` of every folded file.
+    pub(crate) folded: Vec<(String, u64, u64)>,
+    /// The fold state of the folded files' calls.
+    pub(crate) state: AggState,
+}
+
 /// Mergeable fold state — the output of [`fold`], the input of
 /// [`emit`], and the unit the incremental path persists as the stable
 /// (older-than-watermark) aggregate.

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -172,6 +172,99 @@ fn cursor_default_root(home: &Path) -> PathBuf {
     }
 }
 
+/// Per-scan instrumentation. Counted in the per-file read path so
+/// tests (and refresh logs) can assert what a scan actually did —
+/// "0 reparses on a no-change refresh" is a counted fact, not an
+/// inference from wall-clock time.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanCounters {
+    /// Files visited by the cached walks (each costs one `stat`).
+    pub files_statted: u32,
+    /// Files read from disk and parsed (cache miss or no cache).
+    pub parsed: u32,
+    /// Files served from the per-file parse cache (deserialize only).
+    pub cache_hits: u32,
+    /// Files older than the watermark that were skipped entirely —
+    /// no read, no cache lookup (their contribution rides the stable
+    /// aggregate).
+    pub stable_skipped: u32,
+    /// `true` when the persisted stable aggregate was valid and reused
+    /// (no rebuild pass ran).
+    pub stable_reused: bool,
+}
+
+/// What the per-file read path does with files older than the
+/// watermark.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StablePolicy {
+    /// Fast path: record `(path, mtime, size)` and skip the file —
+    /// its calls are already in the persisted stable aggregate.
+    Skip,
+    /// Rebuild pass: read the file (cache-served when warm) and route
+    /// its calls into [`ScanCtx::stable_calls`].
+    Collect,
+}
+
+/// Mutable per-scan context threaded through the cached provider
+/// walks in place of the bare cache handle. Carries the watermark
+/// partition policy, the routed stable output, and the counters.
+pub(crate) struct ScanCtx<'a> {
+    /// Per-file parse cache (None = cache-less, every file parses).
+    pub(crate) cache: &'a mut Option<crate::cache::UsageCache>,
+    /// Files with `mtime < watermark` are stable. `None` disables the
+    /// partition entirely — every file is "recent" (the legacy full
+    /// scan, byte-for-byte).
+    pub(crate) watermark_nanos: Option<u64>,
+    pub(crate) stable_policy: StablePolicy,
+    /// `(path, mtime_nanos, size)` of every stable file seen.
+    pub(crate) stable_present: Vec<(String, u64, u64)>,
+    /// Stable files' calls — populated only under
+    /// [`StablePolicy::Collect`].
+    pub(crate) stable_calls: Vec<ProviderCall>,
+    pub(crate) counters: ScanCounters,
+}
+
+impl<'a> ScanCtx<'a> {
+    /// Full-scan context: no watermark, no partition — the legacy
+    /// behavior every existing entry point keeps.
+    pub(crate) fn full(cache: &'a mut Option<crate::cache::UsageCache>) -> Self {
+        Self {
+            cache,
+            watermark_nanos: None,
+            stable_policy: StablePolicy::Skip,
+            stable_present: Vec::new(),
+            stable_calls: Vec::new(),
+            counters: ScanCounters::default(),
+        }
+    }
+
+    /// Watermark-partitioned context for the incremental path.
+    pub(crate) fn incremental(
+        cache: &'a mut Option<crate::cache::UsageCache>,
+        watermark_nanos: u64,
+        stable_policy: StablePolicy,
+    ) -> Self {
+        Self {
+            cache,
+            watermark_nanos: Some(watermark_nanos),
+            stable_policy,
+            stable_present: Vec::new(),
+            stable_calls: Vec::new(),
+            counters: ScanCounters::default(),
+        }
+    }
+}
+
+/// Result of an incremental scan: the snapshot, what the scan did,
+/// and the (reused or rebuilt) stable aggregate the caller should
+/// persist when `stable_rebuilt` is set.
+pub(crate) struct ScanOutcome {
+    pub(crate) data: UsageData,
+    pub(crate) counters: ScanCounters,
+    pub(crate) stable: StableAggregate,
+    pub(crate) stable_rebuilt: bool,
+}
+
 /// Run every provider parser, aggregate, return a snapshot.
 ///
 /// Cache-less convenience wrapper around [`scan_with_cache`] for
@@ -250,27 +343,122 @@ pub fn scan_with_cache_and_progress(
         reporter.set_total(u32::try_from(total).unwrap_or(u32::MAX));
     }
 
-    let mut all_calls = Vec::new();
+    let mut ctx = ScanCtx::full(cache);
+    let all_calls = walk_providers(roots, &mut ctx, reporter);
+    aggregate(all_calls)
+}
+
+/// Walk every provider through `ctx`. Claude and Codex go through the
+/// cached, watermark-aware per-file path; Gemini / Copilot / Cursor
+/// parsers are uncached and always contribute to the returned (recent)
+/// calls — identically in the full and incremental paths, so the
+/// partition stays a valid split of the same total.
+#[cfg(not(target_arch = "wasm32"))]
+fn walk_providers(
+    roots: &ProviderRoots,
+    ctx: &mut ScanCtx<'_>,
+    reporter: &mut ProgressReporter,
+) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
     if let Some(root) = &roots.claude_projects {
-        all_calls.extend(crate::parsers::claude::parse_dir_cached_with_progress(
-            root, cache, reporter,
+        calls.extend(crate::parsers::claude::parse_dir_cached_with_progress(
+            root, ctx, reporter,
         ));
     }
     if let Some(root) = &roots.codex_sessions {
-        all_calls.extend(crate::parsers::codex::parse_dir_cached_with_progress(
-            root, cache, reporter,
+        calls.extend(crate::parsers::codex::parse_dir_cached_with_progress(
+            root, ctx, reporter,
         ));
     }
     if let Some(root) = &roots.gemini_sessions {
-        all_calls.extend(crate::parsers::gemini::parse_dir(root));
+        calls.extend(crate::parsers::gemini::parse_dir(root));
     }
     if let Some(root) = &roots.copilot_sessions {
-        all_calls.extend(crate::parsers::copilot::parse_dir(root));
+        calls.extend(crate::parsers::copilot::parse_dir(root));
     }
     if let Some(root) = &roots.cursor_sessions {
-        all_calls.extend(crate::parsers::cursor::parse_dir(root));
+        calls.extend(crate::parsers::cursor::parse_dir(root));
     }
-    aggregate(all_calls)
+    calls
+}
+
+/// Incremental scan: re-aggregate only files newer than the watermark
+/// and fold the persisted stable rollup in via [`AggState::absorb`].
+///
+/// Pass 1 walks with [`StablePolicy::Skip`]: recent files take the
+/// normal cached-read path; stable files cost one `stat` each and are
+/// recorded, not read. If the recorded stable set exactly matches
+/// `stored.folded`, the stored state is reused (`stable_reused`).
+///
+/// Any mismatch — a file aged past the watermark, was deleted, or
+/// changed `(mtime, size)` — triggers one rebuild pass with
+/// [`StablePolicy::Collect`]: stable files are read (cache-served when
+/// warm, so typically deserialize-only) and folded into a fresh stable
+/// state, which the caller persists. This set-equality contract is
+/// what makes appended/edited old files impossible to double-count:
+/// an appended file's mtime moves it to the recent side AND breaks
+/// equality, so its stale contribution is rebuilt out.
+///
+/// The published snapshot is `emit(stable ⊕ fold(recent))`, sharing
+/// [`emit`]/[`fold`] with [`aggregate`] — the property tests pin the
+/// result byte-identical to a one-shot full scan of the same tree.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)] // wired into the plugin dispatch in P5
+pub(crate) fn scan_incremental(
+    roots: &ProviderRoots,
+    cache: &mut Option<crate::cache::UsageCache>,
+    stored: Option<StableAggregate>,
+    watermark_nanos: u64,
+    reporter: &mut ProgressReporter,
+) -> ScanOutcome {
+    // Pass 1: skip stable files, parse-or-cache recent ones.
+    let mut ctx = ScanCtx::incremental(cache, watermark_nanos, StablePolicy::Skip);
+    let recent_calls = walk_providers(roots, &mut ctx, reporter);
+    let mut counters = ctx.counters;
+    let mut stable_present = std::mem::take(&mut ctx.stable_present);
+    stable_present.sort_unstable();
+
+    let (stable, stable_rebuilt, recent_calls) = match stored {
+        Some(st) if st.folded == stable_present => {
+            counters.stable_reused = true;
+            (st, false, recent_calls)
+        }
+        _ => {
+            // Rebuild pass: read stable files too (cache-served when
+            // warm) and fold a fresh rollup. Progress already ticked
+            // in pass 1, so this pass reports to a noop sink.
+            let mut rebuild_ctx =
+                ScanCtx::incremental(cache, watermark_nanos, StablePolicy::Collect);
+            let mut noop = ProgressReporter::noop();
+            let recent2 = walk_providers(roots, &mut rebuild_ctx, &mut noop);
+            counters.files_statted += rebuild_ctx.counters.files_statted;
+            counters.parsed += rebuild_ctx.counters.parsed;
+            counters.cache_hits += rebuild_ctx.counters.cache_hits;
+            let mut folded = std::mem::take(&mut rebuild_ctx.stable_present);
+            folded.sort_unstable();
+            let state = fold(std::mem::take(&mut rebuild_ctx.stable_calls));
+            (
+                StableAggregate {
+                    watermark_nanos,
+                    folded,
+                    state,
+                },
+                true,
+                recent2,
+            )
+        }
+    };
+
+    let mut merged = stable.state.clone();
+    merged.absorb(fold(recent_calls));
+    let data = emit(merged);
+
+    ScanOutcome {
+        data,
+        counters,
+        stable,
+        stable_rebuilt,
+    }
 }
 
 /// Count `.jsonl` files in the Claude layout: `<root>/<project>/<session>.jsonl`.
@@ -638,10 +826,6 @@ impl AggState {
     /// On key collisions buckets merge and sets union; for the
     /// project-path last-write the side with the greater
     /// `(timestamp, id)` wins, mirroring fold's iteration order.
-    // Exercised by the byte-identity property tests today; production
-    // call site is `scan_incremental` (P4, same branch). Remove the
-    // allow when that lands.
-    #[allow(dead_code)]
     pub(crate) fn absorb(&mut self, other: Self) {
         // Merge two (timestamp, id)-sorted call vecs; `self` first on
         // (impossible-in-practice) equal keys to mirror stable sort.
@@ -709,7 +893,6 @@ impl AggState {
     }
 }
 
-#[allow(dead_code)] // wired in by scan_incremental (P4)
 fn merge_bucket_acc(into: &mut BucketAccumulator, from: BucketAccumulator) {
     merge(&mut into.bucket, &from.bucket);
     add_cost_nanos(&mut into.cost_nanos, from.cost_nanos);
@@ -752,7 +935,6 @@ struct ProjectAccumulator {
 }
 
 impl ProjectAccumulator {
-    #[allow(dead_code)] // wired in by scan_incremental (P4)
     fn absorb(&mut self, other: Self) {
         if other.last_path_key >= self.last_path_key {
             self.path = other.path;
@@ -776,7 +958,6 @@ struct SessionAccumulator {
 }
 
 impl SessionAccumulator {
-    #[allow(dead_code)] // wired in by scan_incremental (P4)
     fn absorb(&mut self, other: &Self) {
         if other.first_timestamp < self.first_timestamp {
             self.first_timestamp = other.first_timestamp;
@@ -1326,6 +1507,356 @@ mod tests {
     #[test]
     fn aggregate_empty_still_returns_default_usage_data() {
         assert_eq!(aggregate(Vec::new()), UsageData::default());
+    }
+
+    // ── incremental scan integration (L1 counters + L2 oracle) ──────
+    //
+    // Every scenario asserts the incremental snapshot is byte-identical
+    // to a cache-less full scan (`scan`) of the SAME tree state — the
+    // legacy path is the oracle — plus the counter facts that prove
+    // what the scan actually did.
+
+    use tempfile::TempDir;
+
+    fn claude_line(ts: &str, session: &str, input: u64, output: u64) -> String {
+        format!(
+            r#"{{"type":"assistant","timestamp":"{ts}","sessionId":"{session}","cwd":"/tmp/proj","gitBranch":"main","message":{{"model":"claude-3-5-sonnet","content":[{{"type":"text","text":"hi"}},{{"type":"tool_use","name":"Read"}}],"usage":{{"input_tokens":{input},"output_tokens":{output},"cache_read_input_tokens":7}}}}}}"#
+        )
+    }
+
+    struct IncrFixture {
+        _tmp: TempDir,
+        claude_root: PathBuf,
+        roots: ProviderRoots,
+        cache_dir: TempDir,
+    }
+
+    impl IncrFixture {
+        fn new() -> Self {
+            let tmp = TempDir::new().expect("tempdir");
+            let claude_root = tmp.path().join("claude/projects");
+            std::fs::create_dir_all(&claude_root).expect("mkdir");
+            let roots = ProviderRoots {
+                claude_projects: Some(claude_root.clone()),
+                ..ProviderRoots::default()
+            };
+            let cache_dir = TempDir::new().expect("cache dir");
+            Self {
+                _tmp: tmp,
+                claude_root,
+                roots,
+                cache_dir,
+            }
+        }
+
+        fn write_file(&self, project: &str, name: &str, lines: &[String]) {
+            let dir = self.claude_root.join(project);
+            std::fs::create_dir_all(&dir).expect("mkdir project");
+            std::fs::write(dir.join(name), lines.join("\n")).expect("write jsonl");
+        }
+
+        fn open_cache(&self) -> Option<crate::cache::UsageCache> {
+            Some(
+                crate::cache::UsageCache::open(&self.cache_dir.path().join("usage.sqlite"))
+                    .expect("open cache"),
+            )
+        }
+
+        fn oracle_bytes(&self) -> Vec<u8> {
+            encode(&scan(&self.roots))
+        }
+    }
+
+    fn now_nanos() -> u64 {
+        u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos(),
+        )
+        .unwrap_or(u64::MAX)
+    }
+
+    /// Sleep long enough for the filesystem mtime clock to tick past
+    /// `now` so a watermark captured between writes cleanly splits them.
+    fn tick() {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    #[test]
+    fn incremental_cold_rebuild_matches_full_scan_oracle() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "old.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let out = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+
+        assert!(out.stable_rebuilt, "no stored stable => rebuild");
+        assert!(!out.counters.stable_reused);
+        assert_eq!(out.stable.folded.len(), 1, "old.jsonl folded");
+        assert_eq!(
+            encode(&out.data),
+            fx.oracle_bytes(),
+            "matches full-scan oracle"
+        );
+    }
+
+    #[test]
+    fn incremental_no_change_refresh_parses_zero_and_reuses_stable() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "old.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+
+        // Second refresh, nothing changed on disk: the CPU-fix gate.
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            &mut reporter,
+        );
+
+        assert!(
+            second.counters.stable_reused,
+            "stable set unchanged => reuse"
+        );
+        assert!(!second.stable_rebuilt);
+        assert_eq!(
+            second.counters.parsed, 0,
+            "no-change refresh parses ZERO files"
+        );
+        assert_eq!(
+            second.counters.stable_skipped, 1,
+            "old file skipped entirely"
+        );
+        assert_eq!(
+            second.counters.cache_hits, 1,
+            "recent file served from cache"
+        );
+        assert_eq!(
+            encode(&second.data),
+            fx.oracle_bytes(),
+            "matches full-scan oracle"
+        );
+    }
+
+    #[test]
+    fn incremental_new_recent_file_parses_only_it() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "old.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+
+        fx.write_file(
+            "proj-b",
+            "new2.jsonl",
+            &[claude_line("2026-06-02T11:00:00Z", "s3", 5, 5)],
+        );
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            &mut reporter,
+        );
+
+        assert!(second.counters.stable_reused, "stable side untouched");
+        assert_eq!(second.counters.parsed, 1, "only the new file parses");
+        assert_eq!(
+            encode(&second.data),
+            fx.oracle_bytes(),
+            "matches full-scan oracle"
+        );
+    }
+
+    #[test]
+    fn incremental_aged_out_file_rebuilds_without_double_count() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "a.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let wm1 = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "b.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, wm1, &mut reporter);
+        assert_eq!(first.stable.folded.len(), 1);
+
+        // The watermark advances past b.jsonl — it ages into the
+        // stable set, breaking fingerprint equality.
+        let wm2 = now_nanos();
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            wm2,
+            &mut reporter,
+        );
+
+        assert!(second.stable_rebuilt, "aged-in file forces rebuild");
+        assert_eq!(second.stable.folded.len(), 2, "both files folded now");
+        assert_eq!(
+            second.counters.parsed, 0,
+            "rebuild is cache-served, no reparse"
+        );
+        assert_eq!(
+            encode(&second.data),
+            fx.oracle_bytes(),
+            "matches full-scan oracle"
+        );
+    }
+
+    #[test]
+    fn incremental_deleted_old_file_drops_its_contribution() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "doomed.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        fx.write_file(
+            "proj-a",
+            "keeper.jsonl",
+            &[claude_line("2026-05-02T10:00:00Z", "s9", 1, 1)],
+        );
+        tick();
+        let watermark = now_nanos();
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        assert_eq!(first.stable.folded.len(), 2);
+
+        std::fs::remove_file(fx.claude_root.join("proj-a/doomed.jsonl")).expect("rm");
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            &mut reporter,
+        );
+
+        assert!(
+            second.stable_rebuilt,
+            "deletion breaks fingerprint equality"
+        );
+        assert_eq!(
+            second.stable.folded.len(),
+            1,
+            "only the keeper remains folded"
+        );
+        assert_eq!(
+            encode(&second.data),
+            fx.oracle_bytes(),
+            "matches post-delete oracle"
+        );
+    }
+
+    #[test]
+    fn incremental_appended_old_file_moves_to_recent_without_double_count() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "grow.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let watermark = now_nanos();
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        assert_eq!(first.stable.folded.len(), 1, "grow.jsonl folded as stable");
+
+        // Append a line: mtime bumps past the watermark, so the file
+        // flips to the recent side AND vanishes from the stable set —
+        // its old contribution must be rebuilt out, not double-counted.
+        let path = fx.claude_root.join("proj-a/grow.jsonl");
+        let mut content = std::fs::read_to_string(&path).expect("read");
+        content.push('\n');
+        content.push_str(&claude_line("2026-05-01T10:05:00Z", "s1", 11, 22));
+        std::fs::write(&path, content).expect("append");
+
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            &mut reporter,
+        );
+
+        assert!(second.stable_rebuilt, "stable set lost the appended file");
+        assert!(second.stable.folded.is_empty(), "nothing stable remains");
+        assert_eq!(
+            second.data.grand_total.call_count, 2,
+            "old + appended call, counted once each"
+        );
+        assert_eq!(
+            encode(&second.data),
+            fx.oracle_bytes(),
+            "matches post-append oracle"
+        );
+    }
+
+    #[test]
+    fn incremental_without_stored_stable_on_empty_tree_is_default() {
+        let fx = IncrFixture::new();
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let out = scan_incremental(&fx.roots, &mut cache, None, now_nanos(), &mut reporter);
+        assert_eq!(encode(&out.data), encode(&UsageData::default()));
+        assert!(out.stable.folded.is_empty());
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -403,7 +403,6 @@ fn walk_providers(
 /// [`emit`]/[`fold`] with [`aggregate`] — the property tests pin the
 /// result byte-identical to a one-shot full scan of the same tree.
 #[cfg(not(target_arch = "wasm32"))]
-#[allow(dead_code)] // wired into the plugin dispatch in P5
 pub(crate) fn scan_incremental(
     roots: &ProviderRoots,
     cache: &mut Option<crate::cache::UsageCache>,

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -29,6 +29,7 @@ use ainb_plugin_types_sessions::{
     SessionUsage, TokenBucket, UsageData,
 };
 use chrono::{Datelike, Duration, NaiveDate};
+use serde::{Deserialize, Serialize};
 
 /// Minimum gap between progress emits. Caps emission to 10 events/s and
 /// satisfies the "every 100 ms or every 10 files, whichever first"
@@ -324,13 +325,32 @@ fn count_jsonl_recursive(root: &Path) -> usize {
 }
 
 /// Pure aggregation: `Vec<ProviderCall>` → `UsageData`.
-#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
-pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
-    if calls.is_empty() {
-        return UsageData::default();
-    }
+///
+/// Implemented as [`fold`] (per-call accumulation) followed by [`emit`]
+/// (derive the sorted, deterministic snapshot). The incremental refresh
+/// path reuses the same two stages — it folds only recent calls, merges
+/// onto a persisted stable [`AggState`] via [`AggState::absorb`], and
+/// emits — so both paths share the exact code that determines the
+/// published bytes.
+pub fn aggregate(calls: Vec<ProviderCall>) -> UsageData {
+    emit(fold(calls))
+}
 
-    calls.sort_by_key(|c| c.timestamp);
+/// Fold stage: accumulate calls into mergeable per-dimension state.
+///
+/// Calls sort by `(timestamp, id)` — a total order (`id` is FNV-1a 64
+/// of `path:offset`, unique per call) — so the fold result is
+/// independent of input order and [`AggState::absorb`] reproduces
+/// exactly what one fold over the concatenated input would build.
+///
+/// Costs accumulate as integer nano-USD ([`usd_to_nanos`]) rather than
+/// `f64`: float addition is not associative, so summing in a different
+/// order (incremental merge vs one-shot fold) could drift in the last
+/// ulp and break the byte-identity contract. Integer addition is
+/// exact; [`emit`] materializes the `f64` once at the end.
+#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
+pub(crate) fn fold(mut calls: Vec<ProviderCall>) -> AggState {
+    calls.sort_by_key(|c| (c.timestamp, c.id));
 
     let mut daily: BTreeMap<NaiveDate, BucketAccumulator> = BTreeMap::new();
     let mut weekly: BTreeMap<NaiveDate, BucketAccumulator> = BTreeMap::new();
@@ -342,9 +362,11 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
     let mut shell_commands: BTreeMap<String, usize> = BTreeMap::new();
     let mut model_project_counts: BTreeMap<String, BTreeMap<String, usize>> = BTreeMap::new();
     let mut grand_total = TokenBucket::default();
+    let mut grand_cost_nanos: Option<i64> = None;
 
     for call in &calls {
         let bucket = call_bucket(call);
+        let cost = call.cost_usd.map(usd_to_nanos);
         let day = call.timestamp.date_naive();
         let week = week_start(day);
         let session_key = format!(
@@ -355,16 +377,23 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
         );
 
         merge(&mut grand_total, &bucket);
+        add_cost_nanos(&mut grand_cost_nanos, cost);
 
-        daily.entry(day).or_default().ingest(&bucket, &call.project, &session_key);
-        weekly.entry(week).or_default().ingest(&bucket, &call.project, &session_key);
-        models
-            .entry(call.model.clone())
+        daily.entry(day).or_default().ingest(&bucket, cost, &call.project, &session_key);
+        weekly
+            .entry(week)
             .or_default()
-            .ingest(&bucket, &call.project, &session_key);
+            .ingest(&bucket, cost, &call.project, &session_key);
+        models.entry(call.model.clone()).or_default().ingest(
+            &bucket,
+            cost,
+            &call.project,
+            &session_key,
+        );
         if let Some(branch) = call.branch.as_deref().filter(|b| !b.is_empty()) {
             branches.entry(branch.to_string()).or_default().ingest(
                 &bucket,
+                cost,
                 &call.project,
                 &session_key,
             );
@@ -372,12 +401,16 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
 
         let project = projects.entry(call.project.clone()).or_insert_with(|| ProjectAccumulator {
             path: call.project_path.clone(),
+            last_path_key: (call.timestamp, call.id),
             bucket: TokenBucket::default(),
+            cost_nanos: None,
             sessions: HashSet::new(),
         });
         project.path = call.project_path.clone();
+        project.last_path_key = (call.timestamp, call.id);
         project.sessions.insert(session_key.clone());
         merge(&mut project.bucket, &bucket);
+        add_cost_nanos(&mut project.cost_nanos, cost);
 
         let session = sessions.entry(session_key.clone()).or_insert_with(|| SessionAccumulator {
             provider: call.provider,
@@ -386,6 +419,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
             first_timestamp: call.timestamp,
             last_timestamp: call.timestamp,
             bucket: TokenBucket::default(),
+            cost_nanos: None,
         });
         if call.timestamp < session.first_timestamp {
             session.first_timestamp = call.timestamp;
@@ -394,6 +428,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
             session.last_timestamp = call.timestamp;
         }
         merge(&mut session.bucket, &bucket);
+        add_cost_nanos(&mut session.cost_nanos, cost);
 
         for tool in &call.tools {
             *tools.entry(tool.clone()).or_insert(0) += 1;
@@ -408,9 +443,47 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
             .or_insert(0) += 1;
     }
 
+    AggState {
+        calls,
+        daily,
+        weekly,
+        projects,
+        sessions,
+        models,
+        branches,
+        tools,
+        shell_commands,
+        model_project_counts,
+        grand_total,
+        grand_cost_nanos,
+    }
+}
+
+/// Emit stage: derive the sorted, deterministic [`UsageData`] from a
+/// fold state. Shared verbatim by [`aggregate`] and the incremental
+/// merge path, so both produce byte-identical snapshots for the same
+/// underlying calls.
+#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
+pub(crate) fn emit(state: AggState) -> UsageData {
+    let AggState {
+        calls,
+        daily,
+        weekly,
+        projects,
+        sessions,
+        models,
+        branches,
+        tools,
+        shell_commands,
+        model_project_counts,
+        mut grand_total,
+        grand_cost_nanos,
+    } = state;
+
     grand_total.call_count = calls.len();
     grand_total.session_count = sessions.len();
     grand_total.project_count = projects.len();
+    grand_total.cost_usd = grand_cost_nanos.map(nanos_to_usd);
 
     UsageData {
         daily: daily
@@ -418,6 +491,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
             .map(|(d, mut a)| {
                 a.bucket.session_count = a.sessions.len();
                 a.bucket.project_count = a.projects.len();
+                a.bucket.cost_usd = a.cost_nanos.map(nanos_to_usd);
                 (d, a.bucket)
             })
             .collect(),
@@ -426,6 +500,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
             .map(|(d, mut a)| {
                 a.bucket.session_count = a.sessions.len();
                 a.bucket.project_count = a.projects.len();
+                a.bucket.cost_usd = a.cost_nanos.map(nanos_to_usd);
                 (d, a.bucket)
             })
             .collect(),
@@ -435,6 +510,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
                 .map(|(name, mut p)| {
                     p.bucket.session_count = p.sessions.len();
                     p.bucket.project_count = 1;
+                    p.bucket.cost_usd = p.cost_nanos.map(nanos_to_usd);
                     ProjectUsage {
                         name,
                         path: p.path,
@@ -446,17 +522,20 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
             |p| p.bucket,
         ),
         grand_total,
-        calls: calls.clone(),
+        calls,
         sessions: sort_sessions_by_recency(
             sessions
                 .into_iter()
-                .map(|(_k, s)| SessionUsage {
-                    provider: s.provider,
-                    project: s.project,
-                    session_id: s.session_id,
-                    first_timestamp: s.first_timestamp,
-                    last_timestamp: s.last_timestamp,
-                    bucket: s.bucket,
+                .map(|(_k, mut s)| {
+                    s.bucket.cost_usd = s.cost_nanos.map(nanos_to_usd);
+                    SessionUsage {
+                        provider: s.provider,
+                        project: s.project,
+                        session_id: s.session_id,
+                        first_timestamp: s.first_timestamp,
+                        last_timestamp: s.last_timestamp,
+                        bucket: s.bucket,
+                    }
                 })
                 .collect(),
         ),
@@ -466,6 +545,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
                 .map(|(model, mut a)| {
                     a.bucket.session_count = a.sessions.len();
                     a.bucket.project_count = a.projects.len();
+                    a.bucket.cost_usd = a.cost_nanos.map(nanos_to_usd);
                     ModelUsage {
                         model,
                         bucket: a.bucket,
@@ -484,6 +564,7 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
                 .map(|(branch, mut a)| {
                     a.bucket.session_count = a.sessions.len();
                     a.bucket.project_count = a.projects.len();
+                    a.bucket.cost_usd = a.cost_nanos.map(nanos_to_usd);
                     BranchUsage {
                         branch,
                         bucket: a.bucket,
@@ -503,27 +584,166 @@ pub fn aggregate(mut calls: Vec<ProviderCall>) -> UsageData {
     }
 }
 
-#[derive(Default)]
+/// Mergeable fold state — the output of [`fold`], the input of
+/// [`emit`], and the unit the incremental path persists as the stable
+/// (older-than-watermark) aggregate.
+///
+/// Every field merges associatively in [`Self::absorb`]: token sums
+/// add, distinct-id sets union, session first/last take min/max, and
+/// costs add as integer nano-USD. Distinct counts are NOT stored here —
+/// [`emit`] derives them from the set sizes, which is what makes the
+/// merge exact where naive `session_count` addition would over-count.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct AggState {
+    /// All calls, sorted by `(timestamp, id)`.
+    pub(crate) calls: Vec<ProviderCall>,
+    daily: BTreeMap<NaiveDate, BucketAccumulator>,
+    weekly: BTreeMap<NaiveDate, BucketAccumulator>,
+    projects: BTreeMap<String, ProjectAccumulator>,
+    sessions: BTreeMap<String, SessionAccumulator>,
+    models: BTreeMap<String, BucketAccumulator>,
+    branches: BTreeMap<String, BucketAccumulator>,
+    tools: BTreeMap<String, usize>,
+    shell_commands: BTreeMap<String, usize>,
+    model_project_counts: BTreeMap<String, BTreeMap<String, usize>>,
+    grand_total: TokenBucket,
+    grand_cost_nanos: Option<i64>,
+}
+
+impl AggState {
+    /// Merge `other` into `self` so that
+    /// `emit(fold(a) ⊕ fold(b)) == emit(fold(a ++ b))` byte-for-byte.
+    ///
+    /// On key collisions buckets merge and sets union; for the
+    /// project-path last-write the side with the greater
+    /// `(timestamp, id)` wins, mirroring fold's iteration order.
+    // Exercised by the byte-identity property tests today; production
+    // call site is `scan_incremental` (P4, same branch). Remove the
+    // allow when that lands.
+    #[allow(dead_code)]
+    pub(crate) fn absorb(&mut self, other: Self) {
+        // Merge two (timestamp, id)-sorted call vecs; `self` first on
+        // (impossible-in-practice) equal keys to mirror stable sort.
+        let mut merged = Vec::with_capacity(self.calls.len() + other.calls.len());
+        let mut a = std::mem::take(&mut self.calls).into_iter().peekable();
+        let mut b = other.calls.into_iter().peekable();
+        loop {
+            match (a.peek(), b.peek()) {
+                (Some(x), Some(y)) => {
+                    if (x.timestamp, x.id) <= (y.timestamp, y.id) {
+                        merged.push(a.next().expect("peeked"));
+                    } else {
+                        merged.push(b.next().expect("peeked"));
+                    }
+                }
+                (Some(_), None) => merged.push(a.next().expect("peeked")),
+                (None, Some(_)) => merged.push(b.next().expect("peeked")),
+                (None, None) => break,
+            }
+        }
+        self.calls = merged;
+
+        for (k, v) in other.daily {
+            merge_bucket_acc(self.daily.entry(k).or_default(), v);
+        }
+        for (k, v) in other.weekly {
+            merge_bucket_acc(self.weekly.entry(k).or_default(), v);
+        }
+        for (k, v) in other.models {
+            merge_bucket_acc(self.models.entry(k).or_default(), v);
+        }
+        for (k, v) in other.branches {
+            merge_bucket_acc(self.branches.entry(k).or_default(), v);
+        }
+        for (k, v) in other.projects {
+            match self.projects.entry(k) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().absorb(v),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(v);
+                }
+            }
+        }
+        for (k, v) in other.sessions {
+            match self.sessions.entry(k) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().absorb(&v),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(v);
+                }
+            }
+        }
+        for (k, n) in other.tools {
+            *self.tools.entry(k).or_insert(0) += n;
+        }
+        for (k, n) in other.shell_commands {
+            *self.shell_commands.entry(k).or_insert(0) += n;
+        }
+        for (model, inner) in other.model_project_counts {
+            let mine = self.model_project_counts.entry(model).or_default();
+            for (project, n) in inner {
+                *mine.entry(project).or_insert(0) += n;
+            }
+        }
+        merge(&mut self.grand_total, &other.grand_total);
+        add_cost_nanos(&mut self.grand_cost_nanos, other.grand_cost_nanos);
+    }
+}
+
+#[allow(dead_code)] // wired in by scan_incremental (P4)
+fn merge_bucket_acc(into: &mut BucketAccumulator, from: BucketAccumulator) {
+    merge(&mut into.bucket, &from.bucket);
+    add_cost_nanos(&mut into.cost_nanos, from.cost_nanos);
+    into.sessions.extend(from.sessions);
+    into.projects.extend(from.projects);
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct BucketAccumulator {
     bucket: TokenBucket,
+    cost_nanos: Option<i64>,
     sessions: HashSet<String>,
     projects: HashSet<String>,
 }
 
 impl BucketAccumulator {
-    fn ingest(&mut self, bucket: &TokenBucket, project: &str, session_key: &str) {
+    fn ingest(
+        &mut self,
+        bucket: &TokenBucket,
+        cost: Option<i64>,
+        project: &str,
+        session_key: &str,
+    ) {
         merge(&mut self.bucket, bucket);
+        add_cost_nanos(&mut self.cost_nanos, cost);
         self.sessions.insert(session_key.to_string());
         self.projects.insert(project.to_string());
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ProjectAccumulator {
     path: String,
+    /// `(timestamp, id)` of the call that last wrote `path` — fold's
+    /// last-write-wins replayed exactly during [`AggState::absorb`].
+    last_path_key: (chrono::DateTime<chrono::Utc>, u64),
     bucket: TokenBucket,
+    cost_nanos: Option<i64>,
     sessions: HashSet<String>,
 }
 
+impl ProjectAccumulator {
+    #[allow(dead_code)] // wired in by scan_incremental (P4)
+    fn absorb(&mut self, other: Self) {
+        if other.last_path_key >= self.last_path_key {
+            self.path = other.path;
+            self.last_path_key = other.last_path_key;
+        }
+        merge(&mut self.bucket, &other.bucket);
+        add_cost_nanos(&mut self.cost_nanos, other.cost_nanos);
+        self.sessions.extend(other.sessions);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct SessionAccumulator {
     provider: Provider,
     project: String,
@@ -531,6 +751,46 @@ struct SessionAccumulator {
     first_timestamp: chrono::DateTime<chrono::Utc>,
     last_timestamp: chrono::DateTime<chrono::Utc>,
     bucket: TokenBucket,
+    cost_nanos: Option<i64>,
+}
+
+impl SessionAccumulator {
+    #[allow(dead_code)] // wired in by scan_incremental (P4)
+    fn absorb(&mut self, other: &Self) {
+        if other.first_timestamp < self.first_timestamp {
+            self.first_timestamp = other.first_timestamp;
+        }
+        if other.last_timestamp > self.last_timestamp {
+            self.last_timestamp = other.last_timestamp;
+        }
+        merge(&mut self.bucket, &other.bucket);
+        add_cost_nanos(&mut self.cost_nanos, other.cost_nanos);
+    }
+}
+
+/// Convert a per-call USD cost to integer nano-USD for exact,
+/// associative accumulation. Rounded once per call, so one-shot and
+/// incremental paths see identical integer inputs.
+fn usd_to_nanos(usd: f64) -> i64 {
+    (usd * 1e9).round() as i64
+}
+
+/// Materialize one accumulated nano-USD sum back to the published
+/// `f64`. Callers map over their `Option` cost.
+#[allow(clippy::cast_precision_loss)]
+fn nanos_to_usd(nanos: i64) -> f64 {
+    nanos as f64 / 1e9
+}
+
+/// `Option` cost addition with the same None-coalescing semantics as
+/// [`merge`]'s `cost_usd` arm: any `Some` survives, two `Some`s add.
+fn add_cost_nanos(into: &mut Option<i64>, from: Option<i64>) {
+    *into = match (*into, from) {
+        (Some(a), Some(b)) => Some(a + b),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
 }
 
 fn call_bucket(call: &ProviderCall) -> TokenBucket {
@@ -543,7 +803,9 @@ fn call_bucket(call: &ProviderCall) -> TokenBucket {
         session_count: 0,
         project_count: 0,
         call_count: 1,
-        cost_usd: call.cost_usd,
+        // Cost rides the accumulators as integer nano-USD (see `fold`);
+        // the bucket's f64 is materialized once in `emit`.
+        cost_usd: None,
     }
 }
 
@@ -886,6 +1148,178 @@ mod tests {
         assert_eq!(
             evts[0].total, 3,
             "pre-walk set total to count of progress-aware files"
+        );
+    }
+
+    // ── merge ≡ aggregate property tests ────────────────────────────
+    //
+    // The byte-identity contract: folding a partition of the calls and
+    // absorbing the parts must emit EXACTLY the bytes a one-shot
+    // aggregate over all calls emits. Seeded xorshift PRNG instead of
+    // a proptest dependency — reproducible, zero new deps, hundreds of
+    // randomized cases per run.
+
+    fn xorshift(state: &mut u64) -> u64 {
+        let mut x = *state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *state = x;
+        x
+    }
+
+    fn random_call(rng: &mut u64, id: u64) -> ProviderCall {
+        let providers = [Provider::Claude, Provider::Codex, Provider::Gemini];
+        let projects = ["alpha", "beta", "gamma", "delta"];
+        let sessions = ["s1", "s2", "s3"];
+        let models = ["m-small", "m-big", "m-think"];
+        let tool_pool = ["Read", "Edit", "Bash", "Grep"];
+        let cmd_pool = ["ls", "cargo test"];
+        let branch_pool = [None, Some("main"), Some("dev"), Some("")];
+
+        // Narrow timestamp range (~4 days) so daily/weekly/session
+        // buckets collide across partitions; allow exact-duplicate
+        // timestamps to exercise the (timestamp, id) tiebreak.
+        let ts = 1_700_000_000 + i64::try_from(xorshift(rng) % 350_000).unwrap();
+        let cost = match xorshift(rng) % 3 {
+            0 => None,
+            // Adversarial float costs: tiny + huge magnitudes in one
+            // sum is exactly where f64 association order would leak.
+            1 => Some((xorshift(rng) % 1_000_000) as f64 / 1e6),
+            _ => Some((xorshift(rng) % 97) as f64 + 0.000_001),
+        };
+        let n_tools = (xorshift(rng) % 3) as usize;
+
+        ProviderCall {
+            id,
+            provider: providers[(xorshift(rng) % 3) as usize],
+            model: models[(xorshift(rng) % 3) as usize].into(),
+            session_id: sessions[(xorshift(rng) % 3) as usize].into(),
+            project: projects[(xorshift(rng) % 4) as usize].into(),
+            project_path: format!("/tmp/{}", projects[(xorshift(rng) % 4) as usize]),
+            timestamp: DateTime::<Utc>::from_timestamp(ts, 0).unwrap(),
+            input_tokens: xorshift(rng) % 10_000,
+            cache_creation_tokens: xorshift(rng) % 1_000,
+            cache_read_tokens: xorshift(rng) % 50_000,
+            output_tokens: xorshift(rng) % 5_000,
+            reasoning_tokens: xorshift(rng) % 2_000,
+            cost_usd: cost,
+            tools: tool_pool[..n_tools].iter().map(|s| (*s).into()).collect(),
+            bash_commands: cmd_pool[..(xorshift(rng) % 2) as usize]
+                .iter()
+                .map(|s| (*s).into())
+                .collect(),
+            user_message: String::new(),
+            branch: branch_pool[(xorshift(rng) % 4) as usize].map(Into::into),
+        }
+    }
+
+    fn encode(data: &UsageData) -> Vec<u8> {
+        rmp_serde::to_vec_named(data).expect("encode UsageData")
+    }
+
+    #[test]
+    fn absorb_of_random_two_way_partition_is_byte_identical_to_aggregate() {
+        let mut rng: u64 = 0x5EED_CAFE_F00D_0001;
+        for case in 0..300 {
+            let n = (xorshift(&mut rng) % 60) as usize;
+            let calls: Vec<ProviderCall> =
+                (0..n).map(|i| random_call(&mut rng, 1_000 + i as u64)).collect();
+
+            let (mut left, mut right) = (Vec::new(), Vec::new());
+            for c in &calls {
+                if xorshift(&mut rng) % 2 == 0 {
+                    left.push(c.clone());
+                } else {
+                    right.push(c.clone());
+                }
+            }
+
+            let oracle = aggregate(calls);
+            let mut merged = fold(left);
+            merged.absorb(fold(right));
+            let incremental = emit(merged);
+
+            assert_eq!(
+                encode(&incremental),
+                encode(&oracle),
+                "case {case}: merged partition must emit identical bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn absorb_is_associative_across_three_way_partition() {
+        let mut rng: u64 = 0xDEAD_BEEF_0BAD_F00D;
+        for case in 0..150 {
+            let n = (xorshift(&mut rng) % 45) as usize;
+            let calls: Vec<ProviderCall> =
+                (0..n).map(|i| random_call(&mut rng, 5_000 + i as u64)).collect();
+
+            let mut parts: [Vec<ProviderCall>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+            for c in &calls {
+                parts[(xorshift(&mut rng) % 3) as usize].push(c.clone());
+            }
+            let [a, b, c] = parts;
+
+            let oracle = encode(&aggregate(calls));
+
+            // (A ⊕ B) ⊕ C
+            let mut left = fold(a.clone());
+            left.absorb(fold(b.clone()));
+            left.absorb(fold(c.clone()));
+            // A ⊕ (B ⊕ C)
+            let mut right_inner = fold(b);
+            right_inner.absorb(fold(c));
+            let mut right = fold(a);
+            right.absorb(right_inner);
+
+            assert_eq!(encode(&emit(left)), oracle, "case {case}: left-assoc");
+            assert_eq!(encode(&emit(right)), oracle, "case {case}: right-assoc");
+        }
+    }
+
+    #[test]
+    fn absorb_empty_is_identity() {
+        let mut rng: u64 = 0x1234_5678_9ABC_DEF0;
+        let calls: Vec<ProviderCall> = (0..25).map(|i| random_call(&mut rng, 9_000 + i)).collect();
+        let oracle = encode(&aggregate(calls.clone()));
+
+        let mut left = fold(calls.clone());
+        left.absorb(fold(Vec::new()));
+        assert_eq!(encode(&emit(left)), oracle, "X ⊕ ∅ == X");
+
+        let mut right = fold(Vec::new());
+        right.absorb(fold(calls));
+        assert_eq!(encode(&emit(right)), oracle, "∅ ⊕ X == X");
+
+        let mut both = fold(Vec::new());
+        both.absorb(fold(Vec::new()));
+        assert_eq!(
+            encode(&emit(both)),
+            encode(&UsageData::default()),
+            "∅ ⊕ ∅ == default"
+        );
+    }
+
+    #[test]
+    fn aggregate_empty_still_returns_default_usage_data() {
+        assert_eq!(aggregate(Vec::new()), UsageData::default());
+    }
+
+    #[test]
+    fn agg_state_roundtrips_through_bincode() {
+        // P3 persists AggState as the stable aggregate blob — prove the
+        // serde derives round-trip through the same codec the cache uses.
+        let mut rng: u64 = 0xFEED_FACE_CAFE_BEEF;
+        let calls: Vec<ProviderCall> = (0..30).map(|i| random_call(&mut rng, 7_000 + i)).collect();
+        let state = fold(calls);
+        let bytes = bincode::serialize(&state).expect("serialize AggState");
+        let back: AggState = bincode::deserialize(&bytes).expect("deserialize AggState");
+        assert_eq!(
+            encode(&emit(back)),
+            encode(&emit(state)),
+            "round-tripped state emits identical bytes"
         );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -547,6 +547,34 @@ mod tests {
     }
 
     #[test]
+    fn refresh_request_roundtrip_and_default() {
+        let bytes = rmp_serde::to_vec_named(&RefreshRequest { hard: true }).unwrap();
+        let back: RefreshRequest = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(back.hard);
+
+        // Empty map (a publisher encoding `{}`) → hard defaults off.
+        let back: RefreshRequest = rmp_serde::from_slice(&[0x80]).unwrap();
+        assert!(!back.hard);
+    }
+
+    /// Wire-format pin: the host CLI (`ainb-core/src/cli/registry.rs`,
+    /// `--hard` branch of `dispatch_inner`) publishes this exact byte
+    /// sequence WITHOUT linking this crate, to stay decoupled from the
+    /// plugin codec. If the canonical `to_vec_named` encoding of
+    /// `RefreshRequest { hard: true }` ever drifts from those
+    /// hand-pinned bytes, this test fails and both sides must move
+    /// together.
+    #[test]
+    fn refresh_request_hard_wire_bytes_are_pinned() {
+        const HARD_REFRESH_MSGPACK: [u8; 7] = [0x81, 0xA4, b'h', b'a', b'r', b'd', 0xC3];
+        let canonical = rmp_serde::to_vec_named(&RefreshRequest { hard: true }).unwrap();
+        assert_eq!(
+            canonical, HARD_REFRESH_MSGPACK,
+            "host CLI pinned bytes drifted"
+        );
+    }
+
+    #[test]
     fn envelope_roundtrip() {
         let env = UsageDataEvent {
             version: WIRE_VERSION,

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -78,6 +78,27 @@ pub struct ScanProgressEvent {
     pub current_project: String,
 }
 
+/// Optional payload for the `sessions.refresh_request` topic.
+///
+/// Historically the topic was a bare ping (empty payload) and most
+/// publishers — the host FS watcher, burndown s `r` key — still send
+/// exactly that, which decodes to the default: a normal incremental
+/// refresh. A `hard` refresh (msgpack `{hard: true}`) tells
+/// session-reader to distrust every cache layer and rebuild from
+/// source — the CPU-heavy path, so publishers gate it behind explicit
+/// user intent (`R` confirm in the TUI, `--hard` on the CLI).
+///
+/// Schema is intentionally unversioned, mirroring
+/// [`ScanProgressEvent`]: new fields arrive with `#[serde(default)]`
+/// so older publishers payloads keep decoding cleanly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefreshRequest {
+    /// `true` = full rebuild from source (wipe parse cache + stable
+    /// rollup first). `false`/absent = incremental refresh.
+    #[serde(default)]
+    pub hard: bool,
+}
+
 /// Top-level envelope published on the `sessions.usage_data` topic.
 ///
 /// `published_ns` is filled in from the host's wall-clock at publish

--- a/ainb-tui/scripts/soak-session-reader.sh
+++ b/ainb-tui/scripts/soak-session-reader.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Soak watch for the session-reader incremental-refresh contract.
+#
+# Tails the host JSONL logs (~/.agents-in-a-box/logs/) for the
+# counter line session-reader emits via host.log() after every refresh:
+#
+#   session-reader: incremental refresh statted=N parsed=N cache_hits=N
+#     stable_skipped=N stable_reused=true|false rebuilt=true|false
+#
+# and samples the CPU of every running session-reader process. What a
+# healthy steady state looks like:
+#
+#   - refreshes triggered by file changes report a small parsed=N
+#   - a refresh with NO session-log changes reports parsed=0 and
+#     stable_reused=true  ← the original 97%-CPU bug is dead when you
+#     see this repeatedly
+#   - rebuilt=true should appear at most ~once/day (a file aged past
+#     the window) or after a hard refresh / flush
+#   - session-reader CPU returns to ~0% between refreshes
+#
+# Usage:
+#   scripts/soak-session-reader.sh            # follow logs + CPU
+#   scripts/soak-session-reader.sh --history  # one-shot: grep existing logs, no follow
+#
+# Run one per machine (it watches every TUI's log file at once).
+set -euo pipefail
+
+LOG_DIR="${AINB_LOG_DIR:-$HOME/.agents-in-a-box/logs}"
+MODE="${1:-follow}"
+
+if [[ ! -d "$LOG_DIR" ]]; then
+    echo "no log dir at $LOG_DIR — start an ainb TUI first" >&2
+    exit 1
+fi
+
+# The counter line + cold-start + hard-refresh markers.
+PATTERN='incremental refresh statted=|built full usage history|HARD refresh requested|flush_cache requested'
+
+# Pull the interesting fields out of a JSONL line. jq if present,
+# otherwise pass the raw line through.
+pretty() {
+    if command -v jq >/dev/null 2>&1; then
+        jq --unbuffered -r '
+            select(.fields.message? // "" | test("'"$PATTERN"'")) |
+            "\(.timestamp)  \(.fields.plugin // "session-reader")  \(.fields.message)"
+        ' 2>/dev/null
+    else
+        grep --line-buffered -E "$PATTERN"
+    fi
+}
+
+newest_logs() {
+    # Every TUI writes its own timestamped file — watch the 6 newest so
+    # a multi-instance soak sees all of them.
+    ls -t "$LOG_DIR"/agents-in-a-box-*.jsonl 2>/dev/null | head -6
+}
+
+if [[ "$MODE" == "--history" ]]; then
+    echo "── refresh history (all logs) ──────────────────────────────"
+    cat "$LOG_DIR"/agents-in-a-box-*.jsonl 2>/dev/null | pretty
+    exit 0
+fi
+
+LOGS=$(newest_logs)
+if [[ -z "$LOGS" ]]; then
+    echo "no JSONL logs in $LOG_DIR yet — start an ainb TUI first" >&2
+    exit 1
+fi
+
+echo "── soaking session-reader ──────────────────────────────────────"
+echo "logs:"
+printf '  %s\n' $LOGS
+echo "watch for: parsed=0 stable_reused=true on no-change refreshes,"
+echo "and session-reader CPU ~0%% between refreshes. Ctrl-C to stop."
+echo "────────────────────────────────────────────────────────────────"
+
+# CPU sampler: one line every 10s, only when a session-reader runs.
+(
+    while true; do
+        ps -Ao pcpu,pid,etime,comm \
+            | grep -E "[s]ession-reader$|[a]inb-plugin-session-reader" \
+            | while read -r pcpu pid etime comm; do
+                printf 'cpu   %s  pid=%s  %%cpu=%s  up=%s\n' \
+                    "$(date '+%Y-%m-%dT%H:%M:%S')" "$pid" "$pcpu" "$etime"
+            done
+        sleep 10
+    done
+) &
+CPU_PID=$!
+trap 'kill "$CPU_PID" 2>/dev/null' EXIT
+
+# tail -F follows across rotations; new TUI instances create NEW files,
+# so re-run the script after launching additional TUIs mid-soak.
+# shellcheck disable=SC2086
+tail -F -n +1 $LOGS 2>/dev/null | pretty


### PR DESCRIPTION
## What

Splits session-reader's refresh into two modes and kills the sustained ~97% CPU it caused:

- **Incremental refresh** (default — auto FS-watcher path, `r` key, `ainb usage`): re-aggregates only files modified inside a configurable trailing window (`[session_reader] incremental_window_days = 30`); everything older is served from a **persisted stable rollup** and never read, parsed, or re-aggregated. A no-change refresh parses **zero** files.
- **Hard refresh** (user-gated — `R` + ⚠ confirm in the TUI, `ainb usage --hard` on the CLI): wipes the parse cache + rollup and rebuilds everything from source.

## Why

Every `sessions.refresh_request` used to trigger a full walk: deserialize every cached blob + re-aggregate the entire call history, every time (observed: session-reader pegging ~97% of a core for hours). Two concurrent ainb instances made it worse: the shared `usage.sqlite` had no `busy_timeout`, so overlapping scans hit `SQLITE_BUSY` and silently fell back to **cache-less full re-parses**.

## How (commit per phase)

| Commit | Phase |
|---|---|
| `712b835b` | `busy_timeout=5s` + bounded BUSY retry — two instances serialize instead of degrading to re-parse |
| `0803db19` | `aggregate()` split into mergeable `fold`/`emit` + `AggState::absorb`; `(timestamp,id)` total order; costs accumulate as integer nano-USD (f64 addition isn't associative — last-ulp drift would break byte-identity) |
| `e7e8c1c1` | `incremental_window_days` config (read-only disk load, defaults on any failure) |
| `f589ef25` | cache schema v2: persisted `StableAggregate` (rollup + fingerprint set + watermark); additive v1→v2 migration |
| `05bbfe00` | `scan_incremental`: watermark partition, stable-set equality validity, rebuild-from-warm-cache, instrumented `ScanCounters` |
| `cc8e694e` | `RefreshRequest{hard}` payload (empty payload = incremental, full back-compat); plugin dispatch; cold-start seeding; counters logged per refresh |
| `d0bee70d` | TUI: `r`/`R` split, ⚠ confirm overlay, `y`/`n`, parse-pacing for cold/hard scans |
| `79b867d0` | CLI `--hard` (wire-byte-pinned publish, host stays decoupled from plugin codec) + tmux journey tripwire |

## Correctness contract (how this is validated)

**The legacy full scan is the oracle.** The incremental path shares `fold`/`emit` with it, and tests pin byte-identity:

- **L0 property tests** (seeded randomized, no new deps): random two-way partitions emit msgpack **byte-identical** to one-shot `aggregate()` (300 cases); `absorb` associative across three-way partitions (150 cases); empty identity; `AggState` bincode roundtrip.
- **L1 integration** (tempdir provider trees + real sqlite cache): cold rebuild, **no-change refresh ⇒ `parsed == 0` + `stable_reused`** (the CPU-fix gate, asserted via counters), new file parses only itself, aged-in file rebuilds without double-count, deleted old file drops out, appended old file moves to recent without double-count — every scenario byte-identical to a cache-less full scan of the same tree.
- **L2 oracle equivalence**: built into every L1 scenario (`encode(incremental) == encode(scan(tree))`).
- **L4 journeys**: TestBackend render test for the confirm overlay; new tmux tripwire `tripwire_burndown_hard_refresh_confirm.rs` (R ⇒ overlay, no rebuild; `n` ⇒ cancel with data intact; `R y` ⇒ rebuild + republish). Existing burndown determinism tripwire untouched and green.
- Wire-format pin: host CLI's hand-pinned msgpack bytes for `{hard:true}` are asserted against the canonical `to_vec_named` encoding in types-sessions.

**Test totals:** session-reader 95/95 · types-sessions 13/13 · burndown 190/190 · fmt clean · clippy: zero warnings in changed files (pre-existing crate-level warnings untouched).

## Deliberate scope cuts (documented, not faked)

- **No mid-scan cancel**: `plugin/handle_event` is dispatched inline in receive order by SDK design (`server.rs` read_loop — ordering is load-bearing for chunked publishes), so a cancel event cannot preempt a running scan without a protocol-level concurrency change. Cancel works at the confirm stage.
- **No macOS thread-QoS**: the plugin crate `#![forbid(unsafe_code)]`, so pthread QoS FFI is unavailable. Instead the parser paces itself (500µs per parsed file) — softens cold/hard scans (thousands of parses), costs warm refreshes (~0–2 parses) nothing.
- Accepted debt: a same-`(mtime,size)` in-place rewrite is invisible to the incremental path; hard refresh is the documented escape hatch.
- `subprocess_smoke` hangs **on the dev box** identically at v1.5.0 / every commit of this branch (bisected; environmental — plugin stdio handshake wedges under this host's conditions). CI is the arbiter for it.
- The tmux tripwires could not be validated locally either: the **pre-existing** `tripwire_burndown_keys` fails on this box at the home-screen-render stage (before any analytics/burndown code runs) with the exact same signature as the new `tripwire_burndown_hard_refresh_confirm` — the TUI launches but the home chrome the predicate expects never appears in the pane. Both die in untouched host code; CI is the arbiter. (The overlay journey IS covered locally by the TestBackend render test in `ui.rs`.)

## Manual validation for the reviewer (L5 soak)

1. Build + stage: `cd ainb-tui && ./scripts/build-plugins.sh`
2. Run **two** ainb TUIs against your real `$HOME`, open Analytics in both.
3. First open after upgrade does the one-time seeding scan (progress bar; host log announces it).
4. After it settles: touch a session file → incremental refresh; check the session-reader log line `incremental refresh … parsed=N stable_skipped=M stable_reused=true` and that `ps` shows session-reader back at ~0% CPU between refreshes (the original symptom was a sustained ~97%).
5. `R` in Analytics → ⚠ confirm → `y` → gauge → rebuilt dashboard. `ainb usage --hard` for the CLI path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hard refresh capability (`--hard` flag and `R` keystroke) to completely rebuild analytics from source by clearing cache and parse data
  * Added confirmation overlay for hard refresh operations
  * Introduced incremental refresh option (`r` keystroke) for faster data updates
  * Added `incremental_window_days` configuration setting for session reader (default: 30 days)

* **Improvements**
  * Enhanced caching reliability with better handling of concurrent access
  * Improved refresh behavior with separate incremental and hard refresh workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->