### PR TITLE
feat(fleet): ainb fleet cost — spend rollups + budget caps with notifyd alerts

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
@@ -8,12 +8,13 @@
 // landing as a row in `notifications.db`. No new alert kind is introduced —
 // budget caps reuse the same delivery path as idle/permission prompts.
 
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::os::unix::net::UnixStream;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use ainb_plugin_notifyd::envelope::PROTOCOL_VERSION;
 use ainb_plugin_notifyd::paths::Paths;
@@ -49,7 +50,12 @@ pub struct BudgetBreach {
 }
 
 impl BudgetBreach {
-    pub fn session(session_id: String, cwd: Option<String>, cost_usd: f64, limit_usd: f64) -> Self {
+    pub const fn session(
+        session_id: String,
+        cwd: Option<String>,
+        cost_usd: f64,
+        limit_usd: f64,
+    ) -> Self {
         Self {
             scope: BudgetScope::Session,
             subject: session_id,
@@ -59,7 +65,7 @@ impl BudgetBreach {
         }
     }
 
-    pub fn group(group: String, cost_usd: f64, limit_usd: f64) -> Self {
+    pub const fn group(group: String, cost_usd: f64, limit_usd: f64) -> Self {
         Self {
             scope: BudgetScope::Group,
             subject: group,
@@ -70,7 +76,7 @@ impl BudgetBreach {
     }
 
     /// Stable lowercase label for the scope (`"session"` / `"group"`).
-    pub fn scope_label(&self) -> &'static str {
+    pub const fn scope_label(&self) -> &'static str {
         match self.scope {
             BudgetScope::Session => "session",
             BudgetScope::Group => "group",
@@ -146,10 +152,200 @@ pub fn emit_to(socket: &Path, breach: &BudgetBreach) -> Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Alert debounce.
+//
+// notifyd has no content dedup, so a naive `ainb fleet cost` would re-emit an
+// Envelope for every standing breach on every run, accumulating duplicate
+// `notifications.db` rows. We debounce by remembering, per subject, the
+// highest cap-multiple we've already alerted on, persisted to
+// `~/.agents-in-a-box/fleet-cost-alerts.json`. A breach only re-alerts when
+// its spend crosses into a *new* multiple of the cap (1×, 2×, 3× …) — so a
+// session that's been stuck just over its $5 cap alerts once at $5 and stays
+// quiet until $10, while a genuinely escalating runaway still pages.
+// ---------------------------------------------------------------------------
+
+/// Filename for the persisted debounce ledger, under the notifyd base dir.
+const LEDGER_FILE: &str = "fleet-cost-alerts.json";
+
+/// Per-subject record of the highest cap-multiple already alerted on.
+/// Keyed by `"<scope>:<subject>"` so a session and a group that happen to
+/// share a name never alias.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AlertLedger {
+    #[serde(default)]
+    alerted_multiple: BTreeMap<String, u64>,
+}
+
+/// Stable ledger key for a breach: scope + subject.
+fn ledger_key(breach: &BudgetBreach) -> String {
+    format!("{}:{}", breach.scope_label(), breach.subject)
+}
+
+/// How many whole multiples of its cap a breach has reached
+/// (`floor(cost / limit)`), clamped to ≥1. A breach by definition has
+/// `cost > limit`, so this is at least 1; a non-positive limit (which never
+/// produces a breach) defensively yields 1.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn breach_multiple(breach: &BudgetBreach) -> u64 {
+    if breach.limit_usd <= 0.0 {
+        return 1;
+    }
+    // A breach has cost > limit, so the ratio is finite and ≥1; the floor
+    // is a small non-negative integer well within u64.
+    let m = (breach.cost_usd / breach.limit_usd).floor();
+    if m < 1.0 { 1 } else { m as u64 }
+}
+
+impl AlertLedger {
+    /// True when this breach has crossed into a cap-multiple we have not
+    /// alerted on yet (so it warrants a fresh notifyd write).
+    pub fn should_alert(&self, breach: &BudgetBreach) -> bool {
+        let current = breach_multiple(breach);
+        match self.alerted_multiple.get(&ledger_key(breach)) {
+            Some(&seen) => current > seen,
+            None => true,
+        }
+    }
+
+    /// Record that we've alerted on this breach's current cap-multiple.
+    pub fn record(&mut self, breach: &BudgetBreach) {
+        let current = breach_multiple(breach);
+        let entry = self.alerted_multiple.entry(ledger_key(breach)).or_default();
+        if current > *entry {
+            *entry = current;
+        }
+    }
+
+    /// Load the ledger from `path`, returning an empty ledger when the file
+    /// is missing or unreadable (debounce must never block alerting on a
+    /// corrupt/absent state file — worst case we re-alert once).
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    /// Persist the ledger to `path`, creating parent dirs as needed.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let json = serde_json::to_string_pretty(self).context("serializing alert ledger")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("writing alert ledger {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Default debounce-ledger path (`~/.agents-in-a-box/fleet-cost-alerts.json`).
+pub fn ledger_path() -> Result<PathBuf> {
+    let paths = Paths::from_home().context("resolving notifyd paths")?;
+    Ok(paths.base.join(LEDGER_FILE))
+}
+
+/// Emit only the breaches that have crossed a new cap-multiple since the
+/// last run, then persist the updated ledger. Pure decision logic lives in
+/// [`AlertLedger`]; this wires it to the default ledger path + notifyd
+/// socket. Returns the breaches actually delivered.
+///
+/// Best-effort throughout: a notifyd write failure for one breach is logged
+/// and skipped (it is NOT recorded, so it retries next run), and the ledger
+/// is still saved for the breaches that did land.
+pub fn emit_debounced(breaches: &[BudgetBreach]) -> Vec<&BudgetBreach> {
+    let path = match ledger_path() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("warning: budget alert ledger path unresolved: {e}");
+            // Fall back to alerting everything (no debounce) rather than
+            // going silent.
+            for breach in breaches {
+                if let Err(e) = emit(breach) {
+                    eprintln!("warning: budget alert delivery failed: {e}");
+                }
+            }
+            return breaches.iter().collect();
+        }
+    };
+    let mut ledger = AlertLedger::load(&path);
+    let mut delivered = Vec::new();
+    for breach in breaches {
+        if !ledger.should_alert(breach) {
+            continue;
+        }
+        match emit(breach) {
+            Ok(()) => {
+                ledger.record(breach);
+                delivered.push(breach);
+            }
+            Err(e) => eprintln!("warning: budget alert delivery failed: {e}"),
+        }
+    }
+    if let Err(e) = ledger.save(&path) {
+        eprintln!("warning: persisting budget alert ledger failed: {e}");
+    }
+    delivered
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use ainb_plugin_notifyd::envelope::Envelope;
+
+    #[test]
+    fn first_breach_alerts_then_debounces_until_next_multiple() {
+        let mut ledger = AlertLedger::default();
+        // $6 against a $5 cap → 1× multiple. First sighting alerts.
+        let b1 = BudgetBreach::session("s".into(), None, 6.0, 5.0);
+        assert!(ledger.should_alert(&b1));
+        ledger.record(&b1);
+        // Same standing breach (still ~1×) does NOT re-alert.
+        let b1_again = BudgetBreach::session("s".into(), None, 7.0, 5.0);
+        assert!(!ledger.should_alert(&b1_again));
+        // Crossing into 2× ($10+) alerts again.
+        let b2 = BudgetBreach::session("s".into(), None, 11.0, 5.0);
+        assert!(ledger.should_alert(&b2));
+        ledger.record(&b2);
+        // And then debounces at 2× until 3×.
+        let b2_again = BudgetBreach::session("s".into(), None, 12.0, 5.0);
+        assert!(!ledger.should_alert(&b2_again));
+    }
+
+    #[test]
+    fn session_and_group_with_same_name_do_not_alias() {
+        let mut ledger = AlertLedger::default();
+        let sess = BudgetBreach::session("infra".into(), None, 6.0, 5.0);
+        let group = BudgetBreach::group("infra".into(), 6.0, 5.0);
+        ledger.record(&sess);
+        // The group breach shares the subject string but a different scope,
+        // so it must still alert.
+        assert!(ledger.should_alert(&group));
+    }
+
+    #[test]
+    fn ledger_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("alerts.json");
+        let mut ledger = AlertLedger::default();
+        let breach = BudgetBreach::group("ws".into(), 30.0, 10.0); // 3×
+        ledger.record(&breach);
+        ledger.save(&path).unwrap();
+
+        let reloaded = AlertLedger::load(&path);
+        assert_eq!(reloaded, ledger);
+        // A fresh process at the same 3× spend stays quiet.
+        assert!(!reloaded.should_alert(&BudgetBreach::group("ws".into(), 31.0, 10.0)));
+        // A 4× escalation re-alerts.
+        assert!(reloaded.should_alert(&BudgetBreach::group("ws".into(), 41.0, 10.0)));
+    }
+
+    #[test]
+    fn missing_ledger_file_loads_empty_and_alerts() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = AlertLedger::load(&dir.path().join("does-not-exist.json"));
+        assert!(ledger.should_alert(&BudgetBreach::session("x".into(), None, 9.0, 1.0)));
+    }
 
     #[test]
     fn breach_envelope_validates_and_classifies_as_user_facing() {

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
@@ -1,0 +1,246 @@
+// ABOUTME: Budget-breach alert delivery for `ainb fleet cost`.
+//
+// A breach is surfaced through the existing notifyd substrate: a valid
+// `Envelope` is written to the daemon's Unix socket
+// (`~/.agents-in-a-box/notify.sock`), one JSON line per write. We use the
+// `Notification:budget_exceeded` raw event so it classifies as
+// `AlertKind::WaitingOnUser` and passes notifyd's `is_user_facing` filter,
+// landing as a row in `notifications.db`. No new alert kind is introduced —
+// budget caps reuse the same delivery path as idle/permission prompts.
+
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use ainb_plugin_notifyd::envelope::PROTOCOL_VERSION;
+use ainb_plugin_notifyd::paths::Paths;
+
+/// Raw event used for budget alerts. The `Notification` head classifies as
+/// [`ainb_plugin_notifyd::AlertKind::WaitingOnUser`]; the `:budget_exceeded`
+/// matcher suffix is preserved verbatim through notifyd for the inbox view.
+const BUDGET_RAW_EVENT: &str = "Notification:budget_exceeded";
+
+/// What kind of budget ceiling was crossed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BudgetScope {
+    Session,
+    Group,
+}
+
+/// A single budget breach: a session or group whose spend crossed its
+/// configured USD ceiling. Serialized into the `fleet cost` JSON report and
+/// turned into a notifyd `Envelope`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BudgetBreach {
+    pub scope: BudgetScope,
+    /// The session id (scope = session) or group name (scope = group).
+    pub subject: String,
+    /// Working directory of the offending session, when known. Used as the
+    /// notifyd `cwd` so the alert correlates to the fleet session by the
+    /// canonical `Session.workspace_path == Notification.cwd` join.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    pub cost_usd: f64,
+    pub limit_usd: f64,
+}
+
+impl BudgetBreach {
+    pub fn session(session_id: String, cwd: Option<String>, cost_usd: f64, limit_usd: f64) -> Self {
+        Self {
+            scope: BudgetScope::Session,
+            subject: session_id,
+            cwd,
+            cost_usd,
+            limit_usd,
+        }
+    }
+
+    pub fn group(group: String, cost_usd: f64, limit_usd: f64) -> Self {
+        Self {
+            scope: BudgetScope::Group,
+            subject: group,
+            cwd: None,
+            cost_usd,
+            limit_usd,
+        }
+    }
+
+    /// Stable lowercase label for the scope (`"session"` / `"group"`).
+    pub fn scope_label(&self) -> &'static str {
+        match self.scope {
+            BudgetScope::Session => "session",
+            BudgetScope::Group => "group",
+        }
+    }
+
+    /// Human-readable one-liner used as the notification body.
+    fn message(&self) -> String {
+        format!(
+            "{} {} spent ${:.2}, over its ${:.2} budget cap",
+            self.scope_label(),
+            self.subject,
+            self.cost_usd,
+            self.limit_usd
+        )
+    }
+
+    /// Render this breach as a notifyd `Envelope` JSON object.
+    fn envelope_json(&self) -> serde_json::Value {
+        let cwd = self.cwd.clone().unwrap_or_default();
+        let project = if cwd.is_empty() {
+            self.subject.clone()
+        } else {
+            Path::new(&cwd)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&self.subject)
+                .to_string()
+        };
+        serde_json::json!({
+            "protocol_version": PROTOCOL_VERSION,
+            "agent": "ainb",
+            "raw_event": BUDGET_RAW_EVENT,
+            "session_id": match self.scope {
+                BudgetScope::Session => self.subject.clone(),
+                BudgetScope::Group => String::new(),
+            },
+            "cwd": cwd,
+            "project": project,
+            "ts": chrono::Utc::now().timestamp_millis(),
+            "payload": {
+                "kind": "budget_exceeded",
+                "scope": self.scope_label(),
+                "subject": self.subject,
+                "cost_usd": self.cost_usd,
+                "limit_usd": self.limit_usd,
+                "message": self.message(),
+            },
+        })
+    }
+}
+
+/// Deliver a breach alert to the default notifyd socket
+/// (`~/.agents-in-a-box/notify.sock`).
+pub fn emit(breach: &BudgetBreach) -> Result<()> {
+    let paths = Paths::from_home().context("resolving notifyd paths")?;
+    emit_to(&paths.socket, breach)
+}
+
+/// Deliver a breach alert to a specific notifyd socket path. Pulled out so
+/// tests can target a daemon running on a temp socket without touching the
+/// user's real `~/.agents-in-a-box`.
+pub fn emit_to(socket: &Path, breach: &BudgetBreach) -> Result<()> {
+    let mut line = serde_json::to_string(&breach.envelope_json())
+        .context("serializing budget alert envelope")?;
+    line.push('\n');
+    let mut stream = UnixStream::connect(socket)
+        .with_context(|| format!("connecting to notifyd socket {}", socket.display()))?;
+    stream
+        .write_all(line.as_bytes())
+        .context("writing budget alert envelope to notifyd socket")?;
+    stream.flush().ok();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_plugin_notifyd::envelope::Envelope;
+
+    #[test]
+    fn breach_envelope_validates_and_classifies_as_user_facing() {
+        let breach = BudgetBreach::session("sess-x".into(), Some("/work/x".into()), 7.5, 5.0);
+        let json = breach.envelope_json();
+        let bytes = serde_json::to_vec(&json).unwrap();
+        // The envelope must parse + validate under notifyd's contract.
+        let env = Envelope::from_bytes(&bytes).expect("valid envelope");
+        assert_eq!(env.raw_event, "Notification:budget_exceeded");
+        assert_eq!(env.cwd, "/work/x");
+        assert_eq!(env.session_id, "sess-x");
+        // And it must survive notifyd's user-facing filter (else the daemon
+        // would silently drop it).
+        assert!(ainb_plugin_notifyd::osnotify::is_user_facing(&env));
+        assert_eq!(
+            ainb_plugin_notifyd::classify_attention(&env.raw_event),
+            Some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
+        );
+    }
+
+    #[test]
+    fn group_breach_has_empty_session_id() {
+        let breach = BudgetBreach::group("ws-infra".into(), 30.0, 25.0);
+        let json = breach.envelope_json();
+        assert_eq!(json["session_id"], "");
+        assert_eq!(json["project"], "ws-infra");
+    }
+
+    /// End-to-end proof of success-criterion #2: crossing a low budget
+    /// threshold delivers a notifyd row. Spins the real daemon on a temp
+    /// socket, emits a session breach, and asserts the row lands in
+    /// `notifications.db` with the budget raw event.
+    #[tokio::test]
+    async fn budget_breach_lands_in_notifications_db() {
+        use ainb_plugin_notifyd::{Paths, RetentionPolicy, RunConfig, Store, run_daemon};
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = Paths::under(dir.path().join(".agents-in-a-box"));
+        paths.ensure_base().unwrap();
+
+        let config = RunConfig {
+            paths: paths.clone(),
+            // 0/0 disables pruning so the single test row survives.
+            retention: RetentionPolicy {
+                retention_days: 0,
+                max_rows: 0,
+            },
+            os_notifications: false,
+        };
+        let socket = paths.socket.clone();
+        let daemon = tokio::spawn(async move { run_daemon(config).await });
+
+        // Wait for the daemon to bind its socket.
+        for _ in 0..200 {
+            if socket.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(socket.exists(), "daemon socket never appeared");
+
+        // The breach: a session that spent $9 against a $1 cap.
+        let breach = BudgetBreach::session("sess-over".into(), Some("/work/over".into()), 9.0, 1.0);
+        let socket_for_blocking = socket.clone();
+        tokio::task::spawn_blocking(move || emit_to(&socket_for_blocking, &breach))
+            .await
+            .unwrap()
+            .expect("emit budget alert");
+
+        // Give the daemon a tick to drain the write.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        let store = Store::open(&paths.db).unwrap();
+        let rows = store.list(false, None, None, 100).unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "expected exactly one alert row, got {rows:?}"
+        );
+        let row = &rows[0];
+        assert_eq!(row.agent, "ainb");
+        assert_eq!(row.raw_event, "Notification:budget_exceeded");
+        assert_eq!(row.session_id, "sess-over");
+        assert_eq!(row.cwd, "/work/over");
+        assert!(
+            row.payload_json.contains("budget_exceeded"),
+            "payload missing budget marker: {}",
+            row.payload_json
+        );
+
+        daemon.abort();
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/cost.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/cost.rs
@@ -57,7 +57,7 @@ pub struct CostBucket {
 
 impl CostBucket {
     /// Total tokens across every category.
-    pub fn total_tokens(&self) -> u64 {
+    pub const fn total_tokens(&self) -> u64 {
         self.input_tokens
             + self.cache_creation_tokens
             + self.cache_read_tokens
@@ -67,7 +67,7 @@ impl CostBucket {
 
     /// Fold `other` into `self`, summing tokens/calls and adding cost when
     /// either side carries a priced value.
-    fn merge(&mut self, other: &CostBucket) {
+    fn merge(&mut self, other: &Self) {
         self.input_tokens += other.input_tokens;
         self.cache_creation_tokens += other.cache_creation_tokens;
         self.cache_read_tokens += other.cache_read_tokens;
@@ -87,21 +87,20 @@ impl CostBucket {
     }
 }
 
-/// Project rollup row. Only `name` + `path` matter here — they supply the
-/// project-name → cwd join. The `bucket` is intentionally not modelled (we
-/// derive project/group spend from the session rows instead), and serde
-/// ignores the extra key on the wire.
-#[derive(Debug, Clone, Deserialize)]
-struct ProjectRow {
-    name: String,
-    path: String,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 struct SessionRow {
     #[serde(default)]
     provider: String,
     project: String,
+    /// Raw working directory the session ran in — the cross-system join
+    /// key against the fleet `Session.cwd`. Burndown's `project` is the
+    /// sanitised name (folder basename for non-git, but the project
+    /// *rollup* is keyed on the resolved `owner/repo` slug); joining on
+    /// `name` therefore misses for every session in a git repo with a
+    /// remote. We join on this raw path instead. `#[serde(default)]` keeps
+    /// us tolerant of older burndown payloads that predate the field.
+    #[serde(default)]
+    project_path: String,
     session_id: String,
     bucket: CostBucket,
 }
@@ -120,8 +119,6 @@ pub struct UsageReportView {
     #[serde(default)]
     daily: Vec<(String, CostBucket)>,
     #[serde(default)]
-    projects: Vec<ProjectRow>,
-    #[serde(default)]
     sessions: Vec<SessionRow>,
     #[serde(default)]
     models: Vec<ModelRow>,
@@ -138,8 +135,9 @@ pub struct SessionCost {
     pub provider: String,
     /// Burndown project name (display label / aggregation key).
     pub project: String,
-    /// Working directory resolved via the project rollup, when known. This
-    /// is the cross-system join key to the fleet `Session`.
+    /// Raw working directory the session ran in (burndown's
+    /// `project_path`), when non-empty. This is the cross-system join key
+    /// to the fleet `Session.cwd`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
     /// Workspace/group this session belongs to, resolved from the live
@@ -205,23 +203,28 @@ pub struct CostReport {
 /// the live fleet sessions, then evaluate budget caps.
 ///
 /// Pure — no I/O, no clock. `fleet_sessions` supplies the cwd→group join:
-/// a burndown session is attributed to a fleet group when its resolved cwd
-/// matches a fleet `Session.cwd`, using that session's `workspace_name`
-/// (falling back to the project name) as the group label.
+/// a burndown session is attributed to a fleet group when its raw
+/// `project_path` matches a fleet `Session.cwd`, using that session's
+/// `workspace_name` (falling back to the cwd basename) as the group label.
+///
+/// The join is keyed on the raw cwd, NOT the burndown project *name*: the
+/// project rollup is keyed on the resolved `owner/repo` slug while a
+/// session's name is the sanitised folder, so a name-based join misses for
+/// every session in a git repo with a remote. `project_path` is the same
+/// string on both sides (it's literally `ProviderCall.project_path`), so the
+/// join is exact.
 pub fn build_cost_report(
     view: &UsageReportView,
     fleet_sessions: &[Session],
     budget: &CostBudgetConfig,
 ) -> CostReport {
-    // project name -> cwd, from the project rollup (the only place cost
-    // data is tied to a path).
-    let project_cwd: BTreeMap<&str, &str> =
-        view.projects.iter().map(|p| (p.name.as_str(), p.path.as_str())).collect();
-
     // cwd -> group label, from the live fleet. workspace_name is the
     // group/workspace identity; fall back to the cwd basename when absent.
+    // Empty fleet cwds are skipped so they can't cross-join unrelated
+    // sessions whose path is also empty.
     let cwd_group: BTreeMap<&str, String> = fleet_sessions
         .iter()
+        .filter(|s| !s.cwd.is_empty())
         .map(|s| {
             let group =
                 s.workspace_name.clone().unwrap_or_else(|| cwd_basename(&s.cwd).to_string());
@@ -233,7 +236,14 @@ pub fn build_cost_report(
         .sessions
         .iter()
         .map(|row| {
-            let cwd = project_cwd.get(row.project.as_str()).map(|s| s.to_string());
+            // Treat an empty project_path as unjoinable: an empty cwd is
+            // never a meaningful path and would otherwise collide with any
+            // other empty-path session, fabricating a bogus group.
+            let cwd = if row.project_path.is_empty() {
+                None
+            } else {
+                Some(row.project_path.clone())
+            };
             let group = cwd.as_deref().and_then(|c| cwd_group.get(c).cloned());
             SessionCost {
                 session_id: row.session_id.clone(),
@@ -393,13 +403,12 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
     let budget = AppConfig::load().unwrap_or_default().fleet.cost;
     let report = build_cost_report(&view, &fleet, &budget);
 
-    // Deliver an alert for every breach. Best-effort: a notifyd write
-    // failure must not fail the command (the report is still useful).
-    for breach in &report.budget_breaches {
-        if let Err(e) = budget_alert::emit(breach) {
-            eprintln!("warning: budget alert delivery failed: {e}");
-        }
-    }
+    // Deliver alerts, debounced so a standing breach doesn't re-page on
+    // every invocation: a breach only fires again when its spend crosses a
+    // new multiple of its cap (see `emit_debounced`). Best-effort — a
+    // notifyd write failure must not fail the command (the report is still
+    // useful).
+    budget_alert::emit_debounced(&report.budget_breaches);
 
     if matches!(format, OutputFormat::Text) {
         print_text(&report);
@@ -494,26 +503,18 @@ mod tests {
                 ("2026-06-13".to_string(), bucket(2.0, 100)),
                 ("2026-06-14".to_string(), bucket(4.0, 200)),
             ],
-            projects: vec![
-                ProjectRow {
-                    name: "alpha".to_string(),
-                    path: "/work/alpha".to_string(),
-                },
-                ProjectRow {
-                    name: "beta".to_string(),
-                    path: "/work/beta".to_string(),
-                },
-            ],
             sessions: vec![
                 SessionRow {
                     provider: "claude".to_string(),
                     project: "alpha".to_string(),
+                    project_path: "/work/alpha".to_string(),
                     session_id: "sess-a".to_string(),
                     bucket: bucket(4.0, 200),
                 },
                 SessionRow {
                     provider: "codex".to_string(),
                     project: "beta".to_string(),
+                    project_path: "/work/beta".to_string(),
                     session_id: "sess-b".to_string(),
                     bucket: bucket(2.0, 100),
                 },
@@ -597,11 +598,90 @@ mod tests {
         assert!(report.groups.is_empty());
     }
 
+    /// Regression for the production join bug: burndown keys its project
+    /// *rollup* on the resolved repo slug (`owner/repo`) while a session's
+    /// `project` is the sanitised folder basename (`repo`) — the two
+    /// diverge for every git repo with a remote. Joining on the name (the
+    /// old behaviour) therefore missed every such session, silently killing
+    /// group rollups + group budget caps in production. We now join on the
+    /// raw `project_path` instead; this fixture reproduces the divergent
+    /// shape and asserts cwd + group STILL resolve.
+    #[test]
+    fn session_resolves_cwd_and_group_when_name_diverges_from_repo_slug() {
+        let view = UsageReportView {
+            sessions: vec![SessionRow {
+                provider: "claude".to_string(),
+                // Sanitised basename — what a git-repo session carries.
+                project: "repo".to_string(),
+                // Raw cwd — matches the fleet Session.cwd exactly.
+                project_path: "/home/dev/code/repo".to_string(),
+                session_id: "sess-git".to_string(),
+                bucket: bucket(7.0, 300),
+            }],
+            ..UsageReportView::default()
+        };
+        // The fleet session lives at the same cwd; its workspace_name is
+        // the group label.
+        let fleet = vec![fleet_session("/home/dev/code/repo", "ws-repo")];
+        let report = build_cost_report(&view, &fleet, &CostBudgetConfig::default());
+
+        assert_eq!(
+            report.sessions[0].cwd.as_deref(),
+            Some("/home/dev/code/repo")
+        );
+        assert_eq!(
+            report.sessions[0].group.as_deref(),
+            Some("ws-repo"),
+            "group must resolve via project_path even when project name != repo slug"
+        );
+        assert_eq!(report.groups.len(), 1);
+        assert_eq!(report.groups[0].group, "ws-repo");
+        assert_eq!(report.groups[0].cost_usd, 7.0);
+
+        // And the group budget cap must fire (it was silently dead before).
+        let budget = CostBudgetConfig {
+            group_usd: Some(5.0),
+            ..CostBudgetConfig::default()
+        };
+        let report = build_cost_report(&view, &fleet, &budget);
+        let group_breach = report
+            .budget_breaches
+            .iter()
+            .find(|b| b.scope_label() == "group")
+            .expect("group breach must fire for divergent-name session");
+        assert_eq!(group_breach.subject, "ws-repo");
+        assert_eq!(group_breach.cost_usd, 7.0);
+    }
+
+    /// Fix #3: an empty `project_path` is unjoinable. It must map to
+    /// `cwd = None` and never collide with a fleet session whose cwd is
+    /// also empty, which would otherwise fabricate a bogus group.
+    #[test]
+    fn empty_project_path_is_unjoinable() {
+        let view = UsageReportView {
+            sessions: vec![SessionRow {
+                provider: "claude".to_string(),
+                project: String::new(),
+                project_path: String::new(),
+                session_id: "sess-empty".to_string(),
+                bucket: bucket(3.0, 100),
+            }],
+            ..UsageReportView::default()
+        };
+        // A fleet session with an empty cwd would have cross-joined under
+        // the old map; it must not now.
+        let fleet = vec![fleet_session("", "ws-bogus")];
+        let report = build_cost_report(&view, &fleet, &CostBudgetConfig::default());
+        assert!(report.sessions[0].cwd.is_none());
+        assert!(report.sessions[0].group.is_none());
+        assert!(report.groups.is_empty());
+    }
+
     #[test]
     fn two_sessions_in_one_group_sum_into_one_group_row() {
         let mut view = fixture_view();
-        // Point beta's session at alpha's project so both land in ws-alpha.
-        view.sessions[1].project = "alpha".to_string();
+        // Point beta's session at alpha's cwd so both land in ws-alpha.
+        view.sessions[1].project_path = "/work/alpha".to_string();
         let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
         let report = build_cost_report(&view, &fleet, &CostBudgetConfig::default());
         assert_eq!(report.groups.len(), 1);
@@ -629,7 +709,7 @@ mod tests {
     #[test]
     fn group_budget_breach_detected_when_cost_exceeds_cap() {
         let mut view = fixture_view();
-        view.sessions[1].project = "alpha".to_string();
+        view.sessions[1].project_path = "/work/alpha".to_string();
         let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
         let budget = CostBudgetConfig {
             group_usd: Some(5.0),

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/cost.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/cost.rs
@@ -1,0 +1,683 @@
+// ABOUTME: `ainb fleet cost` — fleet-shaped spend rollups + budget caps.
+//
+// ainb already prices every provider call (`cost_usd` on `ProviderCall` /
+// `TokenBucket`, aggregated by the burndown plugin). This verb does NOT
+// re-price anything: it fetches burndown's `usage report --format json`
+// payload live (via `capture_usage_via_plugin`, the same retry/init path
+// `ainb usage` uses), reshapes it into per-session / per-model / per-day /
+// per-group rollups joined to the live fleet, evaluates configured budget
+// caps, and fires a notifyd alert for every breach.
+//
+// The rollup + budget logic is factored into pure functions
+// (`build_cost_report`, `evaluate_budgets`) that take already-parsed
+// fixture data, so the unit tests exercise aggregation and threshold logic
+// with zero live API spend.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::OutputFormat;
+use crate::config::{AppConfig, CostBudgetConfig};
+use crate::fleet::discover::{
+    discover_from_ainb, discover_from_jobs, discover_from_peers, merge_sessions,
+};
+use crate::fleet::types::Session;
+
+use super::budget_alert::{self, BudgetBreach};
+
+// ---------------------------------------------------------------------------
+// Input shapes — a structural subset of the burndown plugin's
+// `usage report --format json` payload (the `report_json` shape).
+// Only the fields `fleet cost` consumes are modelled; unknown keys are
+// ignored by serde, so additions to burndown's payload don't break us.
+// ---------------------------------------------------------------------------
+
+/// Token + cost counts, mirroring `models::usage::TokenBucket`. Re-declared
+/// here (rather than imported) so the verb stays decoupled from the bincode
+/// cache layout and only depends on the stable JSON wire shape.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+pub struct CostBucket {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub reasoning_tokens: u64,
+    #[serde(default)]
+    pub call_count: usize,
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
+}
+
+impl CostBucket {
+    /// Total tokens across every category.
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens
+            + self.cache_creation_tokens
+            + self.cache_read_tokens
+            + self.output_tokens
+            + self.reasoning_tokens
+    }
+
+    /// Fold `other` into `self`, summing tokens/calls and adding cost when
+    /// either side carries a priced value.
+    fn merge(&mut self, other: &CostBucket) {
+        self.input_tokens += other.input_tokens;
+        self.cache_creation_tokens += other.cache_creation_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.output_tokens += other.output_tokens;
+        self.reasoning_tokens += other.reasoning_tokens;
+        self.call_count += other.call_count;
+        self.cost_usd = match (self.cost_usd, other.cost_usd) {
+            (Some(a), Some(b)) => Some(a + b),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+    }
+
+    fn cost(&self) -> f64 {
+        self.cost_usd.unwrap_or(0.0)
+    }
+}
+
+/// Project rollup row. Only `name` + `path` matter here — they supply the
+/// project-name → cwd join. The `bucket` is intentionally not modelled (we
+/// derive project/group spend from the session rows instead), and serde
+/// ignores the extra key on the wire.
+#[derive(Debug, Clone, Deserialize)]
+struct ProjectRow {
+    name: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SessionRow {
+    #[serde(default)]
+    provider: String,
+    project: String,
+    session_id: String,
+    bucket: CostBucket,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModelRow {
+    model: String,
+    bucket: CostBucket,
+}
+
+/// The structural subset of burndown's `report_json` we consume. `daily`
+/// arrives as `[[date, bucket], ...]` tuples; everything else is a list of
+/// keyed rows.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct UsageReportView {
+    #[serde(default)]
+    daily: Vec<(String, CostBucket)>,
+    #[serde(default)]
+    projects: Vec<ProjectRow>,
+    #[serde(default)]
+    sessions: Vec<SessionRow>,
+    #[serde(default)]
+    models: Vec<ModelRow>,
+}
+
+// ---------------------------------------------------------------------------
+// Output shapes — the documented `ainb --format json fleet cost` contract.
+// ---------------------------------------------------------------------------
+
+/// Per-session spend, joined to the live fleet by cwd where possible.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct SessionCost {
+    pub session_id: String,
+    pub provider: String,
+    /// Burndown project name (display label / aggregation key).
+    pub project: String,
+    /// Working directory resolved via the project rollup, when known. This
+    /// is the cross-system join key to the fleet `Session`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Workspace/group this session belongs to, resolved from the live
+    /// fleet by cwd. `None` when the session isn't in the current fleet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    pub cost_usd: f64,
+    pub bucket: CostBucket,
+}
+
+/// Per-model spend across the whole reporting window.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ModelCost {
+    pub model: String,
+    pub cost_usd: f64,
+    pub bucket: CostBucket,
+}
+
+/// Per-day spend across the whole reporting window.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct DayCost {
+    pub date: String,
+    pub cost_usd: f64,
+    pub bucket: CostBucket,
+}
+
+/// Per-group (workspace) spend, summed from its member sessions.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct GroupCost {
+    pub group: String,
+    pub cost_usd: f64,
+    pub session_count: usize,
+    pub bucket: CostBucket,
+}
+
+/// Fleet-wide totals.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct CostTotals {
+    pub cost_usd: f64,
+    pub bucket: CostBucket,
+    pub session_count: usize,
+    pub model_count: usize,
+}
+
+/// The complete `ainb --format json fleet cost` object.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct CostReport {
+    pub totals: CostTotals,
+    pub sessions: Vec<SessionCost>,
+    pub models: Vec<ModelCost>,
+    pub daily: Vec<DayCost>,
+    pub groups: Vec<GroupCost>,
+    /// Budget breaches detected this run (empty when no caps configured or
+    /// none crossed). Mirrors what was delivered to notifyd.
+    pub budget_breaches: Vec<BudgetBreach>,
+}
+
+// ---------------------------------------------------------------------------
+// Pure rollup core.
+// ---------------------------------------------------------------------------
+
+/// Build the fleet-shaped cost report from burndown's parsed usage view and
+/// the live fleet sessions, then evaluate budget caps.
+///
+/// Pure — no I/O, no clock. `fleet_sessions` supplies the cwd→group join:
+/// a burndown session is attributed to a fleet group when its resolved cwd
+/// matches a fleet `Session.cwd`, using that session's `workspace_name`
+/// (falling back to the project name) as the group label.
+pub fn build_cost_report(
+    view: &UsageReportView,
+    fleet_sessions: &[Session],
+    budget: &CostBudgetConfig,
+) -> CostReport {
+    // project name -> cwd, from the project rollup (the only place cost
+    // data is tied to a path).
+    let project_cwd: BTreeMap<&str, &str> =
+        view.projects.iter().map(|p| (p.name.as_str(), p.path.as_str())).collect();
+
+    // cwd -> group label, from the live fleet. workspace_name is the
+    // group/workspace identity; fall back to the cwd basename when absent.
+    let cwd_group: BTreeMap<&str, String> = fleet_sessions
+        .iter()
+        .map(|s| {
+            let group =
+                s.workspace_name.clone().unwrap_or_else(|| cwd_basename(&s.cwd).to_string());
+            (s.cwd.as_str(), group)
+        })
+        .collect();
+
+    let mut sessions: Vec<SessionCost> = view
+        .sessions
+        .iter()
+        .map(|row| {
+            let cwd = project_cwd.get(row.project.as_str()).map(|s| s.to_string());
+            let group = cwd.as_deref().and_then(|c| cwd_group.get(c).cloned());
+            SessionCost {
+                session_id: row.session_id.clone(),
+                provider: row.provider.clone(),
+                project: row.project.clone(),
+                cwd,
+                group,
+                cost_usd: row.bucket.cost(),
+                bucket: row.bucket.clone(),
+            }
+        })
+        .collect();
+    sessions.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+
+    let mut models: Vec<ModelCost> = view
+        .models
+        .iter()
+        .map(|row| ModelCost {
+            model: row.model.clone(),
+            cost_usd: row.bucket.cost(),
+            bucket: row.bucket.clone(),
+        })
+        .collect();
+    models.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.model.cmp(&b.model))
+    });
+
+    let daily: Vec<DayCost> = view
+        .daily
+        .iter()
+        .map(|(date, bucket)| DayCost {
+            date: date.clone(),
+            cost_usd: bucket.cost(),
+            bucket: bucket.clone(),
+        })
+        .collect();
+
+    // Group rollup — sum member sessions by resolved group label.
+    let mut group_acc: BTreeMap<String, (CostBucket, usize)> = BTreeMap::new();
+    for s in &sessions {
+        if let Some(group) = &s.group {
+            let entry = group_acc.entry(group.clone()).or_default();
+            entry.0.merge(&s.bucket);
+            entry.1 += 1;
+        }
+    }
+    let mut groups: Vec<GroupCost> = group_acc
+        .into_iter()
+        .map(|(group, (bucket, session_count))| GroupCost {
+            group,
+            cost_usd: bucket.cost(),
+            session_count,
+            bucket,
+        })
+        .collect();
+    groups.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.group.cmp(&b.group))
+    });
+
+    let mut totals = CostTotals {
+        session_count: sessions.len(),
+        model_count: models.len(),
+        ..CostTotals::default()
+    };
+    for s in &sessions {
+        totals.bucket.merge(&s.bucket);
+    }
+    totals.cost_usd = totals.bucket.cost();
+
+    let budget_breaches = evaluate_budgets(&sessions, &groups, budget);
+
+    CostReport {
+        totals,
+        sessions,
+        models,
+        daily,
+        groups,
+        budget_breaches,
+    }
+}
+
+/// Detect every session / group whose spend crosses its configured USD
+/// ceiling. Pure — the caller delivers the breaches to notifyd.
+pub fn evaluate_budgets(
+    sessions: &[SessionCost],
+    groups: &[GroupCost],
+    budget: &CostBudgetConfig,
+) -> Vec<BudgetBreach> {
+    let mut breaches = Vec::new();
+    for s in sessions {
+        if let Some(limit) = budget.session_limit(&s.session_id) {
+            if s.cost_usd > limit {
+                breaches.push(BudgetBreach::session(
+                    s.session_id.clone(),
+                    s.cwd.clone(),
+                    s.cost_usd,
+                    limit,
+                ));
+            }
+        }
+    }
+    for g in groups {
+        if let Some(limit) = budget.group_limit(&g.group) {
+            if g.cost_usd > limit {
+                breaches.push(BudgetBreach::group(g.group.clone(), g.cost_usd, limit));
+            }
+        }
+    }
+    breaches
+}
+
+fn cwd_basename(cwd: &str) -> &str {
+    cwd.trim_end_matches('/').rsplit('/').next().unwrap_or(cwd)
+}
+
+// ---------------------------------------------------------------------------
+// Live entry point.
+// ---------------------------------------------------------------------------
+
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    let period = matches.get_one::<String>("period").map(String::as_str).unwrap_or("month");
+
+    // Fetch burndown's priced usage data and discover the live fleet in
+    // parallel — neither depends on the other.
+    let argv = vec![
+        "--format".to_string(),
+        "json".to_string(),
+        "report".to_string(),
+        "--period".to_string(),
+        period.to_string(),
+    ];
+    let (usage_json, ainb_res, jobs_res) = tokio::join!(
+        crate::cli::registry::capture_usage_via_plugin(argv),
+        discover_from_ainb(),
+        async { discover_from_jobs() }
+    );
+    let usage_json = usage_json.context("failed to fetch usage data from the burndown plugin")?;
+    let view: UsageReportView = serde_json::from_str(&usage_json)
+        .context("burndown usage payload did not match the expected report shape")?;
+
+    let ainb = ainb_res.unwrap_or_default();
+    let peers = discover_from_peers().unwrap_or_default();
+    let jobs = jobs_res.unwrap_or_default();
+    let fleet = merge_sessions(vec![ainb, peers, jobs]);
+
+    let budget = AppConfig::load().unwrap_or_default().fleet.cost;
+    let report = build_cost_report(&view, &fleet, &budget);
+
+    // Deliver an alert for every breach. Best-effort: a notifyd write
+    // failure must not fail the command (the report is still useful).
+    for breach in &report.budget_breaches {
+        if let Err(e) = budget_alert::emit(breach) {
+            eprintln!("warning: budget alert delivery failed: {e}");
+        }
+    }
+
+    if matches!(format, OutputFormat::Text) {
+        print_text(&report);
+    } else {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    }
+    Ok(())
+}
+
+fn print_text(report: &CostReport) {
+    println!(
+        "ainb fleet cost — ${:.2} across {} sessions / {} models",
+        report.totals.cost_usd, report.totals.session_count, report.totals.model_count
+    );
+
+    if !report.sessions.is_empty() {
+        println!("\nBy session");
+        println!("{:<28}  {:<20}  {:>10}", "session", "group", "cost");
+        for s in report.sessions.iter().take(10) {
+            let group = s.group.as_deref().unwrap_or("—");
+            println!(
+                "{:<28}  {:<20}  {:>9.2}$",
+                truncate(&s.session_id, 28),
+                truncate(group, 20),
+                s.cost_usd
+            );
+        }
+    }
+
+    if !report.groups.is_empty() {
+        println!("\nBy group");
+        println!("{:<24}  {:>8}  {:>10}", "group", "sessions", "cost");
+        for g in &report.groups {
+            println!(
+                "{:<24}  {:>8}  {:>9.2}$",
+                truncate(&g.group, 24),
+                g.session_count,
+                g.cost_usd
+            );
+        }
+    }
+
+    if !report.models.is_empty() {
+        println!("\nBy model");
+        println!("{:<32}  {:>10}", "model", "cost");
+        for m in report.models.iter().take(10) {
+            println!("{:<32}  {:>9.2}$", truncate(&m.model, 32), m.cost_usd);
+        }
+    }
+
+    if !report.budget_breaches.is_empty() {
+        println!("\n⚠ Budget breaches");
+        for b in &report.budget_breaches {
+            println!(
+                "  {} {} — ${:.2} over ${:.2} cap",
+                b.scope_label(),
+                b.subject,
+                b.cost_usd,
+                b.limit_usd
+            );
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bucket(cost: f64, tokens: u64) -> CostBucket {
+        CostBucket {
+            input_tokens: tokens,
+            output_tokens: 0,
+            call_count: 1,
+            cost_usd: Some(cost),
+            ..CostBucket::default()
+        }
+    }
+
+    fn fixture_view() -> UsageReportView {
+        UsageReportView {
+            daily: vec![
+                ("2026-06-13".to_string(), bucket(2.0, 100)),
+                ("2026-06-14".to_string(), bucket(4.0, 200)),
+            ],
+            projects: vec![
+                ProjectRow {
+                    name: "alpha".to_string(),
+                    path: "/work/alpha".to_string(),
+                },
+                ProjectRow {
+                    name: "beta".to_string(),
+                    path: "/work/beta".to_string(),
+                },
+            ],
+            sessions: vec![
+                SessionRow {
+                    provider: "claude".to_string(),
+                    project: "alpha".to_string(),
+                    session_id: "sess-a".to_string(),
+                    bucket: bucket(4.0, 200),
+                },
+                SessionRow {
+                    provider: "codex".to_string(),
+                    project: "beta".to_string(),
+                    session_id: "sess-b".to_string(),
+                    bucket: bucket(2.0, 100),
+                },
+            ],
+            models: vec![
+                ModelRow {
+                    model: "claude-opus-4-8".to_string(),
+                    bucket: bucket(4.0, 200),
+                },
+                ModelRow {
+                    model: "gpt-5".to_string(),
+                    bucket: bucket(2.0, 100),
+                },
+            ],
+        }
+    }
+
+    fn fleet_session(cwd: &str, workspace: &str) -> Session {
+        Session {
+            id: cwd.to_string(),
+            cwd: cwd.to_string(),
+            pid: None,
+            git_root: None,
+            tmux_session: None,
+            workspace_name: Some(workspace.to_string()),
+            worktree_path: None,
+            peer_id: None,
+            bg_job_id: None,
+            transcript_path: None,
+            sources: vec![],
+            summary: None,
+            last_seen_ms: None,
+        }
+    }
+
+    #[test]
+    fn rollups_aggregate_sessions_models_and_days() {
+        let view = fixture_view();
+        let fleet = vec![
+            fleet_session("/work/alpha", "ws-alpha"),
+            fleet_session("/work/beta", "ws-beta"),
+        ];
+        let report = build_cost_report(&view, &fleet, &CostBudgetConfig::default());
+
+        // Totals sum the per-session spend.
+        assert_eq!(report.totals.cost_usd, 6.0);
+        assert_eq!(report.totals.session_count, 2);
+        assert_eq!(report.totals.model_count, 2);
+        assert_eq!(report.totals.bucket.total_tokens(), 300);
+
+        // Sessions sorted by descending cost, joined to cwd + group.
+        assert_eq!(report.sessions[0].session_id, "sess-a");
+        assert_eq!(report.sessions[0].cwd.as_deref(), Some("/work/alpha"));
+        assert_eq!(report.sessions[0].group.as_deref(), Some("ws-alpha"));
+        assert_eq!(report.sessions[1].group.as_deref(), Some("ws-beta"));
+
+        // Models sorted by descending cost.
+        assert_eq!(report.models[0].model, "claude-opus-4-8");
+        assert_eq!(report.models[0].cost_usd, 4.0);
+
+        // Daily rollup preserved.
+        assert_eq!(report.daily.len(), 2);
+        assert_eq!(report.daily[1].date, "2026-06-14");
+        assert_eq!(report.daily[1].cost_usd, 4.0);
+
+        // Group rollup: one session each.
+        assert_eq!(report.groups.len(), 2);
+        assert_eq!(report.groups[0].group, "ws-alpha");
+        assert_eq!(report.groups[0].cost_usd, 4.0);
+        assert_eq!(report.groups[0].session_count, 1);
+    }
+
+    #[test]
+    fn sessions_without_fleet_match_have_no_group() {
+        let view = fixture_view();
+        // Empty fleet — nothing to join against.
+        let report = build_cost_report(&view, &[], &CostBudgetConfig::default());
+        assert!(report.sessions.iter().all(|s| s.group.is_none()));
+        // cwd still resolves from the project rollup even without a fleet.
+        assert_eq!(report.sessions[0].cwd.as_deref(), Some("/work/alpha"));
+        assert!(report.groups.is_empty());
+    }
+
+    #[test]
+    fn two_sessions_in_one_group_sum_into_one_group_row() {
+        let mut view = fixture_view();
+        // Point beta's session at alpha's project so both land in ws-alpha.
+        view.sessions[1].project = "alpha".to_string();
+        let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
+        let report = build_cost_report(&view, &fleet, &CostBudgetConfig::default());
+        assert_eq!(report.groups.len(), 1);
+        assert_eq!(report.groups[0].group, "ws-alpha");
+        assert_eq!(report.groups[0].session_count, 2);
+        assert_eq!(report.groups[0].cost_usd, 6.0);
+    }
+
+    #[test]
+    fn session_budget_breach_detected_when_cost_exceeds_cap() {
+        let view = fixture_view();
+        let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
+        let budget = CostBudgetConfig {
+            session_usd: Some(3.0),
+            ..CostBudgetConfig::default()
+        };
+        let report = build_cost_report(&view, &fleet, &budget);
+        // sess-a ($4) breaches the $3 cap; sess-b ($2) does not.
+        let breaches: Vec<_> = report.budget_breaches.iter().map(|b| &b.subject).collect();
+        assert_eq!(breaches, vec!["sess-a"]);
+        assert_eq!(report.budget_breaches[0].cost_usd, 4.0);
+        assert_eq!(report.budget_breaches[0].limit_usd, 3.0);
+    }
+
+    #[test]
+    fn group_budget_breach_detected_when_cost_exceeds_cap() {
+        let mut view = fixture_view();
+        view.sessions[1].project = "alpha".to_string();
+        let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
+        let budget = CostBudgetConfig {
+            group_usd: Some(5.0),
+            ..CostBudgetConfig::default()
+        };
+        let report = build_cost_report(&view, &fleet, &budget);
+        // ws-alpha sums to $6 > $5 cap.
+        let group_breach = report
+            .budget_breaches
+            .iter()
+            .find(|b| b.scope_label() == "group")
+            .expect("group breach");
+        assert_eq!(group_breach.subject, "ws-alpha");
+        assert_eq!(group_breach.cost_usd, 6.0);
+    }
+
+    #[test]
+    fn per_session_override_takes_precedence_over_blanket_cap() {
+        let view = fixture_view();
+        let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
+        let mut overrides = std::collections::HashMap::new();
+        // Raise sess-a's ceiling above its $4 spend so it no longer breaches.
+        overrides.insert("sess-a".to_string(), 10.0);
+        let budget = CostBudgetConfig {
+            session_usd: Some(1.0),
+            session_overrides: overrides,
+            ..CostBudgetConfig::default()
+        };
+        let report = build_cost_report(&view, &fleet, &budget);
+        // sess-a exempt by override; sess-b ($2) still breaches the $1 blanket.
+        let subjects: Vec<_> = report.budget_breaches.iter().map(|b| b.subject.as_str()).collect();
+        assert_eq!(subjects, vec!["sess-b"]);
+    }
+
+    #[test]
+    fn no_caps_yields_no_breaches() {
+        let view = fixture_view();
+        let fleet = vec![fleet_session("/work/alpha", "ws-alpha")];
+        let report = build_cost_report(&view, &fleet, &CostBudgetConfig::default());
+        assert!(report.budget_breaches.is_empty());
+    }
+
+    #[test]
+    fn cost_bucket_merge_sums_costs_and_tokens() {
+        let mut a = bucket(1.5, 50);
+        a.merge(&bucket(2.5, 25));
+        assert_eq!(a.cost_usd, Some(4.0));
+        assert_eq!(a.total_tokens(), 75);
+        assert_eq!(a.call_count, 2);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -9,6 +9,8 @@ use anyhow::{Result, bail};
 use crate::cli::OutputFormat;
 
 pub mod broadcast;
+pub mod budget_alert;
+pub mod cost;
 pub mod daemon;
 pub mod enrich_cache;
 pub mod needs;
@@ -21,6 +23,7 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
         Some(("broadcast", sub)) => broadcast::execute(sub, format).await,
         Some(("sequence", sub)) => sequence::execute(sub, format).await,
         Some(("needs", sub)) => needs::execute(sub, format).await,
+        Some(("cost", sub)) => cost::execute(sub, format).await,
         Some(("daemon", sub)) => daemon::execute(sub, format).await,
         Some(("enrich-cache", sub)) => enrich_cache::execute(sub, format).await,
         _ => bail!("unknown `ainb fleet` subcommand — try `ainb fleet --help`"),

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -726,75 +726,7 @@ async fn dispatch_inner(
         }
     }
 
-    // Retry contract: burndown reports `exit_code = 1` + empty stdout +
-    // a stderr containing this exact byte sequence when `self.data` is
-    // None. Any *other* exit/stdout/stderr shape (including a real
-    // error from clap, a runtime fault, or a successful report with
-    // exit 0) breaks out of the retry loop immediately so we don't
-    // mask a genuine failure as "still waiting".
-    let install_hint_marker = b"install session-reader";
-    let wait_budget = plugin_data_wait();
-    let deadline = std::time::Instant::now() + wait_budget;
-    let started = std::time::Instant::now();
-    let mut last_trace = started;
-    let mut attempt: u32 = 0;
-    let mut outcome;
-    loop {
-        attempt = attempt.wrapping_add(1);
-        if trace && last_trace.elapsed() >= std::time::Duration::from_secs(2) {
-            // Periodic heartbeat: include plugin lifecycle state so a
-            // user running `AINB_USAGE_TRACE=1` can distinguish "scan
-            // in progress" from "plugin crashed". Mirrors
-            // `ainb plugin watch` semantics.
-            for p in &registered {
-                let state = handle.lifecycle_state(&p.id);
-                eprintln!(
-                    "[usage-cli] @{:.1}s attempt {attempt} plugin {} lifecycle={:?}",
-                    started.elapsed().as_secs_f32(),
-                    p.id,
-                    state
-                );
-            }
-            last_trace = std::time::Instant::now();
-        }
-        outcome = handle.dispatch_cli(&burndown, "usage", argv.clone()).await.map_err(|e| {
-            anyhow::anyhow!("burndown plugin task disconnected before replying: {e}")
-        })?;
-        let should_retry = matches!(
-            &outcome,
-            CliOutcome::Ok(r)
-                if r.exit_code == 1
-                    && r.stdout.is_empty()
-                    && r.stderr
-                        .windows(install_hint_marker.len())
-                        .any(|w| w == install_hint_marker)
-        );
-        if !should_retry {
-            if trace {
-                eprintln!(
-                    "[usage-cli] dispatch returned in {:.1}s (attempt {attempt})",
-                    started.elapsed().as_secs_f32()
-                );
-            }
-            break;
-        }
-        if std::time::Instant::now() >= deadline {
-            anyhow::bail!(
-                "error: session-reader plugin didn't publish usage data within {}s \
-                 — rerun with RUST_LOG=ainb_plugin_runtime=debug,ainb_plugin_session_reader=debug \
-                 to see scan progress, or raise the budget via AINB_USAGE_TIMEOUT_SECS=<n>",
-                wait_budget.as_secs()
-            );
-        }
-        if trace {
-            eprintln!(
-                "[usage-cli] attempt {attempt} returned 'install session-reader' \
-                 (snapshot not yet finalised); retrying in {}ms",
-                PLUGIN_DATA_POLL.as_millis()
-            );
-        }
-        tokio::time::sleep(PLUGIN_DATA_POLL).await;
-    }
+    let outcome = poll_burndown(handle, &burndown, &registered, argv, trace).await?;
 
     let exit = match outcome {
         CliOutcome::Ok(result) => {
@@ -815,6 +747,148 @@ async fn dispatch_inner(
         }
     };
     Ok(exit)
+}
+
+/// Dispatch `usage <argv>` to the burndown plugin, retrying while the
+/// plugin reports the "install session-reader" sentinel (snapshot not yet
+/// finalised). Shared by [`dispatch_inner`] (the `ainb usage` exit path)
+/// and [`capture_usage_via_plugin`] (the in-process consumer used by
+/// `ainb fleet cost`). The caller owns interpreting the returned
+/// [`CliOutcome`].
+///
+/// Retry contract: burndown reports `exit_code = 1` + empty stdout + a
+/// stderr containing the `install session-reader` marker when `self.data`
+/// is None. Any *other* exit/stdout/stderr shape (a real clap error, a
+/// runtime fault, or a successful report with exit 0) breaks out of the
+/// retry loop immediately so we don't mask a genuine failure as "still
+/// waiting".
+async fn poll_burndown(
+    handle: &ainb_plugin_runtime::RuntimeHandle,
+    burndown: &ainb_plugin_runtime::PluginId,
+    registered: &[std::sync::Arc<ainb_plugin_runtime::RegisteredPlugin>],
+    argv: Vec<String>,
+    trace: bool,
+) -> anyhow::Result<ainb_plugin_runtime::CliOutcome> {
+    use ainb_plugin_runtime::CliOutcome;
+
+    let install_hint_marker = b"install session-reader";
+    let wait_budget = plugin_data_wait();
+    let deadline = std::time::Instant::now() + wait_budget;
+    let started = std::time::Instant::now();
+    let mut last_trace = started;
+    let mut attempt: u32 = 0;
+    loop {
+        attempt = attempt.wrapping_add(1);
+        if trace && last_trace.elapsed() >= std::time::Duration::from_secs(2) {
+            // Periodic heartbeat: include plugin lifecycle state so a
+            // user running `AINB_USAGE_TRACE=1` can distinguish "scan
+            // in progress" from "plugin crashed". Mirrors
+            // `ainb plugin watch` semantics.
+            for p in registered {
+                let state = handle.lifecycle_state(&p.id);
+                eprintln!(
+                    "[usage-cli] @{:.1}s attempt {attempt} plugin {} lifecycle={:?}",
+                    started.elapsed().as_secs_f32(),
+                    p.id,
+                    state
+                );
+            }
+            last_trace = std::time::Instant::now();
+        }
+        let outcome = handle.dispatch_cli(burndown, "usage", argv.clone()).await.map_err(|e| {
+            anyhow::anyhow!("burndown plugin task disconnected before replying: {e}")
+        })?;
+        let should_retry = matches!(
+            &outcome,
+            CliOutcome::Ok(r)
+                if r.exit_code == 1
+                    && r.stdout.is_empty()
+                    && r.stderr
+                        .windows(install_hint_marker.len())
+                        .any(|w| w == install_hint_marker)
+        );
+        if !should_retry {
+            if trace {
+                eprintln!(
+                    "[usage-cli] dispatch returned in {:.1}s (attempt {attempt})",
+                    started.elapsed().as_secs_f32()
+                );
+            }
+            return Ok(outcome);
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "error: session-reader plugin didn't publish usage data within {}s \
+                 — rerun with RUST_LOG=ainb_plugin_runtime=debug,ainb_plugin_session_reader=debug \
+                 to see scan progress, or raise the budget via AINB_USAGE_TIMEOUT_SECS=<n>",
+                wait_budget.as_secs()
+            );
+        }
+        if trace {
+            eprintln!(
+                "[usage-cli] attempt {attempt} returned 'install session-reader' \
+                 (snapshot not yet finalised); retrying in {}ms",
+                PLUGIN_DATA_POLL.as_millis()
+            );
+        }
+        tokio::time::sleep(PLUGIN_DATA_POLL).await;
+    }
+}
+
+/// Run `ainb usage <argv>` against the burndown plugin and return its
+/// captured stdout, instead of streaming it to the process stdout and
+/// exiting like [`dispatch_usage_via_plugin`] does.
+///
+/// This is the in-process entry point for `ainb fleet cost`, which needs
+/// burndown's `usage report --format json` payload as a string to build
+/// its own fleet-shaped rollups. It owns the same runtime init +
+/// spawn_blocking drop dance as [`run_usage_via_plugin`] so the tokio
+/// "Cannot drop a runtime in a context where blocking is not allowed"
+/// panic doesn't bite on shutdown.
+///
+/// `argv` must already carry the leading `--format <token>` pair (the
+/// plugin reads format from argv via its own `extract_format`).
+pub async fn capture_usage_via_plugin(argv: Vec<String>) -> anyhow::Result<String> {
+    let (runtime, handle, _outcome) = crate::plugins::init_plugin_runtime()
+        .map_err(|e| anyhow::anyhow!("plugin runtime init failed: {e}"))?;
+    let result = capture_inner(&handle, argv).await;
+    tokio::task::spawn_blocking(move || drop(runtime)).await.ok();
+    result
+}
+
+async fn capture_inner(
+    handle: &ainb_plugin_runtime::RuntimeHandle,
+    argv: Vec<String>,
+) -> anyhow::Result<String> {
+    use ainb_plugin_runtime::{CliOutcome, PluginId};
+
+    let trace = std::env::var("AINB_USAGE_TRACE").is_ok();
+    let burndown = PluginId::from("burndown");
+    let registered = handle.registered_plugins();
+    if !registered.iter().any(|p| p.id == burndown) {
+        anyhow::bail!(
+            "error: fleet cost analytics requires the burndown plugin \
+             (install via 'ainb plugin install burndown')"
+        );
+    }
+
+    match poll_burndown(handle, &burndown, &registered, argv, trace).await? {
+        CliOutcome::Ok(result) => {
+            if result.exit_code != 0 {
+                let stderr = String::from_utf8_lossy(&result.stderr);
+                anyhow::bail!(
+                    "burndown plugin exited {} while fetching usage data: {}",
+                    result.exit_code,
+                    stderr.trim()
+                );
+            }
+            Ok(String::from_utf8_lossy(&result.stdout).into_owned())
+        }
+        CliOutcome::PluginError { code, message } => {
+            anyhow::bail!("burndown plugin error {code}: {message}")
+        }
+        CliOutcome::RuntimeError(msg) => anyhow::bail!("plugin runtime: {msg}"),
+    }
 }
 
 /// Legacy top-level `ainb statusline`. Kept (hidden) so existing
@@ -1377,6 +1451,15 @@ impl CliCommand for FleetCommand {
                     .about("Read a cached suggestion by enrich_key (exit non-zero on miss)")
                     .arg(clap::Arg::new("key").long("key").required(true)),
             );
+        let cost = Command::new("cost")
+            .about("Per-session / model / day / group spend rollups + budget caps")
+            .arg(
+                clap::Arg::new("period")
+                    .long("period")
+                    .value_parser(["today", "week", "30days", "month", "all"])
+                    .default_value("month")
+                    .help("Reporting window passed to the burndown plugin"),
+            );
         let daemon = Command::new("daemon")
             .about("Watcher: registers as ainb-fleet-cp peer, auto-continues API errors")
             .arg(
@@ -1387,13 +1470,16 @@ impl CliCommand for FleetCommand {
             );
         app.subcommand(
             Command::new(self.name())
-                .about("Fleet orchestration: standup / broadcast / sequence / needs / daemon")
+                .about(
+                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon",
+                )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
                 .subcommand(standup)
                 .subcommand(broadcast)
                 .subcommand(sequence)
                 .subcommand(needs)
+                .subcommand(cost)
                 .subcommand(daemon)
                 .subcommand(enrich_cache),
         )

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -255,6 +255,11 @@ pub struct AppConfig {
     /// Where the single `presets.toml` lives. See [`PresetsConfig`].
     #[serde(default)]
     pub presets: PresetsConfig,
+
+    /// Fleet orchestration configuration (budget caps, etc.). See
+    /// [`FleetConfig`].
+    #[serde(default)]
+    pub fleet: FleetConfig,
 }
 
 /// Where the single `presets.toml` file lives.
@@ -362,6 +367,83 @@ pub struct PluginsConfig {
     /// deterministic across saves.
     #[serde(default, flatten)]
     pub values: BTreeMap<String, toml::Value>,
+}
+
+/// Fleet orchestration configuration.
+///
+/// Currently only carries cost budget caps; reserved as the home for
+/// future fleet-wide knobs so they share one `[fleet]` table in
+/// `config.toml`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct FleetConfig {
+    /// Budget caps for `ainb fleet cost`. See [`CostBudgetConfig`].
+    #[serde(default)]
+    pub cost: CostBudgetConfig,
+}
+
+/// Spend ceilings consumed by `ainb fleet cost`.
+///
+/// A breach fires a notifyd alert (`Notification:budget_exceeded`) for the
+/// offending session or group. All thresholds are lifetime USD totals over
+/// the reporting window. The blanket `session_usd` / `group_usd` apply to
+/// every session / group; the per-key override maps pin a tighter (or
+/// looser) ceiling for a named session id or group, taking precedence over
+/// the blanket value.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [fleet.cost]
+/// session_usd = 5.0     # warn when any single session crosses $5
+/// group_usd = 25.0      # warn when any workspace group crosses $25
+///
+/// [fleet.cost.session_overrides]
+/// "abc123" = 50.0       # this long-running session gets a $50 ceiling
+///
+/// [fleet.cost.group_overrides]
+/// "infra" = 100.0       # the infra workspace gets a $100 ceiling
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct CostBudgetConfig {
+    /// Blanket per-session USD ceiling. `None` disables session caps
+    /// (except where a `session_overrides` entry sets one explicitly).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_usd: Option<f64>,
+    /// Blanket per-group USD ceiling. `None` disables group caps (except
+    /// where a `group_overrides` entry sets one explicitly).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_usd: Option<f64>,
+    /// Per-session USD ceilings keyed by session id. Overrides
+    /// `session_usd` for the named session.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub session_overrides: HashMap<String, f64>,
+    /// Per-group USD ceilings keyed by group name. Overrides `group_usd`
+    /// for the named group.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub group_overrides: HashMap<String, f64>,
+}
+
+impl CostBudgetConfig {
+    /// True when no cap of any kind is configured. The default value is
+    /// empty; an empty project layer must not clobber a populated user
+    /// layer (see `merge_loaded`).
+    pub fn is_empty(&self) -> bool {
+        self.session_usd.is_none()
+            && self.group_usd.is_none()
+            && self.session_overrides.is_empty()
+            && self.group_overrides.is_empty()
+    }
+
+    /// Resolve the effective USD ceiling for a session id: the override
+    /// map wins over the blanket `session_usd`.
+    pub fn session_limit(&self, session_id: &str) -> Option<f64> {
+        self.session_overrides.get(session_id).copied().or(self.session_usd)
+    }
+
+    /// Resolve the effective USD ceiling for a group name: the override
+    /// map wins over the blanket `group_usd`.
+    pub fn group_limit(&self, group: &str) -> Option<f64> {
+        self.group_overrides.get(group).copied().or(self.group_usd)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -859,6 +941,16 @@ impl AppConfig {
             self.usage = other.usage;
         }
 
+        // Fleet cost budgets layer like the plugin tables: a higher layer
+        // (project) that declares any cap replaces the lower layer's caps,
+        // so a project can pin a tighter spend ceiling without the user
+        // default leaking through. An all-empty `[fleet.cost]` (the
+        // default) is treated as "not set" and leaves the lower layer
+        // intact.
+        if !other.fleet.cost.is_empty() {
+            self.fleet.cost = other.fleet.cost;
+        }
+
         // Plugin enable/disable lists: a higher layer that sets either list
         // replaces the lower layer's (matches the allowlist/denylist intent —
         // the most specific config layer decides which plugins load).
@@ -925,6 +1017,7 @@ impl Default for AppConfig {
             usage: UsageConfig::default(),
             plugins: PluginsConfig::default(),
             presets: PresetsConfig::default(),
+            fleet: FleetConfig::default(),
         };
 
         // Load built-in templates
@@ -1272,6 +1365,59 @@ qmd_collection = "learnings"
         // Absent `[plugins.<x>]` → empty map via serde default.
         let bare: AppConfig = toml::from_str("[plugins]\n").expect("bare plugins");
         assert!(bare.plugins.values.is_empty(), "absent table → empty map");
+    }
+
+    #[test]
+    fn test_fleet_cost_budget_roundtrip_and_resolution() {
+        let toml_src = r#"
+[fleet.cost]
+session_usd = 5.0
+group_usd = 25.0
+
+[fleet.cost.session_overrides]
+"abc123" = 50.0
+
+[fleet.cost.group_overrides]
+"infra" = 100.0
+"#;
+        let cfg: AppConfig = toml::from_str(toml_src).expect("parse fleet.cost");
+        let cost = &cfg.fleet.cost;
+        assert_eq!(cost.session_usd, Some(5.0));
+        assert_eq!(cost.group_usd, Some(25.0));
+
+        // Overrides win over the blanket caps; everything else falls back.
+        assert_eq!(cost.session_limit("abc123"), Some(50.0));
+        assert_eq!(cost.session_limit("other"), Some(5.0));
+        assert_eq!(cost.group_limit("infra"), Some(100.0));
+        assert_eq!(cost.group_limit("other"), Some(25.0));
+
+        // save()→reload identity.
+        let serialized = toml::to_string_pretty(&cfg).expect("serialize");
+        let reloaded: AppConfig = toml::from_str(&serialized).expect("reparse");
+        assert_eq!(reloaded.fleet.cost, cfg.fleet.cost);
+
+        // Absent `[fleet.cost]` → empty (no caps).
+        let bare: AppConfig = toml::from_str("[fleet]\n").expect("bare fleet");
+        assert!(bare.fleet.cost.is_empty());
+        assert_eq!(bare.fleet.cost.session_limit("x"), None);
+    }
+
+    #[test]
+    fn test_fleet_cost_project_layer_overrides_user_layer() {
+        // User layer sets a $5 session cap; an empty project `[fleet.cost]`
+        // must NOT clobber it, but a populated one must replace it.
+        let mut user: AppConfig = toml::from_str("[fleet.cost]\nsession_usd = 5.0\n").unwrap();
+
+        // Empty project fleet config → user cap preserved.
+        let empty_project: AppConfig = toml::from_str("[fleet]\n").unwrap();
+        let mut merged = user.clone();
+        merged.merge(empty_project);
+        assert_eq!(merged.fleet.cost.session_usd, Some(5.0));
+
+        // Populated project config → replaces the user cap.
+        let project: AppConfig = toml::from_str("[fleet.cost]\nsession_usd = 2.0\n").unwrap();
+        user.merge(project);
+        assert_eq!(user.fleet.cost.session_usd, Some(2.0));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/tests/test_events.rs
+++ b/ainb-tui/crates/ainb-core/tests/test_events.rs
@@ -1,11 +1,6 @@
 // ABOUTME: Unit tests for event handling to ensure keyboard inputs map to correct app actions
 
-use ainb::app::events::AppEvent;
-use ainb::app::screens::ids as screen_ids;
 use ainb::app::{AppState, EventHandler};
-// UsagePeriod / UsageProviderFilter no longer used in this file —
-// the test that referenced them has moved into the burndown plugin.
-use chrono::NaiveDate;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 const fn create_key_event(code: KeyCode) -> KeyEvent {
@@ -54,59 +49,13 @@ fn test_navigation_key_events() {
     assert!(right_event.is_some());
 }
 
-#[tokio::test]
-async fn test_n_key_triggers_new_session() {
-    use ainb::app::state::AsyncAction;
-
-    let mut state = AppState::default();
-
-    // Simulate pressing 'n' key
-    let key_event = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE);
-
-    // Handle the key event
-    let app_event = EventHandler::handle_key_event(key_event, &mut state);
-
-    // Should return NewSession event
-    assert!(app_event.is_some());
-
-    // Process the event
-    if let Some(event) = app_event {
-        EventHandler::process_event(event, &mut state);
-    }
-
-    // Should have set pending async action
-    assert!(state.pending_async_action.is_some());
-
-    // Should be NewSessionNormal
-    if state.pending_async_action == Some(AsyncAction::NewSessionNormal) {
-        // Test passed
-    } else {
-        panic!(
-            "Expected AsyncAction::NewSessionNormal, got: {:?}",
-            state.pending_async_action
-        );
-    }
-
-    // Process the async action to complete the flow
-    if let Err(e) = state.process_async_action().await {
-        panic!("Failed to process async action: {e}");
-    }
-
-    // After processing, the behavior depends on whether current dir is a git repo
-    // If it is, we should be in NewSession view with current dir
-    // If it's not, we should be in SearchWorkspace view
-    // Or we might still be in SessionList if auth setup is required
-    assert!(
-        state.current_screen == screen_ids::NEW_SESSION
-            || state.current_screen == screen_ids::SEARCH_WORKSPACE
-            || state.current_screen == screen_ids::SESSION_LIST
-            || state.current_screen == screen_ids::AUTH_SETUP,
-        "Unexpected screen: {:?}",
-        state.current_screen
-    );
-    // The new session state might not be set if auth setup is required
-    assert!(state.pending_async_action.is_none());
-}
+// test_n_key_triggers_new_session removed — it asserted against the legacy
+// `AsyncAction::NewSessionNormal` variant, which was deleted in the Phase-6
+// new-session redesign (the 2-screen preset-driven wizard; see
+// `48c1ea99 feat(tui): redesign new-session flow`). The whole legacy
+// new-session async-action set is gone, so this test no longer compiles.
+// The 'n' keypress is still covered by `test_action_key_events` below
+// (asserts the event fires); the wizard flow has its own coverage.
 
 #[test]
 fn test_arrow_key_navigation() {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -5,7 +5,7 @@ use crate::config::{AppConfig, CurrencyConfig, UsagePlan, UsagePlanId, UsagePlan
 use crate::data::usage::{
     ActivityUsage, NamedUsage, ProjectUsage, SessionUsage, UsageData, UsageFilters, UsagePeriod,
     UsageProviderFilter, UsageQuery, UsageSourceRoots, analyze_yield, billing_period,
-    compare_models, disabled_cache, optimize_usage, parse_usage_for,
+    compare_models, disabled_cache, filter_usage_data_full, optimize_usage, parse_usage_for,
     parse_usage_for_with_roots_and_cache, shared_cache,
 };
 use crate::output_format::OutputFormat;
@@ -296,15 +296,17 @@ fn print_report_with_data(
     format: OutputFormat,
     title: &str,
 ) -> Result<()> {
-    // Apply the same filter pipeline the host-side `print_report` uses,
-    // but operate on the supplied snapshot directly instead of opening
-    // the cache.
+    // Apply the same period / provider / chip filter pipeline the
+    // host-side cache path applies, but re-aggregate the supplied
+    // snapshot's `calls` instead of opening the cache. `--period`
+    // (today/week/30days/month/all/--month/--quarter/--last-n-days/--ytd/
+    // --from/--to) genuinely scopes the data here: `filter_usage_data_full`
+    // date-bounds the call set and re-rolls every dimension, so the plugin
+    // path is no longer a lifetime-only all-time snapshot.
     let filters = build_filters_from_args(args);
-    let view = if filters.is_empty() {
-        data.clone()
-    } else {
-        crate::data::usage::filter_usage_data(data, &filters)
-    };
+    let period = period_from_args(args)?;
+    let provider = provider_filter_from_args(args);
+    let view = filter_usage_data_full(data, &filters, &period, provider);
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report_json(&view))?);
@@ -1366,15 +1368,21 @@ fn load_usage(args: &UsageReportArgs) -> Result<UsageData> {
     }
 }
 
-fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
-    // Period precedence (top wins; clap rejects combinations via the
-    // conflicts_with_all groups on UsageReportArgs):
-    //   --month YYYY-MM            -> SpecificMonth
-    //   --quarter YYYY-Qn          -> SpecificQuarter
-    //   --last-n-days N            -> LastNDays(N)
-    //   --ytd                      -> YearToDate
-    //   --from / --to              -> Custom (existing free-text behaviour)
-    //   --period {today|week|30days|month|all}  (default)
+/// Resolve the effective [`UsagePeriod`] from the report args.
+///
+/// Period precedence (top wins; clap rejects combinations via the
+/// `conflicts_with_all` groups on [`UsageReportArgs`]):
+///   --month YYYY-MM            -> SpecificMonth
+///   --quarter YYYY-Qn          -> SpecificQuarter
+///   --last-n-days N            -> LastNDays(N)
+///   --ytd                      -> YearToDate
+///   --from / --to              -> Custom (existing free-text behaviour)
+///   --period {today|week|30days|month|all}  (default)
+///
+/// Shared by the host cache path ([`query_from_args`]) and the plugin
+/// snapshot path ([`print_report_with_data`]) so `--period` scopes the
+/// data identically regardless of which path produced the [`UsageData`].
+fn period_from_args(args: &UsageReportArgs) -> Result<UsagePeriod> {
     let period = if let Some(month_str) = &args.month {
         parse_month_arg(month_str)?
     } else if let Some(quarter_str) = &args.quarter {
@@ -1408,17 +1416,25 @@ fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
             PeriodArg::All => UsagePeriod::All,
         }
     };
+    Ok(period)
+}
 
+/// Map the `--provider` arg onto the internal [`UsageProviderFilter`].
+fn provider_filter_from_args(args: &UsageReportArgs) -> UsageProviderFilter {
+    match args.provider {
+        ProviderArg::All => UsageProviderFilter::All,
+        ProviderArg::Claude => UsageProviderFilter::Claude,
+        ProviderArg::Codex => UsageProviderFilter::Codex,
+        ProviderArg::Cursor => UsageProviderFilter::Cursor,
+        ProviderArg::Copilot => UsageProviderFilter::Copilot,
+        ProviderArg::Gemini => UsageProviderFilter::Gemini,
+    }
+}
+
+fn query_from_args(args: &UsageReportArgs) -> Result<UsageQuery> {
     Ok(UsageQuery {
-        period,
-        provider_filter: match args.provider {
-            ProviderArg::All => UsageProviderFilter::All,
-            ProviderArg::Claude => UsageProviderFilter::Claude,
-            ProviderArg::Codex => UsageProviderFilter::Codex,
-            ProviderArg::Cursor => UsageProviderFilter::Cursor,
-            ProviderArg::Copilot => UsageProviderFilter::Copilot,
-            ProviderArg::Gemini => UsageProviderFilter::Gemini,
-        },
+        period: period_from_args(args)?,
+        provider_filter: provider_filter_from_args(args),
         include_projects: args.include.clone(),
         exclude_projects: args.exclude.clone(),
         filters: UsageFilters {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -576,6 +576,14 @@ pub struct ProjectUsage {
 pub struct SessionUsage {
     pub provider: String,
     pub project: String,
+    /// Raw working directory the session ran in (`ProviderCall.project_path`).
+    /// `project` is the sanitised folder/repo *name*; `project_path` is the
+    /// unmodified cwd, the cross-system join key against the fleet
+    /// `Session.cwd`. Kept distinct so consumers (e.g. `ainb fleet cost`)
+    /// can join on the path directly instead of round-tripping through the
+    /// repo-slug-keyed `ProjectUsage.name`.
+    #[serde(default)]
+    pub project_path: String,
     pub session_id: String,
     pub first_timestamp: DateTime<Utc>,
     pub last_timestamp: DateTime<Utc>,
@@ -1712,6 +1720,7 @@ fn aggregate_calls_with_analysis(
         let session = session_map.entry(session_key).or_insert_with(|| SessionUsageAccumulator {
             provider: call.provider.clone(),
             project: call.project.clone(),
+            project_path: call.project_path.clone(),
             session_id: call.session_id.clone(),
             first_timestamp: call.timestamp,
             last_timestamp: call.timestamp,
@@ -2849,6 +2858,7 @@ pub fn analyze_yield(data: &UsageData) -> YieldResult {
 struct SessionUsageAccumulator {
     provider: String,
     project: String,
+    project_path: String,
     session_id: String,
     first_timestamp: DateTime<Utc>,
     last_timestamp: DateTime<Utc>,
@@ -2861,6 +2871,7 @@ impl SessionUsageAccumulator {
         SessionUsage {
             provider: self.provider,
             project: self.project,
+            project_path: self.project_path,
             session_id: self.session_id,
             first_timestamp: self.first_timestamp,
             last_timestamp: self.last_timestamp,

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -1647,6 +1647,7 @@ mod chunk_accumulator_tests {
             SessionUsage {
                 provider: Provider::Claude,
                 project: "p".into(),
+                project_path: "/tmp/p".into(),
                 session_id: id.into(),
                 first_timestamp: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
                 last_timestamp: DateTime::from_timestamp(1_700_000_001, 0).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -4679,6 +4679,7 @@ mod cross_filter_tests {
                 SessionUsage {
                     provider: "claude".into(),
                     project: "alpha".into(),
+                    project_path: "/work/alpha".into(),
                     session_id: "sess-A".into(),
                     first_timestamp: now,
                     last_timestamp: now,
@@ -4687,6 +4688,7 @@ mod cross_filter_tests {
                 SessionUsage {
                     provider: "claude".into(),
                     project: "beta".into(),
+                    project_path: "/work/beta".into(),
                     session_id: "sess-B".into(),
                     first_timestamp: now,
                     last_timestamp: now,
@@ -4788,6 +4790,7 @@ mod cross_filter_tests {
         let session_alpha = SessionUsage {
             provider: "claude".into(),
             project: "alpha".into(),
+            project_path: "/work/alpha".into(),
             session_id: "s1".into(),
             first_timestamp: now,
             last_timestamp: now,
@@ -4796,6 +4799,7 @@ mod cross_filter_tests {
         let session_beta = SessionUsage {
             provider: "claude".into(),
             project: "beta".into(),
+            project_path: "/work/beta".into(),
             session_id: "s1".into(),
             first_timestamp: now,
             last_timestamp: now,
@@ -5833,6 +5837,7 @@ mod zoom_table_tests {
                 SessionUsage {
                     provider: "claude".into(),
                     project: LONG_PATH.into(),
+                    project_path: LONG_PATH.into(),
                     session_id: "01HXYZABCDEFGHJKMNPQRSTVWX".into(),
                     first_timestamp: now,
                     last_timestamp: now,
@@ -5841,6 +5846,7 @@ mod zoom_table_tests {
                 SessionUsage {
                     provider: "codex".into(),
                     project: "beta".into(),
+                    project_path: "/work/beta".into(),
                     session_id: "sess-B".into(),
                     first_timestamp: now,
                     last_timestamp: now,
@@ -5861,6 +5867,7 @@ mod zoom_table_tests {
             data.sessions.push(SessionUsage {
                 provider: "claude".into(),
                 project: format!("proj-{i}"),
+                project_path: format!("/work/proj-{i}"),
                 session_id: format!("sid-{i}"),
                 first_timestamp: now,
                 last_timestamp: now,

--- a/ainb-tui/crates/ainb-plugin-burndown/src/wire.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/wire.rs
@@ -97,6 +97,7 @@ pub fn wire_to_local(w: W::UsageData) -> UsageData {
             .map(|s| L::SessionUsage {
                 provider: s.provider.as_str().to_string(),
                 project: s.project,
+                project_path: s.project_path,
                 session_id: s.session_id,
                 first_timestamp: s.first_timestamp,
                 last_timestamp: s.last_timestamp,

--- a/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/tests/stdio_smoke.rs
@@ -154,18 +154,41 @@ fn init_render_shutdown_round_trip() {
         .expect("write scan_progress subscribe reply");
     stdin.flush().expect("flush scan_progress subscribe reply");
 
-    let rev3 = read_frame(&mut stdout, deadline).expect("publish notification");
+    // Before publishing the refresh request, the plugin subscribes to the
+    // `sessions.refresh_request` topic so it doesn't miss the rescan it is
+    // about to trigger (added on main in c058c6d3 to close a startup race).
+    let rev3 = read_frame(&mut stdout, deadline).expect("refresh_request subscribe");
     assert_eq!(
-        rev3["method"], "host/snapshot/publish",
+        rev3["method"], "host/snapshot/subscribe",
         "reverse #3: {rev3}"
     );
     assert_eq!(
         rev3["params"]["topic"], "sessions.refresh_request",
         "reverse #3 topic: {rev3}"
     );
+    let rev3_id = rev3["id"].as_i64().expect("reverse request must have id");
+    let rev3_reply = json!({
+        "jsonrpc": "2.0",
+        "id": rev3_id,
+        "result": {}
+    });
+    stdin
+        .write_all(&encode(&rev3_reply))
+        .expect("write refresh_request subscribe reply");
+    stdin.flush().expect("flush refresh_request subscribe reply");
+
+    let rev4 = read_frame(&mut stdout, deadline).expect("publish notification");
+    assert_eq!(
+        rev4["method"], "host/snapshot/publish",
+        "reverse #4: {rev4}"
+    );
+    assert_eq!(
+        rev4["params"]["topic"], "sessions.refresh_request",
+        "reverse #4 topic: {rev4}"
+    );
     assert!(
-        rev3.get("id").is_none(),
-        "refresh_request publish must be a notification (no id): {rev3}"
+        rev4.get("id").is_none(),
+        "refresh_request publish must be a notification (no id): {rev4}"
     );
 
     // Now the init reply itself.

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/plugin.rs
@@ -1403,6 +1403,7 @@ mod tests {
             .map(|i| SessionUsage {
                 provider: Provider::Claude,
                 project: format!("proj-{i}"),
+                project_path: format!("/tmp/proj-{i}"),
                 session_id: format!("sess-{i}"),
                 first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
                 last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
@@ -1430,6 +1431,7 @@ mod tests {
             .map(|i| SessionUsage {
                 provider: Provider::Claude,
                 project: format!("project-with-a-fairly-long-name-{i:04}"),
+                project_path: format!("/tmp/project-with-a-fairly-long-name-{i:04}"),
                 session_id: format!("session-id-uuid-style-{i:020}"),
                 first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
                 last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
@@ -1484,6 +1486,7 @@ mod tests {
             .map(|i| SessionUsage {
                 provider: Provider::Claude,
                 project: "p".into(),
+                project_path: "/tmp/p".into(),
                 session_id: format!("s-{i}"),
                 first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
                 last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
@@ -1561,6 +1564,7 @@ mod tests {
             .map(|i| SessionUsage {
                 provider: Provider::Claude,
                 project: format!("proj-{i}"),
+                project_path: format!("/tmp/proj-{i}"),
                 session_id: format!("session-{i}"),
                 first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
                 last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -715,12 +715,15 @@ pub(crate) fn fold(mut calls: Vec<ProviderCall>) -> AggState {
             provider: call.provider,
             project: call.project.clone(),
             project_path: call.project_path.clone(),
+            path_key: (call.timestamp, call.id),
             session_id: call.session_id.clone(),
             first_timestamp: call.timestamp,
             last_timestamp: call.timestamp,
             bucket: TokenBucket::default(),
             cost_nanos: None,
         });
+        session.project_path = call.project_path.clone();
+        session.path_key = (call.timestamp, call.id);
         if call.timestamp < session.first_timestamp {
             session.first_timestamp = call.timestamp;
         }
@@ -1064,6 +1067,9 @@ struct SessionAccumulator {
     provider: Provider,
     project: String,
     project_path: String,
+    /// `(timestamp, id)` of the call that last wrote `project_path` —
+    /// fold's last-write-wins replayed exactly during [`AggState::absorb`].
+    path_key: (chrono::DateTime<chrono::Utc>, u64),
     session_id: String,
     first_timestamp: chrono::DateTime<chrono::Utc>,
     last_timestamp: chrono::DateTime<chrono::Utc>,
@@ -1073,6 +1079,10 @@ struct SessionAccumulator {
 
 impl SessionAccumulator {
     fn absorb(&mut self, other: &Self) {
+        if other.path_key >= self.path_key {
+            self.project_path = other.project_path.clone();
+            self.path_key = other.path_key;
+        }
         if other.first_timestamp < self.first_timestamp {
             self.first_timestamp = other.first_timestamp;
         }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -714,6 +714,7 @@ pub(crate) fn fold(mut calls: Vec<ProviderCall>) -> AggState {
         let session = sessions.entry(session_key.clone()).or_insert_with(|| SessionAccumulator {
             provider: call.provider,
             project: call.project.clone(),
+            project_path: call.project_path.clone(),
             session_id: call.session_id.clone(),
             first_timestamp: call.timestamp,
             last_timestamp: call.timestamp,
@@ -830,6 +831,7 @@ pub(crate) fn emit(state: AggState) -> UsageData {
                     SessionUsage {
                         provider: s.provider,
                         project: s.project,
+                        project_path: s.project_path,
                         session_id: s.session_id,
                         first_timestamp: s.first_timestamp,
                         last_timestamp: s.last_timestamp,
@@ -1061,6 +1063,7 @@ impl ProjectAccumulator {
 struct SessionAccumulator {
     provider: Provider,
     project: String,
+    project_path: String,
     session_id: String,
     first_timestamp: chrono::DateTime<chrono::Utc>,
     last_timestamp: chrono::DateTime<chrono::Utc>,

--- a/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-types-sessions/src/lib.rs
@@ -300,6 +300,11 @@ pub struct SessionUsage {
     pub provider: Provider,
     /// Project label this session belongs to.
     pub project: String,
+    /// Raw working directory the session ran in. `project` is the
+    /// sanitised name; `project_path` is the unmodified cwd — the
+    /// cross-system join key against the fleet `Session.cwd`.
+    #[serde(default)]
+    pub project_path: String,
     /// Provider-assigned session id.
     pub session_id: String,
     /// Earliest call timestamp.
@@ -466,6 +471,7 @@ mod tests {
             sessions: vec![SessionUsage {
                 provider: Provider::Claude,
                 project: "ainb".into(),
+                project_path: "/tmp/ainb".into(),
                 session_id: "s1".into(),
                 first_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
                 last_timestamp: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),

--- a/docs/toolkit/plugins/ainb-fleet.md
+++ b/docs/toolkit/plugins/ainb-fleet.md
@@ -29,6 +29,7 @@ The daemon skill describes a long-running watcher that scans each session's rece
 | `ainb-fleet:sequence` | Send ordered multi-step prompts, ack-gated between steps via JSONL turn-end detection |
 | `ainb-fleet:needs` | Center control panel — enumerate sessions blocked on ASK / ERR / IDLE / WAIT signals, render the Jarvis HUD |
 | `ainb-fleet:fleet-needs` | Workflow-backed `needs` — runs the `hangar` workflow, renders the HUD, fires `AskUserQuestion`, routes answers back |
+| `ainb-fleet:cost` | Per-session / model / day / group USD spend rollups sourced from burndown, plus `config.toml` budget caps that fire notifyd alerts |
 | `ainb-fleet:daemon` | Background watcher that auto-`continue`s sessions matching an API-error regex |
 
 ### Workflow

--- a/docs/tui/fleet-cost.md
+++ b/docs/tui/fleet-cost.md
@@ -1,0 +1,93 @@
+---
+title: "ainb fleet cost"
+description: "Per-session / model / day / group spend rollups + budget caps for an ainb fleet."
+---
+
+`ainb fleet cost` surfaces ainb's existing cost tracking as fleet-shaped
+spend rollups, plus configurable budget caps that fire notifyd alerts.
+
+ainb already prices every provider call — `cost_usd` is recorded on each
+`ProviderCall` / `TokenBucket` and aggregated by the **burndown** plugin
+(the same data behind `ainb usage`). This verb does **not** re-price
+anything: it fetches burndown's `usage report --format json` payload live
+(over the same plugin runtime + retry path `ainb usage` uses), reshapes it
+into per-session / per-model / per-day / per-group rollups joined to the
+live fleet, evaluates configured budget caps, and delivers a notifyd alert
+for every breach.
+
+## Usage
+
+```bash
+ainb fleet cost                                  # text tables (default)
+ainb --format json fleet cost                    # JSON
+ainb --format json fleet cost --period week      # today | week | 30days | month | all
+```
+
+`--format` is a global flag — it precedes `fleet`. `--period` (default
+`month`) is passed through to the burndown plugin.
+
+## JSON shape
+
+```jsonc
+{
+  "totals":  { "cost_usd": 6.0, "bucket": { /* tokens */ }, "session_count": 2, "model_count": 2 },
+  "sessions": [ { "session_id", "provider", "project", "cwd?", "group?", "cost_usd", "bucket" } ],
+  "models":   [ { "model", "cost_usd", "bucket" } ],
+  "daily":    [ { "date", "cost_usd", "bucket" } ],
+  "groups":   [ { "group", "cost_usd", "session_count", "bucket" } ],
+  "budget_breaches": [ { "scope", "subject", "cwd?", "cost_usd", "limit_usd" } ]
+}
+```
+
+`sessions` and `models` are sorted by descending cost. `groups` contains
+only sessions whose resolved `cwd` matches a session in the live fleet
+(joined via `workspace_name`). `bucket` is the token breakdown
+(`input_tokens`, `cache_creation_tokens`, `cache_read_tokens`,
+`output_tokens`, `reasoning_tokens`, `call_count`, `cost_usd`).
+
+## Budget caps
+
+Spend ceilings live in `config.toml` under `[fleet.cost]`. Project config
+(`./.agents-box/config.toml`) overrides user config
+(`~/.agents-in-a-box/config/config.toml`).
+
+```toml
+[fleet.cost]
+session_usd = 5.0      # any single session over $5 → alert
+group_usd = 25.0       # any workspace group over $25 → alert
+
+[fleet.cost.session_overrides]
+"abc123" = 50.0        # a specific session's own ceiling
+
+[fleet.cost.group_overrides]
+"infra" = 100.0        # a specific group's own ceiling
+```
+
+The override maps take precedence over the blanket `session_usd` /
+`group_usd`. With no caps configured, no breaches are produced.
+
+### Alert delivery
+
+A breach is delivered through the existing **notifyd** substrate: a valid
+`Envelope` is written to `~/.agents-in-a-box/notify.sock` with raw event
+`Notification:budget_exceeded`. It classifies as `AlertKind::WaitingOnUser`,
+passes notifyd's user-facing filter, and lands as a row in
+`notifications.db` — the same path idle/permission prompts take. No new
+alert kind is introduced. Delivery is best-effort: if the socket is
+unreachable the report still prints, with a warning on stderr.
+
+## Environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `AINB_USAGE_TIMEOUT_SECS` | `120` | Budget for the first (cold-cache) burndown scan. |
+| `AINB_USAGE_TRACE` | unset | Emit plugin-dispatch trace lines on stderr. |
+
+## Notes
+
+- The first call on a cold cache can take ~40s while session-reader scans
+  `~/.claude/projects`; subsequent calls hit the cache and return sub-second.
+- Requires the burndown plugin (`ainb plugin install burndown`), the same
+  dependency `ainb usage` has.
+- To change pricing or the spend plan, use `ainb usage plan ...` — this verb
+  consumes ainb's pricing, it does not own it.

--- a/docs/tui/fleet-cost.md
+++ b/docs/tui/fleet-cost.md
@@ -24,7 +24,9 @@ ainb --format json fleet cost --period week      # today | week | 30days | month
 ```
 
 `--format` is a global flag — it precedes `fleet`. `--period` (default
-`month`) is passed through to the burndown plugin.
+`month`) scopes the reporting window: the burndown plugin date-bounds its
+call set and re-aggregates every rollup, so a narrower period returns less
+spend. `all` reports lifetime totals.
 
 ## JSON shape
 

--- a/plugins/ainb-fleet/skills/cost/SKILL.md
+++ b/plugins/ainb-fleet/skills/cost/SKILL.md
@@ -38,8 +38,9 @@ ainb --format json fleet cost --period week      # window: today|week|30days|mon
 ```
 
 `--format` is a **global** flag — it goes before `fleet`, not after `cost`.
-The `--period` window is passed through to the burndown plugin (default
-`month`).
+The `--period` window scopes the data (default `month`): burndown date-bounds
+its call set and re-aggregates, so a narrower period returns less spend; `all`
+reports lifetime totals.
 
 ## Output fields (JSON)
 

--- a/plugins/ainb-fleet/skills/cost/SKILL.md
+++ b/plugins/ainb-fleet/skills/cost/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ainb-fleet:cost
+description: |
+  Show fleet spend — per-session, per-model, per-day, and per-group USD
+  cost rollups for every claude/codex session, sourced live from ainb's
+  burndown analytics (which already prices every provider call). Use when
+  you need spend visibility across a multi-session fleet, want to find the
+  most expensive session/model, or are checking whether any session/group
+  has crossed a configured budget cap. Budget breaches are also delivered
+  as notifyd alerts.
+  Default output: text tables. Pass --format json for LLM consumption.
+version: "0.1.0"
+user-invocable: true
+triggers:
+  - ainb-fleet:cost
+  - fleet cost
+  - fleet spend
+  - how much have my sessions cost
+  - which session is most expensive
+  - fleet budget
+allowed-tools:
+  - Bash
+---
+
+# ainb fleet:cost
+
+Fleet-shaped spend rollups. ainb already tracks `cost_usd` per provider call
+(the burndown plugin aggregates it); this verb reshapes that data into
+per-session / per-model / per-day / per-group USD totals joined to the live
+fleet, and evaluates configured budget caps.
+
+## Run
+
+```bash
+ainb fleet cost                                  # text tables (default)
+ainb --format json fleet cost                    # JSON for piping
+ainb --format json fleet cost --period week      # window: today|week|30days|month|all
+```
+
+`--format` is a **global** flag — it goes before `fleet`, not after `cost`.
+The `--period` window is passed through to the burndown plugin (default
+`month`).
+
+## Output fields (JSON)
+
+| field | meaning |
+|---|---|
+| `totals` | fleet-wide `{cost_usd, bucket, session_count, model_count}` |
+| `sessions[]` | per-session `{session_id, provider, project, cwd?, group?, cost_usd, bucket}`, sorted by descending cost |
+| `models[]` | per-model `{model, cost_usd, bucket}`, sorted by descending cost |
+| `daily[]` | per-day `{date, cost_usd, bucket}` |
+| `groups[]` | per-workspace `{group, cost_usd, session_count, bucket}` (only sessions that match a live fleet cwd) |
+| `budget_breaches[]` | `{scope, subject, cwd?, cost_usd, limit_usd}` — caps crossed this run (also delivered to notifyd) |
+
+`bucket` is the token breakdown: `input_tokens`, `cache_creation_tokens`,
+`cache_read_tokens`, `output_tokens`, `reasoning_tokens`, `call_count`,
+`cost_usd`.
+
+## Budget caps
+
+Configure spend ceilings in `config.toml` (project config overrides user
+config). A breach fires a notifyd alert (`Notification:budget_exceeded`,
+surfacing as `WaitingOnUser`) and lands in `notifications.db`.
+
+```toml
+[fleet.cost]
+session_usd = 5.0      # warn when any single session crosses $5
+group_usd = 25.0       # warn when any workspace group crosses $25
+
+[fleet.cost.session_overrides]
+"abc123" = 50.0        # a long-running session gets its own ceiling
+
+[fleet.cost.group_overrides]
+"infra" = 100.0        # the infra workspace gets a higher ceiling
+```
+
+Override maps take precedence over the blanket `session_usd` / `group_usd`.
+With no caps configured, `budget_breaches` is always empty.
+
+## Composition patterns
+
+```bash
+# Most expensive session
+ainb --format json fleet cost | jq '.sessions[0]'
+
+# Total spend this month
+ainb --format json fleet cost | jq '.totals.cost_usd'
+
+# Any budget breaches right now?
+ainb --format json fleet cost | jq '.budget_breaches'
+
+# Spend by group, biggest first
+ainb --format json fleet cost | jq '.groups[] | {group, cost_usd}'
+```
+
+## Caveats
+
+- Cost data is sourced live from the burndown plugin. The first call on a
+  cold cache can take ~40s while session-reader scans `~/.claude/projects`;
+  raise the budget with `AINB_USAGE_TIMEOUT_SECS=<n>` for very large
+  archives. Subsequent calls hit the cache and return in well under a second.
+- The `group` on a session is only populated when its resolved `cwd` matches
+  a session in the live fleet (via `workspace_name`). Sessions that have
+  ended drop out of the group rollup but still appear in `sessions[]`.
+- Budget alert delivery is best-effort: if notifyd's socket is unreachable
+  the command still prints the report (with a warning on stderr).
+- This verb never re-prices anything — it relies entirely on ainb's existing
+  pricing. To change pricing or plan, use `ainb usage plan ...`.


### PR DESCRIPTION
## What

Adds `ainb fleet cost` — spend visibility across the fleet — plus configurable budget caps that fire notifyd alerts when a session or group exceeds a USD threshold.

Ports agent-deck's cost *surface* without re-porting the engine: ainb's `burndown` plugin already prices per-provider (`cost_usd` on `ProviderCall`/`TokenBucket`). This verb exposes that existing data; it does **not** parse the opaque bincode usage blob or add a pricing table.

## Surface

- `ainb --format json fleet cost` → per-session / per-model / per-day USD + token rollups (group rollups when sessions carry workspace/group info)
- `ainb fleet cost` → human-readable table
- `config.toml` budget caps (per-session + per-group, project layer overrides user)
- Budget breach → `Envelope` written to notifyd (`~/.agents-in-a-box/notify.sock`), surfaced as an `AlertKind` and persisted to `notifications.db`

## Files

- `cli/fleet/cost.rs` (+683) — verb, rollups, budget-breach detection
- `cli/fleet/budget_alert.rs` (+246) — notifyd alert envelope
- `cli/fleet/enrich_cache.rs`, `fleet/enrich_cache.rs` — enrich cache
- `config.toml` fleet cost budget caps + resolution
- `docs/tui/fleet-cost.md`, `plugins/ainb-fleet/skills/cost/SKILL.md`

## Gates (verified locally)

- ✅ `cargo build -p ainb` — clean (2m59s)
- ✅ `cargo test -p ainb --lib fleet` — **37 passed, 0 failed**, incl. real on-target tests:
  - `rollups_aggregate_sessions_models_and_days`
  - `budget_breach_lands_in_notifications_db`, `breach_envelope_validates_and_classifies_as_user_facing`
  - `session/group_budget_breach_detected_when_cost_exceeds_cap`, `per_session_override_takes_precedence_over_blanket_cap`, `no_caps_yields_no_breaches`
  - `test_fleet_cost_budget_roundtrip_and_resolution`, project-over-user layering
- ✅ `cargo fmt --check` — clean

## Known follow-ups (do not block; reviewer to decide)

- ~15 trivial clippy **style** nits in the new files (`map().unwrap_or` → `map_or`, `const fn`, redundant closures, one dead `total_tokens`, one long doc line). The repo carries a large pre-existing clippy backlog (~3355 warnings on `main`), so it does not gate on `clippy -D warnings`; these new-code nits are cosmetic and isolated. Happy to clean in a follow-up commit if desired.

## Success criteria (from goal)

- [x] `ainb fleet cost` returns documented JSON rollups + readable table
- [x] Budget caps configurable; breach delivered via notifyd → notifications.db (proven by test)
- [x] build / test / fmt green; cost+budget unit tests cover aggregation + threshold logic against fixtures (no live API spend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ainb fleet cost` command showing per-session, per-model, per-day, and per-group USD spend rollups from burndown pricing data.
  * Added fleet budget cap configuration in `config.toml` with session/group limits and per-session/per-group overrides.
  * Budget breach alerts are delivered via the notification system and are debounced/persisted to avoid repeat notifications for the same standing breach.
  * Supports both text and JSON output formats.
* **Documentation**
  * Expanded documentation for `ainb fleet cost`, including configuration examples, JSON schema, and alert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->