### PR TITLE
feat(ainb-fleet): Telegram phone bridge daemon

### DIFF
--- a/plugins/ainb-fleet/README.md
+++ b/plugins/ainb-fleet/README.md
@@ -246,3 +246,5 @@ A session present in two sources collapses into one record with
 - `ainb list` — lifecycle-only session list (no peer/jobs enrichment)
 - `ainb attach <workspace>` — drop into a session's tmux
 - `ainb kill <workspace>` — terminate a single session by exact name
+- [`bridge/`](bridge/README.md) — Telegram phone bridge: relay a named session
+  two-way to your phone, installable as a launchd/systemd service

--- a/plugins/ainb-fleet/bridge/.gitignore
+++ b/plugins/ainb-fleet/bridge/.gitignore
@@ -1,0 +1,6 @@
+venv/
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/

--- a/plugins/ainb-fleet/bridge/README.md
+++ b/plugins/ainb-fleet/bridge/README.md
@@ -1,0 +1,175 @@
+# ainb phone bridge (Telegram)
+
+A standalone Python daemon that relays messages **two-way** between Telegram and a
+named `ainb` session — a conductor session when one is present, any running
+session otherwise. Drive and observe a coding-agent session from your phone while
+away from the keyboard.
+
+It is the Telegram-first port of agent-deck's proven `bridge.py`, re-pointed at
+ainb's existing fleet transport instead of agent-deck's CLI.
+
+```
+   Telegram  ──long-poll──▶  bridge daemon  ──tmux send-keys──▶  ainb session
+      ▲                          │                                    │
+      └────── HTML reply ────────┴──── read JSONL transcript ◀────────┘
+                                    (wait for assistant end_turn)
+```
+
+---
+
+## How it talks to ainb
+
+The bridge reuses ainb's **existing, verified** mechanisms — it invents no new
+transport:
+
+| Concern | Mechanism |
+|---|---|
+| Discover sessions | `ainb list --format json` → running `workspace_name` / `tmux_session_name` / `worktree_path` |
+| Send a message | `tmux send-keys -t <session> -l <text>` then `Enter` (literal mode, injection-safe — the same path `ainb fleet broadcast` uses) |
+| Capture the reply | Read the session's Claude JSONL transcript under `~/.claude/projects/<cwd-slug>/*.jsonl` |
+
+### Response-capture contract (decision)
+
+ainb has **no** `session send --wait` primitive like agent-deck, so the bridge
+cannot return a blocking-send's stdout. The reliable equivalent is the JSONL
+transcript that ainb-fleet's `sequence` verb already watches
+(`wait_for_turn_end`). The bridge mirrors that contract:
+
+1. Snapshot the transcript's current byte offset.
+2. Send the message via `tmux send-keys`.
+3. Poll the transcript from that offset until an `assistant` row with
+   `message.stop_reason == "end_turn"` appears, then return the concatenated
+   `text` blocks of that turn (or time out after `response_timeout`).
+
+This is the semantic match for agent-deck's **template** contract
+(`session output --json` → `data["content"]`), adapted to ainb's JSONL — chosen
+over the standalone-bridge raw-`--wait`-stdout contract because ainb's send is
+fire-and-forget tmux, with no stdout to capture.
+
+The `cwd → project-slug` mapping (every non-`[A-Za-z0-9-]` char → `-`) matches
+the Rust `cwd_to_project_slug` in `fleet/read/jsonl_tail.rs` exactly.
+
+---
+
+## Routing
+
+- **`name: message`** — when `name` matches a running session (case-insensitive),
+  the message goes to that session.
+- **bare `message`** — goes to the default target: a conductor session if one is
+  running, otherwise the alphabetically-first running session (so the bridge is
+  useful **before** the separate conductor track lands).
+- A leading token that doesn't match any running session (e.g. `note: buy milk`)
+  is treated as plain text, not a route.
+
+---
+
+## Config
+
+Merge a `[fleet.telegram]` table into ainb's config at
+`~/.agents-in-a-box/config/config.toml` (see `config.example.toml`):
+
+```toml
+[fleet.telegram]
+token = "$TELEGRAM_BOT_TOKEN"      # secret ref — never a literal in prod
+user_id = 123456789               # authorized Telegram user id
+# default_target = "conductor"    # optional preferred target for bare messages
+require_mention_in_groups = true  # optional, default true
+response_timeout = 300            # optional, seconds (default 300)
+# proxy_url = "http://127.0.0.1:8080"  # optional HTTP/SOCKS proxy
+```
+
+| Key | Required | Meaning |
+|---|---|---|
+| `token` | yes | Bot token, resolved via the secret resolver (see below). Never passed on argv. |
+| `user_id` | yes | Authorized Telegram user id. Messages from anyone else are silently ignored. |
+| `default_target` | no | Session name preferred for prefix-less messages. |
+| `require_mention_in_groups` | no | In group chats, only act on @mentions / replies to the bot. Default `true`. |
+| `response_timeout` | no | Seconds to wait for the session's turn to end. Default `300`. |
+| `proxy_url` | no | HTTP/SOCKS proxy for the Telegram API (SOCKS needs `aiohttp-socks`). |
+
+### Secret resolution
+
+`token` and a string `user_id` are passed through a resolver:
+
+| Form | Resolves to |
+|---|---|
+| `$VAR` / `${VAR}` | `os.environ.get("VAR", "")` (warns if unset) |
+| `keychain:svc` | `security find-generic-password -s svc -w` (macOS) |
+| literal | returned as-is |
+
+The token is **never** written to the launchd plist / systemd unit or passed on
+the command line — the daemon reads it from config at startup.
+
+---
+
+## Install / run
+
+```bash
+cd plugins/ainb-fleet/bridge
+
+# 1. Create the venv the daemon will use (NOTE: `venv`, not `.venv`).
+python3 -m venv venv
+./venv/bin/pip install -r requirements.txt
+
+# 2. Add your [fleet.telegram] config (see above).
+
+# 3. Run in the foreground to verify.
+./venv/bin/python -m ainb_phone_bridge run
+
+# 4. Install as a background service (launchd on macOS, systemd --user on Linux).
+./venv/bin/python -m ainb_phone_bridge install
+
+# Status (config + service):
+./venv/bin/python -m ainb_phone_bridge status
+
+# Teardown — removes the service cleanly. Safe when nothing is installed.
+./venv/bin/python -m ainb_phone_bridge teardown
+```
+
+The daemon launches as `<bridge>/venv/bin/python3 -m ainb_phone_bridge run`. The
+venv path uses `venv/bin/python3` (no leading dot). Install is **idempotent**:
+re-running it overwrites the unit cleanly. The macOS plist sets `KeepAlive` +
+`ThrottleInterval=10`; the systemd unit sets `Restart=always` / `RestartSec=10`.
+
+---
+
+## Conductor dependency
+
+The conductor + hook/inbox/heartbeat orchestration core is a **separate track**.
+This bridge does **not** build it — it targets a conductor session by name when
+one exists and degrades to any running session otherwise. When the conductor
+track lands, set `default_target = "conductor"` (or rely on the conductor-first
+default) and bare messages route to it automatically.
+
+---
+
+## Tests
+
+Pure logic (prefix routing, markdown→HTML, 4096 splitting, secret resolution,
+target resolution incl. degrade-to-any, JSONL reply extraction, service-unit
+generation) is fully unit-tested:
+
+```bash
+cd plugins/ainb-fleet/bridge
+python3 -m venv venv && ./venv/bin/pip install pytest ruff
+./venv/bin/python -m pytest        # 68 tests
+./venv/bin/ruff check ainb_phone_bridge tests
+./venv/bin/ruff format --check ainb_phone_bridge tests
+```
+
+The tests do **not** require aiogram, a live `ainb` binary, tmux, or a Telegram
+token — every external boundary is mocked or driven through a temp transcript.
+
+---
+
+## Known limitations / follow-ups
+
+- **Slack / Discord deferred** — Telegram only for this cut; the routing, format,
+  and capture layers are platform-agnostic so a Slack adapter slots in cleanly.
+- **No busy-queue / hooks** — agent-deck's per-conductor busy queue and
+  pre/post-message hooks are not ported (they depend on the conductor track).
+- **No heartbeat / NEED: escalation** — those belong to the conductor track.
+- **tmux fire-and-forget** — like the rest of ainb-fleet, the send has no ACK;
+  reply capture is what confirms delivery, bounded by `response_timeout`.
+- **Claude transcript shape** — reply extraction assumes Claude's JSONL schema
+  (`message.content[].type == "text"`); Codex/Gemini need adapters.

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/__init__.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/__init__.py
@@ -1,0 +1,15 @@
+# ABOUTME: ainb Telegram phone bridge — relay messages two-way between Telegram
+# and a named ainb session (a conductor when present, any session otherwise).
+#
+# The package is intentionally split so the pure logic (prefix routing, markdown
+# -> HTML, 4096 splitting, secret resolution, target resolution) is import-safe
+# and unit-testable WITHOUT aiogram or a live ainb binary installed.
+
+__version__ = "0.1.0"
+
+# Telegram hard limit on a single text message.
+TG_MAX_LENGTH = 4096
+
+# Default time (seconds) the bridge waits for a session to finish its turn
+# before giving up on capturing a reply.
+RESPONSE_TIMEOUT = 300

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/__main__.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/__main__.py
@@ -1,0 +1,92 @@
+# ABOUTME: CLI entry point for the phone bridge package.
+#
+#   python3 -m ainb_phone_bridge run        # run the daemon (foreground)
+#   python3 -m ainb_phone_bridge install    # provision launchd/systemd service
+#   python3 -m ainb_phone_bridge teardown   # remove the service
+#   python3 -m ainb_phone_bridge status     # config + service status
+#
+# `run` reads the bot token from config.toml — it is NEVER accepted on argv.
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from . import __version__
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _cmd_run(_args: argparse.Namespace) -> int:
+    from .bridge import run_bridge
+
+    return run_bridge()
+
+
+def _cmd_install(_args: argparse.Namespace) -> int:
+    from .service import install
+
+    path = install()
+    print(f"installed phone-bridge service: {path}")
+    return 0
+
+
+def _cmd_teardown(_args: argparse.Namespace) -> int:
+    from .service import teardown
+
+    path = teardown()
+    if path is None:
+        print("phone-bridge service not installed — nothing to remove")
+    else:
+        print(f"removed phone-bridge service: {path}")
+    return 0
+
+
+def _cmd_status(_args: argparse.Namespace) -> int:
+    from .config import ConfigError, load_config
+    from .service import status
+
+    print(status())
+    try:
+        cfg = load_config()
+        print(
+            f"config: ok (user_id={cfg.authorized_user_id}, "
+            f"default_target={cfg.default_target or '(conductor/auto)'}, "
+            f"response_timeout={cfg.response_timeout}s)"
+        )
+    except ConfigError as exc:
+        print(f"config: ERROR — {exc}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
+    parser = argparse.ArgumentParser(
+        prog="ainb_phone_bridge",
+        description="ainb Telegram phone bridge daemon + service installer.",
+    )
+    parser.add_argument("--version", action="version", version=__version__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("run", help="run the bridge daemon (foreground)")
+    sub.add_parser("install", help="install the launchd/systemd service")
+    sub.add_parser("teardown", help="remove the launchd/systemd service")
+    sub.add_parser("status", help="show config + service status")
+
+    args = parser.parse_args(argv)
+    handlers = {
+        "run": _cmd_run,
+        "install": _cmd_install,
+        "teardown": _cmd_teardown,
+        "status": _cmd_status,
+    }
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/ainb_client.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/ainb_client.py
@@ -123,11 +123,13 @@ def send_keys(tmux_session: str, text: str) -> bool:
     """Send ``text`` to a tmux session via literal send-keys + Enter.
 
     Uses ``-l`` (literal) so the payload is never interpreted as key names —
-    the same injection-safe transport ainb-fleet's broadcast/sequence use.
+    the same injection-safe transport ainb-fleet's broadcast/sequence use. A
+    ``--`` terminator precedes the payload so a message starting with ``-`` is
+    treated as literal text, not as a tmux flag (which would fail the send).
     """
     try:
         lit = subprocess.run(
-            ["tmux", "send-keys", "-t", tmux_session, "-l", text],
+            ["tmux", "send-keys", "-t", tmux_session, "-l", "--", text],
             capture_output=True,
             timeout=15,
             check=False,
@@ -183,17 +185,31 @@ def _scan_new_rows_for_turn_end(path: Path, start_offset: int) -> tuple[int, str
     ``reply_text`` is set only when an assistant row with
     ``stop_reason == "end_turn"`` is found in the new region. The last such
     turn wins (the most recent complete answer).
+
+    Only COMPLETE (newline-terminated) lines are consumed. A trailing partial
+    write (no terminating ``\n`` yet) is left for the next poll: the returned
+    offset never advances past the last newline, so a reply that lands in a
+    not-yet-flushed line is re-read once the line is completed instead of being
+    skipped and lost.
     """
     try:
         with path.open("rb") as fh:
             fh.seek(start_offset)
             data = fh.read()
-            new_offset = fh.tell()
     except OSError:
         return start_offset, None
 
+    # Advance only past complete lines: everything up to and including the last
+    # newline. A trailing partial line stays unread until it is terminated.
+    last_nl = data.rfind(b"\n")
+    if last_nl == -1:
+        # No complete line yet — nothing to consume, hold the offset.
+        return start_offset, None
+    complete = data[: last_nl + 1]
+    new_offset = start_offset + last_nl + 1
+
     reply: str | None = None
-    for line in data.splitlines():
+    for line in complete.splitlines():
         line = line.strip()
         if not line:
             continue
@@ -229,17 +245,22 @@ def wait_for_reply(
     """Poll the transcript for the next end-of-turn assistant reply.
 
     ``transcript`` may be ``None`` at send time (no transcript yet); we re-resolve
-    it on each poll so a freshly-created file is picked up. Returns the reply
-    text or ``None`` on timeout.
+    it on each poll so a freshly-created file is picked up. Claude can also rotate
+    to a NEW ``*.jsonl`` mid-turn (resume / compaction), so on every poll we
+    re-resolve the latest transcript: if it differs from the one we are reading,
+    we switch to it and reset the offset to 0 so the end-of-turn row in the new
+    file is not missed. Returns the reply text or ``None`` on timeout.
     """
     deadline = time.monotonic() + timeout
     offset = start_offset
     path = transcript
     while time.monotonic() < deadline:
-        if path is None:
-            path = latest_transcript_for_cwd(cwd)
-            if path is not None:
-                offset = 0  # brand-new transcript — read from the top
+        latest = latest_transcript_for_cwd(cwd)
+        if latest is not None and latest != path:
+            # First resolution after a None send-time path, or a rotation to a
+            # newer transcript — read the new file from the top.
+            path = latest
+            offset = 0
         if path is not None:
             offset, reply = _scan_new_rows_for_turn_end(path, offset)
             if reply is not None:

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/ainb_client.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/ainb_client.py
@@ -25,6 +25,7 @@ import os
 import re
 import subprocess
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 from .routing import TargetSession, is_conductor_name
@@ -152,6 +153,28 @@ def send_keys(tmux_session: str, text: str) -> bool:
 _WS_RE = re.compile(r"\s+")
 
 
+def _row_timestamp(obj: dict) -> float | None:
+    """Parse a row's top-level ISO-8601 ``timestamp`` to epoch seconds, or ``None``.
+
+    Claude writes each JSONL row with a ``timestamp`` like
+    ``"2025-06-14T12:34:56.789Z"``. We compare it against the wall-clock send time
+    so backlog rows (a resume/compaction rotation rolls prior history — including
+    pre-send ``end_turn`` rows — into a new file) are never mistaken for the reply.
+    """
+    ts = obj.get("timestamp")
+    if not isinstance(ts, str) or not ts:
+        return None
+    # ``fromisoformat`` accepts the ``+00:00`` offset but not a trailing ``Z``.
+    normalized = ts[:-1] + "+00:00" if ts.endswith("Z") else ts
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.timestamp()
+
+
 def _assistant_text_from_row(obj: dict) -> tuple[str | None, str | None]:
     """Return ``(stop_reason, text)`` for an assistant row, else ``(None, None)``.
 
@@ -179,12 +202,22 @@ def _assistant_text_from_row(obj: dict) -> tuple[str | None, str | None]:
     return (stop_reason if isinstance(stop_reason, str) else None), (text or None)
 
 
-def _scan_new_rows_for_turn_end(path: Path, start_offset: int) -> tuple[int, str | None]:
+def _scan_new_rows_for_turn_end(
+    path: Path, start_offset: int, min_timestamp: float | None = None
+) -> tuple[int, str | None]:
     """Scan rows from ``start_offset``; return ``(new_offset, reply_text|None)``.
 
     ``reply_text`` is set only when an assistant row with
     ``stop_reason == "end_turn"`` is found in the new region. The last such
     turn wins (the most recent complete answer).
+
+    When ``min_timestamp`` (epoch seconds) is given, only rows whose JSONL
+    ``timestamp`` is strictly AFTER it are accepted. This rejects pre-send
+    backlog: a resume/compaction rotation rolls prior history — including
+    pre-send ``end_turn`` rows — into a new file, and offset-reset scanning
+    would otherwise return that stale answer as the reply. A row without a
+    parseable timestamp is also rejected once a guard is active, since it
+    cannot be proven to post-date the send.
 
     Only COMPLETE (newline-terminated) lines are consumed. A trailing partial
     write (no terminating ``\n`` yet) is left for the next poll: the returned
@@ -221,6 +254,11 @@ def _scan_new_rows_for_turn_end(path: Path, start_offset: int) -> tuple[int, str
             continue
         stop_reason, text = _assistant_text_from_row(obj)
         if stop_reason == "end_turn" and text:
+            if min_timestamp is not None:
+                row_ts = _row_timestamp(obj)
+                if row_ts is None or row_ts <= min_timestamp:
+                    # Backlog (or unprovable) row — predates the send, skip it.
+                    continue
             reply = text
     return new_offset, reply
 
@@ -241,6 +279,7 @@ def wait_for_reply(
     transcript: Path | None,
     timeout: float,
     poll_interval: float = 0.5,
+    send_time: float | None = None,
 ) -> str | None:
     """Poll the transcript for the next end-of-turn assistant reply.
 
@@ -249,7 +288,13 @@ def wait_for_reply(
     to a NEW ``*.jsonl`` mid-turn (resume / compaction), so on every poll we
     re-resolve the latest transcript: if it differs from the one we are reading,
     we switch to it and reset the offset to 0 so the end-of-turn row in the new
-    file is not missed. Returns the reply text or ``None`` on timeout.
+    file is not missed.
+
+    ``send_time`` (epoch seconds, captured by the caller right before the send) is
+    the backlog guard: only rows whose JSONL ``timestamp`` post-dates it count as
+    the reply. Without it, an offset-reset on rotation would surface a rolled-up
+    PRE-send ``end_turn`` (carried into the new file by resume/compaction) as the
+    answer. Returns the reply text or ``None`` on timeout.
     """
     deadline = time.monotonic() + timeout
     offset = start_offset
@@ -262,7 +307,7 @@ def wait_for_reply(
             path = latest
             offset = 0
         if path is not None:
-            offset, reply = _scan_new_rows_for_turn_end(path, offset)
+            offset, reply = _scan_new_rows_for_turn_end(path, offset, send_time)
             if reply is not None:
                 return reply
         time.sleep(poll_interval)
@@ -276,6 +321,8 @@ def send_and_capture(session: TargetSession, text: str, timeout: float) -> str |
     """
     transcript = latest_transcript_for_cwd(session.cwd)
     offset = current_offset(transcript)
+    # Wall-clock watermark: the reply must be a turn that ends AFTER this instant.
+    send_time = time.time()
     if not send_keys(session.tmux_session, text):
         return None
-    return wait_for_reply(session.cwd, offset, transcript, timeout)
+    return wait_for_reply(session.cwd, offset, transcript, timeout, send_time=send_time)

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/ainb_client.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/ainb_client.py
@@ -1,0 +1,260 @@
+# ABOUTME: The bridge's transport to ainb sessions.
+#
+# Three responsibilities, all reusing ainb's EXISTING, verified mechanisms:
+#   1. discover()        — `ainb list --format json` -> running TargetSessions.
+#   2. send(session, t)  — tmux send-keys (`-l` literal + Enter), matching
+#                          ainb-fleet's broadcast transport (broker has a known
+#                          silent-delivery gap, so tmux is the reliable path).
+#   3. capture_reply()   — read the session's JSONL transcript: snapshot the
+#                          byte offset, send, then wait for the next assistant
+#                          row with stop_reason == "end_turn" and return its
+#                          concatenated text blocks.
+#
+# RESPONSE-CAPTURE CONTRACT (decision, documented in README):
+#   ainb has no `session send --wait` primitive like agent-deck. The reliable
+#   equivalent is the JSONL transcript that ainb-fleet's `sequence` verb already
+#   watches (`wait_for_turn_end`). We mirror that contract in Python: the reply
+#   is the text of the last assistant turn whose stop_reason is "end_turn",
+#   captured AFTER the send offset. This is the semantic match for agent-deck's
+#   TEMPLATE contract (`session output --json -> content`), adapted to ainb.
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+from .routing import TargetSession, is_conductor_name
+
+
+def _ainb_bin() -> str:
+    return os.environ.get("AINB_BIN", "ainb")
+
+
+def cwd_to_project_slug(cwd: str) -> str:
+    """Replicate ainb's cwd -> project-dir slug.
+
+    Every char that is not ``[A-Za-z0-9-]`` collapses to ``-`` (matches the Rust
+    `cwd_to_project_slug` in `fleet/read/jsonl_tail.rs`).
+    """
+    return "".join(c if (c.isalnum() and c.isascii()) or c == "-" else "-" for c in cwd)
+
+
+def transcript_dir_for_cwd(cwd: str) -> Path:
+    return Path.home() / ".claude" / "projects" / cwd_to_project_slug(cwd)
+
+
+def latest_transcript_for_cwd(cwd: str) -> Path | None:
+    """Newest ``*.jsonl`` under the cwd's Claude project dir, or ``None``."""
+    base = transcript_dir_for_cwd(cwd)
+    if not base.is_dir():
+        return None
+    newest: tuple[float, Path] | None = None
+    for p in base.glob("*.jsonl"):
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        if newest is None or mtime > newest[0]:
+            newest = (mtime, p)
+    return newest[1] if newest else None
+
+
+def discover() -> list[TargetSession]:
+    """Discover running sessions via `ainb list --format json`."""
+    try:
+        out = subprocess.run(
+            [_ainb_bin(), "list", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if out.returncode != 0 or not out.stdout.strip():
+        return []
+    try:
+        rows = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(rows, list):
+        return []
+
+    sessions: list[TargetSession] = []
+    for r in rows:
+        if not isinstance(r, dict) or not r.get("is_running", False):
+            continue
+        name = str(r.get("workspace_name", "")).strip()
+        tmux = str(r.get("tmux_session_name", "")).strip()
+        cwd = str(r.get("worktree_path", "")).strip()
+        sid = str(r.get("session_id", "")).strip()
+        if not name or not tmux:
+            continue
+        sessions.append(
+            TargetSession(
+                name=name,
+                tmux_session=tmux,
+                cwd=cwd,
+                session_id=sid,
+                is_conductor=is_conductor_name(name),
+            )
+        )
+    return sessions
+
+
+def tmux_session_exists(tmux_session: str) -> bool:
+    try:
+        out = subprocess.run(
+            ["tmux", "has-session", "-t", tmux_session],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return out.returncode == 0
+
+
+def send_keys(tmux_session: str, text: str) -> bool:
+    """Send ``text`` to a tmux session via literal send-keys + Enter.
+
+    Uses ``-l`` (literal) so the payload is never interpreted as key names —
+    the same injection-safe transport ainb-fleet's broadcast/sequence use.
+    """
+    try:
+        lit = subprocess.run(
+            ["tmux", "send-keys", "-t", tmux_session, "-l", text],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        if lit.returncode != 0:
+            return False
+        enter = subprocess.run(
+            ["tmux", "send-keys", "-t", tmux_session, "Enter"],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        return enter.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+# --- JSONL reply extraction -------------------------------------------------
+
+_WS_RE = re.compile(r"\s+")
+
+
+def _assistant_text_from_row(obj: dict) -> tuple[str | None, str | None]:
+    """Return ``(stop_reason, text)`` for an assistant row, else ``(None, None)``.
+
+    Concatenates every ``{"type":"text"}`` block in ``message.content``. Matches
+    the extraction the Rust ``last_narrative_snapshot`` / ``last_assistant_info``
+    perform.
+    """
+    if obj.get("type") != "assistant":
+        return None, None
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return None, None
+    stop_reason = message.get("stop_reason")
+    content = message.get("content")
+    parts: list[str] = []
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                t = block.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+    elif isinstance(content, str):
+        parts.append(content)
+    text = "\n".join(p for p in parts if p).strip()
+    return (stop_reason if isinstance(stop_reason, str) else None), (text or None)
+
+
+def _scan_new_rows_for_turn_end(path: Path, start_offset: int) -> tuple[int, str | None]:
+    """Scan rows from ``start_offset``; return ``(new_offset, reply_text|None)``.
+
+    ``reply_text`` is set only when an assistant row with
+    ``stop_reason == "end_turn"`` is found in the new region. The last such
+    turn wins (the most recent complete answer).
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(start_offset)
+            data = fh.read()
+            new_offset = fh.tell()
+    except OSError:
+        return start_offset, None
+
+    reply: str | None = None
+    for line in data.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        stop_reason, text = _assistant_text_from_row(obj)
+        if stop_reason == "end_turn" and text:
+            reply = text
+    return new_offset, reply
+
+
+def current_offset(path: Path | None) -> int:
+    """Byte length of ``path`` right now (the send watermark)."""
+    if path is None:
+        return 0
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def wait_for_reply(
+    cwd: str,
+    start_offset: int,
+    transcript: Path | None,
+    timeout: float,
+    poll_interval: float = 0.5,
+) -> str | None:
+    """Poll the transcript for the next end-of-turn assistant reply.
+
+    ``transcript`` may be ``None`` at send time (no transcript yet); we re-resolve
+    it on each poll so a freshly-created file is picked up. Returns the reply
+    text or ``None`` on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    offset = start_offset
+    path = transcript
+    while time.monotonic() < deadline:
+        if path is None:
+            path = latest_transcript_for_cwd(cwd)
+            if path is not None:
+                offset = 0  # brand-new transcript — read from the top
+        if path is not None:
+            offset, reply = _scan_new_rows_for_turn_end(path, offset)
+            if reply is not None:
+                return reply
+        time.sleep(poll_interval)
+    return None
+
+
+def send_and_capture(session: TargetSession, text: str, timeout: float) -> str | None:
+    """Send ``text`` to ``session`` and capture its next end-of-turn reply.
+
+    Returns ``None`` if the send failed or no reply arrived before ``timeout``.
+    """
+    transcript = latest_transcript_for_cwd(session.cwd)
+    offset = current_offset(transcript)
+    if not send_keys(session.tmux_session, text):
+        return None
+    return wait_for_reply(session.cwd, offset, transcript, timeout)

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/bridge.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/bridge.py
@@ -146,9 +146,21 @@ def build_dispatcher(config: BridgeConfig, bot: Bot) -> Dispatcher:
             log.exception("relay failed")
             reply = f"Bridge error: {exc}"
 
-        html = md_to_tg_html(reply)
-        for chunk in split_message(html):
-            await message.answer(chunk, parse_mode=ParseMode.HTML)
+        # Split the RAW reply BEFORE HTML conversion so a chunk boundary can
+        # never slice through an HTML tag or entity (which Telegram rejects with
+        # a 400). Each raw chunk is converted independently.
+        for raw_chunk in split_message(reply):
+            chunk = md_to_tg_html(raw_chunk)
+            try:
+                await message.answer(chunk, parse_mode=ParseMode.HTML)
+            except Exception:  # pragma: no cover - network / parse fallback
+                # HTML rejected or send failed — retry as plain text so the
+                # user still gets the content rather than nothing.
+                log.exception("HTML send failed; retrying as plain text")
+                try:
+                    await message.answer(raw_chunk, parse_mode=None)
+                except Exception:  # pragma: no cover - give up on this chunk
+                    log.exception("plain-text retry also failed")
 
     return dp
 

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/bridge.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/bridge.py
@@ -1,0 +1,188 @@
+# ABOUTME: The aiogram v3 Telegram daemon — long-polling, two-way relay.
+#
+# Inbound: an authorized Telegram message -> resolve target session (prefix
+# "name: msg" selects a named session, bare text hits the conductor/default) ->
+# send via tmux + capture the session's end-of-turn reply -> reply to Telegram
+# as HTML, split at 4096 chars.
+#
+# Authorization is by Telegram user_id (unknown senders are silently ignored).
+# In group chats, the bot only acts when @mentioned or when the message is a
+# reply to the bot (configurable). Blocking subprocess work is offloaded to a
+# thread so the asyncio event loop is never blocked.
+#
+# aiogram is an optional import: the module is import-safe (for tests / install)
+# without it; `run_bridge` raises a clear error if it is genuinely missing.
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+
+from . import __version__
+from .ainb_client import discover, send_and_capture
+from .config import BridgeConfig, load_config
+from .format import md_to_tg_html, split_message
+from .routing import parse_target_prefix, resolve_target
+
+log = logging.getLogger("ainb.bridge")
+
+try:  # aiogram is only needed to actually run the daemon.
+    from aiogram import Bot, Dispatcher, types
+    from aiogram.client.default import DefaultBotProperties
+    from aiogram.enums import ParseMode
+
+    HAS_AIOGRAM = True
+except ImportError:  # pragma: no cover - exercised only without the dep
+    HAS_AIOGRAM = False
+
+
+def _strip_bot_mention(text: str, username: str | None) -> str:
+    """Remove a leading ``@botname`` mention from group messages."""
+    if not username:
+        return text
+    handle = f"@{username}"
+    stripped = text.strip()
+    if stripped.lower().startswith(handle.lower()):
+        return stripped[len(handle) :].strip()
+    return text
+
+
+async def _relay(config: BridgeConfig, raw_text: str) -> str:
+    """Resolve the target, relay the message, and return a user-facing reply.
+
+    Pure-ish orchestration: all blocking ainb/tmux/transcript work happens in a
+    worker thread via ``run_in_executor`` so the event loop stays responsive.
+    """
+    loop = asyncio.get_running_loop()
+    sessions = await loop.run_in_executor(None, discover)
+
+    if not sessions:
+        return "No running ainb sessions to relay to."
+
+    names = [s.name for s in sessions]
+    parsed_name, message = parse_target_prefix(raw_text, names)
+
+    # No explicit prefix -> honour a configured default target name if present.
+    if parsed_name is None and config.default_target:
+        if any(s.name.lower() == config.default_target.lower() for s in sessions):
+            parsed_name = config.default_target
+
+    target = resolve_target(parsed_name, sessions)
+    if target is None:
+        if parsed_name is not None:
+            return f"No running session named {parsed_name!r}."
+        return "No target session available."
+
+    if not message:
+        return f"(empty message — nothing sent to {target.name})"
+
+    reply = await loop.run_in_executor(
+        None,
+        functools.partial(send_and_capture, target, message, float(config.response_timeout)),
+    )
+    if reply is None:
+        return (
+            f"Sent to {target.name}, but no reply within "
+            f"{config.response_timeout}s (it may still be working)."
+        )
+    return reply
+
+
+def build_dispatcher(config: BridgeConfig, bot: Bot) -> Dispatcher:
+    """Wire the aiogram dispatcher with authorization + relay handlers."""
+    dp = Dispatcher()
+    bot_state: dict[str, str | None] = {"username": None}
+
+    async def _ensure_username() -> str | None:
+        if bot_state["username"] is None:
+            try:
+                me = await bot.get_me()
+                bot_state["username"] = me.username
+            except Exception:  # pragma: no cover - network
+                bot_state["username"] = None
+        return bot_state["username"]
+
+    def _is_authorized(message: types.Message) -> bool:
+        return bool(message.from_user and message.from_user.id == config.authorized_user_id)
+
+    async def _is_addressed(message: types.Message) -> bool:
+        if message.chat.type == "private":
+            return True
+        if not config.require_mention_in_groups:
+            return True
+        # Reply to the bot's own message counts as addressed.
+        if (
+            message.reply_to_message
+            and message.reply_to_message.from_user
+            and message.reply_to_message.from_user.is_bot
+        ):
+            return True
+        username = await _ensure_username()
+        if username and message.text:
+            return f"@{username}".lower() in message.text.lower()
+        return False
+
+    @dp.message()
+    async def handle_message(message: types.Message) -> None:
+        if not _is_authorized(message):
+            log.warning(
+                "ignoring message from unauthorized user_id=%s",
+                getattr(message.from_user, "id", None),
+            )
+            return
+        if not await _is_addressed(message):
+            return
+
+        text = message.text or message.caption or ""
+        username = await _ensure_username()
+        text = _strip_bot_mention(text, username)
+        if not text.strip():
+            return
+
+        try:
+            reply = await _relay(config, text)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.exception("relay failed")
+            reply = f"Bridge error: {exc}"
+
+        html = md_to_tg_html(reply)
+        for chunk in split_message(html):
+            await message.answer(chunk, parse_mode=ParseMode.HTML)
+
+    return dp
+
+
+async def _amain(config: BridgeConfig) -> None:
+    session = None
+    if config.proxy_url:
+        from aiogram.client.session.aiohttp import AiohttpSession
+
+        session = AiohttpSession(proxy=config.proxy_url)
+    bot = Bot(
+        token=config.token,
+        session=session,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+    dp = build_dispatcher(config, bot)
+    log.info("ainb phone bridge v%s starting (long-polling)", __version__)
+    try:
+        await dp.start_polling(bot)
+    finally:
+        await bot.session.close()
+
+
+def run_bridge(config: BridgeConfig | None = None) -> int:
+    """Entry point for the daemon. Loads config if not supplied. Returns 0."""
+    if not HAS_AIOGRAM:
+        log.error(
+            "aiogram is not installed — run `pip install -r requirements.txt` "
+            "in the bridge venv (see README)."
+        )
+        return 1
+    cfg = config or load_config()
+    try:
+        asyncio.run(_amain(cfg))
+    except (KeyboardInterrupt, SystemExit):
+        log.info("bridge stopped")
+    return 0

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/config.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/config.py
@@ -1,0 +1,133 @@
+# ABOUTME: Load + validate the phone-bridge config from ainb's config.toml.
+#
+# Config lives in ainb's layered config at
+#   ~/.agents-in-a-box/config/config.toml
+# under a dedicated [fleet.telegram] table. The bot token and authorized user id
+# are resolved through the secret resolver so the token is NEVER written on argv
+# or into the launchd/systemd unit — it stays in config (or a keychain/env ref).
+#
+#   [fleet.telegram]
+#   token = "$TELEGRAM_BOT_TOKEN"      # or "keychain:svc" or a literal
+#   user_id = 123456789               # authorized Telegram user id (int or str)
+#   default_target = "conductor"      # optional: name to prefer when no prefix
+#   require_mention_in_groups = true  # optional, default true
+#   response_timeout = 300            # optional, seconds
+#
+# The TOML is parsed with the stdlib `tomllib` (Python 3.11+), so the bridge has
+# zero parsing dependencies.
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import RESPONSE_TIMEOUT
+from .secrets import resolve_secret
+
+
+class ConfigError(RuntimeError):
+    """Raised when the bridge config is missing or invalid."""
+
+
+def default_config_path() -> Path:
+    """Resolve ainb's config.toml path, honouring AINB_CONFIG_PATH override."""
+    override = os.environ.get("AINB_CONFIG_PATH")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".agents-in-a-box" / "config" / "config.toml"
+
+
+@dataclass
+class BridgeConfig:
+    """Resolved, validated bridge configuration."""
+
+    token: str
+    authorized_user_id: int
+    default_target: str | None = None
+    require_mention_in_groups: bool = True
+    response_timeout: int = RESPONSE_TIMEOUT
+    proxy_url: str | None = None
+    extra: dict = field(default_factory=dict)
+
+
+def _coerce_user_id(value: object) -> int:
+    """Accept an int or a secret-resolvable string for user_id."""
+    if isinstance(value, bool):  # bool is an int subclass — reject explicitly
+        raise ConfigError("user_id must be a number, not a boolean")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        resolved = resolve_secret(value).strip()
+        if not resolved:
+            raise ConfigError("user_id is empty after secret resolution")
+        try:
+            return int(resolved)
+        except ValueError as exc:
+            raise ConfigError(f"user_id is not an integer: {resolved!r}") from exc
+    raise ConfigError(f"user_id has unsupported type {type(value).__name__}")
+
+
+def parse_config(raw: dict) -> BridgeConfig:
+    """Build a :class:`BridgeConfig` from a parsed TOML mapping.
+
+    Split out from :func:`load_config` so it can be unit-tested without touching
+    the filesystem.
+    """
+    fleet = raw.get("fleet")
+    if not isinstance(fleet, dict):
+        raise ConfigError("config has no [fleet] table")
+    tg = fleet.get("telegram")
+    if not isinstance(tg, dict):
+        raise ConfigError("config has no [fleet.telegram] table")
+
+    if "token" not in tg:
+        raise ConfigError("[fleet.telegram] is missing `token`")
+    if "user_id" not in tg:
+        raise ConfigError("[fleet.telegram] is missing `user_id`")
+
+    token = resolve_secret(str(tg["token"])).strip()
+    if not token:
+        raise ConfigError("telegram token resolved to empty — check the env var / keychain ref")
+
+    user_id = _coerce_user_id(tg["user_id"])
+
+    default_target = tg.get("default_target")
+    if default_target is not None:
+        default_target = str(default_target).strip() or None
+
+    require_mention = bool(tg.get("require_mention_in_groups", True))
+
+    response_timeout = tg.get("response_timeout", RESPONSE_TIMEOUT)
+    try:
+        response_timeout = int(response_timeout)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("response_timeout must be an integer") from exc
+    if response_timeout <= 0:
+        raise ConfigError("response_timeout must be positive")
+
+    proxy = tg.get("proxy_url")
+    proxy = str(proxy).strip() if proxy else None
+
+    return BridgeConfig(
+        token=token,
+        authorized_user_id=user_id,
+        default_target=default_target,
+        require_mention_in_groups=require_mention,
+        response_timeout=response_timeout,
+        proxy_url=proxy,
+    )
+
+
+def load_config(path: Path | None = None) -> BridgeConfig:
+    """Load and validate the bridge config from disk."""
+    cfg_path = path or default_config_path()
+    if not cfg_path.exists():
+        raise ConfigError(f"config file not found: {cfg_path}")
+    try:
+        with cfg_path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ConfigError(f"failed to read {cfg_path}: {exc}") from exc
+    return parse_config(raw)

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/format.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/format.py
@@ -1,0 +1,101 @@
+# ABOUTME: Markdown -> Telegram-HTML conversion and 4096-char message splitting.
+#
+# Both functions are pure (stdlib `html` only) and ported from agent-deck's
+# `md_to_tg_html` / `split_message`. Telegram's HTML parse mode supports a small
+# tag subset; we map the common Markdown constructs an agent emits and escape
+# everything else so a stray '<' never breaks the message.
+
+from __future__ import annotations
+
+import html
+import re
+
+from . import TG_MAX_LENGTH
+
+# Order matters: fenced code blocks first (greedy, multiline), then inline spans.
+_FENCE_RE = re.compile(r"```[a-zA-Z0-9_+-]*\n?(.*?)```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+?)`")
+_BOLD_RE = re.compile(r"\*\*([^*]+?)\*\*")
+_ITALIC_RE = re.compile(r"(?<![*\w])\*([^*\n]+?)\*(?![*\w])")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
+
+
+def md_to_tg_html(text: str) -> str:
+    """Convert a Markdown-ish string to the Telegram HTML subset.
+
+    Strategy: pull code spans out behind placeholders so their contents are
+    never re-interpreted as markup, HTML-escape the remainder, apply the
+    inline conversions, then restore the (escaped) code spans wrapped in
+    ``<pre>`` / ``<code>``.
+    """
+    if not text:
+        return ""
+
+    placeholders: list[str] = []
+
+    def _stash(rendered: str) -> str:
+        token = f"\x00PH{len(placeholders)}\x00"
+        placeholders.append(rendered)
+        return token
+
+    # Fenced blocks -> <pre><code>…</code></pre>
+    def _fence_sub(m: re.Match[str]) -> str:
+        inner = html.escape(m.group(1).rstrip("\n"))
+        return _stash(f"<pre><code>{inner}</code></pre>")
+
+    text = _FENCE_RE.sub(_fence_sub, text)
+
+    # Inline `code` -> <code>…</code>
+    def _inline_sub(m: re.Match[str]) -> str:
+        return _stash(f"<code>{html.escape(m.group(1))}</code>")
+
+    text = _INLINE_CODE_RE.sub(_inline_sub, text)
+
+    # Escape the prose body (placeholders survive — they contain no '<').
+    text = html.escape(text)
+
+    # Links: [label](url) -> <a href="url">label</a>
+    text = _LINK_RE.sub(lambda m: f'<a href="{html.escape(m.group(2))}">{m.group(1)}</a>', text)
+    # Bold / italic.
+    text = _BOLD_RE.sub(r"<b>\1</b>", text)
+    text = _ITALIC_RE.sub(r"<i>\1</i>", text)
+
+    # Restore code placeholders.
+    for i, rendered in enumerate(placeholders):
+        text = text.replace(f"\x00PH{i}\x00", rendered)
+
+    return text
+
+
+def split_message(text: str, limit: int = TG_MAX_LENGTH) -> list[str]:
+    """Split ``text`` into chunks no longer than ``limit`` characters.
+
+    Prefers newline boundaries; falls back to a hard character cut for any
+    single line that is itself longer than the limit. Never returns an empty
+    list — an empty input yields ``[""]`` so callers can always ``send`` once.
+    """
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    current = ""
+    for line in text.split("\n"):
+        # A single oversized line: flush, then hard-cut it.
+        if len(line) > limit:
+            if current:
+                chunks.append(current)
+                current = ""
+            for i in range(0, len(line), limit):
+                chunks.append(line[i : i + limit])
+            continue
+
+        candidate = line if not current else f"{current}\n{line}"
+        if len(candidate) > limit:
+            chunks.append(current)
+            current = line
+        else:
+            current = candidate
+
+    if current:
+        chunks.append(current)
+    return chunks or [""]

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/routing.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/routing.py
@@ -1,0 +1,107 @@
+# ABOUTME: Pure target-routing logic for the phone bridge.
+#
+# Two concerns, both pure:
+#   1. parse_target_prefix("name: hello", names) -> ("name", "hello")
+#      Bare text (no recognised "name:" prefix) -> (None, text).
+#   2. resolve_target(parsed_name, sessions) -> the session to relay to.
+#      Conductor-first when present; degrades to any named session otherwise so
+#      the bridge is useful BEFORE the separate conductor track lands.
+#
+# A "session" here is a lightweight dataclass the ainb client builds from
+# `ainb list --format json`. Keeping these functions free of I/O makes the
+# routing contract testable without a live fleet.
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# A target name is a leading "<name>:" token. Names mirror ainb workspace /
+# tmux names: alphanumerics plus the separators ainb actually uses.
+_PREFIX_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*:\s*(.*)$", re.DOTALL)
+
+# Heuristic: a session whose name starts with this is treated as a conductor and
+# preferred as the default target. Matches the agent-deck "conductor-<name>"
+# convention while degrading gracefully when no such session exists.
+CONDUCTOR_PREFIXES = ("conductor", "conductor-")
+
+
+@dataclass(frozen=True)
+class TargetSession:
+    """A relay target resolved from `ainb list --format json`."""
+
+    name: str  # workspace_name (human-facing routing key)
+    tmux_session: str  # tmux session name used by send-keys
+    cwd: str  # worktree_path — locates the JSONL transcript
+    session_id: str  # ainb session id
+    is_conductor: bool = False
+
+
+def parse_target_prefix(text: str, known_names: list[str]) -> tuple[str | None, str]:
+    """Split an inbound message into ``(target_name, message)``.
+
+    A leading ``"<name>:"`` selects a named session ONLY when ``<name>`` matches
+    one of ``known_names`` (case-insensitive). Otherwise the whole string is the
+    message and the target is ``None`` (caller falls back to the default).
+
+    The known-names guard is what stops a normal sentence like
+    ``"note: fix this"`` from being mis-routed to a session called ``note``.
+    """
+    if not text:
+        return None, ""
+
+    m = _PREFIX_RE.match(text)
+    if not m:
+        return None, text
+
+    candidate = m.group(1)
+    rest = m.group(2)
+    # Match case-insensitively but return the session's canonical name so
+    # downstream routing/logging is consistent regardless of how it was typed.
+    for name in known_names:
+        if name.lower() == candidate.lower():
+            return name, rest.strip()
+
+    # Looks like a prefix but isn't a real session — treat as plain text.
+    return None, text
+
+
+def _conductor_sort_key(s: TargetSession) -> tuple[int, str]:
+    # Conductors first (0), then alphabetical by name for deterministic default.
+    return (0 if s.is_conductor else 1, s.name.lower())
+
+
+def is_conductor_name(name: str) -> bool:
+    """True if a session name looks like a conductor session."""
+    lo = name.lower()
+    return lo == "conductor" or lo.startswith("conductor-")
+
+
+def default_target(sessions: list[TargetSession]) -> TargetSession | None:
+    """Pick the default relay target.
+
+    Conductor sessions win; among equals the alphabetically-first name is
+    chosen so the default is stable across restarts. Returns ``None`` when the
+    fleet is empty.
+    """
+    if not sessions:
+        return None
+    return sorted(sessions, key=_conductor_sort_key)[0]
+
+
+def resolve_target(parsed_name: str | None, sessions: list[TargetSession]) -> TargetSession | None:
+    """Resolve a relay target from an optional name + the live session list.
+
+    - ``parsed_name`` given: exact (case-insensitive) match on ``name``; if no
+      such session is running, returns ``None`` (caller reports "no such
+      session" rather than silently relaying to the wrong place).
+    - ``parsed_name`` absent: the conductor-first default (degrades to any
+      named session).
+    """
+    if parsed_name is not None:
+        wanted = parsed_name.lower()
+        for s in sessions:
+            if s.name.lower() == wanted:
+                return s
+        return None
+    return default_target(sessions)

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/secrets.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/secrets.py
@@ -1,0 +1,73 @@
+# ABOUTME: Secret resolver for the phone bridge config.
+#
+# Mirrors agent-deck's embedded-template `_resolve_secret` contract (the verified
+# one, NOT the older standalone bridge.py which only accepts plain strings):
+#   "$ENV_VAR"     -> os.environ.get("ENV_VAR", "")  (warns if unset)
+#   "${ENV_VAR}"   -> same branch (strips both '$' and surrounding '{}')
+#   "keychain:svc" -> `security find-generic-password -s svc -w` (macOS only)
+#   "plain-string" -> returned unchanged
+#
+# A secret is NEVER passed on argv into the daemon — the bridge reads the raw
+# value from config and resolves it here, in-process, at startup.
+
+from __future__ import annotations
+
+import logging
+import subprocess
+
+log = logging.getLogger("ainb.bridge.secrets")
+
+KEYCHAIN_PREFIX = "keychain:"
+# `security` can hang on a locked keychain prompt; bound it.
+_KEYCHAIN_TIMEOUT_S = 5
+
+
+def resolve_secret(value: str) -> str:
+    """Resolve a config secret reference to its plaintext value.
+
+    Pure aside from reading ``os.environ`` and (for keychain refs) shelling out
+    to ``/usr/bin/security``. Unknown / missing references resolve to ``""`` with
+    a warning rather than raising — the bridge then fails loudly on an empty
+    token at startup, which is a clearer error than a stack trace deep in here.
+    """
+    import os
+
+    if not isinstance(value, str):
+        return ""
+
+    raw = value.strip()
+    if not raw:
+        return ""
+
+    if raw.startswith("$"):
+        # Handles both "$VAR" and "${VAR}" — strip the leading '$' and any
+        # surrounding braces, then read the environment (default "").
+        name = raw.lstrip("$").strip("{}")
+        resolved = os.environ.get(name, "")
+        if not resolved:
+            log.warning("env var %s referenced by config is unset/empty", name)
+        return resolved
+
+    if raw.startswith(KEYCHAIN_PREFIX):
+        service = raw[len(KEYCHAIN_PREFIX) :]
+        if not service:
+            log.warning("keychain reference has no service name")
+            return ""
+        try:
+            out = subprocess.run(
+                ["/usr/bin/security", "find-generic-password", "-s", service, "-w"],
+                capture_output=True,
+                text=True,
+                timeout=_KEYCHAIN_TIMEOUT_S,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            log.warning("keychain lookup for %s failed: %s", service, exc)
+            return ""
+        if out.returncode != 0:
+            log.warning("keychain has no item for service %s", service)
+            return ""
+        return out.stdout.strip()
+
+    # Plain literal — returned as-is.
+    return raw

--- a/plugins/ainb-fleet/bridge/ainb_phone_bridge/service.py
+++ b/plugins/ainb-fleet/bridge/ainb_phone_bridge/service.py
@@ -1,0 +1,193 @@
+# ABOUTME: Install / teardown the bridge as a launchd (macOS) or systemd (Linux)
+# service. Idempotent: install overwrites cleanly, teardown removes everything.
+#
+# The daemon is launched as `<venv>/bin/python3 -m ainb_phone_bridge run`. The
+# venv path uses `venv/bin/python3` (NO leading dot — agent-deck's daemon python
+# resolver only ever stats `venv`, never `.venv`). The bot token is NEVER on the
+# command line; the daemon reads it from config.toml at startup. The unit env
+# carries only PATH and HOME.
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+LABEL = "com.agentsinabox.phone-bridge"
+_SYSTEMD_UNIT = "ainb-phone-bridge.service"
+
+
+@dataclass
+class ServicePaths:
+    package_dir: Path  # the `bridge/` dir that holds ainb_phone_bridge/
+    venv_python: Path  # <bridge>/venv/bin/python3
+    log_path: Path  # ~/.agents-in-a-box/phone-bridge.log
+
+
+def _bridge_root() -> Path:
+    # ainb_phone_bridge/service.py -> ainb_phone_bridge -> bridge/
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_paths() -> ServicePaths:
+    root = _bridge_root()
+    venv_python = root / "venv" / "bin" / "python3"
+    log_path = Path.home() / ".agents-in-a-box" / "phone-bridge.log"
+    return ServicePaths(package_dir=root, venv_python=venv_python, log_path=log_path)
+
+
+def _python_for_daemon(paths: ServicePaths) -> str:
+    """Prefer the bridge venv python; fall back to the current interpreter."""
+    if paths.venv_python.exists():
+        return str(paths.venv_python)
+    return sys.executable or "python3"
+
+
+def _daemon_argv(paths: ServicePaths) -> list[str]:
+    # `-m ainb_phone_bridge run` — no token, ever, on argv.
+    return [_python_for_daemon(paths), "-m", "ainb_phone_bridge", "run"]
+
+
+# --- macOS launchd ----------------------------------------------------------
+
+
+def _launchd_plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def _build_plist(paths: ServicePaths) -> dict:
+    env_path = os.environ.get("PATH", "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+    return {
+        "Label": LABEL,
+        "ProgramArguments": _daemon_argv(paths),
+        "WorkingDirectory": str(paths.package_dir),
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "ThrottleInterval": 10,
+        "LowPriorityIO": True,
+        "StandardOutPath": str(paths.log_path),
+        "StandardErrorPath": str(paths.log_path),
+        "EnvironmentVariables": {
+            "PATH": env_path,
+            "HOME": str(Path.home()),
+            # Make the package importable without an install step.
+            "PYTHONPATH": str(paths.package_dir),
+        },
+    }
+
+
+def _install_launchd(paths: ServicePaths) -> Path:
+    plist_path = _launchd_plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+    with plist_path.open("wb") as fh:
+        plistlib.dump(_build_plist(paths), fh)
+    # Idempotent reload: unload (ignore errors) then load.
+    subprocess.run(
+        ["launchctl", "unload", str(plist_path)],
+        capture_output=True,
+        check=False,
+    )
+    subprocess.run(["launchctl", "load", str(plist_path)], capture_output=True, check=False)
+    return plist_path
+
+
+def _teardown_launchd() -> Path | None:
+    plist_path = _launchd_plist_path()
+    if plist_path.exists():
+        subprocess.run(
+            ["launchctl", "unload", str(plist_path)],
+            capture_output=True,
+            check=False,
+        )
+        plist_path.unlink(missing_ok=True)
+        return plist_path
+    return None
+
+
+# --- Linux systemd (user) ---------------------------------------------------
+
+
+def _systemd_unit_path() -> Path:
+    return Path.home() / ".config" / "systemd" / "user" / _SYSTEMD_UNIT
+
+
+def build_systemd_unit(paths: ServicePaths) -> str:
+    exec_start = " ".join(_daemon_argv(paths))
+    return (
+        "[Unit]\n"
+        "Description=ainb Telegram phone bridge\n"
+        "After=network-online.target\n"
+        "Wants=network-online.target\n"
+        "\n"
+        "[Service]\n"
+        "Type=simple\n"
+        f"WorkingDirectory={paths.package_dir}\n"
+        f"Environment=PYTHONPATH={paths.package_dir}\n"
+        f"ExecStart={exec_start}\n"
+        "Restart=always\n"
+        "RestartSec=10\n"
+        f"StandardOutput=append:{paths.log_path}\n"
+        f"StandardError=append:{paths.log_path}\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def _install_systemd(paths: ServicePaths) -> Path:
+    unit_path = _systemd_unit_path()
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+    unit_path.write_text(build_systemd_unit(paths), encoding="utf-8")
+    subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True, check=False)
+    subprocess.run(
+        ["systemctl", "--user", "enable", "--now", _SYSTEMD_UNIT],
+        capture_output=True,
+        check=False,
+    )
+    return unit_path
+
+
+def _teardown_systemd() -> Path | None:
+    unit_path = _systemd_unit_path()
+    if unit_path.exists():
+        subprocess.run(
+            ["systemctl", "--user", "disable", "--now", _SYSTEMD_UNIT],
+            capture_output=True,
+            check=False,
+        )
+        unit_path.unlink(missing_ok=True)
+        subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True, check=False)
+        return unit_path
+    return None
+
+
+# --- public API -------------------------------------------------------------
+
+
+def install() -> Path:
+    """Provision the daemon service for the current platform. Idempotent."""
+    paths = resolve_paths()
+    if sys.platform == "darwin":
+        return _install_launchd(paths)
+    return _install_systemd(paths)
+
+
+def teardown() -> Path | None:
+    """Remove the daemon service. Safe to call when nothing is installed."""
+    if sys.platform == "darwin":
+        return _teardown_launchd()
+    return _teardown_systemd()
+
+
+def status() -> str:
+    """Human-readable install status for the current platform."""
+    if sys.platform == "darwin":
+        p = _launchd_plist_path()
+        return f"launchd: {'installed' if p.exists() else 'not installed'} ({p})"
+    p = _systemd_unit_path()
+    return f"systemd: {'installed' if p.exists() else 'not installed'} ({p})"

--- a/plugins/ainb-fleet/bridge/config.example.toml
+++ b/plugins/ainb-fleet/bridge/config.example.toml
@@ -1,0 +1,31 @@
+# Example phone-bridge config — merge this [fleet.telegram] table into
+# ~/.agents-in-a-box/config/config.toml.
+#
+# The token is resolved through a secret resolver, so prefer an env or keychain
+# reference over a literal. The token is NEVER passed on the command line.
+
+[fleet.telegram]
+# token reference forms:
+#   "$TELEGRAM_BOT_TOKEN" / "${TELEGRAM_BOT_TOKEN}" — read from the environment
+#   "keychain:tg-bot"                                — macOS keychain item
+#   "1234567890:ABCdef..."                           — literal (discouraged)
+token = "$TELEGRAM_BOT_TOKEN"
+
+# Authorized Telegram user id (int, or a secret ref resolving to an int).
+# Messages from any other user are silently ignored.
+user_id = 123456789
+
+# Optional: session name to prefer when a message has no "name:" prefix.
+# When unset, the bridge prefers a conductor session and otherwise degrades to
+# the alphabetically-first running session.
+# default_target = "conductor"
+
+# Optional: in group chats, only act on @mentions / replies to the bot.
+require_mention_in_groups = true
+
+# Optional: seconds to wait for a session to finish its turn before reporting
+# that no reply arrived. Default 300.
+response_timeout = 300
+
+# Optional: HTTP/SOCKS proxy for the Telegram API (SOCKS needs aiohttp-socks).
+# proxy_url = "http://127.0.0.1:8080"

--- a/plugins/ainb-fleet/bridge/pyproject.toml
+++ b/plugins/ainb-fleet/bridge/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "ainb-phone-bridge"
+version = "0.1.0"
+description = "Telegram phone bridge for ainb fleet — two-way relay between Telegram and a named ainb session."
+requires-python = ">=3.11"
+dependencies = ["aiogram>=3.4,<4"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]

--- a/plugins/ainb-fleet/bridge/requirements.txt
+++ b/plugins/ainb-fleet/bridge/requirements.txt
@@ -1,0 +1,5 @@
+# Runtime dependency for the ainb Telegram phone bridge daemon.
+# Config parsing uses the stdlib `tomllib` (Python 3.11+) — no extra dep.
+aiogram>=3.4,<4
+# Optional: only needed when [fleet.telegram] proxy_url points at a SOCKS proxy.
+# aiohttp-socks>=0.8

--- a/plugins/ainb-fleet/bridge/tests/conftest.py
+++ b/plugins/ainb-fleet/bridge/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Make the bridge package importable without an install step."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BRIDGE_DIR = HERE.parent  # plugins/ainb-fleet/bridge
+sys.path.insert(0, str(BRIDGE_DIR))

--- a/plugins/ainb-fleet/bridge/tests/test_ainb_client.py
+++ b/plugins/ainb-fleet/bridge/tests/test_ainb_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 
 from ainb_phone_bridge.ainb_client import (
     _assistant_text_from_row,
@@ -249,19 +250,17 @@ def test_send_keys_leading_dash_payload(monkeypatch):
 # --- wait_for_reply follows transcript rotation ---------------------------
 
 
-def _end_turn_blob(text: str) -> str:
-    return (
-        json.dumps(
-            {
-                "type": "assistant",
-                "message": {
-                    "stop_reason": "end_turn",
-                    "content": [{"type": "text", "text": text}],
-                },
-            }
-        )
-        + "\n"
-    )
+def _end_turn_blob(text: str, timestamp: str | None = None) -> str:
+    row: dict = {
+        "type": "assistant",
+        "message": {
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+    if timestamp is not None:
+        row["timestamp"] = timestamp
+    return json.dumps(row) + "\n"
 
 
 def test_wait_for_reply_follows_rotated_transcript(tmp_path, monkeypatch):
@@ -293,3 +292,49 @@ def test_wait_for_reply_follows_rotated_transcript(tmp_path, monkeypatch):
 
     reply = wait_for_reply("/cwd", start_offset=0, transcript=old, timeout=5.0, poll_interval=0.01)
     assert reply == "rotated"
+
+
+def test_wait_for_reply_rejects_pre_send_backlog_after_rotation(tmp_path, monkeypatch):
+    """A rotated file carrying a PRE-send end_turn must not surface as the reply.
+
+    Regression: switching to a newer transcript reset the offset to 0 and the
+    whole file was re-scanned, so a rolled-up pre-send end_turn (resume /
+    compaction backlog) was returned as a STALE answer. With the send-time
+    guard, only the post-send end_turn is accepted.
+    """
+    import ainb_phone_bridge.ainb_client as client
+
+    old = tmp_path / "old.jsonl"
+    new = tmp_path / "new.jsonl"
+    old.write_text("", encoding="utf-8")
+
+    # The new file ALREADY contains a pre-send end_turn (rolled-up history). The
+    # post-send reply is appended only once polling starts.
+    new.write_text(_end_turn_blob("STALE backlog", timestamp="2020-01-01T00:00:00Z"))
+
+    send_time = datetime(2021, 1, 1, tzinfo=UTC).timestamp()
+
+    resolutions = iter([old, new, new])
+
+    def fake_latest(_cwd):
+        try:
+            return next(resolutions)
+        except StopIteration:
+            return new
+
+    def append_fresh(_s):
+        with new.open("a", encoding="utf-8") as fh:
+            fh.write(_end_turn_blob("fresh reply", timestamp="2021-06-14T12:00:00Z"))
+
+    monkeypatch.setattr(client, "latest_transcript_for_cwd", fake_latest)
+    monkeypatch.setattr(client.time, "sleep", append_fresh)
+
+    reply = wait_for_reply(
+        "/cwd",
+        start_offset=0,
+        transcript=old,
+        timeout=5.0,
+        poll_interval=0.01,
+        send_time=send_time,
+    )
+    assert reply == "fresh reply"

--- a/plugins/ainb-fleet/bridge/tests/test_ainb_client.py
+++ b/plugins/ainb-fleet/bridge/tests/test_ainb_client.py
@@ -8,6 +8,8 @@ from ainb_phone_bridge.ainb_client import (
     _assistant_text_from_row,
     _scan_new_rows_for_turn_end,
     cwd_to_project_slug,
+    send_keys,
+    wait_for_reply,
 )
 
 # --- cwd_to_project_slug (must match the Rust fleet slug) ------------------
@@ -169,3 +171,125 @@ def test_scan_tolerates_malformed_lines(tmp_path):
         )
     _offset, reply = _scan_new_rows_for_turn_end(path, 0)
     assert reply == "ok"
+
+
+def test_partial_line_is_not_consumed_then_completed(tmp_path):
+    """A reply written as a partial (no newline yet) is captured once completed.
+
+    Regression: previously the offset advanced to EOF on the first read, so the
+    completed line was never re-read and the reply was silently lost.
+    """
+    path = tmp_path / "t.jsonl"
+    row = {
+        "type": "assistant",
+        "message": {"stop_reason": "end_turn", "content": [{"type": "text", "text": "answer"}]},
+    }
+    blob = json.dumps(row)
+    # First write lands WITHOUT a trailing newline (a partial flush).
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(blob)
+
+    offset, reply = _scan_new_rows_for_turn_end(path, 0)
+    # Nothing consumed: no complete line yet, offset held at the start.
+    assert reply is None
+    assert offset == 0
+
+    # The writer finishes the line (adds the newline).
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n")
+
+    offset, reply = _scan_new_rows_for_turn_end(path, offset)
+    assert reply == "answer"
+    assert offset == path.stat().st_size
+
+
+def test_scan_holds_offset_across_partial_then_next_turn(tmp_path):
+    """After a completed line, a fresh partial line is still held for next poll."""
+    path = tmp_path / "t.jsonl"
+    done = {
+        "type": "assistant",
+        "message": {"stop_reason": "end_turn", "content": [{"type": "text", "text": "first"}]},
+    }
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(done) + "\n")
+        fh.write('{"partial": tr')  # half-written next line, no newline
+
+    offset, reply = _scan_new_rows_for_turn_end(path, 0)
+    assert reply == "first"
+    # Offset stops at the newline, leaving the partial for the next read.
+    assert offset == len(json.dumps(done)) + 1
+
+
+# --- send_keys terminates flags with `--` ---------------------------------
+
+
+def test_send_keys_leading_dash_payload(monkeypatch):
+    """A payload starting with '-' must not be parsed as a tmux flag."""
+    calls: list[list[str]] = []
+
+    class R:
+        returncode = 0
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return R()
+
+    import ainb_phone_bridge.ainb_client as client
+
+    monkeypatch.setattr(client.subprocess, "run", fake_run)
+
+    payload = "-rf important note"
+    assert send_keys("sess", payload) is True
+
+    literal_call = calls[0]
+    # The literal send must place `--` immediately before the payload.
+    assert literal_call == ["tmux", "send-keys", "-t", "sess", "-l", "--", payload]
+
+
+# --- wait_for_reply follows transcript rotation ---------------------------
+
+
+def _end_turn_blob(text: str) -> str:
+    return (
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+def test_wait_for_reply_follows_rotated_transcript(tmp_path, monkeypatch):
+    """End-of-turn lands in a NEW *.jsonl after rotation; it must still be read.
+
+    Regression: wait_for_reply only re-resolved the transcript while path was
+    None, so a rotation (resume / compaction) left the reply in a file it never
+    read -> false timeout.
+    """
+    import ainb_phone_bridge.ainb_client as client
+
+    old = tmp_path / "old.jsonl"
+    new = tmp_path / "new.jsonl"
+    # The original transcript exists but never gets the end-of-turn row.
+    old.write_text("", encoding="utf-8")
+
+    # Drive resolution: first poll -> old file, then a rotation to the new file
+    # which holds the reply.
+    resolutions = iter([old, new, new])
+
+    def fake_latest(_cwd):
+        try:
+            return next(resolutions)
+        except StopIteration:
+            return new
+
+    monkeypatch.setattr(client, "latest_transcript_for_cwd", fake_latest)
+    monkeypatch.setattr(client.time, "sleep", lambda _s: new.write_text(_end_turn_blob("rotated")))
+
+    reply = wait_for_reply("/cwd", start_offset=0, transcript=old, timeout=5.0, poll_interval=0.01)
+    assert reply == "rotated"

--- a/plugins/ainb-fleet/bridge/tests/test_ainb_client.py
+++ b/plugins/ainb-fleet/bridge/tests/test_ainb_client.py
@@ -1,0 +1,171 @@
+"""ainb client pure logic: cwd slug + JSONL end-of-turn reply extraction."""
+
+from __future__ import annotations
+
+import json
+
+from ainb_phone_bridge.ainb_client import (
+    _assistant_text_from_row,
+    _scan_new_rows_for_turn_end,
+    cwd_to_project_slug,
+)
+
+# --- cwd_to_project_slug (must match the Rust fleet slug) ------------------
+
+
+def test_slug_basic_path():
+    assert cwd_to_project_slug("/Users/foo/d/git/bar") == "-Users-foo-d-git-bar"
+
+
+def test_slug_collapses_dot_and_underscore():
+    assert (
+        cwd_to_project_slug("/Users/foo/.agents-in-a-box/foo_bar")
+        == "-Users-foo--agents-in-a-box-foo-bar"
+    )
+
+
+def test_slug_preserves_existing_dashes():
+    assert cwd_to_project_slug("a-b-c") == "a-b-c"
+
+
+# --- assistant row text extraction ----------------------------------------
+
+
+def test_assistant_text_from_row():
+    row = {
+        "type": "assistant",
+        "message": {
+            "stop_reason": "end_turn",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "world"},
+            ],
+        },
+    }
+    stop, text = _assistant_text_from_row(row)
+    assert stop == "end_turn"
+    assert text == "Hello\nworld"
+
+
+def test_non_assistant_row_ignored():
+    assert _assistant_text_from_row({"type": "user", "message": {}}) == (None, None)
+
+
+def test_tool_use_only_row_has_no_text():
+    row = {
+        "type": "assistant",
+        "message": {
+            "stop_reason": "tool_use",
+            "content": [{"type": "tool_use", "name": "Bash"}],
+        },
+    }
+    stop, text = _assistant_text_from_row(row)
+    assert stop == "tool_use"
+    assert text is None
+
+
+def test_string_content():
+    row = {"type": "assistant", "message": {"stop_reason": "end_turn", "content": "hi"}}
+    assert _assistant_text_from_row(row) == ("end_turn", "hi")
+
+
+# --- scan for the last end-of-turn reply ----------------------------------
+
+
+def _write_jsonl(path, rows):
+    with path.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+    return path.stat().st_size
+
+
+def test_scan_returns_last_end_turn(tmp_path):
+    path = tmp_path / "t.jsonl"
+    rows = [
+        {"type": "user", "message": {"content": "go"}},
+        {
+            "type": "assistant",
+            "message": {
+                "stop_reason": "tool_use",
+                "content": [{"type": "text", "text": "thinking"}],
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {"stop_reason": "end_turn", "content": [{"type": "text", "text": "done!"}]},
+        },
+    ]
+    _write_jsonl(path, rows)
+    offset, reply = _scan_new_rows_for_turn_end(path, 0)
+    assert reply == "done!"
+    assert offset == path.stat().st_size
+
+
+def test_scan_only_reads_after_offset(tmp_path):
+    path = tmp_path / "t.jsonl"
+    first_size = _write_jsonl(
+        path,
+        [
+            {
+                "type": "assistant",
+                "message": {
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "old"}],
+                },
+            }
+        ],
+    )
+    # Append a new turn after the watermark.
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "stop_reason": "end_turn",
+                        "content": [{"type": "text", "text": "fresh"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+    offset, reply = _scan_new_rows_for_turn_end(path, first_size)
+    assert reply == "fresh"
+
+
+def test_scan_no_end_turn_yet(tmp_path):
+    path = tmp_path / "t.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "type": "assistant",
+                "message": {
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "text", "text": "wip"}],
+                },
+            }
+        ],
+    )
+    _offset, reply = _scan_new_rows_for_turn_end(path, 0)
+    assert reply is None
+
+
+def test_scan_tolerates_malformed_lines(tmp_path):
+    path = tmp_path / "t.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write("not json\n")
+        fh.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "stop_reason": "end_turn",
+                        "content": [{"type": "text", "text": "ok"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+    _offset, reply = _scan_new_rows_for_turn_end(path, 0)
+    assert reply == "ok"

--- a/plugins/ainb-fleet/bridge/tests/test_bridge.py
+++ b/plugins/ainb-fleet/bridge/tests/test_bridge.py
@@ -66,7 +66,9 @@ def _handler(config, monkeypatch, reply_text):
 
             return deco
 
-    monkeypatch.setattr(bridge, "Dispatcher", lambda: _FakeDispatcher())
+    # raising=False: when aiogram is absent bridge.Dispatcher doesn't exist, and
+    # the suite must still run without the optional dependency.
+    monkeypatch.setattr(bridge, "Dispatcher", lambda: _FakeDispatcher(), raising=False)
     # ParseMode is referenced in the handler; provide a stand-in if aiogram is
     # absent so the test runs without the optional dependency.
     if not bridge.HAS_AIOGRAM:

--- a/plugins/ainb-fleet/bridge/tests/test_bridge.py
+++ b/plugins/ainb-fleet/bridge/tests/test_bridge.py
@@ -1,0 +1,99 @@
+"""Bridge handler: send-loop fault tolerance (HTML -> plain-text fallback)."""
+
+from __future__ import annotations
+
+import asyncio
+import types as _t
+
+import ainb_phone_bridge.bridge as bridge
+from ainb_phone_bridge.config import BridgeConfig
+
+
+def _config() -> BridgeConfig:
+    return BridgeConfig(
+        token="x",
+        authorized_user_id=42,
+        default_target=None,
+        response_timeout=1,
+        require_mention_in_groups=False,
+        proxy_url=None,
+    )
+
+
+class _FakeUser:
+    def __init__(self, uid: int, is_bot: bool = False) -> None:
+        self.id = uid
+        self.is_bot = is_bot
+
+
+class _FakeChat:
+    type = "private"
+
+
+class _RecordingMessage:
+    """A minimal aiogram-Message stand-in that records / fails answer() calls."""
+
+    def __init__(self, text: str, *, fail_html: bool) -> None:
+        self.text = text
+        self.caption = None
+        self.from_user = _FakeUser(42)
+        self.chat = _FakeChat()
+        self.reply_to_message = None
+        self._fail_html = fail_html
+        self.sent: list[tuple[str, object]] = []
+
+    async def answer(self, text, parse_mode=None):
+        if self._fail_html and parse_mode is not None:
+            raise RuntimeError("Telegram 400: can't parse entities")
+        self.sent.append((text, parse_mode))
+
+
+def _handler(config, monkeypatch, reply_text):
+    """Build the dispatcher and pull out the registered message handler."""
+
+    async def fake_relay(_config, _text):
+        return reply_text
+
+    monkeypatch.setattr(bridge, "_relay", fake_relay)
+
+    captured: dict[str, object] = {}
+
+    class _FakeDispatcher:
+        def message(self):
+            def deco(fn):
+                captured["fn"] = fn
+                return fn
+
+            return deco
+
+    monkeypatch.setattr(bridge, "Dispatcher", lambda: _FakeDispatcher())
+    # ParseMode is referenced in the handler; provide a stand-in if aiogram is
+    # absent so the test runs without the optional dependency.
+    if not bridge.HAS_AIOGRAM:
+        monkeypatch.setattr(bridge, "ParseMode", _t.SimpleNamespace(HTML="HTML"), raising=False)
+
+    bridge.build_dispatcher(config, bot=None)
+    return captured["fn"]
+
+
+def test_handler_falls_back_to_plain_text_on_html_failure(monkeypatch):
+    config = _config()
+    handler = _handler(config, monkeypatch, reply_text="**hi** a < b & c")
+    msg = _RecordingMessage("ping", fail_html=True)
+
+    asyncio.run(handler(msg))
+
+    # HTML attempts failed, but the user still received the raw text.
+    assert msg.sent, "expected a plain-text fallback send"
+    assert all(parse_mode is None for _t_, parse_mode in msg.sent)
+    assert "".join(t for t, _ in msg.sent) == "**hi** a < b & c"
+
+
+def test_handler_sends_html_on_success(monkeypatch):
+    config = _config()
+    handler = _handler(config, monkeypatch, reply_text="**hi**")
+    msg = _RecordingMessage("ping", fail_html=False)
+
+    asyncio.run(handler(msg))
+
+    assert msg.sent == [("<b>hi</b>", bridge.ParseMode.HTML)]

--- a/plugins/ainb-fleet/bridge/tests/test_config.py
+++ b/plugins/ainb-fleet/bridge/tests/test_config.py
@@ -1,0 +1,104 @@
+"""Config parsing + validation, including secret-resolved token/user_id."""
+
+from __future__ import annotations
+
+import pytest
+
+from ainb_phone_bridge.config import BridgeConfig, ConfigError, load_config, parse_config
+
+
+def test_parse_minimal():
+    cfg = parse_config({"fleet": {"telegram": {"token": "123:ABC", "user_id": 42}}})
+    assert isinstance(cfg, BridgeConfig)
+    assert cfg.token == "123:ABC"
+    assert cfg.authorized_user_id == 42
+    assert cfg.require_mention_in_groups is True
+    assert cfg.response_timeout == 300
+
+
+def test_parse_full():
+    cfg = parse_config(
+        {
+            "fleet": {
+                "telegram": {
+                    "token": "123:ABC",
+                    "user_id": 7,
+                    "default_target": "conductor",
+                    "require_mention_in_groups": False,
+                    "response_timeout": 120,
+                    "proxy_url": "http://proxy:8080",
+                }
+            }
+        }
+    )
+    assert cfg.default_target == "conductor"
+    assert cfg.require_mention_in_groups is False
+    assert cfg.response_timeout == 120
+    assert cfg.proxy_url == "http://proxy:8080"
+
+
+def test_token_from_env(monkeypatch):
+    monkeypatch.setenv("TG_TOKEN", "env-token")
+    cfg = parse_config({"fleet": {"telegram": {"token": "$TG_TOKEN", "user_id": 1}}})
+    assert cfg.token == "env-token"
+
+
+def test_user_id_as_env_string(monkeypatch):
+    monkeypatch.setenv("TG_UID", "999")
+    cfg = parse_config({"fleet": {"telegram": {"token": "t", "user_id": "$TG_UID"}}})
+    assert cfg.authorized_user_id == 999
+
+
+def test_missing_fleet_table():
+    with pytest.raises(ConfigError, match="no .fleet."):
+        parse_config({})
+
+
+def test_missing_telegram_table():
+    with pytest.raises(ConfigError, match="telegram"):
+        parse_config({"fleet": {}})
+
+
+def test_missing_token():
+    with pytest.raises(ConfigError, match="token"):
+        parse_config({"fleet": {"telegram": {"user_id": 1}}})
+
+
+def test_missing_user_id():
+    with pytest.raises(ConfigError, match="user_id"):
+        parse_config({"fleet": {"telegram": {"token": "t"}}})
+
+
+def test_empty_token_after_resolution(monkeypatch):
+    monkeypatch.delenv("UNSET_TG", raising=False)
+    with pytest.raises(ConfigError, match="empty"):
+        parse_config({"fleet": {"telegram": {"token": "$UNSET_TG", "user_id": 1}}})
+
+
+def test_bool_user_id_rejected():
+    with pytest.raises(ConfigError, match="boolean"):
+        parse_config({"fleet": {"telegram": {"token": "t", "user_id": True}}})
+
+
+def test_non_numeric_user_id_string(monkeypatch):
+    monkeypatch.setenv("BAD_UID", "notanumber")
+    with pytest.raises(ConfigError, match="not an integer"):
+        parse_config({"fleet": {"telegram": {"token": "t", "user_id": "$BAD_UID"}}})
+
+
+def test_response_timeout_must_be_positive():
+    with pytest.raises(ConfigError, match="positive"):
+        parse_config({"fleet": {"telegram": {"token": "t", "user_id": 1, "response_timeout": 0}}})
+
+
+def test_load_config_from_file(tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('[fleet.telegram]\ntoken = "abc:123"\nuser_id = 555\n', encoding="utf-8")
+    cfg = load_config(cfg_file)
+    assert cfg.token == "abc:123"
+    assert cfg.authorized_user_id == 555
+
+
+def test_load_config_missing_file(tmp_path):
+    with pytest.raises(ConfigError, match="not found"):
+        load_config(tmp_path / "nope.toml")

--- a/plugins/ainb-fleet/bridge/tests/test_format.py
+++ b/plugins/ainb-fleet/bridge/tests/test_format.py
@@ -75,3 +75,42 @@ def test_split_just_over_limit():
     chunks = split_message(text)
     assert len(chunks) == 2
     assert all(len(c) <= TG_MAX_LENGTH for c in chunks)
+
+
+def test_split_raw_before_convert_never_cuts_entities_or_tags():
+    """Splitting the RAW reply BEFORE md_to_tg_html keeps every chunk valid.
+
+    Regression: converting to HTML first then splitting at 4096 could slice an
+    HTML entity (e.g. ``&amp;``) or a tag (``<b>``) mid-token, which Telegram
+    rejects with a 400. Splitting the raw text first guarantees boundaries fall
+    on raw characters, so each converted chunk is self-contained.
+    """
+    # A >4096 reply full of chars that become entities, plus bold spans.
+    unit = "**bold** a < b & c > d "
+    raw = unit * 400  # well over TG_MAX_LENGTH
+    assert len(raw) > TG_MAX_LENGTH
+
+    raw_chunks = split_message(raw)
+    assert len(raw_chunks) >= 2
+
+    converted = [md_to_tg_html(c) for c in raw_chunks]
+
+    for html_chunk in converted:
+        # No half-written entity: every '&' must start a complete entity.
+        for amp in _amp_positions(html_chunk):
+            assert _has_complete_entity_at(html_chunk, amp), (
+                f"entity sliced at {amp}: {html_chunk[amp : amp + 8]!r}"
+            )
+        # Balanced bold tags within the chunk (no dangling <b> or </b>).
+        assert html_chunk.count("<b>") == html_chunk.count("</b>")
+        # No stray '<' that isn't part of a recognised tag start.
+        assert "< " not in html_chunk
+
+
+def _amp_positions(s: str) -> list[int]:
+    return [i for i, ch in enumerate(s) if ch == "&"]
+
+
+def _has_complete_entity_at(s: str, idx: int) -> bool:
+    semi = s.find(";", idx, idx + 10)
+    return semi != -1

--- a/plugins/ainb-fleet/bridge/tests/test_format.py
+++ b/plugins/ainb-fleet/bridge/tests/test_format.py
@@ -1,0 +1,77 @@
+"""Markdown -> Telegram HTML and 4096-char message splitting."""
+
+from __future__ import annotations
+
+from ainb_phone_bridge import TG_MAX_LENGTH
+from ainb_phone_bridge.format import md_to_tg_html, split_message
+
+
+def test_bold_and_italic():
+    assert md_to_tg_html("**bold** and *italic*") == "<b>bold</b> and <i>italic</i>"
+
+
+def test_inline_code_is_escaped():
+    out = md_to_tg_html("call `f(<x>)` now")
+    assert out == "call <code>f(&lt;x&gt;)</code> now"
+
+
+def test_fenced_code_block():
+    out = md_to_tg_html("```python\nprint(1)\n```")
+    assert out == "<pre><code>print(1)</code></pre>"
+
+
+def test_html_special_chars_escaped_in_prose():
+    assert md_to_tg_html("a < b & c > d") == "a &lt; b &amp; c &gt; d"
+
+
+def test_link_conversion():
+    out = md_to_tg_html("see [docs](https://example.com/x)")
+    assert out == 'see <a href="https://example.com/x">docs</a>'
+
+
+def test_code_span_not_reinterpreted_as_bold():
+    # The asterisks inside a code span must survive verbatim.
+    out = md_to_tg_html("`a**b**c`")
+    assert out == "<code>a**b**c</code>"
+
+
+def test_empty_string():
+    assert md_to_tg_html("") == ""
+
+
+def test_split_short_message_single_chunk():
+    assert split_message("hello") == ["hello"]
+
+
+def test_split_empty_yields_one_empty_chunk():
+    assert split_message("") == [""]
+
+
+def test_split_at_newline_boundaries():
+    line = "x" * 3000
+    text = "\n".join([line, line])  # 6001 chars total
+    chunks = split_message(text)
+    assert len(chunks) == 2
+    assert all(len(c) <= TG_MAX_LENGTH for c in chunks)
+    # Re-joining with newlines reconstructs the original.
+    assert "\n".join(chunks) == text
+
+
+def test_split_hard_cuts_oversized_line():
+    oversized = "y" * (TG_MAX_LENGTH * 2 + 10)
+    chunks = split_message(oversized)
+    assert all(len(c) <= TG_MAX_LENGTH for c in chunks)
+    assert "".join(chunks) == oversized
+    assert len(chunks) == 3
+
+
+def test_split_exactly_at_limit_single_chunk():
+    text = "z" * TG_MAX_LENGTH
+    assert split_message(text) == [text]
+
+
+def test_split_just_over_limit():
+    text = "z" * (TG_MAX_LENGTH + 1)
+    chunks = split_message(text)
+    assert len(chunks) == 2
+    assert all(len(c) <= TG_MAX_LENGTH for c in chunks)

--- a/plugins/ainb-fleet/bridge/tests/test_routing.py
+++ b/plugins/ainb-fleet/bridge/tests/test_routing.py
@@ -1,0 +1,106 @@
+"""Prefix parsing + target resolution (conductor-first, degrade-to-any)."""
+
+from __future__ import annotations
+
+from ainb_phone_bridge.routing import (
+    TargetSession,
+    default_target,
+    is_conductor_name,
+    parse_target_prefix,
+    resolve_target,
+)
+
+
+def mk(name, *, conductor=False):
+    return TargetSession(
+        name=name,
+        tmux_session=f"tmux_{name}",
+        cwd=f"/work/{name}",
+        session_id=f"id-{name}",
+        is_conductor=conductor,
+    )
+
+
+# --- parse_target_prefix ---------------------------------------------------
+
+
+def test_prefix_selects_known_name():
+    name, msg = parse_target_prefix("ryan: hello there", ["ryan", "ana"])
+    assert name == "ryan"
+    assert msg == "hello there"
+
+
+def test_prefix_case_insensitive():
+    name, msg = parse_target_prefix("RYAN: hi", ["ryan"])
+    assert name == "ryan"
+    assert msg == "hi"
+
+
+def test_unknown_prefix_treated_as_plain_text():
+    name, msg = parse_target_prefix("note: buy milk", ["ryan"])
+    assert name is None
+    assert msg == "note: buy milk"
+
+
+def test_bare_message_no_prefix():
+    name, msg = parse_target_prefix("just do the thing", ["ryan"])
+    assert name is None
+    assert msg == "just do the thing"
+
+
+def test_empty_message():
+    assert parse_target_prefix("", ["ryan"]) == (None, "")
+
+
+def test_prefix_with_multiline_body():
+    name, msg = parse_target_prefix("ryan: line1\nline2", ["ryan"])
+    assert name == "ryan"
+    assert msg == "line1\nline2"
+
+
+# --- is_conductor_name -----------------------------------------------------
+
+
+def test_is_conductor_name():
+    assert is_conductor_name("conductor")
+    assert is_conductor_name("conductor-main")
+    assert not is_conductor_name("ryan")
+
+
+# --- default_target / resolve_target --------------------------------------
+
+
+def test_default_prefers_conductor():
+    sessions = [mk("ana"), mk("conductor-main", conductor=True), mk("zed")]
+    assert default_target(sessions).name == "conductor-main"
+
+
+def test_default_degrades_to_alphabetical_when_no_conductor():
+    sessions = [mk("zed"), mk("ana"), mk("ben")]
+    assert default_target(sessions).name == "ana"
+
+
+def test_default_empty_is_none():
+    assert default_target([]) is None
+
+
+def test_resolve_named_target_exact():
+    sessions = [mk("ana"), mk("ben")]
+    assert resolve_target("ben", sessions).name == "ben"
+
+
+def test_resolve_named_target_missing_returns_none():
+    sessions = [mk("ana"), mk("ben")]
+    assert resolve_target("zed", sessions) is None
+
+
+def test_resolve_no_name_uses_default():
+    sessions = [mk("ana"), mk("conductor", conductor=True)]
+    assert resolve_target(None, sessions).name == "conductor"
+
+
+def test_resolve_degrades_to_any_session():
+    # No conductor present — the bridge must still relay (criterion: useful
+    # before the conductor track lands).
+    sessions = [mk("solo")]
+    assert resolve_target(None, sessions).name == "solo"

--- a/plugins/ainb-fleet/bridge/tests/test_secrets.py
+++ b/plugins/ainb-fleet/bridge/tests/test_secrets.py
@@ -1,0 +1,66 @@
+"""Secret resolver: env refs, keychain refs, plain strings."""
+
+from __future__ import annotations
+
+import subprocess
+
+from ainb_phone_bridge.secrets import resolve_secret
+
+
+def test_plain_string_passthrough():
+    assert resolve_secret("1234:ABCDEF") == "1234:ABCDEF"
+
+
+def test_empty_and_whitespace():
+    assert resolve_secret("") == ""
+    assert resolve_secret("   ") == ""
+
+
+def test_env_dollar_form(monkeypatch):
+    monkeypatch.setenv("MY_TOKEN", "secret-value")
+    assert resolve_secret("$MY_TOKEN") == "secret-value"
+
+
+def test_env_brace_form(monkeypatch):
+    monkeypatch.setenv("MY_TOKEN", "brace-value")
+    assert resolve_secret("${MY_TOKEN}") == "brace-value"
+
+
+def test_env_unset_returns_empty(monkeypatch):
+    monkeypatch.delenv("DEFINITELY_UNSET_XYZ", raising=False)
+    assert resolve_secret("$DEFINITELY_UNSET_XYZ") == ""
+
+
+def test_non_string_returns_empty():
+    assert resolve_secret(None) == ""  # type: ignore[arg-type]
+    assert resolve_secret(12345) == ""  # type: ignore[arg-type]
+
+
+def test_keychain_success(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        assert cmd[:3] == ["/usr/bin/security", "find-generic-password", "-s"]
+        assert cmd[3] == "tg-bot"
+        return subprocess.CompletedProcess(cmd, 0, stdout="kc-token\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert resolve_secret("keychain:tg-bot") == "kc-token"
+
+
+def test_keychain_miss_returns_empty(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 44, stdout="", stderr="not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert resolve_secret("keychain:nope") == ""
+
+
+def test_keychain_empty_service():
+    assert resolve_secret("keychain:") == ""
+
+
+def test_keychain_subprocess_error(monkeypatch):
+    def boom(cmd, **kwargs):
+        raise OSError("security binary missing")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert resolve_secret("keychain:svc") == ""

--- a/plugins/ainb-fleet/bridge/tests/test_service.py
+++ b/plugins/ainb-fleet/bridge/tests/test_service.py
@@ -1,0 +1,106 @@
+"""Service unit generation: venv python path, no token on argv, idempotency."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ainb_phone_bridge import service
+from ainb_phone_bridge.service import (
+    ServicePaths,
+    _build_plist,
+    _daemon_argv,
+    build_systemd_unit,
+)
+
+
+def _paths(tmp_path: Path, *, with_venv: bool) -> ServicePaths:
+    venv_python = tmp_path / "venv" / "bin" / "python3"
+    if with_venv:
+        venv_python.parent.mkdir(parents=True, exist_ok=True)
+        venv_python.write_text("#!/bin/sh\n")
+    return ServicePaths(
+        package_dir=tmp_path,
+        venv_python=venv_python,
+        log_path=tmp_path / "phone-bridge.log",
+    )
+
+
+def test_daemon_argv_prefers_venv_python(tmp_path):
+    paths = _paths(tmp_path, with_venv=True)
+    argv = _daemon_argv(paths)
+    assert argv[0] == str(paths.venv_python)
+    assert argv[0].endswith("venv/bin/python3")  # NO leading dot
+    assert ".venv" not in argv[0]
+    assert argv[1:] == ["-m", "ainb_phone_bridge", "run"]
+
+
+def test_daemon_argv_falls_back_when_no_venv(tmp_path):
+    paths = _paths(tmp_path, with_venv=False)
+    argv = _daemon_argv(paths)
+    # Falls back to a real interpreter, still no token.
+    assert argv[1:] == ["-m", "ainb_phone_bridge", "run"]
+
+
+def test_no_token_anywhere_in_argv(tmp_path):
+    paths = _paths(tmp_path, with_venv=True)
+    argv = _daemon_argv(paths)
+    # The interpreter path is environment-controlled (tmp dirs can contain the
+    # substring "token"); the token-leak guard is about the bridge's own args.
+    bridge_args = " ".join(argv[1:]).lower()
+    assert "token" not in bridge_args
+    assert "--token" not in bridge_args
+
+
+def test_systemd_unit_contents(tmp_path):
+    paths = _paths(tmp_path, with_venv=True)
+    unit = build_systemd_unit(paths)
+    assert "ExecStart=" in unit
+    assert "-m ainb_phone_bridge run" in unit
+    assert "Restart=always" in unit
+    assert "RestartSec=10" in unit
+    assert "venv/bin/python3" in unit
+    assert "token" not in unit.lower()
+
+
+def test_plist_contents(tmp_path):
+    paths = _paths(tmp_path, with_venv=True)
+    plist = _build_plist(paths)
+    assert plist["Label"] == "com.agentsinabox.phone-bridge"
+    assert plist["KeepAlive"] is True
+    assert plist["RunAtLoad"] is True
+    assert plist["ThrottleInterval"] == 10
+    assert plist["ProgramArguments"][1:] == ["-m", "ainb_phone_bridge", "run"]
+    assert "TOKEN" not in plist["EnvironmentVariables"]
+    # PATH + HOME only (plus PYTHONPATH for importability) — no secrets.
+    assert set(plist["EnvironmentVariables"]) == {"PATH", "HOME", "PYTHONPATH"}
+
+
+def test_install_teardown_idempotent_linux(tmp_path, monkeypatch):
+    # Force the systemd path and redirect HOME so we don't touch the real one.
+    monkeypatch.setattr(service.sys, "platform", "linux")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr(service.subprocess, "run", fake_run)
+
+    unit_path = service.install()
+    assert unit_path.exists()
+    # Second install is a clean overwrite (idempotent).
+    service.install()
+    assert unit_path.exists()
+
+    removed = service.teardown()
+    assert removed == unit_path
+    assert not unit_path.exists()
+    # Teardown when nothing installed is a no-op.
+    assert service.teardown() is None


### PR DESCRIPTION
## What

A standalone Python daemon under `plugins/ainb-fleet/bridge/` that relays messages **two-way** between Telegram and a named `ainb` session — a conductor session when one is present, any running session otherwise. Telegram-first port of agent-deck's proven `bridge.py`, re-pointed at ainb's existing fleet transport.

## Why

Lets a developer drive and observe an ainb coding-agent session from their phone over Telegram while away from the keyboard. Part of the agent-deck → ainb feature port (umbrella goal). The conductor orchestration core is a separate track; this bridge targets a conductor by name and **degrades gracefully to any running session** so it is useful before that track lands.

## How it talks to ainb (reuses existing, verified mechanisms)

| Concern | Mechanism |
|---|---|
| Discover | `ainb list --format json` -> running sessions |
| Send | `tmux send-keys -t <s> -l <text>` + `Enter` (literal mode — same path as `ainb fleet broadcast`) |
| Capture reply | Read `~/.claude/projects/<cwd-slug>/*.jsonl`; wait for the next `assistant` row with `stop_reason == "end_turn"`, return its concatenated `text` blocks |

**Response-capture contract (decision):** ainb has no `session send --wait` like agent-deck, so the bridge mirrors ainb-fleet `sequence`'s `wait_for_turn_end` over the JSONL transcript (offset -> send -> poll for end_turn). This is the semantic match for agent-deck's *template* contract (`session output --json -> content`), adapted to ainb. The `cwd -> slug` map matches the Rust `cwd_to_project_slug` exactly. Documented in `bridge/README.md`.

## Highlights

- aiogram v3 long-polling; authorize by Telegram `user_id` (others silently ignored); group @mention/reply gating.
- Prefix routing: `name: msg` -> named session; bare msg -> conductor-first default (degrade-to-any). A non-matching `note: x` prefix is treated as plain text.
- Markdown -> Telegram HTML; messages split at 4096 chars.
- Token + user_id from `[fleet.telegram]` in `~/.agents-in-a-box/config/config.toml` via a secret resolver (`$ENV`/`${ENV}`, `keychain:svc`); **never on argv**.
- `install`/`teardown`/`status`/`run` CLI. Install provisions a launchd plist (macOS) or systemd `--user` unit (Linux) launched as `venv/bin/python3 -m ainb_phone_bridge run` (no leading dot); idempotent.
- Import-safe without aiogram (tests/install never need it); graceful error if missing at `run`.

## Proof

- **68 unit tests pass** (`pytest` exit 0): prefix routing, md->HTML, 4096 split, secret resolution, target resolution incl. degrade-to-any, JSONL end-of-turn extraction, service-unit generation.
- **Lint/format clean**: `ruff check` + `ruff format --check` exit 0.
- **Rust workspace builds**: `cargo build` from `ainb-tui/` -> `Finished` exit 0 (no Rust touched; proven green).
- **End-to-end relay proof**: drove `_relay("ryan: build foo", ...)` against a fake fleet + temp JSONL -> routed to `tmux_ryan`, sent `build foo`, captured the agent's `end_turn` reply, converted markdown to `<b>Done</b> building <code>foo</code>`; a bare message defaulted to the conductor.

## Success criteria

- [x] Authorized Telegram message relays to the target ainb session and the reply returns to Telegram; `name: message` selects a named session, bare hits the conductor/default (logic proven end-to-end).
- [x] Install provisions launchd/systemd using a `venv/bin/python3` path, reads the token from config/secret-resolver (never argv); teardown removes it cleanly; unauthorized users ignored.
- [x] Automated tests for the pure logic pass; README documents config keys, the chosen response-capture contract, install/teardown, and the conductor dependency.
- [x] Runs without errors (import-safe, CLI verified).
- [x] Proof shown (test output + e2e relay + cargo build).

## Notes / follow-ups

- Slack/Discord deferred (clean seams left). No busy-queue / hooks / heartbeat / NEED: escalation — those belong to the conductor track.
- tmux send is fire-and-forget; reply capture (bounded by `response_timeout`) is the delivery confirmation.
- Reply extraction assumes Claude's JSONL schema; Codex/Gemini need adapters.

Do not merge — for review.