### PR TITLE
perf(session-reader): kill the 5-minute CPU spike — per-item chunk sizing + unchanged-snapshot short-circuit

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -1730,6 +1730,7 @@ mod chunk_accumulator_tests {
             scanned: 7,
             total: 100,
             current_project: "alpha".into(),
+            done: false,
         });
         let _ = p.apply_chunk_pure(chunk(0, true, vec![fake_call(1)]));
         assert!(
@@ -1810,6 +1811,7 @@ mod scan_progress_tests {
             scanned,
             total,
             current_project: project.into(),
+            done: false,
         })
         .expect("encode scan_progress")
     }
@@ -1856,6 +1858,7 @@ mod scan_progress_tests {
             scanned: 5,
             total: 10,
             current_project: "good".into(),
+            done: false,
         });
         let bad = b"\xff\xff\xff not msgpack";
         let result = rmp_serde::from_slice::<ScanProgressEvent>(bad);

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -674,11 +674,14 @@ impl BurndownPlugin {
     /// latest known progress. Malformed payloads are logged and
     /// dropped — the skeleton just keeps showing the previous tick (or
     /// the ⏳ waiting line if no tick has arrived yet).
+    ///
+    /// A `done: true` event is terminal: the scan finished but decided
+    /// not to republish (session-reader's unchanged-snapshot
+    /// short-circuit), so no `usage_data` chunk is coming to clear the
+    /// banner — clear it here instead.
     async fn ingest_scan_progress(&mut self, host: &HostClient, payload: &[u8]) {
         match rmp_serde::from_slice::<ScanProgressEvent>(payload) {
-            Ok(evt) => {
-                self.scan_progress = Some(evt);
-            }
+            Ok(evt) => self.apply_scan_progress(evt),
             Err(e) => {
                 let _ = host
                     .log_info(format!(
@@ -686,6 +689,16 @@ impl BurndownPlugin {
                     ))
                     .await;
             }
+        }
+    }
+
+    /// Pure half of [`Self::ingest_scan_progress`] — unit-testable
+    /// without a `HostClient`.
+    fn apply_scan_progress(&mut self, evt: ScanProgressEvent) {
+        if evt.done {
+            self.scan_progress = None;
+        } else {
+            self.scan_progress = Some(evt);
         }
     }
 
@@ -1847,6 +1860,54 @@ mod scan_progress_tests {
         let outcome = p.apply_chunk_pure(event);
         assert_eq!(outcome, ChunkOutcome::Finalised);
         assert!(p.scan_progress.is_none());
+    }
+
+    #[test]
+    fn done_event_clears_in_flight_banner_without_data() {
+        // The unchanged-snapshot short-circuit (issue #255) ends a
+        // scan with NO usage_data publish — the terminal `done` event
+        // is the only thing that clears the banner.
+        let mut p = BurndownPlugin::default();
+        p.apply_scan_progress(ScanProgressEvent {
+            scanned: 7,
+            total: 10,
+            current_project: "mid-scan".into(),
+            done: false,
+        });
+        assert!(p.scan_progress.is_some(), "banner armed mid-scan");
+
+        let bytes = rmp_serde::to_vec_named(&ScanProgressEvent {
+            done: true,
+            ..ScanProgressEvent::default()
+        })
+        .expect("encode");
+        let decoded: ScanProgressEvent = rmp_serde::from_slice(&bytes).expect("decode");
+        p.apply_scan_progress(decoded);
+        assert!(
+            p.scan_progress.is_none(),
+            "done event clears the banner with no data publish"
+        );
+    }
+
+    #[test]
+    fn pre_done_publisher_payload_decodes_with_done_false() {
+        // Wire back-compat: a pre-#255 session-reader publishes maps
+        // without the `done` key — serde's default must fill `false`.
+        #[derive(serde::Serialize)]
+        struct LegacyScanProgress {
+            scanned: u32,
+            total: u32,
+            current_project: String,
+        }
+        let bytes = rmp_serde::to_vec_named(&LegacyScanProgress {
+            scanned: 3,
+            total: 9,
+            current_project: "legacy".into(),
+        })
+        .expect("encode legacy");
+        let decoded: ScanProgressEvent = rmp_serde::from_slice(&bytes).expect("decode legacy");
+        assert!(!decoded.done, "missing field defaults to false");
+        assert_eq!(decoded.scanned, 3);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -5647,6 +5647,7 @@ mod scan_progress_tests {
             scanned,
             total,
             current_project: project.into(),
+            done: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
@@ -69,6 +69,13 @@ where
     let path_str = path.to_string_lossy().into_owned();
     let stat = stat_for_cache(path);
     ctx.counters.files_statted = ctx.counters.files_statted.saturating_add(1);
+    if stat.is_none() {
+        // A file that fails to stat can still parse (metadata denied,
+        // contents readable) — it would be invisible to the recent
+        // fingerprint memo, so it must poison the unchanged-snapshot
+        // short-circuit for this scan.
+        ctx.stat_failures = ctx.stat_failures.saturating_add(1);
+    }
 
     if let (Some(watermark), Some((mtime, size))) = (ctx.watermark_nanos, stat) {
         if mtime < watermark {
@@ -85,6 +92,9 @@ where
                 }
             }
         }
+        // Recent file under an incremental scan: record its
+        // fingerprint for the unchanged-snapshot short-circuit.
+        ctx.recent_present.push((path_str.clone(), mtime, size));
     }
 
     read_one_cached(path, &path_str, stat, ctx, parse)

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -143,8 +143,8 @@ pub(crate) fn run_blocking_scan(
 /// land at ~600 KiB, others at ~12 MiB because of long bash-command
 /// strings or user_message bodies. A fixed call-count budget therefore
 /// can't guarantee staying under the wire cap. [`chunk_usage_data`]
-/// re-encodes the candidate chunk after each call appended and cuts
-/// as soon as the actual msgpack size crosses this threshold.
+/// sizes each item once as it's appended and cuts as soon as the
+/// running encoded size would cross this threshold.
 ///
 /// Set to 2 MiB → ~2.7 MiB after base64 → ~2.7 MiB JSON frame, well
 /// under the 16 MiB framer cap.
@@ -545,22 +545,34 @@ impl SessionReader {
     }
 }
 
-/// How many calls to push into a chunk between size probes. Tuned
-/// to balance encoder cost (O(n^2) worst case if STEP=1) against
-/// chunk granularity (larger STEP = fatter chunks because we only
-/// detect overshoot at probe time). With STEP=64 and a 2 MiB target,
-/// the chunker pays at most `target/avg_call_bytes` encodes per
-/// chunk — a few dozen for real data.
-const CHUNKER_PROBE_STEP: usize = 64;
+/// Headroom added to the per-chunk running-size estimate to cover
+/// msgpack array-header growth: each of the three tail arrays encodes
+/// a 1-byte header while empty (fixarray) that grows to at most 5
+/// bytes (`array 32`) as items append — ≤ 12 bytes of growth total,
+/// rounded up generously.
+const CHUNKER_HEADER_SLACK: usize = 64;
 
 /// Identifier for which tail-chunkable vec a chunker push came from.
 /// Lets the spill-back path return the just-popped item to the right
-/// queue when an over-target probe forces a cut.
+/// queue when the per-chunk verification encode finds an overshoot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TailQueue {
     Calls,
     Sessions,
     ShellCommands,
+}
+
+/// Encoded msgpack size of one value on its own. msgpack array
+/// elements are plain concatenated values, so an item's standalone
+/// encoding is byte-for-byte what it contributes inside a tail vec —
+/// which is what makes the chunker's running-sum sizing exact (modulo
+/// the array headers covered by [`CHUNKER_HEADER_SLACK`]).
+///
+/// An encode failure returns 0: the item still ships, and the same
+/// failure then surfaces at publish time exactly as it would have
+/// before sizing existed.
+fn encoded_len<T: serde::Serialize>(item: &T) -> usize {
+    rmp_serde::to_vec_named(item).map_or(0, |b| b.len())
 }
 
 /// Split a `UsageData` snapshot into one or more `UsageDataEvent`
@@ -589,11 +601,19 @@ enum TailQueue {
 /// to ~17 MiB and tripped the 16 MiB framer cap — see WIRE_VERSION
 /// docs for the incident report.
 ///
-/// Re-encodes the candidate chunk after every [`CHUNKER_PROBE_STEP`]
-/// items appended; cuts when the encoded msgpack size crosses
-/// `target_bytes`. Pop priority is `calls` → `sessions` →
-/// `shell_commands`, draining the biggest queue first so the chunk
-/// count for call-dominated snapshots matches the v3 distribution.
+/// **Sizing strategy (issue #255).** Each tail item is encoded exactly
+/// once, when it's popped: the chunk cuts when `envelope base +
+/// Σ item sizes + header slack` would cross `target_bytes`. One
+/// verification encode runs per chunk as a safety net (spilling items
+/// back if the estimate ever under-counted — it shouldn't, msgpack
+/// array elements concatenate). The previous implementation re-encoded
+/// the whole candidate chunk every 64 items, which on a ~126-chunk
+/// real-data snapshot meant ~7.8 GB of redundant encoding and ~20 s of
+/// the measured ~23 s refresh cost.
+///
+/// Pop priority is `calls` → `sessions` → `shell_commands`, draining
+/// the biggest queue first so the chunk count for call-dominated
+/// snapshots matches the v3 distribution.
 pub(crate) fn chunk_usage_data(
     mut data: UsageData,
     published_ns: u64,
@@ -624,124 +644,144 @@ pub(crate) fn chunk_usage_data(
         data,
     });
 
+    // Envelope base: encoded size of an empty tail chunk. msgpack
+    // encodes `u32` with 1–5 bytes depending on magnitude, so probe
+    // with `u32::MAX` — the base must never under-count a late chunk.
+    let envelope_base = encoded_len(&UsageDataEvent {
+        version: WIRE_VERSION,
+        published_ns,
+        partial,
+        chunk_index: u32::MAX,
+        is_final: true,
+        data: UsageData::default(),
+    });
+
     let mut chunk_index: u32 = 1;
     while !(calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty()) {
         let mut chunk_data = UsageData::default();
-        let mut since_probe = 0usize;
+        let mut running = envelope_base + CHUNKER_HEADER_SLACK;
+        let mut items_in_chunk = 0usize;
 
         loop {
             // Pop priority: calls (largest) → sessions → shell_commands.
+            // Peek-encode-decide: an item that would push the chunk over
+            // target stays at the front of its queue for the next chunk
+            // — no spill bookkeeping on the normal path.
+            let item_size = if let Some(c) = calls_q.front() {
+                encoded_len(c)
+            } else if let Some(s) = sessions_q.front() {
+                encoded_len(s)
+            } else if let Some(s) = shell_q.front() {
+                encoded_len(s)
+            } else {
+                break; // every queue drained
+            };
+
+            // Cut before the overshooting item — unless the chunk is
+            // still empty: single-item chunks always ship so a giant
+            // outlier (e.g. one 5 MiB user_message) can't stall the loop.
+            if items_in_chunk > 0 && running + item_size >= target_bytes {
+                break;
+            }
+
             if let Some(c) = calls_q.pop_front() {
                 chunk_data.calls.push(c);
             } else if let Some(s) = sessions_q.pop_front() {
                 chunk_data.sessions.push(s);
             } else if let Some(s) = shell_q.pop_front() {
                 chunk_data.shell_commands.push(s);
-            } else {
-                break; // every queue drained
             }
-            since_probe += 1;
+            running += item_size;
+            items_in_chunk += 1;
+        }
 
-            let all_empty = calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty();
-            // Probe when we've accumulated STEP items, or when every
-            // queue just drained (so we don't miss tiny final overshoots).
-            if since_probe < CHUNKER_PROBE_STEP && !all_empty {
-                continue;
-            }
-            since_probe = 0;
+        // Safety net: one verification encode per chunk. The running
+        // sum is exact up to array headers (covered by the slack), so
+        // this should never trigger — but an estimate bug here would
+        // otherwise ship a frame the host framer rejects, so verify
+        // and spill items back until the chunk really fits.
+        let verify_event = UsageDataEvent {
+            version: WIRE_VERSION,
+            published_ns,
+            partial,
+            chunk_index,
+            is_final: calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty(),
+            data: chunk_data.clone(),
+        };
+        let verified_size =
+            rmp_serde::to_vec_named(&verify_event).map(|b| b.len()).unwrap_or(target_bytes);
+        let chunk_item_count =
+            chunk_data.calls.len() + chunk_data.sessions.len() + chunk_data.shell_commands.len();
+        if verified_size >= target_bytes && chunk_item_count > 1 {
+            tracing::warn!(
+                verified_size,
+                target_bytes,
+                "session-reader chunker: size estimate under-counted; spilling"
+            );
+            loop {
+                // Choose the spill source: whichever tail vec
+                // currently has the most items. Re-evaluate every
+                // iteration because vecs shrink.
+                let from = if chunk_data.calls.len() >= chunk_data.sessions.len()
+                    && chunk_data.calls.len() >= chunk_data.shell_commands.len()
+                    && !chunk_data.calls.is_empty()
+                {
+                    TailQueue::Calls
+                } else if chunk_data.sessions.len() >= chunk_data.shell_commands.len()
+                    && !chunk_data.sessions.is_empty()
+                {
+                    TailQueue::Sessions
+                } else if !chunk_data.shell_commands.is_empty() {
+                    TailQueue::ShellCommands
+                } else {
+                    break; // nothing left to spill
+                };
 
-            let probe_event = UsageDataEvent {
-                version: WIRE_VERSION,
-                published_ns,
-                partial,
-                chunk_index,
-                is_final: all_empty,
-                data: chunk_data.clone(),
-            };
-            let probe_size =
-                rmp_serde::to_vec_named(&probe_event).map(|b| b.len()).unwrap_or(target_bytes);
-
-            // Cut on probe overshoot, but only if the chunk has >1 item
-            // total — single-item chunks always ship so a giant outlier
-            // (e.g. one 5 MiB user_message) can't stall the loop.
-            //
-            // Spill in a loop, not just once: STEP=64 means the chunk
-            // can land many MiB over budget when one of those 64 items
-            // is a 100+ KiB outlier. Single-spill would still ship a
-            // chunk 50× over target. Each iteration picks the largest
-            // tail vec as the spill source (best chance of cheaply
-            // shrinking the chunk) and re-probes; keep spilling until
-            // we're back under target or only 1 item remains.
-            let chunk_item_count = chunk_data.calls.len()
-                + chunk_data.sessions.len()
-                + chunk_data.shell_commands.len();
-            if probe_size >= target_bytes && chunk_item_count > 1 {
-                loop {
-                    // Choose the spill source: whichever tail vec
-                    // currently has the most items. Re-evaluate every
-                    // iteration because vecs shrink.
-                    let from = if chunk_data.calls.len() >= chunk_data.sessions.len()
-                        && chunk_data.calls.len() >= chunk_data.shell_commands.len()
-                        && !chunk_data.calls.is_empty()
-                    {
-                        TailQueue::Calls
-                    } else if chunk_data.sessions.len() >= chunk_data.shell_commands.len()
-                        && !chunk_data.sessions.is_empty()
-                    {
-                        TailQueue::Sessions
-                    } else if !chunk_data.shell_commands.is_empty() {
-                        TailQueue::ShellCommands
-                    } else {
-                        break; // nothing left to spill
-                    };
-
-                    match from {
-                        TailQueue::Calls => {
-                            if let Some(spill) = chunk_data.calls.pop() {
-                                calls_q.push_front(spill);
-                            }
-                        }
-                        TailQueue::Sessions => {
-                            if let Some(spill) = chunk_data.sessions.pop() {
-                                sessions_q.push_front(spill);
-                            }
-                        }
-                        TailQueue::ShellCommands => {
-                            if let Some(spill) = chunk_data.shell_commands.pop() {
-                                shell_q.push_front(spill);
-                            }
+                match from {
+                    TailQueue::Calls => {
+                        if let Some(spill) = chunk_data.calls.pop() {
+                            calls_q.push_front(spill);
                         }
                     }
-
-                    let remaining_items = chunk_data.calls.len()
-                        + chunk_data.sessions.len()
-                        + chunk_data.shell_commands.len();
-                    if remaining_items <= 1 {
-                        // Single-item chunks always ship (giant-outlier
-                        // protection). Even if still oversize, exit
-                        // here rather than spill the lone survivor.
-                        break;
+                    TailQueue::Sessions => {
+                        if let Some(spill) = chunk_data.sessions.pop() {
+                            sessions_q.push_front(spill);
+                        }
                     }
-
-                    // Re-probe. Cost is O(chunk_data_encoded_size) per
-                    // probe — at ~1 MiB target and 100 KiB outliers,
-                    // worst case ~10 probes per cut, totally affordable
-                    // relative to the I/O cost of the actual publish.
-                    let probe = UsageDataEvent {
-                        version: WIRE_VERSION,
-                        published_ns,
-                        partial,
-                        chunk_index,
-                        is_final: calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty(),
-                        data: chunk_data.clone(),
-                    };
-                    let probe_after_spill =
-                        rmp_serde::to_vec_named(&probe).map(|b| b.len()).unwrap_or(target_bytes);
-                    if probe_after_spill < target_bytes {
-                        break;
+                    TailQueue::ShellCommands => {
+                        if let Some(spill) = chunk_data.shell_commands.pop() {
+                            shell_q.push_front(spill);
+                        }
                     }
                 }
-                break;
+
+                let remaining_items = chunk_data.calls.len()
+                    + chunk_data.sessions.len()
+                    + chunk_data.shell_commands.len();
+                if remaining_items <= 1 {
+                    // Single-item chunks always ship (giant-outlier
+                    // protection). Even if still oversize, exit
+                    // here rather than spill the lone survivor.
+                    break;
+                }
+
+                // Re-probe. Cost is O(chunk_data_encoded_size) per
+                // probe — at ~1 MiB target and 100 KiB outliers,
+                // worst case ~10 probes per cut, totally affordable
+                // relative to the I/O cost of the actual publish.
+                let probe = UsageDataEvent {
+                    version: WIRE_VERSION,
+                    published_ns,
+                    partial,
+                    chunk_index,
+                    is_final: calls_q.is_empty() && sessions_q.is_empty() && shell_q.is_empty(),
+                    data: chunk_data.clone(),
+                };
+                let probe_after_spill =
+                    rmp_serde::to_vec_named(&probe).map(|b| b.len()).unwrap_or(target_bytes);
+                if probe_after_spill < target_bytes {
+                    break;
+                }
             }
         }
 

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -56,12 +56,20 @@ fn decode_refresh_request(payload: &[u8]) -> RefreshRequest {
 /// testable without a `HostClient`.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct BlockingScanOutcome {
-    pub(crate) data: ainb_plugin_types_sessions::UsageData,
+    /// The snapshot to publish — `None` when the scanner proved this
+    /// refresh byte-identical to the previous one (unchanged-snapshot
+    /// short-circuit, issue #255): the caller keeps the published
+    /// snapshot and skips the publish entirely.
+    pub(crate) data: Option<ainb_plugin_types_sessions::UsageData>,
     /// The (reused or rebuilt) stable rollup to keep in memory for the
     /// next refresh. `None` on the cache-less full-scan path.
     pub(crate) stable: Option<scanner::StableAggregate>,
     /// Cache handle returned to the plugin for reuse.
     pub(crate) cache: Option<crate::cache::UsageCache>,
+    /// What the incremental scan saw on the recent side — feed back as
+    /// `prev_memo` next refresh to arm the short-circuit. `None` on
+    /// the cache-less full-scan path.
+    pub(crate) memo: Option<scanner::RecentMemo>,
     /// Scan instrumentation — `Some` iff the incremental path ran.
     pub(crate) counters: Option<scanner::ScanCounters>,
     pub(crate) stable_rebuilt: bool,
@@ -86,6 +94,7 @@ pub(crate) fn run_blocking_scan(
     roots: &ProviderRoots,
     cache: Option<crate::cache::UsageCache>,
     stored: Option<scanner::StableAggregate>,
+    prev_memo: Option<&scanner::RecentMemo>,
     window_days: u32,
     reporter: &mut scanner::ProgressReporter,
 ) -> BlockingScanOutcome {
@@ -102,7 +111,14 @@ pub(crate) fn run_blocking_scan(
     if cache_opt.is_some() {
         let watermark =
             now_ns().saturating_sub(u64::from(window_days).saturating_mul(NANOS_PER_DAY));
-        let outcome = scanner::scan_incremental(roots, &mut cache_opt, stored, watermark, reporter);
+        let outcome = scanner::scan_incremental(
+            roots,
+            &mut cache_opt,
+            stored,
+            watermark,
+            prev_memo,
+            reporter,
+        );
         if outcome.stable_rebuilt {
             if let Some(cache) = cache_opt.as_mut() {
                 if let Err(err) = cache.store_stable(&outcome.stable) {
@@ -117,6 +133,7 @@ pub(crate) fn run_blocking_scan(
             data: outcome.data,
             stable: Some(outcome.stable),
             cache: cache_opt,
+            memo: Some(outcome.memo),
             counters: Some(outcome.counters),
             stable_rebuilt: outcome.stable_rebuilt,
             cold_start,
@@ -124,9 +141,10 @@ pub(crate) fn run_blocking_scan(
     } else {
         let data = scanner::scan_with_cache_and_progress(roots, &mut cache_opt, reporter);
         BlockingScanOutcome {
-            data,
+            data: Some(data),
             stable: None,
             cache: cache_opt,
+            memo: None,
             counters: None,
             stable_rebuilt: false,
             cold_start,
@@ -198,6 +216,13 @@ pub struct SessionReader {
     stable: Option<scanner::StableAggregate>,
     #[cfg(not(target_arch = "wasm32"))]
     cache: Option<crate::cache::UsageCache>,
+    /// What the previous *successfully published* refresh saw on the
+    /// recent side — arms the scanner's unchanged-snapshot
+    /// short-circuit. Deliberately `None` until a publish lands (and
+    /// reset to `None` whenever one fails) so a skipped publish can
+    /// never strand consumers on a snapshot that was never delivered.
+    #[cfg(not(target_arch = "wasm32"))]
+    last_memo: Option<scanner::RecentMemo>,
     /// Set to `true` once we've attempted (and possibly failed) to open
     /// the cache so we don't retry on every publish.
     #[cfg(not(target_arch = "wasm32"))]
@@ -218,6 +243,8 @@ impl SessionReader {
             #[cfg(not(target_arch = "wasm32"))]
             cache: None,
             #[cfg(not(target_arch = "wasm32"))]
+            last_memo: None,
+            #[cfg(not(target_arch = "wasm32"))]
             cache_init: false,
         }
     }
@@ -235,6 +262,8 @@ impl SessionReader {
             stable: None,
             #[cfg(not(target_arch = "wasm32"))]
             cache: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            last_memo: None,
             #[cfg(not(target_arch = "wasm32"))]
             cache_init: false,
         }
@@ -256,8 +285,12 @@ impl SessionReader {
     async fn flush_cache(&mut self, host: &HostClient) {
         // The persisted stable rollup dies with the cache (clear()
         // wipes both tables); the in-memory copy must die with it or
-        // the next refresh would resurrect stale history.
+        // the next refresh would resurrect stale history. The refresh
+        // memo dies too — a hard refresh exists precisely because the
+        // user distrusts cached state, so the unchanged-snapshot
+        // short-circuit must not suppress the rebuilt publish.
         self.stable = None;
+        self.last_memo = None;
         self.ensure_cache();
         if let Some(cache) = self.cache.as_mut() {
             match cache.clear() {
@@ -381,21 +414,33 @@ impl SessionReader {
     }
 
     /// Run the scan on a blocking task and publish progress events to
-    /// `host` as they arrive. Returns the assembled `UsageData` once
-    /// the scan task completes.
+    /// `host` as they arrive. Returns the assembled `UsageData` (or
+    /// `None` when the unchanged-snapshot short-circuit fired) plus
+    /// the refresh's memo, which the caller commits to
+    /// [`Self::last_memo`] only after the publish lands.
     ///
     /// The blocking task owns the cache for the duration of the scan
     /// (moved out of `self.cache`), then hands it back so the plugin
-    /// can reuse it on the next publish. Progress events flow over a
+    /// can reuse it on the next publish. The previous memo travels the
+    /// same way — taken at scan start, so a panicked task or a failed
+    /// publish leaves `last_memo` empty and the next refresh publishes
+    /// unconditionally. Progress events flow over a
     /// `tokio::sync::mpsc::unbounded` channel: the rate-limit lives in
     /// the [`scanner::ProgressReporter`] inside the blocking task, so
     /// the async drain loop never sees more than ~10 events/s.
     #[cfg(not(target_arch = "wasm32"))]
-    async fn scan_streaming(&mut self, host: &HostClient) -> ainb_plugin_types_sessions::UsageData {
+    async fn scan_streaming(
+        &mut self,
+        host: &HostClient,
+    ) -> (
+        Option<ainb_plugin_types_sessions::UsageData>,
+        Option<scanner::RecentMemo>,
+    ) {
         self.ensure_cache();
         let roots = self.roots.clone();
         let cache = self.cache.take();
         let stored = self.stable.take();
+        let prev_memo = self.last_memo.take();
         let window_days = self.window_days;
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ScanProgressEvent>();
@@ -407,7 +452,14 @@ impl SessionReader {
                 // we hold `rx` until `scan_handle` resolves).
                 let _ = tx.send(evt);
             });
-            run_blocking_scan(&roots, cache, stored, window_days, &mut reporter)
+            run_blocking_scan(
+                &roots,
+                cache,
+                stored,
+                prev_memo.as_ref(),
+                window_days,
+                &mut reporter,
+            )
         });
 
         // Drain progress events. `rx.recv()` returns `None` once the
@@ -466,7 +518,7 @@ impl SessionReader {
                         ))
                         .await;
                 }
-                outcome.data
+                (outcome.data, outcome.memo)
             }
             Err(err) => {
                 // The panicked closure took ownership of the cache and
@@ -484,7 +536,7 @@ impl SessionReader {
                         falling back to in-line scan"
                     ))
                     .await;
-                self.scan_now()
+                (Some(self.scan_now()), None)
             }
         }
     }
@@ -509,9 +561,34 @@ impl SessionReader {
     /// `is_final = true`.
     async fn publish(&mut self, host: &HostClient) -> Result<()> {
         #[cfg(not(target_arch = "wasm32"))]
-        let data = self.scan_streaming(host).await;
+        let (data, memo) = self.scan_streaming(host).await;
         #[cfg(target_arch = "wasm32")]
-        let data = self.scan_now();
+        let (data, memo) = (Some(self.scan_now()), None);
+
+        let Some(data) = data else {
+            // Unchanged-snapshot short-circuit: the scanner proved the
+            // snapshot byte-identical to the one already published —
+            // consumers keep what they have, nothing goes on the wire.
+            let _ = host.log_info("publish: snapshot unchanged — publish skipped").await;
+            // ...except the terminal progress event: consumers clear
+            // their "Scanning sessions…" banner on the final
+            // usage_data chunk, and no such chunk is coming. `done`
+            // tells them the scan ended without a republish.
+            let done = ScanProgressEvent {
+                done: true,
+                ..ScanProgressEvent::default()
+            };
+            if let Ok(bytes) = rmp_serde::to_vec_named(&done) {
+                let _ = host.snapshot_publish(TOPIC_SCAN_PROGRESS, bytes).await;
+            }
+            self.set_last_memo(memo);
+            return Ok(());
+        };
+
+        // The memo commits only after every chunk lands: an error exit
+        // below leaves it empty, so the next refresh re-publishes
+        // rather than skipping consumers onto a half-delivered
+        // snapshot. (`scan_streaming` already took the previous memo.)
         let published_ns = now_ns();
         let chunks = chunk_usage_data(data, published_ns, false, CHUNK_TARGET_BYTES);
         let total_chunks = chunks.len();
@@ -541,8 +618,20 @@ impl SessionReader {
                 self.last_event = Some(event);
             }
         }
+        self.set_last_memo(memo);
         Ok(())
     }
+
+    /// Store the refresh memo that arms the next scan's
+    /// unchanged-snapshot short-circuit. No-op on wasm32, where the
+    /// incremental path (and the memo) don't exist.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn set_last_memo(&mut self, memo: Option<scanner::RecentMemo>) {
+        self.last_memo = memo;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn set_last_memo(&mut self, _memo: Option<()>) {}
 }
 
 /// Headroom added to the per-chunk running-size estimate to cover
@@ -930,12 +1019,16 @@ mod tests {
         let mut reporter = scanner::ProgressReporter::noop();
 
         // First refresh: cold start seeds + persists the rollup.
-        let first = run_blocking_scan(&roots, open_cache(&cache_dir), None, 0, &mut reporter);
+        let first = run_blocking_scan(&roots, open_cache(&cache_dir), None, None, 0, &mut reporter);
         assert!(first.cold_start, "no rollup anywhere yet");
         assert!(first.stable_rebuilt);
         let c = first.counters.expect("incremental path ran");
         assert_eq!(c.parsed, 2, "seed scan parses both files");
-        assert_eq!(encode(&first.data), oracle, "matches full-scan oracle");
+        assert_eq!(
+            encode(first.data.as_ref().expect("changed scan publishes")),
+            oracle,
+            "matches full-scan oracle"
+        );
         assert!(
             first.cache.expect("cache returned").load_stable().expect("load").is_some(),
             "rollup persisted for the next process"
@@ -944,7 +1037,8 @@ mod tests {
         // Simulated plugin restart: in-memory rollup gone (stored =
         // None), fresh cache handle on the same file. The glue must
         // rehydrate from disk and reuse — zero parses.
-        let second = run_blocking_scan(&roots, open_cache(&cache_dir), None, 0, &mut reporter);
+        let second =
+            run_blocking_scan(&roots, open_cache(&cache_dir), None, None, 0, &mut reporter);
         assert!(!second.cold_start, "rollup rehydrated from the cache");
         assert!(!second.stable_rebuilt);
         let c = second.counters.expect("incremental path ran");
@@ -955,10 +1049,69 @@ mod tests {
         assert!(c.stable_reused);
         assert_eq!(c.stable_skipped, 2, "both stable files skipped outright");
         assert_eq!(
-            encode(&second.data),
+            encode(second.data.as_ref().expect("changed scan publishes")),
             oracle,
             "still byte-identical to the oracle"
         );
+    }
+
+    #[test]
+    fn glue_unchanged_refresh_returns_no_data_and_memo_round_trips() {
+        let (tree, roots, cache_dir) = glue_fixture();
+        let oracle = encode(&scanner::scan(&roots));
+        let mut reporter = scanner::ProgressReporter::noop();
+
+        // Seed (window 36500 days → everything is recent, exercising
+        // the recent fingerprint memo rather than the stable rollup).
+        let first = run_blocking_scan(
+            &roots,
+            open_cache(&cache_dir),
+            None,
+            None,
+            36_500,
+            &mut reporter,
+        );
+        assert!(first.data.is_some(), "first refresh publishes");
+        let memo = first.memo.clone().expect("incremental path produces a memo");
+
+        // Unchanged refresh with the memo armed: no data → no publish.
+        let second = run_blocking_scan(
+            &roots,
+            open_cache(&cache_dir),
+            Some(first.stable.expect("rollup")),
+            Some(&memo),
+            36_500,
+            &mut reporter,
+        );
+        assert!(
+            second.data.is_none(),
+            "unchanged refresh short-circuits the publish"
+        );
+        let memo = second.memo.expect("memo still round-trips on a skip");
+
+        // Touch a file: the same memo must now disarm and re-publish.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::fs::write(
+            tree.path().join("claude/projects/proj-a/two.jsonl"),
+            format!(
+                "{}\n{}",
+                glue_claude_line("2026-06-01T10:00:00Z", "s2"),
+                glue_claude_line("2026-06-02T10:00:00Z", "s2")
+            ),
+        )
+        .expect("append");
+        let third = run_blocking_scan(
+            &roots,
+            open_cache(&cache_dir),
+            second.stable,
+            Some(&memo),
+            36_500,
+            &mut reporter,
+        );
+        let data = third.data.as_ref().expect("changed file re-publishes");
+        let fresh_oracle = encode(&scanner::scan(&roots));
+        assert_ne!(encode(data), oracle, "snapshot moved past the seed state");
+        assert_eq!(encode(data), fresh_oracle, "matches the post-change oracle");
     }
 
     #[test]
@@ -967,7 +1120,7 @@ mod tests {
         let oracle = encode(&scanner::scan(&roots));
         let mut reporter = scanner::ProgressReporter::noop();
 
-        let out = run_blocking_scan(&roots, None, None, 0, &mut reporter);
+        let out = run_blocking_scan(&roots, None, None, None, 0, &mut reporter);
         assert!(
             out.counters.is_none(),
             "cache-less refresh takes the legacy full path"
@@ -975,7 +1128,7 @@ mod tests {
         assert!(out.stable.is_none(), "nothing to persist a rollup into");
         assert!(!out.stable_rebuilt);
         assert_eq!(
-            encode(&out.data),
+            encode(out.data.as_ref().expect("changed scan publishes")),
             oracle,
             "full path matches the oracle trivially"
         );

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -99,6 +99,7 @@ impl ProgressReporter {
                 scanned: self.scanned,
                 total: self.total,
                 current_project: current_project.to_string(),
+                done: false,
             });
             self.last_emit = Some(now);
         }
@@ -116,6 +117,7 @@ impl ProgressReporter {
             scanned: self.scanned,
             total: self.total,
             current_project: current_project.to_string(),
+            done: false,
         });
         self.last_emit = Some(Instant::now());
     }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -1067,6 +1067,126 @@ mod tests {
     use chrono::{DateTime, Utc};
     use std::sync::{Arc, Mutex};
 
+    /// Profiling harness for issue #255 — NOT a correctness test.
+    ///
+    /// Replays one steady-state incremental refresh phase by phase
+    /// against a copy of the real on-disk cache + the real `$HOME`
+    /// session data, printing wall-clock per phase. Run manually:
+    ///
+    /// ```sh
+    /// cargo test -p ainb-plugin-session-reader --release \
+    ///   profile_real_refresh_phases -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "profiling harness against real $HOME data — run manually"]
+    fn profile_real_refresh_phases() {
+        use std::time::Instant;
+
+        let Some(db) = crate::cache::default_db_path() else {
+            eprintln!("profile: no resolvable cache path; skipping");
+            return;
+        };
+        if !db.exists() {
+            eprintln!("profile: no real cache at {}; skipping", db.display());
+            return;
+        }
+        // Copy the live db (plus WAL/SHM so an in-flight write is
+        // recoverable) — never contend with a running plugin instance.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let copy = tmp.path().join("usage.sqlite");
+        std::fs::copy(&db, &copy).expect("copy db");
+        for sfx in ["-wal", "-shm"] {
+            let mut src = db.as_os_str().to_owned();
+            src.push(sfx);
+            let src = std::path::PathBuf::from(src);
+            if src.exists() {
+                let mut dst = copy.as_os_str().to_owned();
+                dst.push(sfx);
+                std::fs::copy(&src, std::path::PathBuf::from(dst)).expect("copy sidecar");
+            }
+        }
+        let mut cache = Some(crate::cache::UsageCache::open(&copy).expect("open copy"));
+
+        let t = Instant::now();
+        let stored = cache.as_ref().unwrap().load_stable().unwrap_or_default();
+        let load_stable_t = t.elapsed();
+        let Some(stored) = stored else {
+            eprintln!("profile: no stable rollup in cache; run a refresh first");
+            return;
+        };
+        eprintln!(
+            "load_stable: {load_stable_t:?} (folded={} stable_calls={})",
+            stored.folded.len(),
+            stored.state.calls.len()
+        );
+
+        // Reuse the rollup's own watermark so the stored fingerprint
+        // set stays valid (steady-state path, no rebuild pass).
+        let watermark = stored.watermark_nanos;
+        let roots = ProviderRoots::defaults();
+
+        let t = Instant::now();
+        let mut ctx = ScanCtx::incremental(&mut cache, watermark, StablePolicy::Skip);
+        let mut reporter = ProgressReporter::noop();
+        let recent_calls = walk_providers(&roots, &mut ctx, &mut reporter);
+        let walk_t = t.elapsed();
+        eprintln!(
+            "pass1 walk (stat + recent hydrate): {walk_t:?} \
+             (statted={} parsed={} cache_hits={} stable_skipped={} recent_calls={})",
+            ctx.counters.files_statted,
+            ctx.counters.parsed,
+            ctx.counters.cache_hits,
+            ctx.counters.stable_skipped,
+            recent_calls.len()
+        );
+        let mut stable_present = std::mem::take(&mut ctx.stable_present);
+        stable_present.sort_unstable();
+        eprintln!(
+            "stable set match: {} (walk={} stored={})",
+            stable_present == stored.folded,
+            stable_present.len(),
+            stored.folded.len()
+        );
+
+        let t = Instant::now();
+        let folded_recent = fold(recent_calls);
+        eprintln!("fold(recent): {:?}", t.elapsed());
+
+        let t = Instant::now();
+        // Deliberate clone: this measures exactly the clone the
+        // production merge path pays per refresh.
+        #[allow(clippy::redundant_clone)]
+        let mut merged = stored.state.clone();
+        eprintln!("stable.state.clone(): {:?}", t.elapsed());
+
+        let t = Instant::now();
+        merged.absorb(folded_recent);
+        eprintln!("absorb: {:?}", t.elapsed());
+
+        let t = Instant::now();
+        let data = emit(merged);
+        eprintln!("emit: {:?} (total_calls={})", t.elapsed(), data.calls.len());
+
+        let t = Instant::now();
+        let chunks = crate::plugin::chunk_usage_data(data, 0, false, 2 * 1024 * 1024);
+        eprintln!(
+            "chunk_usage_data: {:?} ({} chunks)",
+            t.elapsed(),
+            chunks.len()
+        );
+
+        let t = Instant::now();
+        let total: usize = chunks
+            .iter()
+            .map(|c| rmp_serde::to_vec_named(c).map(|b| b.len()).unwrap_or(0))
+            .sum();
+        eprintln!(
+            "final encode all chunks: {:?} ({} bytes)",
+            t.elapsed(),
+            total
+        );
+    }
+
     #[test]
     fn progress_reporter_emits_on_first_file() {
         let captured: Arc<Mutex<Vec<ScanProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -220,9 +220,18 @@ pub(crate) struct ScanCtx<'a> {
     pub(crate) stable_policy: StablePolicy,
     /// `(path, mtime_nanos, size)` of every stable file seen.
     pub(crate) stable_present: Vec<(String, u64, u64)>,
+    /// `(path, mtime_nanos, size)` of every *recent* (newer than the
+    /// watermark) cached-provider file seen. Only collected when a
+    /// watermark is set — the full-scan path doesn't pay for it. Feeds
+    /// the unchanged-snapshot short-circuit in [`scan_incremental`].
+    pub(crate) recent_present: Vec<(String, u64, u64)>,
     /// Stable files' calls — populated only under
     /// [`StablePolicy::Collect`].
     pub(crate) stable_calls: Vec<ProviderCall>,
+    /// Files whose `stat` failed this scan. Any non-zero count poisons
+    /// the unchanged-snapshot short-circuit: such a file can still
+    /// parse, but has no fingerprint for the memo to compare.
+    pub(crate) stat_failures: u32,
     pub(crate) counters: ScanCounters,
 }
 
@@ -235,7 +244,9 @@ impl<'a> ScanCtx<'a> {
             watermark_nanos: None,
             stable_policy: StablePolicy::Skip,
             stable_present: Vec::new(),
+            recent_present: Vec::new(),
             stable_calls: Vec::new(),
+            stat_failures: 0,
             counters: ScanCounters::default(),
         }
     }
@@ -251,20 +262,49 @@ impl<'a> ScanCtx<'a> {
             watermark_nanos: Some(watermark_nanos),
             stable_policy,
             stable_present: Vec::new(),
+            recent_present: Vec::new(),
             stable_calls: Vec::new(),
+            stat_failures: 0,
             counters: ScanCounters::default(),
         }
     }
+}
+
+/// What the previous refresh saw on the recent (newer-than-watermark)
+/// side — the unchanged-snapshot short-circuit's comparison key.
+///
+/// A refresh whose stable fingerprint set, recent fingerprint set, and
+/// uncached-provider output all equal the previous refresh's must
+/// produce a byte-identical snapshot (the cached-provider calls are a
+/// pure function of `(path, mtime, size)` via the parse cache, and
+/// fold/emit are deterministic) — so the aggregation and publish can
+/// be skipped outright.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct RecentMemo {
+    /// Sorted `(path, mtime_nanos, size)` of every recent
+    /// cached-provider file.
+    pub(crate) recent_present: Vec<(String, u64, u64)>,
+    /// Gemini / Copilot / Cursor output, in walk order. These parsers
+    /// are uncached so fingerprints don't exist for them; whole-output
+    /// equality is the (cheap — usually empty) correctness guard.
+    pub(crate) uncached_calls: Vec<ProviderCall>,
 }
 
 /// Result of an incremental scan: the snapshot, what the scan did,
 /// and the (reused or rebuilt) stable aggregate the caller should
 /// persist when `stable_rebuilt` is set.
 pub(crate) struct ScanOutcome {
-    pub(crate) data: UsageData,
+    /// The emitted snapshot — `None` when the unchanged-snapshot
+    /// short-circuit proved this refresh byte-identical to the
+    /// previous one (the caller keeps its published snapshot and skips
+    /// the publish).
+    pub(crate) data: Option<UsageData>,
     pub(crate) counters: ScanCounters,
     pub(crate) stable: StableAggregate,
     pub(crate) stable_rebuilt: bool,
+    /// What this refresh saw on the recent side — feed back as `prev`
+    /// on the next refresh to arm the short-circuit.
+    pub(crate) memo: RecentMemo,
 }
 
 /// Run every provider parser, aggregate, return a snapshot.
@@ -361,6 +401,19 @@ fn walk_providers(
     ctx: &mut ScanCtx<'_>,
     reporter: &mut ProgressReporter,
 ) -> Vec<ProviderCall> {
+    let mut calls = walk_cached_providers(roots, ctx, reporter);
+    calls.extend(parse_uncached_providers(roots));
+    calls
+}
+
+/// The cache-aware half of [`walk_providers`]: Claude and Codex,
+/// through the watermark-partitioned per-file path.
+#[cfg(not(target_arch = "wasm32"))]
+fn walk_cached_providers(
+    roots: &ProviderRoots,
+    ctx: &mut ScanCtx<'_>,
+    reporter: &mut ProgressReporter,
+) -> Vec<ProviderCall> {
     let mut calls = Vec::new();
     if let Some(root) = &roots.claude_projects {
         calls.extend(crate::parsers::claude::parse_dir_cached_with_progress(
@@ -372,6 +425,16 @@ fn walk_providers(
             root, ctx, reporter,
         ));
     }
+    calls
+}
+
+/// The uncached half of [`walk_providers`]: Gemini / Copilot / Cursor
+/// parse from scratch on every scan (no per-file cache, no watermark
+/// partition). Split out so [`scan_incremental`] can compare their
+/// output across refreshes for the unchanged-snapshot short-circuit.
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_uncached_providers(roots: &ProviderRoots) -> Vec<ProviderCall> {
+    let mut calls = Vec::new();
     if let Some(root) = &roots.gemini_sessions {
         calls.extend(crate::parsers::gemini::parse_dir(root));
     }
@@ -404,61 +467,108 @@ fn walk_providers(
 /// The published snapshot is `emit(stable ⊕ fold(recent))`, sharing
 /// [`emit`]/[`fold`] with [`aggregate`] — the property tests pin the
 /// result byte-identical to a one-shot full scan of the same tree.
+///
+/// **Unchanged-snapshot short-circuit (issue #255).** When `prev` is
+/// the memo of the previous refresh and (a) the stable fingerprint set
+/// matches `stored.folded`, (b) the recent fingerprint set matches
+/// `prev.recent_present`, and (c) the uncached providers' output
+/// matches `prev.uncached_calls`, the snapshot is provably
+/// byte-identical to the previous one — fold/clone/absorb/emit are
+/// all skipped and `data` comes back `None` so the caller can skip
+/// the (multi-hundred-MB) republish too.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn scan_incremental(
     roots: &ProviderRoots,
     cache: &mut Option<crate::cache::UsageCache>,
     stored: Option<StableAggregate>,
     watermark_nanos: u64,
+    prev: Option<&RecentMemo>,
     reporter: &mut ProgressReporter,
 ) -> ScanOutcome {
     // Pass 1: skip stable files, parse-or-cache recent ones.
     let mut ctx = ScanCtx::incremental(cache, watermark_nanos, StablePolicy::Skip);
-    let recent_calls = walk_providers(roots, &mut ctx, reporter);
+    let recent_calls = walk_cached_providers(roots, &mut ctx, reporter);
+    let uncached_calls = parse_uncached_providers(roots);
     let mut counters = ctx.counters;
     let mut stable_present = std::mem::take(&mut ctx.stable_present);
     stable_present.sort_unstable();
+    let mut recent_present = std::mem::take(&mut ctx.recent_present);
+    recent_present.sort_unstable();
 
-    let (stable, stable_rebuilt, recent_calls) = match stored {
-        Some(st) if st.folded == stable_present => {
+    let stable_matches = stored.as_ref().is_some_and(|st| st.folded == stable_present);
+
+    // Short-circuit: nothing moved since the previous refresh — the
+    // snapshot is byte-identical, skip aggregation and tell the caller
+    // to skip the publish. Any stat failure disarms it: a file without
+    // a fingerprint can still contribute calls the memo can't see.
+    if let (true, 0, Some(prev)) = (stable_matches, ctx.stat_failures, prev) {
+        if prev.recent_present == recent_present && prev.uncached_calls == uncached_calls {
             counters.stable_reused = true;
-            (st, false, recent_calls)
-        }
-        _ => {
-            // Rebuild pass: read stable files too (cache-served when
-            // warm) and fold a fresh rollup. Progress already ticked
-            // in pass 1, so this pass reports to a noop sink.
-            let mut rebuild_ctx =
-                ScanCtx::incremental(cache, watermark_nanos, StablePolicy::Collect);
-            let mut noop = ProgressReporter::noop();
-            let recent2 = walk_providers(roots, &mut rebuild_ctx, &mut noop);
-            counters.files_statted += rebuild_ctx.counters.files_statted;
-            counters.parsed += rebuild_ctx.counters.parsed;
-            counters.cache_hits += rebuild_ctx.counters.cache_hits;
-            let mut folded = std::mem::take(&mut rebuild_ctx.stable_present);
-            folded.sort_unstable();
-            let state = fold(std::mem::take(&mut rebuild_ctx.stable_calls));
-            (
-                StableAggregate {
-                    watermark_nanos,
-                    folded,
-                    state,
+            return ScanOutcome {
+                data: None,
+                counters,
+                stable: stored.expect("matched above"),
+                stable_rebuilt: false,
+                memo: RecentMemo {
+                    recent_present,
+                    uncached_calls,
                 },
-                true,
-                recent2,
-            )
+            };
         }
+    }
+
+    let (stable, stable_rebuilt, recent_calls, recent_present) = if stable_matches {
+        counters.stable_reused = true;
+        (
+            stored.expect("matched above"),
+            false,
+            recent_calls,
+            recent_present,
+        )
+    } else {
+        // Rebuild pass: read stable files too (cache-served when
+        // warm) and fold a fresh rollup. Progress already ticked
+        // in pass 1, so this pass reports to a noop sink. The
+        // uncached providers are NOT re-parsed — pass 1's output is
+        // reused (they have no stable/recent partition).
+        let mut rebuild_ctx = ScanCtx::incremental(cache, watermark_nanos, StablePolicy::Collect);
+        let mut noop = ProgressReporter::noop();
+        let recent2 = walk_cached_providers(roots, &mut rebuild_ctx, &mut noop);
+        counters.files_statted += rebuild_ctx.counters.files_statted;
+        counters.parsed += rebuild_ctx.counters.parsed;
+        counters.cache_hits += rebuild_ctx.counters.cache_hits;
+        let mut folded = std::mem::take(&mut rebuild_ctx.stable_present);
+        folded.sort_unstable();
+        let mut recent_present2 = std::mem::take(&mut rebuild_ctx.recent_present);
+        recent_present2.sort_unstable();
+        let state = fold(std::mem::take(&mut rebuild_ctx.stable_calls));
+        (
+            StableAggregate {
+                watermark_nanos,
+                folded,
+                state,
+            },
+            true,
+            recent2,
+            recent_present2,
+        )
     };
 
     let mut merged = stable.state.clone();
-    merged.absorb(fold(recent_calls));
+    let mut all_recent = recent_calls;
+    all_recent.extend(uncached_calls.iter().cloned());
+    merged.absorb(fold(all_recent));
     let data = emit(merged);
 
     ScanOutcome {
-        data,
+        data: Some(data),
         counters,
         stable,
         stable_rebuilt,
+        memo: RecentMemo {
+            recent_present,
+            uncached_calls,
+        },
     }
 }
 
@@ -1729,13 +1839,13 @@ mod tests {
 
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let out = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        let out = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
 
         assert!(out.stable_rebuilt, "no stored stable => rebuild");
         assert!(!out.counters.stable_reused);
         assert_eq!(out.stable.folded.len(), 1, "old.jsonl folded");
         assert_eq!(
-            encode(&out.data),
+            encode(out.data.as_ref().expect("changed scan publishes")),
             fx.oracle_bytes(),
             "matches full-scan oracle"
         );
@@ -1760,7 +1870,7 @@ mod tests {
 
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
 
         // Second refresh, nothing changed on disk: the CPU-fix gate.
         let second = scan_incremental(
@@ -1768,6 +1878,7 @@ mod tests {
             &mut cache,
             Some(first.stable),
             watermark,
+            None,
             &mut reporter,
         );
 
@@ -1789,10 +1900,205 @@ mod tests {
             "recent file served from cache"
         );
         assert_eq!(
-            encode(&second.data),
+            encode(second.data.as_ref().expect("changed scan publishes")),
             fx.oracle_bytes(),
             "matches full-scan oracle"
         );
+    }
+
+    // ── unchanged-snapshot short-circuit (issue #255) ───────────────
+
+    #[test]
+    fn unchanged_refresh_short_circuits_with_memo() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "old.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
+        assert!(first.data.is_some(), "first refresh always publishes");
+        assert_eq!(
+            first.memo.recent_present.len(),
+            1,
+            "one recent file fingerprinted"
+        );
+
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            Some(&first.memo),
+            &mut reporter,
+        );
+        assert!(
+            second.data.is_none(),
+            "unchanged refresh skips aggregation entirely"
+        );
+        assert!(second.counters.stable_reused);
+        assert!(!second.stable_rebuilt);
+        assert_eq!(second.counters.parsed, 0);
+        assert_eq!(second.memo, first.memo, "memo carries forward unchanged");
+
+        // The short-circuit re-arms from its own returned memo.
+        let third = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(second.stable),
+            watermark,
+            Some(&second.memo),
+            &mut reporter,
+        );
+        assert!(third.data.is_none(), "still unchanged on the third refresh");
+    }
+
+    #[test]
+    fn short_circuit_disarms_when_recent_file_changes() {
+        let fx = IncrFixture::new();
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
+
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[
+                claude_line("2026-06-01T10:00:00Z", "s2", 10, 20),
+                claude_line("2026-06-01T11:00:00Z", "s2", 1, 2),
+            ],
+        );
+
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            Some(&first.memo),
+            &mut reporter,
+        );
+        let data = second.data.as_ref().expect("changed file must re-publish");
+        assert_eq!(data.grand_total.call_count, 2);
+        assert_eq!(encode(data), fx.oracle_bytes(), "matches full-scan oracle");
+        assert_ne!(second.memo, first.memo, "memo reflects the new fingerprint");
+    }
+
+    #[test]
+    fn short_circuit_disarms_when_recent_file_deleted() {
+        // Deletion is the trap a naive `parsed == 0` check would miss:
+        // nothing parses, the stable set is untouched, but the snapshot
+        // must shrink — the recent fingerprint set is what catches it.
+        let fx = IncrFixture::new();
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "keep.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+        fx.write_file(
+            "proj-b",
+            "gone.jsonl",
+            &[claude_line("2026-06-02T10:00:00Z", "s3", 30, 40)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
+        assert_eq!(
+            first.data.as_ref().expect("publishes").grand_total.call_count,
+            2
+        );
+
+        std::fs::remove_file(fx.claude_root.join("proj-b/gone.jsonl")).expect("delete");
+
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            Some(&first.memo),
+            &mut reporter,
+        );
+        assert_eq!(second.counters.parsed, 0, "nothing re-parses on a delete");
+        let data = second.data.as_ref().expect("deletion must re-publish");
+        assert_eq!(
+            data.grand_total.call_count, 1,
+            "deleted file's call is gone"
+        );
+        assert_eq!(encode(data), fx.oracle_bytes(), "matches full-scan oracle");
+    }
+
+    #[test]
+    fn short_circuit_disarms_when_stable_file_touched() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-a",
+            "old.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "s1", 100, 200)],
+        );
+        tick();
+        let watermark = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-b",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "s2", 10, 20)],
+        );
+
+        let mut cache = fx.open_cache();
+        let mut reporter = ProgressReporter::noop();
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
+
+        // Rewrite the stable file: its mtime moves it to the recent
+        // side AND breaks the stable fingerprint set.
+        tick();
+        fx.write_file(
+            "proj-a",
+            "old.jsonl",
+            &[
+                claude_line("2026-05-01T10:00:00Z", "s1", 100, 200),
+                claude_line("2026-05-01T11:00:00Z", "s1", 5, 6),
+            ],
+        );
+
+        let second = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            Some(first.stable),
+            watermark,
+            Some(&first.memo),
+            &mut reporter,
+        );
+        assert!(
+            second.stable_rebuilt,
+            "touched stable file forces a rebuild"
+        );
+        let data = second.data.as_ref().expect("stable change must re-publish");
+        assert_eq!(data.grand_total.call_count, 3);
+        assert_eq!(encode(data), fx.oracle_bytes(), "matches full-scan oracle");
     }
 
     #[test]
@@ -1814,7 +2120,7 @@ mod tests {
 
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
 
         fx.write_file(
             "proj-b",
@@ -1826,13 +2132,14 @@ mod tests {
             &mut cache,
             Some(first.stable),
             watermark,
+            None,
             &mut reporter,
         );
 
         assert!(second.counters.stable_reused, "stable side untouched");
         assert_eq!(second.counters.parsed, 1, "only the new file parses");
         assert_eq!(
-            encode(&second.data),
+            encode(second.data.as_ref().expect("changed scan publishes")),
             fx.oracle_bytes(),
             "matches full-scan oracle"
         );
@@ -1857,7 +2164,7 @@ mod tests {
 
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let first = scan_incremental(&fx.roots, &mut cache, None, wm1, &mut reporter);
+        let first = scan_incremental(&fx.roots, &mut cache, None, wm1, None, &mut reporter);
         assert_eq!(first.stable.folded.len(), 1);
 
         // The watermark advances past b.jsonl — it ages into the
@@ -1868,6 +2175,7 @@ mod tests {
             &mut cache,
             Some(first.stable),
             wm2,
+            None,
             &mut reporter,
         );
 
@@ -1878,7 +2186,7 @@ mod tests {
             "rebuild is cache-served, no reparse"
         );
         assert_eq!(
-            encode(&second.data),
+            encode(second.data.as_ref().expect("changed scan publishes")),
             fx.oracle_bytes(),
             "matches full-scan oracle"
         );
@@ -1902,7 +2210,7 @@ mod tests {
 
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
         assert_eq!(first.stable.folded.len(), 2);
 
         std::fs::remove_file(fx.claude_root.join("proj-a/doomed.jsonl")).expect("rm");
@@ -1911,6 +2219,7 @@ mod tests {
             &mut cache,
             Some(first.stable),
             watermark,
+            None,
             &mut reporter,
         );
 
@@ -1924,7 +2233,7 @@ mod tests {
             "only the keeper remains folded"
         );
         assert_eq!(
-            encode(&second.data),
+            encode(second.data.as_ref().expect("changed scan publishes")),
             fx.oracle_bytes(),
             "matches post-delete oracle"
         );
@@ -1943,7 +2252,7 @@ mod tests {
 
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, &mut reporter);
+        let first = scan_incremental(&fx.roots, &mut cache, None, watermark, None, &mut reporter);
         assert_eq!(first.stable.folded.len(), 1, "grow.jsonl folded as stable");
 
         // Append a line: mtime bumps past the watermark, so the file
@@ -1960,17 +2269,19 @@ mod tests {
             &mut cache,
             Some(first.stable),
             watermark,
+            None,
             &mut reporter,
         );
 
         assert!(second.stable_rebuilt, "stable set lost the appended file");
         assert!(second.stable.folded.is_empty(), "nothing stable remains");
         assert_eq!(
-            second.data.grand_total.call_count, 2,
+            second.data.as_ref().expect("changed scan publishes").grand_total.call_count,
+            2,
             "old + appended call, counted once each"
         );
         assert_eq!(
-            encode(&second.data),
+            encode(second.data.as_ref().expect("changed scan publishes")),
             fx.oracle_bytes(),
             "matches post-append oracle"
         );
@@ -1981,8 +2292,18 @@ mod tests {
         let fx = IncrFixture::new();
         let mut cache = fx.open_cache();
         let mut reporter = ProgressReporter::noop();
-        let out = scan_incremental(&fx.roots, &mut cache, None, now_nanos(), &mut reporter);
-        assert_eq!(encode(&out.data), encode(&UsageData::default()));
+        let out = scan_incremental(
+            &fx.roots,
+            &mut cache,
+            None,
+            now_nanos(),
+            None,
+            &mut reporter,
+        );
+        assert_eq!(
+            encode(out.data.as_ref().expect("changed scan publishes")),
+            encode(&UsageData::default())
+        );
         assert!(out.stable.folded.is_empty());
     }
 

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -76,6 +76,14 @@ pub struct ScanProgressEvent {
     /// Project label (basename of the project dir or rollout date) for
     /// the most recently scanned file.
     pub current_project: String,
+    /// `true` on the terminal event of a scan whose refresh decided
+    /// NOT to republish (unchanged-snapshot short-circuit): consumers
+    /// must clear any in-flight scan UI now, because no
+    /// `sessions.usage_data` chunk is coming to clear it for them.
+    /// Absent/`false` on every per-file tick (and from pre-#255
+    /// publishers, which decode-default cleanly).
+    #[serde(default)]
+    pub done: bool,
 }
 
 /// Optional payload for the `sessions.refresh_request` topic.


### PR DESCRIPTION
Closes #255

## What

Two measured fixes for the ~75 s near-100%-CPU spike session-reader pays on every 5-minute refresh, plus the consumer-contract change the second one needs.

### 1. Chunker: size per item instead of re-probing whole chunks (the actual hot spot)
Profiling against real `$HOME` data (harness included, first commit) showed **20.2 s of the 23 s release-mode refresh** was `chunk_usage_data` re-encoding the entire candidate chunk every 64 items — ~7.8 GB of redundant msgpack encoding for 261 MB of output. Items are now encoded exactly once; the chunk cuts on a running size sum (exact up to array headers, covered by slack), with one verification encode per chunk as a safety net. Same wire format, same chunk count on real data.

### 2. Unchanged-snapshot short-circuit
When the stable fingerprint set, the recent fingerprint set, and the uncached providers' output all equal the previous refresh's, the snapshot is provably byte-identical — aggregation and the 261 MB republish are skipped outright. Guards: memo commits only after a publish fully lands; deletions caught by set equality (not parsed-count); stat failures poison the skip; hard refresh wipes the memo.

### 3. Wire: `done` flag on `ScanProgressEvent` + burndown banner clear
A skipped publish means no final chunk arrives to clear burndown's 'Scanning sessions…' banner — the terminal `done` progress event clears it instead. `#[serde(default)]` keeps old publishers compatible (pinned by test).

## Measured (real data, release)

| phase | before | after |
|---|---|---|
| chunker | 20.2 s | 0.8 s |
| whole refresh | ~23 s | ~3.5 s |
| refresh with nothing changed | ~23 s | ~2.5 s scan, **no publish** |

Live debug-build TUI: ~75 s spike → ~10 s, and the 261 MB per-refresh pipe traffic disappears whenever nothing changed.

## Tests
- All existing chunker invariants green (no-loss, order, size cap, pop priority, giant-outlier progress)
- 4 new scanner short-circuit tests — skip arms/re-arms; disarms on file change, **deletion** (the parsed=0 trap), stable-file touch; all disarm paths byte-identical to the cache-less full-scan oracle
- Glue test: memo round-trips through `run_blocking_scan`, skip returns no data, change re-publishes
- Burndown: done-clears-banner + legacy wire back-compat
- session-reader 103 ✓, burndown 196 ✓, types-sessions 13 ✓; clippy parity with main (zero new lints)

Note: `stdio_smoke` / `subprocess_smoke` integration tests hang/fail on the dev box identically on main (environmental) — CI is the gate for those.