### PR TITLE
feat: add AntV Infographic external agent-skill

### DIFF
--- a/toolkit/external-dependencies.yaml
+++ b/toolkit/external-dependencies.yaml
@@ -237,6 +237,30 @@ agent-skills:
       - "rsvg-convert (librsvg) for PNG export — `brew install librsvg`"
     docs: "https://github.com/yizhiyanhua-ai/fireworks-tech-graph"
 
+  - name: antv-infographic
+    repo: https://github.com/antvis/Infographic
+    version: "0.2.19"
+    multi-subpath: skills
+    applies-to: [claude, codex, copilot, gemini]
+    purpose: "AntV's declarative infographic generation + rendering engine — turn words/data into high-quality SVG infographics from ~200 templates, AI-friendly config, hand-drawn + gradient themes"
+    multi-skill: true
+    skills:
+      - infographic-creator: "Primary entry point — generate a complete infographic from a topic/dataset, picking template + structure + items"
+      - infographic-syntax-creator: "Author the declarative infographic syntax (the @antv/infographic config spec)"
+      - infographic-structure-creator: "Design the layout/structure skeleton an infographic hangs off"
+      - infographic-item-creator: "Create individual infographic items/blocks within a structure"
+      - infographic-template-updater: "Update or extend the bundled template library"
+    features:
+      - Declarative @antv/infographic engine with streaming SVG rendering
+      - ~200 built-in templates + built-in editor
+      - AI-friendly configuration syntax (words/data → infographic)
+      - Theme system (hand-drawn + gradient styles)
+      - 5 cross-agent skills under skills/ (SKILL.md standard)
+      - MIT licensed
+    requires:
+      - "node.js (>=18) + npm if rendering locally (`npm install @antv/infographic`)"
+    docs: "https://github.com/antvis/Infographic"
+
   # ---------------------------------------------------------------------------
   # Catalog-only entries below — listed for discoverability / alternatives
   # consideration but NOT installed by bootstrap. Flip `catalog-only: true` to

--- a/toolkit/packages/skills/explain-to-me/SKILL.md
+++ b/toolkit/packages/skills/explain-to-me/SKILL.md
@@ -124,6 +124,7 @@ skill rather than hand-drawing SVG:
 |---|---|---|
 | Architecture · data flow · sequence · agent/memory · concept map | `/fireworks-tech-graph` | SVG + PNG (drop SVG inline) |
 | Knowledge graph from code/docs/papers — clustered, communities | `/graphify` | HTML / JSON / SVG |
+| Data-driven infographic — stats, comparisons, processes, timelines as a designed poster-style figure | `/infographic-creator` (AntV) | SVG (drop inline) |
 
 For small bespoke SVG (decorative icons, hero glyphs, simple
 illustrations) — author the inline SVG directly. You're capable of it

--- a/toolkit/scripts/update-externals.sh
+++ b/toolkit/scripts/update-externals.sh
@@ -92,6 +92,30 @@ update_agent_skills() {
       run "git clone --depth 1 '$url' '$dir'"
     fi
   done
+  # antv-infographic is multi-subpath (bundles 5 skills under skills/). A flat
+  # clone would bury them under skills/, so clone to a temp dir and flatten each
+  # SKILL.md-bearing child into ~/.claude/skills/ (mirrors bootstrap setup-external).
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  DRY: git clone --depth 1 https://github.com/antvis/Infographic + flatten skills/* into $AS_DIR"
+  else
+    local aig_tmp
+    aig_tmp=$(mktemp -d)
+    if git clone --depth 1 https://github.com/antvis/Infographic "$aig_tmp/repo" 2>/dev/null; then
+      for sub in "$aig_tmp/repo/skills"/*/; do
+        local sub_name
+        sub_name=$(basename "$sub")
+        if [ -f "$sub/SKILL.md" ]; then
+          rm -rf "$AS_DIR/$sub_name"
+          mkdir -p "$AS_DIR/$sub_name"
+          cp -R "$sub". "$AS_DIR/$sub_name/"
+          echo "    Installed/updated $sub_name"
+        fi
+      done
+    else
+      echo "    (antv-infographic clone failed — continuing)"
+    fi
+    rm -rf "$aig_tmp"
+  fi
   # scrapling-official has its own install path
   run "scrapling install --force"
   # mcporter ships its SKILL.md via the openclaw/mcporter repo above; the

--- a/toolkit/scripts/update-externals.sh
+++ b/toolkit/scripts/update-externals.sh
@@ -104,10 +104,10 @@ update_agent_skills() {
       for sub in "$aig_tmp/repo/skills"/*/; do
         local sub_name
         sub_name=$(basename "$sub")
-        if [ -f "$sub/SKILL.md" ]; then
+        if [ -n "$sub_name" ] && [ -f "$sub/SKILL.md" ]; then
           rm -rf "$AS_DIR/$sub_name"
           mkdir -p "$AS_DIR/$sub_name"
-          cp -R "$sub". "$AS_DIR/$sub_name/"
+          cp -R "$sub/." "$AS_DIR/$sub_name/"
           echo "    Installed/updated $sub_name"
         fi
       done


### PR DESCRIPTION
## What

Registers [AntV Infographic](https://github.com/antvis/Infographic) (`antvis/Infographic`, MIT, v0.2.19) as an external **agent-skill** so bootstrap installs it for Claude, Codex, Copilot, and Gemini, and wires it into `/explain-to-me` as a sister skill.

AntV Infographic ships 5 SKILL.md-bearing skills under `skills/`, so it uses the existing `multi-subpath` pattern (same as `ui-ux-pro-max`): clone once, flatten each `skills/*` child into `~/.{tool}/skills/`.

## Changes

| File | Change |
|---|---|
| `toolkit/external-dependencies.yaml` | New `agent-skills` entry — `multi-subpath: skills`, `applies-to: [claude, codex, copilot, gemini]`, v0.2.19 pinned, 5 sub-skills documented |
| `toolkit/scripts/update-externals.sh` | Multi-subpath refresh block (clone-to-temp + flatten `skills/*`). A flat clone would bury the sub-skills under `skills/`, so this mirrors bootstrap's `setup-external.sh` install logic |
| `toolkit/packages/skills/explain-to-me/SKILL.md` | New sister-skills row routing data-driven infographic needs to `/infographic-creator` |

## Skills installed

`infographic-creator`, `infographic-syntax-creator`, `infographic-structure-creator`, `infographic-item-creator`, `infographic-template-updater`

## Verification

- `external-dependencies.yaml` parses (yaml.safe_load)
- `bash -n toolkit/scripts/update-externals.sh` clean
- All 5 skills cloned and verified present (SKILL.md in each) under `~/.claude/skills/` and `~/.codex/skills/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integrated infographic generation for data-driven, poster-style visual diagrams (creator, syntax, structure, item and template updates), producing inline SVG outputs.

* **Documentation**
  * Guidance updated to recommend using /infographic-creator for generating and inserting poster-style SVG infographics.

* **Chores**
  * Installer now includes automatic setup of the infographic tool; local installs require Node.js >= 18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->