### PR TITLE
feat(tui): make abtop a first-class overlay panel (open from session list)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1296,14 +1296,15 @@ impl EventHandler {
             KeyCode::Char('b') => Some(AppEvent::GoToInbox),
             // Panel screens mirror their home-menu letters here so every
             // panel opens from the session list too (i stats, w witr,
-            // k skills — same set `handle_home_screen_keys` binds).
+            // k skills, t abtop — same set `handle_home_screen_keys` binds).
             // GoToStats/GoToSkills save `previous_screen`, so closing the
-            // panel lands back on the session list, not home. GoToWitr is
-            // a tmux suspend/attach that never changes `current_screen`,
-            // so quitting witr resumes here automatically.
+            // panel lands back on the session list, not home. GoToWitr /
+            // GoToAbtop are tmux suspend/attach that never change
+            // `current_screen`, so quitting them resumes here automatically.
             KeyCode::Char('i') => Some(AppEvent::GoToStats),
             KeyCode::Char('w') => Some(AppEvent::GoToWitr),
             KeyCode::Char('k') => Some(AppEvent::GoToSkills),
+            KeyCode::Char('t') => Some(AppEvent::GoToAbtop),
 
             // Tmux preview scroll mode (Shift + Up/Down)
             KeyCode::Up if key_event.modifiers.contains(KeyModifiers::SHIFT) => {

--- a/ainb-tui/crates/ainb-core/src/components/help.rs
+++ b/ainb-tui/crates/ainb-core/src/components/help.rs
@@ -62,6 +62,7 @@ impl HelpComponent {
             ListItem::new("  i          Stats / usage analytics (Esc closes)"),
             ListItem::new("  w          Witr process browser (quit witr to return)"),
             ListItem::new("  k          Skills browser (Esc closes)"),
+            ListItem::new("  t          Abtop agent monitor (quit abtop to return)"),
             ListItem::new(""),
             ListItem::new("Views:")
                 .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -322,7 +322,9 @@ impl LayoutComponent {
             key("w", GOLD),
             desc(" witr "),
             key("k", GOLD),
-            desc(" skills"),
+            desc(" skills "),
+            key("t", GOLD),
+            desc(" abtop"),
             sep(),
             key("?/H", CORNFLOWER_BLUE),
             desc(" help "),
@@ -1117,6 +1119,7 @@ mod menu_bar_tests {
             "stats",    // i — analytics panel
             "witr",     // w — process-causality browser
             "skills",   // k — skills browser
+            "abtop",    // t — top-for-agents monitor
         ] {
             assert!(
                 rendered.contains(token),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_abtop.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_abtop.rs
@@ -239,3 +239,113 @@ fn pressing_t_offers_setup_then_embeds_abtop() {
         "`{ABTOP_SESSION}` exists but isn't running abtop's monitor:\n---\n{abtop_pane}\n---"
     );
 }
+
+/// Overlay-panels parity: abtop opened FROM THE SESSION LIST (the `t`
+/// shortcut is now mirrored there, like stats/witr/skills) returns to the
+/// session list when the user quits abtop — not home.
+///
+/// Like witr, abtop is a tmux suspend/attach (`AttachAbtop` never touches
+/// `current_screen`), so resume-on-origin is automatic — this proves it
+/// end-to-end and that the new session-list `t` binding actually launches
+/// abtop. Seeds `abtop-setup-dismissed` so the first-run consent dialog
+/// doesn't intercept `t` (that leg is covered by the test above).
+#[test]
+fn abtop_opened_from_session_list_resumes_on_session_list() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+    if !abtop_available() {
+        eprintln!("SKIP: real `abtop` binary not on PATH — the embed runs `abtop --exit-on-jump`");
+        return;
+    }
+
+    kill_session(ABTOP_SESSION);
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_home(home_tmp.path());
+    // Skip the one-time setup consent so `t` launches abtop directly.
+    fs::write(
+        home_tmp.path().join(".agents-in-a-box").join("abtop-setup-dismissed"),
+        b"1",
+    )
+    .expect("seed abtop-setup-dismissed");
+
+    let session = format!("tripwire-abtop-resume-{}", std::process::id());
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "200", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    let cmd = format!(
+        "HOME={} exec {} tui",
+        home_tmp.path().display(),
+        ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux send launch cmd");
+
+    // Home → session list (plugins enabled — abtop needs the real PATH —
+    // so cold start is slower; keep the deadline generous).
+    let home_ok = poll(Instant::now() + Duration::from_secs(90), || {
+        let c = capture_pane(&session);
+        c.contains("Stats") && c.contains("[i]")
+    });
+    if !home_ok {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("HomeScreen never rendered; last:\n---\n{last}\n---");
+    }
+    send_key(&session, "s");
+    let on_sessions = poll(Instant::now() + Duration::from_secs(40), || {
+        capture_pane(&session).contains("del-sel")
+    });
+    if !on_sessions {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("session list never rendered after `s`; last:\n---\n{last}\n---");
+    }
+
+    // Press `t` → ainb spawns `ainb-abtop` running the monitor and attaches.
+    send_key(&session, "t");
+    let spawned = poll(Instant::now() + Duration::from_secs(25), || {
+        has_session(ABTOP_SESSION)
+    });
+    if !spawned {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!(
+            "`t` from session list did not spawn `{ABTOP_SESSION}`; ainb pane:\n---\n{last}\n---"
+        );
+    }
+
+    // Quit abtop (`q`). Its tmux session ends and ainb's attach returns.
+    send_key(ABTOP_SESSION, "q");
+    let gone = poll(Instant::now() + Duration::from_secs(15), || {
+        !has_session(ABTOP_SESSION)
+    });
+    if !gone {
+        send_key(ABTOP_SESSION, "q");
+        let _ = poll(Instant::now() + Duration::from_secs(10), || {
+            !has_session(ABTOP_SESSION)
+        });
+    }
+
+    // Resume must land back on the SESSION LIST (origin), not home.
+    let resumed = poll(Instant::now() + Duration::from_secs(15), || {
+        let c = capture_pane(&session);
+        c.contains("del-sel") && !c.contains("Getting Started")
+    });
+    let final_cap = capture_pane(&session);
+    kill_session(ABTOP_SESSION);
+    kill_session(&session);
+
+    assert!(
+        resumed,
+        "after quitting abtop (opened from the session list) ainb did not resume on the \
+         session list within 15s. Final pane:\n---\n{final_cap}\n---"
+    );
+}


### PR DESCRIPTION
## What

`abtop` (the top-for-agents monitor, added by the abtop epic) had a home sidebar tile + `t` shortcut and gets resume-to-origin for free (it's a tmux suspend/attach like witr — `AttachAbtop` never touches `current_screen`). But it was never mirrored onto the **session list**, the **menu legend**, or the **help overlay**, so it wasn't a first-class "open from anywhere" panel like inbox/stats/witr/skills.

This closes that gap (a follow-up to the merged overlay-panels PR #249, same shape as the Hangar consistency fix in that review):

- Bind `t` in the session-list key handler (mirrors `i`/`w`/`k`/`b`).
- Add `t abtop` to legend line 4 — still fits 80 cols (width test extended with the `abtop` token).
- List abtop in the help overlay's "Panels" section.

Resume-on-origin needs no new wiring — `AttachAbtop` is a suspend/attach, so quitting abtop resumes wherever it was opened from.

## Tests

- `menu_bar_keys_not_truncated_at_80_cols` extended (legend fits with abtop).
- New tmux tripwire `abtop_opened_from_session_list_resumes_on_session_list` (mirrors the witr resume test): launch → session list → `t` → ainb-abtop spawns → quit abtop → ainb resumes on the **session list**, not home. Skip-gated on the `abtop` binary. Green locally.

## Proof
```
session-list legend line 4:
  b inbox i stats w witr k skills t abtop │ ?/H help q home
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `t` keyboard shortcut to access the Abtop agent monitor from the session list.

* **Documentation**
  * Updated help menu and bottom menu bar to display the new Abtop shortcut.

* **Tests**
  * Added end-to-end integration test verifying Abtop navigation and return to session list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->