### PR TITLE
fix(home): escape the Memory panel + add its missing sidebar tile

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3540,6 +3540,12 @@ impl EventHandler {
                         tracing::info!("Navigating to Skills from sidebar");
                         Self::process_event(AppEvent::GoToSkills, state);
                     }
+                    SidebarItem::Memory => {
+                        tracing::info!("Navigating to Memory (knowledge base) from sidebar");
+                        // Canonical event saves `previous_screen` so the
+                        // panel's Esc-close returns here, not to a stale origin.
+                        Self::process_event(AppEvent::GoToLearnings, state);
+                    }
                     SidebarItem::Changelog => {
                         state.current_screen = screen_ids::CHANGELOG.to_string();
                     }
@@ -5394,6 +5400,23 @@ mod panel_back_tests {
             matches!(evt, AppEvent::GoToLearnings),
             "`m` must map to GoToLearnings, got {evt:?}"
         );
+    }
+
+    /// Activating the Memory tile on the home sidebar (Enter) must open the
+    /// learnings panel, saving home as the origin so the panel's Esc-close
+    /// returns there. The tile was missing entirely before — every other
+    /// overlay panel had one.
+    #[test]
+    fn home_sidebar_memory_tile_opens_learnings() {
+        use crate::components::sidebar::SidebarItem;
+        let mut state = AppState::default();
+        state.current_screen = ids::HOME.to_string();
+        state.home_screen_v2_state.sidebar.select(SidebarItem::Memory);
+
+        EventHandler::process_event(AppEvent::HomeScreenSidebarSelect, &mut state);
+
+        assert_eq!(state.current_screen, ids::LEARNINGS);
+        assert_eq!(state.previous_screen.as_deref(), Some(ids::HOME));
     }
 
     /// Re-firing the open event while already on the panel must not

--- a/ainb-tui/crates/ainb-core/src/components/sidebar.rs
+++ b/ainb-tui/crates/ainb-core/src/components/sidebar.rs
@@ -42,6 +42,7 @@ pub enum SidebarItem {
     Witr,      // Process causality (witr plugin)
     Abtop,     // top-for-agents — live agent monitor (abtop plugin)
     Skills,    // Browse per-agent skills
+    Memory,    // Knowledge-base browser (learnings plugin)
     Changelog, // Version history
     Setup,     // Setup wizard & factory reset
     Help,      // Docs & guides
@@ -62,6 +63,7 @@ impl SidebarItem {
             Self::Witr => "🌳",
             Self::Abtop => "📡",
             Self::Skills => "🧠",
+            Self::Memory => "📚",
             Self::Changelog => "📝",
             Self::Setup => "🛠️",
             Self::Help => "❓",
@@ -82,6 +84,7 @@ impl SidebarItem {
             Self::Witr => "Witr",
             Self::Abtop => "abtop",
             Self::Skills => "Skills",
+            Self::Memory => "Memory",
             Self::Changelog => "Changelog",
             Self::Setup => "Setup",
             Self::Help => "Help",
@@ -102,6 +105,7 @@ impl SidebarItem {
             Self::Witr => "Process Causality",
             Self::Abtop => "top-for-agents",
             Self::Skills => "Per-Agent Skills",
+            Self::Memory => "Knowledge & Recall",
             Self::Changelog => "Version History",
             Self::Setup => "Setup & Reset",
             Self::Help => "Docs & Guides",
@@ -122,6 +126,7 @@ impl SidebarItem {
             Self::Witr => "w",
             Self::Abtop => "t",
             Self::Skills => "k",
+            Self::Memory => "m",
             Self::Changelog => "v",
             Self::Setup => "S",
             Self::Help => "?",
@@ -142,6 +147,7 @@ impl SidebarItem {
             Self::Witr,
             Self::Abtop,
             Self::Skills,
+            Self::Memory,
             Self::Changelog,
             Self::Setup,
             Self::Help,
@@ -522,6 +528,29 @@ mod tests {
         let collisions =
             all.iter().filter(|i| **i != SidebarItem::Inbox && i.shortcut() == "b").count();
         assert_eq!(collisions, 0, "sidebar shortcut 'b' collides");
+    }
+
+    #[test]
+    fn memory_tile_registered_with_discoverable_shortcut() {
+        // The learnings/Memory panel was reachable by the `m` key but had no
+        // sidebar tile, so it couldn't be discovered from the home menu like
+        // every other overlay panel (Inbox/Stats/Witr/Skills/Abtop). Lock the
+        // tile shape + position + a non-colliding shortcut so it can't be
+        // dropped again.
+        let all = SidebarItem::all();
+        let memory_pos = all
+            .iter()
+            .position(|i| *i == SidebarItem::Memory)
+            .expect("SidebarItem::Memory missing from all()");
+        assert!(memory_pos > 0, "Memory shouldn't be first sidebar item");
+        assert_eq!(SidebarItem::Memory.icon(), "📚");
+        assert_eq!(SidebarItem::Memory.label(), "Memory");
+        assert_eq!(SidebarItem::Memory.shortcut(), "m");
+        assert_eq!(SidebarItem::Memory.description(), "Knowledge & Recall");
+        // 'm' must not collide with any other tile shortcut.
+        let collisions =
+            all.iter().filter(|i| **i != SidebarItem::Memory && i.shortcut() == "m").count();
+        assert_eq!(collisions, 0, "sidebar shortcut 'm' collides");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-learnings/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-learnings/src/plugin.rs
@@ -18,8 +18,8 @@ use std::sync::mpsc::{self, Receiver};
 use async_trait::async_trait;
 
 use ainb_plugin_sdk::{
-    Cell, Color, Coord, HandleKeyParams, HandleMouseParams, HostClient, InitContext, MouseButton,
-    MouseKind, Plugin, RenderParams, Result, WireBuffer,
+    Cell, Color, Coord, HandleKeyParams, HandleMouseParams, HostClient, InitContext, KeyCode,
+    MouseButton, MouseKind, Plugin, RenderParams, Result, WireBuffer, topics,
 };
 use ratatui::buffer::Buffer as RBuffer;
 use ratatui::layout::Rect as RRect;
@@ -387,10 +387,14 @@ impl Plugin for LearningsPlugin {
         Ok(wire)
     }
 
-    /// Route a forwarded key into the UI. The host reserves global nav (Esc,
-    /// etc.) and only forwards keys it hasn't consumed, so a no-op here for an
-    /// unhandled key is correct.
-    async fn handle_key(&mut self, _host: &HostClient, params: HandleKeyParams) -> Result<()> {
+    /// Route a forwarded key into the UI. The host forwards every non-reserved
+    /// key here (Esc included — it is plugin-owned, not host-reserved). The UI
+    /// pops its own internal levels (detail drawer, picker, focused graph); at
+    /// the root view, an unconsumed Esc must close the screen, so we publish
+    /// `ui.close_request` for the host to pop back to wherever the panel was
+    /// opened from. Without it the user is trapped on the panel (only Ctrl+C
+    /// quits). Mirrors the burndown plugin's root-Esc path.
+    async fn handle_key(&mut self, host: &HostClient, params: HandleKeyParams) -> Result<()> {
         // Build the Search context fresh from the resolved config: the
         // collection/index the Search tab threads into its query. The `qmd`
         // runner is NOT in the context — a search submit returns a request and
@@ -403,6 +407,16 @@ impl Plugin for LearningsPlugin {
         let outcome = self.ui.handle_key(&params.key.code, &ctx);
         if outcome.changed {
             self.generation = self.generation.wrapping_add(1);
+        }
+        // Root-level Esc: the UI consumed nothing (`changed == false`), so there
+        // was no inner level to pop — ask the host to close this screen. Best
+        // effort; if the publish is lost the user just presses Esc again.
+        if matches!(params.key.code, KeyCode::Esc) && !outcome.changed {
+            let req = topics::UiCloseRequest {
+                screen_id: params.screen_id.clone(),
+            };
+            let payload = serde_json::to_vec(&req).unwrap_or_default();
+            let _ = host.snapshot_publish(topics::UI_CLOSE_REQUEST, payload).await;
         }
         // A fresh Search submit: kick the `qmd` worker OFF this thread. The
         // result is polled back in on the next render.

--- a/ainb-tui/crates/ainb-plugin-learnings/tests/detail.rs
+++ b/ainb-tui/crates/ainb-plugin-learnings/tests/detail.rs
@@ -184,6 +184,27 @@ async fn esc_closes_detail_back_to_list() {
 }
 
 #[tokio::test]
+async fn esc_at_root_publishes_close_request() {
+    // At the Browse root there is no inner level (Detail / picker / focused
+    // graph) to pop, so Esc must ask the host to close the screen — otherwise
+    // the user is trapped on the panel with only Ctrl+C. The host forwards Esc
+    // to the plugin (it is no longer host-reserved), so the plugin owns this
+    // escape hatch via `ui.close_request`. Guards the regression where the
+    // learnings panel had no way out.
+    let mut h = init_over_fixture().await;
+
+    h.send_notification(methods::PLUGIN_HANDLE_KEY, key_params(KeyCode::Esc))
+        .await
+        .expect("send Esc at root");
+
+    h.assert_publishes_topic(ainb_plugin_protocol::topics::UI_CLOSE_REQUEST)
+        .await
+        .expect("root Esc must publish ui.close_request");
+
+    h.close().await.expect("clean close");
+}
+
+#[tokio::test]
 async fn backspace_closes_detail_back_to_list() {
     // Backspace is the host-FORWARDED close key (Esc is host-reserved). This
     // is the path the real TUI + tmux tripwire exercise.


### PR DESCRIPTION
Two related cleanups for the Memory (learnings/knowledge-base) panel.

## 1. `fix(learnings)` — Esc was a trap

The host stopped reserving `Esc` for plugin screens; it now **forwards** `Esc` to the plugin and expects the plugin to pop its own inner levels and, at the root view, publish `ui.close_request` so the host closes the screen. The learnings plugin still assumed `Esc` was host-reserved (stale doc comment) and published nothing — so `Esc` was delivered, ignored, and swallowed. The panel had **no way out except Ctrl+C**.

Fix mirrors the burndown plugin: when `Esc` reaches the root view (the UI consumed nothing to pop), publish `ui.close_request`. The detail-drawer `Esc` still just pops the drawer.

## 2. `feat(home)` — Memory had no menu tile

The home sidebar menu lists every overlay panel — Inbox, Stats, Witr, Abtop, Skills — **except** the Memory panel. It was only reachable by the `m` key, undiscoverable from the menu. Added a `Memory` `SidebarItem` (icon 📚, label, `m` shortcut) and routed its activation through the canonical `GoToLearnings` event so the panel's Esc-close returns to home.

## Tests
- `esc_at_root_publishes_close_request` — root Esc publishes `ui.close_request` (the escape hatch).
- `esc_closes_detail_back_to_list` (unchanged) — detail-drawer Esc still pops the drawer, doesn't escape the screen.
- `memory_tile_registered_with_discoverable_shortcut` — tile shape + non-colliding `m` shortcut.
- `home_sidebar_memory_tile_opens_learnings` — Enter on the tile opens the panel, saving home as origin.

Learnings plugin tests 5/5, sidebar 18/18, events 34/34. `cargo fmt --all --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added a new Memory sidebar navigation item, accessible via keyboard shortcut 'm', for quick access to the learnings panel
* Enhanced learnings panel with Esc key support to close the panel and return to the previous screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->