### PR TITLE
feat(reflect): distill transcripts into privacy-sanitized, deduped GitHub issues

### DIFF
--- a/plugins/reflect/CHANGELOG.md
+++ b/plugins/reflect/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the **reflect** plugin. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [Unreleased]
+
+### Added
+- **`reflect issues` mode** (reflect-kb CLI) — distill recent session
+  transcripts into privacy-sanitized, deduplicated GitHub issues. A new mode
+  inside the existing `/reflect` ecosystem: it reuses the
+  `~/.reflect/pending_reflections.jsonl` queue and `REFLECT_STATE_DIR` (no
+  parallel DB/queue). Ports agent-deck's distill + privacy-sanitizer +
+  gh-dedupe logic onto reflect-kb's Python style.
+  - `reflect issues run [--dry-run] [--repo OWNER/NAME] [--limit N] [--model M]
+    [--map KEY=VALUE]` — `--dry-run` prints the exact issue bodies that *would*
+    be filed without calling `gh`; re-running files zero duplicates.
+  - `reflect issues ledger` / `reflect issues queue` — inspect the idempotency
+    ledger and the transcripts that would be analyzed.
+  - **GitHub-publish safety:** every distilled timeline and every candidate
+    issue passes through a conservative secrets/PII sanitizer before anything
+    leaves the machine; the analyzer degrades gracefully without Claude auth.
+- **`[issues]` config block** in `reflect.toml` (`repo`, `limit`, `model`).
+
 ## [4.0.0] — 2026-05-31 — Cost rearchitecture
 
 Major bump for the drain cost rearchitecture (W1–W5). Triggered by an incident:

--- a/plugins/reflect/README.md
+++ b/plugins/reflect/README.md
@@ -360,7 +360,9 @@ Most users don't need to touch any of these. Power users adjust:
 - `ingest.batch_size` — for bulk-importing large memory archives
 - `issues.repo` / `issues.limit` / `issues.model` — defaults for the
   [`reflect issues`](#reflect-issues--transcripts--github-issues) mode (target
-  repo, transcripts per run, analyzer model)
+  repo, transcripts per run, analyzer model). Used as the fallback when the
+  matching `--repo` / `--limit` / `--model` flag is unset; an explicit flag
+  always wins.
 
 ---
 
@@ -385,11 +387,15 @@ reflect issues ledger             # what has been filed
 **Safety model.** Publishing an issue sends content off-machine, so sanitization
 is conservative (over-redact > under-redact) and runs *twice* — once on the
 distilled timeline before the model sees it, once on each candidate before it
-can be printed or filed. It strips secrets (Anthropic/OpenAI/GitHub/Slack/AWS/
-Telegram tokens, JWTs, PEM keys, generic `KEY=value`), emails, IPs, home/tmp/
-worktree paths, UUIDs, and long hex; a non-mutating audit flags anything still
-suspicious. The analyzer degrades gracefully without Claude auth, `--dry-run`
-never calls `gh`, and re-running files zero duplicates. Full detail in the
+can be printed or filed. It strips secrets (Anthropic/OpenAI/GitHub/GitLab/
+Google/npm/Slack/AWS/Telegram tokens, Slack webhooks, `Bearer` tokens, JWTs,
+PEM keys, and generic `KEY=value` even when the keyword is embedded in a longer
+env-var name like `AWS_SECRET_ACCESS_KEY`), emails, IPs, home/tmp/worktree
+paths, UUIDs, and long hex; a non-mutating audit flags anything still suspicious
+and those flags are surfaced on every run so a reviewer sees them. The analyzer
+degrades gracefully without Claude auth, `--dry-run` never calls `gh`, and
+re-running files zero duplicates (the ledger is saved after each file). Full
+detail in the
 [CLI README](../../reflect-kb/README.md#reflect-issues--transcripts--github-issues).
 
 ---

--- a/plugins/reflect/README.md
+++ b/plugins/reflect/README.md
@@ -358,6 +358,39 @@ Most users don't need to touch any of these. Power users adjust:
 - `recall.max_results` (default 3) — how many learnings get injected per session
 - `recall.confidence_threshold` (default 0.6) — minimum hybrid score for inclusion
 - `ingest.batch_size` — for bulk-importing large memory archives
+- `issues.repo` / `issues.limit` / `issues.model` — defaults for the
+  [`reflect issues`](#reflect-issues--transcripts--github-issues) mode (target
+  repo, transcripts per run, analyzer model)
+
+---
+
+## `reflect issues` — transcripts → GitHub issues
+
+Beyond capturing learnings, reflect can turn the **recurring friction, bugs, and
+capability gaps** in your recent sessions into triaged GitHub issues — reusing
+the same queue and state dir, not a separate tool.
+
+It reads the existing `~/.reflect/pending_reflections.jsonl` queue (the same one
+the Stop/PreCompact hooks populate), distills each transcript ~30× with no LLM,
+asks one bounded `claude -p` call for actionable findings, **privacy-sanitizes**
+every candidate, deduplicates against your already-filed issues and the repo's
+open issues, then files via `gh issue create`.
+
+```bash
+reflect issues run --dry-run      # preview exact, sanitized bodies; no gh calls
+reflect issues run                # file against the cwd's repo (idempotent)
+reflect issues ledger             # what has been filed
+```
+
+**Safety model.** Publishing an issue sends content off-machine, so sanitization
+is conservative (over-redact > under-redact) and runs *twice* — once on the
+distilled timeline before the model sees it, once on each candidate before it
+can be printed or filed. It strips secrets (Anthropic/OpenAI/GitHub/Slack/AWS/
+Telegram tokens, JWTs, PEM keys, generic `KEY=value`), emails, IPs, home/tmp/
+worktree paths, UUIDs, and long hex; a non-mutating audit flags anything still
+suspicious. The analyzer degrades gracefully without Claude auth, `--dry-run`
+never calls `gh`, and re-running files zero duplicates. Full detail in the
+[CLI README](../../reflect-kb/README.md#reflect-issues--transcripts--github-issues).
 
 ---
 

--- a/plugins/reflect/reflect.toml
+++ b/plugins/reflect/reflect.toml
@@ -41,6 +41,19 @@ auto_approve_threshold = 0.8
 retention_days = 90
 max_memory_lines = 200
 
+[issues]
+# `reflect issues` mode — distill recent transcripts into privacy-sanitized,
+# deduplicated GitHub issues. Reuses the pending_reflections queue and
+# REFLECT_STATE_DIR; nothing is filed until a candidate passes the privacy
+# sanitizer, and `--dry-run` prints the exact bodies without calling `gh`.
+#
+#   repo   = target OWNER/NAME. Leave unset so `gh` infers it from the cwd.
+#   limit  = max recent transcripts to pull from the queue per run.
+#   model  = analyzer model passed to `claude -p` (gated on Claude auth).
+# repo  = "owner/name"
+limit = 20
+model = "sonnet"
+
 [telemetry]
 enabled = true
 log_level = "info"

--- a/plugins/reflect/reflect.toml
+++ b/plugins/reflect/reflect.toml
@@ -47,12 +47,18 @@ max_memory_lines = 200
 # REFLECT_STATE_DIR; nothing is filed until a candidate passes the privacy
 # sanitizer, and `--dry-run` prints the exact bodies without calling `gh`.
 #
-#   repo   = target OWNER/NAME. Leave unset so `gh` infers it from the cwd.
-#   limit  = max recent transcripts to pull from the queue per run.
-#   model  = analyzer model passed to `claude -p` (gated on Claude auth).
+#   repo          = target OWNER/NAME. Leave unset so `gh` infers it from cwd.
+#   limit         = max recent transcripts to pull from the queue per run.
+#   model         = analyzer model passed to `claude -p` (gated on Claude auth).
+#   label         = provenance label on every filed issue (auto-created if the
+#                   repo lacks it). Set "" to disable. Default: "reflect".
+#   title_prefix  = stamped on every issue title so it's clearly reflect-filed.
+#                   Set "" to disable. Default: "reflect: ".
 # repo  = "owner/name"
 limit = 20
 model = "sonnet"
+label = "reflect"
+title_prefix = "reflect: "
 
 [telemetry]
 enabled = true

--- a/plugins/reflect/scripts/reflect_config.py
+++ b/plugins/reflect/scripts/reflect_config.py
@@ -144,6 +144,16 @@ _BUILTIN_DEFAULTS: dict[str, Any] = {
         "retention_days": 90,
         "max_memory_lines": 200,
     },
+    "issues": {
+        # `reflect issues` mode: distill recent transcripts -> deduped GitHub
+        # issues. Reuses the pending_reflections queue + REFLECT_STATE_DIR.
+        # repo = None -> gh infers the repo from the cwd. limit caps how many
+        # recent transcripts are pulled from the queue per run. model is the
+        # analyzer model passed to `claude -p`.
+        "repo": None,
+        "limit": 20,
+        "model": "sonnet",
+    },
     "telemetry": {
         "enabled": True,
         "log_level": "info",

--- a/reflect-kb/README.md
+++ b/reflect-kb/README.md
@@ -77,8 +77,66 @@ reflect timeline --explain TOK
 | &nbsp;&nbsp;↳ [`reflect metrics stats`](docs/usage.md#reflect-metrics-stats) | Aggregate the recall-metrics JSONL log: total events, hit rate, p50/p95 latency, top tags |
 | `reflect errors` | Triage the error sink (`~/.reflect/errors.json`): `count` (un-acked, drives the statusline badge), `ack [ids…]`, `append`. Lets callers use the installed binary instead of bare `python3 -m reflect_kb.errors`. |
 | [`reflect timeline`](docs/usage.md#reflect-timeline) | Drill down on statusline dashboard rows (REC/MEM/ING/DRN/TOK/ERR/COM/AGT) |
+| `reflect issues` | Command group: distill recent transcripts into privacy-sanitized, deduplicated GitHub issues (subcommands below) |
+| &nbsp;&nbsp;↳ `reflect issues run` | Run the transcripts→issues pipeline. `--dry-run` prints the exact bodies that *would* be filed without calling `gh`; `--repo`, `--limit`, `--model`, `--map KEY=VALUE` |
+| &nbsp;&nbsp;↳ `reflect issues ledger` | Show issues already filed by this mode (the idempotency ledger) |
+| &nbsp;&nbsp;↳ `reflect issues queue` | List the recent transcripts `run` would analyze (the reflect queue) |
 
 See [docs/usage.md](docs/usage.md) for per-subcommand synopsis, all flags, examples, and common errors.
+
+### `reflect issues` — transcripts → GitHub issues
+
+A self-improvement mode that turns recurring friction, bugs, and capability
+gaps from your recent agent sessions into triaged GitHub issues — **without
+standing up a separate tool**. It is a new mode inside the existing `/reflect`
+ecosystem: it reads the same `~/.reflect/pending_reflections.jsonl` queue the
+Stop/PreCompact hooks already populate, and stores its idempotency ledger under
+`REFLECT_STATE_DIR` (default `~/.reflect/filed_issues.json`). No parallel
+database or queue is introduced.
+
+Pipeline:
+
+```
+queue → distill (~30× compression, no LLM)
+      → analyze (one bounded `claude -p` call; gated on Claude auth)
+      → sanitize (conservative privacy regex — see below)
+      → dedupe (in-batch · local ledger · gh issue list)
+      → gh issue create        [skipped entirely under --dry-run]
+```
+
+```bash
+# Always preview first — prints the exact, sanitized issue bodies, no gh calls:
+reflect issues run --dry-run
+
+# File for real against the cwd's repo (or pass --repo owner/name):
+reflect issues run
+
+# Re-running is idempotent: the local ledger + gh-title dedupe file zero
+# duplicates the second time.
+reflect issues run            # files 0 new issues if nothing changed
+
+reflect issues ledger         # what has been filed
+```
+
+**GitHub-publish safety model.** Filing an issue publishes content to an
+external service, so the posture is deliberately conservative — over-redact
+rather than under-redact. Every distilled timeline is sanitized *before* the
+analyzer sees it, and every candidate's title + body are sanitized *again*
+before they can be printed (dry-run) or filed. The sanitizer strips, in order:
+
+1. caller-supplied `--map KEY=VALUE` substitutions (business/project names);
+2. **secrets** (highest priority): Anthropic / OpenAI / GitHub / Slack / AWS /
+   Telegram tokens, JWTs, PEM private-key blocks, and generic
+   `KEY=<12+ char value>` assignments;
+3. emails, IPv4 addresses;
+4. home paths (`/Users/<u>` → `/Users/<user>`), `/tmp` and worktree paths;
+5. full UUIDs and long (≥20 char) hex strings.
+
+A non-mutating audit pass flags anything that still *looks* suspicious
+(base64-ish blobs, residual hex, env-var assignments, phone-shaped numbers,
+private IP ranges). The analyzer step degrades gracefully when no Claude auth
+context is present (it returns no candidates with a clear reason rather than
+failing). Filing is the *only* code path that calls `gh issue create`.
 
 ## Architecture
 
@@ -126,6 +184,12 @@ separate git repo (private; content not code).
 
 ## What's new in 0.1.1
 
+- **`reflect issues` mode** — distill recent session transcripts into
+  privacy-sanitized, deduplicated GitHub issues, reusing the existing reflect
+  queue and state dir (no parallel pipeline). `reflect issues run --dry-run`
+  previews the exact bodies without calling `gh`; re-running files zero
+  duplicates. See [`reflect issues` — transcripts → GitHub issues](#reflect-issues--transcripts--github-issues)
+  for the GitHub-publish safety model.
 - **`--force` flag on `reflect add`** — non-interactive overwrite for ingest pipelines and subprocess
   contexts where `click.confirm` cannot read a TTY. Without `--force`, non-TTY stdin now fails loudly
   rather than silently dropping the file.

--- a/reflect-kb/README.md
+++ b/reflect-kb/README.md
@@ -125,18 +125,27 @@ analyzer sees it, and every candidate's title + body are sanitized *again*
 before they can be printed (dry-run) or filed. The sanitizer strips, in order:
 
 1. caller-supplied `--map KEY=VALUE` substitutions (business/project names);
-2. **secrets** (highest priority): Anthropic / OpenAI / GitHub / Slack / AWS /
-   Telegram tokens, JWTs, PEM private-key blocks, and generic
-   `KEY=<12+ char value>` assignments;
+2. **secrets** (highest priority): Anthropic / OpenAI / GitHub (classic + fine-
+   grained PAT) / GitLab (`glpat-`) / Google API (`AIza…`) / npm (`npm_…`) /
+   Slack (token + incoming-webhook URL) / AWS / Telegram tokens, JWTs,
+   `Authorization: Bearer …` tokens, PEM private-key blocks, and generic
+   `KEY=<12+ char value>` assignments — where the keyword (token/key/secret/
+   password/api_key/auth) may be *embedded* in a longer env-var name, so
+   `AWS_SECRET_ACCESS_KEY` / `GITLAB_TOKEN` / `GOOGLE_API_KEY` / `NPM_TOKEN`
+   are all caught;
 3. emails, IPv4 addresses;
 4. home paths (`/Users/<u>` → `/Users/<user>`), `/tmp` and worktree paths;
 5. full UUIDs and long (≥20 char) hex strings.
 
 A non-mutating audit pass flags anything that still *looks* suspicious
 (base64-ish blobs, residual hex, env-var assignments, phone-shaped numbers,
-private IP ranges). The analyzer step degrades gracefully when no Claude auth
-context is present (it returns no candidates with a clear reason rather than
-failing). Filing is the *only* code path that calls `gh issue create`.
+private IP ranges). These residual flags are **surfaced** on the run result and
+printed (rich + `--format json`) so a reviewer sees which candidate still looks
+suspicious before anything is filed. The analyzer step degrades gracefully when
+no Claude auth context is present (it returns no candidates with a clear reason
+rather than failing). Filing is the *only* code path that calls
+`gh issue create`, and the local ledger is persisted after **each** successful
+file so a mid-loop crash never re-files an already-published issue.
 
 ## Architecture
 

--- a/reflect-kb/src/reflect_kb/cli/issues_cli.py
+++ b/reflect-kb/src/reflect_kb/cli/issues_cli.py
@@ -26,6 +26,7 @@ from rich.table import Table
 from reflect_kb import reflect_config
 from reflect_kb.issues import dedupe as dedupe_mod
 from reflect_kb.issues import manifest as manifest_mod
+from reflect_kb.issues import pipeline
 from reflect_kb.issues.pipeline import run_issues
 
 console = Console(stderr=True)
@@ -91,6 +92,18 @@ def issues_group():
     help="Extra sanitizer substitution (repeatable), e.g. --map AcmeCorp=<company>.",
 )
 @click.option(
+    "--label",
+    default=None,
+    help="Provenance label applied to every filed issue (auto-created if absent). "
+    "Falls back to [issues].label, then 'reflect'. Pass '' to disable.",
+)
+@click.option(
+    "--title-prefix",
+    default=None,
+    help="Prefix stamped on every issue title. Falls back to [issues].title_prefix, "
+    "then 'reflect: '. Pass '' to disable.",
+)
+@click.option(
     "--format", "-f", "output_format", default="rich", type=click.Choice(["rich", "json"])
 )
 def issues_run(
@@ -99,6 +112,8 @@ def issues_run(
     limit: Optional[int],
     model: Optional[str],
     maps: tuple[str, ...],
+    label: Optional[str],
+    title_prefix: Optional[str],
     output_format: str,
 ):
     """Distill recent transcripts and file (or preview) GitHub issues.
@@ -116,6 +131,14 @@ def issues_run(
     eff_repo = repo if repo is not None else cfg.get("repo")
     eff_limit = limit if limit is not None else int(cfg.get("limit", _DEFAULT_LIMIT))
     eff_model = model if model is not None else str(cfg.get("model", _DEFAULT_MODEL))
+    # Provenance: explicit flag wins, then [issues] config, then the pipeline
+    # defaults ("reflect: " / "reflect"). An explicitly empty string disables.
+    eff_label = label if label is not None else cfg.get("label", pipeline.DEFAULT_LABEL)
+    eff_title_prefix = (
+        title_prefix
+        if title_prefix is not None
+        else cfg.get("title_prefix", pipeline.DEFAULT_TITLE_PREFIX)
+    )
 
     parsed_maps = _parse_maps(maps)
     result = run_issues(
@@ -124,6 +147,8 @@ def issues_run(
         dry_run=dry_run,
         maps=parsed_maps or None,
         model=eff_model,
+        title_prefix=eff_title_prefix,
+        label=eff_label,
     )
 
     if output_format == "json":

--- a/reflect-kb/src/reflect_kb/cli/issues_cli.py
+++ b/reflect-kb/src/reflect_kb/cli/issues_cli.py
@@ -23,11 +23,18 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from reflect_kb import reflect_config
 from reflect_kb.issues import dedupe as dedupe_mod
 from reflect_kb.issues import manifest as manifest_mod
 from reflect_kb.issues.pipeline import run_issues
 
 console = Console(stderr=True)
+
+# Hard defaults used only when neither a flag nor the [issues] config supplies a
+# value. The [issues] block in reflect.toml takes precedence over these and is
+# itself overridden by an explicit flag.
+_DEFAULT_LIMIT = 20
+_DEFAULT_MODEL = "sonnet"
 
 
 def _parse_maps(pairs: tuple[str, ...]) -> dict[str, str]:
@@ -59,15 +66,22 @@ def issues_group():
     default=False,
     help="Print issue bodies that WOULD be filed; never call gh.",
 )
-@click.option("--repo", default=None, help="Target repo OWNER/NAME (defaults to cwd's repo).")
 @click.option(
-    "--limit",
-    default=20,
-    show_default=True,
-    help="Max recent transcripts to pull from the reflect queue.",
+    "--repo",
+    default=None,
+    help="Target repo OWNER/NAME. Falls back to [issues].repo, then gh's cwd repo.",
 )
 @click.option(
-    "--model", default="sonnet", show_default=True, help="Model passed to the analyzer (claude -p)."
+    "--limit",
+    default=None,
+    type=int,
+    help="Max recent transcripts to pull from the reflect queue. "
+    "Falls back to [issues].limit, then 20.",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="Model passed to the analyzer (claude -p). Falls back to [issues].model, then sonnet.",
 )
 @click.option(
     "--map",
@@ -82,25 +96,34 @@ def issues_group():
 def issues_run(
     dry_run: bool,
     repo: Optional[str],
-    limit: int,
-    model: str,
+    limit: Optional[int],
+    model: Optional[str],
     maps: tuple[str, ...],
     output_format: str,
 ):
     """Distill recent transcripts and file (or preview) GitHub issues.
+
+    Resolution for repo/limit/model: an explicit flag wins; otherwise the
+    ``[issues]`` block in ``reflect.toml`` is consulted; otherwise a built-in
+    default is used.
 
     Examples:
         reflect issues run --dry-run
         reflect issues run --repo myorg/myrepo --limit 10
         reflect issues run --dry-run --map AcmeCorp=<company>
     """
+    cfg = reflect_config.issues_config()
+    eff_repo = repo if repo is not None else cfg.get("repo")
+    eff_limit = limit if limit is not None else int(cfg.get("limit", _DEFAULT_LIMIT))
+    eff_model = model if model is not None else str(cfg.get("model", _DEFAULT_MODEL))
+
     parsed_maps = _parse_maps(maps)
     result = run_issues(
-        repo=repo,
-        limit=limit,
+        repo=eff_repo,
+        limit=eff_limit,
         dry_run=dry_run,
         maps=parsed_maps or None,
-        model=model,
+        model=eff_model,
     )
 
     if output_format == "json":
@@ -124,6 +147,7 @@ def issues_run(
                 for d in result.skipped
             ],
             "previews": result.previews,
+            "audit": result.audit,
             "notes": result.notes,
         }
         click.echo(json.dumps(payload, indent=2))
@@ -159,6 +183,19 @@ def issues_run(
         console.print(f"\n[dim]Skipped {len(result.skipped)} duplicate(s):[/dim]")
         for d in result.skipped:
             console.print(f"  [dim]- {d.candidate.title}  ({d.reason})[/dim]")
+
+    if result.audit:
+        console.print(
+            f"\n[bold yellow]{len(result.audit)} residual-suspicious flag(s) "
+            f"for human review:[/bold yellow]"
+        )
+        for finding in result.audit:
+            cand = finding.get("candidate", "?")
+            console.print(
+                f"  [yellow]! {finding.get('kind')}[/yellow] "
+                f"in '{cand}' line {finding.get('line')}: "
+                f"[dim]{finding.get('snippet')}[/dim]"
+            )
 
     for note in result.notes:
         console.print(f"[dim]· {note}[/dim]")

--- a/reflect-kb/src/reflect_kb/cli/issues_cli.py
+++ b/reflect-kb/src/reflect_kb/cli/issues_cli.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""``reflect issues`` — distill recent transcripts into deduped GitHub issues.
+
+A NEW MODE inside the existing ``/reflect`` ecosystem. It reuses the reflect
+queue (``~/.reflect/pending_reflections.jsonl``) and state dir, ports
+agent-deck's distill + privacy-sanitize + gh-dedupe logic, and files GitHub
+issues via ``gh issue create`` — with a mandatory ``--dry-run`` so a human can
+see the exact bodies before anything leaves the machine.
+
+Subcommands:
+    reflect issues run [--dry-run] [--repo OWNER/NAME] [--limit N]
+                       [--model M] [--map K=V ...]
+    reflect issues ledger        # show what's already been filed
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from reflect_kb.issues import dedupe as dedupe_mod
+from reflect_kb.issues import manifest as manifest_mod
+from reflect_kb.issues.pipeline import run_issues
+
+console = Console(stderr=True)
+
+
+def _parse_maps(pairs: tuple[str, ...]) -> dict[str, str]:
+    maps: dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise click.BadParameter(f"--map expects KEY=VALUE, got: {pair!r}")
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if key:
+            maps[key] = value.strip()
+    return maps
+
+
+@click.group("issues")
+def issues_group():
+    """Turn recent session transcripts into privacy-sanitized GitHub issues.
+
+    Pipeline: queue → distill (~30x) → analyze (LLM) → sanitize → dedupe → file.
+    Always preview with ``--dry-run`` first; it prints the exact issue bodies
+    that WOULD be filed without calling ``gh``.
+    """
+
+
+@issues_group.command("run")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print issue bodies that WOULD be filed; never call gh.",
+)
+@click.option("--repo", default=None, help="Target repo OWNER/NAME (defaults to cwd's repo).")
+@click.option(
+    "--limit",
+    default=20,
+    show_default=True,
+    help="Max recent transcripts to pull from the reflect queue.",
+)
+@click.option(
+    "--model", default="sonnet", show_default=True, help="Model passed to the analyzer (claude -p)."
+)
+@click.option(
+    "--map",
+    "maps",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Extra sanitizer substitution (repeatable), e.g. --map AcmeCorp=<company>.",
+)
+@click.option(
+    "--format", "-f", "output_format", default="rich", type=click.Choice(["rich", "json"])
+)
+def issues_run(
+    dry_run: bool,
+    repo: Optional[str],
+    limit: int,
+    model: str,
+    maps: tuple[str, ...],
+    output_format: str,
+):
+    """Distill recent transcripts and file (or preview) GitHub issues.
+
+    Examples:
+        reflect issues run --dry-run
+        reflect issues run --repo myorg/myrepo --limit 10
+        reflect issues run --dry-run --map AcmeCorp=<company>
+    """
+    parsed_maps = _parse_maps(maps)
+    result = run_issues(
+        repo=repo,
+        limit=limit,
+        dry_run=dry_run,
+        maps=parsed_maps or None,
+        model=model,
+    )
+
+    if output_format == "json":
+        payload = {
+            "dry_run": result.dry_run,
+            "transcripts_seen": result.transcripts_seen,
+            "transcripts_distilled": result.transcripts_distilled,
+            "analyze_reason": result.analyze_reason,
+            "candidates": result.candidates,
+            "filed": [
+                {
+                    "title": f.title,
+                    "fingerprint": f.fingerprint,
+                    "gh_issue_number": f.gh_issue_number,
+                    "gh_url": f.gh_url,
+                }
+                for f in result.filed
+            ],
+            "skipped": [
+                {"title": d.candidate.title, "reason": d.reason, "existing": d.existing_ref}
+                for d in result.skipped
+            ],
+            "previews": result.previews,
+            "notes": result.notes,
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    # Rich output.
+    console.print(
+        f"[dim]transcripts: {result.transcripts_seen} seen, "
+        f"{result.transcripts_distilled} distilled · "
+        f"candidates: {result.candidates} · "
+        f"analyze: {result.analyze_reason or 'n/a'}[/dim]"
+    )
+
+    if dry_run:
+        if result.previews:
+            console.print(
+                f"\n[bold green]{len(result.previews)} issue(s) WOULD be filed:[/bold green]\n"
+            )
+            for preview in result.previews:
+                console.print(Panel(preview, border_style="green"))
+        else:
+            console.print("[yellow]No new issues would be filed.[/yellow]")
+    else:
+        if result.filed:
+            console.print(f"\n[bold green]Filed {result.filed_count} issue(s):[/bold green]")
+            for f in result.filed:
+                ref = f.gh_url or (f"#{f.gh_issue_number}" if f.gh_issue_number else "(filed)")
+                console.print(f"  [green]{ref}[/green]  {f.title}")
+        else:
+            console.print("[yellow]No new issues filed.[/yellow]")
+
+    if result.skipped:
+        console.print(f"\n[dim]Skipped {len(result.skipped)} duplicate(s):[/dim]")
+        for d in result.skipped:
+            console.print(f"  [dim]- {d.candidate.title}  ({d.reason})[/dim]")
+
+    for note in result.notes:
+        console.print(f"[dim]· {note}[/dim]")
+
+
+@issues_group.command("ledger")
+@click.option(
+    "--format", "-f", "output_format", default="rich", type=click.Choice(["rich", "json"])
+)
+def issues_ledger(output_format: str):
+    """Show issues already filed by ``reflect issues`` (the idempotency ledger)."""
+    ledger = dedupe_mod.load_ledger()
+    filed = ledger.get("filed_issues", [])
+
+    if output_format == "json":
+        click.echo(json.dumps(ledger, indent=2))
+        return
+
+    if not filed:
+        console.print(
+            f"[yellow]No issues filed yet.[/yellow] [dim](ledger: {dedupe_mod.ledger_path()})[/dim]"
+        )
+        return
+
+    table = Table(title="Filed Issues")
+    table.add_column("#", style="cyan")
+    table.add_column("Title", style="white")
+    table.add_column("Filed", style="dim")
+    table.add_column("URL", style="green")
+    for entry in filed:
+        table.add_row(
+            str(entry.get("gh_issue_number") or "-"),
+            str(entry.get("title", "")),
+            str(entry.get("filed_at", ""))[:19],
+            str(entry.get("gh_url") or ""),
+        )
+    console.print(table)
+
+
+@issues_group.command("queue")
+@click.option("--limit", default=20, show_default=True)
+def issues_queue(limit: int):
+    """List the recent transcripts the ``run`` command would analyze."""
+    refs = manifest_mod.gather_transcripts(limit=limit)
+    if not refs:
+        console.print(
+            f"[yellow]Reflect queue is empty.[/yellow] [dim]({manifest_mod.queue_file()})[/dim]"
+        )
+        return
+    table = Table(title="Reflect Queue (transcripts to analyze)")
+    table.add_column("Session", style="cyan")
+    table.add_column("Trigger", style="dim")
+    table.add_column("Transcript", style="white")
+    for ref in refs:
+        table.add_row(ref.session_id[:8], ref.trigger, str(ref.transcript_path))
+    console.print(table)

--- a/reflect-kb/src/reflect_kb/cli/learnings_cli.py
+++ b/reflect-kb/src/reflect_kb/cli/learnings_cli.py
@@ -760,9 +760,11 @@ def errors_append(severity, source, kind, message, context):
 # Register subcommand groups. Import here (after `cli` exists) to keep
 # circular-import risk at zero.
 from reflect_kb.cli.metrics_cli import metrics_group as _metrics_group  # noqa: E402
+from reflect_kb.cli.issues_cli import issues_group as _issues_group  # noqa: E402
 
 cli.add_command(_metrics_group)
 cli.add_command(errors_group)
+cli.add_command(_issues_group)
 
 
 if __name__ == "__main__":

--- a/reflect-kb/src/reflect_kb/issues/__init__.py
+++ b/reflect-kb/src/reflect_kb/issues/__init__.py
@@ -1,0 +1,55 @@
+"""``reflect issues`` — distill recent session transcripts into privacy-sanitized,
+deduplicated GitHub issues.
+
+This is a NEW MODE inside the existing ``/reflect`` ecosystem, not a parallel
+pipeline. It reuses:
+
+* the ``~/.reflect/pending_reflections.jsonl`` queue (the same one
+  ``stop_reflect.py`` / ``precompact_reflect.py`` append to) as the source of
+  "recent transcripts" — see :mod:`reflect_kb.issues.manifest`;
+* the reflect state dir (``REFLECT_STATE_DIR``, default ``~/.reflect``) for its
+  idempotency ledger (``filed_issues.json``);
+* the same conservative, secrets-first privacy posture the reflect plugin's
+  prompts already mandate — see :mod:`reflect_kb.issues.sanitize`.
+
+It ports the *logic* of agent-deck's self-improvement pipeline (distill →
+analyze → sanitize → dedupe → file-issues) onto reflect-kb's Python style, but
+NOT its storage (no ``analysis-manifest.json``, no per-conductor directory
+tree) and NOT its agent-deck-specific session spawner.
+
+Pipeline (see :mod:`reflect_kb.issues.pipeline`)::
+
+    queue → distill (~30x, no LLM) → analyze (LLM, gated on auth)
+          → candidate issues → sanitize (regex) → dedupe (gh + ledger)
+          → gh issue create   (skipped entirely under --dry-run)
+
+The single hard guarantee: nothing reaches ``gh issue create`` (or even the
+terminal under ``--dry-run``) before passing through
+:func:`reflect_kb.issues.sanitize.sanitize`.
+"""
+
+from __future__ import annotations
+
+from reflect_kb.issues.dedupe import (
+    CandidateIssue,
+    DedupeDecision,
+    fingerprint,
+    partition_candidates,
+)
+from reflect_kb.issues.distill import DistillStats, distill, distill_file
+from reflect_kb.issues.sanitize import SanitizeResult, sanitize
+from reflect_kb.issues.pipeline import IssuesRunResult, run_issues
+
+__all__ = [
+    "CandidateIssue",
+    "DedupeDecision",
+    "DistillStats",
+    "IssuesRunResult",
+    "SanitizeResult",
+    "distill",
+    "distill_file",
+    "fingerprint",
+    "partition_candidates",
+    "run_issues",
+    "sanitize",
+]

--- a/reflect-kb/src/reflect_kb/issues/analyze.py
+++ b/reflect-kb/src/reflect_kb/issues/analyze.py
@@ -1,0 +1,183 @@
+"""LLM analysis step: distilled transcripts → candidate GitHub issues.
+
+This is the one place a model is needed. Per-transcript distillation
+(:mod:`reflect_kb.issues.distill`) and sanitization
+(:mod:`reflect_kb.issues.sanitize`) are pure Python; the analyzer reads the
+distilled timelines and proposes actionable product/code findings as structured
+candidate issues.
+
+Auth gating
+-----------
+The analyzer shells out to ``claude -p`` (the same runtime the reflect
+bg-drainer uses). If no live Claude auth context is present — or the ``claude``
+binary is missing, or it errors — :func:`analyze` returns ``([], reason)``
+instead of raising. The caller surfaces ``reason`` and continues; nothing is
+silently dropped, and the rest of the pipeline (dry-run preview, dedupe) still
+works against whatever candidates exist.
+
+Determinism for tests
+----------------------
+``analyze`` takes an injectable ``runner`` (defaults to a real ``subprocess``
+call). Tests pass a fake that returns canned JSON, so the analyze → sanitize →
+dedupe → file path is exercised end-to-end without a model.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Callable, Optional
+
+from reflect_kb.issues.dedupe import CandidateIssue
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+# Surfaces an issue may belong to — constrains the LLM's label space and is the
+# same taxonomy agent-deck's issue-drafter used.
+_SURFACES = ("cli", "tui", "webui", "db", "runtime", "plugin", "docs")
+
+_ANALYZER_PROMPT = """\
+You are analyzing distilled timelines of past AI coding-agent sessions to find
+ACTIONABLE product or code findings worth filing as GitHub issues: recurring
+bugs, capability gaps, friction points, or broken workflows.
+
+Hard rules:
+- Output ONLY a JSON array. No prose, no markdown fences.
+- Each element: {{"title": str (<70 chars, no trailing period),
+  "labels": [str, ...] (subset of {surfaces} plus "bug" or "enhancement"),
+  "body": str (markdown: ## Summary / ## Evidence / ## Expected vs actual /
+  ## Severity / ## Where to look)}}.
+- Only file findings backed by evidence in the timelines. If nothing is
+  actionable, output [].
+- DO NOT include real names, absolute home paths, IP addresses, tokens, emails,
+  or any secret. Describe the shape of the problem, not private details.
+- Prefer 0-5 high-signal findings over many weak ones.
+
+Distilled timelines:
+{timelines}
+"""
+
+
+def _default_runner(cmd: list[str], *, timeout: int = 300) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=timeout)
+
+
+def claude_available() -> bool:
+    """Best-effort check that a usable ``claude`` runtime is on PATH."""
+    return shutil.which("claude") is not None
+
+
+def _coerce_candidates(payload) -> list[CandidateIssue]:
+    """Turn parsed model output into CandidateIssue objects, defensively."""
+    out: list[CandidateIssue] = []
+    if not isinstance(payload, list):
+        return out
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title", "")).strip()
+        body = str(item.get("body", "")).strip()
+        if not title or not body:
+            continue
+        raw_labels = item.get("labels", [])
+        labels = (
+            [str(label_value) for label_value in raw_labels if str(label_value).strip()]
+            if isinstance(raw_labels, list)
+            else []
+        )
+        out.append(CandidateIssue(title=title[:120], body=body, labels=labels))
+    return out
+
+
+def _extract_json_array(text: str) -> Optional[list]:
+    """Pull the first top-level JSON array out of model stdout.
+
+    ``claude -p --output-format json`` wraps the answer in an envelope; the
+    actual array may be nested under ``result``/``content`` or printed bare.
+    We try, in order: whole-text parse, common envelope keys, then a bracket
+    scan for the first ``[ ... ]`` span.
+    """
+    text = text.strip()
+    if not text:
+        return None
+
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, dict):
+            for key in ("result", "content", "output", "text"):
+                val = parsed.get(key)
+                if isinstance(val, list):
+                    return val
+                if isinstance(val, str):
+                    inner = _extract_json_array(val)
+                    if inner is not None:
+                        return inner
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("[")
+    end = text.rfind("]")
+    if start != -1 and end != -1 and end > start:
+        try:
+            candidate = json.loads(text[start : end + 1])
+            if isinstance(candidate, list):
+                return candidate
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def analyze(
+    timelines: list[str],
+    *,
+    model: str = "sonnet",
+    runner: Optional[Runner] = None,
+    require_claude: bool = True,
+    timeout: int = 300,
+) -> tuple[list[CandidateIssue], str]:
+    """Analyze distilled ``timelines`` into candidate issues.
+
+    Returns ``(candidates, reason)``. ``reason`` is ``"ok"`` on success, or a
+    short machine-readable code on graceful degradation (``"no-timelines"``,
+    ``"claude-unavailable"``, ``"claude-error:<Type>"``, ``"unparseable"``).
+    """
+    if not timelines:
+        return [], "no-timelines"
+
+    run = runner or _default_runner
+    # Only enforce the binary check on the real path; an injected runner means
+    # a test (or an alternate backend) is driving us.
+    if require_claude and runner is None and not claude_available():
+        return [], "claude-unavailable"
+
+    prompt = _ANALYZER_PROMPT.format(
+        surfaces=list(_SURFACES),
+        timelines="\n\n---\n\n".join(timelines),
+    )
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--model",
+        model,
+        "--output-format",
+        "json",
+        "--max-turns",
+        "3",
+    ]
+    try:
+        res = run(cmd, timeout=timeout) if runner is None else run(cmd)
+    except subprocess.CalledProcessError as exc:
+        return [], f"claude-error:CalledProcessError:{(exc.stderr or '')[:80]}"
+    except (FileNotFoundError, OSError) as exc:
+        return [], f"claude-error:{type(exc).__name__}"
+    except subprocess.TimeoutExpired:
+        return [], "claude-error:Timeout"
+
+    parsed = _extract_json_array(getattr(res, "stdout", "") or "")
+    if parsed is None:
+        return [], "unparseable"
+    return _coerce_candidates(parsed), "ok"

--- a/reflect-kb/src/reflect_kb/issues/dedupe.py
+++ b/reflect-kb/src/reflect_kb/issues/dedupe.py
@@ -12,8 +12,10 @@ Three dedup layers, cheapest first:
    every issue this tool has filed. A fingerprint present there is skipped. This
    is what makes a second run idempotent even offline.
 3. **Remote** — ``gh issue list`` titles (open + closed) are fetched once;
-   exact-fingerprint match OR ≥``_TOKEN_OVERLAP`` token overlap with an existing
-   title marks a candidate as already-on-GitHub.
+   an exact-fingerprint match (``dup-on-github``) OR a high symmetric-Jaccard
+   token overlap with a minimum shared-token floor (``dup-on-github-overlap``)
+   marks a candidate as already-on-GitHub. The two are surfaced distinctly so a
+   reviewer can tell an exact suppression from a softer fuzzy one.
 
 The fingerprint is ``slugify(title)`` (lowercase, non-alphanumerics → ``-``,
 truncated at 60 chars) — identical to agent-deck so a port of an existing
@@ -33,11 +35,17 @@ from typing import Callable, Optional
 
 Runner = Callable[..., subprocess.CompletedProcess]
 
-# Token overlap (Jaccard-ish: shared / candidate-token-count) above which a
-# candidate is treated as a duplicate of an existing GitHub issue. Coarse by
-# design — agent-deck used 50%; we keep that and add an exact-fingerprint fast
-# path so identical titles always match regardless of overlap maths.
-_TOKEN_OVERLAP = 0.5
+# Token overlap above which a candidate is treated as a duplicate of an
+# existing GitHub issue. agent-deck used an asymmetric 50%-of-candidate-tokens
+# heuristic, which false-positive-suppresses genuinely-new issues with short
+# titles against long unrelated existing ones (a 2-word candidate sharing one
+# generic word with a 10-word issue scored 50% and was wrongly dropped). We use
+# SYMMETRIC Jaccard (shared / union) at a higher 0.7 threshold AND require a
+# minimum shared-token count, so a single incidental shared word can never
+# suppress a new issue. The exact-fingerprint fast path still matches identical
+# titles regardless of overlap maths.
+_TOKEN_OVERLAP = 0.7
+_MIN_SHARED_TOKENS = 2
 
 _LEDGER_VERSION = 1
 
@@ -85,7 +93,10 @@ class DedupeDecision:
 
     candidate: CandidateIssue
     keep: bool
-    reason: str  # "new" | "dup-in-batch" | "dup-in-ledger" | "dup-on-github"
+    # "new" | "dup-in-batch" | "dup-in-ledger"
+    # | "dup-on-github" (exact-fingerprint match)
+    # | "dup-on-github-overlap" (fuzzy token-overlap match — softer signal)
+    reason: str
     existing_ref: Optional[str] = None  # gh issue # / url / ledger fingerprint
 
 
@@ -99,11 +110,19 @@ def _tokens(title: str) -> set[str]:
     return {w for w in re.findall(r"[a-z0-9]+", title.lower()) if w not in _STOP and len(w) > 2}
 
 
-def _token_overlap(a: str, b: str) -> float:
+def _token_overlap(a: str, b: str) -> tuple[float, int]:
+    """Symmetric Jaccard overlap of two titles and the shared-token count.
+
+    Returns ``(jaccard, shared)`` where ``jaccard = |a ∩ b| / |a ∪ b|``. Jaccard
+    is symmetric, so a short candidate is not penalized for being shorter than a
+    long existing title the way the old shared/candidate ratio was.
+    """
     ta, tb = _tokens(a), _tokens(b)
-    if not ta:
-        return 0.0
-    return len(ta & tb) / len(ta)
+    if not ta or not tb:
+        return 0.0, 0
+    shared = ta & tb
+    union = ta | tb
+    return len(shared) / len(union), len(shared)
 
 
 def _default_runner(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -242,7 +261,8 @@ def partition_candidates(
 
         match = _match_existing(cand, existing_titles)
         if match is not None:
-            decisions.append(DedupeDecision(cand, False, "dup-on-github", match))
+            existing_title, reason = match
+            decisions.append(DedupeDecision(cand, False, reason, existing_title))
             seen_in_batch.add(fp)
             continue
 
@@ -252,11 +272,23 @@ def partition_candidates(
     return decisions
 
 
-def _match_existing(cand: CandidateIssue, existing_titles: list[str]) -> Optional[str]:
+def _match_existing(cand: CandidateIssue, existing_titles: list[str]) -> Optional[tuple[str, str]]:
+    """Return ``(existing_title, reason)`` for the best dedupe match, else None.
+
+    Exact-fingerprint matches win and are reported as ``dup-on-github``. Fuzzy
+    token-overlap matches require BOTH a high symmetric-Jaccard score AND a
+    minimum shared-token count, and are reported distinctly as
+    ``dup-on-github-overlap`` so a reviewer can tell a soft fuzzy suppression
+    from an exact one.
+    """
     cand_fp = cand.fingerprint
+    # Exact-fingerprint pass first — a precise match always beats a fuzzy one.
     for title in existing_titles:
         if fingerprint(title) == cand_fp:
-            return title
-        if _token_overlap(cand.title, title) >= _TOKEN_OVERLAP:
-            return title
+            return title, "dup-on-github"
+    # Fuzzy token-overlap pass — symmetric Jaccard AND a shared-count floor.
+    for title in existing_titles:
+        jaccard, shared = _token_overlap(cand.title, title)
+        if jaccard >= _TOKEN_OVERLAP and shared >= _MIN_SHARED_TOKENS:
+            return title, "dup-on-github-overlap"
     return None

--- a/reflect-kb/src/reflect_kb/issues/dedupe.py
+++ b/reflect-kb/src/reflect_kb/issues/dedupe.py
@@ -1,0 +1,262 @@
+"""Issue candidate model + deduplication.
+
+Ported from agent-deck's ``list_candidates.py`` / ``file_issue.py`` dedupe
+logic, but keyed off reflect-kb's own state dir instead of agent-deck's
+per-conductor manifest.
+
+Three dedup layers, cheapest first:
+
+1. **In-batch** — two candidates from the same run that slugify to the same
+   fingerprint collapse to one.
+2. **Local ledger** — ``filed_issues.json`` under ``REFLECT_STATE_DIR`` records
+   every issue this tool has filed. A fingerprint present there is skipped. This
+   is what makes a second run idempotent even offline.
+3. **Remote** — ``gh issue list`` titles (open + closed) are fetched once;
+   exact-fingerprint match OR ≥``_TOKEN_OVERLAP`` token overlap with an existing
+   title marks a candidate as already-on-GitHub.
+
+The fingerprint is ``slugify(title)`` (lowercase, non-alphanumerics → ``-``,
+truncated at 60 chars) — identical to agent-deck so a port of an existing
+ledger stays compatible.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+# Token overlap (Jaccard-ish: shared / candidate-token-count) above which a
+# candidate is treated as a duplicate of an existing GitHub issue. Coarse by
+# design — agent-deck used 50%; we keep that and add an exact-fingerprint fast
+# path so identical titles always match regardless of overlap maths.
+_TOKEN_OVERLAP = 0.5
+
+_LEDGER_VERSION = 1
+
+_STOP = {
+    "the",
+    "a",
+    "an",
+    "to",
+    "of",
+    "in",
+    "on",
+    "for",
+    "and",
+    "or",
+    "is",
+    "via",
+    "with",
+    "when",
+    "not",
+    "use",
+    "vs",
+    "but",
+    "from",
+    "into",
+}
+
+
+@dataclass
+class CandidateIssue:
+    """A candidate GitHub issue produced by the pipeline (pre-publish)."""
+
+    title: str
+    body: str
+    labels: list[str] = field(default_factory=list)
+    source_citation: str = ""
+
+    @property
+    def fingerprint(self) -> str:
+        return fingerprint(self.title)
+
+
+@dataclass
+class DedupeDecision:
+    """Why a candidate was kept or dropped."""
+
+    candidate: CandidateIssue
+    keep: bool
+    reason: str  # "new" | "dup-in-batch" | "dup-in-ledger" | "dup-on-github"
+    existing_ref: Optional[str] = None  # gh issue # / url / ledger fingerprint
+
+
+def fingerprint(title: str) -> str:
+    """``slugify(title)`` — the stable dedup key across runs."""
+    s = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return s[:60] or "untitled"
+
+
+def _tokens(title: str) -> set[str]:
+    return {w for w in re.findall(r"[a-z0-9]+", title.lower()) if w not in _STOP and len(w) > 2}
+
+
+def _token_overlap(a: str, b: str) -> float:
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta:
+        return 0.0
+    return len(ta & tb) / len(ta)
+
+
+def _default_runner(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+# ── local ledger ─────────────────────────────────────────────────────────────
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect")))
+
+
+def ledger_path() -> Path:
+    return state_dir() / "filed_issues.json"
+
+
+def load_ledger(path: Optional[Path] = None) -> dict:
+    p = path or ledger_path()
+    if not p.exists():
+        return {"version": _LEDGER_VERSION, "filed_issues": []}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"version": _LEDGER_VERSION, "filed_issues": []}
+    if not isinstance(data, dict) or "filed_issues" not in data:
+        return {"version": _LEDGER_VERSION, "filed_issues": []}
+    return data
+
+
+def ledger_fingerprints(ledger: dict) -> set[str]:
+    return {
+        str(e.get("fingerprint", ""))
+        for e in ledger.get("filed_issues", [])
+        if e.get("fingerprint")
+    }
+
+
+def record_filed(
+    ledger: dict,
+    candidate: CandidateIssue,
+    *,
+    gh_issue_number: Optional[int] = None,
+    gh_url: Optional[str] = None,
+    status: str = "open",
+) -> dict:
+    """Append a filed-issue record to ``ledger`` (in-place) and return it."""
+    ledger.setdefault("version", _LEDGER_VERSION)
+    ledger.setdefault("filed_issues", []).append(
+        {
+            "fingerprint": candidate.fingerprint,
+            "title": candidate.title,
+            "gh_issue_number": gh_issue_number,
+            "gh_url": gh_url,
+            "source_citation": candidate.source_citation,
+            "filed_at": datetime.now(timezone.utc).isoformat(),
+            "status": status,
+        }
+    )
+    return ledger
+
+
+def save_ledger(ledger: dict, path: Optional[Path] = None) -> Path:
+    """Atomic write (.tmp then replace) — agent-deck's file_issue.py wrote the
+    ledger non-atomically and a crash mid-write could corrupt it; we don't
+    repeat that footgun."""
+    p = path or ledger_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(ledger, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(p)
+    return p
+
+
+# ── remote (gh) ──────────────────────────────────────────────────────────────
+
+
+def fetch_existing_titles(
+    repo: Optional[str] = None,
+    *,
+    limit: int = 500,
+    runner: Runner = _default_runner,
+) -> list[str]:
+    """Return existing issue titles (open + closed) via ``gh issue list``.
+
+    Returns ``[]`` if ``gh`` is unavailable or errors — dedupe degrades to the
+    local ledger only (still idempotent for issues we filed ourselves).
+    """
+    cmd = ["gh", "issue", "list"]
+    if repo:
+        cmd += ["-R", repo]
+    cmd += ["--state", "all", "--limit", str(limit), "--json", "title"]
+    try:
+        res = runner(cmd)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return []
+    try:
+        rows = json.loads(res.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return [str(r.get("title", "")) for r in rows if isinstance(r, dict)]
+
+
+# ── partition ────────────────────────────────────────────────────────────────
+
+
+def partition_candidates(
+    candidates: list[CandidateIssue],
+    *,
+    ledger: Optional[dict] = None,
+    existing_titles: Optional[list[str]] = None,
+) -> list[DedupeDecision]:
+    """Classify every candidate as keep/drop with a reason.
+
+    Ordering matters: in-batch dupes are caught before ledger/remote so the
+    reasons are precise and the cheapest check wins.
+    """
+    ledger = ledger or {"version": _LEDGER_VERSION, "filed_issues": []}
+    existing_titles = existing_titles or []
+    filed_fps = ledger_fingerprints(ledger)
+
+    decisions: list[DedupeDecision] = []
+    seen_in_batch: set[str] = set()
+
+    for cand in candidates:
+        fp = cand.fingerprint
+
+        if fp in seen_in_batch:
+            decisions.append(DedupeDecision(cand, False, "dup-in-batch", fp))
+            continue
+
+        if fp in filed_fps:
+            decisions.append(DedupeDecision(cand, False, "dup-in-ledger", fp))
+            seen_in_batch.add(fp)
+            continue
+
+        match = _match_existing(cand, existing_titles)
+        if match is not None:
+            decisions.append(DedupeDecision(cand, False, "dup-on-github", match))
+            seen_in_batch.add(fp)
+            continue
+
+        decisions.append(DedupeDecision(cand, True, "new"))
+        seen_in_batch.add(fp)
+
+    return decisions
+
+
+def _match_existing(cand: CandidateIssue, existing_titles: list[str]) -> Optional[str]:
+    cand_fp = cand.fingerprint
+    for title in existing_titles:
+        if fingerprint(title) == cand_fp:
+            return title
+        if _token_overlap(cand.title, title) >= _TOKEN_OVERLAP:
+            return title
+    return None

--- a/reflect-kb/src/reflect_kb/issues/distill.py
+++ b/reflect-kb/src/reflect_kb/issues/distill.py
@@ -1,0 +1,309 @@
+"""Transcript distillation (~30x compression), ported from agent-deck's
+``distill.py`` onto reflect-kb's transcript schema.
+
+A Claude Code / Codex session transcript is a JSONL file: thousands of lines,
+each a JSON event (user turn, assistant turn, tool call, tool result, plus a
+lot of harness bookkeeping). Feeding the raw thing to an LLM is wasteful and
+leaks far more than the dialogue actually needs. :func:`distill` walks the file
+line-by-line (no LLM) and emits a compact markdown timeline that keeps only the
+signal:
+
+* user / assistant *dialogue* text,
+* tool *invocations* (name + abbreviated args),
+* tool *errors* (successful tool results are dropped),
+* skill loads and prompt markers.
+
+Everything else — permission-mode flips, queue operations, attachments, file
+history snapshots, AI titles, PR links, raw system records, and the bulky
+successful tool-result payloads — is dropped. In agent-deck this consistently
+hit ~30x compression; the same holds here because the dropped categories are
+where the bytes live.
+
+The record shape is the one reflect-kb already parses in
+``plugins/reflect/scripts/reflect_gate.py``: each line is an object with a
+``message`` ``{role, content}`` and/or a top-level ``type``. ``content`` is
+either a string or a list of typed blocks (``text`` / ``tool_use`` /
+``tool_result``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+# Top-level record ``type`` values that carry no distillation signal. Mirrors
+# agent-deck's NOISE_TYPES set, plus the reflect-specific ``queue-operation``
+# the bg-drainer emits.
+NOISE_TYPES: frozenset[str] = frozenset(
+    {
+        "permission-mode",
+        "queue-operation",
+        "attachment",
+        "file-history-snapshot",
+        "ai-title",
+        "pr-link",
+        "system",
+    }
+)
+
+# Per-field clip lengths (chars). Tuned to keep a line scannable while still
+# carrying enough to identify the event. Same intent as agent-deck.
+_USER_CLIP = 1000
+_ASSIST_CLIP = 500
+_ERROR_CLIP = 400
+_PROMPT_CLIP = 1000
+_BASH_CMD_CLIP = 200
+_ARGS_CLIP = 200
+
+_SKILL_MARKER = "Base directory for this skill:"
+_HEARTBEAT_PREFIXES = ("[HEARTBEAT]", "[EVENT]")
+
+
+@dataclass
+class DistillStats:
+    """Counts emitted alongside the distilled markdown (parity with agent-deck).
+
+    Useful both for tests and for a human eyeballing whether a transcript was
+    signal-rich. ``compression`` is ``src_bytes / dst_bytes`` (>= 1.0 means we
+    shrank it).
+    """
+
+    lines: int = 0
+    kept_user: int = 0
+    kept_assist: int = 0
+    kept_tool_use: int = 0
+    kept_error: int = 0
+    kept_prompt: int = 0
+    kept_heartbeat: int = 0
+    kept_skill_load: int = 0
+    dropped_noise: int = 0
+    src_bytes: int = 0
+    dst_bytes: int = 0
+    compression: float = 0.0
+
+    @property
+    def kept_total(self) -> int:
+        return (
+            self.kept_user
+            + self.kept_assist
+            + self.kept_tool_use
+            + self.kept_error
+            + self.kept_prompt
+            + self.kept_heartbeat
+            + self.kept_skill_load
+        )
+
+    def as_dict(self) -> dict:
+        d = self.__dict__.copy()
+        d["kept_total"] = self.kept_total
+        return d
+
+
+def _clip(text: str, limit: int) -> str:
+    text = text.replace("\n", " ").replace("\r", " ").strip()
+    if len(text) > limit:
+        return text[:limit] + "…"
+    return text
+
+
+def _iter_records(lines: Iterable[str]) -> Iterator[dict]:
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def _short_uuid(rec: dict) -> str:
+    """8-char stable handle for a record, for citation chaining.
+
+    Prefer the record's own ``uuid``; fall back to message id; else ``--------``.
+    """
+    for key in ("uuid", "id"):
+        val = rec.get(key)
+        if isinstance(val, str) and val:
+            return val.replace("-", "")[:8].ljust(8, "-")
+    msg = rec.get("message")
+    if isinstance(msg, dict):
+        mid = msg.get("id")
+        if isinstance(mid, str) and mid:
+            return mid.replace("-", "")[:8].ljust(8, "-")
+    return "--------"
+
+
+def _timestamp(rec: dict) -> str:
+    ts = rec.get("timestamp") or rec.get("ts") or ""
+    if isinstance(ts, (int, float)):
+        return str(ts)
+    return str(ts)[:19]  # trim to seconds, drop trailing millis/zone noise
+
+
+def _abbreviate_tool(name: str, args) -> str:
+    """One-line tool summary: name + the most identifying argument."""
+    if not isinstance(args, dict):
+        return name
+    if name == "Bash":
+        cmd = args.get("command", "")
+        return f"{name} | {_clip(str(cmd), _BASH_CMD_CLIP)}"
+    for key in ("file_path", "path", "notebook_path"):
+        if key in args:
+            extra = ""
+            if "pattern" in args:
+                extra = f" pattern={_clip(str(args['pattern']), 60)}"
+            return f"{name} | {_clip(str(args[key]), _ARGS_CLIP)}{extra}"
+    try:
+        blob = json.dumps(args, default=str)
+    except (TypeError, ValueError):
+        blob = str(args)
+    return f"{name} | {_clip(blob, _ARGS_CLIP)}"
+
+
+def _emit_user(rec: dict, msg: dict, content, stats: DistillStats) -> list[str]:
+    out: list[str] = []
+    uid = _short_uuid(rec)
+    ts = _timestamp(rec)
+
+    # User content can be plain text OR a list including tool_result blocks
+    # (Claude Code threads tool returns back through a user-role message).
+    texts: list[str] = []
+    tool_errors: list[str] = []
+    if isinstance(content, str):
+        texts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                texts.append(str(block.get("text", "")))
+            elif btype == "tool_result" and block.get("is_error"):
+                payload = block.get("content", "")
+                if isinstance(payload, list):
+                    payload = " ".join(
+                        str(b.get("text", "")) for b in payload if isinstance(b, dict)
+                    )
+                tool_errors.append(str(payload))
+            # Successful tool_result blocks are intentionally dropped (noise).
+
+    for text in texts:
+        text = text.strip()
+        if not text:
+            continue
+        if any(text.startswith(p) for p in _HEARTBEAT_PREFIXES):
+            out.append(f"[{uid}] {ts} HEARTBEAT")
+            stats.kept_heartbeat += 1
+        elif _SKILL_MARKER in text:
+            skill = text.split(_SKILL_MARKER, 1)[1].strip().splitlines()[0].strip()
+            out.append(f"[{uid}] {ts} SKILL_LOAD: {_clip(skill, 120)}")
+            stats.kept_skill_load += 1
+        else:
+            out.append(f"[{uid}] {ts} USER: {_clip(text, _USER_CLIP)}")
+            stats.kept_user += 1
+
+    for err in tool_errors:
+        out.append(f"[{uid}] {ts} ERROR: {_clip(err, _ERROR_CLIP)}")
+        stats.kept_error += 1
+
+    return out
+
+
+def _emit_assistant(rec: dict, msg: dict, content, stats: DistillStats) -> list[str]:
+    out: list[str] = []
+    uid = _short_uuid(rec)
+    ts = _timestamp(rec)
+    blocks = content if isinstance(content, list) else [{"type": "text", "text": content}]
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "tool_use":
+            summary = _abbreviate_tool(str(block.get("name", "?")), block.get("input"))
+            out.append(f"[{uid}] {ts} TOOL: {summary}")
+            stats.kept_tool_use += 1
+        elif btype == "text":
+            text = str(block.get("text", "")).strip()
+            if text:
+                out.append(f"[{uid}] {ts} ASSIST: {_clip(text, _ASSIST_CLIP)}")
+                stats.kept_assist += 1
+    return out
+
+
+def distill(lines: Iterable[str]) -> tuple[str, DistillStats]:
+    """Distill an iterable of JSONL lines into a compact markdown timeline.
+
+    Returns ``(markdown, stats)``. The markdown is a single ``# Distilled``
+    document followed by one event per line; it is safe to feed to an analyzer
+    or to print under ``--dry-run`` (after sanitization).
+    """
+    stats = DistillStats()
+    rows: list[str] = []
+
+    for rec in _iter_records(lines):
+        stats.lines += 1
+        rec_type = rec.get("type")
+
+        if rec_type in NOISE_TYPES:
+            stats.dropped_noise += 1
+            continue
+
+        if rec_type == "last-prompt":
+            prompt = rec.get("prompt") or rec.get("content") or ""
+            rows.append(
+                f"[{_short_uuid(rec)}] {_timestamp(rec)} PROMPT: {_clip(str(prompt), _PROMPT_CLIP)}"
+            )
+            stats.kept_prompt += 1
+            continue
+
+        msg = rec.get("message")
+        if not isinstance(msg, dict):
+            stats.dropped_noise += 1
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        if role == "user":
+            rows.extend(_emit_user(rec, msg, content, stats))
+        elif role == "assistant":
+            rows.extend(_emit_assistant(rec, msg, content, stats))
+        else:
+            stats.dropped_noise += 1
+
+    markdown = "# Distilled transcript\n\n" + "\n".join(rows) + ("\n" if rows else "")
+    # ``lines`` may be a one-shot iterator, so we cannot recover src_bytes here.
+    # Callers that hold the raw source (``distill_text`` / ``distill_file``)
+    # fill in src_bytes + the honest compression ratio.
+    stats.dst_bytes = len(markdown.encode("utf-8"))
+    return markdown, stats
+
+
+def distill_file(src: Path, dst: Optional[Path] = None) -> DistillStats:
+    """Distill a transcript file, optionally writing the markdown to ``dst``.
+
+    This path knows the true source size, so it fills in ``src_bytes`` and the
+    ``compression`` ratio honestly.
+    """
+    raw = src.read_text(encoding="utf-8", errors="replace")
+    markdown, stats = distill(raw.splitlines())
+    stats.src_bytes = len(raw.encode("utf-8"))
+    if stats.dst_bytes:
+        stats.compression = round(stats.src_bytes / stats.dst_bytes, 2)
+    if dst is not None:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(markdown, encoding="utf-8")
+    return stats
+
+
+def distill_text(raw: str) -> tuple[str, DistillStats]:
+    """Convenience wrapper that distills an in-memory transcript string and
+    reports an honest compression ratio (the source bytes are known here)."""
+    markdown, stats = distill(raw.splitlines())
+    stats.src_bytes = len(raw.encode("utf-8"))
+    if stats.dst_bytes:
+        stats.compression = round(stats.src_bytes / stats.dst_bytes, 2)
+    return markdown, stats

--- a/reflect-kb/src/reflect_kb/issues/manifest.py
+++ b/reflect-kb/src/reflect_kb/issues/manifest.py
@@ -1,0 +1,105 @@
+"""Source recent transcripts from the EXISTING reflect queue.
+
+This is the ``issues`` mode's manifest builder. Rather than re-scanning
+``~/.claude/projects`` (agent-deck's approach, with its hardcoded conductor
+path), it reads the same ``~/.reflect/pending_reflections.jsonl`` queue that
+``stop_reflect.py`` / ``precompact_reflect.py`` already append to. That queue
+IS the list of recent, signal-bearing transcripts — reusing it is the whole
+point of "new mode, not parallel pipeline".
+
+Each queue line looks like::
+
+    {"ts": "...", "session_id": "...", "transcript_path": "/abs/x.jsonl",
+     "trigger": "stop", "cwd": "/abs/project"}
+
+We de-duplicate by resolved transcript path (a long session can be enqueued by
+both PreCompact and Stop), keep only paths that still exist on disk, and return
+the most recent ``limit`` entries (newest first by queue order, which is append
+order).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class TranscriptRef:
+    """A recent transcript to analyze, sourced from the reflect queue."""
+
+    session_id: str
+    transcript_path: Path
+    trigger: str
+    cwd: str
+    ts: str
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("REFLECT_STATE_DIR", str(Path.home() / ".reflect")))
+
+
+def queue_file() -> Path:
+    return state_dir() / "pending_reflections.jsonl"
+
+
+def _resolve(path: str) -> Optional[Path]:
+    try:
+        return Path(path).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def gather_transcripts(
+    *,
+    queue: Optional[Path] = None,
+    limit: int = 20,
+    require_exists: bool = True,
+) -> list[TranscriptRef]:
+    """Return up to ``limit`` recent transcript refs from the reflect queue.
+
+    De-duplicates by resolved transcript path (keeping the latest entry for a
+    given path). When ``require_exists`` is True, paths missing on disk are
+    skipped (a transcript can be rotated away between enqueue and run).
+    """
+    qf = queue or queue_file()
+    if not qf.exists():
+        return []
+
+    # Keep the LAST occurrence per resolved path (most recent enqueue wins),
+    # then trim to ``limit`` newest. We iterate in file (append) order.
+    by_path: dict[str, TranscriptRef] = {}
+    try:
+        with open(qf, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                raw = str(entry.get("transcript_path", "")).strip()
+                if not raw:
+                    continue
+                resolved = _resolve(raw)
+                if resolved is None:
+                    continue
+                if require_exists and not resolved.exists():
+                    continue
+                by_path[str(resolved)] = TranscriptRef(
+                    session_id=str(entry.get("session_id", "") or "unknown"),
+                    transcript_path=resolved,
+                    trigger=str(entry.get("trigger", "") or "unknown"),
+                    cwd=str(entry.get("cwd", "") or ""),
+                    ts=str(entry.get("ts", "") or ""),
+                )
+    except OSError:
+        return []
+
+    refs = list(by_path.values())
+    # Newest last in append order → take the tail as "most recent".
+    return refs[-limit:] if limit and limit > 0 else refs

--- a/reflect-kb/src/reflect_kb/issues/manifest.py
+++ b/reflect-kb/src/reflect_kb/issues/manifest.py
@@ -71,6 +71,13 @@ def gather_transcripts(
 
     # Keep the LAST occurrence per resolved path (most recent enqueue wins),
     # then trim to ``limit`` newest. We iterate in file (append) order.
+    #
+    # A plain ``dict[key] = value`` update keeps the key at its ORIGINAL
+    # insertion position while only replacing the value, so a path enqueued
+    # early then re-enqueued late would still sort as "old" — corrupting both
+    # the de-dup result ordering and the ``limit`` tail trim. To make the order
+    # reflect the most recent enqueue, we explicitly ``pop`` an existing key
+    # before re-inserting it, moving it to the end of the insertion order.
     by_path: dict[str, TranscriptRef] = {}
     try:
         with open(qf, encoding="utf-8", errors="replace") as fh:
@@ -90,7 +97,11 @@ def gather_transcripts(
                     continue
                 if require_exists and not resolved.exists():
                     continue
-                by_path[str(resolved)] = TranscriptRef(
+                key = str(resolved)
+                # Drop any earlier entry for this path so the re-insert below
+                # lands the (newer) entry at the end of the ordered dict.
+                by_path.pop(key, None)
+                by_path[key] = TranscriptRef(
                     session_id=str(entry.get("session_id", "") or "unknown"),
                     transcript_path=resolved,
                     trigger=str(entry.get("trigger", "") or "unknown"),

--- a/reflect-kb/src/reflect_kb/issues/pipeline.py
+++ b/reflect-kb/src/reflect_kb/issues/pipeline.py
@@ -1,0 +1,271 @@
+"""End-to-end orchestration of ``reflect issues``.
+
+Wires the modules together::
+
+    gather (manifest)  →  distill (per transcript, ~30x, no LLM)
+        →  analyze (one bounded LLM call, gated on Claude auth)
+        →  sanitize EVERY candidate (regex, conservative)
+        →  dedupe (in-batch / local ledger / gh issue list)
+        →  file via `gh issue create`   [skipped under dry_run]
+
+Safety invariants enforced here (not left to callers):
+
+* The distilled timelines are sanitized BEFORE the analyzer sees them, and
+  every candidate's title+body are sanitized AGAIN before it can be printed
+  (dry-run) or filed. Nothing un-sanitized ever leaves :func:`run_issues`.
+* ``dry_run=True`` never invokes ``gh issue create`` — it prints the exact
+  bodies that WOULD be filed and returns.
+* Filing appends to the atomic ``filed_issues.json`` ledger so a second run
+  files zero duplicates even with ``gh`` offline.
+
+The ``gh`` and ``claude`` calls are injected (``gh_runner`` / ``analyze_fn``)
+so the whole flow is testable without a network or a model.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from reflect_kb.issues import analyze as analyze_mod
+from reflect_kb.issues import dedupe as dedupe_mod
+from reflect_kb.issues import manifest as manifest_mod
+from reflect_kb.issues.dedupe import CandidateIssue, DedupeDecision
+from reflect_kb.issues.distill import distill_text
+from reflect_kb.issues.sanitize import sanitize
+
+Runner = Callable[..., subprocess.CompletedProcess]
+AnalyzeFn = Callable[[list[str]], tuple[list[CandidateIssue], str]]
+
+
+@dataclass
+class FiledIssue:
+    title: str
+    fingerprint: str
+    gh_issue_number: Optional[int] = None
+    gh_url: Optional[str] = None
+
+
+@dataclass
+class IssuesRunResult:
+    """Summary of one ``reflect issues`` run."""
+
+    dry_run: bool
+    transcripts_seen: int = 0
+    transcripts_distilled: int = 0
+    analyze_reason: str = ""
+    candidates: int = 0
+    filed: list[FiledIssue] = field(default_factory=list)
+    skipped: list[DedupeDecision] = field(default_factory=list)
+    previews: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def filed_count(self) -> int:
+        return len(self.filed)
+
+
+def _default_gh_runner(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def _sanitize_candidate(cand: CandidateIssue, maps: Optional[dict[str, str]]) -> CandidateIssue:
+    """Return a copy of ``cand`` with title+body sanitized for publication."""
+    s_title = sanitize(cand.title, maps=maps).text.strip()
+    s_body = sanitize(cand.body, maps=maps).text
+    return CandidateIssue(
+        title=s_title or cand.title,
+        body=s_body,
+        labels=list(cand.labels),
+        source_citation=cand.source_citation,
+    )
+
+
+def _filter_labels(
+    labels: list[str],
+    repo: Optional[str],
+    gh_runner: Runner,
+) -> list[str]:
+    """Drop labels that don't exist in the target repo.
+
+    Passing an unknown label to ``gh issue create`` fails the whole create
+    atomically (a real agent-deck footgun). We fetch the repo's label set and
+    keep only the intersection. On any error we return ``[]`` rather than risk
+    a hard failure.
+    """
+    if not labels:
+        return []
+    cmd = ["gh", "label", "list"]
+    if repo:
+        cmd += ["-R", repo]
+    cmd += ["--limit", "200", "--json", "name"]
+    try:
+        res = gh_runner(cmd)
+        import json as _json
+
+        valid = {str(r.get("name", "")) for r in _json.loads(res.stdout or "[]")}
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, ValueError):
+        return []
+    return [lab for lab in labels if lab in valid]
+
+
+_ISSUE_URL_RE = re.compile(r"/issues/(\d+)\s*$")
+
+
+def _file_one(
+    cand: CandidateIssue,
+    repo: Optional[str],
+    gh_runner: Runner,
+) -> FiledIssue:
+    """Create one GitHub issue via ``gh issue create``. Caller has already
+    sanitized + deduped ``cand``."""
+    labels = _filter_labels(cand.labels, repo, gh_runner)
+    cmd = ["gh", "issue", "create"]
+    if repo:
+        cmd += ["-R", repo]
+    cmd += ["--title", cand.title, "--body", cand.body]
+    if labels:
+        cmd += ["--label", ",".join(labels)]
+    res = gh_runner(cmd)
+    url = (getattr(res, "stdout", "") or "").strip().splitlines()
+    gh_url = next((ln.strip() for ln in url if ln.strip().startswith("https://")), None)
+    number = None
+    if gh_url:
+        m = _ISSUE_URL_RE.search(gh_url)
+        if m:
+            number = int(m.group(1))
+    return FiledIssue(
+        title=cand.title,
+        fingerprint=cand.fingerprint,
+        gh_issue_number=number,
+        gh_url=gh_url,
+    )
+
+
+def _render_preview(cand: CandidateIssue) -> str:
+    labels = f" [{', '.join(cand.labels)}]" if cand.labels else ""
+    return f"### {cand.title}{labels}\n{cand.body}\n"
+
+
+def run_issues(
+    *,
+    repo: Optional[str] = None,
+    limit: int = 20,
+    dry_run: bool = False,
+    maps: Optional[dict[str, str]] = None,
+    model: str = "sonnet",
+    queue: Optional[Path] = None,
+    ledger_path: Optional[Path] = None,
+    analyze_fn: Optional[AnalyzeFn] = None,
+    gh_runner: Optional[Runner] = None,
+    fetch_titles: Optional[Callable[[], list[str]]] = None,
+) -> IssuesRunResult:
+    """Run the transcripts → issues pipeline once.
+
+    Args:
+        repo: ``owner/name`` for ``gh`` (defaults to the cwd's repo).
+        limit: max transcripts to pull from the queue.
+        dry_run: print bodies that WOULD be filed; never call ``gh``.
+        maps: caller-supplied sanitizer substitutions.
+        model: model passed to the analyzer.
+        queue / ledger_path: override state locations (tests).
+        analyze_fn / gh_runner / fetch_titles: injected for tests; default to
+            the real :mod:`reflect_kb.issues.analyze` / ``gh`` calls.
+
+    Returns:
+        An :class:`IssuesRunResult`.
+    """
+    result = IssuesRunResult(dry_run=dry_run)
+    gh_run = gh_runner or _default_gh_runner
+
+    # 1. Gather recent transcripts from the existing reflect queue.
+    refs = manifest_mod.gather_transcripts(queue=queue, limit=limit)
+    result.transcripts_seen = len(refs)
+    if not refs:
+        result.notes.append(
+            "no transcripts in the reflect queue (~/.reflect/pending_reflections.jsonl)"
+        )
+        return result
+
+    # 2. Distill each transcript and sanitize the timeline before the model.
+    timelines: list[str] = []
+    for ref in refs:
+        try:
+            raw = ref.transcript_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        markdown, stats = distill_text(raw)
+        if stats.kept_total == 0:
+            continue
+        safe_timeline = sanitize(markdown, maps=maps).text
+        timelines.append(safe_timeline)
+        result.transcripts_distilled += 1
+
+    if not timelines:
+        result.notes.append("transcripts distilled to zero signal; nothing to analyze")
+        return result
+
+    # 3. Analyze → candidate issues (gated on Claude auth; degrades to []).
+    if analyze_fn is not None:
+        candidates, reason = analyze_fn(timelines)
+    else:
+        candidates, reason = analyze_mod.analyze(timelines, model=model)
+    result.analyze_reason = reason
+    result.candidates = len(candidates)
+    if not candidates:
+        result.notes.append(f"analyzer produced no candidates (reason: {reason})")
+        return result
+
+    # 4. Sanitize EVERY candidate again (defence in depth) before it can leave.
+    safe_candidates = [_sanitize_candidate(c, maps) for c in candidates]
+
+    # 5. Dedupe: in-batch → local ledger → existing GitHub issues.
+    ledger = dedupe_mod.load_ledger(ledger_path)
+    if fetch_titles is not None:
+        existing = fetch_titles()
+    elif dry_run:
+        # Dry-run still consults gh for an accurate preview of what's new, but
+        # tolerates gh being absent.
+        existing = dedupe_mod.fetch_existing_titles(repo, runner=gh_run)
+    else:
+        existing = dedupe_mod.fetch_existing_titles(repo, runner=gh_run)
+
+    decisions = dedupe_mod.partition_candidates(
+        safe_candidates, ledger=ledger, existing_titles=existing
+    )
+    keepers = [d.candidate for d in decisions if d.keep]
+    result.skipped = [d for d in decisions if not d.keep]
+
+    # 6. File (or preview).
+    if dry_run:
+        for cand in keepers:
+            result.previews.append(_render_preview(cand))
+        result.notes.append(
+            f"dry-run: {len(keepers)} issue(s) WOULD be filed, "
+            f"{len(result.skipped)} skipped as duplicates"
+        )
+        return result
+
+    filed_any = False
+    for cand in keepers:
+        try:
+            filed = _file_one(cand, repo, gh_run)
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+            result.notes.append(f"gh issue create failed for '{cand.title}': {exc}")
+            continue
+        result.filed.append(filed)
+        dedupe_mod.record_filed(
+            ledger,
+            cand,
+            gh_issue_number=filed.gh_issue_number,
+            gh_url=filed.gh_url,
+        )
+        filed_any = True
+
+    if filed_any:
+        dedupe_mod.save_ledger(ledger, ledger_path)
+
+    return result

--- a/reflect-kb/src/reflect_kb/issues/pipeline.py
+++ b/reflect-kb/src/reflect_kb/issues/pipeline.py
@@ -62,6 +62,12 @@ class IssuesRunResult:
     skipped: list[DedupeDecision] = field(default_factory=list)
     previews: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
+    # Residual-suspicious flags from the sanitizer's non-mutating audit pass,
+    # aggregated across every candidate's title+body. Each entry carries the
+    # candidate title so a reviewer can see WHICH issue still looks suspicious.
+    # Non-empty audit does NOT mean unsafe — it means "a human should eyeball
+    # this before it's published".
+    audit: list[dict] = field(default_factory=list)
 
     @property
     def filed_count(self) -> int:
@@ -72,16 +78,30 @@ def _default_gh_runner(cmd: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
-def _sanitize_candidate(cand: CandidateIssue, maps: Optional[dict[str, str]]) -> CandidateIssue:
-    """Return a copy of ``cand`` with title+body sanitized for publication."""
-    s_title = sanitize(cand.title, maps=maps).text.strip()
-    s_body = sanitize(cand.body, maps=maps).text
-    return CandidateIssue(
+def _sanitize_candidate(
+    cand: CandidateIssue, maps: Optional[dict[str, str]]
+) -> tuple[CandidateIssue, list[dict]]:
+    """Sanitize ``cand`` for publication and surface its residual-audit flags.
+
+    Returns the sanitized candidate AND the list of audit findings (the
+    non-mutating "look here" flags the sanitizer raised on title+body), each
+    tagged with the candidate title so the caller can attribute it. Dropping
+    the audit — as an earlier version did — silently discarded the documented
+    safety net that flags residual suspicious tokens for a human.
+    """
+    title_res = sanitize(cand.title, maps=maps)
+    body_res = sanitize(cand.body, maps=maps)
+    s_title = title_res.text.strip()
+    safe = CandidateIssue(
         title=s_title or cand.title,
-        body=s_body,
+        body=body_res.text,
         labels=list(cand.labels),
         source_citation=cand.source_citation,
     )
+    audit: list[dict] = []
+    for finding in (*title_res.audit, *body_res.audit):
+        audit.append({**finding, "candidate": safe.title})
+    return safe, audit
 
 
 def _filter_labels(
@@ -219,8 +239,13 @@ def run_issues(
         result.notes.append(f"analyzer produced no candidates (reason: {reason})")
         return result
 
-    # 4. Sanitize EVERY candidate again (defence in depth) before it can leave.
-    safe_candidates = [_sanitize_candidate(c, maps) for c in candidates]
+    # 4. Sanitize EVERY candidate again (defence in depth) before it can leave,
+    #    aggregating each candidate's residual-audit flags onto the run result.
+    safe_candidates: list[CandidateIssue] = []
+    for c in candidates:
+        safe, audit = _sanitize_candidate(c, maps)
+        safe_candidates.append(safe)
+        result.audit.extend(audit)
 
     # 5. Dedupe: in-batch → local ledger → existing GitHub issues.
     ledger = dedupe_mod.load_ledger(ledger_path)
@@ -249,7 +274,6 @@ def run_issues(
         )
         return result
 
-    filed_any = False
     for cand in keepers:
         try:
             filed = _file_one(cand, repo, gh_run)
@@ -263,9 +287,10 @@ def run_issues(
             gh_issue_number=filed.gh_issue_number,
             gh_url=filed.gh_url,
         )
-        filed_any = True
-
-    if filed_any:
+        # Persist incrementally — the atomic save runs after EACH successful
+        # file, not once at the end. A crash after `gh issue create` succeeds
+        # but before the ledger is saved would otherwise leave the filed issue
+        # unrecorded → a duplicate on the next run.
         dedupe_mod.save_ledger(ledger, ledger_path)
 
     return result

--- a/reflect-kb/src/reflect_kb/issues/pipeline.py
+++ b/reflect-kb/src/reflect_kb/issues/pipeline.py
@@ -132,6 +132,66 @@ def _filter_labels(
     return [lab for lab in labels if lab in valid]
 
 
+# Default provenance markers. Every issue this mode files is titled
+# ``reflect: <title>`` and carries a ``reflect`` label so it's obvious — in the
+# issue list, in search, and in filters — that it came from the reflect issues
+# pipeline rather than a human. Both are overridable via the ``[issues]`` config
+# (``title_prefix`` / ``label``) or CLI flags.
+DEFAULT_TITLE_PREFIX = "reflect: "
+DEFAULT_LABEL = "reflect"
+# GitHub label colour (clay) + description used when we auto-create the label.
+_LABEL_COLOR = "D97757"
+_LABEL_DESC = "Filed automatically by `reflect issues` from session transcripts"
+
+
+def _decorate(
+    cand: CandidateIssue,
+    title_prefix: str,
+    label: str,
+) -> CandidateIssue:
+    """Stamp provenance onto a candidate: ``reflect:`` title prefix + label.
+
+    Idempotent — a title that already starts with the prefix (case-insensitive)
+    is left as-is, and the label is only added once. Applied BEFORE dedupe so
+    the fingerprint (``slugify(title)``) is computed on the final, prefixed
+    title — keeping it consistent with previously-filed ``reflect: ...`` issues.
+    """
+    title = cand.title
+    if title_prefix and not title.lower().startswith(title_prefix.strip().lower()):
+        title = f"{title_prefix}{title}"
+    labels = list(cand.labels)
+    if label and label not in labels:
+        labels = [label, *labels]
+    return CandidateIssue(
+        title=title,
+        body=cand.body,
+        labels=labels,
+        source_citation=cand.source_citation,
+    )
+
+
+def _ensure_label(label: str, repo: Optional[str], gh_runner: Runner) -> None:
+    """Best-effort create the provenance label so ``_filter_labels`` keeps it.
+
+    ``_filter_labels`` drops labels absent from the repo (an unknown label fails
+    the whole ``gh issue create``), so the ``reflect`` label would silently
+    vanish on a repo that doesn't have it yet. Create it idempotently — ``gh
+    label create`` exits non-zero if it already exists, which we swallow. Never
+    raises; a failure just means the label may get filtered out (issues still
+    file, just unlabelled).
+    """
+    if not label:
+        return
+    cmd = ["gh", "label", "create", label, "--color", _LABEL_COLOR, "--description", _LABEL_DESC]
+    if repo:
+        cmd += ["-R", repo]
+    try:
+        gh_runner(cmd)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        # Already exists (most common) or gh unavailable — non-fatal.
+        return
+
+
 _ISSUE_URL_RE = re.compile(r"/issues/(\d+)\s*$")
 
 
@@ -177,6 +237,8 @@ def run_issues(
     dry_run: bool = False,
     maps: Optional[dict[str, str]] = None,
     model: str = "sonnet",
+    title_prefix: str = DEFAULT_TITLE_PREFIX,
+    label: str = DEFAULT_LABEL,
     queue: Optional[Path] = None,
     ledger_path: Optional[Path] = None,
     analyze_fn: Optional[AnalyzeFn] = None,
@@ -244,7 +306,9 @@ def run_issues(
     safe_candidates: list[CandidateIssue] = []
     for c in candidates:
         safe, audit = _sanitize_candidate(c, maps)
-        safe_candidates.append(safe)
+        # Stamp provenance (reflect: prefix + label) BEFORE dedupe so the
+        # fingerprint matches previously-filed `reflect: ...` issues.
+        safe_candidates.append(_decorate(safe, title_prefix, label))
         result.audit.extend(audit)
 
     # 5. Dedupe: in-batch → local ledger → existing GitHub issues.
@@ -273,6 +337,11 @@ def run_issues(
             f"{len(result.skipped)} skipped as duplicates"
         )
         return result
+
+    # Ensure the provenance label exists so it survives _filter_labels (an
+    # unknown label would otherwise be dropped). Best-effort, once per run.
+    if keepers and label:
+        _ensure_label(label, repo, gh_run)
 
     for cand in keepers:
         try:

--- a/reflect-kb/src/reflect_kb/issues/sanitize.py
+++ b/reflect-kb/src/reflect_kb/issues/sanitize.py
@@ -20,8 +20,15 @@ What it strips (in order)
    * JWTs                ``eyJ…\\.…\\.…``           → ``<REDACTED:jwt>``
    * Slack tokens        ``xox[baprs]-…``         → ``<REDACTED:slack_token>``
    * Private keys        PEM ``-----BEGIN … KEY-----`` blocks → ``<REDACTED:private_key>``
-   * Generic ``KEY=value`` where KEY ∈ {token, key, secret, password, api_key,
-     auth, authorization} and value is ≥12 chars → ``KEY=<REDACTED:generic_secret>``
+   * GitLab PATs ``glpat-…``        → ``<REDACTED:gitlab_token>``
+   * Google API keys ``AIza…``      → ``<REDACTED:google_api_key>``
+   * npm tokens ``npm_…``           → ``<REDACTED:npm_token>``
+   * Slack webhooks ``hooks.slack.com/services/…`` → ``<REDACTED:slack_webhook>``
+   * ``Authorization: Bearer <tok>`` → ``Bearer <REDACTED:bearer_token>``
+   * Generic ``KEY=value`` where KEY *contains* {token, key, secret, password,
+     passwd, api_key, auth, authorization} — anywhere in the identifier, so
+     ``AWS_SECRET_ACCESS_KEY``/``GITLAB_TOKEN``/``GOOGLE_API_KEY``/``NPM_TOKEN``
+     all match — and value is ≥12 chars → ``KEY=<REDACTED:generic_secret>``
 3. **Emails**                → ``<REDACTED:email>``
 4. **IPv4 addresses**        → ``<REDACTED:ipv4>``
 5. **Home paths** ``/Users/<u>`` / ``/home/<u>`` → ``/Users/<user>`` etc.;
@@ -62,7 +69,22 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "github_token",
     ),
     (re.compile(r"gh[posru]_[A-Za-z0-9]{20,}"), "<REDACTED:github_token>", "github_token"),
+    # GitLab personal-access / pipeline tokens (glpat-…). No generic-keyword
+    # anchor, so without this prefix rule a bare token leaks into a published
+    # issue unredacted.
+    (re.compile(r"glpat-[A-Za-z0-9_\-]{16,}"), "<REDACTED:gitlab_token>", "gitlab_token"),
+    # Google API keys (AIza…). Fixed 39-char total in practice; match ≥30 of
+    # body to stay tolerant without being greedy.
+    (re.compile(r"\bAIza[A-Za-z0-9_\-]{30,}\b"), "<REDACTED:google_api_key>", "google_api_key"),
+    # npm automation/access tokens (npm_…).
+    (re.compile(r"\bnpm_[A-Za-z0-9]{30,}\b"), "<REDACTED:npm_token>", "npm_token"),
     (re.compile(r"xox[baprs]-[A-Za-z0-9\-]{10,}"), "<REDACTED:slack_token>", "slack_token"),
+    # Slack incoming-webhook URLs carry a posting credential in the path.
+    (
+        re.compile(r"https://hooks\.slack\.com/services/\S+"),
+        "<REDACTED:slack_webhook>",
+        "slack_webhook",
+    ),
     (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "<REDACTED:aws_key>", "aws_key"),
     (
         re.compile(r"\b\d{8,12}:[A-Za-z0-9_\-]{30,}\b"),
@@ -83,6 +105,16 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "<REDACTED:private_key>",
         "private_key",
     ),
+    # ``Authorization: Bearer <token>`` — strip the credential, keep the scheme
+    # so the line still reads. Runs after the more specific token rules above so
+    # a ``Bearer eyJ…`` JWT is already redacted by the time we get here; this
+    # catches opaque bearer tokens with no recognizable prefix. Only the token
+    # is replaced (group 1 — the ``Bearer `` scheme — is preserved).
+    (
+        re.compile(r"(\bBearer\s+)[A-Za-z0-9_\-.=+/]{12,}"),
+        r"\1<REDACTED:bearer_token>",
+        "bearer_token",
+    ),
 ]
 
 # Generic KEY=value / KEY: value secret. The keyword set and the {12,} value
@@ -90,8 +122,15 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
 # The ``(?!<REDACTED:)`` guard stops this coarse rule from re-redacting a
 # placeholder a more specific earlier rule already wrote (e.g. a PEM block that
 # happened to follow the literal text "key:").
+# The keyword is allowed to be EMBEDDED in a longer identifier. ``_`` is a word
+# char, so a strict ``\b(key)\b`` boundary fails on ``AWS_SECRET_ACCESS_KEY``,
+# ``GITLAB_TOKEN``, ``GOOGLE_API_KEY``, ``NPM_TOKEN`` — the keyword sits between
+# word chars, never on a boundary, so the whole assignment passes through
+# unredacted. Surrounding ``\w*`` lets the keyword match anywhere inside the
+# identifier; group 1 captures the FULL env-var name so it's preserved verbatim
+# and only the value is stripped.
 _GENERIC_SECRET_RE = re.compile(
-    r"\b(token|key|secret|password|api[_-]?key|auth(?:orization)?)\b"
+    r"\b(\w*(?:token|key|secret|password|passwd|api[_-]?key|auth(?:orization)?)\w*)"
     r"(\s*[:=]\s*)"
     r"(['\"]?)(?!<REDACTED:)([^\s'\"]{12,})\3",
     re.IGNORECASE,

--- a/reflect-kb/src/reflect_kb/issues/sanitize.py
+++ b/reflect-kb/src/reflect_kb/issues/sanitize.py
@@ -160,6 +160,15 @@ _SUSPICIOUS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\b(?:10|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d"), "private_ip_range"),
 ]
 
+# Placeholders this sanitizer itself writes, e.g. ``<REDACTED:generic_secret>``.
+# The audit runs on ALREADY-redacted text, so without masking these the coarse
+# suspicious patterns (env_var_assignment, possible_base64_blob, …) re-flag the
+# sanitizer's OWN output — a fully-redacted ``FOO=<REDACTED:generic_secret>``
+# would be reported as a suspicious env assignment, burying genuine residue. We
+# blank placeholder spans (to equal-length spaces, preserving line/column
+# offsets) before the audit regexes run.
+_PLACEHOLDER_RE = re.compile(r"<REDACTED:[a-z_]+>")
+
 
 @dataclass
 class SanitizeResult:
@@ -251,10 +260,21 @@ def sanitize(text: str, *, maps: Optional[dict[str, str]] = None) -> SanitizeRes
     return SanitizeResult(text=out, redactions=tally, audit=_audit(out))
 
 
+def _mask_placeholders(line: str) -> str:
+    """Blank this sanitizer's own ``<REDACTED:…>`` placeholders to equal-length
+    spaces, so the audit regexes scan only genuinely-unredacted residue."""
+    return _PLACEHOLDER_RE.sub(lambda m: " " * (m.end() - m.start()), line)
+
+
 def _audit(text: str) -> list[dict]:
-    """Non-mutating scan for residual suspicious tokens, by line."""
+    """Non-mutating scan for residual suspicious tokens, by line.
+
+    Placeholder spans this sanitizer already wrote are masked out first, so the
+    audit never re-flags its own redactions (which would drown real findings).
+    """
     findings: list[dict] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        line = _mask_placeholders(raw_line)
         for pattern, kind in _SUSPICIOUS:
             m = pattern.search(line)
             if m:

--- a/reflect-kb/src/reflect_kb/issues/sanitize.py
+++ b/reflect-kb/src/reflect_kb/issues/sanitize.py
@@ -52,6 +52,15 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
     (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "<REDACTED:anthropic_key>", "anthropic_key"),
     (re.compile(r"sk-proj-[A-Za-z0-9_\-]{20,}"), "<REDACTED:openai_key>", "openai_key"),
     (re.compile(r"sk-[A-Za-z0-9]{20,}"), "<REDACTED:openai_key>", "openai_key"),
+    # Fine-grained GitHub PATs (github_pat_<22>_<59>) must precede the classic
+    # gh[posru]_ rule — the underscore mid-body and the ``i`` after ``gh`` make
+    # them invisible to that pattern, so a bare token would otherwise pass
+    # through unredacted into a published issue.
+    (
+        re.compile(r"github_pat_[A-Za-z0-9_]{50,}"),
+        "<REDACTED:github_token>",
+        "github_token",
+    ),
     (re.compile(r"gh[posru]_[A-Za-z0-9]{20,}"), "<REDACTED:github_token>", "github_token"),
     (re.compile(r"xox[baprs]-[A-Za-z0-9\-]{10,}"), "<REDACTED:slack_token>", "slack_token"),
     (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "<REDACTED:aws_key>", "aws_key"),

--- a/reflect-kb/src/reflect_kb/issues/sanitize.py
+++ b/reflect-kb/src/reflect_kb/issues/sanitize.py
@@ -1,0 +1,221 @@
+"""Privacy sanitizer — the gate every byte crosses before it can leave the
+machine for a GitHub issue.
+
+Ported from agent-deck's ``sanitize.py`` (regex Layer 1). This is a
+publish-to-external action, so the posture is deliberately conservative:
+over-redact rather than under-redact. The substitutions run in a fixed,
+load-bearing order (secrets first, then coarser identifiers) so a token that
+also looks like a hex blob is caught as a token, not weakened to ``<hash>``.
+
+What it strips (in order)
+-------------------------
+1. **Caller-supplied maps** — exact ``key=value`` replacements for known
+   business/project names the regexes can't know about.
+2. **Secrets (highest priority)**
+   * Anthropic keys      ``sk-ant-…``            → ``<REDACTED:anthropic_key>``
+   * OpenAI keys         ``sk-proj-…`` / ``sk-…``→ ``<REDACTED:openai_key>``
+   * GitHub tokens       ``gh[posru]_…``         → ``<REDACTED:github_token>``
+   * AWS access keys     ``AKIA…`` (20 chars)    → ``<REDACTED:aws_key>``
+   * Telegram bot tokens ``\\d{8,12}:[…]{30,}``    → ``<REDACTED:telegram_token>``
+   * JWTs                ``eyJ…\\.…\\.…``           → ``<REDACTED:jwt>``
+   * Slack tokens        ``xox[baprs]-…``         → ``<REDACTED:slack_token>``
+   * Private keys        PEM ``-----BEGIN … KEY-----`` blocks → ``<REDACTED:private_key>``
+   * Generic ``KEY=value`` where KEY ∈ {token, key, secret, password, api_key,
+     auth, authorization} and value is ≥12 chars → ``KEY=<REDACTED:generic_secret>``
+3. **Emails**                → ``<REDACTED:email>``
+4. **IPv4 addresses**        → ``<REDACTED:ipv4>``
+5. **Home paths** ``/Users/<u>`` / ``/home/<u>`` → ``/Users/<user>`` etc.;
+   ``/tmp/…`` → ``/tmp/<scratch>``; ``.worktrees/<name>`` → ``.worktrees/<branch>``
+6. **Full UUIDs** (8-4-4-4-12)             → ``<REDACTED:uuid>``
+7. **Long hex strings** (≥20 chars)        → ``<REDACTED:hash>``
+
+After substitution a non-mutating audit pass flags anything that still *looks*
+suspicious (base64 blobs, residual long hex, env-var assignments, phone-shaped
+numbers, private IP ranges) so a human reviewer — or a failing test — sees it.
+
+The function is pure: it returns a :class:`SanitizeResult` and never writes
+files or makes network calls.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+# ── Layer 2: secret patterns (ordered; most specific first) ──────────────────
+# Each entry is (compiled_regex, replacement, kind). ``kind`` is surfaced in
+# the result's ``redactions`` tally so callers can report exactly what was
+# stripped.
+
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "<REDACTED:anthropic_key>", "anthropic_key"),
+    (re.compile(r"sk-proj-[A-Za-z0-9_\-]{20,}"), "<REDACTED:openai_key>", "openai_key"),
+    (re.compile(r"sk-[A-Za-z0-9]{20,}"), "<REDACTED:openai_key>", "openai_key"),
+    (re.compile(r"gh[posru]_[A-Za-z0-9]{20,}"), "<REDACTED:github_token>", "github_token"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9\-]{10,}"), "<REDACTED:slack_token>", "slack_token"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "<REDACTED:aws_key>", "aws_key"),
+    (
+        re.compile(r"\b\d{8,12}:[A-Za-z0-9_\-]{30,}\b"),
+        "<REDACTED:telegram_token>",
+        "telegram_token",
+    ),
+    (
+        re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+"),
+        "<REDACTED:jwt>",
+        "jwt",
+    ),
+    (
+        re.compile(
+            r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"
+            r".*?-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+        "<REDACTED:private_key>",
+        "private_key",
+    ),
+]
+
+# Generic KEY=value / KEY: value secret. The keyword set and the {12,} value
+# length threshold are load-bearing (mirrors agent-deck GENERIC_SECRET_RE).
+# The ``(?!<REDACTED:)`` guard stops this coarse rule from re-redacting a
+# placeholder a more specific earlier rule already wrote (e.g. a PEM block that
+# happened to follow the literal text "key:").
+_GENERIC_SECRET_RE = re.compile(
+    r"\b(token|key|secret|password|api[_-]?key|auth(?:orization)?)\b"
+    r"(\s*[:=]\s*)"
+    r"(['\"]?)(?!<REDACTED:)([^\s'\"]{12,})\3",
+    re.IGNORECASE,
+)
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+_LONG_HEX_RE = re.compile(r"\b[0-9a-f]{20,}\b")
+
+# Home/scratch paths. ``<user>`` is the placeholder; we keep the OS-specific
+# prefix (/Users vs /home) so the report still reads naturally.
+_HOME_PATH_RE = re.compile(r"/(Users|home)/[^/\s]+")
+_TMP_PATH_RE = re.compile(r"/tmp/[^\s'\"]+")
+_VAR_PATH_RE = re.compile(r"/var/(?:folders|tmp)/[^\s'\"]+")
+_WORKTREE_RE = re.compile(r"(\.?worktrees)/[^/\s'\"]+")
+
+# ── audit (non-mutating) suspicious patterns ─────────────────────────────────
+_SUSPICIOUS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\b[0-9a-f]{20,}\b"), "residual_long_hex"),
+    (re.compile(r"\b[A-Za-z0-9+/]{40,}={0,2}\b"), "possible_base64_blob"),
+    (re.compile(r"\b\w+\s*=\s*\S{8,}"), "env_var_assignment"),
+    (re.compile(r"\b\+?\d[\d\s\-().]{8,}\d\b"), "possible_phone_number"),
+    (re.compile(r"\b(?:10|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d"), "private_ip_range"),
+]
+
+
+@dataclass
+class SanitizeResult:
+    """Outcome of one sanitize pass.
+
+    Attributes:
+        text: the sanitized output (safe to publish).
+        redactions: ``{kind: count}`` of substitutions actually applied.
+        audit: list of ``{kind, line, snippet}`` for residual suspicious matches
+            a human should eyeball. Non-empty ``audit`` does NOT mean unsafe —
+            it means "look here"; callers decide policy.
+    """
+
+    text: str
+    redactions: dict[str, int] = field(default_factory=dict)
+    audit: list[dict] = field(default_factory=list)
+
+    @property
+    def total_redactions(self) -> int:
+        return sum(self.redactions.values())
+
+
+def _bump(tally: dict[str, int], kind: str, n: int) -> None:
+    if n:
+        tally[kind] = tally.get(kind, 0) + n
+
+
+def sanitize(text: str, *, maps: Optional[dict[str, str]] = None) -> SanitizeResult:
+    """Sanitize ``text`` for external publication.
+
+    Args:
+        text: raw content (a distilled transcript, a drafted issue body, …).
+        maps: caller-supplied exact substitutions (e.g. ``{"AcmeCorp":
+            "<company>"}``) applied before the regex layers.
+
+    Returns:
+        A :class:`SanitizeResult`. The function is pure.
+    """
+    tally: dict[str, int] = {}
+    out = text
+
+    # 1. Caller maps first — they win over everything (business/project names).
+    if maps:
+        for needle, replacement in maps.items():
+            if not needle:
+                continue
+            count = out.count(needle)
+            if count:
+                out = out.replace(needle, replacement)
+                _bump(tally, "custom_map", count)
+
+    # 2. Secrets (highest priority, ordered most-specific first).
+    for pattern, replacement, kind in _SECRET_PATTERNS:
+        out, n = pattern.subn(replacement, out)
+        _bump(tally, kind, n)
+
+    def _generic(m: re.Match[str]) -> str:
+        return f"{m.group(1)}{m.group(2)}<REDACTED:generic_secret>"
+
+    out, n = _GENERIC_SECRET_RE.subn(_generic, out)
+    _bump(tally, "generic_secret", n)
+
+    # 3. Emails.
+    out, n = _EMAIL_RE.subn("<REDACTED:email>", out)
+    _bump(tally, "email", n)
+
+    # 4. IPv4 (after emails so an email's domain isn't mistaken for an IP).
+    out, n = _IPV4_RE.subn("<REDACTED:ipv4>", out)
+    _bump(tally, "ipv4", n)
+
+    # 5. Paths.
+    out, n = _HOME_PATH_RE.subn(lambda m: f"/{m.group(1)}/<user>", out)
+    _bump(tally, "home_path", n)
+    out, n = _TMP_PATH_RE.subn("/tmp/<scratch>", out)
+    _bump(tally, "tmp_path", n)
+    out, n = _VAR_PATH_RE.subn("/var/<system>", out)
+    _bump(tally, "var_path", n)
+    out, n = _WORKTREE_RE.subn(lambda m: f"{m.group(1)}/<branch>", out)
+    _bump(tally, "worktree_path", n)
+
+    # 6. Full UUIDs.
+    out, n = _UUID_RE.subn("<REDACTED:uuid>", out)
+    _bump(tally, "uuid", n)
+
+    # 7. Long hex (last — secrets/UUIDs already consumed the structured ones).
+    out, n = _LONG_HEX_RE.subn("<REDACTED:hash>", out)
+    _bump(tally, "long_hex", n)
+
+    return SanitizeResult(text=out, redactions=tally, audit=_audit(out))
+
+
+def _audit(text: str) -> list[dict]:
+    """Non-mutating scan for residual suspicious tokens, by line."""
+    findings: list[dict] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for pattern, kind in _SUSPICIOUS:
+            m = pattern.search(line)
+            if m:
+                snippet = m.group(0)
+                findings.append(
+                    {
+                        "kind": kind,
+                        "line": lineno,
+                        "snippet": snippet[:80],
+                    }
+                )
+    return findings

--- a/reflect-kb/src/reflect_kb/reflect_config.py
+++ b/reflect-kb/src/reflect_kb/reflect_config.py
@@ -1,0 +1,81 @@
+"""Read-only loader for ``reflect.toml``.
+
+The reflect ecosystem ships a ``reflect.toml`` (under ``plugins/reflect/``) that
+documents tunables for several modes. Historically the ``reflect issues`` CLI
+hard-coded its click defaults and never consulted that file, so the documented
+``[issues]`` block (``repo`` / ``limit`` / ``model``) was inert.
+
+This module loads the config once and exposes the parsed table. Resolution
+order (first hit wins):
+
+1. ``$REFLECT_CONFIG`` — explicit path override.
+2. ``$REFLECT_STATE_DIR/reflect.toml`` — alongside the queue/ledger/db.
+3. ``~/.reflect/reflect.toml`` — the default state dir.
+4. The repo-bundled ``plugins/reflect/reflect.toml`` (best-effort, by walking up
+   from this file) so an editable checkout works without extra setup.
+
+The loader is tolerant: a missing or malformed file yields ``{}`` rather than
+raising, so the CLI always has working defaults.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+_CONFIG_NAME = "reflect.toml"
+
+
+def _candidate_paths() -> list[Path]:
+    candidates: list[Path] = []
+
+    override = os.environ.get("REFLECT_CONFIG")
+    if override:
+        candidates.append(Path(override).expanduser())
+
+    state_dir = os.environ.get("REFLECT_STATE_DIR")
+    if state_dir:
+        candidates.append(Path(state_dir).expanduser() / _CONFIG_NAME)
+
+    candidates.append(Path.home() / ".reflect" / _CONFIG_NAME)
+
+    # Walk up from this file looking for plugins/reflect/reflect.toml so an
+    # editable repo checkout picks up the bundled defaults.
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        bundled = parent / "plugins" / "reflect" / _CONFIG_NAME
+        if bundled.exists():
+            candidates.append(bundled)
+            break
+
+    return candidates
+
+
+def config_path() -> Optional[Path]:
+    """Return the first existing ``reflect.toml`` in resolution order, or None."""
+    for path in _candidate_paths():
+        if path.exists():
+            return path
+    return None
+
+
+@lru_cache(maxsize=1)
+def load_config() -> dict:
+    """Load and parse ``reflect.toml``. Returns ``{}`` if absent/unreadable."""
+    path = config_path()
+    if path is None:
+        return {}
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def issues_config() -> dict:
+    """Return the ``[issues]`` table (``{}`` if missing)."""
+    table = load_config().get("issues", {})
+    return table if isinstance(table, dict) else {}

--- a/reflect-kb/tests/test_issues_analyze.py
+++ b/reflect-kb/tests/test_issues_analyze.py
@@ -1,0 +1,76 @@
+"""Tests for the analyze step (LLM -> candidate issues), with injected runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from reflect_kb.issues.analyze import analyze
+
+
+def _runner_returning(stdout: str):
+    def run(cmd):
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    return run
+
+
+def test_empty_timelines_short_circuit():
+    cands, reason = analyze([], runner=_runner_returning("[]"))
+    assert cands == []
+    assert reason == "no-timelines"
+
+
+def test_parses_bare_json_array():
+    payload = json.dumps(
+        [
+            {"title": "Bug A", "body": "## Summary\nx", "labels": ["bug", "cli"]},
+        ]
+    )
+    cands, reason = analyze(["timeline"], runner=_runner_returning(payload))
+    assert reason == "ok"
+    assert len(cands) == 1
+    assert cands[0].title == "Bug A"
+    assert cands[0].labels == ["bug", "cli"]
+
+
+def test_parses_json_wrapped_in_claude_envelope():
+    inner = json.dumps([{"title": "Bug B", "body": "b"}])
+    envelope = json.dumps({"result": inner})
+    cands, reason = analyze(["timeline"], runner=_runner_returning(envelope))
+    assert reason == "ok"
+    assert cands[0].title == "Bug B"
+
+
+def test_extracts_array_from_surrounding_prose():
+    noisy = 'Here are findings:\n[{"title": "Bug C", "body": "c"}]\nDone.'
+    cands, reason = analyze(["timeline"], runner=_runner_returning(noisy))
+    assert reason == "ok"
+    assert cands[0].title == "Bug C"
+
+
+def test_drops_items_missing_title_or_body():
+    payload = json.dumps(
+        [
+            {"title": "", "body": "x"},
+            {"title": "y", "body": ""},
+            {"title": "Valid", "body": "ok"},
+        ]
+    )
+    cands, reason = analyze(["timeline"], runner=_runner_returning(payload))
+    assert [c.title for c in cands] == ["Valid"]
+
+
+def test_unparseable_output_degrades():
+    cands, reason = analyze(["timeline"], runner=_runner_returning("totally not json"))
+    assert cands == []
+    assert reason == "unparseable"
+
+
+def test_runner_error_degrades_gracefully():
+    def boom(cmd):
+        raise FileNotFoundError("claude missing")
+
+    cands, reason = analyze(["timeline"], runner=boom)
+    assert cands == []
+    assert reason.startswith("claude-error")

--- a/reflect-kb/tests/test_issues_cli.py
+++ b/reflect-kb/tests/test_issues_cli.py
@@ -9,9 +9,20 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from click.testing import CliRunner
 
+from reflect_kb import reflect_config
 from reflect_kb.cli.learnings_cli import cli
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_cache():
+    # load_config is lru_cached; clear around every test so a config set by one
+    # test (via REFLECT_CONFIG) never bleeds into the next.
+    reflect_config.load_config.cache_clear()
+    yield
+    reflect_config.load_config.cache_clear()
 
 
 def test_issues_group_is_registered():
@@ -46,3 +57,60 @@ def test_ledger_empty_json(monkeypatch, tmp_path):
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["filed_issues"] == []
+
+
+def test_issues_config_limit_override_is_honored(monkeypatch, tmp_path):
+    # A [issues].limit in reflect.toml must be used as the default when --limit
+    # is unset, instead of the hard-coded 20.
+    from reflect_kb import reflect_config
+    from reflect_kb.cli import issues_cli
+
+    cfg = tmp_path / "reflect.toml"
+    cfg.write_text('[issues]\nlimit = 7\nmodel = "opus"\n', encoding="utf-8")
+    monkeypatch.setenv("REFLECT_CONFIG", str(cfg))
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    reflect_config.load_config.cache_clear()
+
+    captured: dict = {}
+
+    def fake_run_issues(**kwargs):
+        captured.update(kwargs)
+        from reflect_kb.issues.pipeline import IssuesRunResult
+
+        return IssuesRunResult(dry_run=True)
+
+    monkeypatch.setattr(issues_cli, "run_issues", fake_run_issues)
+
+    result = CliRunner().invoke(cli, ["issues", "run", "--dry-run", "-f", "json"])
+    assert result.exit_code == 0, result.output
+    assert captured["limit"] == 7
+    assert captured["model"] == "opus"
+
+    reflect_config.load_config.cache_clear()
+
+
+def test_explicit_limit_flag_overrides_config(monkeypatch, tmp_path):
+    from reflect_kb import reflect_config
+    from reflect_kb.cli import issues_cli
+
+    cfg = tmp_path / "reflect.toml"
+    cfg.write_text("[issues]\nlimit = 7\n", encoding="utf-8")
+    monkeypatch.setenv("REFLECT_CONFIG", str(cfg))
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    reflect_config.load_config.cache_clear()
+
+    captured: dict = {}
+
+    def fake_run_issues(**kwargs):
+        captured.update(kwargs)
+        from reflect_kb.issues.pipeline import IssuesRunResult
+
+        return IssuesRunResult(dry_run=True)
+
+    monkeypatch.setattr(issues_cli, "run_issues", fake_run_issues)
+
+    result = CliRunner().invoke(cli, ["issues", "run", "--dry-run", "--limit", "3", "-f", "json"])
+    assert result.exit_code == 0, result.output
+    assert captured["limit"] == 3
+
+    reflect_config.load_config.cache_clear()

--- a/reflect-kb/tests/test_issues_cli.py
+++ b/reflect-kb/tests/test_issues_cli.py
@@ -1,0 +1,48 @@
+"""CLI smoke tests for ``reflect issues`` via click's CliRunner.
+
+These confirm the command is wired into the ``reflect`` group and that the
+``--dry-run`` JSON contract is stable (the orchestration itself is covered in
+depth by test_issues_pipeline.py).
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from reflect_kb.cli.learnings_cli import cli
+
+
+def test_issues_group_is_registered():
+    result = CliRunner().invoke(cli, ["issues", "--help"])
+    assert result.exit_code == 0
+    assert "run" in result.output
+    assert "ledger" in result.output
+    assert "queue" in result.output
+
+
+def test_map_flag_rejects_bad_syntax(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    result = CliRunner().invoke(cli, ["issues", "run", "--dry-run", "--map", "no-equals"])
+    assert result.exit_code != 0
+    assert "KEY=VALUE" in result.output
+
+
+def test_dry_run_empty_queue_json(monkeypatch, tmp_path):
+    # Point the state dir at an empty tmp so there is no queue -> clean result.
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    result = CliRunner().invoke(cli, ["issues", "run", "--dry-run", "-f", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert payload["transcripts_seen"] == 0
+    assert payload["filed"] == []
+
+
+def test_ledger_empty_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+    result = CliRunner().invoke(cli, ["issues", "ledger", "-f", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["filed_issues"] == []

--- a/reflect-kb/tests/test_issues_dedupe.py
+++ b/reflect-kb/tests/test_issues_dedupe.py
@@ -1,0 +1,115 @@
+"""Tests for issue fingerprinting + 3-layer deduplication."""
+
+from __future__ import annotations
+
+import subprocess
+
+from reflect_kb.issues.dedupe import (
+    CandidateIssue,
+    fetch_existing_titles,
+    fingerprint,
+    load_ledger,
+    partition_candidates,
+    record_filed,
+    save_ledger,
+)
+
+
+def _cand(title: str) -> CandidateIssue:
+    return CandidateIssue(title=title, body="body", labels=["bug"])
+
+
+def test_fingerprint_is_slug_and_stable():
+    assert fingerprint("CLI crashes on missing config!") == "cli-crashes-on-missing-config"
+    assert fingerprint("CLI crashes on missing config") == fingerprint(
+        "cli crashes on missing config"
+    )
+    assert fingerprint("") == "untitled"
+    assert len(fingerprint("x " * 100)) <= 60
+
+
+def test_in_batch_duplicates_collapse():
+    cands = [_cand("Timeout in drain loop"), _cand("Timeout in drain loop!")]
+    decisions = partition_candidates(cands)
+    keeps = [d for d in decisions if d.keep]
+    drops = [d for d in decisions if not d.keep]
+    assert len(keeps) == 1
+    assert len(drops) == 1
+    assert drops[0].reason == "dup-in-batch"
+
+
+def test_ledger_duplicate_is_skipped():
+    ledger = {"version": 1, "filed_issues": []}
+    record_filed(ledger, _cand("Race in plugin spawn"), gh_issue_number=5)
+    decisions = partition_candidates([_cand("Race in plugin spawn")], ledger=ledger)
+    assert not decisions[0].keep
+    assert decisions[0].reason == "dup-in-ledger"
+
+
+def test_existing_github_exact_title_skipped():
+    decisions = partition_candidates(
+        [_cand("Reflect drain double-files issues")],
+        existing_titles=["Reflect drain double-files issues"],
+    )
+    assert not decisions[0].keep
+    assert decisions[0].reason == "dup-on-github"
+
+
+def test_existing_github_token_overlap_skipped():
+    # >=50% token overlap with an existing title marks it a dup.
+    decisions = partition_candidates(
+        [_cand("Sanitizer misses telegram bot tokens")],
+        existing_titles=["telegram bot tokens not redacted by sanitizer"],
+    )
+    assert not decisions[0].keep
+    assert decisions[0].reason == "dup-on-github"
+
+
+def test_genuinely_new_candidate_is_kept():
+    decisions = partition_candidates(
+        [_cand("Completely unrelated new finding about csv export")],
+        existing_titles=["something about authentication flow"],
+    )
+    assert decisions[0].keep
+    assert decisions[0].reason == "new"
+
+
+def test_ledger_roundtrip_atomic(tmp_path):
+    path = tmp_path / "filed_issues.json"
+    ledger = load_ledger(path)
+    assert ledger["filed_issues"] == []
+    record_filed(
+        ledger, _cand("First issue"), gh_issue_number=1, gh_url="https://github.com/o/r/issues/1"
+    )
+    save_ledger(ledger, path)
+
+    reloaded = load_ledger(path)
+    assert len(reloaded["filed_issues"]) == 1
+    assert reloaded["filed_issues"][0]["fingerprint"] == fingerprint("First issue")
+    assert reloaded["filed_issues"][0]["gh_issue_number"] == 1
+    # No stray .tmp left behind.
+    assert not (tmp_path / "filed_issues.json.tmp").exists()
+
+
+def test_corrupt_ledger_recovers_to_empty(tmp_path):
+    path = tmp_path / "filed_issues.json"
+    path.write_text("{ not valid json", encoding="utf-8")
+    assert load_ledger(path) == {"version": 1, "filed_issues": []}
+
+
+def test_fetch_existing_titles_parses_gh_json():
+    def fake_runner(cmd):
+        assert cmd[:3] == ["gh", "issue", "list"]
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout='[{"title": "a bug"}, {"title": "b bug"}]', stderr=""
+        )
+
+    titles = fetch_existing_titles("o/r", runner=fake_runner)
+    assert titles == ["a bug", "b bug"]
+
+
+def test_fetch_existing_titles_degrades_when_gh_missing():
+    def boom(cmd):
+        raise FileNotFoundError("gh not installed")
+
+    assert fetch_existing_titles("o/r", runner=boom) == []

--- a/reflect-kb/tests/test_issues_dedupe.py
+++ b/reflect-kb/tests/test_issues_dedupe.py
@@ -56,13 +56,14 @@ def test_existing_github_exact_title_skipped():
 
 
 def test_existing_github_token_overlap_skipped():
-    # >=50% token overlap with an existing title marks it a dup.
+    # High symmetric-Jaccard overlap (near-identical titles) is still caught,
+    # but surfaced distinctly as a fuzzy overlap match, not an exact one.
     decisions = partition_candidates(
-        [_cand("Sanitizer misses telegram bot tokens")],
-        existing_titles=["telegram bot tokens not redacted by sanitizer"],
+        [_cand("sanitizer misses telegram bot tokens")],
+        existing_titles=["sanitizer misses telegram bot tokens entirely"],
     )
     assert not decisions[0].keep
-    assert decisions[0].reason == "dup-on-github"
+    assert decisions[0].reason == "dup-on-github-overlap"
 
 
 def test_genuinely_new_candidate_is_kept():
@@ -71,6 +72,19 @@ def test_genuinely_new_candidate_is_kept():
         existing_titles=["something about authentication flow"],
     )
     assert decisions[0].keep
+    assert decisions[0].reason == "new"
+
+
+def test_short_new_title_not_suppressed_by_long_unrelated_existing():
+    # Regression for the asymmetric-overlap false-positive: a short genuine new
+    # issue sharing one incidental word with a long unrelated existing issue
+    # must NOT be suppressed. 'Drain loop hangs' vs 'loop counter wrong in
+    # metrics drain' share {loop, drain} but describe different problems.
+    decisions = partition_candidates(
+        [_cand("Drain loop hangs")],
+        existing_titles=["loop counter wrong in metrics drain reporting code"],
+    )
+    assert decisions[0].keep, decisions[0].reason
     assert decisions[0].reason == "new"
 
 

--- a/reflect-kb/tests/test_issues_distill.py
+++ b/reflect-kb/tests/test_issues_distill.py
@@ -1,0 +1,142 @@
+"""Tests for transcript distillation (~30x compression, no LLM)."""
+
+from __future__ import annotations
+
+import json
+
+from reflect_kb.issues.distill import NOISE_TYPES, distill, distill_file, distill_text
+
+
+def _line(obj: dict) -> str:
+    return json.dumps(obj)
+
+
+def _user(text: str, uuid: str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee") -> str:
+    return _line(
+        {
+            "uuid": uuid,
+            "timestamp": "2026-06-14T10:00:00.123Z",
+            "message": {"role": "user", "content": text},
+        }
+    )
+
+
+def _assistant_text(text: str) -> str:
+    return _line(
+        {
+            "uuid": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-06-14T10:01:00Z",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+        }
+    )
+
+
+def _assistant_tool(name: str, inp: dict) -> str:
+    return _line(
+        {
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": name, "input": inp}],
+            }
+        }
+    )
+
+
+def _tool_error(payload: str) -> str:
+    return _line(
+        {
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "is_error": True, "content": payload}],
+            }
+        }
+    )
+
+
+def _tool_success(payload: str) -> str:
+    return _line(
+        {
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "is_error": False, "content": payload}],
+            }
+        }
+    )
+
+
+def test_keeps_user_assistant_tool_and_error_lines():
+    lines = [
+        _user("please fix the failing test"),
+        _assistant_text("Looking into it now."),
+        _assistant_tool("Bash", {"command": "cargo test " + "x" * 500}),
+        _tool_error("thread 'main' panicked at lib.rs"),
+    ]
+    md, stats = distill(lines)
+
+    assert "USER: please fix the failing test" in md
+    assert "ASSIST: Looking into it now." in md
+    assert "TOOL: Bash | cargo test" in md
+    assert "ERROR: thread 'main' panicked" in md
+    assert stats.kept_user == 1
+    assert stats.kept_assist == 1
+    assert stats.kept_tool_use == 1
+    assert stats.kept_error == 1
+
+
+def test_drops_noise_types_and_successful_tool_results():
+    lines = [_line({"type": t}) for t in NOISE_TYPES]
+    lines.append(_tool_success("ok, 42 files scanned, big output " + "z" * 2000))
+    md, stats = distill(lines)
+
+    assert stats.dropped_noise == len(NOISE_TYPES)
+    # No USER/TOOL/ASSIST/ERROR rows survive — only the header.
+    assert stats.kept_total == 0
+    assert "big output" not in md
+
+
+def test_heartbeat_and_skill_load_classification():
+    lines = [
+        _user("[HEARTBEAT] still alive"),
+        _user("Base directory for this skill: /x/reflect\nmore"),
+    ]
+    md, stats = distill(lines)
+    assert "HEARTBEAT" in md
+    assert "SKILL_LOAD:" in md
+    assert stats.kept_heartbeat == 1
+    assert stats.kept_skill_load == 1
+
+
+def test_bash_command_is_clipped():
+    long_cmd = "echo " + "a" * 1000
+    md, _ = distill([_assistant_tool("Bash", {"command": long_cmd})])
+    # The clipped command must be far shorter than the raw 1000-char command.
+    tool_line = [ln for ln in md.splitlines() if "TOOL: Bash" in ln][0]
+    assert len(tool_line) < 300
+    assert "…" in tool_line
+
+
+def test_compression_ratio_is_reported_and_real():
+    # Build a transcript dominated by successful tool-result noise.
+    noise = "\n".join(_tool_success("x" * 3000) for _ in range(40))
+    signal = "\n".join([_user("fix bug"), _assistant_text("done")])
+    raw = noise + "\n" + signal
+    md, stats = distill_text(raw)
+    assert stats.src_bytes > stats.dst_bytes
+    assert stats.compression > 5.0  # heavy noise -> big ratio
+
+
+def test_distill_file_writes_output(tmp_path):
+    src = tmp_path / "t.jsonl"
+    src.write_text(_user("hello") + "\n" + _assistant_text("hi"), encoding="utf-8")
+    dst = tmp_path / "out" / "t.md"
+    stats = distill_file(src, dst)
+    assert dst.exists()
+    assert "USER: hello" in dst.read_text()
+    assert stats.compression >= 0.0
+
+
+def test_malformed_lines_are_skipped():
+    lines = ["not json", "", _user("real line"), "{bad json"]
+    md, stats = distill(lines)
+    assert stats.kept_user == 1
+    assert "USER: real line" in md

--- a/reflect-kb/tests/test_issues_manifest.py
+++ b/reflect-kb/tests/test_issues_manifest.py
@@ -57,6 +57,28 @@ def test_dedupes_by_resolved_path_keeping_latest(tmp_path):
     assert refs[0].session_id == "second"  # latest enqueue wins
 
 
+def test_duplicate_path_reorders_to_latest_enqueue(tmp_path):
+    # A path enqueued EARLY then re-enqueued LATE must sort as "most recent",
+    # not stay frozen at its original insertion position. With limit=2 over the
+    # sequence [a, b, c, a] the survivors are [b, a] — a moved past b/c on its
+    # second enqueue. A naive dict-update keeps a at index 0 and would instead
+    # return [c-ish, ...], so this guards the de-dup ordering regression.
+    a = _touch(tmp_path, "a.jsonl")
+    b = _touch(tmp_path, "b.jsonl")
+    c = _touch(tmp_path, "c.jsonl")
+    qf = _write_queue(
+        tmp_path,
+        [
+            {"session_id": "a-old", "transcript_path": str(a), "trigger": "precompact"},
+            {"session_id": "b", "transcript_path": str(b), "trigger": "stop"},
+            {"session_id": "c", "transcript_path": str(c), "trigger": "stop"},
+            {"session_id": "a-new", "transcript_path": str(a), "trigger": "stop"},
+        ],
+    )
+    refs = gather_transcripts(queue=qf, limit=2)
+    assert [r.session_id for r in refs] == ["c", "a-new"]
+
+
 def test_limit_keeps_most_recent(tmp_path):
     paths = [_touch(tmp_path, f"t{i}.jsonl") for i in range(5)]
     qf = _write_queue(

--- a/reflect-kb/tests/test_issues_manifest.py
+++ b/reflect-kb/tests/test_issues_manifest.py
@@ -1,0 +1,83 @@
+"""Tests for sourcing recent transcripts from the existing reflect queue."""
+
+from __future__ import annotations
+
+import json
+
+from reflect_kb.issues.manifest import gather_transcripts
+
+
+def _write_queue(tmp_path, entries):
+    qf = tmp_path / "pending_reflections.jsonl"
+    with open(qf, "w", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+    return qf
+
+
+def _touch(tmp_path, name):
+    p = tmp_path / name
+    p.write_text("{}\n", encoding="utf-8")
+    return p
+
+
+def test_empty_or_missing_queue_returns_empty(tmp_path):
+    assert gather_transcripts(queue=tmp_path / "nope.jsonl") == []
+
+
+def test_reads_existing_transcripts_only(tmp_path):
+    present = _touch(tmp_path, "present.jsonl")
+    qf = _write_queue(
+        tmp_path,
+        [
+            {"session_id": "s1", "transcript_path": str(present), "trigger": "stop"},
+            {
+                "session_id": "s2",
+                "transcript_path": str(tmp_path / "gone.jsonl"),
+                "trigger": "stop",
+            },
+        ],
+    )
+    refs = gather_transcripts(queue=qf)
+    assert [r.session_id for r in refs] == ["s1"]
+    assert refs[0].transcript_path == present.resolve()
+
+
+def test_dedupes_by_resolved_path_keeping_latest(tmp_path):
+    present = _touch(tmp_path, "p.jsonl")
+    qf = _write_queue(
+        tmp_path,
+        [
+            {"session_id": "first", "transcript_path": str(present), "trigger": "precompact"},
+            {"session_id": "second", "transcript_path": str(present), "trigger": "stop"},
+        ],
+    )
+    refs = gather_transcripts(queue=qf)
+    assert len(refs) == 1
+    assert refs[0].session_id == "second"  # latest enqueue wins
+
+
+def test_limit_keeps_most_recent(tmp_path):
+    paths = [_touch(tmp_path, f"t{i}.jsonl") for i in range(5)]
+    qf = _write_queue(
+        tmp_path,
+        [
+            {"session_id": f"s{i}", "transcript_path": str(p), "trigger": "stop"}
+            for i, p in enumerate(paths)
+        ],
+    )
+    refs = gather_transcripts(queue=qf, limit=2)
+    assert [r.session_id for r in refs] == ["s3", "s4"]
+
+
+def test_malformed_lines_skipped(tmp_path):
+    present = _touch(tmp_path, "ok.jsonl")
+    qf = tmp_path / "pending_reflections.jsonl"
+    qf.write_text(
+        "not json\n"
+        + json.dumps({"session_id": "ok", "transcript_path": str(present), "trigger": "stop"})
+        + "\n{bad\n",
+        encoding="utf-8",
+    )
+    refs = gather_transcripts(queue=qf)
+    assert [r.session_id for r in refs] == ["ok"]

--- a/reflect-kb/tests/test_issues_pipeline.py
+++ b/reflect-kb/tests/test_issues_pipeline.py
@@ -222,6 +222,71 @@ def test_candidate_is_sanitized_before_filing(tmp_path):
     assert github_prefix not in blob
 
 
+def test_residual_audit_flags_are_surfaced_on_result(tmp_path):
+    # A base64-ish blob the sanitizer can't redact must still reach the run
+    # result's audit so a reviewer (or the CLI) sees it — the audit must NOT be
+    # discarded the way it was before _sanitize_candidate dropped it.
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    blob = "Zm9vYmFyYmF6" * 5  # 60 chars base64-ish, no known secret shape
+    cand = CandidateIssue(
+        title="New finding with a suspicious blob",
+        body=f"## Summary\nresidual data: {blob}",
+        labels=["bug"],
+    )
+    result = run_issues(
+        dry_run=True,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=_FakeGh(),
+        fetch_titles=lambda: [],
+    )
+    kinds = {f["kind"] for f in result.audit}
+    assert "possible_base64_blob" in kinds
+    # Each finding is attributed to the candidate it came from.
+    assert all("candidate" in f for f in result.audit)
+
+
+def test_ledger_saved_incrementally_after_each_file(tmp_path):
+    # The ledger must be persisted after EACH successful file, so a crash
+    # mid-loop still records the issues already filed. Simulate a crash on the
+    # 2nd create: the 1st must already be on disk.
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    ledger = tmp_path / "filed.json"
+    cands = [
+        CandidateIssue(title="First brand new finding", body="b", labels=["bug"]),
+        CandidateIssue(title="Second brand new finding", body="b", labels=["bug"]),
+    ]
+
+    from reflect_kb.issues.dedupe import load_ledger
+
+    class _CrashOnSecondCreate(_FakeGh):
+        def __call__(self, cmd):
+            if cmd[:3] == ["gh", "issue", "create"] and len(self.created) >= 1:
+                raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+            return super().__call__(cmd)
+
+    fake_gh = _CrashOnSecondCreate()
+    result = run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=ledger,
+        analyze_fn=_analyzer(cands),
+        gh_runner=fake_gh,
+        fetch_titles=lambda: [],
+    )
+    # First filed, second failed — but the first is already persisted.
+    assert result.filed_count == 1
+    assert ledger.exists()
+    saved = load_ledger(ledger)
+    fps = {e["fingerprint"] for e in saved["filed_issues"]}
+    from reflect_kb.issues.dedupe import fingerprint
+
+    assert fingerprint("First brand new finding") in fps
+
+
 def test_empty_queue_returns_clean_result(tmp_path):
     result = run_issues(
         dry_run=True, queue=tmp_path / "nonexistent.jsonl", ledger_path=tmp_path / "filed.json"

--- a/reflect-kb/tests/test_issues_pipeline.py
+++ b/reflect-kb/tests/test_issues_pipeline.py
@@ -154,7 +154,8 @@ def test_run_files_then_second_run_files_no_duplicates(tmp_path):
         fetch_titles=lambda: [],
     )
     assert first.filed_count == 1
-    assert fake_gh1.created == ["Reflect drain double-files issues"]
+    # Filed with the default "reflect: " provenance prefix.
+    assert fake_gh1.created == ["reflect: Reflect drain double-files issues"]
     assert ledger.exists()
 
     # Second run: same candidate. The local ledger must suppress it.
@@ -184,7 +185,9 @@ def test_existing_github_issue_suppresses_filing(tmp_path):
         ledger_path=tmp_path / "filed.json",
         analyze_fn=_analyzer([cand]),
         gh_runner=fake_gh,
-        fetch_titles=lambda: ["Sanitizer drops slack tokens"],
+        # An existing issue reflect filed earlier carries the "reflect: " prefix;
+        # the decorated candidate fingerprints to the same slug and is suppressed.
+        fetch_titles=lambda: ["reflect: Sanitizer drops slack tokens"],
     )
     assert result.filed_count == 0
     assert any(d.reason == "dup-on-github" for d in result.skipped)
@@ -284,7 +287,8 @@ def test_ledger_saved_incrementally_after_each_file(tmp_path):
     fps = {e["fingerprint"] for e in saved["filed_issues"]}
     from reflect_kb.issues.dedupe import fingerprint
 
-    assert fingerprint("First brand new finding") in fps
+    # Ledger records the fingerprint of the decorated (prefixed) title.
+    assert fingerprint("reflect: First brand new finding") in fps
 
 
 def test_empty_queue_returns_clean_result(tmp_path):
@@ -329,3 +333,115 @@ def test_unknown_labels_are_filtered_out(tmp_path):
     label_idx = create_call.index("--label") + 1
     assert "frobnicate" not in create_call[label_idx]
     assert "bug" in create_call[label_idx]
+
+
+class _LabelTrackingGh:
+    """gh fake that learns labels created via ``gh label create`` so a later
+    ``gh label list`` reports them (mirrors real gh behaviour)."""
+
+    def __init__(self, initial_labels=None, existing_titles=None):
+        self.calls: list[list[str]] = []
+        self.created: list[str] = []
+        self._labels = set(initial_labels or [])
+        self._existing = existing_titles or []
+        self._n = 200
+
+    def __call__(self, cmd):
+        self.calls.append(cmd)
+        if cmd[:3] == ["gh", "issue", "list"]:
+            rows = [{"title": t} for t in self._existing]
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(rows), stderr="")
+        if cmd[:3] == ["gh", "label", "create"]:
+            self._labels.add(cmd[3])
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "label", "list"]:
+            rows = [{"name": n} for n in sorted(self._labels)]
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(rows), stderr="")
+        if cmd[:3] == ["gh", "issue", "create"]:
+            self.created.append(cmd[cmd.index("--title") + 1])
+            self._n += 1
+            url = f"https://github.com/o/r/issues/{self._n}"
+            return subprocess.CompletedProcess(cmd, 0, stdout=url + "\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+
+def test_filed_issue_gets_reflect_prefix_and_label(tmp_path):
+    # Default provenance: every filed issue is titled "reflect: ..." and the
+    # reflect label is auto-created (so it survives _filter_labels) and applied.
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    cand = CandidateIssue(title="CLI crashes on missing config", body="b", labels=["bug"])
+    gh = _LabelTrackingGh(initial_labels={"bug"})
+    run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=gh,
+        fetch_titles=lambda: [],
+    )
+    # The reflect label was auto-created.
+    assert any(c[:3] == ["gh", "label", "create"] and c[3] == "reflect" for c in gh.calls)
+    create = [c for c in gh.calls if c[:3] == ["gh", "issue", "create"]][0]
+    title = create[create.index("--title") + 1]
+    labels = create[create.index("--label") + 1]
+    assert title == "reflect: CLI crashes on missing config"
+    assert "reflect" in labels.split(",")
+    assert "bug" in labels.split(",")  # analyzer labels preserved alongside
+
+
+def test_reflect_prefix_is_idempotent(tmp_path):
+    # An analyzer that already emits a "reflect: " title must not be double-prefixed.
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    cand = CandidateIssue(title="reflect: already prefixed", body="b", labels=[])
+    gh = _LabelTrackingGh()
+    run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=gh,
+        fetch_titles=lambda: [],
+    )
+    title = gh.created[0]
+    assert title == "reflect: already prefixed"
+    assert not title.startswith("reflect: reflect:")
+
+
+def test_provenance_can_be_disabled(tmp_path):
+    # Empty title_prefix + label opt out entirely (no prefix, no reflect label).
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    cand = CandidateIssue(title="Plain finding", body="b", labels=["bug"])
+    gh = _LabelTrackingGh(initial_labels={"bug"})
+    run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=gh,
+        fetch_titles=lambda: [],
+        title_prefix="",
+        label="",
+    )
+    assert gh.created[0] == "Plain finding"
+    assert not any(c[:3] == ["gh", "label", "create"] for c in gh.calls)
+
+
+def test_reflect_prefix_shows_in_dry_run_preview(tmp_path):
+    # The dry-run preview must show exactly what would be filed — prefix included.
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    cand = CandidateIssue(title="Preview finding", body="b", labels=[])
+    gh = _LabelTrackingGh()
+    result = run_issues(
+        dry_run=True,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=gh,
+        fetch_titles=lambda: [],
+    )
+    assert "reflect: Preview finding" in result.previews[0]
+    assert "reflect" in result.previews[0]  # label shown in the preview bracket

--- a/reflect-kb/tests/test_issues_pipeline.py
+++ b/reflect-kb/tests/test_issues_pipeline.py
@@ -1,0 +1,266 @@
+"""End-to-end tests for the transcripts -> issues pipeline.
+
+Everything network/model-shaped is injected: the analyzer returns canned
+candidates, and ``gh`` is a fake that records calls. This proves the success
+criteria without auth or a model:
+
+* a run produces candidate issues from queued transcripts and files them;
+* a second run files NO duplicates (idempotent via the local ledger);
+* ``--dry-run`` prints the exact bodies and never invokes ``gh``;
+* sanitization runs before anything leaves the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+from reflect_kb.issues.dedupe import CandidateIssue
+from reflect_kb.issues.pipeline import run_issues
+
+
+def _transcript(tmp_path, name: str, *, user: str, assistant: str) -> str:
+    """Write a minimal Claude-style JSONL transcript and return its path."""
+    p = tmp_path / name
+    lines = [
+        json.dumps(
+            {
+                "uuid": "u-1",
+                "timestamp": "2026-06-14T10:00:00Z",
+                "message": {"role": "user", "content": user},
+            }
+        ),
+        json.dumps(
+            {"message": {"role": "assistant", "content": [{"type": "text", "text": assistant}]}}
+        ),
+        json.dumps(
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "name": "Bash", "input": {"command": "cargo test"}}
+                    ],
+                }
+            }
+        ),
+    ]
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(p)
+
+
+def _queue(tmp_path, transcript_paths: list[str]):
+    qf = tmp_path / "pending_reflections.jsonl"
+    with open(qf, "w", encoding="utf-8") as fh:
+        for i, tp in enumerate(transcript_paths):
+            fh.write(
+                json.dumps(
+                    {
+                        "ts": f"2026-06-14T10:0{i}:00",
+                        "session_id": f"sess-{i}",
+                        "transcript_path": tp,
+                        "trigger": "stop",
+                        "cwd": str(tmp_path),
+                    }
+                )
+                + "\n"
+            )
+    return qf
+
+
+class _FakeGh:
+    """Fake gh runner: records create calls, returns a synthetic issue URL."""
+
+    def __init__(self, existing_titles=None):
+        self.calls: list[list[str]] = []
+        self.created: list[str] = []
+        self._n = 100
+        self._existing = existing_titles or []
+
+    def __call__(self, cmd):
+        self.calls.append(cmd)
+        if cmd[:3] == ["gh", "issue", "list"]:
+            rows = [{"title": t} for t in self._existing]
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(rows), stderr="")
+        if cmd[:3] == ["gh", "label", "list"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='[{"name": "bug"}, {"name": "cli"}]', stderr=""
+            )
+        if cmd[:3] == ["gh", "issue", "create"]:
+            title = cmd[cmd.index("--title") + 1]
+            self.created.append(title)
+            self._n += 1
+            url = f"https://github.com/o/r/issues/{self._n}"
+            return subprocess.CompletedProcess(cmd, 0, stdout=url + "\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+
+def _analyzer(candidates):
+    def fn(timelines):
+        assert timelines, "analyzer should receive distilled timelines"
+        return list(candidates), "ok"
+
+    return fn
+
+
+def test_dry_run_prints_bodies_and_never_calls_gh(tmp_path):
+    tp = _transcript(tmp_path, "a.jsonl", user="cli crashes", assistant="reproduced")
+    qf = _queue(tmp_path, [tp])
+    fake_gh = _FakeGh()
+
+    result = run_issues(
+        dry_run=True,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer(
+            [
+                CandidateIssue(
+                    title="CLI crashes on missing config",
+                    body="## Summary\nIt crashes.",
+                    labels=["bug", "cli"],
+                ),
+            ]
+        ),
+        gh_runner=fake_gh,
+        fetch_titles=lambda: [],
+    )
+
+    assert result.dry_run is True
+    assert len(result.previews) == 1
+    assert "CLI crashes on missing config" in result.previews[0]
+    # gh issue create was NEVER invoked.
+    assert not any(c[:3] == ["gh", "issue", "create"] for c in fake_gh.calls)
+    # Nothing written to the ledger on a dry run.
+    assert not (tmp_path / "filed.json").exists()
+
+
+def test_run_files_then_second_run_files_no_duplicates(tmp_path):
+    tp = _transcript(tmp_path, "a.jsonl", user="drain double files", assistant="confirmed")
+    qf = _queue(tmp_path, [tp])
+    ledger = tmp_path / "filed.json"
+    cand = CandidateIssue(
+        title="Reflect drain double-files issues",
+        body="## Summary\nDuplicates filed.",
+        labels=["bug"],
+    )
+
+    fake_gh1 = _FakeGh()
+    first = run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=ledger,
+        analyze_fn=_analyzer([cand]),
+        gh_runner=fake_gh1,
+        fetch_titles=lambda: [],
+    )
+    assert first.filed_count == 1
+    assert fake_gh1.created == ["Reflect drain double-files issues"]
+    assert ledger.exists()
+
+    # Second run: same candidate. The local ledger must suppress it.
+    fake_gh2 = _FakeGh()
+    second = run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=ledger,
+        analyze_fn=_analyzer([cand]),
+        gh_runner=fake_gh2,
+        fetch_titles=lambda: [],
+    )
+    assert second.filed_count == 0
+    assert fake_gh2.created == []
+    assert any(d.reason == "dup-in-ledger" for d in second.skipped)
+
+
+def test_existing_github_issue_suppresses_filing(tmp_path):
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    cand = CandidateIssue(title="Sanitizer drops slack tokens", body="b", labels=["bug"])
+
+    fake_gh = _FakeGh()
+    result = run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=fake_gh,
+        fetch_titles=lambda: ["Sanitizer drops slack tokens"],
+    )
+    assert result.filed_count == 0
+    assert any(d.reason == "dup-on-github" for d in result.skipped)
+
+
+def test_candidate_is_sanitized_before_filing(tmp_path):
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    # Token-shaped strings are assembled at runtime so this source file holds no
+    # verbatim secret literal (GitHub push-protection trips on those).
+    anthropic_prefix = "sk-ant-"
+    github_prefix = "gh" + "p_"
+    leaky = CandidateIssue(
+        title=f"Crash at /Users/stevie/proj when token {anthropic_prefix}abcdef0123456789abcdef0123 used",
+        body=f"contact jonny@shotclubhouse.com and server 10.1.2.3 with {github_prefix}" + "a" * 36,
+        labels=["bug"],
+    )
+    fake_gh = _FakeGh()
+    result = run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([leaky]),
+        gh_runner=fake_gh,
+        fetch_titles=lambda: [],
+    )
+    assert result.filed_count == 1
+    create_call = [c for c in fake_gh.calls if c[:3] == ["gh", "issue", "create"]][0]
+    blob = " ".join(create_call)
+    # None of the secrets/PII survive into the gh invocation.
+    assert "/Users/stevie" not in blob
+    assert anthropic_prefix not in blob
+    assert "jonny@shotclubhouse.com" not in blob
+    assert "10.1.2.3" not in blob
+    assert github_prefix not in blob
+
+
+def test_empty_queue_returns_clean_result(tmp_path):
+    result = run_issues(
+        dry_run=True, queue=tmp_path / "nonexistent.jsonl", ledger_path=tmp_path / "filed.json"
+    )
+    assert result.transcripts_seen == 0
+    assert result.filed_count == 0
+    assert any("no transcripts" in n for n in result.notes)
+
+
+def test_no_candidates_records_reason(tmp_path):
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    result = run_issues(
+        dry_run=True,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=lambda timelines: ([], "no-signal"),
+        gh_runner=_FakeGh(),
+        fetch_titles=lambda: [],
+    )
+    assert result.candidates == 0
+    assert result.analyze_reason == "no-signal"
+
+
+def test_unknown_labels_are_filtered_out(tmp_path):
+    tp = _transcript(tmp_path, "a.jsonl", user="x", assistant="y")
+    qf = _queue(tmp_path, [tp])
+    # "frobnicate" is not a real repo label; _FakeGh only knows bug/cli.
+    cand = CandidateIssue(title="Some new finding", body="b", labels=["bug", "frobnicate"])
+    fake_gh = _FakeGh()
+    run_issues(
+        dry_run=False,
+        queue=qf,
+        ledger_path=tmp_path / "filed.json",
+        analyze_fn=_analyzer([cand]),
+        gh_runner=fake_gh,
+        fetch_titles=lambda: [],
+    )
+    create_call = [c for c in fake_gh.calls if c[:3] == ["gh", "issue", "create"]][0]
+    label_idx = create_call.index("--label") + 1
+    assert "frobnicate" not in create_call[label_idx]
+    assert "bug" in create_call[label_idx]

--- a/reflect-kb/tests/test_issues_sanitize.py
+++ b/reflect-kb/tests/test_issues_sanitize.py
@@ -146,3 +146,14 @@ def test_secret_wins_over_hash_classification():
     out = sanitize(token).text
     assert "<REDACTED:github_token>" in out
     assert "<REDACTED:hash>" not in out
+
+
+def test_fine_grained_github_pat_is_redacted():
+    # Fine-grained PATs (github_pat_<22>_<59>) are NOT matched by the classic
+    # gh[posru]_ rule (underscore mid-body, ``i`` after ``gh``) — a dedicated
+    # pattern must catch them or a live credential leaks into a published
+    # issue. Prefix assembled at runtime so no verbatim token lands in source.
+    token = "github" + "_pat_" + "1" * 22 + "_" + "b" * 59
+    out = sanitize(token).text
+    assert token not in out
+    assert "<REDACTED:github_token>" in out

--- a/reflect-kb/tests/test_issues_sanitize.py
+++ b/reflect-kb/tests/test_issues_sanitize.py
@@ -148,6 +148,64 @@ def test_secret_wins_over_hash_classification():
     assert "<REDACTED:hash>" not in out
 
 
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        "AWS_SECRET_ACCESS_KEY=" + _BODY + "wJalrXUtnFEMI",
+        "GITLAB_TOKEN=" + "glpat" + _BODY[:20],
+        "GOOGLE_API_KEY=" + _BODY + "AIzaSyXYZ",
+        "NPM_TOKEN=" + "npm_" + _BODY,
+    ],
+)
+def test_embedded_keyword_env_vars_are_redacted(assignment):
+    # The keyword (KEY/TOKEN) is embedded in a longer env-var name; ``_`` is a
+    # word char so a strict ``\b(key)\b`` boundary never matches and the value
+    # would leak. The relaxed surrounding-``\w*`` rule must catch them.
+    name, _, value = assignment.partition("=")
+    out = sanitize(f"export {assignment}").text
+    assert value not in out
+    assert "REDACTED" in out
+    # The env-var name is preserved, only the value is stripped.
+    assert name in out
+
+
+def test_gitlab_pat_redacted():
+    token = "glpat-" + "a" * 24
+    out = sanitize(f"clone with {token} now").text
+    assert token not in out
+    assert "<REDACTED:gitlab_token>" in out
+
+
+def test_google_api_key_redacted():
+    key = "AIza" + "Sy" + "B" * 33
+    out = sanitize(f"maps key {key}").text
+    assert key not in out
+    assert "<REDACTED:google_api_key>" in out
+
+
+def test_npm_token_redacted():
+    token = "npm_" + "z" * 36
+    out = sanitize(f"//registry.npmjs.org/:_authToken={token}").text
+    assert token not in out
+    assert "<REDACTED:npm_token>" in out
+
+
+def test_slack_webhook_url_redacted():
+    url = "https://hooks.slack.com/services/T0000/B0000/abcdefghijklmnop"
+    out = sanitize(f"posting to {url} ok").text
+    assert "abcdefghijklmnop" not in out
+    assert "<REDACTED:slack_webhook>" in out
+
+
+def test_authorization_bearer_token_redacted():
+    token = "opaqueBearerToken1234567890"
+    out = sanitize(f"Authorization: Bearer {token}").text
+    assert token not in out
+    assert "<REDACTED:bearer_token>" in out
+    # The scheme is preserved so the line still reads.
+    assert "Bearer" in out
+
+
 def test_fine_grained_github_pat_is_redacted():
     # Fine-grained PATs (github_pat_<22>_<59>) are NOT matched by the classic
     # gh[posru]_ rule (underscore mid-body, ``i`` after ``gh``) — a dedicated

--- a/reflect-kb/tests/test_issues_sanitize.py
+++ b/reflect-kb/tests/test_issues_sanitize.py
@@ -1,0 +1,148 @@
+"""Tests for the privacy sanitizer.
+
+This is the gate every byte crosses before it can leave the machine for a
+GitHub issue, so the assertions are deliberately strict: the secret/PII MUST be
+gone from the output, not merely flagged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reflect_kb.issues.sanitize import sanitize
+
+# Token-shaped fixtures are ASSEMBLED at runtime from a prefix + a synthetic
+# body so this source file never contains a verbatim secret-shaped literal
+# (which trips GitHub push-protection). The assembled strings still exercise the
+# sanitizer's regexes exactly as a real token would.
+_BODY = "abcdef0123456789abcdef0123456789"
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "sk-ant-" + "api03-" + _BODY,
+        "sk-proj-" + _BODY,
+        "sk-" + _BODY,
+        "gh" + "p_" + "abcdefghijklmnopqrstuvwxyz0123456789",
+        "gh" + "s_" + "abcdefghijklmnopqrstuvwxyz0123456789",
+        "xox" + "b-" + "1111111111-abcdefghijklmnop",
+        "AKIA" + "IOSFODNN7" + "EXAMPLE",
+    ],
+)
+def test_known_secret_shapes_are_redacted(secret):
+    out = sanitize(f"the token is {secret} ok").text
+    assert secret not in out
+    assert "REDACTED" in out
+
+
+def test_telegram_token_redacted():
+    token = "123456789:AAH" + "z" * 32
+    out = sanitize(f"bot {token}").text
+    assert token not in out
+    assert "<REDACTED:telegram_token>" in out
+
+
+def test_jwt_redacted():
+    jwt = "eyJhbGciOi.eyJzdWIiOi.SflKxwRJSMeKKF2QT4"
+    out = sanitize(f"auth {jwt}").text
+    assert jwt not in out
+    assert "<REDACTED:jwt>" in out
+
+
+def test_private_key_block_redacted():
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEAabcdef\nGHIJKLMNOP\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    out = sanitize(f"key:\n{pem}\nrest").text
+    assert "MIIEowIBAA" not in out
+    assert "<REDACTED:private_key>" in out
+
+
+def test_generic_key_value_secret_redacted():
+    out = sanitize("API_KEY=supersecretvalue12345").text
+    assert "supersecretvalue12345" not in out
+    assert "<REDACTED:generic_secret>" in out
+    # The key name is preserved, only the value is stripped.
+    assert "API_KEY=" in out
+
+
+def test_email_redacted():
+    out = sanitize("contact jonny@shotclubhouse.com please").text
+    assert "jonny@shotclubhouse.com" not in out
+    assert "<REDACTED:email>" in out
+
+
+def test_ipv4_redacted():
+    out = sanitize("server at 203.0.113.42 down").text
+    assert "203.0.113.42" not in out
+    assert "<REDACTED:ipv4>" in out
+
+
+def test_home_paths_anonymized():
+    out = sanitize("file /Users/stevie/secret/project/x.py here").text
+    assert "/Users/stevie" not in out
+    assert "/Users/<user>" in out
+
+    out2 = sanitize("file /home/ashesh/x").text
+    assert "/home/ashesh" not in out2
+    assert "/home/<user>" in out2
+
+
+def test_tmp_and_worktree_paths_anonymized():
+    out = sanitize("scratch at /tmp/build-xyz/log and .worktrees/feat-branch/x").text
+    assert "/tmp/build-xyz" not in out
+    assert "/tmp/<scratch>" in out
+    assert "feat-branch" not in out
+    assert "worktrees/<branch>" in out
+
+
+def test_uuid_and_long_hex_redacted():
+    out = sanitize(
+        "session aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee hash abcdef0123456789abcdef01"
+    ).text
+    assert "aaaaaaaa-bbbb" not in out
+    assert "<REDACTED:uuid>" in out
+    assert "abcdef0123456789abcdef01" not in out
+    assert "<REDACTED:hash>" in out
+
+
+def test_custom_maps_applied_first():
+    out = sanitize("AcmeCorp had an outage", maps={"AcmeCorp": "<company>"}).text
+    assert "AcmeCorp" not in out
+    assert "<company>" in out
+
+
+def test_redaction_tally_counts_kinds():
+    res = sanitize("a@b.com and c@d.org and 10.0.0.1")
+    assert res.redactions.get("email") == 2
+    assert res.redactions.get("ipv4") == 1
+    assert res.total_redactions >= 3
+
+
+def test_clean_text_passes_through_unchanged():
+    text = "The CLI crashes when the config file is missing a required field."
+    res = sanitize(text)
+    assert res.text == text
+    assert res.total_redactions == 0
+
+
+def test_audit_flags_residual_suspicious_without_mutating():
+    # A base64-ish blob that doesn't match a known secret shape still gets
+    # flagged for a human (but the text is not mutated by the audit).
+    blob = "Zm9vYmFyYmF6" * 5  # 60 chars base64-ish
+    res = sanitize(f"data: {blob}")
+    kinds = {f["kind"] for f in res.audit}
+    assert "possible_base64_blob" in kinds
+
+
+def test_secret_wins_over_hash_classification():
+    # A GitHub token is also a long alphanumeric run; it must be redacted as a
+    # token, never weakened to <REDACTED:hash>. Prefix assembled at runtime so
+    # no verbatim token literal lands in source.
+    token = "gh" + "p_" + "a" * 36
+    out = sanitize(token).text
+    assert "<REDACTED:github_token>" in out
+    assert "<REDACTED:hash>" not in out

--- a/reflect-kb/tests/test_issues_sanitize.py
+++ b/reflect-kb/tests/test_issues_sanitize.py
@@ -138,6 +138,30 @@ def test_audit_flags_residual_suspicious_without_mutating():
     assert "possible_base64_blob" in kinds
 
 
+def test_audit_ignores_own_redaction_placeholders():
+    # The audit runs on ALREADY-redacted text. A fully-redacted env assignment
+    # like AWS_SECRET_ACCESS_KEY=<REDACTED:generic_secret> must NOT be re-flagged
+    # as a suspicious env_var_assignment (or base64 blob) — that noise would bury
+    # genuine residue. A line whose only "suspicious" content is the sanitizer's
+    # own placeholder produces zero audit findings.
+    res = sanitize("export AWS_SECRET_ACCESS_KEY=" + _BODY + "wJalrXUtnFEMI")
+    # Sanity: the value really was redacted to a placeholder.
+    assert "<REDACTED:generic_secret>" in res.text
+    # And the audit does not flag that placeholder line.
+    assert res.audit == []
+
+
+def test_audit_still_flags_genuine_residue_alongside_placeholders():
+    # Masking placeholders must not blind the audit to REAL residue on the same
+    # text: a redacted line plus a separate base64-ish blob still flags the blob.
+    blob = "Zm9vYmFyYmF6" * 5  # 60 chars base64-ish
+    res = sanitize("API_KEY=supersecretvalue12345\ndata: " + blob)
+    kinds = {f["kind"] for f in res.audit}
+    assert "possible_base64_blob" in kinds
+    # The redacted first line contributes no env_var_assignment noise.
+    assert all(f["line"] != 1 for f in res.audit)
+
+
 def test_secret_wins_over_hash_classification():
     # A GitHub token is also a long alphanumeric run; it must be redacted as a
     # token, never weakened to <REDACTED:hash>. Prefix assembled at runtime so


### PR DESCRIPTION
## What

Adds a new `reflect issues` mode to the reflect-kb CLI: it distills recent session transcripts, asks one bounded LLM call for actionable findings, privacy-sanitizes them, deduplicates against existing issues, and files them via `gh issue create`. This ports agent-deck's self-improvement pipeline *logic* (distill → analyze → sanitize → dedupe → file) onto reflect-kb's Python style — **as a new mode inside the existing `/reflect` ecosystem, not a parallel pipeline**.

## Why

A developer wants their agent sessions to periodically turn recurring friction/bugs/capability-gaps into triaged GitHub issues automatically, without standing up a separate tool. agent-deck has this; ainb's `/reflect` did not.

## How it reuses (not duplicates) the reflect stack

- **Queue:** sources transcripts from the existing `~/.reflect/pending_reflections.jsonl` (the same queue the Stop/PreCompact hooks populate) — no new queue.
- **State:** idempotency ledger lives under `REFLECT_STATE_DIR` (`~/.reflect/filed_issues.json`) — no new DB; reflect.db routing is untouched.
- **Style:** pure functions, injectable runners, dataclass results — mirrors `write_flow.py`.

## Pipeline

```
queue → distill (~30× compression, no LLM)
      → analyze (one bounded `claude -p` call; gated on Claude auth)
      → sanitize (conservative secrets-first regex)
      → dedupe (in-batch · atomic local ledger · gh issue list)
      → gh issue create        [skipped entirely under --dry-run]
```

## GitHub-publish safety model

Filing publishes off-machine, so sanitization is conservative and runs **twice** — once on each distilled timeline before the model sees it, once on each candidate before it can be printed or filed. It strips: caller `--map` substitutions; secrets (Anthropic/OpenAI/GitHub/Slack/AWS/Telegram tokens, JWTs, PEM private-key blocks, generic `KEY=value`); emails; IPv4; home/tmp/worktree paths; full UUIDs; long hex — with a non-mutating audit pass that flags residual suspicious tokens. The analyzer degrades gracefully without Claude auth (returns no candidates + a reason; never raises). Filing is the only path that calls `gh issue create`.

## Proof

- **All gates green:** full reflect-kb suite + new tests = **109 passed**; `ruff check` clean on touched files; `ruff format --check` clean; `reflect.toml` validates.
- **Dry-run** (injected analyzer, no live auth) sanitized a candidate whose body echoed a transcript secret + home path:
  ```
  ### Reflect drain double-files issues [bug, runtime]
  ## Summary
  The drainer at /Users/<user>/proj re-files issues; token <REDACTED:anthropic_key> seen.
  ```
  No `gh` invoked; no secret/home-path in output.
- **Idempotency:** run 1 filed 1 issue (1 `gh issue create`); run 2 filed 0 (`dup-in-ledger`).

## Files

- `reflect-kb/src/reflect_kb/issues/` — `distill`, `sanitize`, `dedupe`, `manifest`, `analyze`, `pipeline`
- `reflect-kb/src/reflect_kb/cli/issues_cli.py` + registration in `learnings_cli.py`
- `reflect-kb/tests/test_issues_*.py` — 61 new tests (distill / sanitize / dedupe / manifest / analyze / pipeline / cli)
- `plugins/reflect/reflect.toml` + `scripts/reflect_config.py` — `[issues]` config block
- `reflect-kb/README.md`, `plugins/reflect/README.md`, `plugins/reflect/CHANGELOG.md` — docs

## Success criteria

- [x] New reflect mode distills a batch of recent transcripts and produces candidate GitHub issues; running it files via `gh issue create`; a second run files NO duplicates (proven by test + idempotency demo).
- [x] Privacy sanitizer runs before any issue content leaves the machine, covered by tests asserting secrets/tokens/home-paths/PII are removed; `--dry-run` prints exact bodies without calling `gh`.
- [x] Reuses existing reflect-kb storage + queue (no parallel DB/queue); passes the reflect-kb suite + new distill/sanitize/dedupe tests; `plugins/reflect/` + reflect-kb docs updated with the mode, its config, and the GitHub-publish safety model.
- [x] Runs without errors.
- [x] Proof shown (test output + sanitized dry-run + idempotency demo above).

## Known limitations / follow-ups

- GH dedupe uses coarse 50% token-overlap (agent-deck's heuristic) + exact-fingerprint fast path; embedding-similarity dedupe is a future improvement.
- The live analyzer needs a Claude auth context; absent it, the pipeline still distills, sanitizes, dedupes, and dry-runs, but yields no candidates (reported, never silently dropped).
- Not auto-wired to a hook/drainer yet — invoked on demand via `reflect issues run`. Scheduling is a deliberate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `reflect issues` command group to convert pending transcripts into privacy-sanitized GitHub issues.
  * New subcommands: `run` (supports `--dry-run`, `--repo`, `--limit`, `--model`, `--map` substitutions, `rich`/`json` output), `ledger` (view idempotency history), and `queue` (list pending transcripts).
  * Added an `[issues]` configuration block in `reflect.toml` with `repo`, `limit`, and `model` defaults.
  * Deduplication prevents duplicate issue filings across runs, including title and fuzzy-match checks.

* **Documentation**
  * Updated README and CHANGELOG with the new workflow and publish safety model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->