### PR TITLE
feat(bridge): native Rust phone bridge (Telegram + Slack) — ainb fleet bridge

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -69,6 +69,13 @@ toml_edit = "0.22"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
 async-stream = "0.3"
 tokio-stream = "0.1"
+# Slack socket-mode WebSocket transport for the native phone bridge
+# (`ainb fleet bridge`). rustls-only (no OpenSSL) to match reqwest above and
+# keep the single-binary build cross-compilable.
+tokio-tungstenite = { version = "0.21", default-features = false, features = [
+    "connect",
+    "rustls-tls-webpki-roots",
+] }
 
 # Utils
 shell-escape = "0.1"

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -52,6 +52,8 @@ toml_edit = { workspace = true }
 # Claude API integration
 reqwest = { workspace = true }
 tokio-stream = { workspace = true }
+# Slack socket-mode WebSocket transport for `ainb fleet bridge`.
+tokio-tungstenite = { workspace = true }
 
 # Utils
 shell-escape = { workspace = true }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
@@ -1,0 +1,48 @@
+// ABOUTME: `ainb fleet bridge {run,install,uninstall,status}` dispatcher.
+//
+// Thin CLI shim over `crate::fleet::bridge`. `run` starts the native daemon
+// (Telegram + Slack channels sharing one relay core); install/uninstall manage
+// the launchd/systemd service; status reports install state. Tokens are read
+// from config.toml via the secret resolver — never passed on argv here.
+
+use anyhow::Result;
+
+use crate::cli::OutputFormat;
+
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    match matches.subcommand() {
+        Some(("run", _)) | None => crate::fleet::bridge::run().await,
+        Some(("install", _)) => {
+            let path = crate::fleet::bridge::install()?;
+            emit(
+                format,
+                &format!("phone bridge installed: {}", path.display()),
+            );
+            Ok(())
+        }
+        Some(("uninstall", _)) => {
+            match crate::fleet::bridge::uninstall()? {
+                Some(path) => emit(format, &format!("phone bridge removed: {}", path.display())),
+                None => emit(format, "phone bridge was not installed"),
+            }
+            Ok(())
+        }
+        Some(("status", _)) => {
+            let status = crate::fleet::bridge::status()?;
+            emit(format, &status);
+            Ok(())
+        }
+        Some((other, _)) => {
+            anyhow::bail!("unknown `ainb fleet bridge` subcommand: {other}")
+        }
+    }
+}
+
+fn emit(format: OutputFormat, message: &str) {
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::json!({ "message": message }));
+        }
+        _ => println!("{message}"),
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{Result, bail};
 
 use crate::cli::OutputFormat;
 
+pub mod bridge;
 pub mod broadcast;
 pub mod budget_alert;
 pub mod cost;
@@ -25,6 +26,7 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
         Some(("needs", sub)) => needs::execute(sub, format).await,
         Some(("cost", sub)) => cost::execute(sub, format).await,
         Some(("daemon", sub)) => daemon::execute(sub, format).await,
+        Some(("bridge", sub)) => bridge::execute(sub, format).await,
         Some(("enrich-cache", sub)) => enrich_cache::execute(sub, format).await,
         _ => bail!("unknown `ainb fleet` subcommand — try `ainb fleet --help`"),
     }

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1548,10 +1548,24 @@ impl CliCommand for FleetCommand {
                     .short('v')
                     .action(clap::ArgAction::SetTrue),
             );
+        let bridge = Command::new("bridge")
+            .about(
+                "Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions",
+            )
+            .subcommand_required(false)
+            .subcommand(
+                Command::new("run")
+                    .about("Run the bridge daemon in the foreground (default; reads config.toml)"),
+            )
+            .subcommand(Command::new("install").about(
+                "Install as a launchd/systemd service (tokens read from config, never argv)",
+            ))
+            .subcommand(Command::new("uninstall").about("Remove the bridge service"))
+            .subcommand(Command::new("status").about("Report bridge service install status"));
         app.subcommand(
             Command::new(self.name())
                 .about(
-                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon",
+                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / bridge",
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
@@ -1561,6 +1575,7 @@ impl CliCommand for FleetCommand {
                 .subcommand(needs)
                 .subcommand(cost)
                 .subcommand(daemon)
+                .subcommand(bridge)
                 .subcommand(enrich_cache),
         )
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/config.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/config.rs
@@ -1,0 +1,427 @@
+// ABOUTME: Load + validate the native phone-bridge config from ainb's config.toml.
+//
+// Config lives in ainb's layered config at
+//   ~/.agents-in-a-box/config/config.toml
+// under `[fleet.bridge.telegram]` and/or `[fleet.bridge.slack]`. Tokens and the
+// authorized user id are resolved through the secret resolver so the token is
+// NEVER written on argv or into the launchd/systemd unit — it stays in config
+// (or a keychain/env ref) and is read in-process at startup.
+//
+//   [fleet.bridge]
+//   response_timeout = 300            # optional, seconds (shared default)
+//
+//   [fleet.bridge.telegram]
+//   token = "$TELEGRAM_BOT_TOKEN"     # or "keychain:svc" or a literal
+//   user_id = 123456789              # authorized Telegram user id
+//   default_target = "conductor"     # optional: name to prefer with no prefix
+//   require_mention_in_groups = true # optional, default true
+//   response_timeout = 300           # optional, overrides the shared default
+//
+//   [fleet.bridge.slack]
+//   bot_token = "$SLACK_BOT_TOKEN"    # xoxb-… (Web API calls)
+//   app_token = "$SLACK_APP_TOKEN"    # xapp-… (socket-mode connection)
+//   user_id = "U0123ABC"             # authorized Slack user id (string)
+//   default_target = "conductor"     # optional
+//   listen_mode = "mentions"         # "mentions" (default) | "all"
+//   response_timeout = 300           # optional
+//
+// At least ONE channel table must be present and valid.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+
+use super::secrets::resolve_secret;
+
+/// Default time (seconds) the bridge waits for a session to finish its turn
+/// before giving up on capturing a reply.
+pub const RESPONSE_TIMEOUT: u64 = 300;
+
+/// How a Slack channel decides a message is addressed to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlackListenMode {
+    /// Only act on messages that @mention the bot (or are DMs). Default.
+    Mentions,
+    /// Act on every message in channels the bot is a member of (and DMs).
+    All,
+}
+
+/// Resolved, validated Telegram channel config.
+#[derive(Debug, Clone)]
+pub struct TelegramConfig {
+    pub token: String,
+    pub authorized_user_id: i64,
+    pub default_target: Option<String>,
+    pub require_mention_in_groups: bool,
+    pub response_timeout: u64,
+}
+
+/// Resolved, validated Slack channel config.
+#[derive(Debug, Clone)]
+pub struct SlackConfig {
+    pub bot_token: String,
+    pub app_token: String,
+    pub authorized_user_id: String,
+    pub default_target: Option<String>,
+    pub listen_mode: SlackListenMode,
+    pub response_timeout: u64,
+}
+
+/// Resolved bridge config — at least one channel is present.
+#[derive(Debug, Clone)]
+pub struct BridgeConfig {
+    pub telegram: Option<TelegramConfig>,
+    pub slack: Option<SlackConfig>,
+}
+
+impl BridgeConfig {
+    /// Whether any channel is configured to run.
+    #[must_use]
+    pub fn any_channel(&self) -> bool {
+        self.telegram.is_some() || self.slack.is_some()
+    }
+}
+
+// ── Raw TOML shapes ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRoot {
+    fleet: Option<RawFleet>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawFleet {
+    bridge: Option<RawBridge>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawBridge {
+    response_timeout: Option<toml::Value>,
+    telegram: Option<RawTelegram>,
+    slack: Option<RawSlack>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawTelegram {
+    token: Option<String>,
+    user_id: Option<toml::Value>,
+    default_target: Option<String>,
+    require_mention_in_groups: Option<bool>,
+    response_timeout: Option<toml::Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawSlack {
+    bot_token: Option<String>,
+    app_token: Option<String>,
+    user_id: Option<String>,
+    default_target: Option<String>,
+    listen_mode: Option<String>,
+    response_timeout: Option<toml::Value>,
+}
+
+/// Resolve ainb's config.toml path, honouring `AINB_CONFIG_PATH`.
+#[must_use]
+pub fn default_config_path() -> PathBuf {
+    if let Ok(override_path) = std::env::var("AINB_CONFIG_PATH") {
+        return PathBuf::from(override_path);
+    }
+    let mut p = dirs::home_dir().unwrap_or_default();
+    p.push(".agents-in-a-box");
+    p.push("config");
+    p.push("config.toml");
+    p
+}
+
+/// Coerce a TOML scalar (`response_timeout`) into a positive `u64` seconds.
+fn coerce_timeout(value: Option<&toml::Value>, default: u64) -> Result<u64> {
+    let Some(value) = value else {
+        return Ok(default);
+    };
+    let secs = match value {
+        toml::Value::Integer(i) => *i,
+        toml::Value::String(s) => {
+            s.trim().parse::<i64>().context("response_timeout is not an integer")?
+        }
+        _ => bail!("response_timeout must be an integer"),
+    };
+    if secs <= 0 {
+        bail!("response_timeout must be positive");
+    }
+    Ok(secs as u64)
+}
+
+/// Coerce a TOML scalar into an `i64` user id, resolving string refs via the
+/// secret resolver (so `user_id = "$MY_ID"` works).
+fn coerce_user_id_i64(value: Option<&toml::Value>) -> Result<i64> {
+    match value {
+        Some(toml::Value::Integer(i)) => Ok(*i),
+        Some(toml::Value::String(s)) => {
+            let resolved = resolve_secret(s);
+            let resolved = resolved.trim();
+            if resolved.is_empty() {
+                bail!("user_id is empty after secret resolution");
+            }
+            resolved
+                .parse::<i64>()
+                .with_context(|| format!("user_id is not an integer: {resolved:?}"))
+        }
+        Some(_) => bail!("user_id must be a number or string"),
+        None => bail!("missing `user_id`"),
+    }
+}
+
+fn parse_telegram(raw: RawTelegram, shared_timeout: u64) -> Result<TelegramConfig> {
+    let token_ref =
+        raw.token.ok_or_else(|| anyhow!("[fleet.bridge.telegram] is missing `token`"))?;
+    let token = resolve_secret(&token_ref);
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        bail!("telegram token resolved to empty — check the env var / keychain ref");
+    }
+    let authorized_user_id =
+        coerce_user_id_i64(raw.user_id.as_ref()).context("[fleet.bridge.telegram] `user_id`")?;
+    let default_target = raw.default_target.and_then(|s| {
+        let t = s.trim().to_string();
+        (!t.is_empty()).then_some(t)
+    });
+    let require_mention_in_groups = raw.require_mention_in_groups.unwrap_or(true);
+    let response_timeout = coerce_timeout(raw.response_timeout.as_ref(), shared_timeout)
+        .context("[fleet.bridge.telegram] `response_timeout`")?;
+    Ok(TelegramConfig {
+        token,
+        authorized_user_id,
+        default_target,
+        require_mention_in_groups,
+        response_timeout,
+    })
+}
+
+fn parse_slack(raw: RawSlack, shared_timeout: u64) -> Result<SlackConfig> {
+    let bot_ref = raw
+        .bot_token
+        .ok_or_else(|| anyhow!("[fleet.bridge.slack] is missing `bot_token`"))?;
+    let app_ref = raw
+        .app_token
+        .ok_or_else(|| anyhow!("[fleet.bridge.slack] is missing `app_token`"))?;
+    let bot_token = resolve_secret(&bot_ref).trim().to_string();
+    if bot_token.is_empty() {
+        bail!("slack bot_token resolved to empty — check the env var / keychain ref");
+    }
+    let app_token = resolve_secret(&app_ref).trim().to_string();
+    if app_token.is_empty() {
+        bail!("slack app_token resolved to empty — check the env var / keychain ref");
+    }
+    let user_ref = raw
+        .user_id
+        .ok_or_else(|| anyhow!("[fleet.bridge.slack] is missing `user_id`"))?;
+    let authorized_user_id = resolve_secret(&user_ref).trim().to_string();
+    if authorized_user_id.is_empty() {
+        bail!("slack user_id resolved to empty");
+    }
+    let default_target = raw.default_target.and_then(|s| {
+        let t = s.trim().to_string();
+        (!t.is_empty()).then_some(t)
+    });
+    let listen_mode = match raw.listen_mode.as_deref().map(str::trim) {
+        Some("all") => SlackListenMode::All,
+        Some("mentions") | None => SlackListenMode::Mentions,
+        Some(other) => {
+            bail!("[fleet.bridge.slack] listen_mode must be \"mentions\" or \"all\", got {other:?}")
+        }
+    };
+    let response_timeout = coerce_timeout(raw.response_timeout.as_ref(), shared_timeout)
+        .context("[fleet.bridge.slack] `response_timeout`")?;
+    Ok(SlackConfig {
+        bot_token,
+        app_token,
+        authorized_user_id,
+        default_target,
+        listen_mode,
+        response_timeout,
+    })
+}
+
+/// Build a [`BridgeConfig`] from a parsed TOML string. Split out so it can be
+/// unit-tested without touching the filesystem.
+pub fn parse_config(toml_text: &str) -> Result<BridgeConfig> {
+    let root: RawRoot = toml::from_str(toml_text).context("parsing config.toml")?;
+    let bridge = root
+        .fleet
+        .and_then(|f| f.bridge)
+        .ok_or_else(|| anyhow!("config has no [fleet.bridge] table"))?;
+
+    let shared_timeout = coerce_timeout(bridge.response_timeout.as_ref(), RESPONSE_TIMEOUT)
+        .context("[fleet.bridge] `response_timeout`")?;
+
+    let telegram = bridge.telegram.map(|t| parse_telegram(t, shared_timeout)).transpose()?;
+    let slack = bridge.slack.map(|s| parse_slack(s, shared_timeout)).transpose()?;
+
+    if telegram.is_none() && slack.is_none() {
+        bail!(
+            "[fleet.bridge] has neither a [fleet.bridge.telegram] nor a \
+             [fleet.bridge.slack] channel — configure at least one"
+        );
+    }
+    Ok(BridgeConfig { telegram, slack })
+}
+
+/// Load and validate the bridge config from disk.
+pub fn load_config(path: Option<&Path>) -> Result<BridgeConfig> {
+    let owned;
+    let cfg_path = match path {
+        Some(p) => p,
+        None => {
+            owned = default_config_path();
+            &owned
+        }
+    };
+    if !cfg_path.exists() {
+        bail!("config file not found: {}", cfg_path.display());
+    }
+    let text = std::fs::read_to_string(cfg_path)
+        .with_context(|| format!("failed to read {}", cfg_path.display()))?;
+    parse_config(&text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_telegram_only() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge.telegram]
+            token = "tg-literal"
+            user_id = 42
+            default_target = "conductor"
+            "#,
+        )
+        .unwrap();
+        let tg = cfg.telegram.unwrap();
+        assert_eq!(tg.token, "tg-literal");
+        assert_eq!(tg.authorized_user_id, 42);
+        assert_eq!(tg.default_target.as_deref(), Some("conductor"));
+        assert!(tg.require_mention_in_groups);
+        assert_eq!(tg.response_timeout, RESPONSE_TIMEOUT);
+        assert!(cfg.slack.is_none());
+    }
+
+    #[test]
+    fn parses_slack_only_with_listen_mode() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge.slack]
+            bot_token = "xoxb-1"
+            app_token = "xapp-1"
+            user_id = "U123"
+            listen_mode = "all"
+            "#,
+        )
+        .unwrap();
+        let sl = cfg.slack.unwrap();
+        assert_eq!(sl.bot_token, "xoxb-1");
+        assert_eq!(sl.app_token, "xapp-1");
+        assert_eq!(sl.authorized_user_id, "U123");
+        assert_eq!(sl.listen_mode, SlackListenMode::All);
+        assert!(cfg.telegram.is_none());
+    }
+
+    #[test]
+    fn parses_both_channels_and_shared_timeout() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge]
+            response_timeout = 120
+
+            [fleet.bridge.telegram]
+            token = "tg"
+            user_id = 1
+
+            [fleet.bridge.slack]
+            bot_token = "xoxb"
+            app_token = "xapp"
+            user_id = "U1"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.telegram.unwrap().response_timeout, 120);
+        assert_eq!(cfg.slack.unwrap().response_timeout, 120);
+    }
+
+    #[test]
+    fn per_channel_timeout_overrides_shared() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge]
+            response_timeout = 120
+
+            [fleet.bridge.telegram]
+            token = "tg"
+            user_id = 1
+            response_timeout = 999
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.telegram.unwrap().response_timeout, 999);
+    }
+
+    #[test]
+    fn missing_bridge_table_errors() {
+        let err = parse_config("[fleet]\n").unwrap_err();
+        assert!(err.to_string().contains("no [fleet.bridge] table"));
+    }
+
+    #[test]
+    fn no_channel_errors() {
+        let err = parse_config("[fleet.bridge]\nresponse_timeout = 60\n").unwrap_err();
+        assert!(err.to_string().contains("at least one"));
+    }
+
+    #[test]
+    fn empty_token_after_resolution_errors() {
+        let err = parse_config(
+            r#"
+            [fleet.bridge.telegram]
+            token = "$AINB_BRIDGE_UNSET_TOKEN_VAR"
+            user_id = 1
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("resolved to empty"));
+    }
+
+    #[test]
+    fn invalid_listen_mode_errors() {
+        let err = parse_config(
+            r#"
+            [fleet.bridge.slack]
+            bot_token = "xoxb"
+            app_token = "xapp"
+            user_id = "U1"
+            listen_mode = "loud"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("listen_mode"));
+    }
+
+    #[test]
+    fn user_id_as_unresolvable_secret_ref_errors() {
+        // A string user_id that resolves to empty (unset env var) must error
+        // rather than silently parsing as 0. (The successful secret-ref path is
+        // covered in `secrets::tests` with an injected env to avoid mutating the
+        // process environment, which the crate's `forbid(unsafe)` would block.)
+        let err = parse_config(
+            r#"
+            [fleet.bridge.telegram]
+            token = "tg"
+            user_id = "$AINB_BRIDGE_USER_ID_DEFINITELY_UNSET"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("user_id"));
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/format.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/format.rs
@@ -1,0 +1,281 @@
+// ABOUTME: Markdown -> Telegram-HTML conversion and 4096-char message splitting.
+//
+// Ported from the Python `ainb_phone_bridge.format` (the verified spec). Both
+// functions are pure. Telegram's HTML parse mode supports a small tag subset;
+// we map the common Markdown constructs an agent emits and escape everything
+// else so a stray `<` never breaks the message.
+//
+// The bridge ALWAYS splits the RAW reply (`split_message`) BEFORE converting
+// each chunk to HTML (`md_to_tg_html`). That ordering — verified in the Python
+// bridge — guarantees a chunk boundary can never slice through an HTML tag or
+// entity, which Telegram rejects with a 400.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Telegram hard limit on a single text message.
+pub const TG_MAX_LENGTH: usize = 4096;
+
+// Order matters: fenced code blocks first (greedy, multiline), then inline spans.
+static FENCE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)```[a-zA-Z0-9_+-]*\n?(.*?)```").unwrap());
+static INLINE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`([^`\n]+?)`").unwrap());
+static BOLD_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\*\*([^*]+?)\*\*").unwrap());
+// Italic: a single `*…*` not adjacent to another `*` or a word char (mirrors the
+// Python lookarounds via explicit boundary captures, since `regex` has no
+// lookaround). We capture the boundary chars and re-emit them around the tag.
+static ITALIC_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^|[^*\w])\*([^*\n]+?)\*([^*\w]|$)").unwrap());
+static LINK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\((https?://[^)\s]+)\)").unwrap());
+
+/// HTML-escape the five characters Telegram's HTML parse-mode cares about,
+/// matching Python's `html.escape` (which also escapes single quotes).
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Convert a Markdown-ish string to the Telegram HTML subset.
+///
+/// Strategy: pull code spans out behind placeholders so their contents are
+/// never re-interpreted as markup, HTML-escape the remainder, apply the inline
+/// conversions, then restore the (escaped) code spans wrapped in `<pre>` /
+/// `<code>`.
+#[must_use]
+pub fn md_to_tg_html(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let mut placeholders: Vec<String> = Vec::new();
+
+    // Placeholder token uses NUL sentinels so it can never appear in real prose.
+    let stash = |placeholders: &mut Vec<String>, rendered: String| -> String {
+        let token = format!("\u{0}PH{}\u{0}", placeholders.len());
+        placeholders.push(rendered);
+        token
+    };
+
+    // Fenced blocks -> <pre><code>…</code></pre>
+    let mut body = String::new();
+    let mut last = 0;
+    for caps in FENCE_RE.captures_iter(text) {
+        let whole = caps.get(0).unwrap();
+        body.push_str(&text[last..whole.start()]);
+        let inner = html_escape(caps.get(1).map_or("", |m| m.as_str()).trim_end_matches('\n'));
+        let token = stash(
+            &mut placeholders,
+            format!("<pre><code>{inner}</code></pre>"),
+        );
+        body.push_str(&token);
+        last = whole.end();
+    }
+    body.push_str(&text[last..]);
+
+    // Inline `code` -> <code>…</code>
+    let mut body2 = String::new();
+    let mut last = 0;
+    for caps in INLINE_CODE_RE.captures_iter(&body) {
+        let whole = caps.get(0).unwrap();
+        body2.push_str(&body[last..whole.start()]);
+        let inner = html_escape(caps.get(1).map_or("", |m| m.as_str()));
+        let token = stash(&mut placeholders, format!("<code>{inner}</code>"));
+        body2.push_str(&token);
+        last = whole.end();
+    }
+    body2.push_str(&body[last..]);
+
+    // Escape the prose body (placeholders survive — they contain no '<').
+    let mut text = html_escape(&body2);
+
+    // Links: [label](url) -> <a href="url">label</a>
+    text = LINK_RE
+        .replace_all(&text, |caps: &regex::Captures| {
+            let label = caps.get(1).map_or("", |m| m.as_str());
+            let url = html_escape(caps.get(2).map_or("", |m| m.as_str()));
+            format!("<a href=\"{url}\">{label}</a>")
+        })
+        .into_owned();
+
+    // Bold / italic.
+    text = BOLD_RE.replace_all(&text, "<b>$1</b>").into_owned();
+    text = ITALIC_RE.replace_all(&text, "$1<i>$2</i>$3").into_owned();
+
+    // Restore code placeholders.
+    for (i, rendered) in placeholders.iter().enumerate() {
+        text = text.replace(&format!("\u{0}PH{i}\u{0}"), rendered);
+    }
+
+    text
+}
+
+/// Split `text` into chunks no longer than `limit` characters.
+///
+/// Prefers newline boundaries; falls back to a hard character cut for any single
+/// line that is itself longer than the limit. Never returns an empty list — an
+/// empty input yields `[""]` so callers can always `send` once.
+///
+/// Length is measured in `char`s (Unicode scalar values), matching Python's
+/// `len(str)` so the 4096 cap is the same code-point budget Telegram enforces.
+#[must_use]
+pub fn split_message(text: &str, limit: usize) -> Vec<String> {
+    if text.chars().count() <= limit {
+        return vec![text.to_string()];
+    }
+
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut current_len = 0usize;
+
+    for line in text.split('\n') {
+        let line_len = line.chars().count();
+        // A single oversized line: flush, then hard-cut it on char boundaries.
+        if line_len > limit {
+            if !current.is_empty() {
+                chunks.push(std::mem::take(&mut current));
+                current_len = 0;
+            }
+            let chars: Vec<char> = line.chars().collect();
+            for piece in chars.chunks(limit) {
+                chunks.push(piece.iter().collect());
+            }
+            continue;
+        }
+
+        // `candidate_len` = current + '\n' + line (the '\n' only when joining).
+        let joined_len = if current.is_empty() {
+            line_len
+        } else {
+            current_len + 1 + line_len
+        };
+        if joined_len > limit {
+            chunks.push(std::mem::take(&mut current));
+            current.push_str(line);
+            current_len = line_len;
+        } else {
+            if !current.is_empty() {
+                current.push('\n');
+                current_len += 1;
+            }
+            current.push_str(line);
+            current_len += line_len;
+        }
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    if chunks.is_empty() {
+        chunks.push(String::new());
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_bare_angle_brackets() {
+        assert_eq!(md_to_tg_html("a < b > c"), "a &lt; b &gt; c");
+    }
+
+    #[test]
+    fn bold_and_italic() {
+        assert_eq!(
+            md_to_tg_html("**bold** and *italic*"),
+            "<b>bold</b> and <i>italic</i>"
+        );
+    }
+
+    #[test]
+    fn inline_code_is_not_reinterpreted() {
+        // `<b>` inside code must be escaped, not rendered as a tag.
+        assert_eq!(
+            md_to_tg_html("use `<b>` here"),
+            "use <code>&lt;b&gt;</code> here"
+        );
+    }
+
+    #[test]
+    fn fenced_block_becomes_pre_code() {
+        let out = md_to_tg_html("```rust\nlet x = 1 < 2;\n```");
+        assert_eq!(out, "<pre><code>let x = 1 &lt; 2;</code></pre>");
+    }
+
+    #[test]
+    fn link_is_anchored() {
+        assert_eq!(
+            md_to_tg_html("see [docs](https://example.com/a)"),
+            "see <a href=\"https://example.com/a\">docs</a>"
+        );
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        assert_eq!(md_to_tg_html(""), "");
+    }
+
+    #[test]
+    fn short_text_is_one_chunk() {
+        assert_eq!(
+            split_message("hello", TG_MAX_LENGTH),
+            vec!["hello".to_string()]
+        );
+    }
+
+    #[test]
+    fn empty_text_yields_single_empty_chunk() {
+        assert_eq!(split_message("", TG_MAX_LENGTH), vec![String::new()]);
+    }
+
+    #[test]
+    fn splits_on_newline_boundaries() {
+        // limit 5: "aaa" + "bbb" can't both fit in one 5-char chunk.
+        let chunks = split_message("aaa\nbbb", 5);
+        assert_eq!(chunks, vec!["aaa".to_string(), "bbb".to_string()]);
+    }
+
+    #[test]
+    fn hard_cuts_an_oversized_line() {
+        let chunks = split_message("aaaaaaaaaa", 4);
+        assert_eq!(
+            chunks,
+            vec!["aaaa".to_string(), "aaaa".to_string(), "aa".to_string()]
+        );
+    }
+
+    #[test]
+    fn every_chunk_within_limit() {
+        let big = "word ".repeat(2000); // ~10k chars
+        for chunk in split_message(&big, TG_MAX_LENGTH) {
+            assert!(chunk.chars().count() <= TG_MAX_LENGTH);
+        }
+    }
+
+    #[test]
+    fn split_before_convert_never_breaks_a_tag() {
+        // The bridge contract: split raw, then convert each chunk. A chunk
+        // boundary landing mid-markdown must still produce valid HTML per chunk.
+        let raw = format!("{}\n```\ncode < here\n```", "x".repeat(TG_MAX_LENGTH - 2));
+        let chunks = split_message(&raw, TG_MAX_LENGTH);
+        assert!(chunks.len() >= 2);
+        for chunk in &chunks {
+            let html = md_to_tg_html(chunk);
+            // No raw unescaped '<' that isn't part of a tag we emitted.
+            assert!(!html.contains("< here") || html.contains("&lt; here"));
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/format.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/format.rs
@@ -111,7 +111,16 @@ pub fn md_to_tg_html(text: &str) -> String {
 
     // Bold / italic.
     text = BOLD_RE.replace_all(&text, "<b>$1</b>").into_owned();
-    text = ITALIC_RE.replace_all(&text, "$1<i>$2</i>$3").into_owned();
+    // `replace_all` consumes the trailing boundary capture, so two italic spans
+    // sharing a single separating space leave the second unconverted on a single
+    // pass. Re-run until the output stabilises so every span is caught.
+    loop {
+        let next = ITALIC_RE.replace_all(&text, "$1<i>$2</i>$3").into_owned();
+        if next == text {
+            break;
+        }
+        text = next;
+    }
 
     // Restore code placeholders.
     for (i, rendered) in placeholders.iter().enumerate() {
@@ -198,6 +207,13 @@ mod tests {
             md_to_tg_html("**bold** and *italic*"),
             "<b>bold</b> and <i>italic</i>"
         );
+    }
+
+    #[test]
+    fn adjacent_italics_separated_by_one_space() {
+        // The two spans share the single separating space as a boundary; both
+        // must convert even though `replace_all` consumes that space once.
+        assert_eq!(md_to_tg_html("*one* *two*"), "<i>one</i> <i>two</i>");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -1,0 +1,92 @@
+// ABOUTME: Native single-binary phone bridge — `ainb fleet bridge`.
+//
+// A Rust port of the Python `ainb_phone_bridge`, folding both channels into the
+// ainb binary so there is no separate Python runtime to install or manage:
+//
+//   * Telegram (long-polling getUpdates over reqwest) — `telegram.rs`
+//   * Slack    (socket-mode WebSocket via tokio-tungstenite) — `slack.rs`
+//
+// Both channels share ONE relay/routing core (`relay.rs`) over one transport
+// (`transport.rs`: discover via `ainb list`, deliver via tmux send-keys with the
+// `--` terminator, capture the reply from the JSONL transcript tail with the
+// complete-line / rotation-follow / send-time-guard fixes verified in Python).
+//
+// Config (`config.rs`) lives under `[fleet.bridge.telegram]` / `[fleet.bridge.slack]`
+// in ainb's config.toml; tokens resolve via the secret resolver (`secrets.rs`)
+// and are NEVER passed on argv or written into the launchd/systemd unit
+// (`service.rs`). The pure logic (routing, markdown/split, secrets, relay) is
+// unit-tested without a live fleet or network.
+
+pub mod config;
+pub mod format;
+pub mod relay;
+pub mod routing;
+pub mod secrets;
+pub mod service;
+pub mod slack;
+pub mod telegram;
+pub mod transport;
+
+use anyhow::{Result, bail};
+
+use config::{BridgeConfig, load_config};
+use transport::AinbTransport;
+
+/// Run the bridge daemon: load config, then drive every configured channel
+/// concurrently over the shared transport. Runs until the process is stopped
+/// (or every channel exits, which only happens on a fatal error).
+pub async fn run() -> Result<()> {
+    let cfg: BridgeConfig = load_config(None)?;
+    run_with_config(cfg).await
+}
+
+/// Run with an already-loaded config (the testable seam — no disk access).
+pub async fn run_with_config(cfg: BridgeConfig) -> Result<()> {
+    if !cfg.any_channel() {
+        bail!("no bridge channel configured — add [fleet.bridge.telegram] or [fleet.bridge.slack]");
+    }
+
+    // The shared transport is cheap (a zero-sized marker); each channel borrows
+    // it. We leak a single instance so both channel tasks can hold a `'static`
+    // reference for the lifetime of the daemon (it lives until process exit).
+    let transport: &'static AinbTransport = Box::leak(Box::new(AinbTransport));
+
+    let mut tasks = Vec::new();
+
+    if let Some(tg) = cfg.telegram {
+        tasks.push(tokio::spawn(async move {
+            if let Err(e) = telegram::run(tg, transport).await {
+                tracing::error!(error = %e, "Telegram channel exited with error");
+            }
+        }));
+    }
+    if let Some(sl) = cfg.slack {
+        tasks.push(tokio::spawn(async move {
+            if let Err(e) = slack::run(sl, transport).await {
+                tracing::error!(error = %e, "Slack channel exited with error");
+            }
+        }));
+    }
+
+    // Wait for all channel tasks. Each channel loops forever internally, so this
+    // only returns if a channel panics or its loop terminates.
+    for task in tasks {
+        let _ = task.await;
+    }
+    bail!("all bridge channels stopped");
+}
+
+/// Install the bridge as a launchd/systemd service (idempotent).
+pub fn install() -> Result<std::path::PathBuf> {
+    service::install()
+}
+
+/// Uninstall the bridge service. Returns the removed unit path, if any.
+pub fn uninstall() -> Result<Option<std::path::PathBuf>> {
+    service::uninstall()
+}
+
+/// Human-readable install status.
+pub fn status() -> Result<String> {
+    service::status()
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/relay.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/relay.rs
@@ -1,0 +1,225 @@
+// ABOUTME: Channel-agnostic relay core shared by the Telegram + Slack channels.
+//
+// Ported from the Python `bridge._relay`: resolve the target session from the
+// raw message (conductor-prefix routing, degrade-to-default), send it, and
+// return a single user-facing reply string. Both channels call exactly this —
+// the ONE relay/routing core the goal requires — so their behaviour can never
+// diverge. The channel layer owns only transport-specific concerns (auth,
+// mention-gating, markdown rendering, message splitting).
+
+use std::time::Duration;
+
+use super::routing::{TargetSession, parse_target_prefix, resolve_target};
+
+/// The transport seam the relay drives. The real implementation shells out to
+/// `ainb`/tmux (`transport.rs`); tests substitute an in-memory fake so the
+/// routing + degrade logic is verified without a live fleet.
+///
+/// Uses native `async fn` in traits (stable since Rust 1.75) — the relay only
+/// ever calls it through a generic `&T`, never a `dyn` object, so the
+/// `async_fn_in_trait` auto-trait caveat does not apply here (the returned
+/// futures are awaited inline in `Send` channel tasks).
+#[allow(async_fn_in_trait)]
+pub trait FleetTransport: Send + Sync {
+    /// Currently-running relay targets.
+    async fn discover(&self) -> Vec<TargetSession>;
+    /// Send `text` to `session` and capture its end-of-turn reply (or `None`
+    /// on send failure / timeout).
+    async fn send_and_capture(
+        &self,
+        session: &TargetSession,
+        text: &str,
+        timeout: Duration,
+    ) -> Option<String>;
+}
+
+/// Parameters that shape a single relay, supplied per-channel.
+pub struct RelayParams<'a> {
+    /// Optional configured default target name (used when no `name:` prefix).
+    pub default_target: Option<&'a str>,
+    /// How long to wait for the session's reply.
+    pub response_timeout: Duration,
+}
+
+/// Resolve the target, relay `raw_text`, and return a user-facing reply.
+///
+/// Mirrors the Python `_relay` outcomes exactly:
+/// - no running sessions -> "No running ainb sessions to relay to."
+/// - `name:` prefix to a missing session -> "No running session named '<n>'."
+/// - empty message body -> "(empty message — nothing sent to <target>)"
+/// - send ok but no reply in time -> "Sent to <t>, but no reply within <s>s …"
+/// - reply captured -> the reply text.
+pub async fn relay<T: FleetTransport + ?Sized>(
+    transport: &T,
+    params: &RelayParams<'_>,
+    raw_text: &str,
+) -> String {
+    let sessions = transport.discover().await;
+    if sessions.is_empty() {
+        return "No running ainb sessions to relay to.".to_string();
+    }
+
+    let names: Vec<String> = sessions.iter().map(|s| s.name.clone()).collect();
+    let (mut parsed_name, message) = parse_target_prefix(raw_text, &names);
+
+    // No explicit prefix -> honour a configured default target name if present
+    // and actually running (case-insensitive).
+    if parsed_name.is_none() {
+        if let Some(default) = params.default_target {
+            if sessions.iter().any(|s| s.name.eq_ignore_ascii_case(default)) {
+                parsed_name = Some(default.to_string());
+            }
+        }
+    }
+
+    let Some(target) = resolve_target(parsed_name.as_deref(), &sessions) else {
+        return match parsed_name {
+            Some(name) => format!("No running session named {name:?}."),
+            None => "No target session available.".to_string(),
+        };
+    };
+
+    if message.is_empty() {
+        return format!("(empty message — nothing sent to {})", target.name);
+    }
+
+    match transport.send_and_capture(target, &message, params.response_timeout).await {
+        Some(reply) => reply,
+        None => format!(
+            "Sent to {}, but no reply within {}s (it may still be working).",
+            target.name,
+            params.response_timeout.as_secs()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FakeTransport {
+        sessions: Vec<TargetSession>,
+        /// Records (target_name, message) of the last send.
+        last_send: Mutex<Option<(String, String)>>,
+        reply: Option<String>,
+    }
+
+    impl FakeTransport {
+        fn new(sessions: Vec<TargetSession>, reply: Option<String>) -> Self {
+            Self {
+                sessions,
+                last_send: Mutex::new(None),
+                reply,
+            }
+        }
+    }
+
+    impl FleetTransport for FakeTransport {
+        async fn discover(&self) -> Vec<TargetSession> {
+            self.sessions.clone()
+        }
+        async fn send_and_capture(
+            &self,
+            session: &TargetSession,
+            text: &str,
+            _timeout: Duration,
+        ) -> Option<String> {
+            *self.last_send.lock().unwrap() = Some((session.name.clone(), text.to_string()));
+            self.reply.clone()
+        }
+    }
+
+    fn sess(name: &str) -> TargetSession {
+        TargetSession::new(
+            name,
+            format!("tmux-{name}"),
+            format!("/cwd/{name}"),
+            format!("id-{name}"),
+        )
+    }
+
+    fn params() -> RelayParams<'static> {
+        RelayParams {
+            default_target: None,
+            response_timeout: Duration::from_secs(300),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_fleet_message() {
+        let t = FakeTransport::new(vec![], Some("x".into()));
+        let out = relay(&t, &params(), "hello").await;
+        assert_eq!(out, "No running ainb sessions to relay to.");
+    }
+
+    #[tokio::test]
+    async fn named_prefix_routes_to_session() {
+        let t = FakeTransport::new(vec![sess("backend"), sess("frontend")], Some("ok".into()));
+        let out = relay(&t, &params(), "backend: run tests").await;
+        assert_eq!(out, "ok");
+        let (target, msg) = t.last_send.lock().unwrap().clone().unwrap();
+        assert_eq!(target, "backend");
+        assert_eq!(msg, "run tests");
+    }
+
+    #[tokio::test]
+    async fn bare_message_hits_conductor_default() {
+        let t = FakeTransport::new(vec![sess("zebra"), sess("conductor")], Some("done".into()));
+        let out = relay(&t, &params(), "status?").await;
+        assert_eq!(out, "done");
+        let (target, msg) = t.last_send.lock().unwrap().clone().unwrap();
+        assert_eq!(target, "conductor");
+        assert_eq!(msg, "status?");
+    }
+
+    #[tokio::test]
+    async fn configured_default_target_used_when_no_prefix() {
+        let t = FakeTransport::new(vec![sess("alpha"), sess("beta")], Some("hi".into()));
+        let p = RelayParams {
+            default_target: Some("beta"),
+            response_timeout: Duration::from_secs(5),
+        };
+        let out = relay(&t, &p, "do it").await;
+        assert_eq!(out, "hi");
+        assert_eq!(t.last_send.lock().unwrap().clone().unwrap().0, "beta");
+    }
+
+    #[tokio::test]
+    async fn named_prefix_to_missing_session_reports() {
+        let t = FakeTransport::new(vec![sess("backend")], Some("x".into()));
+        let out = relay(&t, &params(), "ghost: hello").await;
+        // "ghost" isn't a session, so it's treated as plain text and hits the
+        // default ("backend") — matching the Python known-names guard.
+        assert_eq!(out, "x");
+        assert_eq!(
+            t.last_send.lock().unwrap().clone().unwrap().1,
+            "ghost: hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_body_after_prefix_reports() {
+        let t = FakeTransport::new(vec![sess("backend")], Some("x".into()));
+        let out = relay(&t, &params(), "backend:   ").await;
+        assert_eq!(out, "(empty message — nothing sent to backend)");
+        assert!(
+            t.last_send.lock().unwrap().is_none(),
+            "nothing should be sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_reply_in_time_reports_timeout() {
+        let t = FakeTransport::new(vec![sess("backend")], None);
+        let p = RelayParams {
+            default_target: None,
+            response_timeout: Duration::from_secs(42),
+        };
+        let out = relay(&t, &p, "backend: slow task").await;
+        assert_eq!(
+            out,
+            "Sent to backend, but no reply within 42s (it may still be working)."
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/routing.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/routing.rs
@@ -1,0 +1,229 @@
+// ABOUTME: Pure target-routing logic for the native phone bridge.
+//
+// Ported verbatim from the Python `ainb_phone_bridge.routing` (the verified
+// behavioral spec). Two concerns, both pure:
+//   1. `parse_target_prefix("name: hello", names)` -> `(Some("name"), "hello")`.
+//      Bare text (no recognised "name:" prefix) -> `(None, text)`.
+//   2. `resolve_target(parsed_name, sessions)` -> the session to relay to.
+//      Conductor-first when present; degrades to any named session otherwise so
+//      the bridge is useful BEFORE the separate ATC/conductor track lands.
+//
+// A `TargetSession` is the lightweight relay target the transport builds from
+// `ainb list --format json`. Keeping these functions free of I/O makes the
+// routing contract testable without a live fleet.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// A target name is a leading `<name>:` token. Names mirror ainb workspace /
+/// tmux names: alphanumerics plus the separators ainb actually uses. The
+/// `(?s)` flag makes `.` match newlines so a multi-line message body survives.
+static PREFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)^([A-Za-z0-9][A-Za-z0-9._-]*)\s*:\s*(.*)$").unwrap());
+
+/// A relay target resolved from `ainb list --format json`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetSession {
+    /// `workspace_name` — the human-facing routing key.
+    pub name: String,
+    /// tmux session name used by send-keys.
+    pub tmux_session: String,
+    /// `worktree_path` — locates the JSONL transcript.
+    pub cwd: String,
+    /// ainb session id.
+    pub session_id: String,
+    /// Whether the name looks like a conductor/ATC session.
+    pub is_conductor: bool,
+}
+
+impl TargetSession {
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        tmux_session: impl Into<String>,
+        cwd: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        let name = name.into();
+        let is_conductor = is_conductor_name(&name);
+        Self {
+            name,
+            tmux_session: tmux_session.into(),
+            cwd: cwd.into(),
+            session_id: session_id.into(),
+            is_conductor,
+        }
+    }
+}
+
+/// Split an inbound message into `(target_name, message)`.
+///
+/// A leading `"<name>:"` selects a named session ONLY when `<name>` matches one
+/// of `known_names` (case-insensitive). Otherwise the whole string is the
+/// message and the target is `None` (caller falls back to the default).
+///
+/// The known-names guard is what stops a normal sentence like `"note: fix this"`
+/// from being mis-routed to a session called `note`.
+#[must_use]
+pub fn parse_target_prefix(text: &str, known_names: &[String]) -> (Option<String>, String) {
+    if text.is_empty() {
+        return (None, String::new());
+    }
+    let Some(caps) = PREFIX_RE.captures(text) else {
+        return (None, text.to_string());
+    };
+    let candidate = caps.get(1).map_or("", |m| m.as_str());
+    let rest = caps.get(2).map_or("", |m| m.as_str());
+    // Match case-insensitively but return the session's canonical name so
+    // downstream routing/logging stays consistent regardless of how it was typed.
+    for name in known_names {
+        if name.eq_ignore_ascii_case(candidate) {
+            return (Some(name.clone()), rest.trim().to_string());
+        }
+    }
+    // Looks like a prefix but isn't a real session — treat as plain text.
+    (None, text.to_string())
+}
+
+/// True if a session name looks like a conductor/ATC session.
+#[must_use]
+pub fn is_conductor_name(name: &str) -> bool {
+    let lo = name.to_ascii_lowercase();
+    lo == "conductor" || lo.starts_with("conductor-")
+}
+
+/// Conductors first (0), then alphabetical by lowercased name for a stable
+/// default. Mirrors the Python `_conductor_sort_key`.
+fn conductor_sort_key(s: &TargetSession) -> (u8, String) {
+    (u8::from(!s.is_conductor), s.name.to_ascii_lowercase())
+}
+
+/// Pick the default relay target.
+///
+/// Conductor sessions win; among equals the alphabetically-first name is chosen
+/// so the default is stable across restarts. Returns `None` when the fleet is
+/// empty.
+#[must_use]
+pub fn default_target(sessions: &[TargetSession]) -> Option<&TargetSession> {
+    sessions.iter().min_by(|a, b| conductor_sort_key(a).cmp(&conductor_sort_key(b)))
+}
+
+/// Resolve a relay target from an optional name + the live session list.
+///
+/// - `parsed_name` given: exact (case-insensitive) match on `name`; if no such
+///   session is running, returns `None` (caller reports "no such session"
+///   rather than silently relaying to the wrong place).
+/// - `parsed_name` absent: the conductor-first default (degrades to any named
+///   session).
+#[must_use]
+pub fn resolve_target<'a>(
+    parsed_name: Option<&str>,
+    sessions: &'a [TargetSession],
+) -> Option<&'a TargetSession> {
+    if let Some(wanted) = parsed_name {
+        return sessions.iter().find(|s| s.name.eq_ignore_ascii_case(wanted));
+    }
+    default_target(sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn sess(name: &str) -> TargetSession {
+        TargetSession::new(
+            name,
+            format!("tmux-{name}"),
+            format!("/cwd/{name}"),
+            format!("id-{name}"),
+        )
+    }
+
+    #[test]
+    fn parses_named_prefix_case_insensitively() {
+        let known = names(&["Backend", "frontend"]);
+        let (target, msg) = parse_target_prefix("backend: run the tests", &known);
+        assert_eq!(target.as_deref(), Some("Backend")); // canonical casing returned
+        assert_eq!(msg, "run the tests");
+    }
+
+    #[test]
+    fn bare_text_has_no_target() {
+        let known = names(&["backend"]);
+        let (target, msg) = parse_target_prefix("just do it", &known);
+        assert_eq!(target, None);
+        assert_eq!(msg, "just do it");
+    }
+
+    #[test]
+    fn unknown_prefix_is_treated_as_plain_text() {
+        // "note:" is NOT a session — the whole string stays the message.
+        let known = names(&["backend"]);
+        let (target, msg) = parse_target_prefix("note: fix this bug", &known);
+        assert_eq!(target, None);
+        assert_eq!(msg, "note: fix this bug");
+    }
+
+    #[test]
+    fn multiline_body_survives_prefix_split() {
+        let known = names(&["worker"]);
+        let (target, msg) = parse_target_prefix("worker: line one\nline two", &known);
+        assert_eq!(target.as_deref(), Some("worker"));
+        assert_eq!(msg, "line one\nline two");
+    }
+
+    #[test]
+    fn empty_text_yields_none_and_empty() {
+        assert_eq!(
+            parse_target_prefix("", &names(&["x"])),
+            (None, String::new())
+        );
+    }
+
+    #[test]
+    fn conductor_names_detected() {
+        assert!(is_conductor_name("conductor"));
+        assert!(is_conductor_name("Conductor-main"));
+        assert!(is_conductor_name("conductor-atc"));
+        assert!(!is_conductor_name("backend"));
+        assert!(!is_conductor_name("conductors")); // no hyphen, not bare "conductor"
+    }
+
+    #[test]
+    fn default_prefers_conductor() {
+        let sessions = vec![sess("zebra"), sess("conductor-main"), sess("alpha")];
+        assert_eq!(default_target(&sessions).unwrap().name, "conductor-main");
+    }
+
+    #[test]
+    fn default_degrades_to_alphabetical_when_no_conductor() {
+        let sessions = vec![sess("zebra"), sess("alpha"), sess("mango")];
+        assert_eq!(default_target(&sessions).unwrap().name, "alpha");
+    }
+
+    #[test]
+    fn default_on_empty_is_none() {
+        assert!(default_target(&[]).is_none());
+    }
+
+    #[test]
+    fn resolve_named_hit_and_miss() {
+        let sessions = vec![sess("backend"), sess("frontend")];
+        assert_eq!(
+            resolve_target(Some("FRONTEND"), &sessions).unwrap().name,
+            "frontend"
+        );
+        assert!(resolve_target(Some("missing"), &sessions).is_none());
+    }
+
+    #[test]
+    fn resolve_no_name_uses_default() {
+        let sessions = vec![sess("zebra"), sess("conductor")];
+        assert_eq!(resolve_target(None, &sessions).unwrap().name, "conductor");
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/secrets.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/secrets.rs
@@ -1,0 +1,134 @@
+// ABOUTME: Secret resolver for the native phone-bridge config.
+//
+// Ported from the Python `ainb_phone_bridge.secrets` (the verified contract):
+//   "$ENV_VAR"     -> std::env::var("ENV_VAR").unwrap_or_default()  (warns if unset)
+//   "${ENV_VAR}"   -> same branch (strips '$' and surrounding '{}')
+//   "keychain:svc" -> `security find-generic-password -s svc -w` (macOS only)
+//   "plain-string" -> returned unchanged
+//
+// A secret is NEVER passed on argv into the daemon — the bridge reads the raw
+// reference from config and resolves it here, in-process, at startup. Unknown /
+// missing references resolve to "" with a warning rather than erroring, so the
+// bridge fails loudly on an empty token at startup (a clearer error than a deep
+// stack trace).
+
+use std::process::Command;
+use std::time::Duration;
+
+const KEYCHAIN_PREFIX: &str = "keychain:";
+/// `security` can hang on a locked-keychain prompt; bound it. (Enforced via a
+/// watchdog thread because `std::process` has no built-in timeout.)
+const KEYCHAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Resolve a config secret reference to its plaintext value.
+///
+/// Pure aside from reading the process environment and (for keychain refs)
+/// shelling out to `/usr/bin/security`.
+#[must_use]
+pub fn resolve_secret(value: &str) -> String {
+    resolve_secret_with(value, |name| std::env::var(name).ok())
+}
+
+/// Inner resolver with an injectable env lookup, so the `$VAR` / `${VAR}` branch
+/// is unit-testable without mutating the process environment (the crate forbids
+/// `unsafe`, and `std::env::set_var` is process-global / racy anyway).
+fn resolve_secret_with(value: &str, env: impl Fn(&str) -> Option<String>) -> String {
+    let raw = value.trim();
+    if raw.is_empty() {
+        return String::new();
+    }
+
+    if let Some(rest) = raw.strip_prefix('$') {
+        // Handles both "$VAR" and "${VAR}" — strip the leading '$' and any
+        // surrounding braces, then read the environment (default "").
+        let name = rest.trim_matches(|c| c == '{' || c == '}');
+        let resolved = env(name).unwrap_or_default();
+        if resolved.is_empty() {
+            tracing::warn!(
+                env_var = name,
+                "env var referenced by bridge config is unset/empty"
+            );
+        }
+        return resolved;
+    }
+
+    if let Some(service) = raw.strip_prefix(KEYCHAIN_PREFIX) {
+        if service.is_empty() {
+            tracing::warn!("keychain reference has no service name");
+            return String::new();
+        }
+        return resolve_keychain(service);
+    }
+
+    // Plain literal — returned as-is.
+    raw.to_string()
+}
+
+/// macOS keychain lookup, bounded by a watchdog so a locked-keychain prompt
+/// can't hang the bridge at startup.
+fn resolve_keychain(service: &str) -> String {
+    let service_owned = service.to_string();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let out = Command::new("/usr/bin/security")
+            .args(["find-generic-password", "-s", &service_owned, "-w"])
+            .output();
+        let _ = tx.send(out);
+    });
+
+    match rx.recv_timeout(KEYCHAIN_TIMEOUT) {
+        Ok(Ok(out)) if out.status.success() => {
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        }
+        Ok(Ok(_)) => {
+            tracing::warn!(service, "keychain has no item for service");
+            String::new()
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(service, error = %e, "keychain lookup failed");
+            String::new()
+        }
+        Err(_) => {
+            tracing::warn!(service, "keychain lookup timed out");
+            String::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_literal_passes_through() {
+        assert_eq!(resolve_secret("xoxb-123"), "xoxb-123");
+    }
+
+    #[test]
+    fn whitespace_only_is_empty() {
+        assert_eq!(resolve_secret("   "), "");
+        assert_eq!(resolve_secret(""), "");
+    }
+
+    #[test]
+    fn dollar_env_is_read() {
+        // Inject a fake env so the test never mutates the process environment.
+        let env = |name: &str| (name == "MYVAR").then(|| "resolved-token".to_string());
+        assert_eq!(resolve_secret_with("$MYVAR", &env), "resolved-token");
+        assert_eq!(resolve_secret_with("${MYVAR}", &env), "resolved-token");
+    }
+
+    #[test]
+    fn missing_env_resolves_to_empty() {
+        let env = |_: &str| None;
+        assert_eq!(
+            resolve_secret_with("$AINB_BRIDGE_DEFINITELY_UNSET_XYZ", &env),
+            ""
+        );
+    }
+
+    #[test]
+    fn empty_keychain_service_is_empty() {
+        assert_eq!(resolve_secret("keychain:"), "");
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -1,0 +1,352 @@
+// ABOUTME: Install / teardown the native bridge as a launchd (macOS) or systemd
+// (Linux) service. Idempotent: install overwrites cleanly, teardown removes
+// everything.
+//
+// The daemon is launched as `<ainb-binary> fleet bridge run`. The token is
+// NEVER on the command line — the daemon reads it from config.toml at startup
+// via the secret resolver. The unit environment carries only PATH and HOME (and
+// AINB_CONFIG_PATH when the running process has an override, so the service
+// reads the same config the operator installed from).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+const LABEL: &str = "com.agentsinabox.phone-bridge";
+const SYSTEMD_UNIT: &str = "ainb-phone-bridge.service";
+
+/// Resolved paths used to build the service definition.
+#[derive(Debug, Clone)]
+pub struct ServicePaths {
+    /// Absolute path to the running `ainb` binary (ProgramArguments[0]).
+    pub ainb_bin: PathBuf,
+    /// `~/.agents-in-a-box/phone-bridge.log`.
+    pub log_path: PathBuf,
+    /// Optional config override to propagate into the unit env.
+    pub config_override: Option<String>,
+}
+
+/// Resolve the service paths from the current process. The binary is the
+/// canonical absolute path to the running `ainb` so the service runs the exact
+/// binary the operator installed from.
+pub fn resolve_paths() -> Result<ServicePaths> {
+    let ainb_bin = std::env::current_exe().context("resolving the current ainb binary path")?;
+    let mut log_path = dirs::home_dir().context("no home directory")?;
+    log_path.push(".agents-in-a-box");
+    log_path.push("phone-bridge.log");
+    let config_override = std::env::var("AINB_CONFIG_PATH").ok();
+    Ok(ServicePaths {
+        ainb_bin,
+        log_path,
+        config_override,
+    })
+}
+
+/// ProgramArguments / ExecStart argv: `<ainb> fleet bridge run`. No token, ever.
+fn daemon_argv(paths: &ServicePaths) -> Vec<String> {
+    vec![
+        paths.ainb_bin.to_string_lossy().into_owned(),
+        "fleet".to_string(),
+        "bridge".to_string(),
+        "run".to_string(),
+    ]
+}
+
+// ── macOS launchd ───────────────────────────────────────────────────────────
+
+fn launchd_plist_path() -> Result<PathBuf> {
+    let mut p = dirs::home_dir().context("no home directory")?;
+    p.push("Library");
+    p.push("LaunchAgents");
+    p.push(format!("{LABEL}.plist"));
+    Ok(p)
+}
+
+/// Render the launchd plist XML. Public for unit testing the generated content
+/// (token never present, argv correct, env scoped).
+#[must_use]
+pub fn build_plist(paths: &ServicePaths) -> String {
+    let path_env = std::env::var("PATH")
+        .unwrap_or_else(|_| "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_string());
+    let home = dirs::home_dir().unwrap_or_default();
+    let argv = daemon_argv(paths)
+        .into_iter()
+        .map(|a| format!("\t\t<string>{}</string>", xml_escape(&a)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut env_entries = format!(
+        "\t\t<key>PATH</key>\n\t\t<string>{}</string>\n\t\t<key>HOME</key>\n\t\t<string>{}</string>",
+        xml_escape(&path_env),
+        xml_escape(&home.to_string_lossy()),
+    );
+    if let Some(cfg) = &paths.config_override {
+        env_entries.push_str(&format!(
+            "\n\t\t<key>AINB_CONFIG_PATH</key>\n\t\t<string>{}</string>",
+            xml_escape(cfg)
+        ));
+    }
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>{label}</string>
+	<key>ProgramArguments</key>
+	<array>
+{argv}
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>{log}</string>
+	<key>StandardErrorPath</key>
+	<string>{log}</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+{env_entries}
+	</dict>
+</dict>
+</plist>
+"#,
+        label = LABEL,
+        log = xml_escape(&paths.log_path.to_string_lossy()),
+    )
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
+fn install_launchd(paths: &ServicePaths) -> Result<PathBuf> {
+    let plist_path = launchd_plist_path()?;
+    if let Some(parent) = plist_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    if let Some(parent) = paths.log_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(&plist_path, build_plist(paths))
+        .with_context(|| format!("writing {}", plist_path.display()))?;
+    // Idempotent reload: unload (ignore errors), then load.
+    let _ = std::process::Command::new("launchctl")
+        .args(["unload", &plist_path.to_string_lossy()])
+        .output();
+    let _ = std::process::Command::new("launchctl")
+        .args(["load", &plist_path.to_string_lossy()])
+        .output();
+    Ok(plist_path)
+}
+
+fn teardown_launchd() -> Result<Option<PathBuf>> {
+    let plist_path = launchd_plist_path()?;
+    if plist_path.exists() {
+        let _ = std::process::Command::new("launchctl")
+            .args(["unload", &plist_path.to_string_lossy()])
+            .output();
+        std::fs::remove_file(&plist_path).ok();
+        return Ok(Some(plist_path));
+    }
+    Ok(None)
+}
+
+// ── Linux systemd (user) ────────────────────────────────────────────────────
+
+fn systemd_unit_path() -> Result<PathBuf> {
+    let mut p = dirs::config_dir().context("no config directory")?;
+    p.push("systemd");
+    p.push("user");
+    p.push(SYSTEMD_UNIT);
+    Ok(p)
+}
+
+/// Render the systemd user unit. Public for unit testing.
+#[must_use]
+pub fn build_systemd_unit(paths: &ServicePaths) -> String {
+    let exec_start = daemon_argv(paths)
+        .iter()
+        .map(|a| {
+            if a.contains(char::is_whitespace) {
+                format!("\"{a}\"")
+            } else {
+                a.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let config_env = paths
+        .config_override
+        .as_ref()
+        .map(|c| format!("Environment=AINB_CONFIG_PATH={c}\n"))
+        .unwrap_or_default();
+    format!(
+        "[Unit]\n\
+         Description=ainb phone bridge (Telegram + Slack)\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         {config_env}\
+         ExecStart={exec_start}\n\
+         Restart=always\n\
+         RestartSec=10\n\
+         StandardOutput=append:{log}\n\
+         StandardError=append:{log}\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        log = paths.log_path.display(),
+    )
+}
+
+fn install_systemd(paths: &ServicePaths) -> Result<PathBuf> {
+    let unit_path = systemd_unit_path()?;
+    if let Some(parent) = unit_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    if let Some(parent) = paths.log_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(&unit_path, build_systemd_unit(paths))
+        .with_context(|| format!("writing {}", unit_path.display()))?;
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .output();
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "enable", "--now", SYSTEMD_UNIT])
+        .output();
+    Ok(unit_path)
+}
+
+fn teardown_systemd() -> Result<Option<PathBuf>> {
+    let unit_path = systemd_unit_path()?;
+    if unit_path.exists() {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "disable", "--now", SYSTEMD_UNIT])
+            .output();
+        std::fs::remove_file(&unit_path).ok();
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .output();
+        return Ok(Some(unit_path));
+    }
+    Ok(None)
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Provision the daemon service for the current platform. Idempotent.
+pub fn install() -> Result<PathBuf> {
+    let paths = resolve_paths()?;
+    if cfg!(target_os = "macos") {
+        install_launchd(&paths)
+    } else {
+        install_systemd(&paths)
+    }
+}
+
+/// Remove the daemon service. Safe to call when nothing is installed.
+pub fn uninstall() -> Result<Option<PathBuf>> {
+    if cfg!(target_os = "macos") {
+        teardown_launchd()
+    } else {
+        teardown_systemd()
+    }
+}
+
+/// Human-readable install status for the current platform.
+pub fn status() -> Result<String> {
+    if cfg!(target_os = "macos") {
+        let p = launchd_plist_path()?;
+        Ok(format!(
+            "launchd: {} ({})",
+            if p.exists() {
+                "installed"
+            } else {
+                "not installed"
+            },
+            p.display()
+        ))
+    } else {
+        let p = systemd_unit_path()?;
+        Ok(format!(
+            "systemd: {} ({})",
+            if p.exists() {
+                "installed"
+            } else {
+                "not installed"
+            },
+            p.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths() -> ServicePaths {
+        ServicePaths {
+            ainb_bin: PathBuf::from("/usr/local/bin/ainb"),
+            log_path: PathBuf::from("/home/u/.agents-in-a-box/phone-bridge.log"),
+            config_override: None,
+        }
+    }
+
+    #[test]
+    fn plist_argv_is_fleet_bridge_run_and_carries_no_token() {
+        let xml = build_plist(&paths());
+        assert!(xml.contains("<string>/usr/local/bin/ainb</string>"));
+        assert!(xml.contains("<string>fleet</string>"));
+        assert!(xml.contains("<string>bridge</string>"));
+        assert!(xml.contains("<string>run</string>"));
+        // No token leakage: nothing token-ish in the rendered plist.
+        let lower = xml.to_lowercase();
+        assert!(!lower.contains("token"), "plist must never embed a token");
+        assert!(
+            !lower.contains("xoxb"),
+            "plist must never embed a slack token"
+        );
+    }
+
+    #[test]
+    fn plist_scopes_env_to_path_and_home() {
+        let xml = build_plist(&paths());
+        assert!(xml.contains("<key>PATH</key>"));
+        assert!(xml.contains("<key>HOME</key>"));
+    }
+
+    #[test]
+    fn plist_includes_config_override_when_set() {
+        let mut p = paths();
+        p.config_override = Some("/custom/config.toml".to_string());
+        let xml = build_plist(&p);
+        assert!(xml.contains("<key>AINB_CONFIG_PATH</key>"));
+        assert!(xml.contains("<string>/custom/config.toml</string>"));
+    }
+
+    #[test]
+    fn systemd_exec_start_is_fleet_bridge_run() {
+        let unit = build_systemd_unit(&paths());
+        assert!(unit.contains("ExecStart=/usr/local/bin/ainb fleet bridge run"));
+        assert!(unit.contains("Restart=always"));
+        assert!(!unit.to_lowercase().contains("token"));
+    }
+
+    #[test]
+    fn systemd_includes_config_override_when_set() {
+        let mut p = paths();
+        p.config_override = Some("/custom/config.toml".to_string());
+        let unit = build_systemd_unit(&p);
+        assert!(unit.contains("Environment=AINB_CONFIG_PATH=/custom/config.toml"));
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/slack.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/slack.rs
@@ -1,0 +1,431 @@
+// ABOUTME: The Slack channel — socket-mode, two-way relay.
+//
+// Flow: `apps.connections.open` (xapp- app token) returns a WSS URL; we connect
+// with tokio-tungstenite, receive `events_api` envelopes (message events), ACK
+// each by envelope_id, run authorized messages through the SHARED relay core,
+// and post the reply via `chat.postMessage` (xoxb- bot token).
+//
+// Parity with the Telegram channel's policy:
+//   * Authorization by Slack user id (unknown senders silently ignored).
+//   * listen_mode = "mentions" (default): act only on app_mention events or DMs;
+//     "all": act on every message event in subscribed channels + DMs.
+//   * The bot's own messages (and other bots) are ignored to avoid loops.
+//   * Replies are split at Slack's 4000-char limit; markdown passes through as
+//     Slack mrkdwn (Slack renders **bold**/`code` natively, so the reply text is
+//     posted verbatim with a light leading-mention strip).
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::config::{SlackConfig, SlackListenMode};
+use super::relay::{FleetTransport, RelayParams, relay};
+
+const API_BASE: &str = "https://slack.com/api";
+/// Slack message text limit (chat.postMessage). We split below this.
+const SLACK_MAX_LENGTH: usize = 3900;
+
+/// Run the Slack channel forever (reconnecting on disconnect).
+pub async fn run<T: FleetTransport>(cfg: SlackConfig, transport: &T) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("building Slack HTTP client")?;
+
+    // Resolve our own bot user id once so we never relay our own posts.
+    let self_user_id = auth_test(&client, &cfg.bot_token).await;
+    tracing::info!(
+        bot_user = self_user_id.as_deref().unwrap_or("?"),
+        mode = ?cfg.listen_mode,
+        "ainb phone bridge: Slack channel online (socket-mode)"
+    );
+
+    loop {
+        match connect_and_serve(&client, &cfg, self_user_id.as_deref(), transport).await {
+            Ok(()) => {
+                tracing::info!("Slack socket closed; reconnecting");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Slack socket error; reconnecting in 5s");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+}
+
+async fn connect_and_serve<T: FleetTransport>(
+    client: &reqwest::Client,
+    cfg: &SlackConfig,
+    self_user_id: Option<&str>,
+    transport: &T,
+) -> Result<()> {
+    let ws_url = open_connection(client, &cfg.app_token).await?;
+    let (ws, _resp) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .context("connecting to Slack socket-mode WSS")?;
+    let (mut write, mut read) = ws.split();
+
+    while let Some(frame) = read.next().await {
+        use tokio_tungstenite::tungstenite::Message;
+        let text = match frame.context("reading Slack socket frame")? {
+            Message::Text(t) => t,
+            Message::Ping(p) => {
+                write.send(Message::Pong(p)).await.ok();
+                continue;
+            }
+            Message::Close(_) => break,
+            _ => continue,
+        };
+
+        let Ok(envelope) = serde_json::from_str::<SocketEnvelope>(&text) else {
+            continue;
+        };
+
+        // ACK every envelope that carries one, immediately (Slack requires an
+        // ack within 3s or it redelivers).
+        if let Some(envelope_id) = &envelope.envelope_id {
+            let ack = json!({ "envelope_id": envelope_id }).to_string();
+            write.send(Message::Text(ack)).await.ok();
+        }
+
+        match envelope.envelope_type.as_deref() {
+            Some("hello") => tracing::debug!("Slack socket hello"),
+            Some("disconnect") => {
+                tracing::info!("Slack requested disconnect (refresh)");
+                break;
+            }
+            Some("events_api") => {
+                if let Some(event) = envelope.payload.and_then(|p| p.event) {
+                    handle_event(client, cfg, self_user_id, transport, event).await;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn handle_event<T: FleetTransport>(
+    client: &reqwest::Client,
+    cfg: &SlackConfig,
+    self_user_id: Option<&str>,
+    transport: &T,
+    event: SlackEvent,
+) {
+    if classify_event(cfg, self_user_id, &event).is_none() {
+        return;
+    }
+
+    let text = strip_leading_mention(event.text.as_deref().unwrap_or_default());
+    if text.trim().is_empty() {
+        return;
+    }
+
+    let params = RelayParams {
+        default_target: cfg.default_target.as_deref(),
+        response_timeout: Duration::from_secs(cfg.response_timeout),
+    };
+    let reply = relay(transport, &params, &text).await;
+
+    let Some(channel) = event.channel.as_deref() else {
+        return;
+    };
+    let thread_ts = event.thread_ts.clone().or_else(|| event.ts.clone());
+    for chunk in split_for_slack(&reply) {
+        if let Err(e) = post_message(
+            client,
+            &cfg.bot_token,
+            channel,
+            &chunk,
+            thread_ts.as_deref(),
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "Slack chat.postMessage failed");
+        }
+    }
+}
+
+/// Decide whether to act on an event. Returns `Some(())` to act, `None` to skip.
+/// Pure — exercised directly in tests.
+fn classify_event(cfg: &SlackConfig, self_user_id: Option<&str>, event: &SlackEvent) -> Option<()> {
+    // Only message-bearing events.
+    match event.event_type.as_deref() {
+        Some("message") | Some("app_mention") => {}
+        _ => return None,
+    }
+
+    // Ignore message subtypes (edits, joins, bot_message, deletions) and our
+    // own / any bot's posts — prevents reply loops.
+    if event.subtype.is_some() {
+        return None;
+    }
+    if event.bot_id.is_some() {
+        return None;
+    }
+    let sender = event.user.as_deref()?;
+    if Some(sender) == self_user_id {
+        return None;
+    }
+
+    // Authorization by Slack user id.
+    if sender != cfg.authorized_user_id {
+        tracing::warn!(
+            user = sender,
+            "ignoring Slack message from unauthorized user"
+        );
+        return None;
+    }
+
+    let is_dm = event.channel_type.as_deref() == Some("im");
+    let is_mention = event.event_type.as_deref() == Some("app_mention")
+        || self_user_id.is_some_and(|id| {
+            event.text.as_deref().is_some_and(|t| t.contains(&format!("<@{id}>")))
+        });
+
+    match cfg.listen_mode {
+        SlackListenMode::All => {
+            if is_dm || is_mention || event.channel.is_some() {
+                Some(())
+            } else {
+                None
+            }
+        }
+        SlackListenMode::Mentions => (is_dm || is_mention).then_some(()),
+    }
+}
+
+/// Strip a leading `<@U…>` Slack mention (and any following whitespace) from the
+/// message text. Pure.
+fn strip_leading_mention(text: &str) -> String {
+    let trimmed = text.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("<@") {
+        if let Some(close) = rest.find('>') {
+            return rest[close + 1..].trim_start().to_string();
+        }
+    }
+    text.to_string()
+}
+
+/// Split a reply for Slack's message-length limit on newline boundaries (with a
+/// hard char cut for oversized lines). Mirrors `format::split_message` but at
+/// Slack's limit, keeping markdown intact (Slack renders mrkdwn natively).
+fn split_for_slack(text: &str) -> Vec<String> {
+    super::format::split_message(text, SLACK_MAX_LENGTH)
+}
+
+// ── Slack Web API calls ─────────────────────────────────────────────────────
+
+async fn auth_test(client: &reqwest::Client, bot_token: &str) -> Option<String> {
+    let resp = client
+        .post(format!("{API_BASE}/auth.test"))
+        .bearer_auth(bot_token)
+        .send()
+        .await
+        .ok()?;
+    let body: Value = resp.json().await.ok()?;
+    body.get("user_id").and_then(Value::as_str).map(str::to_string)
+}
+
+async fn open_connection(client: &reqwest::Client, app_token: &str) -> Result<String> {
+    let resp = client
+        .post(format!("{API_BASE}/apps.connections.open"))
+        .bearer_auth(app_token)
+        .send()
+        .await
+        .context("apps.connections.open request")?;
+    let body: Value = resp.json().await.context("apps.connections.open decode")?;
+    if body.get("ok").and_then(Value::as_bool) != Some(true) {
+        anyhow::bail!(
+            "apps.connections.open failed: {}",
+            body.get("error").and_then(Value::as_str).unwrap_or("unknown")
+        );
+    }
+    body.get("url")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .context("apps.connections.open returned no url")
+}
+
+async fn post_message(
+    client: &reqwest::Client,
+    bot_token: &str,
+    channel: &str,
+    text: &str,
+    thread_ts: Option<&str>,
+) -> Result<()> {
+    let mut payload = json!({ "channel": channel, "text": text });
+    if let Some(ts) = thread_ts {
+        payload["thread_ts"] = json!(ts);
+    }
+    let resp = client
+        .post(format!("{API_BASE}/chat.postMessage"))
+        .bearer_auth(bot_token)
+        .json(&payload)
+        .send()
+        .await
+        .context("chat.postMessage request")?;
+    let body: Value = resp.json().await.context("chat.postMessage decode")?;
+    if body.get("ok").and_then(Value::as_bool) != Some(true) {
+        anyhow::bail!(
+            "chat.postMessage failed: {}",
+            body.get("error").and_then(Value::as_str).unwrap_or("unknown")
+        );
+    }
+    Ok(())
+}
+
+// ── Socket-mode wire types ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct SocketEnvelope {
+    #[serde(rename = "type")]
+    envelope_type: Option<String>,
+    envelope_id: Option<String>,
+    #[serde(default)]
+    payload: Option<SocketPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SocketPayload {
+    #[serde(default)]
+    event: Option<SlackEvent>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SlackEvent {
+    #[serde(rename = "type")]
+    event_type: Option<String>,
+    #[serde(default)]
+    subtype: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    bot_id: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    channel: Option<String>,
+    #[serde(default)]
+    channel_type: Option<String>,
+    #[serde(default)]
+    ts: Option<String>,
+    #[serde(default)]
+    thread_ts: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(mode: SlackListenMode) -> SlackConfig {
+        SlackConfig {
+            bot_token: "xoxb".into(),
+            app_token: "xapp".into(),
+            authorized_user_id: "UAUTH".into(),
+            default_target: None,
+            listen_mode: mode,
+            response_timeout: 300,
+        }
+    }
+
+    fn ev(event_type: &str, user: &str) -> SlackEvent {
+        SlackEvent {
+            event_type: Some(event_type.into()),
+            user: Some(user.into()),
+            text: Some("hello".into()),
+            channel: Some("C1".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn mentions_mode_ignores_plain_channel_message() {
+        let e = ev("message", "UAUTH"); // no mention, no DM
+        assert!(classify_event(&cfg(SlackListenMode::Mentions), Some("UBOT"), &e).is_none());
+    }
+
+    #[test]
+    fn mentions_mode_acts_on_app_mention() {
+        let e = ev("app_mention", "UAUTH");
+        assert!(classify_event(&cfg(SlackListenMode::Mentions), Some("UBOT"), &e).is_some());
+    }
+
+    #[test]
+    fn mentions_mode_acts_on_dm() {
+        let mut e = ev("message", "UAUTH");
+        e.channel_type = Some("im".into());
+        assert!(classify_event(&cfg(SlackListenMode::Mentions), Some("UBOT"), &e).is_some());
+    }
+
+    #[test]
+    fn mentions_mode_acts_on_inline_mention() {
+        let mut e = ev("message", "UAUTH");
+        e.text = Some("hey <@UBOT> status".into());
+        assert!(classify_event(&cfg(SlackListenMode::Mentions), Some("UBOT"), &e).is_some());
+    }
+
+    #[test]
+    fn all_mode_acts_on_plain_channel_message() {
+        let e = ev("message", "UAUTH");
+        assert!(classify_event(&cfg(SlackListenMode::All), Some("UBOT"), &e).is_some());
+    }
+
+    #[test]
+    fn unauthorized_user_ignored() {
+        let e = ev("app_mention", "USTRANGER");
+        assert!(classify_event(&cfg(SlackListenMode::Mentions), Some("UBOT"), &e).is_none());
+    }
+
+    #[test]
+    fn own_message_ignored() {
+        let e = ev("message", "UBOT");
+        assert!(classify_event(&cfg(SlackListenMode::All), Some("UBOT"), &e).is_none());
+    }
+
+    #[test]
+    fn bot_and_subtype_messages_ignored() {
+        let mut e = ev("message", "UAUTH");
+        e.bot_id = Some("B1".into());
+        assert!(classify_event(&cfg(SlackListenMode::All), Some("UBOT"), &e).is_none());
+        let mut e2 = ev("message", "UAUTH");
+        e2.subtype = Some("message_changed".into());
+        assert!(classify_event(&cfg(SlackListenMode::All), Some("UBOT"), &e2).is_none());
+    }
+
+    #[test]
+    fn non_message_events_ignored() {
+        let e = ev("reaction_added", "UAUTH");
+        assert!(classify_event(&cfg(SlackListenMode::All), Some("UBOT"), &e).is_none());
+    }
+
+    #[test]
+    fn strips_leading_mention() {
+        assert_eq!(strip_leading_mention("<@UBOT> run tests"), "run tests");
+        assert_eq!(strip_leading_mention("  <@UBOT>   spaced"), "spaced");
+    }
+
+    #[test]
+    fn leaves_text_without_leading_mention() {
+        assert_eq!(strip_leading_mention("just text"), "just text");
+        assert_eq!(strip_leading_mention("ping <@UBOT>"), "ping <@UBOT>");
+    }
+
+    #[test]
+    fn parses_events_api_envelope() {
+        let raw = r#"{
+            "type":"events_api",
+            "envelope_id":"abc-123",
+            "payload":{"event":{"type":"app_mention","user":"UAUTH","text":"<@UBOT> hi","channel":"C9","ts":"1.2"}}
+        }"#;
+        let env: SocketEnvelope = serde_json::from_str(raw).unwrap();
+        assert_eq!(env.envelope_type.as_deref(), Some("events_api"));
+        assert_eq!(env.envelope_id.as_deref(), Some("abc-123"));
+        let event = env.payload.unwrap().event.unwrap();
+        assert_eq!(event.event_type.as_deref(), Some("app_mention"));
+        assert_eq!(event.channel.as_deref(), Some("C9"));
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
@@ -121,8 +121,15 @@ fn is_addressed(cfg: &TelegramConfig, bot_username: Option<&str>, message: &TgMe
             return true;
         }
     }
-    if let (Some(username), Some(text)) = (bot_username, &message.text) {
-        return text.to_lowercase().contains(&format!("@{}", username.to_lowercase()));
+    // Media messages carry their text in `caption`; `handle_message` falls back
+    // to it, so the mention check must scan both fields to stay consistent.
+    if let Some(username) = bot_username {
+        let needle = format!("@{}", username.to_lowercase());
+        return message
+            .text
+            .iter()
+            .chain(message.caption.iter())
+            .any(|s| s.to_lowercase().contains(&needle));
     }
     false
 }
@@ -292,6 +299,15 @@ mod tests {
             Some("MyBot"),
             &msg("group", Some("@mybot status"))
         ));
+    }
+
+    #[test]
+    fn group_caption_mention_is_addressed() {
+        // A media message carries its only text in `caption`; the mention there
+        // must address the bot just as it would in `text`.
+        let mut m = msg("group", None);
+        m.caption = Some("@mybot look at this".into());
+        assert!(is_addressed(&cfg(true), Some("MyBot"), &m));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
@@ -1,0 +1,347 @@
+// ABOUTME: The Telegram channel — long-polling getUpdates, two-way relay.
+//
+// Ported from the Python `bridge.py` (aiogram) dispatcher, reimplemented over
+// the Bot API's getUpdates long-poll via reqwest (no aiogram/teloxide runtime).
+//
+// Inbound: an authorized Telegram message -> the shared relay core resolves the
+// target session and captures its reply -> reply to Telegram as HTML, splitting
+// the RAW reply BEFORE HTML conversion at 4096 chars (so a chunk boundary can
+// never slice an HTML tag — Telegram rejects that with a 400). HTML send
+// failures fall back to plain text so the user still gets the content.
+//
+// Authorization is by Telegram user_id (unknown senders are silently ignored).
+// In group chats the bot only acts when @mentioned or when the message is a
+// reply to the bot (gated by `require_mention_in_groups`).
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::json;
+
+use super::config::TelegramConfig;
+use super::format::{TG_MAX_LENGTH, md_to_tg_html, split_message};
+use super::relay::{FleetTransport, RelayParams, relay};
+
+const API_BASE: &str = "https://api.telegram.org";
+/// Long-poll timeout (seconds) passed to getUpdates. The HTTP request waits up
+/// to this long for an update before returning empty, so we don't hot-loop.
+const LONG_POLL_SECS: u64 = 30;
+
+/// Run the Telegram channel forever (until the task is cancelled). Drives the
+/// shared `transport` through the relay core.
+pub async fn run<T: FleetTransport>(cfg: TelegramConfig, transport: &T) -> Result<()> {
+    let client = reqwest::Client::builder()
+        // Slightly longer than the long-poll so the socket isn't killed mid-wait.
+        .timeout(Duration::from_secs(LONG_POLL_SECS + 15))
+        .build()
+        .context("building Telegram HTTP client")?;
+
+    let me = get_me(&client, &cfg.token).await;
+    let bot_username = me.as_ref().and_then(|m| m.username.clone());
+    tracing::info!(
+        bot = bot_username.as_deref().unwrap_or("?"),
+        "ainb phone bridge: Telegram channel online (long-polling)"
+    );
+
+    let mut offset: i64 = 0;
+    loop {
+        let updates = match get_updates(&client, &cfg.token, offset).await {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::warn!(error = %e, "getUpdates failed; backing off");
+                tokio::time::sleep(Duration::from_secs(3)).await;
+                continue;
+            }
+        };
+        for update in updates {
+            offset = offset.max(update.update_id + 1);
+            if let Some(message) = update.message {
+                handle_message(&client, &cfg, bot_username.as_deref(), transport, message).await;
+            }
+        }
+    }
+}
+
+async fn handle_message<T: FleetTransport>(
+    client: &reqwest::Client,
+    cfg: &TelegramConfig,
+    bot_username: Option<&str>,
+    transport: &T,
+    message: TgMessage,
+) {
+    // Authorization by user_id — unknown senders are silently ignored.
+    let from_id = message.from.as_ref().map(|u| u.id);
+    if from_id != Some(cfg.authorized_user_id) {
+        tracing::warn!(user_id = ?from_id, "ignoring message from unauthorized user");
+        return;
+    }
+
+    if !is_addressed(cfg, bot_username, &message) {
+        return;
+    }
+
+    let raw = message.text.clone().or_else(|| message.caption.clone()).unwrap_or_default();
+    let text = strip_bot_mention(&raw, bot_username);
+    if text.trim().is_empty() {
+        return;
+    }
+
+    let params = RelayParams {
+        default_target: cfg.default_target.as_deref(),
+        response_timeout: Duration::from_secs(cfg.response_timeout),
+    };
+    let reply = relay(transport, &params, &text).await;
+
+    // Split the RAW reply BEFORE HTML conversion (the verified ordering).
+    for raw_chunk in split_message(&reply, TG_MAX_LENGTH) {
+        let html = md_to_tg_html(&raw_chunk);
+        if let Err(e) = send_message(client, &cfg.token, message.chat.id, &html, true).await {
+            tracing::warn!(error = %e, "HTML send failed; retrying as plain text");
+            if let Err(e2) =
+                send_message(client, &cfg.token, message.chat.id, &raw_chunk, false).await
+            {
+                tracing::warn!(error = %e2, "plain-text retry also failed");
+            }
+        }
+    }
+}
+
+/// Whether the bot should act on this message.
+fn is_addressed(cfg: &TelegramConfig, bot_username: Option<&str>, message: &TgMessage) -> bool {
+    if message.chat.chat_type == "private" {
+        return true;
+    }
+    if !cfg.require_mention_in_groups {
+        return true;
+    }
+    // A reply to the bot's own message counts as addressed.
+    if let Some(reply) = &message.reply_to_message {
+        if reply.from.as_ref().is_some_and(|u| u.is_bot) {
+            return true;
+        }
+    }
+    if let (Some(username), Some(text)) = (bot_username, &message.text) {
+        return text.to_lowercase().contains(&format!("@{}", username.to_lowercase()));
+    }
+    false
+}
+
+/// Remove a leading `@botname` mention from group messages.
+fn strip_bot_mention(text: &str, username: Option<&str>) -> String {
+    let Some(username) = username else {
+        return text.to_string();
+    };
+    let handle = format!("@{username}");
+    let stripped = text.trim_start();
+    if stripped.to_lowercase().starts_with(&handle.to_lowercase()) {
+        return stripped[handle.len()..].trim_start().to_string();
+    }
+    text.to_string()
+}
+
+// ── Bot API calls ───────────────────────────────────────────────────────────
+
+async fn get_me(client: &reqwest::Client, token: &str) -> Option<TgUser> {
+    let url = format!("{API_BASE}/bot{token}/getMe");
+    let resp = client.get(&url).send().await.ok()?;
+    let body: TgResponse<TgUser> = resp.json().await.ok()?;
+    body.result
+}
+
+async fn get_updates(client: &reqwest::Client, token: &str, offset: i64) -> Result<Vec<TgUpdate>> {
+    let url = format!("{API_BASE}/bot{token}/getUpdates");
+    let resp = client
+        .get(&url)
+        .query(&[
+            ("offset", offset.to_string()),
+            ("timeout", LONG_POLL_SECS.to_string()),
+            ("allowed_updates", "[\"message\"]".to_string()),
+        ])
+        .send()
+        .await
+        .context("getUpdates request")?;
+    let body: TgResponse<Vec<TgUpdate>> = resp.json().await.context("getUpdates decode")?;
+    if !body.ok {
+        anyhow::bail!("getUpdates returned ok=false: {:?}", body.description);
+    }
+    Ok(body.result.unwrap_or_default())
+}
+
+async fn send_message(
+    client: &reqwest::Client,
+    token: &str,
+    chat_id: i64,
+    text: &str,
+    html: bool,
+) -> Result<()> {
+    let url = format!("{API_BASE}/bot{token}/sendMessage");
+    let mut payload = json!({ "chat_id": chat_id, "text": text });
+    if html {
+        payload["parse_mode"] = json!("HTML");
+    }
+    let resp = client.post(&url).json(&payload).send().await.context("sendMessage request")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("sendMessage HTTP {status}: {body}");
+    }
+    Ok(())
+}
+
+// ── Bot API wire types (only the fields we read) ────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct TgResponse<R> {
+    ok: bool,
+    // `Option` fields default to `None` when absent without `#[serde(default)]`,
+    // which keeps the generic `R` free of a spurious `Default` bound.
+    description: Option<String>,
+    result: Option<R>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TgUpdate {
+    update_id: i64,
+    #[serde(default)]
+    message: Option<TgMessage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TgMessage {
+    chat: TgChat,
+    #[serde(default)]
+    from: Option<TgUser>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    caption: Option<String>,
+    #[serde(default)]
+    reply_to_message: Option<Box<TgMessage>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TgChat {
+    id: i64,
+    #[serde(rename = "type")]
+    chat_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TgUser {
+    id: i64,
+    #[serde(default)]
+    is_bot: bool,
+    #[serde(default)]
+    username: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(require_mention: bool) -> TelegramConfig {
+        TelegramConfig {
+            token: "t".into(),
+            authorized_user_id: 1,
+            default_target: None,
+            require_mention_in_groups: require_mention,
+            response_timeout: 300,
+        }
+    }
+
+    fn msg(chat_type: &str, text: Option<&str>) -> TgMessage {
+        TgMessage {
+            chat: TgChat {
+                id: 9,
+                chat_type: chat_type.into(),
+            },
+            from: Some(TgUser {
+                id: 1,
+                is_bot: false,
+                username: None,
+            }),
+            text: text.map(str::to_string),
+            caption: None,
+            reply_to_message: None,
+        }
+    }
+
+    #[test]
+    fn private_chat_is_always_addressed() {
+        assert!(is_addressed(
+            &cfg(true),
+            Some("bot"),
+            &msg("private", Some("hi"))
+        ));
+    }
+
+    #[test]
+    fn group_without_mention_is_ignored_when_required() {
+        assert!(!is_addressed(
+            &cfg(true),
+            Some("bot"),
+            &msg("group", Some("hello there"))
+        ));
+    }
+
+    #[test]
+    fn group_with_mention_is_addressed() {
+        assert!(is_addressed(
+            &cfg(true),
+            Some("MyBot"),
+            &msg("group", Some("@mybot status"))
+        ));
+    }
+
+    #[test]
+    fn group_addressed_when_mention_not_required() {
+        assert!(is_addressed(
+            &cfg(false),
+            Some("bot"),
+            &msg("group", Some("anything"))
+        ));
+    }
+
+    #[test]
+    fn reply_to_bot_counts_as_addressed() {
+        let mut m = msg("group", Some("ok"));
+        m.reply_to_message = Some(Box::new(TgMessage {
+            chat: TgChat {
+                id: 9,
+                chat_type: "group".into(),
+            },
+            from: Some(TgUser {
+                id: 5,
+                is_bot: true,
+                username: Some("bot".into()),
+            }),
+            text: None,
+            caption: None,
+            reply_to_message: None,
+        }));
+        assert!(is_addressed(&cfg(true), Some("bot"), &m));
+    }
+
+    #[test]
+    fn strips_leading_bot_mention() {
+        assert_eq!(
+            strip_bot_mention("@MyBot run tests", Some("MyBot")),
+            "run tests"
+        );
+        assert_eq!(
+            strip_bot_mention("@mybot   spaced", Some("MyBot")),
+            "spaced"
+        );
+    }
+
+    #[test]
+    fn leaves_non_leading_mention_intact() {
+        assert_eq!(strip_bot_mention("hey @MyBot", Some("MyBot")), "hey @MyBot");
+    }
+
+    #[test]
+    fn no_username_returns_text_unchanged() {
+        assert_eq!(strip_bot_mention("@bot hi", None), "@bot hi");
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/transport.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/transport.rs
@@ -1,0 +1,442 @@
+// ABOUTME: The bridge's transport to ainb sessions — discover, send, capture reply.
+//
+// Ported from the Python `ainb_phone_bridge.ainb_client` (the verified spec),
+// reusing ainb's EXISTING mechanisms where they exist:
+//   1. discover()        — `crate::fleet::discover_from_ainb` -> TargetSessions.
+//   2. send_keys()       — tmux send-keys (`-l` literal + `--` terminator +
+//                          Enter). The `--` terminator is the verified fix that
+//                          stops a payload starting with `-` from being parsed
+//                          as a tmux flag; the in-tree `fleet::send::tmux_send`
+//                          lacks it, so the bridge owns its own send.
+//   3. capture_reply()   — read the session's JSONL transcript: snapshot the
+//                          byte offset + wall-clock send time, send, then wait
+//                          for the next assistant row with stop_reason ==
+//                          "end_turn" that post-dates the send.
+//
+// RESPONSE-CAPTURE CONTRACT (the three verified bug-fixes preserved verbatim):
+//   * COMPLETE-LINE-ONLY: only advance the offset past newline-terminated
+//     lines, so a reply landing in a not-yet-flushed partial write is re-read
+//     once the line completes instead of being skipped.
+//   * ROTATION-FOLLOW: re-resolve the latest transcript every poll; on a
+//     resume/compaction rotation to a new *.jsonl, switch to it and reset the
+//     offset to 0 so the end-of-turn row in the new file is not missed.
+//   * SEND-TIME GUARD: only rows whose JSONL `timestamp` strictly post-dates
+//     the wall-clock send instant count as the reply. Without it an offset
+//     reset on rotation would surface a rolled-up PRE-send end_turn (carried
+//     into the new file by resume/compaction) as the answer. A row with no
+//     parseable timestamp is rejected once the guard is active.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::process::Command;
+
+use super::relay::FleetTransport;
+use super::routing::TargetSession;
+use crate::fleet::discover::discover_from_ainb;
+use crate::fleet::read::cwd_to_project_slug;
+
+/// The live transport: discovery via `ainb list`, delivery via tmux send-keys,
+/// reply capture via the JSONL transcript tail. This is the production
+/// [`FleetTransport`] both channels relay through.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AinbTransport;
+
+impl FleetTransport for AinbTransport {
+    async fn discover(&self) -> Vec<TargetSession> {
+        discover().await
+    }
+
+    async fn send_and_capture(
+        &self,
+        session: &TargetSession,
+        text: &str,
+        timeout: Duration,
+    ) -> Option<String> {
+        send_and_capture(session, text, timeout).await
+    }
+}
+
+/// Discover running sessions via the shared fleet discovery (`ainb list`).
+pub async fn discover() -> Vec<TargetSession> {
+    let sessions = discover_from_ainb().await.unwrap_or_default();
+    sessions
+        .into_iter()
+        .filter_map(|s| {
+            let name = s.workspace_name.unwrap_or_default();
+            let tmux = s.tmux_session.unwrap_or_default();
+            if name.is_empty() || tmux.is_empty() {
+                return None;
+            }
+            let cwd = s.worktree_path.unwrap_or(s.cwd);
+            Some(TargetSession::new(name, tmux, cwd, s.id))
+        })
+        .collect()
+}
+
+/// Send `text` to a tmux session via literal send-keys + Enter.
+///
+/// Uses `-l` (literal) so the payload is never interpreted as key names, and a
+/// `--` terminator so a message starting with `-` is treated as literal text,
+/// not as a tmux flag. This is the injection-safe transport the Python bridge
+/// verified; the Enter is sent as a separate key event afterwards.
+pub async fn send_keys(tmux_session: &str, text: &str) -> bool {
+    let lit = Command::new("tmux")
+        .args(["send-keys", "-t", tmux_session, "-l", "--", text])
+        .status()
+        .await;
+    let lit_ok = matches!(lit, Ok(s) if s.success());
+    if !lit_ok {
+        return false;
+    }
+    let enter = Command::new("tmux")
+        .args(["send-keys", "-t", tmux_session, "Enter"])
+        .status()
+        .await;
+    matches!(enter, Ok(s) if s.success())
+}
+
+/// Newest `*.jsonl` under the cwd's Claude project dir, or `None`.
+#[must_use]
+pub fn latest_transcript_for_cwd(cwd: &str) -> Option<PathBuf> {
+    let mut base = dirs::home_dir()?;
+    base.push(".claude");
+    base.push("projects");
+    base.push(cwd_to_project_slug(cwd));
+    let entries = std::fs::read_dir(&base).ok()?;
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    for e in entries.flatten() {
+        let path = e.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = e.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
+            newest = Some((mtime, path));
+        }
+    }
+    newest.map(|(_, p)| p)
+}
+
+/// Byte length of `path` right now (the send watermark).
+#[must_use]
+pub fn current_offset(path: Option<&Path>) -> u64 {
+    let Some(path) = path else { return 0 };
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Parse a row's top-level ISO-8601 `timestamp` to epoch milliseconds, or
+/// `None`. Claude writes each row with a `timestamp` like
+/// `"2025-06-14T12:34:56.789Z"`.
+fn row_timestamp_ms(obj: &Value) -> Option<i64> {
+    let ts = obj.get("timestamp").and_then(Value::as_str)?;
+    if ts.is_empty() {
+        return None;
+    }
+    chrono::DateTime::parse_from_rfc3339(ts).ok().map(|dt| dt.timestamp_millis())
+}
+
+/// Return `(stop_reason, text)` for an assistant row, concatenating every
+/// `{"type":"text"}` block in `message.content`. Mirrors the Python
+/// `_assistant_text_from_row` and the in-tree narrative extraction.
+fn assistant_text_from_row(obj: &Value) -> Option<(Option<String>, Option<String>)> {
+    if obj.get("type").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let message = obj.get("message")?;
+    let stop_reason = message.get("stop_reason").and_then(Value::as_str).map(str::to_string);
+    let mut parts: Vec<String> = Vec::new();
+    match message.get("content") {
+        Some(Value::Array(blocks)) => {
+            for block in blocks {
+                if block.get("type").and_then(Value::as_str) == Some("text") {
+                    if let Some(t) = block.get("text").and_then(Value::as_str) {
+                        if !t.is_empty() {
+                            parts.push(t.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        Some(Value::String(s)) => parts.push(s.clone()),
+        _ => {}
+    }
+    let text = parts.join("\n");
+    let text = text.trim();
+    Some((stop_reason, (!text.is_empty()).then(|| text.to_string())))
+}
+
+/// Scan rows from `start_offset`; return `(new_offset, reply_text|None)`.
+///
+/// `reply_text` is set only when an assistant row with
+/// `stop_reason == "end_turn"` is found in the new region; the LAST such turn
+/// wins. When `min_ts_ms` is given, only rows whose JSONL `timestamp` is
+/// strictly AFTER it are accepted (the send-time backlog guard). Only
+/// COMPLETE (newline-terminated) lines are consumed — a trailing partial write
+/// is left for the next poll.
+pub fn scan_new_rows_for_turn_end(
+    path: &Path,
+    start_offset: u64,
+    min_ts_ms: Option<i64>,
+) -> (u64, Option<String>) {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return (start_offset, None);
+    };
+    if file.seek(SeekFrom::Start(start_offset)).is_err() {
+        return (start_offset, None);
+    }
+    let mut data = Vec::new();
+    if file.read_to_end(&mut data).is_err() {
+        return (start_offset, None);
+    }
+
+    // Advance only past complete lines: up to and including the last newline.
+    let Some(last_nl) = data.iter().rposition(|&b| b == b'\n') else {
+        // No complete line yet — nothing to consume, hold the offset.
+        return (start_offset, None);
+    };
+    let complete = &data[..=last_nl];
+    let new_offset = start_offset + (last_nl as u64) + 1;
+
+    let mut reply: Option<String> = None;
+    for raw_line in complete.split(|&b| b == b'\n') {
+        let line = String::from_utf8_lossy(raw_line);
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some((stop_reason, text)) = assistant_text_from_row(&obj) else {
+            continue;
+        };
+        if stop_reason.as_deref() == Some("end_turn") {
+            if let Some(text) = text {
+                if let Some(min_ts) = min_ts_ms {
+                    match row_timestamp_ms(&obj) {
+                        Some(row_ts) if row_ts > min_ts => {}
+                        // Backlog (or unprovable) row — predates the send, skip.
+                        _ => continue,
+                    }
+                }
+                reply = Some(text);
+            }
+        }
+    }
+    (new_offset, reply)
+}
+
+/// Poll the transcript for the next end-of-turn assistant reply.
+///
+/// `transcript` may be `None` at send time (no transcript yet); it is
+/// re-resolved on each poll so a freshly-created file is picked up. On a
+/// rotation to a newer transcript the offset resets to 0. `send_time_ms` is the
+/// backlog guard. Returns the reply text or `None` on timeout.
+pub async fn wait_for_reply(
+    cwd: &str,
+    start_offset: u64,
+    transcript: Option<PathBuf>,
+    timeout: Duration,
+    poll_interval: Duration,
+    send_time_ms: Option<i64>,
+) -> Option<String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut offset = start_offset;
+    let mut path = transcript;
+
+    while tokio::time::Instant::now() < deadline {
+        let cwd = cwd.to_string();
+        let latest = tokio::task::spawn_blocking(move || latest_transcript_for_cwd(&cwd))
+            .await
+            .ok()
+            .flatten();
+        if let Some(latest) = latest {
+            if path.as_deref() != Some(latest.as_path()) {
+                // First resolution of a None send-time path, or a rotation to a
+                // newer transcript — read the new file from the top.
+                path = Some(latest);
+                offset = 0;
+            }
+        }
+        if let Some(ref p) = path {
+            let p = p.clone();
+            let scan = tokio::task::spawn_blocking(move || {
+                scan_new_rows_for_turn_end(&p, offset, send_time_ms)
+            })
+            .await;
+            if let Ok((new_offset, reply)) = scan {
+                offset = new_offset;
+                if reply.is_some() {
+                    return reply;
+                }
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+    None
+}
+
+/// Send `text` to `session` and capture its next end-of-turn reply.
+///
+/// Returns `None` if the send failed or no reply arrived before `timeout`.
+pub async fn send_and_capture(
+    session: &TargetSession,
+    text: &str,
+    timeout: Duration,
+) -> Option<String> {
+    let cwd = session.cwd.clone();
+    let transcript = tokio::task::spawn_blocking(move || latest_transcript_for_cwd(&cwd))
+        .await
+        .ok()
+        .flatten();
+    let offset = current_offset(transcript.as_deref());
+    // Wall-clock watermark: the reply must be a turn that ends AFTER this instant.
+    let send_time_ms = chrono::Utc::now().timestamp_millis();
+    if !send_keys(&session.tmux_session, text).await {
+        return None;
+    }
+    wait_for_reply(
+        &session.cwd,
+        offset,
+        transcript,
+        timeout,
+        Duration::from_millis(500),
+        Some(send_time_ms),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmp_jsonl(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("ainb-bridge-{}-{}.jsonl", name, std::process::id()))
+    }
+
+    #[test]
+    fn captures_last_end_turn_text() {
+        let path = tmp_jsonl("end-turn");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","timestamp":"2025-06-14T12:00:01Z","message":{{"stop_reason":"tool_use","content":[{{"type":"text","text":"thinking"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","timestamp":"2025-06-14T12:00:02Z","message":{{"stop_reason":"end_turn","content":[{{"type":"text","text":"done!"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        let (_, reply) = scan_new_rows_for_turn_end(&path, 0, None);
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(reply.as_deref(), Some("done!"));
+    }
+
+    #[test]
+    fn holds_offset_on_partial_trailing_line() {
+        let path = tmp_jsonl("partial");
+        let mut f = std::fs::File::create(&path).unwrap();
+        // A complete line, then a partial (no trailing newline) one.
+        write!(
+            f,
+            "{}\n{}",
+            r#"{"type":"user","message":{"content":"go"}}"#,
+            r#"{"type":"assistant","message":{"stop_reason":"end_t"#
+        )
+        .unwrap();
+        drop(f);
+        let total = std::fs::metadata(&path).unwrap().len();
+        let (new_offset, reply) = scan_new_rows_for_turn_end(&path, 0, None);
+        let _ = std::fs::remove_file(&path);
+        // Offset advanced only past the complete first line; partial held back.
+        assert!(
+            new_offset < total,
+            "offset {new_offset} should be < total {total}"
+        );
+        assert!(reply.is_none());
+    }
+
+    #[test]
+    fn send_time_guard_rejects_backlog_rows() {
+        let path = tmp_jsonl("backlog");
+        let mut f = std::fs::File::create(&path).unwrap();
+        // A pre-send end_turn (e.g. rolled in by compaction) — must be ignored.
+        writeln!(
+            f,
+            r#"{{"type":"assistant","timestamp":"2025-06-14T11:59:00Z","message":{{"stop_reason":"end_turn","content":[{{"type":"text","text":"stale answer"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        // Send happened at 12:00:00Z.
+        let send_ms = chrono::DateTime::parse_from_rfc3339("2025-06-14T12:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        let (_, reply) = scan_new_rows_for_turn_end(&path, 0, Some(send_ms));
+        let _ = std::fs::remove_file(&path);
+        assert!(reply.is_none(), "pre-send backlog must be rejected");
+    }
+
+    #[test]
+    fn send_time_guard_accepts_post_send_rows() {
+        let path = tmp_jsonl("postsend");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","timestamp":"2025-06-14T12:00:05Z","message":{{"stop_reason":"end_turn","content":[{{"type":"text","text":"fresh answer"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        let send_ms = chrono::DateTime::parse_from_rfc3339("2025-06-14T12:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        let (_, reply) = scan_new_rows_for_turn_end(&path, 0, Some(send_ms));
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(reply.as_deref(), Some("fresh answer"));
+    }
+
+    #[test]
+    fn guard_rejects_rows_without_timestamp() {
+        let path = tmp_jsonl("nots");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"stop_reason":"end_turn","content":[{{"type":"text","text":"no ts"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        let (_, reply) = scan_new_rows_for_turn_end(&path, 0, Some(0));
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            reply.is_none(),
+            "unprovable (no-timestamp) row must be rejected under guard"
+        );
+    }
+
+    #[test]
+    fn concatenates_multiple_text_blocks() {
+        let path = tmp_jsonl("multiblock");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"stop_reason":"end_turn","content":[{{"type":"text","text":"line one"}},{{"type":"tool_use","name":"X"}},{{"type":"text","text":"line two"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        let (_, reply) = scan_new_rows_for_turn_end(&path, 0, None);
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(reply.as_deref(), Some("line one\nline two"));
+    }
+
+    #[test]
+    fn current_offset_of_none_is_zero() {
+        assert_eq!(current_offset(None), 0);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/mod.rs
@@ -12,6 +12,7 @@
 
 #![allow(missing_docs)]
 
+pub mod bridge;
 pub mod discover;
 pub mod enrich_cache;
 pub mod read;

--- a/docs/fleet-bridge.md
+++ b/docs/fleet-bridge.md
@@ -1,0 +1,161 @@
+# `ainb fleet bridge` — native phone bridge (Telegram + Slack)
+
+A single-binary Rust daemon, built into `ainb`, that relays messages **two-way**
+between a chat app and a named `ainb` session — a conductor/ATC session when one
+is present, any running session otherwise. Drive and observe a coding-agent
+session from your phone while away from the keyboard, with **no separate Python
+runtime** to install or manage.
+
+It ports the proven logic of the Python `ainb_phone_bridge` (now deprecated) and
+adds a **Slack** channel. Both channels share one relay/routing core.
+
+```
+  Telegram ─long-poll─▶                                  ┌─▶ ainb session
+                        ainb fleet bridge ─tmux send-keys─┤
+  Slack ─socket-mode─▶  (shared relay core)              └─ read JSONL transcript
+     ▲                          │                              │
+     └──── reply (split) ───────┴──── wait for assistant end_turn ◀──┘
+```
+
+## How it talks to ainb
+
+The bridge reuses ainb's existing, verified mechanisms — it invents no new
+transport:
+
+| Concern | Mechanism |
+|---|---|
+| Discover sessions | `crate::fleet::discover_from_ainb` (`ainb list --format json`) → running `workspace_name` / `tmux_session_name` / `worktree_path` |
+| Send a message | `tmux send-keys -t <session> -l -- <text>` then `Enter` (literal mode + `--` terminator — injection-safe, and a payload starting with `-` is treated as text, not a flag) |
+| Capture the reply | Read the session's Claude JSONL transcript under `~/.claude/projects/<cwd-slug>/*.jsonl`, returning the text of the next assistant turn whose `stop_reason` is `end_turn` |
+
+### Reply-capture correctness (the three verified fixes, preserved)
+
+1. **Complete-line-only** — the read offset advances only past newline-terminated
+   lines, so a reply landing in a not-yet-flushed partial write is re-read once
+   the line completes instead of being skipped and lost.
+2. **Rotation-follow** — Claude can roll to a new `*.jsonl` mid-turn (resume /
+   compaction); each poll re-resolves the latest transcript and, on a switch,
+   resets the offset to 0 so the end-of-turn row in the new file is not missed.
+3. **Send-time guard** — only rows whose JSONL `timestamp` strictly post-dates
+   the wall-clock send instant count as the reply. Without it, an offset reset on
+   rotation would surface a rolled-up *pre-send* `end_turn` (carried into the new
+   file by compaction) as the answer. A row with no parseable timestamp is
+   rejected once the guard is active.
+
+## Routing
+
+A leading `name: message` prefix selects a named session (case-insensitive,
+**only** when `name` matches a running session — so a normal sentence like
+`note: fix this` is *not* mis-routed). A bare message hits the default target:
+conductor/ATC sessions win, otherwise the alphabetically-first session (stable
+across restarts). An unknown `name:` prefix is treated as plain text.
+
+## Authorization
+
+- **Telegram** — by `user_id`; unknown senders are silently ignored. In group
+  chats the bot acts only when @mentioned or when the message is a reply to the
+  bot (gated by `require_mention_in_groups`, default `true`).
+- **Slack** — by Slack `user_id`; unknown senders ignored. `listen_mode`
+  (`mentions` default, or `all`) decides whether the bot acts only on
+  app-mentions/DMs or on every message in subscribed channels. The bot ignores
+  its own and other bots' messages (no reply loops).
+
+Tokens are resolved through the **secret resolver** and are **never** placed on
+argv or written into the launchd/systemd unit:
+
+| Reference | Resolves to |
+|---|---|
+| `$ENV_VAR` / `${ENV_VAR}` | the process environment variable (warns if unset) |
+| `keychain:service` | `security find-generic-password -s service -w` (macOS) |
+| anything else | the literal string |
+
+## Configuration
+
+Config lives in ainb's `~/.agents-in-a-box/config/config.toml` (override with
+`AINB_CONFIG_PATH`). At least one channel table must be present.
+
+```toml
+[fleet.bridge]
+response_timeout = 300              # optional shared default (seconds)
+
+[fleet.bridge.telegram]
+token = "$TELEGRAM_BOT_TOKEN"       # or "keychain:svc" or a literal
+user_id = 123456789                # authorized Telegram user id
+default_target = "conductor"        # optional: name to prefer with no prefix
+require_mention_in_groups = true    # optional, default true
+response_timeout = 300              # optional, overrides the shared default
+
+[fleet.bridge.slack]
+bot_token = "$SLACK_BOT_TOKEN"      # xoxb-… (Web API: auth.test, chat.postMessage)
+app_token = "$SLACK_APP_TOKEN"      # xapp-… (socket-mode: apps.connections.open)
+user_id = "U0123ABC"               # authorized Slack user id (string)
+default_target = "conductor"        # optional
+listen_mode = "mentions"            # "mentions" (default) | "all"
+response_timeout = 300              # optional
+```
+
+### Slack app setup (socket-mode)
+
+1. Create a Slack app, enable **Socket Mode**.
+2. Bot token scopes: `chat:write`, `app_mentions:read`, `channels:history` (and
+   `im:history` for DMs).
+3. Event subscriptions (over socket mode): `app_mention`, `message.im` (and
+   `message.channels` if you use `listen_mode = "all"`).
+4. App-level token (`xapp-…`) with `connections:write`.
+
+## Running
+
+```bash
+# Foreground (reads config.toml; runs every configured channel concurrently):
+ainb fleet bridge run
+
+# Install as a launchd (macOS) / systemd-user (Linux) service. The unit's
+# ProgramArguments/ExecStart is `ainb fleet bridge run` — no token on the command
+# line; the daemon reads it from config at startup. Idempotent.
+ainb fleet bridge install
+
+# Status / teardown:
+ainb fleet bridge status
+ainb fleet bridge uninstall
+```
+
+Logs go to `~/.agents-in-a-box/phone-bridge.log`.
+
+## Migration: Python → Rust
+
+| Python (`ainb_phone_bridge`) | Rust (`ainb fleet bridge`) |
+|---|---|
+| `python -m ainb_phone_bridge run` (in a venv) | `ainb fleet bridge run` |
+| `python -m ainb_phone_bridge install` | `ainb fleet bridge install` |
+| `[fleet.telegram]` config table | `[fleet.bridge.telegram]` |
+| Telegram only | Telegram **and** Slack |
+| launchd label `com.agentsinabox.phone-bridge` | same label (uninstall the Python service first to avoid two daemons) |
+
+Steps:
+
+1. `python -m ainb_phone_bridge uninstall` (or remove the old launchd/systemd unit)
+   to stop the Python daemon — both use the same service label.
+2. Move your `[fleet.telegram]` block to `[fleet.bridge.telegram]` (rename the
+   table; keys are unchanged). Add `[fleet.bridge.slack]` if you want Slack.
+3. `ainb fleet bridge install`.
+
+The Python bridge is retained as the behavioral reference and for existing
+installs; it will be removed in a later release.
+
+## Tests
+
+Pure logic is unit-tested without a live fleet or network (run from `ainb-tui/`):
+
+```bash
+cargo test -p ainb --lib fleet::bridge
+```
+
+Coverage: prefix routing + conductor-first default + degrade; markdown→HTML and
+4096-char split (split-before-convert); secret resolution (`$ENV`/`${ENV}`/
+`keychain:`/literal); config parsing/validation for both channel tables; the
+shared relay core (every outcome, via an in-memory transport fake); the JSONL
+reply scan (complete-line-only, send-time guard accept/reject, no-timestamp
+rejection, multi-block concat); Telegram mention-gating + mention-strip; Slack
+event classification (mentions vs all, auth, self/bot/subtype filtering) +
+envelope parsing; and launchd/systemd unit rendering (argv correct, no token
+leakage). A live-token end-to-end run is manual.

--- a/plugins/ainb-fleet/bridge/README.md
+++ b/plugins/ainb-fleet/bridge/README.md
@@ -1,4 +1,13 @@
-# ainb phone bridge (Telegram)
+# ainb phone bridge (Telegram) — DEPRECATED
+
+> **Deprecated — superseded by the native Rust bridge `ainb fleet bridge`.**
+> The single-binary Rust daemon (in `ainb-core`, run via `ainb fleet bridge run`)
+> ports this bridge's verified behaviour AND adds a Slack (socket-mode) channel,
+> with no separate Python runtime to install or manage. Prefer it for new setups.
+> See [`docs/fleet-bridge.md`](../../../docs/fleet-bridge.md) for config + a
+> Python→Rust migration guide. This Python implementation is retained (not
+> deleted) for existing installs and as the behavioral reference spec; it will be
+> removed in a later release.
 
 A standalone Python daemon that relays messages **two-way** between Telegram and a
 named `ainb` session — a conductor session when one is present, any running


### PR DESCRIPTION
## What

A single-binary **native Rust phone bridge** — `ainb fleet bridge` — that relays
messages two-way between a chat app and a named `ainb` session, porting the
proven Python `ainb_phone_bridge` and adding a **Slack** channel. Both Telegram
(long-poll) and Slack (socket-mode) share **one** relay/routing core.

## Why

Replaces the Python phone bridge (shipped in #266) with a single binary so
there is no separate Python runtime to install or manage — the eventual
production shape — and brings two-channel parity (Telegram **+** Slack).

## How

New `crate::fleet::bridge` module in ainb-core (the `ainb` package), exposed via
a `bridge` subcommand under the existing `ainb fleet` dispatcher:

- **routing** — `name:` prefix routing (known-names guarded), conductor-first
  default, degrade-to-any-named-session.
- **format** — markdown → Telegram HTML + 4096-char split, **split-before-convert**
  so a chunk boundary never slices an HTML tag.
- **secrets** — `$ENV` / `${ENV}` / `keychain:` / literal resolver; token is
  **never** on argv or in the launchd/systemd unit.
- **config** — `[fleet.bridge.telegram]` / `[fleet.bridge.slack]` tables, validated.
- **transport** — discover via the shared fleet `discover_from_ainb`; tmux
  send-keys with the `--` terminator; reply capture from the JSONL tail
  preserving the three verified fixes: **complete-line-only**, **rotation-follow**,
  **send-time backlog guard**.
- **relay** — channel-agnostic core both channels relay through (mockable transport).
- **telegram** — getUpdates long-poll, user-id auth, group @mention gating, HTML
  reply with plain-text fallback.
- **slack** — `apps.connections.open` → socket-mode WebSocket (tokio-tungstenite,
  rustls), user-id auth, `mentions`/`all` listen modes, self/bot/subtype filtering.
- **service** — launchd/systemd install/uninstall with `ProgramArguments =
  ainb fleet bridge run` (no token on argv), idempotent.

The Python bridge is **marked deprecated** (README note) and **retained** as the
behavioral reference — not deleted. A new doc (`docs/fleet-bridge.md`) covers
config, both channels, install/teardown, and the Python→Rust migration.

## Proof (honest gate results — run from `ainb-tui/`)

- `cargo build -p ainb` → **Finished, 0 errors** (new code is warning-clean;
  the ~3355 pre-existing clippy warnings are out of scope per the umbrella).
- `cargo test -p ainb --lib fleet::bridge` → **76 passed; 0 failed**.
- `cargo test -p ainb --lib` → **1127 passed; 1 failed**. The one failure,
  `components::code_review::render::tests::renders_large_diff_within_budget`, is
  a **load-sensitive perf benchmark** unrelated to this PR (it touches no bridge
  code) — it **passes in isolation** (1.41s, under its 1500ms budget); it only
  flaked because the suite ran concurrently with a heavy build. The registry
  count test (`built_ins_registers_twenty_six_commands`) **passes** — a fleet
  sub-subcommand does not change the top-level count.
- `cargo fmt --check` → **clean** (exit 0).
- CLI smoke test: `ainb fleet bridge --help` lists run/install/uninstall/status;
  `ainb fleet bridge status` reports install state; `run` errors cleanly on a
  missing / no-channel config.

## Success criteria

- [x] `ainb fleet bridge run` native daemon relays Telegram **and** Slack two-way
  to a named/conductor session; `name:` routes, bare message hits the default,
  unauthorized users ignored. *(Pure routing/relay/auth logic unit-tested with a
  mock transport + live config-load wiring verified; a live-token end-to-end run
  is manual — see follow-ups.)*
- [x] `ainb fleet bridge install` provisions a launchd/systemd service reading
  both channels' tokens from config via the secret resolver (never argv/logs);
  `uninstall` removes it; the Python bridge is marked deprecated (not deleted).
- [x] Rust unit tests cover routing, markdown/split, secret resolution, and the
  shared relay core; build + test + fmt pass; registry count test updated/kept;
  a doc covers config, both channels, install/teardown, and migration.

## Known limitations / follow-ups

- **Live-token e2e is manual.** The pure logic + CLI wiring + config-load paths
  are verified automatically; an end-to-end relay against real Telegram/Slack
  tokens is a manual check (no secrets in CI).
- **Conductor/ATC inbox path not yet used** — the bridge uses the transcript-tail
  reply path. When the ATC plumbing (durable inbox / Stop-drain) lands, prefer it
  over the tail. The relay core's transport seam makes that a drop-in swap.
- `Cargo.lock` isn't committed in this repo, so the new `tokio-tungstenite`
  resolution happens at build time as elsewhere.

DO NOT MERGE without review.
