### PR TITLE
feat(tui): live read-only mirror for tmux session preview

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -433,6 +433,15 @@ pub const SESSIONS_PREVIEW_RESERVE: u16 = 50;
 pub const COLLAPSED_SESSIONS_SIDEBAR_WIDTH: u16 = 5;
 pub const SESSIONS_ROW_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
 
+/// How long the selected tmux row must stay put before `sync_preview_embed`
+/// spawns its read-only live client. Stops arrow-spam from spawning a storm of
+/// `tmux attach` clients (each attach is a real subprocess + reflow). Public so
+/// tripwires can sleep exactly past it instead of guessing.
+pub const PREVIEW_EMBED_DEBOUNCE: Duration = Duration::from_millis(200);
+/// After a failed read-only attach (e.g. the session just died), wait this long
+/// before retrying the same name instead of hammering tmux every frame.
+const PREVIEW_EMBED_FAIL_BACKOFF: Duration = Duration::from_secs(5);
+
 impl AppState {
     /// Enter interactive mode: attach a live embed client to the selected
     /// session's tmux session and focus the preview pane. Returns false (no-op)
@@ -545,9 +554,14 @@ impl AppState {
         }
         let exited = self.embed.as_ref().is_some_and(|e| e.has_exited());
         let invisible = self.current_screen != screen_ids::SESSION_LIST;
+        // Only toast when the user was actively INTERACTING (armed). A
+        // read-only preview mirror exiting (the browsed session just died) is
+        // not worth a notification — the pane silently falls back to the
+        // capture/empty render. Captured before release flips focus.
+        let was_armed = self.is_interactive_pane();
         if exited || invisible {
             self.release_interactive_pane();
-            if exited {
+            if exited && was_armed {
                 self.add_info_notification("Live session ended — released".to_string());
             }
             return true;
@@ -561,6 +575,115 @@ impl AppState {
     /// otherwise hold the pane at the 250ms animation floor.
     pub fn embed_take_dirty(&self) -> bool {
         self.embed.as_ref().is_some_and(|e| e.take_dirty())
+    }
+
+    /// True whenever a live embed exists — the read-only preview mirror OR the
+    /// armed interactive pane. The render path uses this to pick the live
+    /// vt100 render over the lossy `capture-pane` string render.
+    pub fn has_preview_embed(&self) -> bool {
+        self.embed.is_some()
+    }
+
+    /// Disarm the interactive embed: stop forwarding input but KEEP the live
+    /// client so the pane stays a byte-exact READ-ONLY mirror. This is the
+    /// Ctrl+Q target now that the embed is eager — releasing it would just
+    /// flash the capture preview before `sync_preview_embed` respawned it.
+    /// No-op when not currently armed.
+    pub fn disarm_interactive_pane(&mut self) {
+        if self.focused_pane == FocusedPane::Preview {
+            self.focused_pane = FocusedPane::Sessions;
+        }
+    }
+
+    /// Attach a READ-ONLY live embed to the selected tmux session — input stays
+    /// off (`focused_pane` is left untouched, so it is NOT armed). Internal
+    /// helper for [`sync_preview_embed`]. Returns true if a client attached.
+    fn attach_preview_embed(&mut self, rows: u16, cols: u16) -> bool {
+        let Some(name) = self.selected_tmux_name() else {
+            return false;
+        };
+        match crate::tmux::EmbedClient::attach(&name, rows, cols) {
+            Ok(client) => {
+                self.embed = Some(client);
+                self.embed_session = Some(name);
+                self.preview_embed_failed = None;
+                true
+            }
+            Err(e) => {
+                tracing::warn!("read-only preview embed attach to {name} failed: {e}");
+                self.preview_embed_failed = Some((name, std::time::Instant::now()));
+                false
+            }
+        }
+    }
+
+    /// Keep a READ-ONLY live embed mirroring the SELECTED tmux session so the
+    /// preview is byte-exact to `tmux attach` (real status line + chrome, no
+    /// re-wrap). Called once before every paint.
+    ///
+    /// Invariants:
+    ///  - While armed (`is_interactive_pane`) the user owns the embed — never
+    ///    touch it.
+    ///  - Only mirror on the session-list screen; `poll_embed_exit` already
+    ///    releases embeds on other screens.
+    ///  - Selecting a different tmux row (or a non-tmux row) drops the stale
+    ///    client immediately, then a fresh one attaches only after the
+    ///    selection settles for [`PREVIEW_EMBED_DEBOUNCE`] — arrow-spam must
+    ///    not spawn a storm of `tmux attach` clients.
+    ///  - A failed attach backs off for [`PREVIEW_EMBED_FAIL_BACKOFF`] so a
+    ///    dead/unreachable session is not hammered every frame.
+    ///
+    /// Returns true when embed state changed (caller repaints).
+    pub fn sync_preview_embed(&mut self, rows: u16, cols: u16) -> bool {
+        // The armed interactive embed is user-owned; leave it entirely.
+        if self.is_interactive_pane() {
+            return false;
+        }
+        // Only mirror while the session list is on screen.
+        if self.current_screen != screen_ids::SESSION_LIST {
+            return false;
+        }
+
+        let want = self.selected_tmux_name();
+
+        // Already mirroring the right session — nothing to do.
+        if self.embed.is_some() && self.embed_session == want {
+            return false;
+        }
+
+        // Selection changed vs the pending target: restart the debounce window
+        // and drop any stale client now (don't show the wrong session live).
+        if self.preview_embed_target != want {
+            self.preview_embed_target = want.clone();
+            self.preview_embed_target_since = Some(std::time::Instant::now());
+            if self.embed.is_some() {
+                self.release_interactive_pane();
+                return true;
+            }
+            return false;
+        }
+
+        // Non-tmux selection: nothing to attach (capture / live-logs fallback
+        // renders instead).
+        let Some(name) = want else {
+            return false;
+        };
+
+        // Debounce: wait for the selection to settle.
+        if let Some(since) = self.preview_embed_target_since {
+            if since.elapsed() < PREVIEW_EMBED_DEBOUNCE {
+                return false;
+            }
+        }
+
+        // Failure back-off: don't re-spawn against a name that just failed.
+        if let Some((failed_name, at)) = &self.preview_embed_failed {
+            if *failed_name == name && at.elapsed() < PREVIEW_EMBED_FAIL_BACKOFF {
+                return false;
+            }
+        }
+
+        self.attach_preview_embed(rows, cols)
     }
 }
 
@@ -2613,6 +2736,15 @@ pub struct AppState {
     // mouse-coordinate translation into 1-based pane-local SGR sequences.
     // None whenever the embed is not rendering.
     pub embed_pane_area: Option<Rect>,
+    // Read-only preview-embed lifecycle. The embed is now created EAGERLY for
+    // the selected tmux row (input OFF) so the preview is a byte-exact mirror
+    // of `tmux attach`; `A` arms it (focused_pane=Preview), Ctrl+Q disarms back
+    // to read-only. These fields debounce (re)attach on rapid selection
+    // movement (`sync_preview_embed`) and back off after a failed attach so a
+    // dead/unreachable session is not hammered every frame.
+    pub preview_embed_target: Option<String>,
+    pub preview_embed_target_since: Option<Instant>,
+    pub preview_embed_failed: Option<(String, Instant)>,
     // Mouse/layout state for the Sessions split pane.
     pub sessions_pane_state: SessionsPaneState,
     // Track if current directory is a git repository
@@ -3127,6 +3259,52 @@ pub enum AsyncAction {
     OnboardingCheckDeps, // Run dependency check during onboarding
 }
 
+impl AsyncAction {
+    /// Does handling this action SUSPEND the TUI to run a full-screen program
+    /// in this terminal — a `tmux attach`, a workspace shell, or an editor?
+    ///
+    /// The eager read-only preview embed (`sync_preview_embed`) is a background
+    /// `tmux attach` client; before suspending we drop it so it doesn't fight
+    /// the foreground program for the session's window size or burn CPU parsing
+    /// output nobody sees. Exhaustive (no wildcard arm) so a NEW variant must
+    /// consciously classify itself, and biased to `true` when unsure: releasing
+    /// the embed is always safe (it respawns next frame), whereas SKIPPING a
+    /// release before a real suspend risks two clients fighting one session.
+    pub fn suspends_tui(&self) -> bool {
+        match self {
+            AsyncAction::AttachToContainer(_)
+            | AsyncAction::AttachToTmuxSession(_)
+            | AsyncAction::AttachToOtherTmux(_)
+            | AsyncAction::AttachWitr
+            | AsyncAction::AttachAbtop
+            | AsyncAction::SetupAbtopRateLimits
+            | AsyncAction::OpenWorkspaceShell { .. }
+            | AsyncAction::OpenShellAtPath(_)
+            | AsyncAction::OpenInEditor(_) => true,
+            AsyncAction::CreateSessionFromConfigure(_)
+            | AsyncAction::CheckGitAuth
+            | AsyncAction::DeleteSession(_)
+            | AsyncAction::StopSession(_)
+            | AsyncAction::ResumeSession(_, _)
+            | AsyncAction::BulkResumeSessions(_, _)
+            | AsyncAction::BulkDeleteSessions(_)
+            | AsyncAction::RefreshWorkspaces
+            | AsyncAction::FetchContainerLogs(_)
+            | AsyncAction::KillContainer(_)
+            | AsyncAction::AuthSetupOAuth
+            | AsyncAction::AuthSetupApiKey
+            | AsyncAction::ReauthenticateCredentials
+            | AsyncAction::RestartSession(_)
+            | AsyncAction::CleanupOrphaned
+            | AsyncAction::KillOtherTmux(_)
+            | AsyncAction::KillOtherTmuxSessions(_)
+            | AsyncAction::ConfirmOtherTmuxRename
+            | AsyncAction::KillWorkspaceShell(_)
+            | AsyncAction::OnboardingCheckDeps => false,
+        }
+    }
+}
+
 impl Default for AppState {
     fn default() -> Self {
         // Load persistent configuration
@@ -3164,6 +3342,9 @@ impl Default for AppState {
             embed: None,
             embed_session: None,
             embed_pane_area: None,
+            preview_embed_target: None,
+            preview_embed_target_since: None,
+            preview_embed_failed: None,
             sessions_pane_state,
             is_current_dir_git_repo: false,
             last_logs_session_id: None,
@@ -9440,12 +9621,12 @@ impl AppState {
 
             let is_selected = selected_session_id == Some(*session_id);
 
-            // While the interactive embed is live, the selected session's
-            // pane renders straight from the embed's vt100 screen — the full
-            // capture would be pure subprocess waste. Fall through to the
-            // cheap status-dot check instead (the collapsed rail still needs
-            // those for every session).
-            if is_selected && !self.is_interactive_pane() {
+            // While a live embed (read-only mirror OR armed interactive) is
+            // attached, the selected session's pane renders straight from the
+            // embed's vt100 screen — the full capture would be pure subprocess
+            // waste. Fall through to the cheap status-dot check instead (the
+            // collapsed rail still needs those for every session).
+            if is_selected && !self.has_preview_embed() {
                 // Selected session: capture last 200 lines (not full history)
                 // Full history can be megabytes for long-running sessions
                 let opts = CaptureOptions {

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -163,8 +163,24 @@ impl LayoutComponent {
             // 1-based pane-local SGR coordinates (see encode_mouse_event).
             state.embed_pane_area = Some(inner);
             self.tmux_preview.render_interactive(frame, area, state);
+        } else if state.has_preview_embed() {
+            // Read-only live mirror: a (non-armed) embed exists for the selected
+            // session, so the preview is byte-exact to `tmux attach` instead of
+            // the lossy capture render. Same resize/publish path as the armed
+            // branch; only the chrome and input-gating differ.
+            let area = content_chunks[1];
+            let inner = area.inner(Margin {
+                vertical: 1,
+                horizontal: 1,
+            });
+            if let Some(e) = state.embed.as_mut() {
+                let _ = e.resize(inner.height, inner.width);
+            }
+            state.embed_pane_area = Some(inner);
+            self.tmux_preview.render_live_readonly(frame, area, state);
         } else if selected_has_tmux {
-            // Render tmux preview pane (read-only capture)
+            // Read-only capture fallback (embed not yet attached / attach failed /
+            // settling during selection debounce).
             self.tmux_preview.render(frame, content_chunks[1], state);
         } else {
             // Render traditional live logs stream

--- a/ainb-tui/crates/ainb-core/src/components/tmux_preview.rs
+++ b/ainb-tui/crates/ainb-core/src/components/tmux_preview.rs
@@ -107,6 +107,62 @@ impl TmuxPreviewPane {
         }
     }
 
+    /// Render the live READ-ONLY embed mirror — the default preview for the
+    /// selected tmux session. Draws the same embedded vt100 screen as
+    /// [`Self::render_interactive`] (so the pane is byte-exact to `tmux attach`,
+    /// real status line + chrome, no re-wrap) but with non-interactive chrome:
+    /// keystrokes are NOT forwarded here, so the border/badge are calm
+    /// (cornflower, not the green INTERACTIVE cue) and the bottom title carries
+    /// the keys that act on it (`a` attach, `A` interact, `k` kill).
+    pub fn render_live_readonly(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        let name = state.embed_session.as_deref().unwrap_or("");
+        let title = Line::from(vec![
+            Span::styled(
+                " ● ",
+                Style::default().fg(CORNFLOWER_BLUE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "LIVE ",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!("{name} "), Style::default().fg(SOFT_WHITE)),
+        ]);
+        let hints = Line::from(vec![
+            Span::styled(" a", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" attach ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
+            Span::styled(
+                " A",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" interact ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("│", Style::default().fg(SUBDUED_BORDER)),
+            Span::styled(
+                " k",
+                Style::default().fg(Color::Rgb(230, 100, 100)).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" kill ", Style::default().fg(MUTED_GRAY)),
+        ]);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(CORNFLOWER_BLUE))
+            .style(Style::default().bg(DARK_BG))
+            .title(title)
+            .title_bottom(hints);
+
+        match state.embed.as_ref() {
+            Some(embed) => match embed.parser().read() {
+                Ok(g) => {
+                    let term = tui_term::widget::PseudoTerminal::new(g.screen()).block(block);
+                    frame.render_widget(term, area);
+                }
+                Err(_) => frame.render_widget(block, area),
+            },
+            None => frame.render_widget(block, area),
+        }
+    }
+
     /// Render the preview pane
     ///
     /// # Arguments

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -385,6 +385,25 @@ async fn run_tui_loop(
             needs_redraw = true;
         }
 
+        // Keep a READ-ONLY live embed mirroring the selected tmux session so the
+        // preview is byte-exact to `tmux attach` (real status line + chrome, no
+        // re-wrap) rather than the lossy capture render. Debounced + backed-off
+        // inside `sync_preview_embed`; (re)attaching changes the layout, so a
+        // state change is a repaint trigger. Sized to the exact interactive
+        // layout — the render path resizes each frame for terminal resizes.
+        {
+            let sz = terminal.size().unwrap_or(ratatui::layout::Size {
+                width: 80,
+                height: 24,
+            });
+            let sidebar = app.state.sessions_pane_state.effective_width(sz.width);
+            let (rows, cols) =
+                crate::components::layout::interactive_embed_size(sz.width, sz.height, sidebar);
+            if app.state.sync_preview_embed(rows, cols) {
+                needs_redraw = true;
+            }
+        }
+
         if needs_redraw {
             let draw_start = Instant::now();
             terminal.draw(|frame| {
@@ -433,18 +452,21 @@ async fn run_tui_loop(
 
                     use crossterm::event::KeyCode;
 
-                    // Interactive embed escape hatch: Ctrl+Q releases focus and
-                    // kills the ephemeral tmux client. Keyed off the RESOURCE
-                    // (embed exists), never the mode flag, so the hatch works
-                    // even from a leaked state where the embed is alive but
-                    // focus drifted off the preview pane.
+                    // Interactive embed escape hatch: Ctrl+Q DISARMS the embed
+                    // back to the read-only live mirror (it does NOT tear the
+                    // client down — the embed is eager now, so a release would
+                    // just flash the capture preview before sync_preview_embed
+                    // respawned it). Still keyed off the RESOURCE (embed exists)
+                    // so Ctrl+Q is always swallowed while a live client is
+                    // present and never leaks to the quit handler; the action is
+                    // a no-op when the embed is already read-only (not armed).
                     {
                         use crossterm::event::KeyModifiers;
                         if app.state.embed.is_some()
                             && key_event.code == KeyCode::Char('q')
                             && key_event.modifiers.contains(KeyModifiers::CONTROL)
                         {
-                            app.state.release_interactive_pane();
+                            app.state.disarm_interactive_pane();
                             continue;
                         }
                     }
@@ -916,6 +938,17 @@ async fn run_tui_loop(
             if let Some(action) = app.state.pending_async_action.take() {
                 use crate::app::state::AsyncAction;
                 use tracing::{debug, error, info, warn};
+
+                // Actions that suspend the TUI to run a full-screen program
+                // (a `tmux attach`, a shell, an editor) must drop the eager
+                // read-only preview embed first so its background `tmux attach`
+                // client doesn't fight the foreground program for the session's
+                // window size (or burn CPU parsing output nobody sees).
+                // `sync_preview_embed` respawns it on return. Non-suspending
+                // actions leave the mirror untouched (no needless churn).
+                if action.suspends_tui() && app.state.has_preview_embed() {
+                    app.state.release_interactive_pane();
+                }
 
                 match action {
                     AsyncAction::AttachToOtherTmux(session_name) => {

--- a/ainb-tui/crates/ainb-core/tests/tripwire_interactive_pane.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_interactive_pane.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use ainb::app::events::{AppEvent, EventHandler};
-use ainb::app::state::{AppState, FocusedPane};
+use ainb::app::state::{AppState, FocusedPane, PREVIEW_EMBED_DEBOUNCE};
 use ainb::components::{LayoutComponent, TmuxPreviewPane};
 use ainb::models::OtherTmuxSession;
 use ainb::tmux::{encode_key_event, encode_mouse_event};
@@ -398,4 +398,244 @@ fn mode_boundary_holds_for_mouse_and_palette_keys_until_release() {
         host_mouse_back,
         "after release, a preview click must move focus to LiveLogs again"
     );
+}
+
+/// Helper: drive `sync_preview_embed` past its debounce so a READ-ONLY embed
+/// attaches for the current selection. The first sync arms the debounce window;
+/// the second (after it elapses) does the attach.
+fn settle_readonly_embed(state: &mut AppState, rows: u16, cols: u16) {
+    let _ = state.sync_preview_embed(rows, cols);
+    std::thread::sleep(PREVIEW_EMBED_DEBOUNCE + Duration::from_millis(60));
+    assert!(
+        state.sync_preview_embed(rows, cols),
+        "read-only preview embed should attach after the debounce window"
+    );
+}
+
+/// Capstone for the EAGER read-only live preview (goal: exact-tmux-attach-preview).
+/// Selecting a tmux row spins a READ-ONLY live mirror (byte-exact `tmux attach`,
+/// not the lossy capture): it streams the session's live output, renders the LIVE
+/// (not INTERACTIVE) badge, `A` ARMS the SAME client in place, and Ctrl+Q's
+/// `disarm_interactive_pane` returns to the read-only mirror WITHOUT tearing the
+/// client down — the session survives throughout.
+#[test]
+fn readonly_live_mirror_streams_then_arms_and_disarms_keeping_session() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux unavailable");
+        return;
+    }
+    let session = new_session("ro-mirror");
+
+    let mut state = AppState::new();
+    state.current_screen = "session_list".to_string();
+    state.other_tmux_sessions = vec![OtherTmuxSession::new(session.clone(), false, 1)];
+    state.selected_other_tmux_index = Some(0);
+
+    // ── eager attach: selecting the row spins a read-only (NOT armed) embed ──
+    settle_readonly_embed(&mut state, 26, 100);
+    let has_embed = state.has_preview_embed();
+    let read_only = !state.is_interactive_pane();
+    let mirrors_session = state.embed_session.as_deref() == Some(session.as_str());
+
+    let pane = TmuxPreviewPane::new();
+    let mut term = Terminal::new(TestBackend::new(100, 26)).expect("test terminal");
+
+    // ── live proof: output injected into the SESSION must stream into the
+    //    read-only mirror (a capture render could not show a post-attach line) ──
+    let marker = format!("RO_LIVE_{}", std::process::id());
+    let pre_frame = {
+        term.draw(|f| pane.render_live_readonly(f, f.area(), &state)).expect("draw");
+        buffer_text(&term)
+    };
+    assert!(
+        !pre_frame.contains(&marker),
+        "negative placeholder: marker must not pre-exist:\n{pre_frame}"
+    );
+    let _ = Command::new("tmux")
+        .args([
+            "send-keys",
+            "-t",
+            &session,
+            &format!("printf '{marker}\\n'"),
+            "Enter",
+        ])
+        .status();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut streamed = false;
+    let mut live_frame = String::new();
+    while Instant::now() < deadline {
+        term.draw(|f| pane.render_live_readonly(f, f.area(), &state)).expect("draw");
+        live_frame = buffer_text(&term);
+        if live_frame.contains(&marker) {
+            streamed = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let shows_live_badge = live_frame.contains("LIVE") && !live_frame.contains("INTERACTIVE");
+
+    // ── A arms the SAME client in place (read-only -> interactive) ──
+    let session_before_arm = state.embed_session.clone();
+    let armed = state.enter_interactive_pane(26, 100);
+    let armed_same_client = state.embed_session == session_before_arm;
+    term.draw(|f| pane.render_interactive(f, f.area(), &state)).expect("draw");
+    let interactive_badge = buffer_text(&term).contains("INTERACTIVE");
+
+    // ── Ctrl+Q -> disarm: back to read-only mirror, client KEPT ──
+    state.disarm_interactive_pane();
+    let back_to_readonly = !state.is_interactive_pane() && state.has_preview_embed();
+    term.draw(|f| pane.render_live_readonly(f, f.area(), &state)).expect("draw");
+    let live_badge_again = buffer_text(&term).contains("LIVE");
+
+    let alive_before_release = session_alive(&session);
+    state.release_interactive_pane();
+    let alive_after_release = session_alive(&session);
+    kill_session(&session);
+
+    assert!(
+        has_embed,
+        "selecting a tmux row must spin a read-only embed"
+    );
+    assert!(
+        read_only,
+        "eager preview embed must NOT be armed (read-only)"
+    );
+    assert!(mirrors_session, "embed must mirror the selected session");
+    assert!(
+        streamed,
+        "read-only mirror never streamed live session output:\n{live_frame}"
+    );
+    assert!(
+        shows_live_badge,
+        "read-only mirror must show LIVE (not INTERACTIVE):\n{live_frame}"
+    );
+    assert!(armed, "A must arm the existing read-only embed");
+    assert!(
+        armed_same_client,
+        "A must arm in place, not re-attach a new client"
+    );
+    assert!(
+        interactive_badge,
+        "armed pane must show the INTERACTIVE badge"
+    );
+    assert!(
+        back_to_readonly,
+        "Ctrl+Q must disarm to a kept read-only embed, not release it"
+    );
+    assert!(
+        live_badge_again,
+        "after disarm the pane must render the read-only LIVE mirror again"
+    );
+    assert!(
+        alive_before_release,
+        "session must be alive while previewed"
+    );
+    assert!(
+        alive_after_release,
+        "releasing the embed must NOT kill the session"
+    );
+}
+
+/// Moving the selection to a DIFFERENT tmux row tears down the old read-only
+/// client immediately (so the wrong session is never shown live), then attaches
+/// a fresh one for the new selection after the debounce — and BOTH sessions
+/// survive (teardown kills the ephemeral client, never the session).
+#[test]
+fn selection_change_tears_down_readonly_embed_and_both_sessions_survive() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux unavailable");
+        return;
+    }
+    let first = new_session("ro-sel-a");
+    let second = new_session("ro-sel-b");
+
+    let mut state = AppState::new();
+    state.current_screen = "session_list".to_string();
+    state.other_tmux_sessions = vec![
+        OtherTmuxSession::new(first.clone(), false, 1),
+        OtherTmuxSession::new(second.clone(), false, 1),
+    ];
+    state.selected_other_tmux_index = Some(0);
+
+    settle_readonly_embed(&mut state, 26, 100);
+    let first_target = state.embed_session.clone();
+
+    // Move selection to the second row. The first sync detects the change and
+    // drops the stale client immediately (returns true = layout changed).
+    state.selected_other_tmux_index = Some(1);
+    let changed = state.sync_preview_embed(26, 100);
+    let torn_down_immediately = !state.has_preview_embed();
+
+    // After the debounce, a fresh read-only embed attaches for the second row.
+    std::thread::sleep(PREVIEW_EMBED_DEBOUNCE + Duration::from_millis(60));
+    let reattached = state.sync_preview_embed(26, 100);
+    let second_target = state.embed_session.clone();
+
+    state.release_interactive_pane();
+    let both_alive = session_alive(&first) && session_alive(&second);
+    kill_session(&first);
+    kill_session(&second);
+
+    assert_eq!(
+        first_target.as_deref(),
+        Some(first.as_str()),
+        "first mirror"
+    );
+    assert!(changed, "selection change must report a layout change");
+    assert!(
+        torn_down_immediately,
+        "stale read-only client must drop on selection change"
+    );
+    assert!(
+        reattached,
+        "a fresh read-only embed must attach for the new selection"
+    );
+    assert_eq!(
+        second_target.as_deref(),
+        Some(second.as_str()),
+        "re-targeted mirror"
+    );
+    assert!(
+        both_alive,
+        "selection-change teardown must NOT kill either session"
+    );
+}
+
+/// Additive invariant: while the preview embed is READ-ONLY (not armed), host
+/// input is unchanged — a preview-pane click is handled by the host (moves
+/// focus) exactly as it would WITHOUT an embed, NOT swallowed the way the armed
+/// interactive pane swallows it. Proves the eager mirror doesn't regress mouse.
+#[test]
+fn readonly_preview_does_not_swallow_host_mouse() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux unavailable");
+        return;
+    }
+    let session = new_session("ro-mouse");
+    let mut state = AppState::new();
+    state.current_screen = "session_list".to_string();
+    state.other_tmux_sessions = vec![OtherTmuxSession::new(session.clone(), false, 1)];
+    state.selected_other_tmux_index = Some(0);
+    state.sessions_pane_state.restore(Some(40), false);
+
+    settle_readonly_embed(&mut state, 28, 80);
+    let read_only = !state.is_interactive_pane() && state.has_preview_embed();
+
+    // Lay out the normal split (read-only branch), then click the preview pane.
+    let mut layout = LayoutComponent::new();
+    let mut term = Terminal::new(TestBackend::new(120, 30)).expect("test terminal");
+    term.draw(|f| layout.render(f, &mut state)).expect("draw");
+    let _ = EventHandler::handle_mouse_event(AppEvent::MouseClick { x: 80, y: 10 }, &mut state);
+    let host_handled_mouse = state.focused_pane == FocusedPane::LiveLogs;
+
+    state.release_interactive_pane();
+    let alive = session_alive(&session);
+    kill_session(&session);
+
+    assert!(read_only, "embed must be read-only for this invariant");
+    assert!(
+        host_handled_mouse,
+        "a read-only preview must NOT swallow the mouse — host focus handling must still run"
+    );
+    assert!(alive, "session survives");
 }


### PR DESCRIPTION
## What

The selected tmux session's preview now renders a **live, read-only mirror of `tmux attach`** — real status line, chrome, and REPL exactly as an attach shows them — instead of the lossy `capture-pane` string render (which joins wrapped lines, drops the tmux status bar, and re-wraps a second time under ratatui).

Closes the gap in [discussion #278](https://github.com/stevengonsalvez/agents-in-a-box/discussions/278).

```
Before:  capture-pane -e -J  -> ansi_to_tui -> Paragraph(Wrap)   (no statusline, re-wrapped)
After:   tmux attach (PTY)   -> vt100       -> PseudoTerminal     (byte-exact, statusline + chrome)
```

It **reuses the existing `EmbedClient`** (the in-PTY `tmux attach` + vt100 + tui-term that already powered the interactive `A` pane). An eager, debounced **read-only** client is attached for the selected row; `A` arms it in place (forwards input → `INTERACTIVE` badge), `Ctrl+Q` disarms back to the read-only mirror **without** tearing the client down.

## Locked design (via /interview)

| Axis | Decision |
|---|---|
| Engine | Live **read-only** embed (input OFF) → byte-exact attach view + real statusline |
| Activation | **Default** preview for the selected tmux row (eager, 200 ms debounce). No new key |
| Resize | **Accept** tmux default (window may resize to the pane while previewed, reverts on detach) |
| Interaction | **Strictly read-only**; input stays on the unchanged `a` / `A` / `Ctrl+Q` |

## Additive invariant (hard requirement)

No existing TUI behaviour changes: **sidebar / main-width resize, mouse, and the `a` / `A` / `Ctrl+Q` / `B` / `k` / `u` keys all keep working.** Input forwarding stays gated on the armed (Preview-focus) state, so the read-only mirror never swallows host input. New `AsyncAction::suspends_tui()` (exhaustive) drops the mirror before a full-screen attach/shell/editor so two clients never fight one session's window size. Teardown kills only the ephemeral client — never the session/server.

## Proof — `tests/tripwire_interactive_pane.rs` (7/7 pass, real tmux)

Three new tripwires drive the **real render path** against a **real tmux session** and assert on the rendered ratatui buffer (user-visible output):

- `readonly_live_mirror_streams_then_arms_and_disarms_keeping_session` — output injected into the session **streams live** into the read-only render (a capture could not show a post-attach line); shows `LIVE` (not `INTERACTIVE`); `A` arms the **same** client in place; `Ctrl+Q` disarms back to the read-only mirror; session alive throughout.
- `selection_change_tears_down_readonly_embed_and_both_sessions_survive` — moving the selection drops the stale client immediately and re-targets after the debounce; both sessions survive.
- `readonly_preview_does_not_swallow_host_mouse` — a preview click still moves host focus (mouse not swallowed) — the additive invariant.

```
test result: ok. 7 passed; 0 failed; finished in 16.66s
```

`cargo check` (lib+bin) clean; scoped clippy clean on all touched files (the crate-wide clippy debt and the stale `NewSessionState` test files are pre-existing, unrelated).

## Review

`code-reviewer`: **SHIP** — invariant holds, no leak/storm/race, tmux-safe. Its two actionable LOW findings (release-on-every-async-action waste → exhaustive `suspends_tui()`; toast spam on read-only exit → gated to armed-only) are applied in this PR.

## Files

- `src/app/state.rs` — lifecycle fields + `sync_preview_embed` / `attach_preview_embed` / `disarm_interactive_pane` / `has_preview_embed`, `AsyncAction::suspends_tui`, capture-skip + toast gating.
- `src/components/tmux_preview.rs` — `render_live_readonly`.
- `src/components/layout.rs` — read-only render branch.
- `src/main.rs` — pre-draw `sync_preview_embed`, `Ctrl+Q` disarm, release-before-suspend.
- `tests/tripwire_interactive_pane.rs` — 3 new tripwires.