### PR TITLE
feat(tui): slim status bar to a dedicated quota line + graceful shed

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -943,7 +943,14 @@ pub fn build_live_status_spans(state: &mut AppState, max_width: usize) -> Vec<Sp
         Some(StatuslineStatus::NotConfigured | StatuslineStatus::Other(_))
             if decision != StatuslineDecision::Declined =>
         {
-            build_cta_spans()
+            // Vanish (don't clip) the CTA when it can't fit — parity with
+            // the quota widget's shed behaviour and with the old width gate.
+            let cta = build_cta_spans();
+            if spans_width(&cta) <= max_width {
+                cta
+            } else {
+                Vec::new()
+            }
         }
         _ => Vec::new(),
     }

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -621,83 +621,12 @@ impl LayoutComponent {
     fn render_status_bar(&self, frame: &mut Frame, area: Rect, state: &mut AppState) {
         let mut status_spans: Vec<Span> = vec![];
 
-        // Current workspace/repo info
-        if let Some(workspace_idx) = state.selected_workspace_index {
-            if let Some(workspace) = state.workspaces.get(workspace_idx) {
-                if let Some(repo_name) = workspace.path.file_name().and_then(|n| n.to_str()) {
-                    status_spans.push(Span::styled("📁 ", Style::default().fg(GOLD)));
-                    status_spans.push(Span::styled(
-                        repo_name.to_string(),
-                        Style::default().fg(SOFT_WHITE),
-                    ));
-                }
-            }
-        }
-
-        // Active session info
-        if let Some(_session_id) = state.get_selected_session_id() {
-            if let Some(workspace_idx) = state.selected_workspace_index {
-                if let Some(session_idx) = state.selected_session_index {
-                    if let Some(workspace) = state.workspaces.get(workspace_idx) {
-                        if let Some(session) = workspace.sessions.get(session_idx) {
-                            // Separator
-                            if !status_spans.is_empty() {
-                                status_spans.push(Span::styled(
-                                    "  │  ",
-                                    Style::default().fg(SUBDUED_BORDER),
-                                ));
-                            }
-
-                            // Branch info
-                            status_spans
-                                .push(Span::styled("🌿 ", Style::default().fg(SELECTION_GREEN)));
-                            status_spans.push(Span::styled(
-                                session.branch_name.clone(),
-                                Style::default().fg(SOFT_WHITE),
-                            ));
-
-                            // Container info
-                            if let Some(container_id) = &session.container_id {
-                                let short_id = &container_id[..8.min(container_id.len())];
-                                let (status_icon, status_color) = match session.status {
-                                    crate::models::SessionStatus::Running => {
-                                        ("🟢", SELECTION_GREEN)
-                                    }
-                                    crate::models::SessionStatus::Stopped => {
-                                        ("🔴", Color::Rgb(230, 100, 100))
-                                    }
-                                    crate::models::SessionStatus::Idle => ("🟡", WARNING_ORANGE),
-                                    crate::models::SessionStatus::Error(_) => {
-                                        ("❌", Color::Rgb(230, 100, 100))
-                                    }
-                                };
-                                status_spans.push(Span::styled(
-                                    "  │  ",
-                                    Style::default().fg(SUBDUED_BORDER),
-                                ));
-                                status_spans.push(Span::styled(
-                                    format!("{} ", status_icon),
-                                    Style::default().fg(status_color),
-                                ));
-                                status_spans.push(Span::styled(
-                                    format!("{} ", session.name),
-                                    Style::default().fg(SOFT_WHITE),
-                                ));
-                                status_spans.push(Span::styled(
-                                    format!("({})", short_id),
-                                    Style::default().fg(MUTED_GRAY),
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Claude chat status
-        if !status_spans.is_empty() {
-            status_spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
-        }
+        // Claude-chat popup toggle — a small global indicator. The
+        // workspace / branch / session-status that used to live here were
+        // removed: they duplicated the bottom "Session Info" line. This
+        // top bar is now a dedicated, full-width live-quota line so both
+        // providers fit (and degrade gracefully) instead of being squeezed
+        // out by that duplicated content.
         if state.claude_chat_visible {
             status_spans.push(Span::styled("🗨️ ", Style::default().fg(SELECTION_GREEN)));
             status_spans.push(Span::styled("ON", Style::default().fg(SELECTION_GREEN)));
@@ -706,24 +635,17 @@ impl LayoutComponent {
             status_spans.push(Span::styled("OFF", Style::default().fg(MUTED_GRAY)));
         }
 
-        // Live OAuth window: append a compact widget when wired AND fresh,
-        // a red CTA when not wired (and the user hasn't declined).
-        // The status bar gracefully degrades on narrow terminals — we
-        // measure the existing content first and drop the live widget if
-        // it wouldn't fit.
-        let live_spans = build_live_status_spans(state);
-        let existing_w: usize = status_spans.iter().map(|s| s.content.chars().count()).sum();
-        // 4 chars for the " │  " separator we'd add
-        let live_w: usize = live_spans
-            .iter()
-            .map(|s| s.content.chars().count())
-            .sum::<usize>()
-            .saturating_add(5);
+        // Live OAuth quota (claude + codex). With the duplicated content
+        // gone the widget gets nearly the whole bar; it abbreviate-then-
+        // sheds to fit whatever columns remain (see `build_live_widget_spans`).
+        // The unwired case still falls back to the red CTA.
         let area_inner_w = area.width.saturating_sub(2) as usize; // borders
-        if !live_spans.is_empty() && existing_w + live_w <= area_inner_w {
-            if !status_spans.is_empty() {
-                status_spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
-            }
+        let existing_w: usize = status_spans.iter().map(|s| s.content.chars().count()).sum();
+        const SEP_W: usize = 5; // "  │  "
+        let avail = area_inner_w.saturating_sub(existing_w + SEP_W);
+        let live_spans = build_live_status_spans(state, avail);
+        if !live_spans.is_empty() {
+            status_spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
             status_spans.extend(live_spans);
         }
 
@@ -986,7 +908,7 @@ impl Default for LayoutComponent {
 /// The settings.json read goes through [`AppState::statusline_status_cached`]
 /// so the top bar's 30-60Hz redraws don't translate into 30-60Hz
 /// filesystem reads.
-pub fn build_live_status_spans(state: &mut AppState) -> Vec<Span<'static>> {
+pub fn build_live_status_spans(state: &mut AppState, max_width: usize) -> Vec<Span<'static>> {
     use crate::cli::statusline_install::StatuslineStatus;
     use crate::config::StatuslineDecision;
     use crate::models::live_window::Source;
@@ -1009,7 +931,7 @@ pub fn build_live_status_spans(state: &mut AppState) -> Vec<Span<'static>> {
     // statusline still sees their Codex burn instead of the CTA.
     let has_codex = live.codex_five_hour_pct.is_some() || live.codex_seven_day_pct.is_some();
     if live.source == Source::Tier1Cache || has_codex {
-        return build_live_widget_spans(&live);
+        return build_live_widget_spans(&live, max_width);
     }
 
     match status {
@@ -1027,76 +949,181 @@ pub fn build_live_status_spans(state: &mut AppState) -> Vec<Span<'static>> {
     }
 }
 
-fn build_live_widget_spans(live: &crate::models::live_window::LiveWindow) -> Vec<Span<'static>> {
-    let mut out: Vec<Span<'static>> = Vec::new();
+/// Detail level for the live quota widget, richest → poorest. The renderer
+/// picks the richest level whose rendered width fits the available columns
+/// (abbreviate-then-shed): drop the reset dates, then abbreviate the labels
+/// + weekly into `cl 81%/24%`, then shed the weekly entirely to `cl81%`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuotaDetail {
+    /// `claude 5h 81% ↻ Jun 15 16:50 · wk 24% ↻ Jun 15 18:00`
+    FullDated,
+    /// `claude 5h 81% · wk 24%`
+    Full,
+    /// `cl 81%/24%` (5h%/wk%, abbreviated provider label)
+    Abbrev,
+    /// `cl81%` (5h only — last resort, both providers still visible)
+    Tiny,
+}
 
-    // Compact, provider-grouped, each window carrying its reset instant:
-    //   claude 5h 40% ↻ Jun 15 12:24 · wk 8% ↻ Jun 20 10:24   codex 5h 24% ↻ …
-    // One cluster per provider — percentage + the critical reset date/time
-    // (the bars were dropped to fit both providers on one line). Codex is
-    // overlaid from `codex-live.json` (see
-    // `models::live_window::apply_codex_overlay`); an absent provider
-    // renders nothing (hide-on-fail).
+/// All detail levels, richest → poorest.
+const QUOTA_DETAIL_LADDER: [QuotaDetail; 4] = [
+    QuotaDetail::FullDated,
+    QuotaDetail::Full,
+    QuotaDetail::Abbrev,
+    QuotaDetail::Tiny,
+];
+
+/// Total display width (columns) of a span list.
+fn spans_width(spans: &[Span<'static>]) -> usize {
+    spans.iter().map(|s| s.content.chars().count()).sum()
+}
+
+/// Best-fit live quota spans for `max_width` columns. Tries each detail
+/// level richest → poorest and returns the first that fits; if even the
+/// poorest overflows it is returned anyway (ratatui clips — showing a
+/// clipped `cl81% cx14%` beats a blank bar). Empty when there's no data.
+fn build_live_widget_spans(
+    live: &crate::models::live_window::LiveWindow,
+    max_width: usize,
+) -> Vec<Span<'static>> {
+    let mut poorest = Vec::new();
+    for detail in QUOTA_DETAIL_LADDER {
+        let spans = quota_spans(live, detail);
+        if spans.is_empty() {
+            return spans; // no data at all → nothing to render
+        }
+        if spans_width(&spans) <= max_width {
+            return spans;
+        }
+        poorest = spans;
+    }
+    poorest
+}
+
+/// Build both provider clusters (`claude …   codex …`) at one detail level.
+fn quota_spans(
+    live: &crate::models::live_window::LiveWindow,
+    detail: QuotaDetail,
+) -> Vec<Span<'static>> {
+    let mut out: Vec<Span<'static>> = Vec::new();
     push_provider(
         &mut out,
-        "claude",
+        ("claude", "cl"),
         live.five_hour_pct,
         live.five_hour_resets_at,
         live.seven_day_pct,
         live.seven_day_resets_at,
+        detail,
     );
     push_provider(
         &mut out,
-        "codex",
+        ("codex", "cx"),
         live.codex_five_hour_pct,
         live.codex_five_hour_resets_at,
         live.codex_seven_day_pct,
         live.codex_seven_day_resets_at,
+        detail,
     );
-
-    // today_cost_usd intentionally not rendered: Claude Code's
-    // /cost/total_cost_usd is the lifetime cost of a *single* session, not
-    // today's total — misleading at a glance. Kept on the cache schema but
-    // not surfaced.
     out
 }
 
-/// Render one provider cluster — `claude 5h NN% ↻ <reset> · wk MM% ↻ <reset>`
-/// — onto `out`, separated from a preceding cluster by a wide gap. No-op
-/// when both windows are absent (hide-on-fail).
+/// Render one provider cluster at `detail` onto `out`, separated from a
+/// preceding cluster by a gap. No-op when both windows are absent
+/// (hide-on-fail). `labels` is `(full, abbreviated)`.
+#[allow(clippy::too_many_arguments)]
 fn push_provider(
     out: &mut Vec<Span<'static>>,
-    label: &str,
+    labels: (&str, &str),
     five_pct: Option<u8>,
     five_reset: Option<chrono::DateTime<chrono::Utc>>,
     seven_pct: Option<u8>,
     seven_reset: Option<chrono::DateTime<chrono::Utc>>,
+    detail: QuotaDetail,
 ) {
     if five_pct.is_none() && seven_pct.is_none() {
         return;
     }
+    let (full_label, abbr_label) = labels;
+    let label_style = Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD);
     if !out.is_empty() {
-        out.push(Span::styled("   ", Style::default()));
+        let gap = match detail {
+            QuotaDetail::Abbrev | QuotaDetail::Tiny => "  ",
+            _ => "   ",
+        };
+        out.push(Span::styled(gap, Style::default()));
     }
-    out.push(Span::styled(
-        format!("{label} "),
-        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
-    ));
-    let mut first = true;
-    push_quota_window(out, "5h", five_pct, bar_color_5h, five_reset, &mut first);
-    push_quota_window(out, "wk", seven_pct, bar_color_7d, seven_reset, &mut first);
+
+    match detail {
+        QuotaDetail::FullDated | QuotaDetail::Full => {
+            let show_reset = detail == QuotaDetail::FullDated;
+            out.push(Span::styled(format!("{full_label} "), label_style));
+            let mut first = true;
+            push_quota_window(
+                out,
+                "5h",
+                five_pct,
+                bar_color_5h,
+                five_reset,
+                show_reset,
+                &mut first,
+            );
+            push_quota_window(
+                out,
+                "wk",
+                seven_pct,
+                bar_color_7d,
+                seven_reset,
+                show_reset,
+                &mut first,
+            );
+        }
+        QuotaDetail::Abbrev => {
+            // `cl 81%/24%`
+            out.push(Span::styled(format!("{abbr_label} "), label_style));
+            if let Some(p) = five_pct {
+                out.push(Span::styled(
+                    format!("{p}%"),
+                    Style::default().fg(bar_color_5h(p)).add_modifier(Modifier::BOLD),
+                ));
+            }
+            if let Some(p) = seven_pct {
+                if five_pct.is_some() {
+                    out.push(Span::styled("/", Style::default().fg(MUTED_GRAY)));
+                }
+                out.push(Span::styled(
+                    format!("{p}%"),
+                    Style::default().fg(bar_color_7d(p)).add_modifier(Modifier::BOLD),
+                ));
+            }
+        }
+        QuotaDetail::Tiny => {
+            // `cl81%` — 5h only (fall back to wk if 5h is absent) so the
+            // provider still shows a number in the tightest space.
+            out.push(Span::styled(abbr_label.to_string(), label_style));
+            let (pct, color): (u8, fn(u8) -> Color) = match (five_pct, seven_pct) {
+                (Some(p), _) => (p, bar_color_5h),
+                (None, Some(p)) => (p, bar_color_7d),
+                (None, None) => return,
+            };
+            out.push(Span::styled(
+                format!("{pct}%"),
+                Style::default().fg(color(pct)).add_modifier(Modifier::BOLD),
+            ));
+        }
+    }
 }
 
-/// Push one window — `5h NN% ↻ <reset>` — within a provider cluster, with a
-/// ` · ` separator before all but the first window. The reset date/time is
-/// rendered when known (it's the critical "when does my quota come back"
-/// signal). No-op when `pct` is `None`.
+/// Push one window — `5h NN%` (+ ` ↻ <reset>` when `show_reset`) — within a
+/// provider cluster, with a ` · ` separator before all but the first
+/// window. No-op when `pct` is `None`.
+#[allow(clippy::too_many_arguments)]
 fn push_quota_window(
     out: &mut Vec<Span<'static>>,
     label: &str,
     pct: Option<u8>,
     color: fn(u8) -> Color,
     reset: Option<chrono::DateTime<chrono::Utc>>,
+    show_reset: bool,
     first: &mut bool,
 ) {
     let Some(pct) = pct else {
@@ -1114,11 +1141,13 @@ fn push_quota_window(
         format!("{pct}%"),
         Style::default().fg(color(pct)).add_modifier(Modifier::BOLD),
     ));
-    if let Some(reset) = reset {
-        out.push(Span::styled(
-            format!(" ↻ {}", format_reset_at(reset)),
-            Style::default().fg(MUTED_GRAY),
-        ));
+    if show_reset {
+        if let Some(reset) = reset {
+            out.push(Span::styled(
+                format!(" ↻ {}", format_reset_at(reset)),
+                Style::default().fg(MUTED_GRAY),
+            ));
+        }
     }
 }
 
@@ -1194,7 +1223,7 @@ mod live_widget_tests {
             source: Source::Tier1Cache,
             ..Default::default()
         };
-        let spans = build_live_widget_spans(&live);
+        let spans = build_live_widget_spans(&live, 1000);
         let text = flatten(&spans);
         assert!(text.contains("claude"), "provider label present: {text}");
         assert!(text.contains("5h"));
@@ -1225,7 +1254,7 @@ mod live_widget_tests {
             source: Source::Tier1Cache,
             ..Default::default()
         };
-        let spans = build_live_widget_spans(&live);
+        let spans = build_live_widget_spans(&live, 1000);
         let text = flatten(&spans);
         assert!(text.contains("claude"));
         assert!(text.contains("5h"));
@@ -1248,7 +1277,7 @@ mod live_widget_tests {
             codex_seven_day_resets_at: Some(Utc.with_ymd_and_hms(2026, 6, 18, 13, 0, 0).unwrap()),
             ..Default::default()
         };
-        let text = flatten(&build_live_widget_spans(&live));
+        let text = flatten(&build_live_widget_spans(&live, 1000));
         // Both provider clusters render: `claude 5h 40% · wk 8%   codex …`.
         assert!(text.contains("claude"), "claude cluster present: {text}");
         assert!(text.contains("40%"));
@@ -1273,7 +1302,7 @@ mod live_widget_tests {
             codex_seven_day_pct: Some(44),
             ..Default::default()
         };
-        let text = flatten(&build_live_widget_spans(&live));
+        let text = flatten(&build_live_widget_spans(&live, 1000));
         // Codex is the first (and only) cluster — no Claude cluster precedes it.
         assert!(
             text.starts_with("codex"),
@@ -1289,9 +1318,87 @@ mod live_widget_tests {
             source: Source::Tier1Cache,
             ..Default::default()
         };
-        let text = flatten(&build_live_widget_spans(&live));
+        let text = flatten(&build_live_widget_spans(&live, 1000));
         assert!(text.contains("claude"));
         assert!(!text.contains("codex"));
+    }
+
+    /// Both providers, all four windows + resets, for the degradation tests.
+    fn both_providers_live() -> LiveWindow {
+        use chrono::{TimeZone, Utc};
+        LiveWindow {
+            five_hour_pct: Some(40),
+            seven_day_pct: Some(8),
+            five_hour_resets_at: Some(Utc.with_ymd_and_hms(2026, 6, 8, 5, 0, 0).unwrap()),
+            seven_day_resets_at: Some(Utc.with_ymd_and_hms(2026, 6, 12, 5, 0, 0).unwrap()),
+            source: Source::Tier1Cache,
+            codex_five_hour_pct: Some(10),
+            codex_five_hour_resets_at: Some(Utc.with_ymd_and_hms(2026, 6, 15, 0, 21, 0).unwrap()),
+            codex_seven_day_pct: Some(44),
+            codex_seven_day_resets_at: Some(Utc.with_ymd_and_hms(2026, 6, 18, 13, 0, 0).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn degrade_full_dated_when_room() {
+        // Wide → richest: full labels, all four windows, four ↻ reset stamps.
+        let text = flatten(&build_live_widget_spans(&both_providers_live(), 1000));
+        assert!(text.contains("claude") && text.contains("codex"));
+        assert!(text.contains("5h ") && text.contains("wk "));
+        assert_eq!(
+            text.matches('↻').count(),
+            4,
+            "all four reset stamps: {text}"
+        );
+    }
+
+    #[test]
+    fn degrade_drops_dates_first() {
+        // 60 cols fits the no-dates form (~45) but not the dated one (~100+).
+        let text = flatten(&build_live_widget_spans(&both_providers_live(), 60));
+        assert!(text.contains("claude") && text.contains("codex"));
+        assert!(text.contains("40%") && text.contains("8%"));
+        assert!(text.contains("wk "), "weekly still shown: {text}");
+        assert!(!text.contains('↻'), "reset dates dropped first: {text}");
+    }
+
+    #[test]
+    fn degrade_abbreviates_then() {
+        // 30 cols fits the abbreviated `cl 40%/8%  cx 10%/44%` (~21) only.
+        let text = flatten(&build_live_widget_spans(&both_providers_live(), 30));
+        assert!(text.contains("cl ") && text.contains("cx "));
+        assert!(!text.contains("claude") && !text.contains("codex"));
+        assert!(
+            text.contains("40%") && text.contains("8%"),
+            "5h+wk kept: {text}"
+        );
+        assert!(text.contains('/'), "abbreviated 5h/wk: {text}");
+        assert!(!text.contains('↻'));
+    }
+
+    #[test]
+    fn degrade_tiny_keeps_both_providers() {
+        // 15 cols fits only `cl40% cx10%` (~12): 5h-only, both providers.
+        let text = flatten(&build_live_widget_spans(&both_providers_live(), 15));
+        assert!(text.contains("cl40%"), "claude 5h kept: {text}");
+        assert!(text.contains("cx10%"), "codex 5h kept: {text}");
+        assert!(!text.contains('/'), "weekly shed: {text}");
+        assert!(!text.contains("wk"));
+    }
+
+    #[test]
+    fn degrade_tiny_is_floor_even_if_overflowing() {
+        // Absurdly narrow → still return the Tiny floor (clipped), not blank.
+        let text = flatten(&build_live_widget_spans(&both_providers_live(), 1));
+        assert!(!text.is_empty(), "floor renders rather than blanking");
+        assert!(text.contains("cl40%"));
+    }
+
+    #[test]
+    fn degrade_empty_when_no_data() {
+        let text = flatten(&build_live_widget_spans(&LiveWindow::empty(), 1000));
+        assert!(text.is_empty(), "no data → nothing, regardless of width");
     }
 
     #[test]


### PR DESCRIPTION
## Slim the top status bar into a dedicated quota line + abbreviate-then-shed

### Problems (reported)
1. **Both providers vanished on narrow terminals.** The top bar packed workspace + branch + session-status + chat-toggle + the claude+codex quota into one line, then dropped the *entire* quota widget via an all-or-nothing width gate when it didn't fit. Neither provider was prioritized — both disappeared together.
2. **Duplicate info.** The top "Status" bar's workspace/branch/session-status duplicated the bottom "Session Info" line.

### Fix
- **Slim the top bar** to a dedicated full-width live-quota line (chat toggle + quota). The duplicated workspace/branch/status are removed — they already live in the bottom Session Info line.
- **Abbreviate-then-shed** instead of all-or-nothing: render the richest representation that fits the available columns —

  | level | example |
  |-------|---------|
  | FullDated | `claude 5h 81% ↻ Jun 15 17:45 · wk 24% ↻ Jun 20 15:45   codex 5h 14% ↻ … · wk 57% ↻ …` |
  | Full (drop dates) | `claude 5h 81% · wk 24%   codex 5h 14% · wk 57%` |
  | Abbrev | `cl 81%/24%   cx 14%/57%` |
  | Tiny | `cl81% cx14%` |

  Reset date/time is kept until space forces it out; **both providers stay visible** as long as possible (down to the Tiny floor, which renders clipped rather than blanking).

### Proof
- 6 width-level unit tests (`degrade_*`) assert each rung + the floor + the empty case; full lib suite **1064 passed, 0 failed**.
- Verified in a real TUI: wide → FullDated, 90 cols → Full (dates dropped, both providers shown).

UX direction chosen via interview (slim-top + abbreviate-then-shed). Follow-up to the merged Codex-quota feature (#277).
