### PR TITLE
feat(release): bundle first-party plugins into release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,16 +221,28 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
+      # Bundle the first-party plugins (session-reader / burndown / witr)
+      # into the archive. Without them a brew-installed ainb has no
+      # analytics: `ainb plugin install` is still a stub and the runtime
+      # only discovers plugins via AINB_PLUGIN_ROOT / exe-relative /
+      # cwd-relative dist/ — none of which exist on a bare binary
+      # install. The script stages target/<triple>/release binaries into
+      # dist/plugins/<id>/{<id>,manifest.toml} and ad-hoc re-signs on
+      # macOS (AMFI kills moved linker-signed binaries otherwise).
+      - name: Build + stage plugins
+        run: ./scripts/build-plugins.sh --release --target=${{ matrix.target }}
+
       - name: Package
         shell: bash
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           ARCHIVE="${BINARY_NAME}-${VERSION}-${{ matrix.target }}"
 
-          mkdir -p dist
-          cp target/${{ matrix.target }}/release/${BINARY_NAME}${{ matrix.ext }} dist/
-          cd dist
-          tar -czf "${ARCHIVE}.tar.gz" "${BINARY_NAME}${{ matrix.ext }}"
+          mkdir -p out
+          cp target/${{ matrix.target }}/release/${BINARY_NAME}${{ matrix.ext }} out/
+          cp -R dist/plugins out/plugins
+          cd out
+          tar -czf "${ARCHIVE}.tar.gz" "${BINARY_NAME}${{ matrix.ext }}" plugins
           shasum -a 256 "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
 
       - name: Upload artifacts
@@ -238,8 +250,8 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: |
-            ${{ env.WORKING_DIR }}/dist/*.tar.gz
-            ${{ env.WORKING_DIR }}/dist/*.sha256
+            ${{ env.WORKING_DIR }}/out/*.tar.gz
+            ${{ env.WORKING_DIR }}/out/*.sha256
 
   release:
     name: Create Release
@@ -361,7 +373,19 @@ jobs:
             end
 
             def install
-              bin.install "ainb"
+              # Real binary + bundled first-party plugins live in libexec;
+              # bin gets a thin env wrapper pointing the plugin runtime at
+              # them. `ainb plugin install` is not shipped yet, so without
+              # this a brew install has no analytics plugins at all. A
+              # user-set AINB_PLUGIN_ROOT still wins.
+              libexec.install "ainb"
+              libexec.install "plugins" if File.directory?("plugins")
+              (bin/"ainb").write <<~WRAPPER
+                #!/bin/bash
+                export AINB_PLUGIN_ROOT="${AINB_PLUGIN_ROOT:-#{libexec}/plugins}"
+                exec "#{libexec}/ainb" "$@"
+              WRAPPER
+              (bin/"ainb").chmod 0755
             end
 
             test do

--- a/ainb-tui/scripts/build-plugins.sh
+++ b/ainb-tui/scripts/build-plugins.sh
@@ -20,11 +20,17 @@ cd "$(dirname "$0")/.."
 
 PROFILE="dev"
 PROFILE_DIR="debug"
+TARGET=""
 for arg in "$@"; do
     case "$arg" in
         --release)
             PROFILE="release"
             PROFILE_DIR="release"
+            ;;
+        --target=*)
+            # Cross-compile triple (e.g. x86_64-apple-darwin). Cargo
+            # writes to target/<triple>/<profile> when set.
+            TARGET="${arg#*=}"
             ;;
         *)
             printf 'unknown arg: %s\n' "$arg" >&2
@@ -50,14 +56,15 @@ build_plugin() {
     local crate="$1"
     local plugin_id="$2"
 
-    cargo build -p "$crate" --profile "$PROFILE"
+    cargo build -p "$crate" --profile "$PROFILE" ${TARGET:+--target "$TARGET"}
 
     local out_dir="dist/plugins/$plugin_id"
     mkdir -p "$out_dir"
 
     # Cargo binary name == crate name. Staged binary name == plugin id
-    # (the runtime probes <root>/<id>/<id>).
-    cp "target/$PROFILE_DIR/$crate" "$out_dir/$plugin_id"
+    # (the runtime probes <root>/<id>/<id>). Cross-compiles land under
+    # target/<triple>/<profile>.
+    cp "target/${TARGET:+$TARGET/}$PROFILE_DIR/$crate" "$out_dir/$plugin_id"
     resign_macos "$out_dir/$plugin_id"
 
     # The manifest lives next to the crate. Most plugin crates are under


### PR DESCRIPTION
## What

Release tarballs now carry the first-party plugin binaries alongside `ainb`, and the Homebrew formula installs them where the runtime finds them — so `brew install ainb && ainb` has working analytics from **any** directory.

## Why

Previously the tarball shipped only the host binary. `ainb plugin install` is a stub (Phase 7c TBD), and plugin discovery (AINB_PLUGIN_ROOT → exe-relative → cwd-relative `dist/` → `~/.agents-in-a-box/plugins/cache/`) finds nothing on a bare binary install — analytics only worked when `ainb` was launched from inside a source checkout (the cwd fallback).

## How

- `scripts/build-plugins.sh` gains `--target=<triple>` (cargo writes cross-compiles to `target/<triple>/<profile>`); macOS ad-hoc re-sign already handled by the script.
- Release build job stages all first-party plugins (release profile, per matrix target) and the archive becomes `ainb` + `plugins/<id>/{<id>,manifest.toml}`.
- Formula: binary + plugins into `libexec`, thin bash wrapper in `bin` exporting `AINB_PLUGIN_ROOT="${AINB_PLUGIN_ROOT:-#{libexec}/plugins}"` (user override wins) + `chmod 0755`.

## Validated locally

- `build-plugins.sh --release --target=aarch64-apple-darwin` stages all 5 plugins (abtop, burndown, hangar-tui, session-reader, witr) under `dist/plugins/` and the binaries are valid signed arm64 Mach-O.
- Simulated the Package step: tar contains `plugins/<id>/{<id>,manifest.toml}` exactly as the formula expects.
- Formula heredoc extracted + `ruby -c`: syntax OK. Workflow YAML parses.

Note: the release workflow itself only runs on `workflow_dispatch`, so the real end-to-end proof is the next release cut.