### PR TITLE
feat(web): `ainb web` — read-only SSE-live fleet dashboard

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/ainb-core",
+    "crates/ainb-web",
     "crates/ainb-plugin-burndown",
     "crates/ainb-plugin-learnings",
     "crates/ainb-plugin-notifyd",
@@ -124,6 +125,15 @@ fs2 = "0.4"
 
 # Filesystem watch for fleet JSONL transcript tail
 notify = "6.1"
+
+# Web dashboard (`ainb web` / ainb-web crate): axum HTTP + SSE, tower
+# middleware, and rust-embed for the no-build-step vanilla-JS frontend.
+axum = "0.7"
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace"] }
+rust-embed = { version = "8", features = ["mime-guess"] }
+mime_guess = "2"
+subtle = "2.6"
 
 # Dev / test
 mockall = "0.12"

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -95,6 +95,8 @@ ainb-plugin-runtime = { path = "../ainb-plugin-runtime", version = "0.1.0" }
 ainb-plugin-protocol = { path = "../ainb-plugin-protocol", version = "0.1.0" }
 # Notification daemon — used in-process for the Inbox screen reader.
 ainb-plugin-notifyd = { path = "../ainb-plugin-notifyd", version = "1.1.0" }
+# Read-only web dashboard — backs the `ainb web` subcommand.
+ainb-web = { path = "../ainb-web", version = "1.7.0" }
 # CSPRNG for `ainb hangar auth token create` (the OsRng passed to the store's
 # `mint_pat` / `mint_daemon_token`). All hashing/encoding lives in the store +
 # core; the CLI only supplies the random source.

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -106,6 +106,7 @@ impl CommandRegistry {
         r.register(TmuxCommand);
         r.register(CompletionCommand);
         r.register(AbtopCommand);
+        r.register(WebCommand); // read-only web dashboard (ainb-web crate)
         r.register(PluginCommand); // Phase 4 stub — surface reserved now
         r.register(FleetCommand);
         r.register(NotifydCommand); // hidden — ainb-hooks daemon alias
@@ -1170,6 +1171,85 @@ impl CliCommand for AbtopCommand {
     }
 }
 
+/// `ainb web [--listen <addr>] [--token <secret>] [--insecure-bind]` — serve
+/// the read-only fleet dashboard (sessions + fleet needs + cost) with live
+/// SSE updates, from the embedded vanilla-JS frontend (`ainb-web` crate).
+///
+/// Security: binds to loopback by default. A non-loopback bind is REFUSED
+/// unless `--token` is supplied (every `/api/*` route then requires the bearer
+/// token) or `--insecure-bind` is set explicitly. The dashboard never mutates
+/// fleet state. Data is proxied from the existing `ainb --format json`
+/// commands so the browser view never drifts from the CLI/TUI.
+pub struct WebCommand;
+impl CliCommand for WebCommand {
+    fn name(&self) -> &'static str {
+        "web"
+    }
+    fn build(&self, app: Command) -> Command {
+        app.subcommand(
+            Command::new(self.name())
+                .about("Serve a read-only, SSE-live web dashboard for the fleet")
+                .arg(
+                    clap::Arg::new("listen")
+                        .long("listen")
+                        .value_name("ADDR")
+                        .default_value("127.0.0.1:8420")
+                        .help("Address to bind (default loopback; non-loopback needs --token)"),
+                )
+                .arg(
+                    clap::Arg::new("token").long("token").value_name("SECRET").help(
+                        "Bearer token required on every /api/* route (enables non-loopback bind)",
+                    ),
+                )
+                .arg(
+                    clap::Arg::new("insecure-bind")
+                        .long("insecure-bind")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Allow a non-loopback bind with no token (NOT recommended)"),
+                ),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, _ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        // Extract owned values synchronously so only owned data crosses into
+        // the 'static future.
+        let listen_raw = matches
+            .get_one::<String>("listen")
+            .cloned()
+            .unwrap_or_else(|| "127.0.0.1:8420".to_string());
+        let token = matches.get_one::<String>("token").cloned();
+        let insecure_bind = matches.get_flag("insecure-bind");
+
+        Box::pin(async move {
+            use std::net::ToSocketAddrs;
+            let listen = listen_raw
+                .to_socket_addrs()
+                .with_context(|| format!("invalid --listen address: {listen_raw}"))?
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("--listen resolved to no address: {listen_raw}"))?;
+
+            let config = ainb_web::WebConfig {
+                listen,
+                token,
+                insecure_bind,
+                read_only: true,
+            };
+
+            // Validate the bind policy before any socket is opened so the
+            // refusal is clear and nothing ever listens on an unsafe address.
+            if let Err(e) = config.check_bind_security() {
+                anyhow::bail!("{e}");
+            }
+
+            let data = std::sync::Arc::new(ainb_web::AinbCliSource::new());
+            eprintln!("ainb web dashboard → http://{listen}");
+            if config.token.is_some() {
+                eprintln!("  bearer token required on /api/* routes");
+            }
+            ainb_web::serve(config, data).await.map_err(|e| anyhow::anyhow!("{e}"))
+        })
+    }
+}
+
 /// `ainb plugin {marketplace,install,update,remove,list,search}` — Phase 4
 /// marketplace + installer. Argument shapes nailed down in Phase 2b so plugin
 /// authors could target them today; Phase 4 wires the real handlers in
@@ -1445,14 +1525,14 @@ mod tests {
     }
 
     #[test]
-    fn built_ins_registers_twenty_five_commands() {
+    fn built_ins_registers_twenty_six_commands() {
         let r = CommandRegistry::built_ins();
         let names = r.names();
         // 16 user-facing built-ins + doctor + reflect + claudecode namespace
-        // + tmux namespace + abtop + plugin stub + fleet + hidden notifyd
-        // + hangar = 25. The TUI is NOT in the registry — main.rs handles
+        // + tmux namespace + abtop + web + plugin stub + fleet + hidden notifyd
+        // + hangar = 26. The TUI is NOT in the registry — main.rs handles
         // `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 25, "expected 25 entries, got {names:?}");
+        assert_eq!(names.len(), 26, "expected 26 entries, got {names:?}");
         for required in [
             "run",
             "list",
@@ -1475,6 +1555,7 @@ mod tests {
             "tmux",
             "completion",
             "abtop",
+            "web",
             "plugin",
             "fleet",
             "notifyd",

--- a/ainb-tui/crates/ainb-web/Cargo.toml
+++ b/ainb-tui/crates/ainb-web/Cargo.toml
@@ -37,3 +37,5 @@ tempfile = { workspace = true }
 # `util` brings ServiceExt::oneshot for driving the router in route tests.
 tower = { workspace = true, features = ["util"] }
 serde_json = { workspace = true }
+# `test-util` brings tokio::time::{pause,advance} for deterministic poller tests.
+tokio = { workspace = true, features = ["test-util"] }

--- a/ainb-tui/crates/ainb-web/Cargo.toml
+++ b/ainb-tui/crates/ainb-web/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "ainb-web"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Read-only, SSE-live web dashboard for the ainb agent fleet (sessions + fleet needs + cost)"
+
+[lib]
+name = "ainb_web"
+path = "src/lib.rs"
+
+[dependencies]
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+rust-embed = { workspace = true }
+mime_guess = { workspace = true }
+subtle = { workspace = true }
+
+tokio = { workspace = true }
+# `sync` brings in BroadcastStream for the SSE fan-out.
+tokio-stream = { workspace = true, features = ["sync"] }
+async-stream = { workspace = true }
+futures-util = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+# `util` brings ServiceExt::oneshot for driving the router in route tests.
+tower = { workspace = true, features = ["util"] }
+serde_json = { workspace = true }

--- a/ainb-tui/crates/ainb-web/frontend/app.js
+++ b/ainb-tui/crates/ainb-web/frontend/app.js
@@ -1,0 +1,287 @@
+// ainb fleet dashboard — vanilla JS, no framework, no build step.
+//
+// Boot: read ?token= from the URL (strip it), fetch the initial snapshot,
+// render the three panels, then open an SSE stream for live updates. If a
+// token is required and absent/invalid, show the auth prompt.
+
+(() => {
+  "use strict";
+
+  const $ = (id) => document.getElementById(id);
+
+  // ── Auth token: from URL query, then sessionStorage. ──────────────
+  const url = new URL(window.location.href);
+  let token = url.searchParams.get("token") || sessionStorage.getItem("ainb_token") || "";
+  if (url.searchParams.has("token")) {
+    sessionStorage.setItem("ainb_token", token);
+    url.searchParams.delete("token");
+    window.history.replaceState({}, "", url.toString());
+  }
+
+  const authHeaders = () => (token ? { Authorization: `Bearer ${token}` } : {});
+
+  // ── Rendering helpers ─────────────────────────────────────────────
+  const el = (tag, cls, text) => {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  };
+
+  const emptyState = (icon, msg) => {
+    const e = el("div", "empty");
+    e.appendChild(el("span", "empty-icon", icon));
+    e.appendChild(document.createTextNode(msg));
+    return e;
+  };
+
+  // The CLI session list (`ainb list --format json`) is an array of
+  // SessionInfo: { session_id, tmux_session_name, workspace_name,
+  // worktree_path, created_at, is_running, claude_active }.
+  function sessionStatus(s) {
+    if (!s.is_running) return { label: "stopped", cls: "status-stopped" };
+    if (s.claude_active) return { label: "running", cls: "status-running" };
+    return { label: "idle", cls: "status-idle" };
+  }
+
+  function renderSessions(sessions) {
+    const host = $("sessions");
+    host.replaceChildren();
+    const list = Array.isArray(sessions) ? sessions : [];
+    $("stat-sessions").textContent = list.length;
+    $("sessions-meta").textContent = list.length ? `${list.length} tracked` : "";
+
+    if (!list.length) {
+      host.appendChild(emptyState("◇", "No sessions tracked yet."));
+      return;
+    }
+
+    for (const s of list) {
+      const st = sessionStatus(s);
+      const row = el("div", "row");
+      row.appendChild(el("span", `status-dot ${st.cls}`));
+
+      const main = el("div", "row-main");
+      main.appendChild(el("div", "row-name", s.workspace_name || s.tmux_session_name || "session"));
+      const meta = el("div", "row-meta");
+      if (s.worktree_path) {
+        const code = el("code", null, s.worktree_path);
+        meta.appendChild(code);
+      }
+      if (s.tmux_session_name) meta.appendChild(el("span", null, s.tmux_session_name));
+      main.appendChild(meta);
+      row.appendChild(main);
+
+      const badges = el("div", "badges");
+      badges.appendChild(el("span", "badge badge-status", st.label));
+      row.appendChild(badges);
+
+      host.appendChild(row);
+    }
+  }
+
+  // Fleet needs (`ainb fleet needs --format json`) is an array of NeedsRow.
+  // Each row has a flattened { kind: "ASK|ERR|WAIT|IDLE", context: {...} }
+  // plus a nested `session` with `cwd` etc.
+  function needKind(row) {
+    return (row.kind || row.context_kind || "").toUpperCase() || "IDLE";
+  }
+
+  function needTitle(row) {
+    const s = row.session || {};
+    return s.workspace_name || s.summary || s.cwd || s.tmux_session || "session";
+  }
+
+  function needDetail(row) {
+    const ctx = row.context || {};
+    // NeedsContext is internally-tagged; the payload differs per kind. Surface
+    // the most useful human string we can find without coupling to one shape.
+    return (
+      ctx.question ||
+      ctx.message ||
+      ctx.marker ||
+      ctx.detail ||
+      row.enriched ||
+      ""
+    );
+  }
+
+  function renderNeeds(needs) {
+    const host = $("needs");
+    host.replaceChildren();
+    const list = Array.isArray(needs) ? needs : [];
+    // Count only the actionable kinds for the headline stat.
+    const attn = list.filter((r) => ["ASK", "ERR", "WAIT"].includes(needKind(r)));
+    $("stat-needs").textContent = attn.length;
+    $("needs-meta").textContent = list.length ? `${list.length} cards` : "";
+
+    if (!list.length) {
+      host.appendChild(emptyState("✓", "Nothing needs attention."));
+      return;
+    }
+
+    // Sort by priority ASK > ERR > WAIT > IDLE.
+    const order = { ASK: 0, ERR: 1, WAIT: 2, IDLE: 3 };
+    list.sort((a, b) => (order[needKind(a)] ?? 9) - (order[needKind(b)] ?? 9));
+
+    for (const row of list) {
+      const kind = needKind(row);
+      const card = el("div", "need");
+      card.appendChild(el("span", `need-kind kind-${kind}`, kind));
+      const body = el("div", "need-body");
+      body.appendChild(el("div", "need-title", needTitle(row)));
+      const detail = needDetail(row);
+      if (detail) body.appendChild(el("div", "need-detail", detail));
+      card.appendChild(body);
+      host.appendChild(card);
+    }
+  }
+
+  // Cost (`ainb fleet cost --format json`) — shape is owned by Goal 1 and may
+  // be absent (null) in this build. Render whatever rollup numbers we find.
+  function fmtUsd(n) {
+    if (typeof n !== "number" || !isFinite(n)) return "–";
+    return `$${n.toFixed(2)}`;
+  }
+
+  function renderCost(cost) {
+    const host = $("cost");
+    host.replaceChildren();
+
+    if (cost == null) {
+      $("stat-cost").textContent = "–";
+      $("cost-meta").textContent = "unavailable";
+      host.appendChild(emptyState("◷", "Cost surface not available in this build."));
+      return;
+    }
+
+    // Try common rollup shapes without hard-coding one schema.
+    const total =
+      cost.total_usd ?? cost.month_usd ?? cost.today_usd ?? cost.cost_usd ?? null;
+    $("stat-cost").textContent = total != null ? fmtUsd(total) : "–";
+    $("cost-meta").textContent = "";
+
+    const cells = [];
+    const push = (key, val) => {
+      if (val != null) cells.push([key, fmtUsd(val)]);
+    };
+    push("today", cost.today_usd);
+    push("week", cost.week_usd);
+    push("month", cost.month_usd);
+    push("projected", cost.projected_usd);
+    push("total", cost.total_usd);
+
+    if (!cells.length) {
+      // Fall back to dumping numeric top-level fields.
+      for (const [k, v] of Object.entries(cost)) {
+        if (typeof v === "number") cells.push([k, fmtUsd(v)]);
+      }
+    }
+
+    if (!cells.length) {
+      host.appendChild(emptyState("◷", "No cost data recorded yet."));
+      return;
+    }
+
+    const grid = el("div", "cost-grid");
+    for (const [k, v] of cells) {
+      const cell = el("div", "cost-cell");
+      cell.appendChild(el("div", "cost-val", v));
+      cell.appendChild(el("div", "cost-key", k));
+      grid.appendChild(cell);
+    }
+    host.appendChild(grid);
+  }
+
+  function render(snap) {
+    renderSessions(snap.sessions);
+    renderNeeds(snap.needs);
+    renderCost(snap.cost);
+    $("updated").textContent = `Updated ${new Date().toLocaleTimeString()}`;
+  }
+
+  // ── Connection state ──────────────────────────────────────────────
+  function setConn(state) {
+    const c = $("conn");
+    c.classList.remove("live", "down");
+    const label = c.querySelector(".conn-label");
+    if (state === "live") {
+      c.classList.add("live");
+      label.textContent = "";
+    } else if (state === "down") {
+      c.classList.add("down");
+      label.textContent = "disconnected";
+    } else {
+      label.textContent = "connecting…";
+    }
+  }
+
+  function showAuthPrompt() {
+    $("auth-prompt").hidden = false;
+  }
+
+  // ── Data fetch + SSE ──────────────────────────────────────────────
+  async function loadOnce() {
+    const res = await fetch("/api/snapshot", { headers: authHeaders() });
+    if (res.status === 401) {
+      showAuthPrompt();
+      throw new Error("unauthorized");
+    }
+    if (!res.ok) throw new Error(`snapshot failed: ${res.status}`);
+    return res.json();
+  }
+
+  function startSSE() {
+    // EventSource cannot set headers; pass the token via query string. The
+    // server accepts it only on this route and we never persist it in the URL.
+    const sseUrl = token
+      ? `/api/events?token=${encodeURIComponent(token)}`
+      : "/api/events";
+    const es = new EventSource(sseUrl);
+
+    es.addEventListener("snapshot", (e) => {
+      setConn("live");
+      try {
+        render(JSON.parse(e.data));
+      } catch (_) {
+        /* ignore malformed frame */
+      }
+    });
+    es.onopen = () => setConn("live");
+    es.onerror = () => {
+      setConn("down");
+      // EventSource auto-reconnects; nothing else to do.
+    };
+  }
+
+  async function boot() {
+    setConn("connecting");
+    try {
+      render(await loadOnce());
+      startSSE();
+    } catch (e) {
+      if (String(e).includes("unauthorized")) {
+        setConn("down");
+        return; // auth prompt already shown
+      }
+      setConn("down");
+      // Retry the one-shot load after a short delay.
+      setTimeout(boot, 3000);
+    }
+  }
+
+  // Auth prompt wiring.
+  $("auth-go").addEventListener("click", () => {
+    const val = $("auth-input").value.trim();
+    if (!val) return;
+    token = val;
+    sessionStorage.setItem("ainb_token", token);
+    $("auth-prompt").hidden = true;
+    boot();
+  });
+  $("auth-input").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") $("auth-go").click();
+  });
+
+  boot();
+})();

--- a/ainb-tui/crates/ainb-web/frontend/index.html
+++ b/ainb-tui/crates/ainb-web/frontend/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>ainb · fleet dashboard</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <div id="app">
+    <header class="topbar">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">◆</span>
+        <span class="brand-name">ainb</span>
+        <span class="brand-sub">fleet</span>
+      </div>
+      <div class="topbar-right">
+        <div class="stat">
+          <span class="stat-num" id="stat-sessions">–</span>
+          <span class="stat-label">sessions</span>
+        </div>
+        <div class="stat">
+          <span class="stat-num" id="stat-needs">–</span>
+          <span class="stat-label">need attention</span>
+        </div>
+        <div class="stat">
+          <span class="stat-num" id="stat-cost">–</span>
+          <span class="stat-label">cost</span>
+        </div>
+        <div class="conn" id="conn" title="live connection status">
+          <span class="conn-dot"></span>
+          <span class="conn-label">connecting…</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="grid">
+      <section class="panel panel-sessions">
+        <div class="panel-head">
+          <h2>Sessions</h2>
+          <span class="panel-meta" id="sessions-meta"></span>
+        </div>
+        <div class="panel-body" id="sessions"></div>
+      </section>
+
+      <section class="panel panel-needs">
+        <div class="panel-head">
+          <h2>Needs attention</h2>
+          <span class="panel-meta" id="needs-meta"></span>
+        </div>
+        <div class="panel-body" id="needs"></div>
+      </section>
+
+      <section class="panel panel-cost">
+        <div class="panel-head">
+          <h2>Cost</h2>
+          <span class="panel-meta" id="cost-meta"></span>
+        </div>
+        <div class="panel-body" id="cost"></div>
+      </section>
+    </main>
+
+    <footer class="footbar">
+      <span id="updated">—</span>
+      <span class="footbar-sep">·</span>
+      <span>read-only</span>
+      <span class="footbar-sep">·</span>
+      <span>SSE live</span>
+    </footer>
+  </div>
+
+  <div class="auth-prompt" id="auth-prompt" hidden>
+    <div class="auth-card">
+      <h3>Token required</h3>
+      <p>This dashboard requires a bearer token. Paste it to connect.</p>
+      <input type="password" id="auth-input" placeholder="bearer token" autocomplete="off" />
+      <button id="auth-go">Connect</button>
+    </div>
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/ainb-tui/crates/ainb-web/frontend/styles.css
+++ b/ainb-tui/crates/ainb-web/frontend/styles.css
@@ -1,0 +1,269 @@
+/* ainb fleet dashboard — single embedded stylesheet, no build step. */
+
+:root {
+  --bg: #0a0e16;
+  --bg-elev: #111824;
+  --bg-elev-2: #161f2e;
+  --border: #1f2a3c;
+  --border-soft: #18212f;
+  --text: #e6edf6;
+  --text-dim: #8b9bb4;
+  --text-faint: #5c6b85;
+  --accent: #4f9cf9;
+  --accent-soft: rgba(79, 156, 249, 0.14);
+  --green: #3fb950;
+  --amber: #d29922;
+  --red: #f85149;
+  --violet: #a371f7;
+  --radius: 12px;
+  --shadow: 0 1px 0 rgba(255, 255, 255, 0.02), 0 8px 24px rgba(0, 0, 0, 0.4);
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+}
+
+body {
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(79, 156, 249, 0.08), transparent 60%),
+    radial-gradient(900px 500px at 0% 0%, rgba(163, 113, 247, 0.06), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, Inter, system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+/* ── Topbar ─────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px 28px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(10, 14, 22, 0.7);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.brand-mark { color: var(--accent); font-size: 18px; }
+.brand-name { font-weight: 700; letter-spacing: -0.01em; font-size: 17px; }
+.brand-sub {
+  color: var(--text-faint);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.topbar-right { display: flex; align-items: center; gap: 26px; }
+
+.stat { display: flex; flex-direction: column; align-items: flex-end; }
+.stat-num { font-size: 20px; font-weight: 650; font-variant-numeric: tabular-nums; line-height: 1; }
+.stat-label { font-size: 11px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 4px; }
+
+.conn { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-dim); }
+.conn-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-faint); box-shadow: 0 0 0 0 rgba(0,0,0,0); }
+.conn.live .conn-dot { background: var(--green); animation: pulse 2.4s ease-out infinite; }
+.conn.live .conn-label::after { content: "live"; }
+.conn.live .conn-label { font-size: 0; }
+.conn.live .conn-label::after { font-size: 12px; color: var(--green); }
+.conn.down .conn-dot { background: var(--red); }
+@keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(63,185,80,0.5); } 70% { box-shadow: 0 0 0 6px rgba(63,185,80,0); } 100% { box-shadow: 0 0 0 0 rgba(63,185,80,0); } }
+
+/* ── Grid ───────────────────────────────────────────── */
+.grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  grid-template-areas:
+    "sessions needs"
+    "sessions cost";
+  gap: 18px;
+  padding: 22px 28px;
+  max-width: 1500px;
+  width: 100%;
+  margin: 0 auto;
+}
+.panel-sessions { grid-area: sessions; }
+.panel-needs { grid-area: needs; }
+.panel-cost { grid-area: cost; }
+
+@media (max-width: 920px) {
+  .grid { grid-template-columns: 1fr; grid-template-areas: "sessions" "needs" "cost"; }
+  .topbar-right { gap: 16px; }
+}
+
+.panel {
+  background: linear-gradient(180deg, var(--bg-elev), var(--bg-elev-2));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.panel-head h2 { margin: 0; font-size: 13px; font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; color: var(--text-dim); }
+.panel-meta { font-size: 12px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
+.panel-body { padding: 10px; overflow-y: auto; }
+
+/* ── Session rows ───────────────────────────────────── */
+.row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  transition: background 0.12s ease;
+}
+.row:hover { background: var(--accent-soft); }
+.row + .row { margin-top: 2px; }
+
+.status-dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+.status-running { background: var(--green); box-shadow: 0 0 8px rgba(63,185,80,0.6); }
+.status-idle { background: var(--amber); }
+.status-stopped { background: var(--text-faint); }
+.status-error { background: var(--red); box-shadow: 0 0 8px rgba(248,81,73,0.6); }
+
+.row-main { min-width: 0; flex: 1; }
+.row-name { font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.row-meta { display: flex; gap: 10px; margin-top: 3px; color: var(--text-faint); font-size: 12px; }
+.row-meta code { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text-dim); }
+
+.badges { display: flex; gap: 6px; flex: 0 0 auto; }
+.badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 999px;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+.badge-git { background: rgba(163,113,247,0.16); color: var(--violet); }
+.badge-attn { background: rgba(248,81,73,0.16); color: var(--red); }
+.badge-status { background: var(--bg-elev-2); color: var(--text-dim); border: 1px solid var(--border); }
+
+/* ── Needs cards ────────────────────────────────────── */
+.need {
+  display: flex;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border-soft);
+}
+.need + .need { margin-top: 8px; }
+.need-kind {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 4px 8px;
+  border-radius: 6px;
+  height: fit-content;
+  flex: 0 0 auto;
+}
+.kind-ASK { background: rgba(79,156,249,0.16); color: var(--accent); }
+.kind-ERR { background: rgba(248,81,73,0.16); color: var(--red); }
+.kind-WAIT { background: rgba(210,153,34,0.16); color: var(--amber); }
+.kind-IDLE { background: rgba(139,155,180,0.14); color: var(--text-dim); }
+.need-body { min-width: 0; }
+.need-title { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.need-detail { color: var(--text-dim); font-size: 12.5px; margin-top: 3px; word-break: break-word; }
+
+/* ── Cost ───────────────────────────────────────────── */
+.cost-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; }
+.cost-cell { background: var(--bg-elev-2); border: 1px solid var(--border-soft); border-radius: 10px; padding: 14px; }
+.cost-val { font-size: 22px; font-weight: 650; font-variant-numeric: tabular-nums; }
+.cost-key { font-size: 11px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 4px; }
+
+/* ── Empty / placeholder ────────────────────────────── */
+.empty {
+  padding: 28px 14px;
+  text-align: center;
+  color: var(--text-faint);
+  font-size: 13px;
+}
+.empty-icon { font-size: 22px; opacity: 0.5; display: block; margin-bottom: 8px; }
+
+/* ── Footer ─────────────────────────────────────────── */
+.footbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 28px;
+  border-top: 1px solid var(--border);
+  color: var(--text-faint);
+  font-size: 12px;
+}
+.footbar-sep { color: var(--border); }
+
+/* ── Auth prompt ────────────────────────────────────── */
+/* `[hidden]` must win over the class's `display`, so scope display to the
+   not-hidden state. */
+.auth-prompt[hidden] { display: none; }
+.auth-prompt {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(5, 8, 13, 0.82);
+  backdrop-filter: blur(6px);
+  z-index: 50;
+}
+.auth-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+  width: min(380px, 90vw);
+  box-shadow: var(--shadow);
+}
+.auth-card h3 { margin: 0 0 6px; }
+.auth-card p { margin: 0 0 16px; color: var(--text-dim); font-size: 13px; }
+.auth-card input {
+  width: 100%;
+  padding: 11px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+.auth-card input:focus { outline: none; border-color: var(--accent); }
+.auth-card button {
+  width: 100%;
+  padding: 11px;
+  background: var(--accent);
+  color: #04121f;
+  border: none;
+  border-radius: 8px;
+  font-weight: 650;
+  font-size: 14px;
+  cursor: pointer;
+}
+.auth-card button:hover { filter: brightness(1.08); }

--- a/ainb-tui/crates/ainb-web/src/assets.rs
+++ b/ainb-tui/crates/ainb-web/src/assets.rs
@@ -1,0 +1,53 @@
+//! Embedded frontend assets.
+//!
+//! The vanilla-JS/CSS/HTML frontend under `frontend/` is compiled into the
+//! binary with `rust-embed` — no Node build step, no runtime filesystem
+//! dependency. Static routes resolve files from here.
+
+use axum::http::{StatusCode, Uri, header};
+use axum::response::{IntoResponse, Response};
+use rust_embed::RustEmbed;
+
+/// All files under `crates/ainb-web/frontend/` embedded at build time.
+#[derive(RustEmbed)]
+#[folder = "frontend/"]
+pub struct Frontend;
+
+/// Serve an embedded asset by path, inferring the content type from the
+/// extension. Unknown paths fall back to `index.html` so the single-page
+/// dashboard works under any sub-path (clean extension point for routing).
+pub fn serve(path: &str) -> Response {
+    // Map request paths to embedded file names. The frontend references assets
+    // under `/static/<name>`; the embed stores them flat at the folder root, so
+    // strip the `/static/` prefix. `/` (or empty) resolves to the SPA shell.
+    let path = path.trim_start_matches('/');
+    let path = path.strip_prefix("static/").unwrap_or(path);
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    match Frontend::get(path) {
+        Some(content) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            (
+                [(header::CONTENT_TYPE, mime.as_ref())],
+                content.data.into_owned(),
+            )
+                .into_response()
+        }
+        None => {
+            // SPA fallback: any unknown asset path serves the shell.
+            match Frontend::get("index.html") {
+                Some(content) => (
+                    [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                    content.data.into_owned(),
+                )
+                    .into_response(),
+                None => (StatusCode::NOT_FOUND, "asset not found").into_response(),
+            }
+        }
+    }
+}
+
+/// Axum handler for `GET /` and `GET /static/*path`.
+pub async fn handler(uri: Uri) -> Response {
+    serve(uri.path())
+}

--- a/ainb-tui/crates/ainb-web/src/auth.rs
+++ b/ainb-tui/crates/ainb-web/src/auth.rs
@@ -1,0 +1,163 @@
+//! Bearer-token authentication for `/api/*` routes.
+//!
+//! When the server is configured with a token, every API request must carry
+//! `Authorization: Bearer <token>`. Comparison is constant-time to avoid
+//! leaking the token through timing. When no token is configured (the default
+//! loopback dev posture), all requests are authorized.
+
+use axum::extract::State;
+use axum::http::{Request, StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use subtle::ConstantTimeEq;
+
+use crate::routes::AppState;
+
+/// JSON 401 body matching the API error envelope.
+fn unauthorized() -> Response {
+    let body = axum::Json(serde_json::json!({
+        "error": { "code": "UNAUTHORIZED", "message": "missing or invalid bearer token" }
+    }));
+    (StatusCode::UNAUTHORIZED, body).into_response()
+}
+
+/// Extract the `Bearer` value from an `Authorization` header, if present.
+fn bearer_value(req_headers: &header::HeaderMap) -> Option<&str> {
+    req_headers
+        .get(header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+        .map(str::trim)
+}
+
+/// Extract a `token` query-string parameter, if present. Browsers cannot set
+/// headers on an `EventSource` connection, so the SSE endpoint additionally
+/// accepts the token via query string (the client strips it from the URL after
+/// connecting). This mirrors agent-deck's `authorizeWSRequest`.
+fn query_token(query: Option<&str>) -> Option<String> {
+    let query = query?;
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        if k == "token" {
+            Some(urldecode(v))
+        } else {
+            None
+        }
+    })
+}
+
+/// Minimal percent-decoder for query-string token values (handles `%XX` and
+/// `+`). Avoids pulling in a URL crate for one field.
+fn urldecode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(h), Some(l)) = (hi, lo) {
+                    out.push((h * 16 + l) as u8);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// True when `presented` matches `expected` in constant time.
+fn token_matches(expected: &str, presented: &str) -> bool {
+    // ConstantTimeEq over equal-length byte slices; lengths differing is an
+    // immediate non-match but we still feed equal-length work for the common
+    // case by comparing bytes directly via subtle.
+    let exp = expected.as_bytes();
+    let got = presented.as_bytes();
+    if exp.len() != got.len() {
+        return false;
+    }
+    exp.ct_eq(got).into()
+}
+
+/// Axum middleware enforcing bearer auth on `/api/*` when a token is set.
+pub async fn require_bearer(
+    State(state): State<AppState>,
+    req: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let Some(expected) = state.config.token.as_deref() else {
+        // No token configured — loopback dev mode, all requests allowed.
+        return next.run(req).await;
+    };
+
+    // Header is the primary path; query token is accepted only as a fallback
+    // for the SSE EventSource which cannot set request headers.
+    let header_ok = bearer_value(req.headers()).is_some_and(|t| token_matches(expected, t));
+    let query_ok = query_token(req.uri().query())
+        .as_deref()
+        .is_some_and(|t| token_matches(expected, t));
+
+    if header_ok || query_ok {
+        next.run(req).await
+    } else {
+        unauthorized()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_token_accepted() {
+        assert!(token_matches("s3cret", "s3cret"));
+    }
+
+    #[test]
+    fn wrong_token_rejected() {
+        assert!(!token_matches("s3cret", "nope"));
+    }
+
+    #[test]
+    fn length_mismatch_rejected() {
+        assert!(!token_matches("s3cret", "s3cre"));
+        assert!(!token_matches("s3cret", "s3cretx"));
+    }
+
+    #[test]
+    fn bearer_value_parsing() {
+        let mut h = header::HeaderMap::new();
+        h.insert(header::AUTHORIZATION, "Bearer abc123".parse().unwrap());
+        assert_eq!(bearer_value(&h), Some("abc123"));
+
+        let mut h2 = header::HeaderMap::new();
+        h2.insert(header::AUTHORIZATION, "Basic abc123".parse().unwrap());
+        assert_eq!(bearer_value(&h2), None);
+
+        assert_eq!(bearer_value(&header::HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn query_token_extraction() {
+        assert_eq!(query_token(Some("token=abc123")), Some("abc123".into()));
+        assert_eq!(
+            query_token(Some("foo=1&token=s3%20cret&bar=2")),
+            Some("s3 cret".into())
+        );
+        assert_eq!(query_token(Some("foo=1")), None);
+        assert_eq!(query_token(None), None);
+    }
+}

--- a/ainb-tui/crates/ainb-web/src/auth.rs
+++ b/ainb-tui/crates/ainb-web/src/auth.rs
@@ -13,6 +13,12 @@ use subtle::ConstantTimeEq;
 
 use crate::routes::AppState;
 
+/// The only route on which the `?token=` query-string fallback is honored.
+/// Browsers cannot set an `Authorization` header on an `EventSource`, so the
+/// SSE stream accepts the token via query string; every other route requires
+/// the header to keep tokens out of logs/history/`Referer`.
+const SSE_PATH: &str = "/api/events";
+
 /// JSON 401 body matching the API error envelope.
 fn unauthorized() -> Response {
     let body = axum::Json(serde_json::json!({
@@ -103,12 +109,16 @@ pub async fn require_bearer(
         return next.run(req).await;
     };
 
-    // Header is the primary path; query token is accepted only as a fallback
-    // for the SSE EventSource which cannot set request headers.
+    // Header is the primary path, honored on every route. The `?token=` query
+    // fallback is scoped to the SSE endpoint ONLY, because browsers cannot set
+    // headers on an `EventSource`. Tokens in URLs leak via proxy/access logs,
+    // browser history, and `Referer`, so we must not accept them on any other
+    // route — a header is required everywhere except `/api/events`.
     let header_ok = bearer_value(req.headers()).is_some_and(|t| token_matches(expected, t));
-    let query_ok = query_token(req.uri().query())
-        .as_deref()
-        .is_some_and(|t| token_matches(expected, t));
+    let query_ok = req.uri().path() == SSE_PATH
+        && query_token(req.uri().query())
+            .as_deref()
+            .is_some_and(|t| token_matches(expected, t));
 
     if header_ok || query_ok {
         next.run(req).await

--- a/ainb-tui/crates/ainb-web/src/config.rs
+++ b/ainb-tui/crates/ainb-web/src/config.rs
@@ -1,0 +1,118 @@
+//! Runtime configuration + bind-security policy for `ainb web`.
+//!
+//! The security model mirrors agent-deck's `CheckBindSecurity`: the server
+//! binds to loopback by default and *refuses* to start on a non-loopback
+//! address unless the operator either supplies a bearer `--token` (so the
+//! exposed surface is authenticated) or explicitly opts in with
+//! `--insecure-bind`. Every `/api/*` route additionally requires the bearer
+//! token when one is configured.
+
+use std::net::{IpAddr, SocketAddr};
+
+/// Why a requested bind address was refused. Carried out to the CLI layer so
+/// it can render a clear, actionable refusal before any socket is opened.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BindError {
+    /// The address is non-loopback and no token / insecure override was given.
+    #[error(
+        "refusing to bind to non-loopback address {addr} without authentication.\n\
+         This would expose the dashboard to your network unauthenticated.\n\
+         Pass --token <secret> to require a bearer token, or --insecure-bind to override."
+    )]
+    NonLoopbackWithoutToken {
+        /// The offending address.
+        addr: SocketAddr,
+    },
+}
+
+/// Immutable runtime configuration for the dashboard server.
+#[derive(Debug, Clone)]
+pub struct WebConfig {
+    /// Address to bind the HTTP listener to.
+    pub listen: SocketAddr,
+    /// Optional bearer token. When `Some`, every `/api/*` request must carry
+    /// `Authorization: Bearer <token>`; without it the API returns 401.
+    pub token: Option<String>,
+    /// Explicit override allowing a non-loopback bind with no token. Mirrors
+    /// agent-deck's `--insecure-bind`.
+    pub insecure_bind: bool,
+    /// Always `true` in this cut — the dashboard never mutates fleet state.
+    /// Surfaced in `/healthz` and reserved as a clean extension point.
+    pub read_only: bool,
+}
+
+impl WebConfig {
+    /// Validate the bind address against the security policy. Returns the
+    /// refusal reason if the bind would expose an unauthenticated surface.
+    ///
+    /// Policy (first matching rule wins):
+    /// 1. A bearer token is configured → allow (the surface is authenticated).
+    /// 2. `--insecure-bind` was passed → allow (explicit operator override).
+    /// 3. The host is loopback (`127.0.0.0/8`, `::1`) → allow.
+    /// 4. Otherwise → refuse.
+    pub fn check_bind_security(&self) -> Result<(), BindError> {
+        if self.token.is_some() || self.insecure_bind {
+            return Ok(());
+        }
+        if is_loopback(self.listen.ip()) {
+            return Ok(());
+        }
+        Err(BindError::NonLoopbackWithoutToken { addr: self.listen })
+    }
+}
+
+/// True when `ip` is a loopback address. An unspecified address (`0.0.0.0` /
+/// `::`) is treated as non-loopback because it binds every interface, so it
+/// must clear the same authentication bar as an explicit public IP.
+fn is_loopback(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(addr: &str, token: Option<&str>, insecure: bool) -> WebConfig {
+        WebConfig {
+            listen: addr.parse().unwrap(),
+            token: token.map(str::to_string),
+            insecure_bind: insecure,
+            read_only: true,
+        }
+    }
+
+    #[test]
+    fn loopback_v4_allowed_without_token() {
+        assert!(cfg("127.0.0.1:8420", None, false).check_bind_security().is_ok());
+    }
+
+    #[test]
+    fn loopback_v6_allowed_without_token() {
+        assert!(cfg("[::1]:8420", None, false).check_bind_security().is_ok());
+    }
+
+    #[test]
+    fn non_loopback_without_token_is_refused() {
+        let err = cfg("0.0.0.0:8420", None, false).check_bind_security().unwrap_err();
+        assert!(matches!(err, BindError::NonLoopbackWithoutToken { .. }));
+    }
+
+    #[test]
+    fn explicit_public_ip_without_token_is_refused() {
+        let err = cfg("192.168.1.50:8420", None, false).check_bind_security().unwrap_err();
+        assert!(matches!(err, BindError::NonLoopbackWithoutToken { .. }));
+    }
+
+    #[test]
+    fn non_loopback_with_token_is_allowed() {
+        assert!(cfg("0.0.0.0:8420", Some("s3cret"), false).check_bind_security().is_ok());
+    }
+
+    #[test]
+    fn non_loopback_with_insecure_override_is_allowed() {
+        assert!(cfg("0.0.0.0:8420", None, true).check_bind_security().is_ok());
+    }
+}

--- a/ainb-tui/crates/ainb-web/src/data.rs
+++ b/ainb-tui/crates/ainb-web/src/data.rs
@@ -1,0 +1,199 @@
+//! Dashboard data sources.
+//!
+//! The dashboard never re-implements data access — it drives the *same*
+//! `ainb --format json …` commands the CLI and TUI expose, so the browser view
+//! can never drift from the terminal view. [`DataSource`] abstracts that so
+//! tests can inject a deterministic fake instead of spawning subprocesses.
+
+use std::ffi::OsString;
+use std::future::Future;
+use std::pin::Pin;
+
+use serde_json::Value;
+
+/// A `'static` boxed future, the return shape of [`DataSource::snapshot`].
+/// Keeping the trait boxed-future (rather than `async fn`) makes it
+/// object-safe so the router can hold a `dyn DataSource`.
+pub type SnapshotFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<FleetSnapshot, DataError>> + Send + 'a>>;
+
+/// A snapshot of everything the dashboard renders, as opaque JSON values
+/// proxied straight from the underlying `ainb` commands. Keeping these as
+/// [`Value`] (rather than re-deriving the CLI's structs) means new fields the
+/// CLI adds flow through to the frontend with no code change here.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FleetSnapshot {
+    /// `ainb --format json list` — the live session list.
+    pub sessions: Value,
+    /// `ainb --format json fleet needs` — ASK/ERR/IDLE/WAIT cards.
+    pub needs: Value,
+    /// `ainb --format json fleet cost` — cost rollups. `null` when the verb is
+    /// absent from this build (cost-surface not yet merged) so the dashboard
+    /// degrades gracefully instead of failing.
+    pub cost: Value,
+    /// Content fingerprint, used by the SSE layer to suppress duplicate pushes
+    /// when nothing changed. Skipped from the API payload — it's internal.
+    #[serde(skip)]
+    pub fingerprint: u64,
+}
+
+impl FleetSnapshot {
+    /// Compute a stable fingerprint over the rendered payload. Two snapshots
+    /// with identical sessions/needs/cost hash equal, so the SSE stream only
+    /// emits on real change.
+    #[must_use]
+    pub fn compute_fingerprint(sessions: &Value, needs: &Value, cost: &Value) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        // serde_json::Value isn't Hash; hash its compact string form.
+        sessions.to_string().hash(&mut h);
+        needs.to_string().hash(&mut h);
+        cost.to_string().hash(&mut h);
+        h.finish()
+    }
+}
+
+/// Error returned when a data source cannot produce a snapshot.
+#[derive(Debug, thiserror::Error)]
+pub enum DataError {
+    /// The underlying `ainb` command failed to spawn or exited non-zero.
+    #[error("`ainb {verb}` failed: {detail}")]
+    CommandFailed {
+        /// The verb we tried to run, e.g. `list` or `fleet needs`.
+        verb: String,
+        /// Human-readable failure detail (stderr / spawn error).
+        detail: String,
+    },
+    /// The command produced output that wasn't valid JSON.
+    #[error("`ainb {verb}` produced invalid JSON: {detail}")]
+    InvalidJson {
+        /// The verb whose output failed to parse.
+        verb: String,
+        /// Parse error detail.
+        detail: String,
+    },
+}
+
+/// Produces [`FleetSnapshot`]s on demand. Implemented by [`AinbCliSource`] in
+/// production and by a fake in tests. Object-safe via boxed futures.
+pub trait DataSource: Send + Sync + 'static {
+    /// Build a fresh snapshot of the current fleet state.
+    fn snapshot(&self) -> SnapshotFuture<'_>;
+}
+
+/// Production data source: shells out to the `ainb` binary with
+/// `--format json`. Resolves the binary from `AINB_BIN`, else the running
+/// executable (so a dev `cargo run` and an installed `ainb` both work), else
+/// `ainb` on `PATH`.
+#[derive(Debug, Clone)]
+pub struct AinbCliSource {
+    bin: OsString,
+}
+
+impl Default for AinbCliSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AinbCliSource {
+    /// Build a source that invokes the resolved `ainb` binary.
+    #[must_use]
+    pub fn new() -> Self {
+        let bin = std::env::var_os("AINB_BIN")
+            .or_else(|| std::env::current_exe().ok().map(Into::into))
+            .unwrap_or_else(|| OsString::from("ainb"));
+        Self { bin }
+    }
+
+    /// Run `ainb --format json <args...>` and parse stdout as JSON.
+    ///
+    /// `allow_absent`: when the subcommand may legitimately not exist in this
+    /// build (e.g. `fleet cost` before the cost-surface PR merges), a failure
+    /// yields `Value::Null` instead of an error, so the dashboard degrades
+    /// gracefully rather than blocking on an optional feature.
+    async fn run_json(&self, args: &[&str], allow_absent: bool) -> Result<Value, DataError> {
+        let verb = args.join(" ");
+        let mut cmd = tokio::process::Command::new(&self.bin);
+        cmd.arg("--format").arg("json").args(args);
+        cmd.stdin(std::process::Stdio::null());
+
+        let output = match cmd.output().await {
+            Ok(o) => o,
+            Err(e) if allow_absent => {
+                tracing::debug!(verb, error = %e, "optional ainb subcommand unavailable");
+                return Ok(Value::Null);
+            }
+            Err(e) => {
+                return Err(DataError::CommandFailed {
+                    verb,
+                    detail: format!("spawn failed: {e}"),
+                });
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            if allow_absent {
+                tracing::debug!(verb, %stderr, "optional ainb subcommand returned non-zero");
+                return Ok(Value::Null);
+            }
+            return Err(DataError::CommandFailed {
+                verb,
+                detail: if stderr.is_empty() {
+                    format!("exited with {}", output.status)
+                } else {
+                    stderr
+                },
+            });
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let trimmed = stdout.trim();
+        if trimmed.is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(trimmed).map_err(|e| DataError::InvalidJson {
+            verb,
+            detail: e.to_string(),
+        })
+    }
+}
+
+impl DataSource for AinbCliSource {
+    fn snapshot(&self) -> SnapshotFuture<'_> {
+        Box::pin(async move {
+            // Required surfaces fail loudly; cost is best-effort.
+            let sessions = self.run_json(&["list"], false).await?;
+            let needs = self.run_json(&["fleet", "needs"], false).await?;
+            let cost = self.run_json(&["fleet", "cost"], true).await?;
+            let fingerprint = FleetSnapshot::compute_fingerprint(&sessions, &needs, &cost);
+            Ok(FleetSnapshot {
+                sessions,
+                needs,
+                cost,
+                fingerprint,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn fingerprint_is_stable_and_change_sensitive() {
+        let s1 = json!([{"id": 1}]);
+        let n1 = json!([]);
+        let c1 = Value::Null;
+        let fp_a = FleetSnapshot::compute_fingerprint(&s1, &n1, &c1);
+        let fp_b = FleetSnapshot::compute_fingerprint(&s1, &n1, &c1);
+        assert_eq!(fp_a, fp_b, "identical input must hash equal");
+
+        let s2 = json!([{"id": 2}]);
+        let fp_c = FleetSnapshot::compute_fingerprint(&s2, &n1, &c1);
+        assert_ne!(fp_a, fp_c, "changed sessions must change the fingerprint");
+    }
+}

--- a/ainb-tui/crates/ainb-web/src/data.rs
+++ b/ainb-tui/crates/ainb-web/src/data.rs
@@ -17,6 +17,23 @@ use serde_json::Value;
 pub type SnapshotFuture<'a> =
     Pin<Box<dyn Future<Output = Result<FleetSnapshot, DataError>> + Send + 'a>>;
 
+/// The sessions + needs pair fetched on the fast poll cadence (cost excluded).
+/// Returned by [`DataSource::core`].
+#[derive(Debug, Clone)]
+pub struct CoreSnapshot {
+    /// `ainb --format json list` — the live session list.
+    pub sessions: Value,
+    /// `ainb --format json fleet needs` — ASK/ERR/IDLE/WAIT cards.
+    pub needs: Value,
+}
+
+/// A `'static` boxed future, the return shape of [`DataSource::core`].
+pub type CoreFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<CoreSnapshot, DataError>> + Send + 'a>>;
+
+/// A `'static` boxed future, the return shape of [`DataSource::cost`].
+pub type CostFuture<'a> = Pin<Box<dyn Future<Output = Value> + Send + 'a>>;
+
 /// A snapshot of everything the dashboard renders, as opaque JSON values
 /// proxied straight from the underlying `ainb` commands. Keeping these as
 /// [`Value`] (rather than re-deriving the CLI's structs) means new fields the
@@ -38,6 +55,21 @@ pub struct FleetSnapshot {
 }
 
 impl FleetSnapshot {
+    /// Assemble a full snapshot from a fast-cadence [`CoreSnapshot`] and a
+    /// (possibly stale) cost value, recomputing the fingerprint. Used by the
+    /// poller to stitch fresh sessions/needs onto the last-known cost on ticks
+    /// that skip the slow cost fetch.
+    #[must_use]
+    pub fn from_parts(core: CoreSnapshot, cost: Value) -> Self {
+        let fingerprint = Self::compute_fingerprint(&core.sessions, &core.needs, &cost);
+        Self {
+            sessions: core.sessions,
+            needs: core.needs,
+            cost,
+            fingerprint,
+        }
+    }
+
     /// Compute a stable fingerprint over the rendered payload. Two snapshots
     /// with identical sessions/needs/cost hash equal, so the SSE stream only
     /// emits on real change.
@@ -76,9 +108,26 @@ pub enum DataError {
 
 /// Produces [`FleetSnapshot`]s on demand. Implemented by [`AinbCliSource`] in
 /// production and by a fake in tests. Object-safe via boxed futures.
+///
+/// The poller fetches [`core`](DataSource::core) (sessions + needs) on the fast
+/// cadence and [`cost`](DataSource::cost) on a slower one, because
+/// `ainb fleet cost` cold-boots the burndown plugin runtime per call and cost
+/// data rolls up slowly. [`snapshot`](DataSource::snapshot) composes both for
+/// the cold-cache fallback path.
 pub trait DataSource: Send + Sync + 'static {
-    /// Build a fresh snapshot of the current fleet state.
+    /// Build a fresh full snapshot of the current fleet state (sessions, needs,
+    /// and cost). Used only on a cold cache before the poller's first tick.
     fn snapshot(&self) -> SnapshotFuture<'_>;
+
+    /// Fetch only the fast-cadence surfaces (sessions + needs). These are cheap
+    /// relative to cost and need ~2s freshness, so the poller refreshes them on
+    /// every tick.
+    fn core(&self) -> CoreFuture<'_>;
+
+    /// Fetch the slow-cadence cost rollup, best-effort: any failure or absent
+    /// verb resolves to [`Value::Null`] so the dashboard degrades gracefully.
+    /// The poller calls this only every Nth tick.
+    fn cost(&self) -> CostFuture<'_>;
 }
 
 /// Production data source: shells out to the `ainb` binary with
@@ -164,16 +213,27 @@ impl DataSource for AinbCliSource {
     fn snapshot(&self) -> SnapshotFuture<'_> {
         Box::pin(async move {
             // Required surfaces fail loudly; cost is best-effort.
+            let core = self.core().await?;
+            let cost = self.cost().await;
+            Ok(FleetSnapshot::from_parts(core, cost))
+        })
+    }
+
+    fn core(&self) -> CoreFuture<'_> {
+        Box::pin(async move {
+            // Required surfaces fail loudly.
             let sessions = self.run_json(&["list"], false).await?;
             let needs = self.run_json(&["fleet", "needs"], false).await?;
-            let cost = self.run_json(&["fleet", "cost"], true).await?;
-            let fingerprint = FleetSnapshot::compute_fingerprint(&sessions, &needs, &cost);
-            Ok(FleetSnapshot {
-                sessions,
-                needs,
-                cost,
-                fingerprint,
-            })
+            Ok(CoreSnapshot { sessions, needs })
+        })
+    }
+
+    fn cost(&self) -> CostFuture<'_> {
+        Box::pin(async move {
+            // Cost is best-effort: `run_json(.., allow_absent=true)` already
+            // resolves spawn errors / non-zero exits to `Value::Null`, so any
+            // residual error here also degrades to `Null` rather than failing.
+            self.run_json(&["fleet", "cost"], true).await.unwrap_or(Value::Null)
         })
     }
 }

--- a/ainb-tui/crates/ainb-web/src/lib.rs
+++ b/ainb-tui/crates/ainb-web/src/lib.rs
@@ -1,0 +1,74 @@
+//! `ainb-web` — a read-only, SSE-live web dashboard for the ainb agent fleet.
+//!
+//! The dashboard surfaces three things at a glance: the live session list,
+//! fleet `needs` (ASK/ERR/IDLE/WAIT), and cost rollups. It is **read-only** —
+//! there are no mutate endpoints, no terminal bridge, and no web-push in this
+//! cut (those are deliberate, clean extension points).
+//!
+//! ## Security model
+//!
+//! * Binds to loopback by default.
+//! * Refuses a non-loopback bind unless a bearer `--token` is supplied or
+//!   `--insecure-bind` is set explicitly (see [`config::WebConfig::check_bind_security`]).
+//! * When a token is configured, every `/api/*` route requires
+//!   `Authorization: Bearer <token>` (401 otherwise).
+//!
+//! ## Data flow
+//!
+//! Data is proxied from the existing `ainb --format json` commands
+//! ([`data::AinbCliSource`]) so the browser view never drifts from the CLI/TUI.
+//! A background poller refreshes the snapshot and pushes Server-Sent Events to
+//! connected clients whenever the content fingerprint changes.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod assets;
+pub mod auth;
+pub mod config;
+pub mod data;
+pub mod routes;
+
+use std::sync::Arc;
+
+pub use config::{BindError, WebConfig};
+pub use data::{AinbCliSource, DataError, DataSource, FleetSnapshot};
+pub use routes::{AppState, router};
+
+/// Errors raised while starting or running the dashboard server.
+#[derive(Debug, thiserror::Error)]
+pub enum ServeError {
+    /// The requested bind address violated the security policy.
+    #[error(transparent)]
+    Bind(#[from] BindError),
+    /// Binding the TCP listener failed (port in use, permission, …).
+    #[error("failed to bind {addr}: {source}")]
+    Listen {
+        /// The address we tried to bind.
+        addr: std::net::SocketAddr,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+    /// The HTTP server exited with an error.
+    #[error("server error: {0}")]
+    Server(#[source] std::io::Error),
+}
+
+/// Bind and serve the dashboard until the process is interrupted.
+///
+/// Enforces [`WebConfig::check_bind_security`] *before* opening any socket, so
+/// an unsafe bind is refused with a clear error and never listens.
+pub async fn serve(config: WebConfig, data: Arc<dyn DataSource>) -> Result<(), ServeError> {
+    config.check_bind_security()?;
+
+    let addr = config.listen;
+    let state = AppState::new(config, data);
+    let app = router(state);
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|source| ServeError::Listen { addr, source })?;
+
+    tracing::info!(%addr, "ainb web dashboard listening");
+    axum::serve(listener, app).await.map_err(ServeError::Server)
+}

--- a/ainb-tui/crates/ainb-web/src/routes.rs
+++ b/ainb-tui/crates/ainb-web/src/routes.rs
@@ -26,10 +26,24 @@ use crate::auth;
 use crate::config::WebConfig;
 use crate::data::{DataSource, FleetSnapshot};
 
+/// Number of [`POLL_INTERVAL`] ticks between cost re-fetches. At least 1, so the
+/// poller always fetches cost at startup and at least every `COST_POLL_INTERVAL`.
+const COST_TICK_STRIDE: u64 = {
+    let stride = COST_POLL_INTERVAL.as_secs() / POLL_INTERVAL.as_secs();
+    if stride == 0 { 1 } else { stride }
+};
+
 /// How often the background poller refreshes the snapshot. The SSE stream only
 /// emits when the fingerprint changes, so this is a safety-net cadence, not a
 /// per-client cost.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// How often the poller re-fetches `ainb fleet cost`. Cost cold-boots the
+/// burndown plugin runtime per call and rolls up slowly, so it polls far less
+/// often than sessions/needs. Between cost fetches the poller reuses the last
+/// cost value held in the cached snapshot. Must be a multiple of
+/// [`POLL_INTERVAL`]; the poller derives the tick stride from the two.
+const COST_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 /// SSE keep-alive comment cadence (keeps proxies from dropping idle streams).
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
@@ -104,15 +118,23 @@ impl AppState {
         Ok(self.cached().unwrap_or(snap))
     }
 
-    /// Background task: poll the data source every [`POLL_INTERVAL`] and update
-    /// the cached snapshot when the fingerprint changes. The poller runs the
-    /// only `ainb`/`tmux` subprocesses; all requests and SSE streams read the
-    /// cache, so load is bounded to one refresh per interval.
+    /// Background task: poll the data source and update the cached snapshot when
+    /// the fingerprint changes. Sessions + needs refresh every [`POLL_INTERVAL`]
+    /// (~2s); cost refreshes only every [`COST_POLL_INTERVAL`] because
+    /// `ainb fleet cost` cold-boots the burndown plugin runtime per call and
+    /// rolls up slowly. On ticks that skip the cost fetch, the poller reuses the
+    /// last cost value held in the cache, so the cached snapshot always carries
+    /// the most recent cost. The poller runs the only `ainb`/`tmux`
+    /// subprocesses; all requests and SSE streams read the cache.
     fn spawn_poller(&self) {
         let data = Arc::clone(&self.data);
         let tx = self.cache.clone();
         tokio::spawn(async move {
             let mut last_fp: Option<u64> = None;
+            // The cost value carried forward between cost fetches. Seeded `Null`
+            // (cost-absent) until the first cost fetch lands.
+            let mut last_cost: serde_json::Value = serde_json::Value::Null;
+            let mut tick: u64 = 0;
             let mut ticker = tokio::time::interval(POLL_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
@@ -123,19 +145,32 @@ impl AppState {
                 if tx.is_closed() {
                     break;
                 }
-                match data.snapshot().await {
-                    Ok(snap) => {
-                        if last_fp != Some(snap.fingerprint) {
-                            last_fp = Some(snap.fingerprint);
-                            // Replace the cached snapshot; SSE subscribers and
-                            // every handler observe the new value.
-                            let _ = tx.send(Some(Arc::new(snap)));
-                        }
-                    }
+
+                // Fetch the fast-cadence surfaces every tick.
+                let core = match data.core().await {
+                    Ok(core) => core,
                     Err(e) => {
-                        tracing::warn!(error = %e, "snapshot poll failed");
+                        tracing::warn!(error = %e, "core snapshot poll failed");
+                        tick = tick.wrapping_add(1);
+                        continue;
                     }
+                };
+
+                // Re-fetch cost only on the slow cadence (and on the very first
+                // tick). Reuse the carried-forward value in between. Cost is
+                // best-effort and never fails the poll.
+                if tick % COST_TICK_STRIDE == 0 {
+                    last_cost = data.cost().await;
                 }
+
+                let snap = FleetSnapshot::from_parts(core, last_cost.clone());
+                if last_fp != Some(snap.fingerprint) {
+                    last_fp = Some(snap.fingerprint);
+                    // Replace the cached snapshot; SSE subscribers and every
+                    // handler observe the new value.
+                    let _ = tx.send(Some(Arc::new(snap)));
+                }
+                tick = tick.wrapping_add(1);
             }
         });
     }
@@ -244,40 +279,58 @@ async fn events(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::{DataError, FleetSnapshot, SnapshotFuture};
+    use crate::data::{
+        CoreFuture, CoreSnapshot, CostFuture, DataError, FleetSnapshot, SnapshotFuture,
+    };
     use serde_json::{Value, json};
     use std::sync::atomic::{AtomicU64, Ordering};
 
-    /// A data source whose snapshot fingerprint advances on every fetch, so we
-    /// can observe whether the background poller is actually refreshing the
-    /// cache over time.
+    /// A data source whose `core` and `cost` fetch counters advance
+    /// independently, so a test can observe the two poll cadences separately.
+    /// The `core` payload embeds the fetch count as `tick` so cache changes are
+    /// detectable; the `cost` payload embeds its own fetch count as `fetch`.
     struct FakeSource {
-        ticks: AtomicU64,
+        core_fetches: AtomicU64,
+        cost_fetches: AtomicU64,
     }
 
     impl FakeSource {
         fn new() -> Self {
             Self {
-                ticks: AtomicU64::new(0),
+                core_fetches: AtomicU64::new(0),
+                cost_fetches: AtomicU64::new(0),
             }
+        }
+
+        /// Number of times [`DataSource::cost`] has been called.
+        fn cost_fetch_count(&self) -> u64 {
+            self.cost_fetches.load(Ordering::SeqCst)
         }
     }
 
     impl DataSource for FakeSource {
         fn snapshot(&self) -> SnapshotFuture<'_> {
             Box::pin(async move {
-                let n = self.ticks.fetch_add(1, Ordering::SeqCst);
-                let sessions = json!([{ "tick": n }]);
-                let needs: Value = json!([]);
-                let cost = Value::Null;
-                let fingerprint =
-                    FleetSnapshot::compute_fingerprint(&sessions, &needs, &cost);
-                Ok::<_, DataError>(FleetSnapshot {
-                    sessions,
-                    needs,
-                    cost,
-                    fingerprint,
+                let core = self.core().await?;
+                let cost = self.cost().await;
+                Ok::<_, DataError>(FleetSnapshot::from_parts(core, cost))
+            })
+        }
+
+        fn core(&self) -> CoreFuture<'_> {
+            Box::pin(async move {
+                let n = self.core_fetches.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, DataError>(CoreSnapshot {
+                    sessions: json!([{ "tick": n }]),
+                    needs: json!([]),
                 })
+            })
+        }
+
+        fn cost(&self) -> CostFuture<'_> {
+            Box::pin(async move {
+                let n = self.cost_fetches.fetch_add(1, Ordering::SeqCst);
+                json!({ "fetch": n })
             })
         }
     }
@@ -300,9 +353,7 @@ mod tests {
         // initial snapshot.
         tokio::time::advance(Duration::from_millis(1)).await;
         tokio::task::yield_now().await;
-        let first = state
-            .cached()
-            .expect("poller should have seeded the cache on its first tick");
+        let first = state.cached().expect("poller should have seeded the cache on its first tick");
         let first_tick = first.sessions[0]["tick"].clone();
 
         // Advance well past the poll interval with NO SSE subscriber alive.
@@ -312,15 +363,85 @@ mod tests {
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
 
-        let later = state
-            .cached()
-            .expect("cache must still be populated after later polls");
+        let later = state.cached().expect("cache must still be populated after later polls");
         let later_tick = later.sessions[0]["tick"].clone();
 
         assert_ne!(
             first_tick, later_tick,
             "background poller must refresh the cached snapshot over time even \
              with no SSE client connected"
+        );
+    }
+
+    /// Cost must poll on the slow [`COST_POLL_INTERVAL`] cadence while
+    /// sessions/needs poll on the fast [`POLL_INTERVAL`] one. Over a window of
+    /// many fast ticks, `core` is fetched on every tick but `cost` only once per
+    /// `COST_TICK_STRIDE` ticks — and the cached snapshot always carries the
+    /// most recent cost value.
+    #[tokio::test(start_paused = true)]
+    async fn cost_polls_slower_than_sessions_and_needs() {
+        let config = WebConfig {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            token: None,
+            insecure_bind: false,
+            read_only: true,
+        };
+        let source = Arc::new(FakeSource::new());
+        let state = AppState::new(config, Arc::clone(&source) as Arc<dyn DataSource>);
+
+        // First tick fires immediately: one core fetch and one cost fetch.
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            source.cost_fetch_count(),
+            1,
+            "cost must be fetched on the first tick"
+        );
+        let after_first = state.cached().expect("cache seeded on first tick");
+        assert_eq!(
+            after_first.cost,
+            json!({ "fetch": 0 }),
+            "cached snapshot must carry the first cost value"
+        );
+
+        // Advance through (COST_TICK_STRIDE - 1) more fast ticks. Each refreshes
+        // core but must NOT re-fetch cost yet — cost stays carried forward.
+        for _ in 1..COST_TICK_STRIDE {
+            tokio::time::advance(POLL_INTERVAL).await;
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            source.cost_fetch_count(),
+            1,
+            "cost must NOT be re-fetched within a single cost interval"
+        );
+        let mid = state.cached().expect("cache present mid-interval");
+        assert_eq!(
+            mid.cost,
+            json!({ "fetch": 0 }),
+            "between cost fetches the cached snapshot reuses the last cost value"
+        );
+
+        // The next fast tick crosses the cost interval boundary → cost re-fetched.
+        tokio::time::advance(POLL_INTERVAL).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            source.cost_fetch_count(),
+            2,
+            "cost must be re-fetched once a full COST_POLL_INTERVAL elapses"
+        );
+        let after_second = state.cached().expect("cache present after second cost fetch");
+        assert_eq!(
+            after_second.cost,
+            json!({ "fetch": 1 }),
+            "cached snapshot must carry the refreshed cost value"
+        );
+
+        // Core was fetched on every tick across the whole window; cost only twice.
+        assert_eq!(
+            source.core_fetches.load(Ordering::SeqCst),
+            COST_TICK_STRIDE + 1,
+            "core must be fetched on every fast tick"
         );
     }
 }

--- a/ainb-tui/crates/ainb-web/src/routes.rs
+++ b/ainb-tui/crates/ainb-web/src/routes.rs
@@ -55,17 +55,24 @@ pub struct AppState {
     /// Watch channel holding the latest cached snapshot. Handlers borrow it;
     /// SSE subscribers stream changes off it. Updated only by the poller.
     pub cache: watch::Sender<CachedSnapshot>,
+    /// A receiver kept alive for the whole server lifetime so the channel never
+    /// reports zero receivers. Without this, `watch::Sender::is_closed()` would
+    /// be `true` at startup (the SSE handler creates the only other receiver
+    /// lazily), and the background poller's shutdown guard would break on its
+    /// very first tick — freezing the cache as stale forever.
+    _cache_rx: watch::Receiver<CachedSnapshot>,
 }
 
 impl AppState {
     /// Build app state and spawn the background snapshot poller that maintains
     /// the cached snapshot every [`POLL_INTERVAL`].
     pub fn new(config: WebConfig, data: Arc<dyn DataSource>) -> Self {
-        let (tx, _rx) = watch::channel(None);
+        let (tx, rx) = watch::channel(None);
         let state = Self {
             config: Arc::new(config),
             data,
             cache: tx,
+            _cache_rx: rx,
         };
         state.spawn_poller();
         state
@@ -232,4 +239,88 @@ async fn events(
     });
 
     Sse::new(stream).keep_alive(KeepAlive::new().interval(KEEPALIVE_INTERVAL).text("keepalive"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{DataError, FleetSnapshot, SnapshotFuture};
+    use serde_json::{Value, json};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A data source whose snapshot fingerprint advances on every fetch, so we
+    /// can observe whether the background poller is actually refreshing the
+    /// cache over time.
+    struct FakeSource {
+        ticks: AtomicU64,
+    }
+
+    impl FakeSource {
+        fn new() -> Self {
+            Self {
+                ticks: AtomicU64::new(0),
+            }
+        }
+    }
+
+    impl DataSource for FakeSource {
+        fn snapshot(&self) -> SnapshotFuture<'_> {
+            Box::pin(async move {
+                let n = self.ticks.fetch_add(1, Ordering::SeqCst);
+                let sessions = json!([{ "tick": n }]);
+                let needs: Value = json!([]);
+                let cost = Value::Null;
+                let fingerprint =
+                    FleetSnapshot::compute_fingerprint(&sessions, &needs, &cost);
+                Ok::<_, DataError>(FleetSnapshot {
+                    sessions,
+                    needs,
+                    cost,
+                    fingerprint,
+                })
+            })
+        }
+    }
+
+    /// Regression: the background poller must keep refreshing the cache even
+    /// when no SSE client is ever connected. Previously the poller's
+    /// `is_closed()` guard tripped on tick #0 (AppState held only the Sender,
+    /// the seed Receiver was dropped), so the cache froze stale forever.
+    #[tokio::test(start_paused = true)]
+    async fn poller_refreshes_cache_without_any_sse_client() {
+        let config = WebConfig {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            token: None,
+            insecure_bind: false,
+            read_only: true,
+        };
+        let state = AppState::new(config, Arc::new(FakeSource::new()));
+
+        // Let the poller run its first tick (fires immediately) and land an
+        // initial snapshot.
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        let first = state
+            .cached()
+            .expect("poller should have seeded the cache on its first tick");
+        let first_tick = first.sessions[0]["tick"].clone();
+
+        // Advance well past the poll interval with NO SSE subscriber alive.
+        // If the `is_closed()` guard were still tripping, the cache would never
+        // change here.
+        tokio::time::advance(POLL_INTERVAL * 3).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let later = state
+            .cached()
+            .expect("cache must still be populated after later polls");
+        let later_tick = later.sessions[0]["tick"].clone();
+
+        assert_ne!(
+            first_tick, later_tick,
+            "background poller must refresh the cached snapshot over time even \
+             with no SSE client connected"
+        );
+    }
 }

--- a/ainb-tui/crates/ainb-web/src/routes.rs
+++ b/ainb-tui/crates/ainb-web/src/routes.rs
@@ -1,0 +1,206 @@
+//! Axum router, API handlers, and the SSE live-update stream.
+//!
+//! All routes are read-only. The data layer ([`crate::data::DataSource`])
+//! proxies the existing `ainb --format json` commands, so the dashboard never
+//! duplicates data access. Live updates are delivered via Server-Sent Events:
+//! a background poller refreshes the snapshot and pushes to subscribers only
+//! when the content fingerprint changes.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::middleware;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::json;
+use tokio::sync::broadcast;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::auth;
+use crate::config::WebConfig;
+use crate::data::{DataSource, FleetSnapshot};
+
+/// How often the background poller refreshes the snapshot. The SSE stream only
+/// emits when the fingerprint changes, so this is a safety-net cadence, not a
+/// per-client cost.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// SSE keep-alive comment cadence (keeps proxies from dropping idle streams).
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Channel capacity for the snapshot broadcast. Small — subscribers that lag
+/// just receive the next fresh snapshot rather than a backlog.
+const BROADCAST_CAPACITY: usize = 16;
+
+/// Shared, cheaply-clonable application state handed to every handler.
+#[derive(Clone)]
+pub struct AppState {
+    /// Immutable runtime config (bind addr, token, posture).
+    pub config: Arc<WebConfig>,
+    /// The data source backing every API route.
+    pub data: Arc<dyn DataSource>,
+    /// Broadcast channel carrying the latest snapshot JSON to SSE subscribers.
+    pub updates: broadcast::Sender<Arc<String>>,
+}
+
+impl AppState {
+    /// Build app state and spawn the background snapshot poller that feeds the
+    /// SSE broadcast channel.
+    pub fn new(config: WebConfig, data: Arc<dyn DataSource>) -> Self {
+        let (tx, _rx) = broadcast::channel(BROADCAST_CAPACITY);
+        let state = Self {
+            config: Arc::new(config),
+            data,
+            updates: tx,
+        };
+        state.spawn_poller();
+        state
+    }
+
+    /// Background task: poll the data source every [`POLL_INTERVAL`] and
+    /// broadcast the serialized snapshot when the fingerprint changes.
+    fn spawn_poller(&self) {
+        let data = Arc::clone(&self.data);
+        let tx = self.updates.clone();
+        tokio::spawn(async move {
+            let mut last_fp: Option<u64> = None;
+            let mut ticker = tokio::time::interval(POLL_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                // No active SSE subscribers → skip the work entirely.
+                if tx.receiver_count() == 0 {
+                    last_fp = None;
+                    continue;
+                }
+                match data.snapshot().await {
+                    Ok(snap) => {
+                        if last_fp != Some(snap.fingerprint) {
+                            last_fp = Some(snap.fingerprint);
+                            if let Ok(payload) = serde_json::to_string(&snap) {
+                                // Ignore send errors (no receivers is fine).
+                                let _ = tx.send(Arc::new(payload));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "snapshot poll failed");
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// Build the full router with state, auth middleware, and static assets.
+pub fn router(state: AppState) -> Router {
+    let api = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/api/snapshot", get(snapshot))
+        .route("/api/sessions", get(sessions))
+        .route("/api/needs", get(needs))
+        .route("/api/cost", get(cost))
+        .route("/api/events", get(events))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_bearer,
+        ));
+
+    let assets = Router::new()
+        .route("/", get(crate::assets::handler))
+        .route("/static/*path", get(crate::assets::handler));
+
+    api.merge(assets).with_state(state)
+}
+
+/// Map a [`crate::data::DataError`] to a 502 JSON envelope.
+fn data_error_response(e: crate::data::DataError) -> Response {
+    let body = Json(json!({
+        "error": { "code": "UPSTREAM_FAILED", "message": e.to_string() }
+    }));
+    (StatusCode::BAD_GATEWAY, body).into_response()
+}
+
+/// `GET /healthz` — liveness + posture. Token detail is only disclosed when the
+/// request is authorized (the auth middleware already gates this route).
+async fn healthz(State(state): State<AppState>) -> Response {
+    Json(json!({
+        "ok": true,
+        "readOnly": state.config.read_only,
+        "tokenRequired": state.config.token.is_some(),
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+    .into_response()
+}
+
+/// `GET /api/snapshot` — the full dashboard payload in one call.
+async fn snapshot(State(state): State<AppState>) -> Response {
+    match state.data.snapshot().await {
+        Ok(snap) => Json(snap).into_response(),
+        Err(e) => data_error_response(e),
+    }
+}
+
+/// `GET /api/sessions` — just the live session list.
+async fn sessions(State(state): State<AppState>) -> Response {
+    project(&state, |s| s.sessions).await
+}
+
+/// `GET /api/needs` — fleet needs (ASK/ERR/IDLE/WAIT).
+async fn needs(State(state): State<AppState>) -> Response {
+    project(&state, |s| s.needs).await
+}
+
+/// `GET /api/cost` — cost rollups (`null` when the verb is absent).
+async fn cost(State(state): State<AppState>) -> Response {
+    project(&state, |s| s.cost).await
+}
+
+/// Shared helper: fetch a snapshot and return one projected field as JSON.
+async fn project(
+    state: &AppState,
+    pick: impl FnOnce(FleetSnapshot) -> serde_json::Value,
+) -> Response {
+    match state.data.snapshot().await {
+        Ok(snap) => Json(pick(snap)).into_response(),
+        Err(e) => data_error_response(e),
+    }
+}
+
+/// `GET /api/events` — SSE stream of `snapshot` events. Emits the current
+/// snapshot immediately on connect, then pushes a fresh payload whenever the
+/// fingerprint changes (via the background poller's broadcast channel).
+async fn events(
+    State(state): State<AppState>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.updates.subscribe();
+
+    // Initial snapshot, sent eagerly so the client renders without waiting for
+    // the first change.
+    let initial = match state.data.snapshot().await {
+        Ok(snap) => serde_json::to_string(&snap).ok(),
+        Err(e) => {
+            tracing::warn!(error = %e, "initial SSE snapshot failed");
+            None
+        }
+    };
+    let initial_event = initial.map(|payload| Ok(Event::default().event("snapshot").data(payload)));
+
+    let live = BroadcastStream::new(rx).filter_map(|res| match res {
+        Ok(payload) => Some(Ok(Event::default()
+            .event("snapshot")
+            .data((*payload).clone()))),
+        // Lagged: drop the gap, the next fresh snapshot recovers state.
+        Err(_) => None,
+    });
+
+    let stream = tokio_stream::iter(initial_event.into_iter()).chain(live);
+
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(KEEPALIVE_INTERVAL).text("keepalive"))
+}

--- a/ainb-tui/crates/ainb-web/src/routes.rs
+++ b/ainb-tui/crates/ainb-web/src/routes.rs
@@ -18,9 +18,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde_json::json;
-use tokio::sync::broadcast;
+use tokio::sync::watch;
 use tokio_stream::StreamExt;
-use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::WatchStream;
 
 use crate::auth;
 use crate::config::WebConfig;
@@ -34,59 +34,95 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// SSE keep-alive comment cadence (keeps proxies from dropping idle streams).
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
 
-/// Channel capacity for the snapshot broadcast. Small — subscribers that lag
-/// just receive the next fresh snapshot rather than a backlog.
-const BROADCAST_CAPACITY: usize = 16;
+/// The single cached snapshot the whole server reads from. `None` only before
+/// the poller's first successful fetch completes.
+type CachedSnapshot = Option<Arc<FleetSnapshot>>;
 
 /// Shared, cheaply-clonable application state handed to every handler.
+///
+/// Every API request and SSE connection reads the *cached* snapshot maintained
+/// by a single background poller — they never re-shell the `ainb` subprocesses
+/// (which in turn spawn a `tmux capture-pane` per session). This coalesces all
+/// load onto one [`POLL_INTERVAL`]-cadence refresh regardless of request volume
+/// or how many SSE clients are connected.
 #[derive(Clone)]
 pub struct AppState {
     /// Immutable runtime config (bind addr, token, posture).
     pub config: Arc<WebConfig>,
-    /// The data source backing every API route.
+    /// The data source backing the background poller. Handlers do NOT call this
+    /// directly except on a cold cache (before the first poll lands).
     pub data: Arc<dyn DataSource>,
-    /// Broadcast channel carrying the latest snapshot JSON to SSE subscribers.
-    pub updates: broadcast::Sender<Arc<String>>,
+    /// Watch channel holding the latest cached snapshot. Handlers borrow it;
+    /// SSE subscribers stream changes off it. Updated only by the poller.
+    pub cache: watch::Sender<CachedSnapshot>,
 }
 
 impl AppState {
-    /// Build app state and spawn the background snapshot poller that feeds the
-    /// SSE broadcast channel.
+    /// Build app state and spawn the background snapshot poller that maintains
+    /// the cached snapshot every [`POLL_INTERVAL`].
     pub fn new(config: WebConfig, data: Arc<dyn DataSource>) -> Self {
-        let (tx, _rx) = broadcast::channel(BROADCAST_CAPACITY);
+        let (tx, _rx) = watch::channel(None);
         let state = Self {
             config: Arc::new(config),
             data,
-            updates: tx,
+            cache: tx,
         };
         state.spawn_poller();
         state
     }
 
-    /// Background task: poll the data source every [`POLL_INTERVAL`] and
-    /// broadcast the serialized snapshot when the fingerprint changes.
+    /// Return the last good cached snapshot, or `None` if the poller hasn't
+    /// produced one yet.
+    fn cached(&self) -> CachedSnapshot {
+        self.cache.borrow().clone()
+    }
+
+    /// Resolve a snapshot for a request: prefer the cache; on a cold cache
+    /// (before the first poll completes) fall back to a single direct fetch so
+    /// the very first request after startup still succeeds.
+    async fn resolve_snapshot(&self) -> Result<Arc<FleetSnapshot>, crate::data::DataError> {
+        if let Some(snap) = self.cached() {
+            return Ok(snap);
+        }
+        let snap = Arc::new(self.data.snapshot().await?);
+        // Seed the cache so concurrent cold-start requests coalesce too.
+        let _ = self.cache.send_if_modified(|slot| {
+            if slot.is_none() {
+                *slot = Some(Arc::clone(&snap));
+                true
+            } else {
+                false
+            }
+        });
+        Ok(self.cached().unwrap_or(snap))
+    }
+
+    /// Background task: poll the data source every [`POLL_INTERVAL`] and update
+    /// the cached snapshot when the fingerprint changes. The poller runs the
+    /// only `ainb`/`tmux` subprocesses; all requests and SSE streams read the
+    /// cache, so load is bounded to one refresh per interval.
     fn spawn_poller(&self) {
         let data = Arc::clone(&self.data);
-        let tx = self.updates.clone();
+        let tx = self.cache.clone();
         tokio::spawn(async move {
             let mut last_fp: Option<u64> = None;
             let mut ticker = tokio::time::interval(POLL_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
+                // Refresh immediately on the first iteration (the interval's
+                // first tick completes instantly), then every POLL_INTERVAL.
                 ticker.tick().await;
-                // No active SSE subscribers → skip the work entirely.
-                if tx.receiver_count() == 0 {
-                    last_fp = None;
-                    continue;
+                // Stop polling once nothing holds the state (server shut down).
+                if tx.is_closed() {
+                    break;
                 }
                 match data.snapshot().await {
                     Ok(snap) => {
                         if last_fp != Some(snap.fingerprint) {
                             last_fp = Some(snap.fingerprint);
-                            if let Ok(payload) = serde_json::to_string(&snap) {
-                                // Ignore send errors (no receivers is fine).
-                                let _ = tx.send(Arc::new(payload));
-                            }
+                            // Replace the cached snapshot; SSE subscribers and
+                            // every handler observe the new value.
+                            let _ = tx.send(Some(Arc::new(snap)));
                         }
                     }
                     Err(e) => {
@@ -139,68 +175,61 @@ async fn healthz(State(state): State<AppState>) -> Response {
     .into_response()
 }
 
-/// `GET /api/snapshot` — the full dashboard payload in one call.
+/// `GET /api/snapshot` — the full dashboard payload in one call. Served from
+/// the cached snapshot maintained by the background poller.
 async fn snapshot(State(state): State<AppState>) -> Response {
-    match state.data.snapshot().await {
-        Ok(snap) => Json(snap).into_response(),
+    match state.resolve_snapshot().await {
+        Ok(snap) => Json(&*snap).into_response(),
         Err(e) => data_error_response(e),
     }
 }
 
 /// `GET /api/sessions` — just the live session list.
 async fn sessions(State(state): State<AppState>) -> Response {
-    project(&state, |s| s.sessions).await
+    project(&state, |s| &s.sessions).await
 }
 
 /// `GET /api/needs` — fleet needs (ASK/ERR/IDLE/WAIT).
 async fn needs(State(state): State<AppState>) -> Response {
-    project(&state, |s| s.needs).await
+    project(&state, |s| &s.needs).await
 }
 
 /// `GET /api/cost` — cost rollups (`null` when the verb is absent).
 async fn cost(State(state): State<AppState>) -> Response {
-    project(&state, |s| s.cost).await
+    project(&state, |s| &s.cost).await
 }
 
-/// Shared helper: fetch a snapshot and return one projected field as JSON.
+/// Shared helper: read the cached snapshot and return one projected field as
+/// JSON. Borrows the cached value rather than re-shelling per request.
 async fn project(
     state: &AppState,
-    pick: impl FnOnce(FleetSnapshot) -> serde_json::Value,
+    pick: impl FnOnce(&FleetSnapshot) -> &serde_json::Value,
 ) -> Response {
-    match state.data.snapshot().await {
-        Ok(snap) => Json(pick(snap)).into_response(),
+    match state.resolve_snapshot().await {
+        Ok(snap) => Json(pick(&snap)).into_response(),
         Err(e) => data_error_response(e),
     }
 }
 
 /// `GET /api/events` — SSE stream of `snapshot` events. Emits the current
-/// snapshot immediately on connect, then pushes a fresh payload whenever the
-/// fingerprint changes (via the background poller's broadcast channel).
+/// *cached* snapshot immediately on connect, then pushes a fresh payload
+/// whenever the poller updates the cache. A new connection costs nothing beyond
+/// subscribing to the watch channel — it never re-shells `ainb`/`tmux`.
 async fn events(
     State(state): State<AppState>,
 ) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
-    let rx = state.updates.subscribe();
+    // Ensure the cache is warm so a connection that arrives before the first
+    // poll still gets an initial frame (single shared fetch on a cold cache).
+    let _ = state.resolve_snapshot().await;
 
-    // Initial snapshot, sent eagerly so the client renders without waiting for
-    // the first change.
-    let initial = match state.data.snapshot().await {
-        Ok(snap) => serde_json::to_string(&snap).ok(),
-        Err(e) => {
-            tracing::warn!(error = %e, "initial SSE snapshot failed");
-            None
-        }
-    };
-    let initial_event = initial.map(|payload| Ok(Event::default().event("snapshot").data(payload)));
-
-    let live = BroadcastStream::new(rx).filter_map(|res| match res {
-        Ok(payload) => Some(Ok(Event::default()
-            .event("snapshot")
-            .data((*payload).clone()))),
-        // Lagged: drop the gap, the next fresh snapshot recovers state.
-        Err(_) => None,
+    // `WatchStream::new` yields the current value first, then every subsequent
+    // change — so connecting clients receive the initial frame for free.
+    let rx = state.cache.subscribe();
+    let stream = WatchStream::new(rx).filter_map(|cached: CachedSnapshot| {
+        let snap = cached?;
+        let payload = serde_json::to_string(&*snap).ok()?;
+        Some(Ok(Event::default().event("snapshot").data(payload)))
     });
-
-    let stream = tokio_stream::iter(initial_event.into_iter()).chain(live);
 
     Sse::new(stream).keep_alive(KeepAlive::new().interval(KEEPALIVE_INTERVAL).text("keepalive"))
 }

--- a/ainb-tui/crates/ainb-web/tests/routes.rs
+++ b/ainb-tui/crates/ainb-web/tests/routes.rs
@@ -7,7 +7,9 @@
 
 use std::sync::Arc;
 
-use ainb_web::data::{DataError, DataSource, FleetSnapshot, SnapshotFuture};
+use ainb_web::data::{
+    CoreFuture, CoreSnapshot, CostFuture, DataError, DataSource, FleetSnapshot, SnapshotFuture,
+};
 use ainb_web::{AppState, WebConfig, router};
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
@@ -17,32 +19,39 @@ use tower::ServiceExt;
 /// Deterministic data source returning a fixed snapshot — no subprocess.
 struct FakeSource;
 
+impl FakeSource {
+    fn fixed_core() -> CoreSnapshot {
+        let sessions = json!([
+            {
+                "session_id": "abc",
+                "tmux_session_name": "tmux_demo",
+                "workspace_name": "demo",
+                "worktree_path": "/tmp/demo",
+                "created_at": "2026-06-14T00:00:00Z",
+                "is_running": true,
+                "claude_active": true
+            }
+        ]);
+        let needs = json!([
+            { "kind": "ASK", "context": { "question": "pick option 2" }, "session": { "cwd": "/tmp/demo" } }
+        ]);
+        CoreSnapshot { sessions, needs }
+    }
+}
+
 impl DataSource for FakeSource {
     fn snapshot(&self) -> SnapshotFuture<'_> {
         Box::pin(async {
-            let sessions = json!([
-                {
-                    "session_id": "abc",
-                    "tmux_session_name": "tmux_demo",
-                    "workspace_name": "demo",
-                    "worktree_path": "/tmp/demo",
-                    "created_at": "2026-06-14T00:00:00Z",
-                    "is_running": true,
-                    "claude_active": true
-                }
-            ]);
-            let needs = json!([
-                { "kind": "ASK", "context": { "question": "pick option 2" }, "session": { "cwd": "/tmp/demo" } }
-            ]);
-            let cost = Value::Null;
-            let fingerprint = FleetSnapshot::compute_fingerprint(&sessions, &needs, &cost);
-            Ok::<_, DataError>(FleetSnapshot {
-                sessions,
-                needs,
-                cost,
-                fingerprint,
-            })
+            Ok::<_, DataError>(FleetSnapshot::from_parts(Self::fixed_core(), Value::Null))
         })
+    }
+
+    fn core(&self) -> CoreFuture<'_> {
+        Box::pin(async { Ok::<_, DataError>(Self::fixed_core()) })
+    }
+
+    fn cost(&self) -> CostFuture<'_> {
+        Box::pin(async { Value::Null })
     }
 }
 

--- a/ainb-tui/crates/ainb-web/tests/routes.rs
+++ b/ainb-tui/crates/ainb-web/tests/routes.rs
@@ -138,6 +138,60 @@ async fn healthz_token_gated_too() {
     assert_eq!(body["tokenRequired"], true);
 }
 
+// ── Query-string token is honored ONLY on the SSE route. ─────────────
+//
+// Tokens in URLs leak via proxy/access logs, browser history, and `Referer`,
+// so the `?token=` fallback exists solely for `/api/events` (an `EventSource`
+// cannot set request headers). Every other route requires the bearer header.
+
+#[tokio::test]
+async fn query_token_rejected_on_non_sse_route() {
+    let app = app(Some("s3cret"));
+    // Correct token, but via query string on a JSON route → 401 (header required).
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/snapshot?token=s3cret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "query token must NOT authorize a non-SSE route"
+    );
+
+    // Same route still works with the Authorization header.
+    let (status, _) = get(&app, "/api/snapshot", Some("s3cret")).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn query_token_accepted_on_sse_route() {
+    let app = app(Some("s3cret"));
+    // No header, token via query string on the SSE route → 200.
+    let resp = app
+        .clone()
+        .oneshot(Request::builder().uri("/api/events?token=s3cret").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "SSE route must accept the token via query string"
+    );
+
+    // Wrong query token on the SSE route → 401.
+    let resp = app
+        .oneshot(Request::builder().uri("/api/events?token=wrong").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
 // ── Static asset (the SPA shell) is served without auth. ─────────────
 
 #[tokio::test]

--- a/ainb-tui/crates/ainb-web/tests/routes.rs
+++ b/ainb-tui/crates/ainb-web/tests/routes.rs
@@ -1,0 +1,154 @@
+//! Route + auth integration tests for the dashboard router.
+//!
+//! These drive the real axum `Router` (with the bearer-auth middleware and a
+//! fake data source) via `tower::ServiceExt::oneshot`, so they exercise the
+//! full request path — routing, auth, JSON serialization — without binding a
+//! socket or spawning the `ainb` binary.
+
+use std::sync::Arc;
+
+use ainb_web::data::{DataError, DataSource, FleetSnapshot, SnapshotFuture};
+use ainb_web::{AppState, WebConfig, router};
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+/// Deterministic data source returning a fixed snapshot — no subprocess.
+struct FakeSource;
+
+impl DataSource for FakeSource {
+    fn snapshot(&self) -> SnapshotFuture<'_> {
+        Box::pin(async {
+            let sessions = json!([
+                {
+                    "session_id": "abc",
+                    "tmux_session_name": "tmux_demo",
+                    "workspace_name": "demo",
+                    "worktree_path": "/tmp/demo",
+                    "created_at": "2026-06-14T00:00:00Z",
+                    "is_running": true,
+                    "claude_active": true
+                }
+            ]);
+            let needs = json!([
+                { "kind": "ASK", "context": { "question": "pick option 2" }, "session": { "cwd": "/tmp/demo" } }
+            ]);
+            let cost = Value::Null;
+            let fingerprint = FleetSnapshot::compute_fingerprint(&sessions, &needs, &cost);
+            Ok::<_, DataError>(FleetSnapshot {
+                sessions,
+                needs,
+                cost,
+                fingerprint,
+            })
+        })
+    }
+}
+
+fn app(token: Option<&str>) -> axum::Router {
+    let config = WebConfig {
+        listen: "127.0.0.1:0".parse().unwrap(),
+        token: token.map(str::to_string),
+        insecure_bind: false,
+        read_only: true,
+    };
+    let state = AppState::new(config, Arc::new(FakeSource));
+    router(state)
+}
+
+async fn get(app: &axum::Router, path: &str, bearer: Option<&str>) -> (StatusCode, Value) {
+    let mut req = Request::builder().method("GET").uri(path);
+    if let Some(t) = bearer {
+        req = req.header(header::AUTHORIZATION, format!("Bearer {t}"));
+    }
+    let resp = app.clone().oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+// ── No token configured: loopback dev posture, everything allowed. ────
+
+#[tokio::test]
+async fn sessions_ok_without_token_when_none_configured() {
+    let app = app(None);
+    let (status, body) = get(&app, "/api/sessions", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body[0]["workspace_name"], "demo");
+}
+
+#[tokio::test]
+async fn snapshot_returns_all_three_surfaces() {
+    let app = app(None);
+    let (status, body) = get(&app, "/api/snapshot", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["sessions"].is_array());
+    assert!(body["needs"].is_array());
+    assert!(body["cost"].is_null(), "cost degrades to null when absent");
+}
+
+#[tokio::test]
+async fn needs_surface_classified() {
+    let app = app(None);
+    let (status, body) = get(&app, "/api/needs", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body[0]["kind"], "ASK");
+}
+
+#[tokio::test]
+async fn healthz_reports_posture() {
+    let app = app(None);
+    let (status, body) = get(&app, "/healthz", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["readOnly"], true);
+    assert_eq!(body["tokenRequired"], false);
+}
+
+// ── Token configured: every /api/* route is gated. ───────────────────
+
+#[tokio::test]
+async fn api_requires_bearer_when_token_configured() {
+    let app = app(Some("s3cret"));
+
+    // No bearer → 401.
+    let (status, body) = get(&app, "/api/sessions", None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+
+    // Wrong bearer → 401.
+    let (status, _) = get(&app, "/api/sessions", Some("wrong")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Correct bearer → 200.
+    let (status, body) = get(&app, "/api/sessions", Some("s3cret")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body[0]["workspace_name"], "demo");
+}
+
+#[tokio::test]
+async fn healthz_token_gated_too() {
+    let app = app(Some("s3cret"));
+    let (status, _) = get(&app, "/healthz", None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let (status, body) = get(&app, "/healthz", Some("s3cret")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["tokenRequired"], true);
+}
+
+// ── Static asset (the SPA shell) is served without auth. ─────────────
+
+#[tokio::test]
+async fn index_served_without_auth() {
+    let app = app(Some("s3cret"));
+    let resp = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+    let html = String::from_utf8_lossy(&bytes);
+    assert!(html.contains("ainb"), "index.html should be the SPA shell");
+}

--- a/docs/tui/web.md
+++ b/docs/tui/web.md
@@ -1,0 +1,145 @@
+---
+title: "ainb web — fleet dashboard"
+---
+
+`ainb web` serves a **read-only**, browser-based dashboard for your agent fleet:
+the live session list, fleet `needs` (ASK / ERR / IDLE / WAIT), and cost
+rollups — updated live over Server-Sent Events without a manual refresh.
+
+It is intended as a glanceable view of *what's running, what needs attention,
+and what it's costing* — on localhost, or over a tailnet with a bearer token.
+
+> **Read-only by design.** This cut has no mutate endpoints, no terminal
+> bridge, and no web-push. Those are deliberate, clean extension points.
+
+---
+
+## Quick start
+
+```bash
+# Loopback, no token needed (default bind 127.0.0.1:8420)
+ainb web
+
+# Pick a port
+ainb web --listen 127.0.0.1:9000
+
+# Expose over a tailnet / LAN — a token is REQUIRED for a non-loopback bind
+ainb web --listen 0.0.0.0:8420 --token "$(openssl rand -hex 24)"
+```
+
+Then open the printed URL, e.g. <http://127.0.0.1:8420>.
+
+When a token is set, append it once to the URL —
+`http://host:8420/?token=YOUR_TOKEN` — the page stores it for the session and
+strips it from the address bar.
+
+---
+
+## Flags
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--listen <ADDR>` | `127.0.0.1:8420` | Address to bind. Non-loopback requires `--token`. |
+| `--token <SECRET>` | _(none)_ | Bearer token required on every `/api/*` route. Enables a non-loopback bind. |
+| `--insecure-bind` | `false` | Allow a non-loopback bind with **no** token. Not recommended. |
+
+---
+
+## Security model
+
+The bind policy mirrors agent-deck's `CheckBindSecurity` and is enforced
+**before any socket is opened** — an unsafe bind is refused and never listens.
+
+First matching rule wins:
+
+1. A bearer `--token` is configured → **allow** (the surface is authenticated).
+2. `--insecure-bind` was passed → **allow** (explicit operator override).
+3. The host is loopback (`127.0.0.0/8`, `::1`) → **allow**.
+4. Otherwise → **refuse** with a clear message.
+
+```text
+$ ainb web --listen 0.0.0.0:8420
+Error: refusing to bind to non-loopback address 0.0.0.0:8420 without authentication.
+This would expose the dashboard to your network unauthenticated.
+Pass --token <secret> to require a bearer token, or --insecure-bind to override.
+```
+
+When a token is configured:
+
+- Every `/api/*` route (and `/healthz`) returns **401** without
+  `Authorization: Bearer <token>`, **200** with the correct token.
+- The token is compared in **constant time** (no timing oracle).
+- The SSE endpoint additionally accepts the token via `?token=…` query string,
+  because browsers cannot set headers on an `EventSource`. The frontend strips
+  it from the URL after connecting.
+
+The static frontend shell (`/`, `/static/*`) is served **without** auth — only
+data routes are gated.
+
+---
+
+## Routes
+
+All API responses are JSON. Errors use `{ "error": { "code", "message" } }`.
+
+| Method | Path | Response |
+|--------|------|----------|
+| GET | `/` , `/static/*` | Embedded vanilla-JS frontend (no auth). |
+| GET | `/healthz` | `{ ok, readOnly, tokenRequired, version }` |
+| GET | `/api/snapshot` | `{ sessions, needs, cost }` — the full dashboard payload. |
+| GET | `/api/sessions` | Live session list (proxies `ainb --format json list`). |
+| GET | `/api/needs` | Fleet needs (proxies `ainb --format json fleet needs`). |
+| GET | `/api/cost` | Cost rollups (proxies `ainb --format json fleet cost`); `null` when absent. |
+| GET | `/api/events` | **SSE** stream of `snapshot` events (`event: snapshot`). |
+
+`401 UNAUTHORIZED` — missing/invalid bearer (only when a token is configured).
+`502 UPSTREAM_FAILED` — an underlying `ainb` command failed.
+
+---
+
+## How data flows
+
+The dashboard never re-implements data access. It drives the **same**
+`ainb --format json …` commands the CLI and TUI expose, so the browser view can
+never drift from the terminal view:
+
+- `ainb --format json list` → session rows
+- `ainb --format json fleet needs` → attention cards
+- `ainb --format json fleet cost` → cost rollups (best-effort)
+
+A background poller refreshes the snapshot every 2s and pushes an SSE event to
+connected clients **only when the content fingerprint changes**, so idle fleets
+cost nothing and updates land within ~2s of a state change. The poller is
+skipped entirely when there are no SSE subscribers.
+
+### Cost graceful degradation
+
+`ainb fleet cost` ships with the **fleet cost-surface** feature. If it isn't
+present in your build, the dashboard does not fail — the Cost panel shows
+"Cost surface not available in this build" and everything else works.
+
+---
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `AINB_BIN` | Path to the `ainb` binary the dashboard shells out to. Defaults to the running executable, else `ainb` on `PATH`. |
+| `AINB_HOME` | Base dir for `~/.agents-in-a-box` (so the proxied `ainb` commands read the right `sessions.json`). |
+
+---
+
+## Architecture notes
+
+- New core crate `ainb-web` (axum HTTP + SSE), wired in as the `ainb web`
+  subcommand via `cli/registry.rs`.
+- The frontend is a single embedded vanilla-JS bundle (`rust-embed`) — **no
+  Node build step, no framework, no runtime filesystem dependency**.
+- A long-lived HTTP server fits a core crate better than the sandboxed v2
+  plugin runtime, hence a crate (not a plugin).
+
+### Reserved extension points (non-goals in this cut)
+
+- Write/mutate endpoints (the `read_only` flag is already surfaced).
+- A WebSocket terminal bridge.
+- Web-push / PWA.


### PR DESCRIPTION
## What

New `ainb web` subcommand serving a **read-only**, SSE-live web dashboard for the agent fleet — porting agent-deck's web surface (first cut: dashboard + SSE only). Lives in a new `ainb-web` core crate (axum).

The dashboard shows, at a glance:
- **Sessions** — live session list (name, workspace, worktree path, tmux name, status).
- **Needs attention** — fleet `needs` cards classified ASK / ERR / IDLE / WAIT (priority-sorted).
- **Cost** — cost rollups from `ainb fleet cost`.

…and updates **live over Server-Sent Events** without a manual refresh.

## Why

`/ainb:fleet` had no browser surface. A glanceable view of *what's running, what needs attention, and what it's costing* — on localhost or over a tailnet with a token — is the highest-leverage piece of the agent-deck web port (umbrella Goal 2).

## How

- **New crate `ainb-web`** (axum HTTP + SSE). A long-lived HTTP server fits a core crate better than the sandboxed v2 plugin runtime.
- **Data is proxied** from the existing `ainb --format json {list, fleet needs, fleet cost}` commands, so the browser view can never drift from the CLI/TUI. No data-access logic is duplicated.
- **`fleet cost` degrades gracefully** — it ships with the separate cost-surface feature (PR #268); when absent the Cost panel shows "not available in this build" and everything else works.
- **Live updates** — a background poller refreshes the snapshot every 2s and broadcasts an SSE event only when the content fingerprint changes (skipped entirely when there are no subscribers).
- **Frontend** is a single embedded vanilla-JS/CSS/HTML bundle via `rust-embed` — no Node build step, no framework.
- **Subcommand** registered in `cli/registry.rs`; the `built_ins` command-count test updated 25 → 26.

### Security (hard gate)

Mirrors agent-deck's `CheckBindSecurity`, enforced **before any socket opens**:
- Loopback-bound by default (`127.0.0.1:8420`).
- **Refuses** a non-loopback bind without `--token` (or explicit `--insecure-bind`).
- When a token is set, every `/api/*` route (and `/healthz`) returns **401** without the correct bearer, **200** with it. Constant-time compare. SSE accepts the token via `?token=` (EventSource can't set headers); the frontend strips it from the URL.
- Read-only: no mutate endpoints, no terminal bridge, no web-push (clean extension points left).

## Proof

```
# bind-security refusal (negative path)
$ ainb web --listen 0.0.0.0:8420
Error: refusing to bind to non-loopback address 0.0.0.0:8420 without authentication. …

# loopback live
$ curl -s localhost:8541/healthz
{"ok":true,"readOnly":true,"tokenRequired":false,"version":"1.7.0"}
$ curl -s localhost:8541/api/snapshot | jq 'keys'   # ["cost","needs","sessions"]

# token mode
no token    -> 401
wrong token -> 401
right token -> 200
SSE ?token= -> event: snapshot …
```

Screenshot of the running dashboard (two real sessions from `sessions.json`, live SSE indicator, graceful cost empty-state) attached in a comment.

## Gates

- `cargo build -p ainb` — green
- `cargo build -p ainb-web` — green
- `cargo test -p ainb-web` — green (12 unit + 7 route/auth integration)
- registry command-count test (`built_ins_registers_twenty_six_commands`) — green
- `cargo fmt --check` — clean
- new code clippy-clean (`cargo clippy -p ainb-web --all-targets`) — clean

## Success criteria

- [x] `ainb web --listen 127.0.0.1:<port>` serves a dashboard showing sessions + fleet needs + cost; updates live via SSE.
- [x] Non-loopback bind without `--token` exits with a clear refusal (test asserts).
- [x] With `--token`, every `/api/*` returns 401 without / 200 with the bearer (tests assert both); default loopback needs no token.
- [x] `cargo build`, `cargo test` (crate + route/auth integration), `cargo fmt --check` pass; registry count test updated.
- [x] `docs/tui/web.md` documents routes, flags, and the security model.

## Known follow-ups (honest)

- The repo carries pre-existing test drift unrelated to this PR: several `crates/ainb-core/tests/` integration binaries (`session_lifecycle.rs`, `ui_tests.rs`, `test_events.rs`) reference renamed/removed symbols (`AsyncAction::NewSessionNormal`, `NewSessionState::filtered_repos`, model-arg `&str` vs `Option<&str>`), and one lib timing test (`renders_large_diff_within_budget`) is flaky. None are in files this PR touches. Not addressed here.
- `cargo clippy -- -D warnings` repo-wide is not green on `main` (~3355 pre-existing warnings); only the new `ainb-web` code is clippy-clean.
- `fleet cost` data lands with PR #268 (cost-surface). Until merged, the Cost panel shows the graceful empty-state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ainb web` command—a read-only, browser-based fleet dashboard with live updates via Server-Sent Events.
  * Added API endpoints for dashboard data access with optional bearer token authentication.
  * Dashboard displays real-time panels for sessions, needs attention, and cost information.

* **Documentation**
  * Added documentation for the web dashboard covering usage, security model, and API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->