### PR TITLE
perf(tui): eliminate idle redraw burn + per-frame session-list work

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3655,6 +3655,11 @@ impl EventHandler {
                                 ));
                             }
                         }
+
+                        // Favorites changed — refresh the precomputed star
+                        // cache so the session list reflects the toggle without
+                        // re-resolving favorites in the render path. (perf 9ov/8rn)
+                        state.recompute_favorite_workspaces();
                     }
                 }
             }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2669,6 +2669,13 @@ pub struct AppState {
     // Throttled tmux preview updates (avoid spawning subprocesses every 250ms tick)
     pub last_preview_update: Option<Instant>,
 
+    // Throttle for the cheaper non-selected-session status sweep. Status
+    // (running/idle) is not time-critical, so it polls on a longer cadence than
+    // the selected session's live preview — one `capture-pane` subprocess per
+    // non-selected session is only spawned every `STATUS_INTERVAL_SECS`, not on
+    // every 5s preview refresh. (perf: bead 9pb)
+    pub last_status_check: Option<Instant>,
+
     // Background workspace loading state
     pub is_loading_workspaces: bool,
     pub workspace_load_error: Option<String>,
@@ -3098,6 +3105,7 @@ impl Default for AppState {
 
             // Throttled tmux preview updates
             last_preview_update: None,
+            last_status_check: None,
 
             // Background workspace loading state
             is_loading_workspaces: false,
@@ -9223,6 +9231,19 @@ impl AppState {
         }
         self.last_preview_update = Some(now);
 
+        // Non-selected sessions only need a status (running/idle) refresh, which
+        // is not time-critical — sweep them on a longer cadence so we don't
+        // spawn one `capture-pane` per non-selected session on every 5s preview
+        // refresh. (perf: bead 9pb)
+        const STATUS_INTERVAL_SECS: u64 = 20;
+        let do_status_check = match self.last_status_check {
+            Some(last) => now.duration_since(last).as_secs() >= STATUS_INTERVAL_SECS,
+            None => true,
+        };
+        if do_status_check {
+            self.last_status_check = Some(now);
+        }
+
         // updates: (session_id, content, claude_running) for the selected session.
         // Attention markers are derived separately from hook events in
         // `refresh_attention_markers`, not from live pane state.
@@ -9268,9 +9289,10 @@ impl AppState {
                         debug!("Failed to capture selected session {}: {}", session_id, e);
                     }
                 }
-            } else {
-                // Non-selected sessions: only capture visible area for status detection
-                // Much cheaper — just the last screenful (~50 lines)
+            } else if do_status_check {
+                // Non-selected sessions: only capture visible area for status
+                // detection, and only on the longer status cadence. Much
+                // cheaper — just the last screenful (~50 lines). (perf: 9pb)
                 match tmux_session.capture_pane_content().await {
                     Ok(content) => {
                         let claude_running = detector.has_claude_status_bar(&content);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2573,6 +2573,13 @@ pub struct AppState {
     pub pending_plugin_renders:
         std::collections::HashMap<crate::app::screens::ScreenId, ainb_plugin_runtime::WireBuffer>,
 
+    /// Cache of workspace paths that are currently favorited (starred).
+    /// Computed by `recompute_favorite_workspaces()` whenever the workspace
+    /// list or the favorites store changes — NOT in the render path. The
+    /// session-list render reads this set with an O(1) lookup, so it never
+    /// re-parses `favorites.yaml` or opens a git repo per frame.
+    pub favorite_workspace_paths: HashSet<PathBuf>,
+
     /// Last `(width, height)` `PluginScreen::render` was handed for each
     /// screen id. `tick_plugin_renders` reads this and forwards it to
     /// `handle.render(..)` so the plugin paints at the actual allocated
@@ -3068,6 +3075,7 @@ impl Default for AppState {
             inbox_state: crate::components::inbox::InboxState::default(),
 
             pending_plugin_renders: std::collections::HashMap::new(),
+            favorite_workspace_paths: HashSet::new(),
             plugin_render_areas: std::collections::HashMap::new(),
             plugin_render_origins: std::collections::HashMap::new(),
             plugin_last_render_viewport: std::collections::HashMap::new(),
@@ -3876,6 +3884,12 @@ impl AppState {
                             self.ssh_sessions = ssh_sessions;
                             self.workspace_load_error = None;
 
+                            // Resolve favorite status once per workspace now
+                            // that the list changed, so the session-list render
+                            // never opens a git repo or parses favorites.yaml
+                            // per frame (perf: bead 9ov + 8rn).
+                            self.recompute_favorite_workspaces();
+
                             // Populate tmux_sessions HashMap for Interactive mode sessions
                             // This is needed for update_tmux_previews() to capture pane content
                             for workspace in &self.workspaces {
@@ -3994,6 +4008,59 @@ impl AppState {
             }
         }
         false
+    }
+
+    /// Recompute which workspaces are favorited and cache the result in
+    /// `favorite_workspace_paths`. Loads `favorites.yaml` ONCE and resolves
+    /// each workspace's favorite status (by local path or git remote) here,
+    /// off the render path. Call after the workspace list changes or a
+    /// favorite is toggled — never per frame. (perf: beads 9ov + 8rn)
+    pub fn recompute_favorite_workspaces(&mut self) {
+        let favorites = crate::config::FavoritesStore::load();
+        let mut starred: HashSet<PathBuf> = HashSet::new();
+        for workspace in &self.workspaces {
+            if Self::workspace_is_favorite(&workspace.path, &favorites) {
+                starred.insert(workspace.path.clone());
+            }
+        }
+        self.favorite_workspace_paths = starred;
+    }
+
+    /// True if `path` is favorited, by local-path match or by the repo's git
+    /// remote (owner/repo shorthand or full URL). The git remote lookup is the
+    /// expensive part (libgit2 open + config read), so this MUST stay out of
+    /// the render path — it runs only from `recompute_favorite_workspaces`.
+    fn workspace_is_favorite(
+        path: &std::path::Path,
+        favorites: &crate::config::FavoritesStore,
+    ) -> bool {
+        let path_str = path.display().to_string();
+        if favorites.favorites.iter().any(|f| f.source == path_str) {
+            return true;
+        }
+        // Fall back to the repo's `origin` remote. `from_input` is deprecated
+        // for free-form input, but the URL comes from `get_remote_url()` so the
+        // legacy contract holds.
+        crate::perf::record_git_resolve();
+        let Ok(git_repo) = crate::git::RepositoryManager::open(path) else {
+            return false;
+        };
+        let Ok(Some(remote_url)) = git_repo.get_remote_url() else {
+            return false;
+        };
+        #[allow(deprecated)]
+        let Ok(repo_source) = crate::git::RepoSource::from_input(&remote_url) else {
+            return false;
+        };
+        if let Ok(parsed) = repo_source.parse_components() {
+            let shorthand = format!("{}/{}", parsed.owner, parsed.repo_name);
+            favorites
+                .favorites
+                .iter()
+                .any(|f| f.source == shorthand || f.source == remote_url)
+        } else {
+            favorites.favorites.iter().any(|f| f.source == remote_url)
+        }
     }
 
     /// Kick off a background scan of ~/.claude/skills and ~/.claude/agents.
@@ -9517,13 +9584,17 @@ impl App {
     /// burndown + session-reader as Rust subprocess binaries). Loop is
     /// no-op when discovery returned empty; once 7c lands, the screen
     /// routing table below populates again.
-    pub fn tick_plugin_renders(&mut self) {
+    /// Drive plugin-owned screens. Returns `true` if a fresh plugin frame was
+    /// drained into `pending_plugin_renders` this tick, so the render loop can
+    /// treat that as a reason to repaint (perf: bead `wai` dirty-gate).
+    pub fn tick_plugin_renders(&mut self) -> bool {
         // Clone the cheap Send + Clone handle so we can hold a reference
         // to the runtime while also mutably borrowing the various
         // `state.*` plugin caches below.
         let Some(handle) = self.state.plugin_runtime.clone() else {
-            return;
+            return false;
         };
+        let mut drained = false;
 
         // Honour any pending plugin close request (root-view Esc) before
         // kicking renders — a closed screen shouldn't get another paint.
@@ -9558,6 +9629,7 @@ impl App {
             // screen repaints instantly on return.
             if let Some(buf) = handle.try_recv_render(&pid) {
                 self.state.pending_plugin_renders.insert((*screen_id).to_string(), buf);
+                drained = true;
             }
 
             // Visibility gate: only the plugin owning the focused screen
@@ -9632,6 +9704,7 @@ impl App {
             // pickup happens via `try_recv_render` next tick.
             let _ = handle.render(&pid, viewport, 0);
         }
+        drained
     }
 
     pub async fn init(&mut self) {

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -240,8 +240,11 @@ impl SessionListComponent {
     fn build_list_items_static(state: &AppState) -> Vec<ListItem<'static>> {
         let mut items = Vec::new();
 
-        // Load favorites to check which workspaces are starred
-        let favorites = crate::config::FavoritesStore::load();
+        // Favorite status is precomputed off the render path into
+        // `state.favorite_workspace_paths` (see
+        // `AppState::recompute_favorite_workspaces`), so this hot loop does an
+        // O(1) set lookup instead of re-parsing favorites.yaml and opening a
+        // git repo per workspace on every frame. (perf: beads 9ov + 8rn)
 
         // Must stay in lockstep with AppState::attachable_items_in_order;
         // divergence would attach the wrong session for a given digit.
@@ -288,44 +291,10 @@ impl SessionListComponent {
                 String::new()
             };
 
-            // Check if this workspace is a favorite (by local path OR remote URL)
-            let workspace_path_str = workspace.path.display().to_string();
-            let is_favorite = {
-                // First check local path
-                let by_path = favorites.favorites.iter().any(|f| f.source == workspace_path_str);
-                if by_path {
-                    true
-                } else {
-                    // Also check by remote URL (owner/repo format).
-                    // `from_input` is deprecated for free-form input
-                    // (finding #14); the URL here came from
-                    // `get_remote_url()` so the legacy contract is fine.
-                    if let Ok(git_repo) = crate::git::RepositoryManager::open(&workspace.path) {
-                        if let Ok(Some(remote_url)) = git_repo.get_remote_url() {
-                            #[allow(deprecated)]
-                            if let Ok(repo_source) = crate::git::RepoSource::from_input(&remote_url)
-                            {
-                                if let Ok(parsed) = repo_source.parse_components() {
-                                    let shorthand =
-                                        format!("{}/{}", parsed.owner, parsed.repo_name);
-                                    favorites
-                                        .favorites
-                                        .iter()
-                                        .any(|f| f.source == shorthand || f.source == remote_url)
-                                } else {
-                                    favorites.favorites.iter().any(|f| f.source == remote_url)
-                                }
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                }
-            };
+            // Favorite status: O(1) lookup against the precomputed cache
+            // (resolved off the render path in
+            // `AppState::recompute_favorite_workspaces`). No git2 / YAML here.
+            let is_favorite = state.favorite_workspace_paths.contains(&workspace.path);
             let star_indicator = if is_favorite { "⭐ " } else { "" };
 
             let workspace_line = Line::from(vec![

--- a/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
+++ b/ainb-tui/crates/ainb-core/src/config/favorites_store.rs
@@ -165,6 +165,7 @@ impl FavoritesStore {
 
     /// Load from disk (returns empty store if file doesn't exist)
     pub fn load() -> Self {
+        crate::perf::record_favorites_load();
         Self::storage_path()
             .and_then(|path| fs::read_to_string(path).ok())
             .and_then(|content| serde_yaml::from_str(&content).ok())

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod fleet;
 pub mod git;
 pub mod interactive;
 pub mod models;
+pub mod perf;
 pub mod plugins;
 pub mod providers;
 pub mod tmux;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -43,6 +43,7 @@ mod fleet;
 mod git;
 mod interactive;
 mod models;
+mod perf;
 mod plugins;
 mod providers;
 mod tmux;
@@ -85,6 +86,7 @@ fn cleanup_terminal_with_instance<B: Backend + std::io::Write>(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    crate::perf::init();
     setup_logging();
     setup_panic_handler();
 
@@ -296,6 +298,10 @@ async fn run_tui(app: &mut App, layout: &mut LayoutComponent) -> Result<()> {
         cleanup_terminal();
     }
 
+    // Perf trace summary (no-op unless AINB_PERF_TRACE is set). Emitted after
+    // the alternate screen is torn down so the report lands on the real stderr.
+    crate::perf::report();
+
     result
 }
 
@@ -324,6 +330,12 @@ async fn run_tui_loop(
     let mut last_tick = Instant::now();
     let mut last_app_tick = Instant::now();
 
+    // Perf trace: timestamp of the most recent keystroke awaiting its paint.
+    // Set when a key event is read; consumed at the top of the next loop
+    // iteration once the paint that reflects it has completed. Gated behind
+    // `AINB_PERF_TRACE` (see `crate::perf`); zero cost when disabled.
+    let mut pending_key_at: Option<Instant> = None;
+
     // Startup guard: Ignore key events for the first 100ms to prevent stray keypresses
     // from triggering actions (e.g., buffered 'n' key opening New Session dialog)
     let startup_time = Instant::now();
@@ -339,9 +351,16 @@ async fn run_tui_loop(
         // directly.
         app.tick_plugin_renders();
 
+        let draw_start = Instant::now();
         terminal.draw(|frame| {
             layout.render(frame, &mut app.state);
         })?;
+        crate::perf::record_draw(draw_start.elapsed());
+        // This paint is the first one to reflect any key read in the previous
+        // iteration, so it marks the end of the key-to-render interval.
+        if let Some(key_at) = pending_key_at.take() {
+            crate::perf::record_key_to_render(key_at.elapsed());
+        }
 
         let timeout = tick_rate
             .checked_sub(last_tick.elapsed())
@@ -354,6 +373,12 @@ async fn run_tui_loop(
                     // Drop Release so Enter doesn't immediately re-trigger and close popups.
                     if key_event.kind == KeyEventKind::Release {
                         continue;
+                    }
+
+                    // Perf trace: this real keystroke now awaits the next paint.
+                    if crate::perf::enabled() {
+                        crate::perf::record_key();
+                        pending_key_at = Some(Instant::now());
                     }
 
                     // Startup guard: Ignore key events during startup period

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -336,6 +336,18 @@ async fn run_tui_loop(
     // `AINB_PERF_TRACE` (see `crate::perf`); zero cost when disabled.
     let mut pending_key_at: Option<Instant> = None;
 
+    // Dirty-gate for the host layout repaint (perf: bead `wai`). The TUI used
+    // to call `terminal.draw()` unconditionally every 33 ms (~30 fps) even when
+    // nothing changed, burning ~5-6% CPU at idle. Animations and periodic state
+    // already advance only on the 250 ms `app_tick`, so a frame between ticks
+    // was an identical repaint. We now paint only when something actually
+    // changed: an input/resize/paste event, a fresh plugin frame, an
+    // `app_tick` (covers mascot/spinner/state at their existing 250 ms
+    // cadence), or an explicit `ui_needs_refresh`. Starts `true` for the first
+    // paint. Worst-case staleness is one `app_tick` (250 ms) — identical to the
+    // pre-existing animation cadence — so there is no visible regression.
+    let mut needs_redraw = true;
+
     // Startup guard: Ignore key events for the first 100ms to prevent stray keypresses
     // from triggering actions (e.g., buffered 'n' key opening New Session dialog)
     let startup_time = Instant::now();
@@ -349,17 +361,25 @@ async fn run_tui_loop(
         // WireBuffer into `state.pending_plugin_renders`, so layout's
         // `PluginScreen` can paint without touching the plugin host
         // directly.
-        app.tick_plugin_renders();
+        // A fresh plugin frame is a reason to repaint even if nothing else
+        // changed (e.g. a self-animating plugin screen).
+        if app.tick_plugin_renders() {
+            needs_redraw = true;
+        }
 
-        let draw_start = Instant::now();
-        terminal.draw(|frame| {
-            layout.render(frame, &mut app.state);
-        })?;
-        crate::perf::record_draw(draw_start.elapsed());
-        // This paint is the first one to reflect any key read in the previous
-        // iteration, so it marks the end of the key-to-render interval.
-        if let Some(key_at) = pending_key_at.take() {
-            crate::perf::record_key_to_render(key_at.elapsed());
+        if needs_redraw {
+            let draw_start = Instant::now();
+            terminal.draw(|frame| {
+                layout.render(frame, &mut app.state);
+            })?;
+            crate::perf::record_draw(draw_start.elapsed());
+            // This paint is the first one to reflect any key read in the
+            // previous iteration, so it marks the end of the key-to-render
+            // interval.
+            if let Some(key_at) = pending_key_at.take() {
+                crate::perf::record_key_to_render(key_at.elapsed());
+            }
+            needs_redraw = false;
         }
 
         let timeout = tick_rate
@@ -367,6 +387,9 @@ async fn run_tui_loop(
             .unwrap_or_else(|| Duration::from_secs(0));
 
         if crossterm::event::poll(timeout)? {
+            // Any input (key/mouse/paste/resize) warrants a repaint on the next
+            // loop iteration (perf: bead `wai` dirty-gate).
+            needs_redraw = true;
             match event::read()? {
                 Event::Key(key_event) => {
                     // Windows fires Press + Release for every key; macOS/Linux fire only Press.
@@ -1520,14 +1543,9 @@ async fn run_tui_loop(
             match app.tick().await {
                 Ok(()) => {
                     last_app_tick = Instant::now();
-
-                    // Check if UI needs immediate refresh after async operations
-                    if app.needs_ui_refresh() {
-                        // Force immediate redraw by skipping the timeout
-                        terminal.draw(|frame| {
-                            layout.render(frame, &mut app.state);
-                        })?;
-                    }
+                    // Consume the refresh flag; the repaint is handled by the
+                    // app-tick redraw below (perf: bead `wai`).
+                    let _ = app.needs_ui_refresh();
                 }
                 Err(e) => {
                     use tracing::error;
@@ -1536,6 +1554,12 @@ async fn run_tui_loop(
                     last_app_tick = Instant::now();
                 }
             }
+
+            // The app tick is the only place mascot/spinner/streaming state
+            // advances, so repaint once per tick (its existing ~250 ms cadence).
+            // This is the animation floor of the dirty-gate: between ticks, with
+            // no input or plugin frame, we draw nothing. (perf: bead `wai`)
+            needs_redraw = true;
         }
 
         if app.state.should_quit {

--- a/ainb-tui/crates/ainb-core/src/perf.rs
+++ b/ainb-tui/crates/ainb-core/src/perf.rs
@@ -10,9 +10,9 @@
 // This is a measurement aid retained behind a flag (not a product feature).
 // Run with `AINB_PERF_TRACE=1 ainb 2> perf.log` and read the summary at exit.
 
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 /// Whether tracing is active for this process. Resolved once from the
@@ -167,11 +167,7 @@ fn summary_string() -> String {
     let git = m.git_resolves.load(Ordering::Relaxed);
     let keys = m.keys_seen.load(Ordering::Relaxed);
     let first_paint = m.first_paint_ns.get().copied().unwrap_or(0);
-    let mut samples = m
-        .key_to_render_ns
-        .lock()
-        .map(|v| v.clone())
-        .unwrap_or_default();
+    let mut samples = m.key_to_render_ns.lock().map(|v| v.clone()).unwrap_or_default();
     samples.sort_unstable();
 
     let ms = |ns: u64| ns as f64 / 1_000_000.0;
@@ -182,7 +178,12 @@ fn summary_string() -> String {
     let _ = writeln!(s, "cold start -> first paint : {:.2} ms", ms(first_paint));
     let _ = writeln!(s, "frames drawn             : {frames}");
     let _ = writeln!(s, "keys received            : {keys}");
-    let _ = writeln!(s, "draw avg / max           : {:.3} / {:.3} ms", ms(avg_draw), ms(draw_max));
+    let _ = writeln!(
+        s,
+        "draw avg / max           : {:.3} / {:.3} ms",
+        ms(avg_draw),
+        ms(draw_max)
+    );
     let _ = writeln!(s, "total time in draw()     : {:.1} ms", ms(draw_total));
     let _ = writeln!(s, "favorites store loads    : {fav}");
     let _ = writeln!(s, "git remote resolves      : {git}");

--- a/ainb-tui/crates/ainb-core/src/perf.rs
+++ b/ainb-tui/crates/ainb-core/src/perf.rs
@@ -1,0 +1,195 @@
+// ABOUTME: Env-gated runtime performance instrumentation for the TUI hot loop.
+//
+// Enabled only when `AINB_PERF_TRACE` is set in the environment; otherwise
+// every hook is a single relaxed atomic-bool load and returns immediately, so
+// the instrumented binary is representative of normal runtime behaviour. The
+// facility records cold-start (process-start → first paint), per-frame draw
+// duration, the number of times the favorites store is parsed from disk, and
+// key-to-render latency. A summary is printed to stderr on `report()`.
+//
+// This is a measurement aid retained behind a flag (not a product feature).
+// Run with `AINB_PERF_TRACE=1 ainb 2> perf.log` and read the summary at exit.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Whether tracing is active for this process. Resolved once from the
+/// `AINB_PERF_TRACE` env var.
+static ENABLED: OnceLock<bool> = OnceLock::new();
+
+/// Process start, captured as early as possible in `main`.
+static PROCESS_START: OnceLock<Instant> = OnceLock::new();
+
+struct Metrics {
+    frames: AtomicU64,
+    draw_ns_total: AtomicU64,
+    draw_ns_max: AtomicU64,
+    favorites_loads: AtomicU64,
+    keys_seen: AtomicU64,
+    first_paint_ns: OnceLock<u64>,
+    /// Key-to-render samples in nanoseconds (bounded to avoid unbounded growth
+    /// on very long sessions).
+    key_to_render_ns: Mutex<Vec<u64>>,
+}
+
+static METRICS: OnceLock<Metrics> = OnceLock::new();
+
+const MAX_LATENCY_SAMPLES: usize = 200_000;
+
+fn metrics() -> &'static Metrics {
+    METRICS.get_or_init(|| Metrics {
+        frames: AtomicU64::new(0),
+        draw_ns_total: AtomicU64::new(0),
+        draw_ns_max: AtomicU64::new(0),
+        favorites_loads: AtomicU64::new(0),
+        keys_seen: AtomicU64::new(0),
+        first_paint_ns: OnceLock::new(),
+        key_to_render_ns: Mutex::new(Vec::new()),
+    })
+}
+
+/// Mark the process start. Call once at the very top of `main`.
+///
+/// When tracing is enabled, also spawns a low-frequency background thread that
+/// writes the running summary to `$AINB_PERF_TRACE_FILE` (default
+/// `/tmp/ainb-perf/live.txt`) every two seconds. This makes the measurement
+/// independent of how the process exits — a profiling harness can read the
+/// file and then kill the process without relying on a clean shutdown path.
+pub fn init() {
+    let _ = PROCESS_START.set(Instant::now());
+    if enabled() {
+        // Force metric allocation up front so later hooks never race on init.
+        let _ = metrics();
+        std::thread::spawn(|| {
+            let path = trace_file_path();
+            loop {
+                std::thread::sleep(Duration::from_secs(2));
+                let _ = std::fs::write(&path, summary_string());
+            }
+        });
+    }
+}
+
+fn trace_file_path() -> std::path::PathBuf {
+    std::env::var_os("AINB_PERF_TRACE_FILE")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp/ainb-perf/live.txt"))
+}
+
+/// Is performance tracing enabled for this process?
+#[inline]
+pub fn enabled() -> bool {
+    *ENABLED.get_or_init(|| std::env::var_os("AINB_PERF_TRACE").is_some())
+}
+
+/// Record that the favorites store was loaded (parsed) from disk. Cheap hot
+/// path; only counts when tracing is enabled.
+#[inline]
+pub fn record_favorites_load() {
+    if !enabled() {
+        return;
+    }
+    metrics().favorites_loads.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record the duration of a single `terminal.draw()`. Also captures the
+/// time-to-first-paint relative to process start the first time it is called.
+#[inline]
+pub fn record_draw(dur: Duration) {
+    if !enabled() {
+        return;
+    }
+    let m = metrics();
+    let ns = dur.as_nanos() as u64;
+    m.frames.fetch_add(1, Ordering::Relaxed);
+    m.draw_ns_total.fetch_add(ns, Ordering::Relaxed);
+    m.draw_ns_max.fetch_max(ns, Ordering::Relaxed);
+    if m.first_paint_ns.get().is_none() {
+        if let Some(start) = PROCESS_START.get() {
+            let _ = m.first_paint_ns.set(start.elapsed().as_nanos() as u64);
+        }
+    }
+}
+
+/// Record that a key event was received by the event loop.
+#[inline]
+pub fn record_key() {
+    if !enabled() {
+        return;
+    }
+    metrics().keys_seen.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a key-to-render latency sample (keypress observed → next paint done).
+#[inline]
+pub fn record_key_to_render(dur: Duration) {
+    if !enabled() {
+        return;
+    }
+    if let Ok(mut v) = metrics().key_to_render_ns.lock() {
+        if v.len() < MAX_LATENCY_SAMPLES {
+            v.push(dur.as_nanos() as u64);
+        }
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = (p / 100.0 * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+/// Build the human-readable summary string from the current metrics.
+fn summary_string() -> String {
+    use std::fmt::Write as _;
+    let m = metrics();
+    let frames = m.frames.load(Ordering::Relaxed);
+    let draw_total = m.draw_ns_total.load(Ordering::Relaxed);
+    let draw_max = m.draw_ns_max.load(Ordering::Relaxed);
+    let fav = m.favorites_loads.load(Ordering::Relaxed);
+    let keys = m.keys_seen.load(Ordering::Relaxed);
+    let first_paint = m.first_paint_ns.get().copied().unwrap_or(0);
+    let mut samples = m
+        .key_to_render_ns
+        .lock()
+        .map(|v| v.clone())
+        .unwrap_or_default();
+    samples.sort_unstable();
+
+    let ms = |ns: u64| ns as f64 / 1_000_000.0;
+    let avg_draw = if frames > 0 { draw_total / frames } else { 0 };
+
+    let mut s = String::new();
+    let _ = writeln!(s, "=== ainb perf trace ===");
+    let _ = writeln!(s, "cold start -> first paint : {:.2} ms", ms(first_paint));
+    let _ = writeln!(s, "frames drawn             : {frames}");
+    let _ = writeln!(s, "keys received            : {keys}");
+    let _ = writeln!(s, "draw avg / max           : {:.3} / {:.3} ms", ms(avg_draw), ms(draw_max));
+    let _ = writeln!(s, "total time in draw()     : {:.1} ms", ms(draw_total));
+    let _ = writeln!(s, "favorites store loads    : {fav}");
+    let _ = writeln!(s, "key-to-render samples    : {}", samples.len());
+    if !samples.is_empty() {
+        let _ = writeln!(
+            s,
+            "key-to-render p50/p95/p99/max : {:.3} / {:.3} / {:.3} / {:.3} ms",
+            ms(percentile(&samples, 50.0)),
+            ms(percentile(&samples, 95.0)),
+            ms(percentile(&samples, 99.0)),
+            ms(*samples.last().unwrap()),
+        );
+    }
+    let _ = writeln!(s, "=======================");
+    s
+}
+
+/// Emit a human-readable summary to stderr. No-op when tracing is disabled.
+pub fn report() {
+    if !enabled() {
+        return;
+    }
+    eprintln!("\n{}", summary_string());
+}

--- a/ainb-tui/crates/ainb-core/src/perf.rs
+++ b/ainb-tui/crates/ainb-core/src/perf.rs
@@ -27,6 +27,7 @@ struct Metrics {
     draw_ns_total: AtomicU64,
     draw_ns_max: AtomicU64,
     favorites_loads: AtomicU64,
+    git_resolves: AtomicU64,
     keys_seen: AtomicU64,
     first_paint_ns: OnceLock<u64>,
     /// Key-to-render samples in nanoseconds (bounded to avoid unbounded growth
@@ -44,6 +45,7 @@ fn metrics() -> &'static Metrics {
         draw_ns_total: AtomicU64::new(0),
         draw_ns_max: AtomicU64::new(0),
         favorites_loads: AtomicU64::new(0),
+        git_resolves: AtomicU64::new(0),
         keys_seen: AtomicU64::new(0),
         first_paint_ns: OnceLock::new(),
         key_to_render_ns: Mutex::new(Vec::new()),
@@ -113,6 +115,17 @@ pub fn record_draw(dur: Duration) {
     }
 }
 
+/// Record a git remote resolution done while computing favorite status.
+/// Used to prove this work happens at workspace-load / favorite-toggle time
+/// (a handful of calls) rather than once per workspace per render frame.
+#[inline]
+pub fn record_git_resolve() {
+    if !enabled() {
+        return;
+    }
+    metrics().git_resolves.fetch_add(1, Ordering::Relaxed);
+}
+
 /// Record that a key event was received by the event loop.
 #[inline]
 pub fn record_key() {
@@ -151,6 +164,7 @@ fn summary_string() -> String {
     let draw_total = m.draw_ns_total.load(Ordering::Relaxed);
     let draw_max = m.draw_ns_max.load(Ordering::Relaxed);
     let fav = m.favorites_loads.load(Ordering::Relaxed);
+    let git = m.git_resolves.load(Ordering::Relaxed);
     let keys = m.keys_seen.load(Ordering::Relaxed);
     let first_paint = m.first_paint_ns.get().copied().unwrap_or(0);
     let mut samples = m
@@ -171,6 +185,7 @@ fn summary_string() -> String {
     let _ = writeln!(s, "draw avg / max           : {:.3} / {:.3} ms", ms(avg_draw), ms(draw_max));
     let _ = writeln!(s, "total time in draw()     : {:.1} ms", ms(draw_total));
     let _ = writeln!(s, "favorites store loads    : {fav}");
+    let _ = writeln!(s, "git remote resolves      : {git}");
     let _ = writeln!(s, "key-to-render samples    : {}", samples.len());
     if !samples.is_empty() {
         let _ = writeln!(

--- a/ainb-tui/crates/ainb-core/tests/perf_micro.rs
+++ b/ainb-tui/crates/ainb-core/tests/perf_micro.rs
@@ -1,0 +1,93 @@
+// ABOUTME: Micro-measurements for TUI render-path hot spots (perf review aid).
+//
+// These are NOT correctness tests. They quantify the per-call cost of work that
+// the session-list render path performs on every frame, so the performance
+// review can put hard numbers on findings without standing up live sessions.
+//
+// Gated behind `AINB_PERF_MICRO=1` so they never run in CI or normal `cargo
+// test`. Run with:
+//   AINB_PERF_MICRO=1 HOME=/tmp/ainb-perf-home \
+//     cargo test --release -p ainb-core --test perf_micro -- --nocapture
+
+use std::path::Path;
+use std::time::Instant;
+
+fn enabled() -> bool {
+    std::env::var_os("AINB_PERF_MICRO").is_some()
+}
+
+#[test]
+fn micro_favorites_store_load() {
+    if !enabled() {
+        eprintln!("skipped (set AINB_PERF_MICRO=1 to run)");
+        return;
+    }
+    // Warm the page cache.
+    let _ = ainb::config::FavoritesStore::load();
+
+    let iters = 5_000u32;
+    let start = Instant::now();
+    let mut sink = 0usize;
+    for _ in 0..iters {
+        let store = ainb::config::FavoritesStore::load();
+        sink = sink.wrapping_add(store.favorites.len());
+    }
+    let elapsed = start.elapsed();
+    let per = elapsed.as_secs_f64() * 1e6 / iters as f64;
+    eprintln!(
+        "[micro] FavoritesStore::load() x{iters}: total {:.2} ms, {:.2} us/call (favorites seen={})",
+        elapsed.as_secs_f64() * 1e3,
+        per,
+        sink / iters as usize,
+    );
+    eprintln!(
+        "[micro] at 30 fps that is {:.3} ms/s of render-thread time spent re-parsing favorites.yaml",
+        per * 30.0 / 1000.0
+    );
+}
+
+#[test]
+fn micro_git_open_remote() {
+    if !enabled() {
+        eprintln!("skipped (set AINB_PERF_MICRO=1 to run)");
+        return;
+    }
+    // Resolve a real repo path to open: the workspace root (cwd at test time is
+    // the crate dir, so walk up to the git root).
+    let cwd = std::env::current_dir().expect("cwd");
+    let mut repo_path = cwd.as_path();
+    while !repo_path.join(".git").exists() {
+        match repo_path.parent() {
+            Some(p) => repo_path = p,
+            None => break,
+        }
+    }
+    eprintln!("[micro] using repo path: {}", repo_path.display());
+
+    // Warm.
+    if let Ok(r) = ainb::git::RepositoryManager::open(repo_path) {
+        let _ = r.get_remote_url();
+    }
+
+    let iters = 1_000u32;
+    let start = Instant::now();
+    let mut ok = 0u32;
+    for _ in 0..iters {
+        if let Ok(r) = ainb::git::RepositoryManager::open(Path::new(repo_path)) {
+            if r.get_remote_url().is_ok() {
+                ok += 1;
+            }
+        }
+    }
+    let elapsed = start.elapsed();
+    let per = elapsed.as_secs_f64() * 1e6 / iters as f64;
+    eprintln!(
+        "[micro] RepositoryManager::open()+get_remote_url() x{iters}: total {:.2} ms, {:.2} us/call (ok={ok})",
+        elapsed.as_secs_f64() * 1e3,
+        per,
+    );
+    eprintln!(
+        "[micro] per workspace per frame: 10 workspaces at 30 fps = {:.2} ms/s of render-thread time",
+        per * 10.0 * 30.0 / 1000.0
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_perf_render_gate.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_perf_render_gate.rs
@@ -99,9 +99,7 @@ impl TmuxSession {
 
 impl Drop for TmuxSession {
     fn drop(&mut self) {
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &self.name])
-            .status();
+        let _ = Command::new("tmux").args(["kill-session", "-t", &self.name]).status();
     }
 }
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_perf_render_gate.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_perf_render_gate.rs
@@ -1,0 +1,165 @@
+//! Tripwire: the dirty-gated render loop still repaints on input.
+//!
+//! Perf bead `wai` changed `run_tui_loop` from an unconditional ~30 fps
+//! redraw to a dirty-gated one (draw only on input, a fresh plugin frame, or
+//! the 250 ms app-tick animation floor). The regression risk is a frozen /
+//! stale screen — a keystroke that does not trigger a repaint. This drives the
+//! real `ainb tui` binary in tmux and asserts that navigating Home → Inbox →
+//! Home actually changes the rendered pane each time. If the dirty-gate failed
+//! to mark a repaint, a poll below would time out and the test would fail.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).unwrap();
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-20T00:00:00+00:00"
+version = "{}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).unwrap();
+
+    // Suppress the ainb-hooks first-run install dialog — it overlays the home
+    // screen and swallows the navigation keystroke this tripwire sends.
+    fs::write(
+        home.join(".agents-in-a-box").join("install.json"),
+        r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#,
+    )
+    .unwrap();
+}
+
+struct TmuxSession {
+    name: String,
+}
+
+impl TmuxSession {
+    fn new(name: String) -> Self {
+        let status = Command::new("tmux")
+            .args(["new-session", "-d", "-s", &name, "-x", "120", "-y", "40"])
+            .status()
+            .expect("tmux new-session");
+        assert!(status.success(), "tmux new-session failed");
+        Self { name }
+    }
+
+    fn send_keys(&self, keys: &[&str]) {
+        let status = Command::new("tmux")
+            .arg("send-keys")
+            .arg("-t")
+            .arg(&self.name)
+            .args(keys)
+            .status()
+            .expect("tmux send-keys");
+        assert!(status.success(), "tmux send-keys failed");
+    }
+
+    fn capture(&self) -> String {
+        let out = Command::new("tmux")
+            .args(["capture-pane", "-t", &self.name, "-p"])
+            .output()
+            .expect("tmux capture-pane");
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
+    fn poll<F>(&self, deadline: Instant, mut ok: F) -> Option<String>
+    where
+        F: FnMut(&str) -> bool,
+    {
+        while Instant::now() < deadline {
+            let capture = self.capture();
+            if ok(&capture) {
+                return Some(capture);
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        None
+    }
+}
+
+impl Drop for TmuxSession {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &self.name])
+            .status();
+    }
+}
+
+#[test]
+fn render_gate_repaints_on_input() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir");
+    seed_isolated_home(home.path());
+
+    let session = TmuxSession::new(format!("tripwire-rendergate-{}", std::process::id()));
+    let cmd = format!(
+        "HOME={} exec {} tui",
+        home.path().display(),
+        ainb_bin().display()
+    );
+    session.send_keys(&[&cmd, "Enter"]);
+
+    // 1) Home must render (sidebar shows the Stats [i] tile).
+    let home_ready = session.poll(Instant::now() + Duration::from_secs(20), |c| {
+        c.contains("Stats") && c.contains("[i]")
+    });
+    let home_cap = home_ready.unwrap_or_else(|| {
+        panic!("HomeScreen never rendered:\n{}", session.capture());
+    });
+    assert!(
+        home_cap.contains("Inbox") && home_cap.contains("[b]"),
+        "Home sidebar missing Inbox [b] tile:\n{home_cap}"
+    );
+
+    // 2) Press `b` for Inbox. With the dirty-gate, the keystroke must mark a
+    //    repaint; the pane should change to the Inbox screen (its title line
+    //    `📥 Inbox · …` uses a single space, distinct from the sidebar tile).
+    session.send_keys(&["b"]);
+    let inbox = session.poll(Instant::now() + Duration::from_secs(12), |c| {
+        c.contains("📥 Inbox ·")
+    });
+    assert!(
+        inbox.is_some(),
+        "Inbox did not render after pressing 'b' — dirty-gate may have dropped \
+         the repaint. Last capture:\n{}",
+        session.capture()
+    );
+
+    // 3) Press Esc to return Home. Again a keystroke must trigger a repaint
+    //    back to the Home sidebar. (Generous deadline: this is a second paint,
+    //    not a perf assertion.)
+    session.send_keys(&["Escape"]);
+    let back_home = session.poll(Instant::now() + Duration::from_secs(15), |c| {
+        c.contains("Stats") && c.contains("[i]") && !c.contains("📥 Inbox ·")
+    });
+    assert!(
+        back_home.is_some(),
+        "Did not return to Home after Esc — dirty-gate may have dropped the \
+         repaint. Last capture:\n{}",
+        session.capture()
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -142,7 +142,18 @@ async fn serve_conn(
 ) -> std::io::Result<()> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
-    while let Some(body) = read_frame(&mut reader).await? {
+    // Idle read timeout so an abandoned / half-open client connection cannot pin
+    // this per-connection task (and its fd) forever. The RPC is request/response
+    // and clients reconnect per request, so a generous idle window only reclaims
+    // dead connections — it never interrupts an in-flight exchange. (bead `dsp`)
+    const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+    while let Some(body) = match tokio::time::timeout(IDLE_TIMEOUT, read_frame(&mut reader)).await {
+        Ok(frame_result) => frame_result?,
+        Err(_elapsed) => {
+            tracing::debug!("rpc connection idle {IDLE_TIMEOUT:?}; closing");
+            None
+        }
+    } {
         let resp = match serde_json::from_slice::<RpcRequest>(&body) {
             Ok(req) => dispatch(&pool, &req, &health).await,
             Err(e) => RpcResponse {

--- a/ainb-tui/docs/performance-review-2026-06.md
+++ b/ainb-tui/docs/performance-review-2026-06.md
@@ -1,0 +1,109 @@
+# ainb-tui performance review — June 2026
+
+Execution-construct review of the TUI, plugin runtime, all in-tree plugins, and
+the hangar daemon. Scope is runtime behaviour — event loops, timers, threads,
+file IO, subprocess spawns, render cycles — not code style. Findings are backed
+by live profiling on macOS (release builds, no sudo). Each finding has a bead
+labeled `performance-improvement`; this document is the summary.
+
+## How it was measured
+
+- Isolated, synthetic environment only — never touched real sessions: synthetic
+  `HOME`, isolated `TMUX_TMPDIR`, daemon `AINB_HANGAR_HOME` under `/tmp`.
+- In-binary timing via an env-gated facility (`crate::perf`, enabled by
+  `AINB_PERF_TRACE`; zero cost when unset) recording cold-start, per-frame draw
+  duration, favorites-load count, and key-to-render latency. A periodic dump
+  thread writes the summary to `$AINB_PERF_TRACE_FILE` so measurement does not
+  depend on the exit path.
+- Hot-path unit costs via gated micro-benchmarks (`AINB_PERF_MICRO=1`, test
+  `crates/ainb-core/tests/perf_micro.rs`).
+- CPU/RSS sampled with `ps` once per second while the process was driven in an
+  isolated tmux pane.
+
+Both the instrumentation and the micro-benchmarks are retained behind flags and
+are inert in normal runs.
+
+## Headline numbers
+
+| Metric | Measured |
+|---|---|
+| TUI idle CPU (home / session-list) | **~5.7%** (range 4.0–7.2%), RSS ~13 MB flat |
+| Time in `draw()` while idle | **904 ms / 15 s = 6.0%** — accounts for ~all idle CPU |
+| Frames drawn with zero input | ~37 fps (unconditional redraw) |
+| Cold start → first paint | **345 ms** |
+| Key-to-render latency (empty home) | p50 **1.7 ms** / p99 2.7 ms |
+| `FavoritesStore::load()` | **527 µs/call**, once per session-list frame |
+| `git2 open + remote` | **561 µs/call**, **per workspace per frame** |
+| Hangar daemon idle CPU | **0.0%**, RSS ~10 MB flat |
+
+## The story (reframing "TUI lag")
+
+Per-keystroke latency is **low (~1.7 ms)** when the render is cheap. The real
+problems are:
+
+1. **Idle CPU ~6%** from redrawing the full layout ~37×/second when nothing
+   changed. A pure footprint/battery cost. The hangar daemon, by contrast,
+   idles at 0% — the TUI's redraw loop is the dominant idle cost in the system.
+2. **Render cost that scales** with the session list: every frame on the primary
+   screen re-parses `favorites.yaml` (527 µs) and opens each workspace's git repo
+   (561 µs/workspace). At 10 workspaces that is ~184 ms/s (~18% CPU) of redundant
+   work and adds ~5.6 ms/frame, dragging key-to-render from 1.7 ms toward 7 ms+.
+
+One fix — **gate the redraw on dirty state** — removes the idle baseline *and*
+stops the per-frame favorites/git multiplier from running when nothing changed.
+
+## Findings (severity-ranked)
+
+### P1 — TUI lag & idle CPU (primary)
+- **`agents-in-a-box-wai`** — Full layout redrawn every 33 ms unconditionally
+  (`main.rs:344`). 6% idle CPU. Gate on dirty state (plugin renders already are;
+  the host layout is not, at `state.rs:9316`). Keystone fix.
+- **`agents-in-a-box-9ov`** — `git2` open + remote lookup per workspace per frame
+  (`session_list.rs:303-327`) for the ⭐ indicator. 561 µs × N × 30 fps. Cache
+  per-workspace remote/favorite status; never call git2 in render.
+
+### P2 — heavy per-event work
+- **`agents-in-a-box-8rn`** — `favorites.yaml` parsed every session-list frame
+  (`session_list.rs:244` → `favorites_store.rs:167`). Cache in memory.
+- **`agents-in-a-box-h04`** — burndown drops cache+indices and fully recomputes
+  (O(N log N), 13+ rollups) on every `sessions.usage_data` chunk — 50+ times per
+  refresh (`plugin.rs:512,516`; `usage.rs:1614,2286`). Recompute once per data
+  change, after reassembly.
+
+### P3 — IO churn, runtime backpressure, subprocess fan-out
+- **`agents-in-a-box-ma9`** — session-reader walks the provider tree twice per
+  refresh (`scanner.rs:243-271`). Merge count into parse.
+- **`agents-in-a-box-178`** — session-reader chunker clones + re-encodes the whole
+  chunk per size probe (`plugin.rs:479,482,550`). Estimate size incrementally.
+- **`agents-in-a-box-uf3`** — plugin runtime command/key inboxes are unbounded
+  (`plugin_task.rs:144,155`). Bound them; shed stale renders.
+- **`agents-in-a-box-h3t`** — two-pass JSON decode per inbound frame
+  (`rpc.rs:132-164`). Single-pass typed decode.
+- **`agents-in-a-box-9pb`** — `App::tick` spawns `tmux capture-pane` for all
+  non-selected sessions every 5 s (`state.rs:9001-9013`). Capture only the
+  selected pane.
+- **`agents-in-a-box-dsp`** — hangar daemon RPC connections have no read timeout
+  (`rpc/mod.rs:145`). Hung client pins a task.
+
+### P4 — low / already healthy
+- **`agents-in-a-box-cn9`** — daemon claim loop polls every 1 s *when bound to a
+  runtime* (`run_loop.rs:154-173`). Bare daemon measured 0%. Tunable; optional
+  event-driven wakeup.
+- **`agents-in-a-box-nm3`** — notifyd emits OS notifications via blocking
+  subprocess in an async handler (`listener.rs:205`). Debounced; move to
+  `spawn_blocking`.
+- **`agents-in-a-box-10a`** — witr re-spawns `witr --version` on every refresh
+  while non-Ready (`plugin.rs:147-154`). Cache detect with a TTL.
+
+## Coverage
+
+Event loops, timers, threads, and file-IO paths were traced for every in-scope
+crate: `ainb-core`, `ainb-plugin-runtime` (+protocol/sdk/types), `abtop`,
+`burndown`, `cts-v2`, `notifyd`, `session-reader`, `witr`, and
+`ainb-hangar-daemon`/`store`/`core`. `abtop` and `witr` are event-driven and
+clean; `cts-v2` is a test harness, not shipped runtime. The hangar daemon is
+well-architected for idle (0% CPU, bounded buffers, event-driven RPC).
+
+Full method, raw per-crate notes, and sample tables:
+`.agents/research/ainb-tui-perf-review-sweep.md` and
+`.agents/research/ainb-tui-perf-measurements.md`.

--- a/ainb-tui/docs/performance-review-2026-06.md
+++ b/ainb-tui/docs/performance-review-2026-06.md
@@ -1,5 +1,17 @@
 # ainb-tui performance review — June 2026
 
+> **Update — fixes shipped (branch `f/perform-review`).** All P1 + P2 are fixed
+> and proven: **idle TUI CPU ~4.8% → ~0.55%** (~9×), 0 git2 calls in render,
+> favorites parsed once per change (not per frame), key-to-render p99 2.48 ms and
+> now constant in workspace count. P3 `9pb` (tmux status cadence) and `dsp`
+> (daemon RPC idle timeout) fixed; `h04` was already fixed on main. P3 `ma9`,
+> `178`, `uf3`, `h3t` carry documented architecture recommendations on their
+> beads (deferred to focused, individually-reviewed changes). Verified via
+> `AINB_PERF_TRACE` before/after, the `tripwire_perf_render_gate` tmux test
+> (5/5 non-flaky) plus the full existing tripwire suite, and a vhs frame-truth
+> recording of the Home→Inbox→Home journey. Commits: `e8a21461` (wai/9ov/8rn),
+> `75e289c8` (9pb), `54155296` (dsp). Awaiting human sign-off (tmux-verify G6).
+
 Execution-construct review of the TUI, plugin runtime, all in-tree plugins, and
 the hangar daemon. Scope is runtime behaviour — event loops, timers, threads,
 file IO, subprocess spawns, render cycles — not code style. Findings are backed


### PR DESCRIPTION
## What

Execution-construct performance review of ainb-tui + plugins + hangar daemon, plus the fixes for the P1/P2 (and two P3) findings it surfaced.

### Results (measured via env-gated `AINB_PERF_TRACE`, isolated synthetic env)
| Metric (target) | Before | After |
|---|---|---|
| TUI idle CPU (<1%) | ~4.8% | **~0.55%** (~9×) |
| idle frame rate | ~40 fps | ~5 fps |
| git2 calls in render (=0) | 561µs × N/frame | **0** |
| favorites.yaml parse (1×/change) | 527µs/frame | 2 total / 359 frames |
| key-to-render p99 (<5ms) | 2.79ms | 2.48ms (flat at scale) |

### Fixes
- **wai (P1)** — dirty-gate the host layout repaint in `run_tui_loop`; was an unconditional ~30fps redraw. Animations already advance only on the 250ms app-tick, so visuals are unchanged (worst-case 250ms staleness).
- **9ov (P1) + 8rn (P2)** — move per-workspace git-remote + favorites resolution out of the render path into a cached `recompute_favorite_workspaces()` (runs on workspace-load / favorite-toggle); render does an O(1) lookup.
- **9pb (P3)** — non-selected tmux status sweep decoupled to a 20s cadence (selected preview stays 5s).
- **dsp (P3)** — 600s idle read timeout on hangar daemon RPC connections.
- **h04 (P2)** — already fixed on main (verified, closed).

### Verification (tmux-verify G1–G5)
- `tripwire_perf_render_gate` 5/5 non-flaky + full existing 54-test tripwire suite passes.
- vhs recording + ffmpeg frame-truth reads of Home→Inbox→Home (dirty-gate repaints on input).
- Before/after numbers above.

### Deferred P3s (documented architecture on beads `ma9`, `178`, `uf3`, `h3t`)
Touch the scanner's incremental path / plugin IPC hot path / backpressure semantics — warrant focused, cts-v2-validated changes rather than a rushed batch. P4 excluded.

### Notes
- Env-gated instrumentation (`AINB_PERF_TRACE` / `AINB_PERF_MICRO`) retained behind flags, inert by default.
- Findings tracked as `performance-improvement` beads.