### PR TITLE
fix(onboarding): Esc opens the Setup menu instead of cancelling to Home

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -301,7 +301,7 @@ pub enum AppEvent {
     // Onboarding wizard events
     OnboardingNext,            // Go to next step (Enter/Right Arrow)
     OnboardingBack,            // Go to previous step (Backspace/Left Arrow)
-    OnboardingCancel,          // Cancel onboarding (Esc)
+    OnboardingToMenu,          // Leave wizard for the Setup menu (Esc)
     OnboardingInputChar(char), // Input character for git directories
     OnboardingBackspace,       // Backspace in git directories input
     OnboardingDelete,          // Delete character in input
@@ -1703,7 +1703,7 @@ impl EventHandler {
                     // Note: Left/Backspace used for text editing, use Up arrow to go back
                     match key_event.code {
                         KeyCode::Enter => Some(AppEvent::OnboardingNext),
-                        KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                        KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                         KeyCode::Up => Some(AppEvent::OnboardingBack), // Go back (since Left is cursor)
                         KeyCode::Backspace => Some(AppEvent::OnboardingBackspace),
                         KeyCode::Delete => Some(AppEvent::OnboardingDelete),
@@ -1725,7 +1725,7 @@ impl EventHandler {
                                 Some(AppEvent::OnboardingNext)
                             }
                         }
-                        KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                        KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                         KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
                             Some(AppEvent::OnboardingBack)
                         }
@@ -1738,7 +1738,7 @@ impl EventHandler {
                 }
                 OnboardingStep::Authentication => match key_event.code {
                     KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingNext),
-                    KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                    KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                     KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
                         Some(AppEvent::OnboardingBack)
                     }
@@ -1747,7 +1747,7 @@ impl EventHandler {
                 },
                 OnboardingStep::EditorSelection => match key_event.code {
                     KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingNext),
-                    KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                    KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                     KeyCode::Left | KeyCode::Backspace => Some(AppEvent::OnboardingBack),
                     KeyCode::Up => Some(AppEvent::OnboardingEditorUp),
                     KeyCode::Down => Some(AppEvent::OnboardingEditorDown),
@@ -1757,7 +1757,7 @@ impl EventHandler {
                 },
                 OnboardingStep::Summary => match key_event.code {
                     KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingFinish),
-                    KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                    KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                     KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
                         Some(AppEvent::OnboardingBack)
                     }
@@ -1767,7 +1767,7 @@ impl EventHandler {
                     // Welcome and other steps - basic navigation
                     match key_event.code {
                         KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingNext),
-                        KeyCode::Esc => Some(AppEvent::OnboardingCancel),
+                        KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                         KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
                             Some(AppEvent::OnboardingBack)
                         }
@@ -4984,9 +4984,9 @@ impl EventHandler {
                     onboarding_state.go_back();
                 }
             }
-            AppEvent::OnboardingCancel => {
-                tracing::debug!("Onboarding cancelled");
-                state.cancel_onboarding();
+            AppEvent::OnboardingToMenu => {
+                tracing::debug!("Leaving onboarding wizard for the Setup menu");
+                state.onboarding_to_menu();
             }
             AppEvent::OnboardingInputChar(ch) => {
                 if let Some(ref mut onboarding_state) = state.onboarding_state {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3742,6 +3742,20 @@ impl AppState {
         self.current_screen = screen_ids::HOME.to_string();
     }
 
+    /// Leave the onboarding wizard and drop into the Setup menu.
+    ///
+    /// This is the wizard's `Esc` behaviour: rather than abandoning setup all
+    /// the way back to Home, the user lands on the Setup menu where they can
+    /// pick a specific step (re-run wizard, check deps, configure paths, …) or
+    /// back out to Home from there. The menu state is reset so the landing is
+    /// always clean (selection at the top, no stale confirmation open).
+    pub fn onboarding_to_menu(&mut self) {
+        use crate::components::setup_menu::SetupMenuState;
+        self.onboarding_state = None;
+        self.setup_menu_state = SetupMenuState::new();
+        self.current_screen = screen_ids::SETUP_MENU.to_string();
+    }
+
     /// Refresh OAuth tokens using the refresh token
     pub async fn refresh_oauth_tokens(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Attempting to refresh OAuth tokens");

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -198,32 +198,47 @@ impl OnboardingComponent {
         .alignment(Alignment::Center);
         frame.render_widget(welcome, content_layout[1]);
 
-        // Description
-        let description = vec![
-            "",
-            "This wizard will help you set up AINB by:",
-            "",
-            "  • Checking required dependencies",
-            "  • Configuring your project directories",
-            "  • Setting up authentication",
-            "",
-            "Press Enter or → to continue",
+        // Description + clear calls to action.
+        let blank = || Line::from("");
+        let bullet = |text: &str| {
+            Line::from(vec![
+                Span::styled("• ", Style::default().fg(GOLD)),
+                Span::styled(text.to_string(), Style::default().fg(SOFT_WHITE)),
+            ])
+        };
+
+        let mut desc_lines: Vec<Line> = vec![
+            blank(),
+            Line::from(Span::styled(
+                "Let's get you set up — just a few quick steps:",
+                Style::default().fg(MUTED_GRAY),
+            )),
+            blank(),
+            bullet("Check required dependencies"),
+            bullet("Point AINB at your git projects"),
+            bullet("Configure agent authentication"),
+            bullet("Pick your preferred editor"),
+            blank(),
+            blank(),
         ];
 
-        let desc_lines: Vec<Line> = description
-            .iter()
-            .map(|line| {
-                if let Some(rest) = line.strip_prefix("  • ") {
-                    Line::from(vec![
-                        Span::styled("  ", Style::default()),
-                        Span::styled("• ", Style::default().fg(GOLD)),
-                        Span::styled(rest, Style::default().fg(SOFT_WHITE)),
-                    ])
-                } else {
-                    Line::from(Span::styled(*line, Style::default().fg(MUTED_GRAY)))
-                }
-            })
-            .collect();
+        // Primary CTA — filled gold "button" for the main action.
+        desc_lines.push(Line::from(vec![
+            Span::styled(
+                " Enter ",
+                Style::default().fg(DARK_BG).bg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  or  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("→", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled("    Get started", Style::default().fg(SOFT_WHITE)),
+        ]));
+        // Secondary CTA — Esc backs out to the Setup menu.
+        desc_lines.push(Line::from(vec![
+            Span::styled("[", Style::default().fg(SUBDUED_BORDER)),
+            Span::styled("Esc", Style::default().fg(GOLD)),
+            Span::styled("]", Style::default().fg(SUBDUED_BORDER)),
+            Span::styled("    Open the Setup menu", Style::default().fg(MUTED_GRAY)),
+        ]));
 
         let desc_widget = Paragraph::new(desc_lines).alignment(Alignment::Center);
         frame.render_widget(desc_widget, content_layout[2]);

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -888,12 +888,12 @@ impl OnboardingComponent {
             },
         ));
 
-        // Escape hint
+        // Escape hint — backs out to the Setup menu (see `onboarding_to_menu`)
         spans.push(Span::styled("  |  ", Style::default().fg(SUBDUED_BORDER)));
         spans.push(Span::styled("[", Style::default().fg(SUBDUED_BORDER)));
         spans.push(Span::styled("Esc", Style::default().fg(GOLD)));
         spans.push(Span::styled("]", Style::default().fg(SUBDUED_BORDER)));
-        spans.push(Span::styled(" Cancel", Style::default().fg(MUTED_GRAY)));
+        spans.push(Span::styled(" Menu", Style::default().fg(MUTED_GRAY)));
 
         let nav = Paragraph::new(Line::from(spans)).alignment(Alignment::Center);
         frame.render_widget(nav, inner);


### PR DESCRIPTION
## What

On the AINB setup wizard, **Esc** used to dump the user back on the Home hub, discarding all setup context. It now lands on the **Setup menu**, where they can jump to a specific step (re-run wizard, check deps, configure paths, …) or back out to Home from there.

```
Wizard (any step) ── Esc ──▶ Setup Menu ── Esc ──▶ Home
```

## Changes
- Rename `AppEvent::OnboardingCancel` → `OnboardingToMenu` across all six step Esc bindings and the handler
- Add `AppState::onboarding_to_menu()`: drops wizard state, resets `setup_menu_state` (clean landing), switches to the `SETUP_MENU` screen
- Footer hint `[Esc] Cancel` → `[Esc] Menu`

## Verification (tmux, throwaway HOME)
- Esc on Welcome → Setup menu shown ✓
- Esc on Setup menu → back to Home ✓
- Enter/→ still advance Welcome → Dependencies (no regression) ✓
- `cargo build -p ainb` green; no new clippy/fmt findings in the touched files

## Note — the separate "Enter doesn't work" report
Could **not** reproduce a code-side Enter/→ failure: both the shipped brew binary (1.7.0) and a fresh build advance the wizard correctly. Likely environmental (terminal/tmux) — tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the onboarding wizard's Escape key behavior to navigate back to the Setup menu rather than canceling the entire process.
  * Revised on-screen instructions and footer hints to clearly communicate the new menu navigation option when pressing Escape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->