### PR TITLE
feat: unified Daemons observability surface (TUI screen + `ainb fleet daemons`)

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -91,6 +91,12 @@ clap = { version = "4.4", features = ["derive"] }
 clap_complete = "4.4"
 tempfile = "3.8"
 nix = { version = "0.27", features = ["user", "signal"] }
+# Process-identity cross-check for the Daemons liveness probe: a bare
+# `kill(pid,0)` can't tell a live daemon from a recycled pid, so we read the
+# live process's real start time and match it against the heartbeat's
+# `started_at`. Portable across macOS (kinfo_proc) and Linux (/proc/<pid>/stat);
+# `system` feature only (no disk/network/component collectors).
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 arboard = "3.3"
 keyring = { version = "3", features = ["apple-native", "linux-native"] }
 regex = "1.10"

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -71,6 +71,8 @@ tempfile = { workspace = true }
 # (blake3, for exactly-once turn fingerprints, is already a dependency below.)
 fs2 = { workspace = true }
 nix = { workspace = true }
+# Process-identity cross-check in the Daemons liveness probe (see workspace dep).
+sysinfo = { workspace = true }
 arboard = { workspace = true }
 keyring = { workspace = true }
 regex = { workspace = true }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -217,6 +217,7 @@ pub enum AppEvent {
     GoToSkills,              // Navigate to skills view
     GoToRecovery,            // Navigate to session recovery view
     GoToInbox,               // Navigate to ainb-hooks notification inbox
+    GoToDaemons,             // Navigate to the daemon runtime-health view
     PanelBack,               // Close a panel screen: pop previous_screen (home if none)
     GoToHangar,              // Navigate to the Hangar control plane (plugin screen)
     InboxMoveUp,             // Inbox: move selection up one row
@@ -2093,6 +2094,7 @@ impl EventHandler {
         match key_event.code {
             KeyCode::Char('a') => return Some(AppEvent::GoToAgentSelection),
             KeyCode::Char('b') => return Some(AppEvent::GoToInbox),
+            KeyCode::Char('d') => return Some(AppEvent::GoToDaemons),
             KeyCode::Char('c') => return Some(AppEvent::GoToCatalog),
             KeyCode::Char('C') => return Some(AppEvent::GoToConfig),
             KeyCode::Char('s') => return Some(AppEvent::GoToSessionList),
@@ -3533,6 +3535,10 @@ impl EventHandler {
                         // exactly one code path.
                         Self::process_event(AppEvent::GoToInbox, state);
                     }
+                    SidebarItem::Daemons => {
+                        // Same canonical-event routing as Inbox.
+                        Self::process_event(AppEvent::GoToDaemons, state);
+                    }
                     SidebarItem::Recovery => {
                         state.session_recovery_state.refresh();
                         state.current_screen = screen_ids::SESSION_RECOVERY.to_string();
@@ -3816,6 +3822,14 @@ impl EventHandler {
                 }
                 state.current_screen = screen_ids::INBOX.to_string();
                 state.inbox_state.refresh();
+            }
+            AppEvent::GoToDaemons => {
+                tracing::info!("Navigating to Daemons");
+                if state.current_screen != screen_ids::DAEMONS {
+                    state.previous_screen = Some(state.current_screen.clone());
+                }
+                state.current_screen = screen_ids::DAEMONS.to_string();
+                state.daemons_state.refresh();
             }
             AppEvent::GoToHangar => {
                 tracing::info!("Navigating to Hangar");

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1050,6 +1050,14 @@ impl EventHandler {
             return Self::handle_inbox_keys(key_event, state);
         }
 
+        // Daemons observability screen (read-only). Esc/q must pop back to the
+        // origin `GoToDaemons` saved in `previous_screen`, NOT hardcode home —
+        // the generic fallthrough below treats this non-plugin screen as
+        // GoToHomeScreen, which ignored the saved origin (L2).
+        if state.current_screen == screen_ids::DAEMONS {
+            return Self::handle_daemons_keys(key_event, state);
+        }
+
         // AINB 2.0: Handle agent selection view
         if state.current_screen == screen_ids::AGENT_SELECTION {
             return Self::handle_agent_selection_keys(key_event, state);
@@ -2077,6 +2085,20 @@ impl EventHandler {
             KeyCode::Char('a') => Some(AppEvent::InboxToggleArchived),
             KeyCode::Char('p') => Some(AppEvent::InboxCycleAgent),
             KeyCode::Char('r') => Some(AppEvent::InboxRefresh),
+            _ => None,
+        }
+    }
+
+    /// Daemons observability screen key dispatcher. The screen is read-only
+    /// (no list navigation), so the only binding is back:
+    ///
+    ///   - q / Esc   back to the screen it was opened from (home if none)
+    ///
+    /// Routed through `PanelBack` so it pops the `previous_screen` that
+    /// `GoToDaemons` saved, instead of hardcoding home (L2).
+    fn handle_daemons_keys(key_event: KeyEvent, _state: &mut AppState) -> Option<AppEvent> {
+        match key_event.code {
+            KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::PanelBack),
             _ => None,
         }
     }
@@ -5446,6 +5468,51 @@ mod panel_back_tests {
             ids::HOME,
             "Hangar must not pop the stale session_list origin"
         );
+    }
+
+    /// L2 regression: the Daemons screen is read-only and NOT a plugin screen,
+    /// so before the fix its Esc fell through the generic handler to
+    /// `GoToHomeScreen` — discarding the `previous_screen` that `GoToDaemons`
+    /// saved. Drive the real Esc key through the dispatcher and assert it routes
+    /// to `PanelBack` and returns to the origin, not home.
+    #[test]
+    fn daemons_esc_routes_through_panel_back_to_origin() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let mut state = AppState::default();
+        state.current_screen = ids::SESSION_LIST.to_string();
+
+        EventHandler::process_event(AppEvent::GoToDaemons, &mut state);
+        assert_eq!(state.current_screen, ids::DAEMONS);
+        assert_eq!(state.previous_screen.as_deref(), Some(ids::SESSION_LIST));
+
+        // The key dispatcher must turn Esc on the Daemons screen into PanelBack
+        // (the pre-fix bug produced GoToHomeScreen, ignoring the saved origin).
+        let event = EventHandler::handle_key_event(KeyEvent::from(KeyCode::Esc), &mut state);
+        assert!(
+            matches!(event, Some(AppEvent::PanelBack)),
+            "Daemons Esc must resolve to PanelBack, not GoToHomeScreen; got {event:?}"
+        );
+
+        EventHandler::process_event(AppEvent::PanelBack, &mut state);
+        assert_eq!(
+            state.current_screen,
+            ids::SESSION_LIST,
+            "Daemons must pop back to the screen it was opened from"
+        );
+    }
+
+    /// `q` on the Daemons screen behaves identically to Esc.
+    #[test]
+    fn daemons_q_routes_through_panel_back() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let mut state = AppState::default();
+        state.current_screen = ids::HOME.to_string();
+        EventHandler::process_event(AppEvent::GoToDaemons, &mut state);
+
+        let event = EventHandler::handle_key_event(KeyEvent::from(KeyCode::Char('q')), &mut state);
+        assert!(matches!(event, Some(AppEvent::PanelBack)), "got {event:?}");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -622,6 +622,23 @@ impl Screen for InboxScreen {
     }
 }
 
+/// Daemons screen — read-only runtime health of every long-running ainb daemon
+/// (phone bridge / notifyd / ATC / fleet daemon). Renders from
+/// `fleet::daemons::collect` via the shared component, refreshing live on the
+/// render tick. State lives on `AppState::daemons_state` so the cached snapshot
+/// survives cross-screen navigation.
+#[derive(Default)]
+pub struct DaemonsScreen;
+
+impl Screen for DaemonsScreen {
+    fn id(&self) -> &str {
+        ids::DAEMONS
+    }
+    fn render(&mut self, frame: &mut Frame, area: Rect, state: &mut AppState) {
+        crate::components::daemons::render(frame, area, &mut state.daemons_state);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Stateful screens — own their component instance
 // ---------------------------------------------------------------------------
@@ -912,6 +929,7 @@ pub fn register_builtins(registry: &mut ScreenRegistry) {
     registry.register(Box::new(AuthSetupScreen::new()));
     registry.register(Box::new(AttachedTerminalScreen::new()));
     registry.register(Box::new(InboxScreen));
+    registry.register(Box::new(DaemonsScreen));
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-core/src/app/screens/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/mod.rs
@@ -55,6 +55,9 @@ pub mod ids {
     /// Hangar managed-agents control plane — a plugin-owned screen rendered by
     /// the `hangar-tui` subprocess plugin (P4.10). Reached from home with `g`.
     pub const HANGAR: &str = "hangar";
+    /// Daemons observability screen — read-only runtime health of the phone
+    /// bridge / notifyd / ATC / fleet daemon. Reached from home with `d`.
+    pub const DAEMONS: &str = "daemons";
 }
 
 /// Outcome of a screen-handled event.

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2718,6 +2718,9 @@ pub struct AppState {
     /// filters, in-process SQLite store handle).
     pub inbox_state: crate::components::inbox::InboxState,
 
+    /// Daemons screen state (cached runtime-health snapshot + poll tick).
+    pub daemons_state: crate::components::daemons::DaemonsState,
+
     /// WireBuffers freshly drained from plugins, keyed by screen id.
     /// `App::tick_plugin_renders` populates this before each frame so
     /// `PluginScreen::render` can paint without needing access to the
@@ -3235,6 +3238,9 @@ impl Default for AppState {
 
             // ainb-hooks inbox (lazy-opens SQLite on first refresh)
             inbox_state: crate::components::inbox::InboxState::default(),
+
+            // Daemons observability (collects health on first/periodic render)
+            daemons_state: crate::components::daemons::DaemonsState::default(),
 
             pending_plugin_renders: std::collections::HashMap::new(),
             favorite_workspace_paths: HashSet::new(),

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 use anyhow::Result;
 
 use crate::cli::OutputFormat;
+use crate::fleet::daemons::DaemonHeartbeat;
+use crate::fleet::daemons::probe::DaemonKind;
 use crate::fleet::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
 use crate::fleet::read::{capture_pane, detect_error_signals};
 use crate::fleet::send::{broker_health, send};
@@ -16,7 +18,24 @@ const SCAN_INTERVAL_SECS: u64 = 5;
 pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
     let verbose = matches.get_flag("verbose");
 
-    if broker_health().await {
+    // Heartbeat: the fleet daemon had no observability either. Record a startup
+    // record and refresh it every scan so the Daemons surface can show it
+    // running + (when the broker is reachable) connected. The peer-registration
+    // ("connected") signal is the broker health probe — the closest signal we
+    // have until real `ainb-fleet-cp` registration lands.
+    let mut heartbeat = DaemonHeartbeat::starting();
+    let broker_up = broker_health().await;
+    heartbeat.set_connected(
+        broker_up,
+        Some(if broker_up {
+            "broker 127.0.0.1:7899".to_string()
+        } else {
+            "tmux-only (broker down)".to_string()
+        }),
+    );
+    write_heartbeat(&heartbeat);
+
+    if broker_up {
         // Phase 5 will wire actual broker_register/heartbeat for `ainb-fleet-cp`.
         eprintln!("[fleet/daemon] broker healthy at 127.0.0.1:7899");
     } else {
@@ -25,18 +44,42 @@ pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Resul
 
     let mut seen = HashSet::new();
     loop {
-        if let Err(e) = tick(&mut seen, verbose).await {
-            eprintln!("[fleet/daemon] tick failed: {e}");
+        match tick(&mut seen, verbose).await {
+            // `acted` is true when the scan auto-continued at least one session
+            // this tick — a real unit of work worth recording as activity.
+            Ok(acted) => {
+                if acted {
+                    heartbeat.record_activity();
+                } else {
+                    heartbeat.touch();
+                }
+            }
+            Err(e) => {
+                eprintln!("[fleet/daemon] tick failed: {e}");
+                heartbeat.record_error(e.to_string());
+            }
         }
+        write_heartbeat(&heartbeat);
         tokio::time::sleep(Duration::from_secs(SCAN_INTERVAL_SECS)).await;
     }
 }
 
-async fn tick(seen: &mut HashSet<String>, verbose: bool) -> Result<()> {
+/// Best-effort heartbeat write — a failure is logged and swallowed so a transient
+/// FS error never takes the watcher down.
+fn write_heartbeat(heartbeat: &DaemonHeartbeat) {
+    if let Err(e) = heartbeat.write(DaemonKind::FleetDaemon.id()) {
+        eprintln!("[fleet/daemon] heartbeat write failed (continuing): {e}");
+    }
+}
+
+/// Run one scan. Returns `true` when at least one session was auto-continued
+/// this tick (a real unit of work), `false` when the scan found nothing to do.
+async fn tick(seen: &mut HashSet<String>, verbose: bool) -> Result<bool> {
     let (ainb, peers) = tokio::join!(discover_from_ainb(), async { discover_from_peers() });
     let merged = merge_sessions(vec![ainb.unwrap_or_default(), peers.unwrap_or_default()]);
 
     let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut acted = false;
     for s in merged {
         let Some(name) = s.tmux_session.as_deref() else {
             continue;
@@ -59,6 +102,7 @@ async fn tick(seen: &mut HashSet<String>, verbose: bool) -> Result<()> {
             eprintln!("[fleet/daemon] auto-continue -> {name} ({pattern})");
         }
         let _ = send(&s, "continue").await;
+        acted = true;
     }
-    Ok(())
+    Ok(acted)
 }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemons.rs
@@ -1,0 +1,190 @@
+// ABOUTME: `ainb fleet daemons [--format text|json]` — the unified daemon health view.
+//
+// Renders the typed `Vec<DaemonStatus>` from `fleet::daemons::collect` — the
+// SAME aggregator the TUI Daemons screen uses, so the two surfaces can never
+// drift. Text output is a fixed-width table (one row per daemon); `--format
+// json` emits the typed rows verbatim for scripting.
+//
+// This is the runtime-health answer the bridge's install-only status could
+// never give: a running, Telegram-connected bridge shows "running + connected"
+// while a crashed one shows "stopped" with a stale-heartbeat reason.
+
+use anyhow::Result;
+
+use crate::cli::OutputFormat;
+use crate::fleet::daemons::{DaemonState, DaemonStatus, collect};
+
+pub async fn execute(_matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    let rows = collect()?;
+    let now_ms = crate::fleet::daemons::heartbeat::now_ms();
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&rows)?);
+        }
+        _ => {
+            print!("{}", render_text(&rows, now_ms));
+        }
+    }
+    Ok(())
+}
+
+/// Render the daemon rows as a fixed-width text table. `now_ms` is the clock the
+/// relative-time columns (uptime / last-activity) are measured against — passed
+/// in so the rendering is deterministic under test.
+#[must_use]
+pub fn render_text(rows: &[DaemonStatus], now_ms: i64) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<14} {:<9} {:<8} {:<10} {:<12} {:<7} {}\n",
+        "DAEMON", "STATE", "PID", "UPTIME", "LAST ACTIVITY", "ERRORS", "HEALTH"
+    ));
+    out.push_str(&format!("{}\n", "-".repeat(86)));
+    for r in rows {
+        let state = state_glyph(r.state);
+        let pid = r.pid.map_or_else(|| "-".to_string(), |p| p.to_string());
+        let uptime = r.uptime_ms.map_or_else(|| "-".to_string(), fmt_duration_ms);
+        let last_activity =
+            r.last_activity_at.map_or_else(|| "-".to_string(), |ts| fmt_ago(now_ms, ts));
+        let health = health_summary(r);
+        out.push_str(&format!(
+            "{:<14} {:<9} {:<8} {:<10} {:<12} {:<7} {}\n",
+            r.kind.display_name(),
+            state,
+            pid,
+            uptime,
+            last_activity,
+            r.error_count,
+            health,
+        ));
+    }
+    out
+}
+
+/// A glyphed state token for the text table.
+fn state_glyph(state: DaemonState) -> String {
+    match state {
+        DaemonState::Running => "● running".to_string(),
+        DaemonState::Stopped => "○ stopped".to_string(),
+        DaemonState::Unknown => "? unknown".to_string(),
+    }
+}
+
+/// The HEALTH column: connection label + the reason. For a running+connected
+/// daemon this is the channel; otherwise it's the reason (e.g. the stale-
+/// heartbeat explanation) so a crash is legible at a glance.
+fn health_summary(r: &DaemonStatus) -> String {
+    match (r.state, &r.channel) {
+        (DaemonState::Running, Some(ch)) if r.connected => format!("{ch} — {}", r.reason),
+        (DaemonState::Running, _) => r.reason.clone(),
+        _ => r.reason.clone(),
+    }
+}
+
+/// Format an elapsed-millis duration compactly: `5s`, `12m`, `3h`, `2d`.
+#[must_use]
+pub fn fmt_duration_ms(ms: i64) -> String {
+    let secs = ms.max(0) / 1000;
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h", secs / 3600)
+    } else {
+        format!("{}d", secs / 86_400)
+    }
+}
+
+/// Format `ts` (epoch ms) relative to `now_ms`: `5s ago`, `12m ago`, `just now`.
+#[must_use]
+pub fn fmt_ago(now_ms: i64, ts_ms: i64) -> String {
+    let delta = now_ms.saturating_sub(ts_ms);
+    if delta < 1000 {
+        return "just now".to_string();
+    }
+    format!("{} ago", fmt_duration_ms(delta))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet::daemons::probe::DaemonKind;
+
+    fn row(
+        kind: DaemonKind,
+        state: DaemonState,
+        connected: bool,
+        channel: Option<&str>,
+    ) -> DaemonStatus {
+        DaemonStatus {
+            kind,
+            state,
+            pid: Some(4242),
+            uptime_ms: Some(125_000),
+            connected,
+            channel: channel.map(str::to_string),
+            last_activity_at: Some(0),
+            error_count: 0,
+            last_error: None,
+            reason: "running + connected".to_string(),
+        }
+    }
+
+    #[test]
+    fn fmt_duration_buckets() {
+        assert_eq!(fmt_duration_ms(5_000), "5s");
+        assert_eq!(fmt_duration_ms(125_000), "2m");
+        assert_eq!(fmt_duration_ms(7_200_000), "2h");
+        assert_eq!(fmt_duration_ms(172_800_000), "2d");
+        assert_eq!(fmt_duration_ms(-5), "0s");
+    }
+
+    #[test]
+    fn fmt_ago_handles_just_now_and_past() {
+        assert_eq!(fmt_ago(1_000_000, 1_000_000), "just now");
+        assert_eq!(fmt_ago(1_000_000, 1_000_000 - 5_000), "5s ago");
+        assert_eq!(fmt_ago(1_000_000, 1_000_000 - 120_000), "2m ago");
+    }
+
+    #[test]
+    fn render_text_has_header_and_one_row_per_daemon() {
+        let now = 1_000_000;
+        let rows = vec![
+            row(
+                DaemonKind::Bridge,
+                DaemonState::Running,
+                true,
+                Some("Telegram (@bot)"),
+            ),
+            row(DaemonKind::Notifyd, DaemonState::Stopped, false, None),
+        ];
+        let txt = render_text(&rows, now);
+        assert!(txt.contains("DAEMON"));
+        assert!(txt.contains("STATE"));
+        assert!(txt.contains("phone bridge"));
+        assert!(txt.contains("notifyd"));
+        // Running shows the channel; the row carries the running glyph.
+        assert!(txt.contains("Telegram (@bot)"));
+        assert!(txt.contains("● running"));
+        assert!(txt.contains("○ stopped"));
+        // Exactly header(2 lines) + 2 data rows.
+        assert_eq!(txt.lines().count(), 4);
+    }
+
+    #[test]
+    fn render_text_shows_stale_reason_for_crashed_daemon() {
+        let now = 1_000_000;
+        let mut r = row(
+            DaemonKind::Bridge,
+            DaemonState::Stopped,
+            false,
+            Some("Telegram"),
+        );
+        r.reason = "stale heartbeat — pid 4242 not alive (crashed)".to_string();
+        let txt = render_text(&[r], now);
+        assert!(
+            txt.contains("crashed"),
+            "crash reason must be visible: {txt}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -14,6 +14,7 @@ pub mod broadcast;
 pub mod budget_alert;
 pub mod cost;
 pub mod daemon;
+pub mod daemons;
 pub mod enrich_cache;
 pub mod needs;
 pub mod sequence;
@@ -27,6 +28,7 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
         Some(("needs", sub)) => needs::execute(sub, format).await,
         Some(("cost", sub)) => cost::execute(sub, format).await,
         Some(("daemon", sub)) => daemon::execute(sub, format).await,
+        Some(("daemons", sub)) => daemons::execute(sub, format).await,
         Some(("atc", sub)) => atc::execute(sub, format).await,
         Some(("bridge", sub)) => bridge::execute(sub, format).await,
         Some(("enrich-cache", sub)) => enrich_cache::execute(sub, format).await,

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1569,6 +1569,10 @@ impl CliCommand for FleetCommand {
                     .short('v')
                     .action(clap::ArgAction::SetTrue),
             );
+        let daemons = Command::new("daemons").about(
+            "Unified runtime health of every long-running daemon \
+             (phone bridge / notifyd / ATC / fleet daemon)",
+        );
         let atc = build_atc_command();
         let bridge = Command::new("bridge")
             .about(
@@ -1587,7 +1591,7 @@ impl CliCommand for FleetCommand {
         app.subcommand(
             Command::new(self.name())
                 .about(
-                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / atc / bridge",
+                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / daemons / atc / bridge",
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
@@ -1597,6 +1601,7 @@ impl CliCommand for FleetCommand {
                 .subcommand(needs)
                 .subcommand(cost)
                 .subcommand(daemon)
+                .subcommand(daemons)
                 .subcommand(atc)
                 .subcommand(bridge)
                 .subcommand(enrich_cache),
@@ -1807,6 +1812,57 @@ mod tests {
                 "missing required command: {required}"
             );
         }
+    }
+
+    #[test]
+    fn fleet_exposes_ten_subcommands_including_daemons() {
+        // The `fleet` namespace surface. Adding/removing a fleet subcommand MUST
+        // update this count + list — it is the registry guard the daemons-
+        // observability feature wired through. `daemon` (the watcher) and
+        // `daemons` (the health view) are deliberately distinct.
+        let r = CommandRegistry::built_ins();
+        let app = r.build_clap(root());
+        let fleet = app
+            .get_subcommands()
+            .find(|c| c.get_name() == "fleet")
+            .expect("fleet command registered");
+        let mut names: Vec<&str> = fleet.get_subcommands().map(clap::Command::get_name).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            [
+                "atc",
+                "bridge",
+                "broadcast",
+                "cost",
+                "daemon",
+                "daemons",
+                "enrich-cache",
+                "needs",
+                "sequence",
+                "standup",
+            ],
+            "fleet subcommand surface changed — update this guard"
+        );
+        assert_eq!(
+            names.len(),
+            10,
+            "expected 10 fleet subcommands, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn fleet_daemons_subcommand_parses() {
+        // Surface check: `ainb fleet daemons` parses to the daemons subcommand.
+        let r = CommandRegistry::built_ins();
+        let app = r.build_clap(root());
+        let matches = app
+            .try_get_matches_from(["ainb", "fleet", "daemons"])
+            .expect("fleet daemons parses");
+        let (top, sub) = matches.subcommand().expect("subcommand");
+        assert_eq!(top, "fleet");
+        let (name, _) = sub.subcommand().expect("fleet subcommand");
+        assert_eq!(name, "daemons");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -1,0 +1,270 @@
+// ABOUTME: Daemons screen component — live runtime health of the four ainb daemons.
+//
+// Renders a read-only table from `fleet::daemons::collect` (the SAME aggregator
+// behind `ainb fleet daemons`), refreshing on the render tick so a daemon that
+// starts/stops/crashes flips live. No controls in v1 — health only, matching the
+// rest of the app's read-only screens (Inbox/Stats). Follows the ainb-tui style
+// guide: rounded borders, gold title, cornflower-blue panel, green for healthy.
+
+use ratatui::{
+    prelude::*,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table},
+};
+
+use crate::cli::fleet::daemons::{fmt_ago, fmt_duration_ms};
+use crate::fleet::daemons::heartbeat::now_ms;
+use crate::fleet::daemons::probe::{DaemonState, DaemonStatus};
+
+// Palette shared with the rest of ainb-tui (see components/layout.rs).
+const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
+const GOLD: Color = Color::Rgb(255, 215, 0);
+const HEALTHY_GREEN: Color = Color::Rgb(100, 200, 100);
+const STOPPED_RED: Color = Color::Rgb(220, 100, 100);
+const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
+const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+const PANEL_BG: Color = Color::Rgb(30, 30, 40);
+const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
+
+/// Re-poll the aggregator at most every N renders to keep CPU low. The
+/// aggregator only reads a handful of small files, so even 1 is cheap, but a
+/// short throttle avoids re-reading on every redraw of an unchanged screen.
+const POLL_TICKS: u64 = 4;
+
+/// All state owned by the Daemons screen. Stored at app-level so the cached
+/// snapshot survives cross-screen navigation. Cheap to default.
+#[derive(Debug, Default)]
+pub struct DaemonsState {
+    /// Most-recently-collected daemon rows.
+    pub rows: Vec<DaemonStatus>,
+    /// The clock the cached rows' relative-time columns are measured against.
+    pub collected_at_ms: i64,
+    /// Render-tick counter; re-collects every `POLL_TICKS` renders.
+    pub tick: u64,
+}
+
+impl DaemonsState {
+    /// Re-collect the daemon health snapshot from disk. Best-effort: an error
+    /// leaves the prior snapshot in place (and logs) rather than blanking the
+    /// view.
+    pub fn refresh(&mut self) {
+        match crate::fleet::daemons::collect() {
+            Ok(rows) => {
+                self.rows = rows;
+                self.collected_at_ms = now_ms();
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "daemons screen: collect failed");
+            }
+        }
+    }
+}
+
+/// Render the Daemons screen into `area`, polling the aggregator on the tick.
+pub fn render(frame: &mut Frame, area: Rect, state: &mut DaemonsState) {
+    state.tick = state.tick.wrapping_add(1);
+    if state.tick == 1 || state.tick % POLL_TICKS == 0 {
+        state.refresh();
+    }
+
+    let outer = Block::default()
+        .title(Line::from(vec![
+            Span::styled(" ⚙ ", Style::default().fg(CORNFLOWER_BLUE)),
+            Span::styled(
+                "Daemons",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  runtime health",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            ),
+        ]))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(PANEL_BG));
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    // Carve a one-line help footer off the bottom.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    render_table(frame, chunks[0], state);
+    render_footer(frame, chunks[1]);
+}
+
+fn render_table(frame: &mut Frame, area: Rect, state: &DaemonsState) {
+    let now = if state.collected_at_ms > 0 {
+        state.collected_at_ms
+    } else {
+        now_ms()
+    };
+
+    let header = Row::new(vec![
+        Cell::from("DAEMON"),
+        Cell::from("STATE"),
+        Cell::from("PID"),
+        Cell::from("UPTIME"),
+        Cell::from("LAST ACTIVITY"),
+        Cell::from("ERR"),
+        Cell::from("HEALTH"),
+    ])
+    .style(Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = state
+        .rows
+        .iter()
+        .map(|d| {
+            let (glyph, glyph_style) = match d.state {
+                DaemonState::Running => ("● running", Style::default().fg(HEALTHY_GREEN)),
+                DaemonState::Stopped => ("○ stopped", Style::default().fg(STOPPED_RED)),
+                DaemonState::Unknown => ("? unknown", Style::default().fg(MUTED_GRAY)),
+            };
+            let pid = d.pid.map_or_else(|| "-".to_string(), |p| p.to_string());
+            let uptime = d.uptime_ms.map_or_else(|| "-".to_string(), fmt_duration_ms);
+            let last_activity =
+                d.last_activity_at.map_or_else(|| "-".to_string(), |ts| fmt_ago(now, ts));
+            let health = match (&d.channel, d.connected, d.state) {
+                (Some(ch), true, DaemonState::Running) => format!("{ch} — {}", d.reason),
+                _ => d.reason.clone(),
+            };
+            Row::new(vec![
+                Cell::from(d.kind.display_name())
+                    .style(Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)),
+                Cell::from(glyph).style(glyph_style),
+                Cell::from(pid),
+                Cell::from(uptime),
+                Cell::from(last_activity),
+                Cell::from(d.error_count.to_string()).style(if d.error_count > 0 {
+                    Style::default().fg(STOPPED_RED)
+                } else {
+                    Style::default().fg(MUTED_GRAY)
+                }),
+                Cell::from(health).style(Style::default().fg(SOFT_WHITE)),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(14),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(8),
+        Constraint::Length(14),
+        Constraint::Length(4),
+        Constraint::Min(20),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .column_spacing(1)
+        .style(Style::default().bg(PANEL_BG));
+    frame.render_widget(table, area);
+}
+
+fn render_footer(frame: &mut Frame, area: Rect) {
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled("read-only • live", Style::default().fg(MUTED_GRAY)),
+        Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)),
+        Span::styled("q/Esc", Style::default().fg(CORNFLOWER_BLUE)),
+        Span::styled(" back", Style::default().fg(MUTED_GRAY)),
+    ]))
+    .style(Style::default().bg(PANEL_BG));
+    frame.render_widget(footer, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet::daemons::probe::DaemonKind;
+    use ratatui::backend::TestBackend;
+
+    fn status(
+        kind: DaemonKind,
+        state: DaemonState,
+        connected: bool,
+        channel: Option<&str>,
+    ) -> DaemonStatus {
+        DaemonStatus {
+            kind,
+            state,
+            pid: Some(1234),
+            uptime_ms: Some(3_600_000),
+            connected,
+            channel: channel.map(str::to_string),
+            last_activity_at: Some(now_ms() - 5_000),
+            error_count: 0,
+            last_error: None,
+            reason: if connected {
+                "running + connected".to_string()
+            } else {
+                "no heartbeat — not running this session".to_string()
+            },
+        }
+    }
+
+    /// Render the screen against an in-memory TestBackend and return the buffer
+    /// as a single string for substring assertions.
+    fn render_to_string(state: &mut DaemonsState, w: u16, h: u16) -> String {
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, f.area(), state)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        buf.content().iter().map(|c| c.symbol()).collect::<String>()
+    }
+
+    #[test]
+    fn renders_title_header_and_all_four_rows() {
+        // Pre-seed the cache so render doesn't depend on the host's real
+        // ~/.agents-in-a-box state (refresh only fires when tick hits the
+        // throttle; tick starts at 0 → first render refreshes, so seed AFTER a
+        // bump by forcing the cache and a non-trigger tick).
+        let mut state = DaemonsState {
+            rows: vec![
+                status(
+                    DaemonKind::Bridge,
+                    DaemonState::Running,
+                    true,
+                    Some("Telegram (@bot)"),
+                ),
+                status(DaemonKind::Notifyd, DaemonState::Stopped, false, None),
+                status(
+                    DaemonKind::Atc,
+                    DaemonState::Running,
+                    true,
+                    Some("primary (every 15m)"),
+                ),
+                status(DaemonKind::FleetDaemon, DaemonState::Stopped, false, None),
+            ],
+            collected_at_ms: now_ms(),
+            tick: 1, // already past the first-render refresh trigger
+        };
+        let out = render_to_string(&mut state, 120, 12);
+        assert!(out.contains("Daemons"), "title missing: {out}");
+        assert!(out.contains("DAEMON"), "header missing");
+        assert!(out.contains("HEALTH"), "header missing");
+        // Every daemon's display name renders as a row.
+        assert!(out.contains("phone bridge"), "bridge row missing");
+        assert!(out.contains("notifyd"), "notifyd row missing");
+        assert!(out.contains("ATC"), "ATC row missing");
+        assert!(out.contains("fleet daemon"), "fleet daemon row missing");
+        // State glyphs + a connected channel render.
+        assert!(out.contains("running"), "running state missing");
+        assert!(out.contains("stopped"), "stopped state missing");
+        assert!(out.contains("Telegram (@bot)"), "channel missing");
+    }
+
+    #[test]
+    fn refresh_does_not_panic_on_empty_home() {
+        // Even with no cached rows and a real collect(), rendering must not
+        // panic — it surfaces whatever the host's daemons look like.
+        let mut state = DaemonsState::default();
+        let _ = render_to_string(&mut state, 100, 10);
+        // After the first render the cache is populated (4 daemons always).
+        assert_eq!(state.rows.len(), 4);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/components/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/components/mod.rs
@@ -11,6 +11,7 @@ pub mod code_review;
 pub mod config_popup;
 pub mod config_screen;
 pub mod confirmation_dialog;
+pub mod daemons;
 pub mod fuzzy_file_finder;
 pub mod git_view;
 pub mod help;

--- a/ainb-tui/crates/ainb-core/src/components/sidebar.rs
+++ b/ainb-tui/crates/ainb-core/src/components/sidebar.rs
@@ -36,6 +36,7 @@ pub enum SidebarItem {
     Config,    // Settings & presets
     Sessions,  // Session manager
     Inbox,     // ainb-hooks notification inbox
+    Daemons,   // Daemon runtime-health observability
     Recovery,  // Recover orphaned sessions
     Logs,      // Log history viewer
     Stats,     // Analytics & usage
@@ -57,6 +58,7 @@ impl SidebarItem {
             Self::Config => "⚙️",
             Self::Sessions => "🚀",
             Self::Inbox => "📥",
+            Self::Daemons => "⚙️",
             Self::Recovery => "🔄",
             Self::Logs => "📋",
             Self::Stats => "📊",
@@ -78,6 +80,7 @@ impl SidebarItem {
             Self::Config => "Config",
             Self::Sessions => "Sessions",
             Self::Inbox => "Inbox",
+            Self::Daemons => "Daemons",
             Self::Recovery => "Recovery",
             Self::Logs => "Logs",
             Self::Stats => "Stats",
@@ -99,6 +102,7 @@ impl SidebarItem {
             Self::Config => "Settings & Presets",
             Self::Sessions => "Manage Active",
             Self::Inbox => "Hook Notifications",
+            Self::Daemons => "Runtime Health",
             Self::Recovery => "Resume Orphaned",
             Self::Logs => "View Log History",
             Self::Stats => "Usage & Analytics",
@@ -120,6 +124,7 @@ impl SidebarItem {
             Self::Config => "C",
             Self::Sessions => "s",
             Self::Inbox => "b",
+            Self::Daemons => "d",
             Self::Recovery => "R",
             Self::Logs => "l",
             Self::Stats => "i",
@@ -141,6 +146,7 @@ impl SidebarItem {
             Self::Config,
             Self::Sessions,
             Self::Inbox,
+            Self::Daemons,
             Self::Recovery,
             Self::Logs,
             Self::Stats,
@@ -528,6 +534,27 @@ mod tests {
         let collisions =
             all.iter().filter(|i| **i != SidebarItem::Inbox && i.shortcut() == "b").count();
         assert_eq!(collisions, 0, "sidebar shortcut 'b' collides");
+    }
+
+    #[test]
+    fn daemons_tile_registered_with_discoverable_shortcut() {
+        // The Daemons observability screen must be reachable from the home menu
+        // like every other read-only panel. Lock the tile shape + a
+        // non-colliding shortcut so a refactor can't silently drop it.
+        let all = SidebarItem::all();
+        let pos = all
+            .iter()
+            .position(|i| *i == SidebarItem::Daemons)
+            .expect("SidebarItem::Daemons missing from all()");
+        assert!(pos > 0, "Daemons shouldn't be first sidebar item");
+        assert_eq!(SidebarItem::Daemons.label(), "Daemons");
+        assert_eq!(SidebarItem::Daemons.shortcut(), "d");
+        assert_eq!(SidebarItem::Daemons.description(), "Runtime Health");
+        let collisions = all
+            .iter()
+            .filter(|i| **i != SidebarItem::Daemons && i.shortcut() == "d")
+            .count();
+        assert_eq!(collisions, 0, "sidebar shortcut 'd' collides");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/heartbeat.rs
@@ -1,0 +1,186 @@
+// ABOUTME: The phone bridge's heartbeat emitter — closes the original blind spot.
+//
+// Before this, a running bridge that was connected to Telegram and relaying
+// looked identical to a dead one: `ainb fleet bridge status` only reported
+// launchd *install* state. This module makes the bridge write the shared daemon
+// heartbeat (`~/.agents-in-a-box/daemons/bridge.json`) so the Daemons surface
+// can show "Telegram channel online" + last-relay + error count.
+//
+// [`BridgeHeartbeat`] is a cheap clonable handle (an `Arc<Mutex<…>>`) shared by
+// the Telegram and Slack channel tasks. Each mutation rewrites the file
+// atomically; a write failure is logged and swallowed — a heartbeat must never
+// take the daemon down. A background ticker calls [`BridgeHeartbeat::touch`]
+// every few seconds so the liveness clock stays fresh even when the bridge is
+// idle (no inbound messages), which is the common case.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::fleet::daemons::heartbeat::DaemonHeartbeat;
+
+/// The heartbeat file name for the phone bridge. Must match
+/// `fleet::daemons::probe::DaemonKind::Bridge.id()`.
+const BRIDGE_NAME: &str = "bridge";
+
+/// Cadence of the idle liveness refresh. Comfortably inside the probe's 90s
+/// staleness window so an idle-but-healthy bridge is never flagged stale.
+const TICK: Duration = Duration::from_secs(15);
+
+/// A clonable handle the bridge channels share to report their health. Cloning
+/// is cheap (an `Arc` bump); every clone writes the same `bridge.json`.
+///
+/// The ainb home is resolved ONCE at construction and carried on the handle, so
+/// each flush is a pure write to a known path (no env lookup per beat) and tests
+/// can inject a tempdir without touching process-global env.
+#[derive(Clone)]
+pub struct BridgeHeartbeat {
+    inner: Arc<Mutex<DaemonHeartbeat>>,
+    home: Arc<PathBuf>,
+}
+
+impl BridgeHeartbeat {
+    /// Create a fresh handle for the current process and write the initial
+    /// "starting" record under the resolved ainb home. A failure to resolve the
+    /// home or to write is logged, not fatal — the bridge runs regardless.
+    #[must_use]
+    pub fn start() -> Self {
+        let home = crate::fleet::plumbing::paths::ainb_home().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "bridge heartbeat: could not resolve ainb home");
+            PathBuf::from(".")
+        });
+        Self::start_in(home)
+    }
+
+    /// Construction seam: create a handle rooted at an explicit ainb home. Used
+    /// by `start()` (real home) and by tests (a tempdir).
+    #[must_use]
+    pub fn start_in(home: impl Into<PathBuf>) -> Self {
+        let handle = Self {
+            inner: Arc::new(Mutex::new(DaemonHeartbeat::starting())),
+            home: Arc::new(home.into()),
+        };
+        handle.flush();
+        handle
+    }
+
+    /// Spawn the background liveness ticker. It refreshes the heartbeat every
+    /// [`TICK`] for as long as the handle lives, so an idle bridge still proves
+    /// it is alive. Returns the join handle (the daemon ignores it — the task
+    /// ends when the process does).
+    pub fn spawn_ticker(&self) -> tokio::task::JoinHandle<()> {
+        let handle = self.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(TICK);
+            // Skip the immediate first tick — `start()` already wrote one.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                handle.touch();
+            }
+        })
+    }
+
+    /// Mark a channel connected (or not), labelling the channel. Called after
+    /// `getMe` / `auth_test` succeeds.
+    pub fn set_connected(&self, connected: bool, channel: Option<String>) {
+        self.mutate(|hb| hb.set_connected(connected, channel));
+    }
+
+    /// Record a relayed message — the "last relay" signal the operator needs.
+    pub fn record_relay(&self) {
+        self.mutate(DaemonHeartbeat::record_activity);
+    }
+
+    /// Record an error string (a failed getUpdates poll, a send failure, …).
+    pub fn record_error(&self, message: impl Into<String>) {
+        let message = message.into();
+        self.mutate(|hb| hb.record_error(message));
+    }
+
+    /// Refresh the liveness clock (the idle ticker path).
+    pub fn touch(&self) {
+        self.mutate(DaemonHeartbeat::touch);
+    }
+
+    /// Apply `f` to the in-memory record, then flush it to disk.
+    fn mutate(&self, f: impl FnOnce(&mut DaemonHeartbeat)) {
+        if let Ok(mut hb) = self.inner.lock() {
+            f(&mut hb);
+        }
+        self.flush();
+    }
+
+    /// Write the current record to `<home>/daemons/bridge.json`. Best-effort: a
+    /// failure is logged and swallowed so a transient FS error can never crash
+    /// the bridge.
+    fn flush(&self) {
+        let snapshot = match self.inner.lock() {
+            Ok(hb) => hb.clone(),
+            Err(_) => return,
+        };
+        if let Err(e) = snapshot.write_in(self.home.as_path(), BRIDGE_NAME) {
+            tracing::warn!(error = %e, "bridge heartbeat write failed (continuing)");
+        }
+    }
+
+    /// The resolved ainb home this handle writes under.
+    #[must_use]
+    pub fn home(&self) -> &Path {
+        self.home.as_path()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet::daemons::heartbeat::heartbeat_path_in;
+
+    #[test]
+    fn start_in_writes_initial_record() {
+        let home = tempfile::tempdir().unwrap();
+        let _hb = BridgeHeartbeat::start_in(home.path());
+        let on_disk = DaemonHeartbeat::read_in(home.path(), "bridge").expect("heartbeat written");
+        assert_eq!(on_disk.pid, std::process::id());
+        assert!(!on_disk.connected);
+        assert!(heartbeat_path_in(home.path(), "bridge").exists());
+    }
+
+    #[test]
+    fn set_connected_and_relay_persist() {
+        let home = tempfile::tempdir().unwrap();
+        let hb = BridgeHeartbeat::start_in(home.path());
+        hb.set_connected(true, Some("Telegram (@bot)".into()));
+        hb.record_relay();
+        let on_disk = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
+        assert!(on_disk.connected);
+        assert_eq!(on_disk.channel.as_deref(), Some("Telegram (@bot)"));
+        assert!(on_disk.last_activity_at.is_some());
+    }
+
+    #[test]
+    fn record_error_increments_on_disk() {
+        let home = tempfile::tempdir().unwrap();
+        let hb = BridgeHeartbeat::start_in(home.path());
+        hb.record_error("getUpdates timeout");
+        hb.record_error("send failed");
+        let on_disk = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
+        assert_eq!(on_disk.error_count, 2);
+        assert_eq!(on_disk.last_error.as_deref(), Some("send failed"));
+    }
+
+    #[test]
+    fn clones_share_one_file() {
+        let home = tempfile::tempdir().unwrap();
+        let hb = BridgeHeartbeat::start_in(home.path());
+        let clone = hb.clone();
+        hb.set_connected(true, Some("Telegram".into()));
+        clone.record_relay();
+        let on_disk = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
+        // Both mutations landed in the single shared record.
+        assert!(on_disk.connected);
+        assert!(on_disk.last_activity_at.is_some());
+        // The clone writes under the same injected home.
+        assert_eq!(clone.home(), home.path());
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/heartbeat.rs
@@ -93,8 +93,14 @@ impl BridgeHeartbeat {
     }
 
     /// Record an error string (a failed getUpdates poll, a send failure, …).
+    ///
+    /// The message is scrubbed of any known secret shape (Telegram bot tokens,
+    /// Slack `xox*` tokens) BEFORE it is stored — `last_error` is persisted to
+    /// `bridge.json` and shown in the CLI/TUI, and a `reqwest::Error` Display can
+    /// carry the token in the request URL. This is the defense-in-depth sink:
+    /// even a caller that forgot to redact can't leak a token to disk (M1).
     pub fn record_error(&self, message: impl Into<String>) {
-        let message = message.into();
+        let message = super::redact::scrub_secrets(&message.into());
         self.mutate(|hb| hb.record_error(message));
     }
 
@@ -167,6 +173,37 @@ mod tests {
         let on_disk = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
         assert_eq!(on_disk.error_count, 2);
         assert_eq!(on_disk.last_error.as_deref(), Some("send failed"));
+    }
+
+    #[test]
+    fn record_error_scrubs_telegram_and_slack_tokens_on_disk() {
+        // M1 regression: a diagnostic carrying a bot token (as it appears in the
+        // Telegram API URL) and a Slack token must NEVER reach the persisted
+        // `last_error` — it is written to bridge.json and shown in the CLI/TUI.
+        let home = tempfile::tempdir().unwrap();
+        let hb = BridgeHeartbeat::start_in(home.path());
+        hb.record_error(
+            "getUpdates: phase=request kind=connect status=None source=[error sending request \
+             for url (https://api.telegram.org/bot123456789:ABC-tok_ghiJKLmnopqrstuvwxyz012345/getUpdates)]",
+        );
+        hb.record_error("socket error: auth failed for xoxb-9999-8888-supersecretslacktoken");
+        let on_disk = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
+        let last = on_disk.last_error.expect("last_error recorded");
+        assert!(last.contains("<redacted>"), "expected redaction: {last}");
+        assert!(
+            !last.contains("ABC-tok_ghiJKLmnopqrstuvwxyz012345"),
+            "telegram token body leaked to disk: {last}"
+        );
+        assert!(
+            !last.contains("bot123456789:"),
+            "telegram token prefix leaked to disk: {last}"
+        );
+        assert!(
+            !last.contains("xoxb-9999-8888-supersecretslacktoken"),
+            "slack token leaked to disk: {last}"
+        );
+        // The error count still increments — scrubbing must not drop the signal.
+        assert_eq!(on_disk.error_count, 2);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -20,6 +20,7 @@
 pub mod config;
 pub mod format;
 pub mod heartbeat;
+pub mod redact;
 pub mod relay;
 pub mod routing;
 pub mod secrets;

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod config;
 pub mod format;
+pub mod heartbeat;
 pub mod relay;
 pub mod routing;
 pub mod secrets;
@@ -51,18 +52,27 @@ pub async fn run_with_config(cfg: BridgeConfig) -> Result<()> {
     // reference for the lifetime of the daemon (it lives until process exit).
     let transport: &'static AinbTransport = Box::leak(Box::new(AinbTransport));
 
+    // Heartbeat: write the initial "starting" record and keep the liveness clock
+    // fresh via the idle ticker. Each channel reports its own connection +
+    // relay activity through a clone of this handle. This is what closes the
+    // "running bridge is indistinguishable from a dead one" blind spot.
+    let heartbeat = heartbeat::BridgeHeartbeat::start();
+    heartbeat.spawn_ticker();
+
     let mut tasks = Vec::new();
 
     if let Some(tg) = cfg.telegram {
+        let hb = heartbeat.clone();
         tasks.push(tokio::spawn(async move {
-            if let Err(e) = telegram::run(tg, transport).await {
+            if let Err(e) = telegram::run(tg, transport, hb).await {
                 tracing::error!(error = %e, "Telegram channel exited with error");
             }
         }));
     }
     if let Some(sl) = cfg.slack {
+        let hb = heartbeat.clone();
         tasks.push(tokio::spawn(async move {
-            if let Err(e) = slack::run(sl, transport).await {
+            if let Err(e) = slack::run(sl, transport, hb).await {
                 tracing::error!(error = %e, "Slack channel exited with error");
             }
         }));

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/redact.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/redact.rs
@@ -1,0 +1,109 @@
+// ABOUTME: Secret scrubbing for bridge diagnostics — keeps tokens out of disk.
+//
+// The phone bridge persists its most-recent error to `daemons/bridge.json`
+// (`last_error`), which the `ainb fleet daemons` CLI verb and the TUI Daemons
+// screen render. A `reqwest::Error`'s `Display` includes the request URL, and
+// the Telegram Bot API embeds the bot token IN the URL path
+// (`https://api.telegram.org/bot<TOKEN>/getUpdates`). Letting that reach
+// `last_error` leaks the token to disk and to anyone watching the surface.
+//
+// [`scrub_secrets`] is the defense-in-depth sink: every diagnostic string is run
+// through it before it is recorded, so even a future code path that forgets to
+// build a clean message can't leak a known token shape. It is deliberately a
+// pure string transform (no allocation when nothing matches) so it is cheap and
+// exhaustively testable.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    /// Telegram bot tokens: `bot<digits>:<base64ish>` (as they appear in the API
+    /// URL path) and the bare `<digits>:<base64ish>` token form.
+    static ref TELEGRAM_TOKEN: Regex =
+        Regex::new(r"bot\d+:[A-Za-z0-9_-]{20,}").expect("valid telegram token regex");
+    static ref TELEGRAM_BARE_TOKEN: Regex =
+        Regex::new(r"\b\d{6,}:[A-Za-z0-9_-]{20,}").expect("valid bare telegram token regex");
+    /// Slack tokens: bot (`xoxb-…`), the `xox*` families (user `xoxp-`, config
+    /// `xoxe-`, refresh `xoxr-`, …) AND app-level tokens (`xapp-…`), which use a
+    /// distinct `xapp` prefix rather than `xox`.
+    static ref SLACK_TOKEN: Regex =
+        Regex::new(r"(?:xox[baprse]|xapp)-[A-Za-z0-9-]+").expect("valid slack token regex");
+}
+
+/// Replacement marker substituted for any matched secret. Stable so callers and
+/// tests can assert on it.
+pub const REDACTED: &str = "<redacted>";
+
+/// Scrub any known token shape out of a diagnostic string before it is persisted
+/// or displayed. Order matters only in that the more specific `bot…:…` form is
+/// replaced before the bare `digits:base64` form, so the `bot` prefix is also
+/// removed. Returns a new string; secret-free inputs round-trip unchanged.
+#[must_use]
+pub fn scrub_secrets(input: &str) -> String {
+    let s = TELEGRAM_TOKEN.replace_all(input, REDACTED);
+    let s = TELEGRAM_BARE_TOKEN.replace_all(&s, REDACTED);
+    let s = SLACK_TOKEN.replace_all(&s, REDACTED);
+    s.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrubs_telegram_token_in_api_url() {
+        // The exact leak shape: a reqwest error Display carrying the bot token in
+        // the getUpdates URL path.
+        let leak = "kind=connect status=None display=\"error sending request for url \
+                    (https://api.telegram.org/bot123456789:ABC-DEF_ghiJKLmnopqrstuvwxyz012345/getUpdates)\" source=[]";
+        let scrubbed = scrub_secrets(leak);
+        assert!(
+            scrubbed.contains(REDACTED),
+            "expected redaction: {scrubbed}"
+        );
+        assert!(
+            !scrubbed.contains("ABC-DEF_ghiJKLmnopqrstuvwxyz012345"),
+            "token body leaked: {scrubbed}"
+        );
+        assert!(
+            !scrubbed.contains("bot123456789:"),
+            "token prefix leaked: {scrubbed}"
+        );
+    }
+
+    #[test]
+    fn scrubs_bare_telegram_token() {
+        let leak = "getUpdates: 123456789:ABCdefGHIjklMNOpqrstuvwx failed";
+        let scrubbed = scrub_secrets(leak);
+        assert!(scrubbed.contains(REDACTED));
+        assert!(!scrubbed.contains("ABCdefGHIjklMNOpqrstuvwx"));
+        assert!(!scrubbed.contains("123456789:"));
+    }
+
+    #[test]
+    fn scrubs_slack_bot_and_app_tokens() {
+        let leak =
+            "socket error: auth failed for xoxb-1111-2222-aaaaBBBBcccc and xapp-1-A0-99-deadbeef";
+        let scrubbed = scrub_secrets(leak);
+        assert!(
+            !scrubbed.contains("xoxb-1111-2222-aaaaBBBBcccc"),
+            "{scrubbed}"
+        );
+        assert!(!scrubbed.contains("xapp-1-A0-99-deadbeef"), "{scrubbed}");
+        assert_eq!(scrubbed.matches(REDACTED).count(), 2);
+    }
+
+    #[test]
+    fn leaves_secret_free_strings_untouched() {
+        let clean = "kind=timeout status=Some(429) display=\"operation timed out\" source=[]";
+        assert_eq!(scrub_secrets(clean), clean);
+    }
+
+    #[test]
+    fn does_not_redact_innocuous_colon_numbers() {
+        // A short `id:value` like an http status or a chat id must NOT be eaten —
+        // the bare-token rule requires >=6 leading digits AND a >=20-char tail.
+        let clean = "sendMessage HTTP 400: chat_id 42 not found";
+        assert_eq!(scrub_secrets(clean), clean);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/slack.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/slack.rs
@@ -22,14 +22,20 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::config::{SlackConfig, SlackListenMode};
+use super::heartbeat::BridgeHeartbeat;
 use super::relay::{FleetTransport, RelayParams, relay};
 
 const API_BASE: &str = "https://slack.com/api";
 /// Slack message text limit (chat.postMessage). We split below this.
 const SLACK_MAX_LENGTH: usize = 3900;
 
-/// Run the Slack channel forever (reconnecting on disconnect).
-pub async fn run<T: FleetTransport>(cfg: SlackConfig, transport: &T) -> Result<()> {
+/// Run the Slack channel forever (reconnecting on disconnect). Reports
+/// connection + relay activity through the shared `heartbeat`.
+pub async fn run<T: FleetTransport>(
+    cfg: SlackConfig,
+    transport: &T,
+    heartbeat: BridgeHeartbeat,
+) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .build()
@@ -37,6 +43,11 @@ pub async fn run<T: FleetTransport>(cfg: SlackConfig, transport: &T) -> Result<(
 
     // Resolve our own bot user id once so we never relay our own posts.
     let self_user_id = auth_test(&client, &cfg.bot_token).await;
+    // A successful auth_test is the "channel online" signal.
+    heartbeat.set_connected(
+        self_user_id.is_some(),
+        Some("Slack (socket-mode)".to_string()),
+    );
     tracing::info!(
         bot_user = self_user_id.as_deref().unwrap_or("?"),
         mode = ?cfg.listen_mode,
@@ -44,12 +55,21 @@ pub async fn run<T: FleetTransport>(cfg: SlackConfig, transport: &T) -> Result<(
     );
 
     loop {
-        match connect_and_serve(&client, &cfg, self_user_id.as_deref(), transport).await {
+        match connect_and_serve(
+            &client,
+            &cfg,
+            self_user_id.as_deref(),
+            transport,
+            &heartbeat,
+        )
+        .await
+        {
             Ok(()) => {
                 tracing::info!("Slack socket closed; reconnecting");
             }
             Err(e) => {
                 tracing::warn!(error = %e, "Slack socket error; reconnecting in 5s");
+                heartbeat.record_error(format!("socket error: {e}"));
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
         }
@@ -61,6 +81,7 @@ async fn connect_and_serve<T: FleetTransport>(
     cfg: &SlackConfig,
     self_user_id: Option<&str>,
     transport: &T,
+    heartbeat: &BridgeHeartbeat,
 ) -> Result<()> {
     let ws_url = open_connection(client, &cfg.app_token).await?;
     let (ws, _resp) = tokio_tungstenite::connect_async(&ws_url)
@@ -99,7 +120,7 @@ async fn connect_and_serve<T: FleetTransport>(
             }
             Some("events_api") => {
                 if let Some(event) = envelope.payload.and_then(|p| p.event) {
-                    handle_event(client, cfg, self_user_id, transport, event).await;
+                    handle_event(client, cfg, self_user_id, transport, heartbeat, event).await;
                 }
             }
             _ => {}
@@ -113,6 +134,7 @@ async fn handle_event<T: FleetTransport>(
     cfg: &SlackConfig,
     self_user_id: Option<&str>,
     transport: &T,
+    heartbeat: &BridgeHeartbeat,
     event: SlackEvent,
 ) {
     if classify_event(cfg, self_user_id, &event).is_none() {
@@ -129,6 +151,8 @@ async fn handle_event<T: FleetTransport>(
         response_timeout: Duration::from_secs(cfg.response_timeout),
     };
     let reply = relay(transport, &params, &text).await;
+    // A relayed turn is the "last relay" activity signal.
+    heartbeat.record_relay();
 
     let Some(channel) = event.channel.as_deref() else {
         return;
@@ -145,6 +169,7 @@ async fn handle_event<T: FleetTransport>(
         .await
         {
             tracing::warn!(error = %e, "Slack chat.postMessage failed");
+            heartbeat.record_error(format!("chat.postMessage failed: {e}"));
         }
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
@@ -139,9 +139,18 @@ fn describe_get_updates_error(err: &GetUpdatesError) -> String {
 }
 
 /// Render a reqwest error as a single diagnosable line: the kind flags
-/// (`timeout`/`connect`/`request`/`body`/`decode`), the HTTP status if any, the
-/// Display string, and the underlying source chain (e.g. hyper's "connection
-/// closed before message completed" on a stale keep-alive socket).
+/// (`timeout`/`connect`/`request`/`body`/`decode`), the HTTP status if any, and
+/// the underlying source chain (e.g. hyper's "connection closed before message
+/// completed" on a stale keep-alive socket).
+///
+/// SECURITY (M1): the error's own `Display` is deliberately NOT included. A
+/// `reqwest::Error` Display carries the request URL, and the Telegram Bot API
+/// embeds the bot token in the URL path
+/// (`https://api.telegram.org/bot<TOKEN>/…`) — so emitting it would leak the
+/// token into `last_error` (persisted to `bridge.json`, shown in CLI/TUI). The
+/// kind flags + status + source chain give the same diagnosability without the
+/// URL, and the whole line is additionally run through `scrub_secrets` at the
+/// heartbeat sink as defense-in-depth.
 fn describe_reqwest_error(err: &reqwest::Error) -> String {
     let mut kinds = Vec::new();
     if err.is_timeout() {
@@ -166,19 +175,19 @@ fn describe_reqwest_error(err: &reqwest::Error) -> String {
     let status = err.status().map(|s| s.as_u16());
 
     // Walk the std::error::Error source chain (the real cause, e.g. hyper's
-    // "connection closed before message completed" on a stale keep-alive).
+    // "connection closed before message completed" on a stale keep-alive). The
+    // chain is scrubbed too — a source could in principle echo the URL.
     let mut sources = Vec::new();
     let mut src: Option<&dyn std::error::Error> = std::error::Error::source(err);
     while let Some(s) = src {
-        sources.push(s.to_string());
+        sources.push(super::redact::scrub_secrets(&s.to_string()));
         src = s.source();
     }
 
     format!(
-        "kind={} status={:?} display=\"{}\" source=[{}]",
+        "kind={} status={:?} source=[{}]",
         kinds.join("|"),
         status,
-        err,
         sources.join(" -> ")
     )
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/telegram.rs
@@ -21,6 +21,7 @@ use serde_json::json;
 
 use super::config::TelegramConfig;
 use super::format::{TG_MAX_LENGTH, md_to_tg_html, split_message};
+use super::heartbeat::BridgeHeartbeat;
 use super::relay::{FleetTransport, RelayParams, relay};
 
 const API_BASE: &str = "https://api.telegram.org";
@@ -34,12 +35,26 @@ const LONG_POLL_SECS: u64 = 30;
 const CLIENT_TIMEOUT_BUFFER_SECS: u64 = 15;
 
 /// Run the Telegram channel forever (until the task is cancelled). Drives the
-/// shared `transport` through the relay core.
-pub async fn run<T: FleetTransport>(cfg: TelegramConfig, transport: &T) -> Result<()> {
+/// shared `transport` through the relay core, reporting connection + relay
+/// activity through the shared `heartbeat` so the Daemons surface can show
+/// "Telegram channel online" + last-relay (the original blind spot).
+pub async fn run<T: FleetTransport>(
+    cfg: TelegramConfig,
+    transport: &T,
+    heartbeat: BridgeHeartbeat,
+) -> Result<()> {
     let client = build_client()?;
 
     let me = get_me(&client, &cfg.token).await;
     let bot_username = me.as_ref().and_then(|m| m.username.clone());
+    // A successful getMe is the "channel online" signal. Label the channel with
+    // the bot handle so the operator sees exactly which account is relaying.
+    let online = me.is_some();
+    let channel = match &bot_username {
+        Some(u) => format!("Telegram (@{u})"),
+        None => "Telegram".to_string(),
+    };
+    heartbeat.set_connected(online, Some(channel));
     tracing::info!(
         bot = bot_username.as_deref().unwrap_or("?"),
         "ainb phone bridge: Telegram channel online (long-polling)"
@@ -56,19 +71,34 @@ pub async fn run<T: FleetTransport>(cfg: TelegramConfig, transport: &T) -> Resul
             Err(e) => {
                 // Surface the FULL reqwest failure shape, not a generic context
                 // string, so an intermittent flap is diagnosable from the logs.
+                let desc = describe_get_updates_error(&e);
                 tracing::warn!(
                     offset,
-                    error = describe_get_updates_error(&e),
+                    error = desc,
                     "getUpdates failed; backing off (offset preserved)"
                 );
+                // A failed poll means the channel is no longer confirmed online.
+                heartbeat.record_error(format!("getUpdates: {desc}"));
+                heartbeat.set_connected(false, None);
                 tokio::time::sleep(Duration::from_secs(3)).await;
                 continue;
             }
         };
+        // A successful poll (re)confirms the channel is online — recover from a
+        // prior transient failure that flipped connected=false.
+        heartbeat.set_connected(true, None);
         for update in updates {
             offset = offset.max(update.update_id + 1);
             if let Some(message) = update.message {
-                handle_message(&client, &cfg, bot_username.as_deref(), transport, message).await;
+                handle_message(
+                    &client,
+                    &cfg,
+                    bot_username.as_deref(),
+                    transport,
+                    &heartbeat,
+                    message,
+                )
+                .await;
             }
         }
     }
@@ -158,6 +188,7 @@ async fn handle_message<T: FleetTransport>(
     cfg: &TelegramConfig,
     bot_username: Option<&str>,
     transport: &T,
+    heartbeat: &BridgeHeartbeat,
     message: TgMessage,
 ) {
     // Authorization by user_id — unknown senders are silently ignored.
@@ -182,6 +213,8 @@ async fn handle_message<T: FleetTransport>(
         response_timeout: Duration::from_secs(cfg.response_timeout),
     };
     let reply = relay(transport, &params, &text).await;
+    // A relayed turn is the "last relay" activity signal the operator watches.
+    heartbeat.record_relay();
 
     // Split the RAW reply BEFORE HTML conversion (the verified ordering).
     for raw_chunk in split_message(&reply, TG_MAX_LENGTH) {
@@ -192,6 +225,7 @@ async fn handle_message<T: FleetTransport>(
                 send_message(client, &cfg.token, message.chat.id, &raw_chunk, false).await
             {
                 tracing::warn!(error = %e2, "plain-text retry also failed");
+                heartbeat.record_error(format!("sendMessage failed: {e2}"));
             }
         }
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
@@ -1,0 +1,300 @@
+// ABOUTME: The daemon heartbeat status file — `~/.agents-in-a-box/daemons/<name>.json`.
+//
+// A long-running ainb daemon (the phone bridge, the fleet auto-continue watcher)
+// rewrites this tiny file on startup and on every heartbeat tick. The Daemons
+// observability surface (the `ainb fleet daemons` CLI verb + the TUI screen)
+// reads it and cross-checks `pid` liveness so a stale file from a *crashed*
+// daemon shows "stopped (stale heartbeat)" rather than a false "running".
+//
+// The shape is deliberately tiny and stable so it stays cheap to rewrite every
+// few seconds and forward-compatible (new fields are added with `#[serde(default)]`):
+//
+//   {
+//     "pid": 12345,
+//     "started_at": 1700000000000,        // epoch ms — daemon process start
+//     "last_heartbeat_at": 1700000005000, // epoch ms — last refresh of this file
+//     "last_activity_at": 1700000004000,  // epoch ms — last real work (relay, scan)
+//     "connected": true,                  // channel/peer health (daemon-specific)
+//     "channel": "Telegram (@mybot)",     // optional human label for the connection
+//     "last_error": "getUpdates timeout", // optional last error string
+//     "error_count": 0                    // monotonic error counter for this run
+//   }
+//
+// Heartbeats that already have a richer signal elsewhere (ATC's
+// `heartbeat-state.json`, notifyd's PID file + socket + DB) are READ in
+// `super::probe` instead of re-emitted — only daemons with no existing
+// observability write this file.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::fleet::plumbing::atomic::write_atomic_json;
+
+/// Epoch-milliseconds clock, matching the rest of the plumbing's `ts` fields.
+#[must_use]
+pub fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// `<ainb_home>/daemons` — the directory holding every daemon heartbeat file.
+/// Honours `$AINB_HOME` via the shared plumbing resolver so tests isolate to a
+/// tempdir without touching `$HOME`.
+pub fn daemons_dir() -> Result<PathBuf> {
+    Ok(crate::fleet::plumbing::paths::ainb_home()?.join("daemons"))
+}
+
+/// `<home>/daemons` under an explicit ainb home (the test seam).
+#[must_use]
+pub fn daemons_dir_in(home: &Path) -> PathBuf {
+    home.join("daemons")
+}
+
+/// Path to `<name>`'s heartbeat file under the default ainb home.
+pub fn heartbeat_path(name: &str) -> Result<PathBuf> {
+    Ok(daemons_dir()?.join(format!("{}.json", sanitize(name))))
+}
+
+/// Path to `<name>`'s heartbeat file under an explicit ainb home.
+#[must_use]
+pub fn heartbeat_path_in(home: &Path, name: &str) -> PathBuf {
+    daemons_dir_in(home).join(format!("{}.json", sanitize(name)))
+}
+
+/// The on-disk heartbeat record one daemon rewrites on each tick.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonHeartbeat {
+    /// OS pid of the daemon process that wrote this record.
+    pub pid: u32,
+    /// Epoch ms at which the daemon process started.
+    pub started_at: i64,
+    /// Epoch ms at which this record was last rewritten (the liveness clock).
+    pub last_heartbeat_at: i64,
+    /// Epoch ms of the last real unit of work (a relayed message, a scan that
+    /// acted). `None` until the daemon has done anything.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity_at: Option<i64>,
+    /// Daemon-specific connection health: bridge = channel online, fleet = peer
+    /// registered. `false` until proven connected.
+    #[serde(default)]
+    pub connected: bool,
+    /// Optional human label for the connection (e.g. `"Telegram (@mybot)"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// The most recent error string this run, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    /// Monotonic count of errors observed since this daemon started.
+    #[serde(default)]
+    pub error_count: u64,
+}
+
+impl DaemonHeartbeat {
+    /// A fresh heartbeat for the current process at startup: `started_at` and
+    /// `last_heartbeat_at` both `now`, nothing relayed yet, not connected.
+    #[must_use]
+    pub fn starting() -> Self {
+        let now = now_ms();
+        Self {
+            pid: std::process::id(),
+            started_at: now,
+            last_heartbeat_at: now,
+            last_activity_at: None,
+            connected: false,
+            channel: None,
+            last_error: None,
+            error_count: 0,
+        }
+    }
+
+    /// Refresh the liveness clock to `now`, preserving every other field. Called
+    /// on each heartbeat tick when nothing else changed.
+    pub fn touch(&mut self) {
+        self.last_heartbeat_at = now_ms();
+    }
+
+    /// Mark a real unit of work: bumps both `last_activity_at` and the liveness
+    /// clock to `now`.
+    pub fn record_activity(&mut self) {
+        let now = now_ms();
+        self.last_activity_at = Some(now);
+        self.last_heartbeat_at = now;
+    }
+
+    /// Mark the channel/peer connection state, refreshing the liveness clock and
+    /// (optionally) labelling the channel.
+    pub fn set_connected(&mut self, connected: bool, channel: Option<String>) {
+        self.connected = connected;
+        if channel.is_some() {
+            self.channel = channel;
+        }
+        self.last_heartbeat_at = now_ms();
+    }
+
+    /// Record an error: increments the counter, stores the message, and refreshes
+    /// the liveness clock (the daemon is still alive, just unhappy).
+    pub fn record_error(&mut self, message: impl Into<String>) {
+        self.error_count = self.error_count.saturating_add(1);
+        self.last_error = Some(message.into());
+        self.last_heartbeat_at = now_ms();
+    }
+
+    /// Atomically write this record to `<name>`'s heartbeat file under `home`.
+    pub fn write_in(&self, home: &Path, name: &str) -> Result<()> {
+        write_atomic_json(&heartbeat_path_in(home, name), self)
+    }
+
+    /// Atomically write this record to `<name>`'s heartbeat file under the
+    /// default ainb home. Best-effort callers (daemons) should log-and-continue
+    /// on error — a failed heartbeat must never crash the daemon.
+    pub fn write(&self, name: &str) -> Result<()> {
+        self.write_in(&crate::fleet::plumbing::paths::ainb_home()?, name)
+    }
+
+    /// Read `<name>`'s heartbeat file under `home`, if present and parseable.
+    #[must_use]
+    pub fn read_in(home: &Path, name: &str) -> Option<Self> {
+        let text = std::fs::read_to_string(heartbeat_path_in(home, name)).ok()?;
+        serde_json::from_str(&text).ok()
+    }
+
+    /// Read `<name>`'s heartbeat file under the default ainb home.
+    #[must_use]
+    pub fn read(name: &str) -> Option<Self> {
+        let home = crate::fleet::plumbing::paths::ainb_home().ok()?;
+        Self::read_in(&home, name)
+    }
+}
+
+/// Best-effort liveness check: is `pid` still backing a running process? Uses
+/// `kill(pid, 0)`, which succeeds when the process exists (and we may signal
+/// it) and returns `ESRCH` otherwise. Mirrors `ainb-plugin-notifyd::pid`.
+#[must_use]
+pub fn is_pid_alive(pid: u32) -> bool {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    matches!(kill(Pid::from_raw(pid as i32), None), Ok(()))
+}
+
+/// Neutralise a daemon name for use as a filename: keep alphanumerics, `-`, `_`;
+/// everything else becomes `_`. Daemon names are fixed literals in practice, so
+/// this is a no-op guard against a path-traversal name.
+fn sanitize(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn starting_stamps_pid_and_clocks() {
+        let hb = DaemonHeartbeat::starting();
+        assert_eq!(hb.pid, std::process::id());
+        assert_eq!(hb.started_at, hb.last_heartbeat_at);
+        assert!(hb.last_activity_at.is_none());
+        assert!(!hb.connected);
+        assert_eq!(hb.error_count, 0);
+    }
+
+    #[test]
+    fn touch_advances_only_the_liveness_clock() {
+        let mut hb = DaemonHeartbeat::starting();
+        let started = hb.started_at;
+        let before = hb.last_heartbeat_at;
+        hb.last_heartbeat_at = before - 10_000; // pretend time passed
+        hb.touch();
+        assert!(hb.last_heartbeat_at >= before - 10_000);
+        // started_at never moves on a touch.
+        assert_eq!(hb.started_at, started);
+        assert!(hb.last_activity_at.is_none());
+    }
+
+    #[test]
+    fn record_activity_sets_activity_and_liveness() {
+        let mut hb = DaemonHeartbeat::starting();
+        hb.last_heartbeat_at = 0;
+        hb.record_activity();
+        assert!(hb.last_activity_at.is_some());
+        assert_eq!(hb.last_activity_at, Some(hb.last_heartbeat_at));
+    }
+
+    #[test]
+    fn set_connected_labels_channel_and_keeps_it() {
+        let mut hb = DaemonHeartbeat::starting();
+        hb.set_connected(true, Some("Telegram (@bot)".into()));
+        assert!(hb.connected);
+        assert_eq!(hb.channel.as_deref(), Some("Telegram (@bot)"));
+        // A later connected=false with no label must not wipe the label.
+        hb.set_connected(false, None);
+        assert!(!hb.connected);
+        assert_eq!(hb.channel.as_deref(), Some("Telegram (@bot)"));
+    }
+
+    #[test]
+    fn record_error_increments_and_stores() {
+        let mut hb = DaemonHeartbeat::starting();
+        hb.record_error("boom");
+        hb.record_error("bang");
+        assert_eq!(hb.error_count, 2);
+        assert_eq!(hb.last_error.as_deref(), Some("bang"));
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let home = TempDir::new().unwrap();
+        let mut hb = DaemonHeartbeat::starting();
+        hb.set_connected(true, Some("Telegram".into()));
+        hb.record_activity();
+        hb.write_in(home.path(), "bridge").unwrap();
+        let back = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
+        assert_eq!(back, hb);
+    }
+
+    #[test]
+    fn missing_heartbeat_reads_none() {
+        let home = TempDir::new().unwrap();
+        assert!(DaemonHeartbeat::read_in(home.path(), "nope").is_none());
+    }
+
+    #[test]
+    fn corrupt_heartbeat_reads_none_not_panic() {
+        let home = TempDir::new().unwrap();
+        std::fs::create_dir_all(daemons_dir_in(home.path())).unwrap();
+        std::fs::write(heartbeat_path_in(home.path(), "bridge"), b"{not json").unwrap();
+        assert!(DaemonHeartbeat::read_in(home.path(), "bridge").is_none());
+    }
+
+    #[test]
+    fn path_honours_explicit_home() {
+        let home = Path::new("/tmp/x/.agents-in-a-box");
+        assert_eq!(
+            heartbeat_path_in(home, "bridge"),
+            home.join("daemons").join("bridge.json")
+        );
+    }
+
+    #[test]
+    fn sanitize_blocks_path_traversal() {
+        let home = TempDir::new().unwrap();
+        let p = heartbeat_path_in(home.path(), "../../etc/evil");
+        assert!(p.starts_with(daemons_dir_in(home.path())));
+        assert!(!p.to_string_lossy().contains(".."));
+    }
+
+    #[test]
+    fn is_pid_alive_true_for_self_false_for_impossible() {
+        assert!(is_pid_alive(std::process::id()));
+        assert!(!is_pid_alive(0x7fff_ffff));
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
@@ -170,11 +170,84 @@ impl DaemonHeartbeat {
 /// Best-effort liveness check: is `pid` still backing a running process? Uses
 /// `kill(pid, 0)`, which succeeds when the process exists (and we may signal
 /// it) and returns `ESRCH` otherwise. Mirrors `ainb-plugin-notifyd::pid`.
+///
+/// LIVENESS IS NOT IDENTITY. The OS recycles pids, so a `true` here only means
+/// *some* process owns `pid` right now — not that it is the daemon that wrote
+/// the heartbeat. Use [`pid_identity`] to distinguish the original process from
+/// a recycled-pid impostor.
 #[must_use]
 pub fn is_pid_alive(pid: u32) -> bool {
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
     matches!(kill(Pid::from_raw(pid as i32), None), Ok(()))
+}
+
+/// Tolerance (ms) for matching a heartbeat's `started_at` against the live
+/// process's OS-reported start time. The heartbeat clock (`chrono` epoch ms,
+/// stamped *inside* the process a moment after `fork`/`exec`) and the kernel's
+/// start time (whole seconds, stamped at `fork`) are recorded by different
+/// clocks at slightly different instants, so an exact match is impossible. 5s
+/// comfortably covers that skew while staying far tighter than any realistic
+/// pid-recycle gap (a recycled pid's new process started seconds-to-hours after
+/// the dead daemon, never within 5s of the dead daemon's recorded start).
+pub const PID_IDENTITY_TOLERANCE_MS: i64 = 5_000;
+
+/// The verdict of cross-checking a heartbeat's pid against the live process
+/// identity. The whole point of the H1 fix: liveness alone must never equal
+/// "running".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidCheck {
+    /// A live process owns `pid` and its start time matches the heartbeat's
+    /// `started_at` — this is (overwhelmingly likely) the original daemon.
+    Matched,
+    /// A live process owns `pid` but its start time does NOT match — the pid was
+    /// recycled after the daemon died. The heartbeat is a tombstone.
+    Recycled,
+    /// No live process owns `pid`. The daemon is gone.
+    Dead,
+}
+
+/// Read the live process's start time as epoch milliseconds, if `pid` is backed
+/// by a process we can inspect. `sysinfo` reports whole-second granularity on
+/// both macOS (`kinfo_proc`) and Linux (`/proc/<pid>/stat`), so this is the
+/// second floored to ms. `None` means the process is gone or unreadable.
+#[must_use]
+pub fn process_start_ms(pid: u32) -> Option<i64> {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+    let mut sys = System::new();
+    let spid = Pid::from_u32(pid);
+    // Refresh ONLY this pid (no full process-table sweep) and don't mutate a
+    // shared map — `System::new()` starts empty.
+    sys.refresh_processes(ProcessesToUpdate::Some(&[spid]), false);
+    let secs = sys.process(spid)?.start_time();
+    i64::try_from(secs).ok().map(|s| s * 1000)
+}
+
+/// Cross-check a heartbeat's `pid`/`started_at` against the live process,
+/// returning whether it's the original daemon, a recycled-pid impostor, or
+/// dead. This is the identity guard the bare `kill(pid,0)` liveness check
+/// lacked.
+#[must_use]
+pub fn pid_identity(pid: u32, started_at_ms: i64) -> PidCheck {
+    classify_pid_identity(started_at_ms, process_start_ms(pid))
+}
+
+/// Pure core of [`pid_identity`]: given the heartbeat's recorded `started_at`
+/// and the live process's start time (`None` when no process owns the pid),
+/// decide the verdict. Separated so it is exhaustively unit-testable without a
+/// real process.
+#[must_use]
+pub fn classify_pid_identity(started_at_ms: i64, live_start_ms: Option<i64>) -> PidCheck {
+    match live_start_ms {
+        None => PidCheck::Dead,
+        Some(live) => {
+            if (live - started_at_ms).abs() <= PID_IDENTITY_TOLERANCE_MS {
+                PidCheck::Matched
+            } else {
+                PidCheck::Recycled
+            }
+        }
+    }
 }
 
 /// Neutralise a daemon name for use as a filename: keep alphanumerics, `-`, `_`;
@@ -296,5 +369,73 @@ mod tests {
     fn is_pid_alive_true_for_self_false_for_impossible() {
         assert!(is_pid_alive(std::process::id()));
         assert!(!is_pid_alive(0x7fff_ffff));
+    }
+
+    #[test]
+    fn classify_pid_identity_dead_when_no_live_process() {
+        // No process owns the pid → Dead regardless of recorded start.
+        assert_eq!(classify_pid_identity(1_000_000, None), PidCheck::Dead);
+    }
+
+    #[test]
+    fn classify_pid_identity_matches_within_tolerance() {
+        let started = 1_700_000_000_000;
+        // Live start within the tolerance window (sub-second skew between the
+        // chrono stamp and the kernel's whole-second start time).
+        assert_eq!(
+            classify_pid_identity(started, Some(started + 2_000)),
+            PidCheck::Matched
+        );
+        assert_eq!(
+            classify_pid_identity(started, Some(started - PID_IDENTITY_TOLERANCE_MS)),
+            PidCheck::Matched
+        );
+    }
+
+    #[test]
+    fn classify_pid_identity_recycled_when_live_start_far_off() {
+        // H1 core: the pid is alive but the live process started long after the
+        // heartbeat's daemon did → a recycled pid, NOT our daemon.
+        let started = 1_700_000_000_000;
+        assert_eq!(
+            classify_pid_identity(started, Some(started + 3_600_000)),
+            PidCheck::Recycled
+        );
+        // Just past the tolerance edge is already Recycled (no false Matched).
+        assert_eq!(
+            classify_pid_identity(started, Some(started + PID_IDENTITY_TOLERANCE_MS + 1)),
+            PidCheck::Recycled
+        );
+    }
+
+    #[test]
+    fn process_start_ms_reads_self_and_is_in_the_past() {
+        // The live identity probe must read SOMETHING for our own pid, and that
+        // start time must be at or before now (a process can't start in the
+        // future). This is what makes the recycled-pid cross-check possible.
+        let start = process_start_ms(std::process::id()).expect("self start readable");
+        assert!(start > 0);
+        assert!(
+            start <= now_ms() + PID_IDENTITY_TOLERANCE_MS,
+            "self start {start} must not be in the future (now {})",
+            now_ms()
+        );
+    }
+
+    #[test]
+    fn pid_identity_recycled_for_self_pid_with_bogus_started_at() {
+        // End-to-end identity check over a real live pid (ourself) whose recorded
+        // started_at is an hour off the real OS start: alive, but NOT a match →
+        // Recycled. This is exactly the H1 dead-daemon-pid-reuse signature.
+        let bogus_started = now_ms() - 3_600_000;
+        assert_eq!(
+            pid_identity(std::process::id(), bogus_started),
+            PidCheck::Recycled
+        );
+    }
+
+    #[test]
+    fn pid_identity_dead_for_impossible_pid() {
+        assert_eq!(pid_identity(0x7fff_ffff, now_ms()), PidCheck::Dead);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/mod.rs
@@ -1,0 +1,30 @@
+// ABOUTME: Unified daemon observability — one aggregator, two surfaces.
+//
+// This module answers a single question for every long-running ainb daemon:
+// "is it actually running, connected, and doing work — right now?" — not merely
+// "is a launchd service installed?". It powers both the `ainb fleet daemons`
+// CLI verb (`cli/fleet/daemons.rs`) and the TUI Daemons screen
+// (`components/daemons.rs`), which render from the SAME [`collect`] function so
+// the two views can never drift.
+//
+// The mechanism is a lightweight heartbeat file per daemon
+// (`heartbeat.rs` → `~/.agents-in-a-box/daemons/<name>.json`), cross-checked
+// against real liveness signals (is the `pid` alive? is the socket reachable?):
+//
+//   * the phone bridge + the fleet auto-continue watcher WRITE a heartbeat
+//     (they had no observability at all — the bridge's was the original blind
+//     spot this feature closes), and
+//   * notifyd + ATC are READ from the signals they already maintain (notifyd's
+//     PID file + Unix socket + sqlite DB; ATC's `heartbeat-state.json`), so we
+//     don't duplicate state a daemon already owns.
+//
+// The aggregator's contract is the stale-heartbeat cross-check: a heartbeat
+// whose `pid` is no longer alive — or whose `last_heartbeat_at` is older than
+// the staleness window — reports `Stopped` (with a "stale heartbeat" reason),
+// never a false `Running`. That is what makes a crashed daemon visible.
+
+pub mod heartbeat;
+pub mod probe;
+
+pub use heartbeat::{DaemonHeartbeat, is_pid_alive};
+pub use probe::{DaemonKind, DaemonState, DaemonStatus, collect, collect_in};

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use super::heartbeat::{DaemonHeartbeat, is_pid_alive};
+use super::heartbeat::{DaemonHeartbeat, PidCheck, is_pid_alive, pid_identity};
 
 /// A heartbeat older than this (and whose pid is *still* alive — e.g. a wedged
 /// daemon that stopped ticking) is treated as stale. A dead pid is caught
@@ -150,13 +150,18 @@ impl DaemonStatus {
 }
 
 /// Decide a heartbeat-backed daemon's status from its heartbeat (if any),
-/// cross-checking pid liveness and the staleness window against `now_ms`. Pure
-/// over its inputs so it is exhaustively unit-testable without touching disk.
+/// cross-checking process *identity* (not mere liveness) and the staleness
+/// window against `now_ms`. Pure over its inputs so it is exhaustively
+/// unit-testable without touching disk.
+///
+/// `pid_check` is the identity verdict from [`super::heartbeat::pid_identity`]:
+/// liveness alone is never enough — a recycled pid (a different process that
+/// inherited the dead daemon's pid) must report Stopped, not Running.
 #[must_use]
 pub fn classify_heartbeat(
     kind: DaemonKind,
     hb: Option<DaemonHeartbeat>,
-    pid_alive: bool,
+    pid_check: PidCheck,
     now_ms: i64,
 ) -> DaemonStatus {
     let Some(hb) = hb else {
@@ -166,9 +171,20 @@ pub fn classify_heartbeat(
     let age = now_ms.saturating_sub(hb.last_heartbeat_at);
     let uptime = Some(now_ms.saturating_sub(hb.started_at));
 
-    // A dead pid is the strongest possible signal: the writing process is gone,
-    // so the heartbeat is a tombstone no matter how recent it looks.
-    if !pid_alive {
+    // A dead OR recycled pid is the strongest possible signal: the process that
+    // wrote this heartbeat is gone, so the heartbeat is a tombstone no matter
+    // how recent it looks. A recycled pid is *alive* but is a different process
+    // that merely inherited the dead daemon's pid — treating it as Running was
+    // the bug.
+    if matches!(pid_check, PidCheck::Dead | PidCheck::Recycled) {
+        let reason = match pid_check {
+            PidCheck::Recycled => format!(
+                "stale heartbeat — pid {} recycled (different process, crashed)",
+                hb.pid
+            ),
+            // PidCheck::Dead (Matched is excluded by the match arm).
+            _ => format!("stale heartbeat — pid {} not alive (crashed)", hb.pid),
+        };
         return DaemonStatus {
             kind,
             state: DaemonState::Stopped,
@@ -179,7 +195,7 @@ pub fn classify_heartbeat(
             last_activity_at: hb.last_activity_at,
             error_count: hb.error_count,
             last_error: hb.last_error,
-            reason: format!("stale heartbeat — pid {} not alive (crashed)", hb.pid),
+            reason,
         };
     }
 
@@ -224,8 +240,10 @@ pub fn classify_heartbeat(
 #[must_use]
 pub fn probe_heartbeat_daemon(home: &Path, kind: DaemonKind, now_ms: i64) -> DaemonStatus {
     let hb = DaemonHeartbeat::read_in(home, kind.id());
-    let pid_alive = hb.as_ref().is_some_and(|h| is_pid_alive(h.pid));
-    classify_heartbeat(kind, hb, pid_alive, now_ms)
+    // Cross-check process IDENTITY, not bare liveness: a recycled pid is alive
+    // but is not our daemon, so it must classify as Stopped (H1).
+    let pid_check = hb.as_ref().map_or(PidCheck::Dead, |h| pid_identity(h.pid, h.started_at));
+    classify_heartbeat(kind, hb, pid_check, now_ms)
 }
 
 /// Probe notifyd from the signals it already maintains: PID-file liveness, the
@@ -453,7 +471,7 @@ mod tests {
 
     #[test]
     fn no_heartbeat_is_clean_stopped() {
-        let s = classify_heartbeat(DaemonKind::Bridge, None, false, 1000);
+        let s = classify_heartbeat(DaemonKind::Bridge, None, PidCheck::Dead, 1000);
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("not running"));
         assert!(s.pid.is_none());
@@ -465,7 +483,7 @@ mod tests {
         let s = classify_heartbeat(
             DaemonKind::Bridge,
             Some(hb(42, now - 5000, now - 1000, true)),
-            true,
+            PidCheck::Matched,
             now,
         );
         assert_eq!(s.state, DaemonState::Running);
@@ -481,7 +499,7 @@ mod tests {
         let s = classify_heartbeat(
             DaemonKind::Bridge,
             Some(hb(42, now - 5000, now - 1000, false)),
-            true,
+            PidCheck::Matched,
             now,
         );
         assert_eq!(s.state, DaemonState::Running);
@@ -496,7 +514,7 @@ mod tests {
         let s = classify_heartbeat(
             DaemonKind::Bridge,
             Some(hb(42, now - 5000, now - 100, true)),
-            false,
+            PidCheck::Dead,
             now,
         );
         assert_eq!(s.state, DaemonState::Stopped);
@@ -506,12 +524,37 @@ mod tests {
     }
 
     #[test]
+    fn recycled_pid_is_stale_even_with_recent_beat_and_live_pid() {
+        // H1 regression: the writing daemon died, the OS recycled its pid, and a
+        // DIFFERENT live process now owns it. A bare liveness check would say
+        // "running"; the identity cross-check must say Stopped (recycled).
+        let now = 1_000_000;
+        let s = classify_heartbeat(
+            DaemonKind::Bridge,
+            Some(hb(42, now - 5000, now - 100, true)),
+            PidCheck::Recycled,
+            now,
+        );
+        assert_eq!(
+            s.state,
+            DaemonState::Stopped,
+            "a recycled pid (live but not our process) must never report Running"
+        );
+        assert!(s.reason.contains("recycled"), "reason: {}", s.reason);
+        assert!(s.reason.contains("crashed"), "reason: {}", s.reason);
+        assert!(
+            !s.connected,
+            "a recycled-pid daemon must not report connected"
+        );
+    }
+
+    #[test]
     fn wedged_daemon_live_pid_but_old_beat_is_stale() {
         let now = 1_000_000;
         let s = classify_heartbeat(
             DaemonKind::FleetDaemon,
             Some(hb(42, now - 200_000, now - (STALE_AFTER_MS + 5000), true)),
-            true,
+            PidCheck::Matched,
             now,
         );
         assert_eq!(s.state, DaemonState::Stopped);
@@ -526,7 +569,7 @@ mod tests {
         let s = classify_heartbeat(
             DaemonKind::Bridge,
             Some(hb(7, now - 100_000, now - STALE_AFTER_MS, true)),
-            true,
+            PidCheck::Matched,
             now,
         );
         assert_eq!(s.state, DaemonState::Running);
@@ -553,6 +596,12 @@ mod tests {
     fn probe_heartbeat_daemon_running_for_self_pid() {
         let home = TempDir::new().unwrap();
         let mut h = DaemonHeartbeat::starting(); // pid = self, alive
+        // The identity cross-check (H1) matches the heartbeat's `started_at`
+        // against the live process's OS start time. `starting()` stamps
+        // started_at = NOW, but the test process started earlier — so stamp the
+        // real OS start time to simulate an honest daemon heartbeat.
+        h.started_at = super::super::heartbeat::process_start_ms(std::process::id())
+            .expect("self process start time readable");
         h.set_connected(true, Some("Telegram".into()));
         h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
         let s = probe_heartbeat_daemon(
@@ -562,6 +611,32 @@ mod tests {
         );
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
+    }
+
+    #[test]
+    fn probe_heartbeat_daemon_stale_for_recycled_self_pid() {
+        // H1 disk-backed regression: a heartbeat for a LIVE pid (this process)
+        // whose `started_at` does NOT match the process's real start time is the
+        // pid-recycle signature — a dead daemon whose pid the OS handed to a
+        // different, live process. It must classify Stopped (recycled), never
+        // Running, even though `kill(pid,0)` succeeds.
+        let home = TempDir::new().unwrap();
+        let mut h = DaemonHeartbeat::starting(); // pid = self (alive)
+        let now = super::super::heartbeat::now_ms();
+        // started_at one hour ago — far outside the identity tolerance vs the
+        // real process start, but a recent beat so staleness alone wouldn't trip.
+        h.started_at = now - 3_600_000;
+        h.last_heartbeat_at = now - 1_000;
+        h.set_connected(true, Some("Telegram".into()));
+        h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
+        let s = probe_heartbeat_daemon(home.path(), DaemonKind::Bridge, now);
+        assert_eq!(
+            s.state,
+            DaemonState::Stopped,
+            "live-but-mismatched pid must be Stopped (recycled), not Running"
+        );
+        assert!(s.reason.contains("recycled"), "reason: {}", s.reason);
+        assert!(!s.connected);
     }
 
     #[test]
@@ -694,6 +769,10 @@ mod tests {
         let home = TempDir::new().unwrap();
         let notifyd = TempDir::new().unwrap();
         let mut h = DaemonHeartbeat::starting();
+        // Stamp the real OS start time so the H1 identity cross-check matches
+        // (the test process started earlier than `starting()`'s NOW).
+        h.started_at = super::super::heartbeat::process_start_ms(std::process::id())
+            .expect("self process start time readable");
         h.set_connected(true, Some("Telegram (@bot)".into()));
         h.record_activity();
         h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -320,13 +320,29 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
     // Pick the most-recently-beating instance as the representative row, and
     // report it. (v1 surfaces ATC as one daemon; the instance name goes in the
     // channel label.)
+    //
+    // Only instances whose `heartbeat_enabled` is true are running-sources: an
+    // instance with the OS timer DISABLED is not running no matter how recent
+    // its last (pre-disable) heartbeat looks — counting it was the M2 false
+    // "running". Track how many enabled instances we saw so we can distinguish
+    // "all disabled" from "none have beaten yet".
     let mut best: Option<(String, HeartbeatState, u32)> = None;
+    let mut enabled_count = 0_usize;
     for name in &names {
         let p = AtcPaths::under_root(&atc_root, name);
-        let interval_min = std::fs::read_to_string(&p.meta)
-            .ok()
-            .and_then(|s| AtcMeta::from_json(&s).ok())
-            .map_or(15, |m| m.heartbeat_interval_min.max(1));
+        let meta = std::fs::read_to_string(&p.meta).ok().and_then(|s| AtcMeta::from_json(&s).ok());
+        // Default to enabled when meta is unreadable: a missing/corrupt meta is a
+        // probe problem, not proof the timer is off, so we don't silently hide a
+        // possibly-running instance. `AtcMeta::new` defaults `heartbeat_enabled`
+        // to true, matching this.
+        let heartbeat_enabled = meta.as_ref().map_or(true, |m| m.heartbeat_enabled);
+        let interval_min = meta.map_or(15, |m| m.heartbeat_interval_min.max(1));
+        if !heartbeat_enabled {
+            // Disabled instances are never a running-source. Skip before reading
+            // the heartbeat state so a stale beat can't promote it.
+            continue;
+        }
+        enabled_count += 1;
         let Some(hbs) = std::fs::read_to_string(&p.heartbeat_state)
             .ok()
             .map(|s| HeartbeatState::from_json_or_default(&s))
@@ -343,11 +359,22 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
     }
 
     let Some((name, hbs, interval_min)) = best else {
+        // No enabled instance produced a usable heartbeat. If NONE of the
+        // provisioned instances are even enabled, the daemon is configured off.
+        if enabled_count == 0 {
+            return DaemonStatus::stopped(
+                kind,
+                format!(
+                    "{} instance(s) provisioned, all heartbeat-disabled",
+                    names.len()
+                ),
+            );
+        }
         return DaemonStatus::stopped(
             kind,
             format!(
-                "{} instance(s) provisioned, none have beaten yet",
-                names.len()
+                "{} enabled instance(s), none have beaten yet",
+                enabled_count
             ),
         );
     };
@@ -719,6 +746,78 @@ mod tests {
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
         assert!(s.channel.as_deref().unwrap().contains("primary"));
+    }
+
+    #[test]
+    fn probe_atc_heartbeat_disabled_instance_is_stopped_not_running() {
+        // M2 regression: an instance with `heartbeat_enabled:false` but a very
+        // recent `last_heartbeat_ms` must report Stopped — the timer is off, so
+        // a leftover recent beat must not be counted as running.
+        let home = TempDir::new().unwrap();
+        let atc_dir = home.path().join("atc").join("primary");
+        std::fs::create_dir_all(&atc_dir).unwrap();
+        std::fs::write(
+            atc_dir.join("meta.json"),
+            r#"{"name":"primary","heartbeat_enabled":false,"heartbeat_interval_min":15,"idle_pause_min":60}"#,
+        )
+        .unwrap();
+        let now = super::super::heartbeat::now_ms();
+        std::fs::write(
+            atc_dir.join("heartbeat-state.json"),
+            format!(
+                r#"{{"last_heartbeat_ms":{},"last_active_ms":{},"continue_counts":{{}}}}"#,
+                now - 1000,
+                now - 2000
+            ),
+        )
+        .unwrap();
+        let s = probe_atc(home.path(), now);
+        assert_eq!(
+            s.state,
+            DaemonState::Stopped,
+            "a heartbeat-disabled ATC instance must never report Running"
+        );
+        assert!(
+            s.reason.contains("disabled"),
+            "reason should explain the disable: {}",
+            s.reason
+        );
+    }
+
+    #[test]
+    fn probe_atc_disabled_does_not_mask_an_enabled_running_sibling() {
+        // Defense for the multi-instance case: a disabled instance with a recent
+        // beat sits next to an ENABLED instance that is genuinely beating. The
+        // probe must report Running from the enabled one, not be confused by the
+        // disabled sibling.
+        let home = TempDir::new().unwrap();
+        let now = super::super::heartbeat::now_ms();
+        for (name, enabled) in [("off", false), ("on", true)] {
+            let dir = home.path().join("atc").join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("meta.json"),
+                format!(
+                    r#"{{"name":"{name}","heartbeat_enabled":{enabled},"heartbeat_interval_min":15,"idle_pause_min":60}}"#
+                ),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("heartbeat-state.json"),
+                format!(
+                    r#"{{"last_heartbeat_ms":{},"continue_counts":{{}}}}"#,
+                    now - 1000
+                ),
+            )
+            .unwrap();
+        }
+        let s = probe_atc(home.path(), now);
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(
+            s.channel.as_deref().unwrap().contains("on"),
+            "the enabled instance must be the representative row: {:?}",
+            s.channel
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -327,7 +327,10 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
     let Some((name, hbs, interval_min)) = best else {
         return DaemonStatus::stopped(
             kind,
-            format!("{} instance(s) provisioned, none have beaten yet", names.len()),
+            format!(
+                "{} instance(s) provisioned, none have beaten yet",
+                names.len()
+            ),
         );
     };
 
@@ -350,7 +353,10 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
             last_activity_at: hbs.last_active_ms,
             ..DaemonStatus::stopped(
                 kind,
-                format!("stale — last heartbeat {}m ago (timer stopped?)", age / 60_000),
+                format!(
+                    "stale — last heartbeat {}m ago (timer stopped?)",
+                    age / 60_000
+                ),
             )
         };
     }
@@ -420,7 +426,11 @@ pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
             .map(|h| h.join(".agents-in-a-box"))
             .unwrap_or_else(|| ainb_home.clone())
     };
-    Ok(collect_in(&ainb_home, &notifyd_base, super::heartbeat::now_ms()))
+    Ok(collect_in(
+        &ainb_home,
+        &notifyd_base,
+        super::heartbeat::now_ms(),
+    ))
 }
 
 #[cfg(test)]
@@ -452,7 +462,12 @@ mod tests {
     #[test]
     fn fresh_heartbeat_with_live_pid_is_running_connected() {
         let now = 1_000_000;
-        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(42, now - 5000, now - 1000, true)), true, now);
+        let s = classify_heartbeat(
+            DaemonKind::Bridge,
+            Some(hb(42, now - 5000, now - 1000, true)),
+            true,
+            now,
+        );
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
         assert_eq!(s.pid, Some(42));
@@ -463,7 +478,12 @@ mod tests {
     #[test]
     fn fresh_heartbeat_not_yet_connected_is_running_connecting() {
         let now = 1_000_000;
-        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(42, now - 5000, now - 1000, false)), true, now);
+        let s = classify_heartbeat(
+            DaemonKind::Bridge,
+            Some(hb(42, now - 5000, now - 1000, false)),
+            true,
+            now,
+        );
         assert_eq!(s.state, DaemonState::Running);
         assert!(!s.connected);
         assert!(s.reason.contains("connecting"));
@@ -473,7 +493,12 @@ mod tests {
     fn dead_pid_is_stale_even_with_recent_beat() {
         // The crash signal: a very recent heartbeat but the writing pid is gone.
         let now = 1_000_000;
-        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(42, now - 5000, now - 100, true)), false, now);
+        let s = classify_heartbeat(
+            DaemonKind::Bridge,
+            Some(hb(42, now - 5000, now - 100, true)),
+            false,
+            now,
+        );
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("stale heartbeat"));
         assert!(s.reason.contains("crashed"));
@@ -498,7 +523,12 @@ mod tests {
     fn beat_exactly_at_window_edge_is_still_running() {
         let now = 1_000_000;
         // age == STALE_AFTER_MS is NOT > the window, so still running.
-        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(7, now - 100_000, now - STALE_AFTER_MS, true)), true, now);
+        let s = classify_heartbeat(
+            DaemonKind::Bridge,
+            Some(hb(7, now - 100_000, now - STALE_AFTER_MS, true)),
+            true,
+            now,
+        );
         assert_eq!(s.state, DaemonState::Running);
     }
 
@@ -510,7 +540,11 @@ mod tests {
         h.pid = 0x7fff_ffff;
         h.set_connected(true, Some("Telegram".into()));
         h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
-        let s = probe_heartbeat_daemon(home.path(), DaemonKind::Bridge, super::super::heartbeat::now_ms());
+        let s = probe_heartbeat_daemon(
+            home.path(),
+            DaemonKind::Bridge,
+            super::super::heartbeat::now_ms(),
+        );
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("crashed"));
     }
@@ -521,7 +555,11 @@ mod tests {
         let mut h = DaemonHeartbeat::starting(); // pid = self, alive
         h.set_connected(true, Some("Telegram".into()));
         h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
-        let s = probe_heartbeat_daemon(home.path(), DaemonKind::Bridge, super::super::heartbeat::now_ms());
+        let s = probe_heartbeat_daemon(
+            home.path(),
+            DaemonKind::Bridge,
+            super::super::heartbeat::now_ms(),
+        );
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
     }
@@ -547,7 +585,11 @@ mod tests {
     #[test]
     fn probe_notifyd_live_pid_with_socket_and_db_is_connected() {
         let base = TempDir::new().unwrap();
-        std::fs::write(base.path().join("notify.pid"), format!("{}\n", std::process::id())).unwrap();
+        std::fs::write(
+            base.path().join("notify.pid"),
+            format!("{}\n", std::process::id()),
+        )
+        .unwrap();
         std::fs::write(base.path().join("notify.sock"), b"").unwrap();
         std::fs::write(base.path().join("notifications.db"), b"").unwrap();
         let s = probe_notifyd(base.path(), super::super::heartbeat::now_ms());
@@ -559,7 +601,11 @@ mod tests {
     #[test]
     fn probe_notifyd_live_pid_without_socket_is_running_not_connected() {
         let base = TempDir::new().unwrap();
-        std::fs::write(base.path().join("notify.pid"), format!("{}\n", std::process::id())).unwrap();
+        std::fs::write(
+            base.path().join("notify.pid"),
+            format!("{}\n", std::process::id()),
+        )
+        .unwrap();
         let s = probe_notifyd(base.path(), super::super::heartbeat::now_ms());
         assert_eq!(s.state, DaemonState::Running);
         assert!(!s.connected);
@@ -587,7 +633,11 @@ mod tests {
         let now = super::super::heartbeat::now_ms();
         std::fs::write(
             atc_dir.join("heartbeat-state.json"),
-            format!(r#"{{"last_heartbeat_ms":{},"last_active_ms":{},"continue_counts":{{}}}}"#, now - 1000, now - 2000),
+            format!(
+                r#"{{"last_heartbeat_ms":{},"last_active_ms":{},"continue_counts":{{}}}}"#,
+                now - 1000,
+                now - 2000
+            ),
         )
         .unwrap();
         let s = probe_atc(home.path(), now);
@@ -610,7 +660,10 @@ mod tests {
         // last beat hours ago — well past 2*15m + grace.
         std::fs::write(
             atc_dir.join("heartbeat-state.json"),
-            format!(r#"{{"last_heartbeat_ms":{},"continue_counts":{{}}}}"#, now - 10 * 3_600_000),
+            format!(
+                r#"{{"last_heartbeat_ms":{},"continue_counts":{{}}}}"#,
+                now - 10 * 3_600_000
+            ),
         )
         .unwrap();
         let s = probe_atc(home.path(), now);
@@ -622,7 +675,11 @@ mod tests {
     fn collect_in_returns_all_four_in_stable_order() {
         let home = TempDir::new().unwrap();
         let notifyd = TempDir::new().unwrap();
-        let rows = collect_in(home.path(), notifyd.path(), super::super::heartbeat::now_ms());
+        let rows = collect_in(
+            home.path(),
+            notifyd.path(),
+            super::super::heartbeat::now_ms(),
+        );
         assert_eq!(rows.len(), 4);
         assert_eq!(rows[0].kind, DaemonKind::Bridge);
         assert_eq!(rows[1].kind, DaemonKind::Notifyd);
@@ -640,7 +697,11 @@ mod tests {
         h.set_connected(true, Some("Telegram (@bot)".into()));
         h.record_activity();
         h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
-        let rows = collect_in(home.path(), notifyd.path(), super::super::heartbeat::now_ms());
+        let rows = collect_in(
+            home.path(),
+            notifyd.path(),
+            super::super::heartbeat::now_ms(),
+        );
         assert_eq!(rows[0].kind, DaemonKind::Bridge);
         assert_eq!(rows[0].state, DaemonState::Running);
         assert!(rows[0].connected);

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -259,7 +259,11 @@ pub fn probe_notifyd(base: &Path, now_ms: i64) -> DaemonStatus {
 
     let pid = read_pid_file(&pid_path);
     let pid_alive = pid.is_some_and(is_pid_alive);
-    let socket_ok = socket_path.exists();
+    // L1: a bound, ACCEPTING listener — not merely a socket file on disk. A
+    // crashed daemon can leave a stale `notify.sock` behind; `exists()` would
+    // then falsely report "connected". A non-blocking connect proves a listener
+    // is actually serving.
+    let socket_ok = socket_is_listening(&socket_path);
     let db_ok = db_path.exists();
 
     if !pid_alive {
@@ -431,6 +435,18 @@ impl DaemonStatus {
 /// Read a `notify.pid`-style PID file: a single integer, trimmed.
 fn read_pid_file(path: &Path) -> Option<u32> {
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// Is a Unix-socket listener actually bound and accepting at `path`? (L1.)
+///
+/// `path.exists()` only proves a socket FILE is present — a crashed daemon
+/// leaves a stale one behind. A `connect()` succeeds only when a listener is
+/// bound and accepting; a stale socket file refuses the connection
+/// (`ECONNREFUSED`). The connect is immediately dropped, so this is a cheap,
+/// non-blocking liveness probe of the listener itself, not a duplicate read of
+/// `socket_path.exists()`.
+fn socket_is_listening(path: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
 /// Best-effort last-write time of a file as epoch ms — used as notifyd's
@@ -692,12 +708,42 @@ mod tests {
             format!("{}\n", std::process::id()),
         )
         .unwrap();
-        std::fs::write(base.path().join("notify.sock"), b"").unwrap();
+        // L1: connected requires an ACTUAL bound listener, not just a socket
+        // file. Bind one and keep it alive for the duration of the probe.
+        let _listener =
+            std::os::unix::net::UnixListener::bind(base.path().join("notify.sock")).unwrap();
         std::fs::write(base.path().join("notifications.db"), b"").unwrap();
         let s = probe_notifyd(base.path(), super::super::heartbeat::now_ms());
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
         assert!(s.reason.contains("socket bound"));
+    }
+
+    #[test]
+    fn probe_notifyd_stale_socket_file_without_listener_is_not_connected() {
+        // L1 regression: a crashed daemon left a stale `notify.sock` FILE but no
+        // listener is bound. `exists()` would falsely report connected; a
+        // connect() refuses, so we must report running-but-not-connected.
+        let base = TempDir::new().unwrap();
+        std::fs::write(
+            base.path().join("notify.pid"),
+            format!("{}\n", std::process::id()),
+        )
+        .unwrap();
+        // A plain file at the socket path — present but NOT a listener.
+        std::fs::write(base.path().join("notify.sock"), b"").unwrap();
+        std::fs::write(base.path().join("notifications.db"), b"").unwrap();
+        let s = probe_notifyd(base.path(), super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(
+            !s.connected,
+            "a stale socket file with no listener must not report connected"
+        );
+        assert!(
+            s.reason.contains("socket not bound"),
+            "reason: {}",
+            s.reason
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -1,0 +1,665 @@
+// ABOUTME: The per-daemon probes + the [`collect`] aggregator the CLI and TUI share.
+//
+// Each probe turns one daemon's on-disk signals into a typed [`DaemonStatus`].
+// Two probe shapes:
+//
+//   * HEARTBEAT-BACKED (bridge, fleet daemon): read the daemon's
+//     `~/.agents-in-a-box/daemons/<name>.json` heartbeat and cross-check it.
+//     A heartbeat whose `pid` is dead, or whose `last_heartbeat_at` is older
+//     than [`STALE_AFTER_MS`], is reported `Stopped` with a "stale heartbeat"
+//     reason — the crashed-daemon-shows-stale guarantee. No heartbeat file at
+//     all → `Stopped` (clean: never started this session).
+//
+//   * NATIVE-SIGNAL (notifyd, ATC): read the signals the daemon already
+//     maintains instead of a duplicate heartbeat. notifyd = PID-file liveness
+//     + Unix socket present + sqlite DB present. ATC = its existing
+//     `heartbeat-state.json` cadence across all provisioned instances.
+//
+// `STALE_AFTER_MS` is deliberately generous (90s) so a daemon that heartbeats
+// every few seconds is never flagged stale by a slow tick, while a truly dead
+// daemon (whose pid is also gone) is caught immediately by the pid cross-check
+// regardless of the window.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::heartbeat::{DaemonHeartbeat, is_pid_alive};
+
+/// A heartbeat older than this (and whose pid is *still* alive — e.g. a wedged
+/// daemon that stopped ticking) is treated as stale. A dead pid is caught
+/// immediately regardless of this window. 90s comfortably covers the bridge's
+/// 30s long-poll cycle and the fleet daemon's 5s tick with headroom.
+pub const STALE_AFTER_MS: i64 = 90_000;
+
+/// Which daemon a [`DaemonStatus`] describes. Stable wire strings for the JSON
+/// surface and stable display names for the text/TUI surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DaemonKind {
+    /// Native Telegram/Slack phone bridge.
+    Bridge,
+    /// Unix-socket notification daemon (`ainb-notifyd`).
+    Notifyd,
+    /// Air Traffic Control fleet brain.
+    Atc,
+    /// Auto-continue API-error watcher (`ainb fleet daemon`).
+    FleetDaemon,
+}
+
+impl DaemonKind {
+    /// Stable lowercase id (heartbeat filename + JSON `kind`).
+    #[must_use]
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Bridge => "bridge",
+            Self::Notifyd => "notifyd",
+            Self::Atc => "atc",
+            Self::FleetDaemon => "fleet-daemon",
+        }
+    }
+
+    /// Human display name for the text/TUI surfaces.
+    #[must_use]
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Bridge => "phone bridge",
+            Self::Notifyd => "notifyd",
+            Self::Atc => "ATC",
+            Self::FleetDaemon => "fleet daemon",
+        }
+    }
+}
+
+/// Coarse runtime state of a daemon. The whole point of the feature: distinguish
+/// a live-and-working daemon from a dead one, and a clean stop from a crash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DaemonState {
+    /// Process alive and heartbeating (or native signals confirm it's serving).
+    Running,
+    /// Not running. The `reason` on [`DaemonStatus`] says whether it's a clean
+    /// stop, a stale heartbeat from a crash, or never-configured.
+    Stopped,
+    /// We couldn't determine the state (e.g. an error reading a signal). Rare;
+    /// surfaced rather than guessed so the operator knows the probe itself is
+    /// the problem, not the daemon.
+    Unknown,
+}
+
+impl DaemonState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// One row of the Daemons view — the typed model both surfaces render.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonStatus {
+    /// Which daemon this describes.
+    pub kind: DaemonKind,
+    /// Coarse runtime state.
+    pub state: DaemonState,
+    /// OS pid, when known (from a heartbeat or a PID file).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    /// Milliseconds since the daemon started, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uptime_ms: Option<i64>,
+    /// Daemon-specific connection health (Telegram online / peer registered /
+    /// socket+DB reachable / heartbeat alive).
+    #[serde(default)]
+    pub connected: bool,
+    /// Human label for the connection (e.g. `"Telegram (@bot)"`, `"socket+db"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Epoch ms of the daemon's last real activity, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity_at: Option<i64>,
+    /// Count of errors observed this run.
+    #[serde(default)]
+    pub error_count: u64,
+    /// The most recent error string, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    /// A short human explanation of the state — the load-bearing field for
+    /// telling "clean stop" from "crashed (stale heartbeat)".
+    pub reason: String,
+}
+
+impl DaemonStatus {
+    fn stopped(kind: DaemonKind, reason: impl Into<String>) -> Self {
+        Self {
+            kind,
+            state: DaemonState::Stopped,
+            pid: None,
+            uptime_ms: None,
+            connected: false,
+            channel: None,
+            last_activity_at: None,
+            error_count: 0,
+            last_error: None,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Decide a heartbeat-backed daemon's status from its heartbeat (if any),
+/// cross-checking pid liveness and the staleness window against `now_ms`. Pure
+/// over its inputs so it is exhaustively unit-testable without touching disk.
+#[must_use]
+pub fn classify_heartbeat(
+    kind: DaemonKind,
+    hb: Option<DaemonHeartbeat>,
+    pid_alive: bool,
+    now_ms: i64,
+) -> DaemonStatus {
+    let Some(hb) = hb else {
+        return DaemonStatus::stopped(kind, "no heartbeat — not running this session");
+    };
+
+    let age = now_ms.saturating_sub(hb.last_heartbeat_at);
+    let uptime = Some(now_ms.saturating_sub(hb.started_at));
+
+    // A dead pid is the strongest possible signal: the writing process is gone,
+    // so the heartbeat is a tombstone no matter how recent it looks.
+    if !pid_alive {
+        return DaemonStatus {
+            kind,
+            state: DaemonState::Stopped,
+            pid: Some(hb.pid),
+            uptime_ms: None,
+            connected: false,
+            channel: hb.channel,
+            last_activity_at: hb.last_activity_at,
+            error_count: hb.error_count,
+            last_error: hb.last_error,
+            reason: format!("stale heartbeat — pid {} not alive (crashed)", hb.pid),
+        };
+    }
+
+    // The pid is alive but the heartbeat went quiet past the window: the process
+    // exists but its loop is wedged or paused. Report stopped+stale so we don't
+    // claim a healthy daemon.
+    if age > STALE_AFTER_MS {
+        return DaemonStatus {
+            kind,
+            state: DaemonState::Stopped,
+            pid: Some(hb.pid),
+            uptime_ms: uptime,
+            connected: false,
+            channel: hb.channel,
+            last_activity_at: hb.last_activity_at,
+            error_count: hb.error_count,
+            last_error: hb.last_error,
+            reason: format!("stale heartbeat — last beat {}s ago (wedged?)", age / 1000),
+        };
+    }
+
+    DaemonStatus {
+        kind,
+        state: DaemonState::Running,
+        pid: Some(hb.pid),
+        uptime_ms: uptime,
+        connected: hb.connected,
+        channel: hb.channel,
+        last_activity_at: hb.last_activity_at,
+        error_count: hb.error_count,
+        last_error: hb.last_error,
+        reason: if hb.connected {
+            "running + connected".to_string()
+        } else {
+            "running (connecting…)".to_string()
+        },
+    }
+}
+
+/// Probe a heartbeat-backed daemon (bridge / fleet daemon) under an explicit
+/// ainb home. Reads the heartbeat, checks pid liveness, classifies.
+#[must_use]
+pub fn probe_heartbeat_daemon(home: &Path, kind: DaemonKind, now_ms: i64) -> DaemonStatus {
+    let hb = DaemonHeartbeat::read_in(home, kind.id());
+    let pid_alive = hb.as_ref().is_some_and(|h| is_pid_alive(h.pid));
+    classify_heartbeat(kind, hb, pid_alive, now_ms)
+}
+
+/// Probe notifyd from the signals it already maintains: PID-file liveness, the
+/// Unix socket, and the sqlite DB. `base` is notifyd's home (it does NOT honour
+/// `$AINB_HOME` — it always uses `~/.agents-in-a-box` in production — so the
+/// caller passes the resolved base, and tests pass a tempdir).
+#[must_use]
+pub fn probe_notifyd(base: &Path, now_ms: i64) -> DaemonStatus {
+    let kind = DaemonKind::Notifyd;
+    let pid_path = base.join("notify.pid");
+    let socket_path = base.join("notify.sock");
+    let db_path = base.join("notifications.db");
+
+    let pid = read_pid_file(&pid_path);
+    let pid_alive = pid.is_some_and(is_pid_alive);
+    let socket_ok = socket_path.exists();
+    let db_ok = db_path.exists();
+
+    if !pid_alive {
+        // No live pid. If a pid file lingers, the daemon crashed; otherwise it's
+        // simply not running.
+        let reason = match pid {
+            Some(p) => format!("stale pid {p} — not running (crashed)"),
+            None => "no pid file — not running".to_string(),
+        };
+        return DaemonStatus {
+            kind,
+            pid,
+            ..DaemonStatus::stopped(kind, reason)
+        };
+    }
+
+    // Pid is alive. Connection health = the socket is bound AND the DB exists.
+    let connected = socket_ok && db_ok;
+    let reason = if connected {
+        "running + connected (socket bound, db reachable)".to_string()
+    } else if !socket_ok {
+        "running but socket not bound yet".to_string()
+    } else {
+        "running but db not reachable".to_string()
+    };
+    DaemonStatus {
+        kind,
+        state: DaemonState::Running,
+        pid,
+        uptime_ms: None, // notifyd's PID file carries no start time
+        connected,
+        channel: Some("unix socket + sqlite".to_string()),
+        last_activity_at: db_mtime_ms(&db_path),
+        error_count: 0,
+        last_error: None,
+        reason,
+    }
+    .with_now(now_ms)
+}
+
+/// Probe ATC from its existing per-instance `heartbeat-state.json` files. ATC is
+/// timer-driven (no foreground daemon), so "running" here means: at least one
+/// provisioned instance with `heartbeat_enabled` whose last heartbeat is within
+/// the cadence window. Reads, never re-emits.
+#[must_use]
+pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
+    use crate::fleet::atc::heartbeat::HeartbeatState;
+    use crate::fleet::atc::meta::AtcMeta;
+    use crate::fleet::atc::paths::{AtcPaths, list_instance_names_in};
+
+    let kind = DaemonKind::Atc;
+    let atc_root = home.join("atc");
+    let names = list_instance_names_in(&atc_root);
+    if names.is_empty() {
+        return DaemonStatus::stopped(kind, "no ATC instance provisioned");
+    }
+
+    // Pick the most-recently-beating instance as the representative row, and
+    // report it. (v1 surfaces ATC as one daemon; the instance name goes in the
+    // channel label.)
+    let mut best: Option<(String, HeartbeatState, u32)> = None;
+    for name in &names {
+        let p = AtcPaths::under_root(&atc_root, name);
+        let interval_min = std::fs::read_to_string(&p.meta)
+            .ok()
+            .and_then(|s| AtcMeta::from_json(&s).ok())
+            .map_or(15, |m| m.heartbeat_interval_min.max(1));
+        let Some(hbs) = std::fs::read_to_string(&p.heartbeat_state)
+            .ok()
+            .map(|s| HeartbeatState::from_json_or_default(&s))
+        else {
+            continue;
+        };
+        let take = match &best {
+            Some((_, prev, _)) => hbs.last_heartbeat_ms > prev.last_heartbeat_ms,
+            None => true,
+        };
+        if take {
+            best = Some((name.clone(), hbs, interval_min));
+        }
+    }
+
+    let Some((name, hbs, interval_min)) = best else {
+        return DaemonStatus::stopped(
+            kind,
+            format!("{} instance(s) provisioned, none have beaten yet", names.len()),
+        );
+    };
+
+    if hbs.last_heartbeat_ms == 0 {
+        return DaemonStatus {
+            kind,
+            channel: Some(name),
+            ..DaemonStatus::stopped(kind, "instance provisioned but no heartbeat yet")
+        };
+    }
+
+    // The OS timer fires every `interval_min`; allow 2x the cadence + a 90s grace
+    // before we call it stale (timers are not punctual to the second).
+    let window_ms = (interval_min as i64) * 60_000 * 2 + STALE_AFTER_MS;
+    let age = now_ms.saturating_sub(hbs.last_heartbeat_ms);
+    if age > window_ms {
+        return DaemonStatus {
+            kind,
+            channel: Some(name),
+            last_activity_at: hbs.last_active_ms,
+            ..DaemonStatus::stopped(
+                kind,
+                format!("stale — last heartbeat {}m ago (timer stopped?)", age / 60_000),
+            )
+        };
+    }
+
+    DaemonStatus {
+        kind,
+        state: DaemonState::Running,
+        pid: None, // timer-driven; no resident pid
+        uptime_ms: None,
+        connected: true,
+        channel: Some(format!("{name} (every {interval_min}m)")),
+        last_activity_at: hbs.last_active_ms,
+        error_count: 0,
+        last_error: None,
+        reason: format!("heartbeat alive — last beat {}m ago", age / 60_000),
+    }
+}
+
+impl DaemonStatus {
+    /// No-op hook reserved for relative-time rendering; keeps `now_ms` threaded
+    /// through the probe signature so callers always pass a single clock.
+    fn with_now(self, _now_ms: i64) -> Self {
+        self
+    }
+}
+
+/// Read a `notify.pid`-style PID file: a single integer, trimmed.
+fn read_pid_file(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// Best-effort last-write time of a file as epoch ms — used as notifyd's
+/// last-activity proxy (the DB is rewritten on every persisted notification).
+fn db_mtime_ms(path: &Path) -> Option<i64> {
+    let mtime = std::fs::metadata(path).ok()?.modified().ok()?;
+    let dur = mtime.duration_since(std::time::UNIX_EPOCH).ok()?;
+    i64::try_from(dur.as_millis()).ok()
+}
+
+/// Aggregate all four daemons under an explicit ainb home + notifyd base. The
+/// test seam — every path is injected so a test isolates to a tempdir.
+///
+/// `now_ms` is the single clock the staleness checks measure against.
+#[must_use]
+pub fn collect_in(ainb_home: &Path, notifyd_base: &Path, now_ms: i64) -> Vec<DaemonStatus> {
+    vec![
+        probe_heartbeat_daemon(ainb_home, DaemonKind::Bridge, now_ms),
+        probe_notifyd(notifyd_base, now_ms),
+        probe_atc(ainb_home, now_ms),
+        probe_heartbeat_daemon(ainb_home, DaemonKind::FleetDaemon, now_ms),
+    ]
+}
+
+/// Aggregate all four daemons from the real on-disk layout. Resolves the ainb
+/// home (honouring `$AINB_HOME`) for bridge/fleet/ATC, and notifyd's own base
+/// (`~/.agents-in-a-box`, which it does NOT key off `$AINB_HOME`).
+pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
+    let ainb_home = crate::fleet::plumbing::paths::ainb_home()?;
+    // notifyd resolves its base via `dirs::home_dir()/.agents-in-a-box` and does
+    // NOT honour `$AINB_HOME`; mirror that exactly so the probe reads the same
+    // files the daemon writes. When `$AINB_HOME` is set (tests / unusual setups)
+    // we still point notifyd at the ainb home so an isolated run is coherent.
+    let notifyd_base = if std::env::var("AINB_HOME").map(|h| !h.is_empty()).unwrap_or(false) {
+        ainb_home.clone()
+    } else {
+        dirs::home_dir()
+            .map(|h| h.join(".agents-in-a-box"))
+            .unwrap_or_else(|| ainb_home.clone())
+    };
+    Ok(collect_in(&ainb_home, &notifyd_base, super::heartbeat::now_ms()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn hb(pid: u32, started: i64, last_beat: i64, connected: bool) -> DaemonHeartbeat {
+        DaemonHeartbeat {
+            pid,
+            started_at: started,
+            last_heartbeat_at: last_beat,
+            last_activity_at: Some(last_beat),
+            connected,
+            channel: Some("Telegram".into()),
+            last_error: None,
+            error_count: 0,
+        }
+    }
+
+    #[test]
+    fn no_heartbeat_is_clean_stopped() {
+        let s = classify_heartbeat(DaemonKind::Bridge, None, false, 1000);
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("not running"));
+        assert!(s.pid.is_none());
+    }
+
+    #[test]
+    fn fresh_heartbeat_with_live_pid_is_running_connected() {
+        let now = 1_000_000;
+        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(42, now - 5000, now - 1000, true)), true, now);
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(s.connected);
+        assert_eq!(s.pid, Some(42));
+        assert_eq!(s.uptime_ms, Some(5000));
+        assert_eq!(s.reason, "running + connected");
+    }
+
+    #[test]
+    fn fresh_heartbeat_not_yet_connected_is_running_connecting() {
+        let now = 1_000_000;
+        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(42, now - 5000, now - 1000, false)), true, now);
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(!s.connected);
+        assert!(s.reason.contains("connecting"));
+    }
+
+    #[test]
+    fn dead_pid_is_stale_even_with_recent_beat() {
+        // The crash signal: a very recent heartbeat but the writing pid is gone.
+        let now = 1_000_000;
+        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(42, now - 5000, now - 100, true)), false, now);
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("stale heartbeat"));
+        assert!(s.reason.contains("crashed"));
+        assert!(!s.connected, "a crashed daemon must not report connected");
+    }
+
+    #[test]
+    fn wedged_daemon_live_pid_but_old_beat_is_stale() {
+        let now = 1_000_000;
+        let s = classify_heartbeat(
+            DaemonKind::FleetDaemon,
+            Some(hb(42, now - 200_000, now - (STALE_AFTER_MS + 5000), true)),
+            true,
+            now,
+        );
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("stale heartbeat"));
+        assert!(s.reason.contains("wedged"));
+    }
+
+    #[test]
+    fn beat_exactly_at_window_edge_is_still_running() {
+        let now = 1_000_000;
+        // age == STALE_AFTER_MS is NOT > the window, so still running.
+        let s = classify_heartbeat(DaemonKind::Bridge, Some(hb(7, now - 100_000, now - STALE_AFTER_MS, true)), true, now);
+        assert_eq!(s.state, DaemonState::Running);
+    }
+
+    #[test]
+    fn probe_heartbeat_daemon_reads_disk_and_classifies_stale_for_dead_pid() {
+        let home = TempDir::new().unwrap();
+        // Write a heartbeat for an impossible pid → dead → stale.
+        let mut h = DaemonHeartbeat::starting();
+        h.pid = 0x7fff_ffff;
+        h.set_connected(true, Some("Telegram".into()));
+        h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
+        let s = probe_heartbeat_daemon(home.path(), DaemonKind::Bridge, super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("crashed"));
+    }
+
+    #[test]
+    fn probe_heartbeat_daemon_running_for_self_pid() {
+        let home = TempDir::new().unwrap();
+        let mut h = DaemonHeartbeat::starting(); // pid = self, alive
+        h.set_connected(true, Some("Telegram".into()));
+        h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
+        let s = probe_heartbeat_daemon(home.path(), DaemonKind::Bridge, super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(s.connected);
+    }
+
+    #[test]
+    fn probe_notifyd_no_pid_is_stopped() {
+        let base = TempDir::new().unwrap();
+        let s = probe_notifyd(base.path(), 0);
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("no pid file"));
+    }
+
+    #[test]
+    fn probe_notifyd_stale_pid_is_stopped_crashed() {
+        let base = TempDir::new().unwrap();
+        std::fs::write(base.path().join("notify.pid"), "2147483647\n").unwrap();
+        let s = probe_notifyd(base.path(), 0);
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("crashed"));
+        assert_eq!(s.pid, Some(0x7fff_ffff));
+    }
+
+    #[test]
+    fn probe_notifyd_live_pid_with_socket_and_db_is_connected() {
+        let base = TempDir::new().unwrap();
+        std::fs::write(base.path().join("notify.pid"), format!("{}\n", std::process::id())).unwrap();
+        std::fs::write(base.path().join("notify.sock"), b"").unwrap();
+        std::fs::write(base.path().join("notifications.db"), b"").unwrap();
+        let s = probe_notifyd(base.path(), super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(s.connected);
+        assert!(s.reason.contains("socket bound"));
+    }
+
+    #[test]
+    fn probe_notifyd_live_pid_without_socket_is_running_not_connected() {
+        let base = TempDir::new().unwrap();
+        std::fs::write(base.path().join("notify.pid"), format!("{}\n", std::process::id())).unwrap();
+        let s = probe_notifyd(base.path(), super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(!s.connected);
+        assert!(s.reason.contains("socket not bound"));
+    }
+
+    #[test]
+    fn probe_atc_no_instance_is_stopped() {
+        let home = TempDir::new().unwrap();
+        let s = probe_atc(home.path(), 0);
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("no ATC instance"));
+    }
+
+    #[test]
+    fn probe_atc_fresh_heartbeat_is_running() {
+        let home = TempDir::new().unwrap();
+        let atc_dir = home.path().join("atc").join("primary");
+        std::fs::create_dir_all(&atc_dir).unwrap();
+        std::fs::write(
+            atc_dir.join("meta.json"),
+            r#"{"name":"primary","heartbeat_enabled":true,"heartbeat_interval_min":15,"idle_pause_min":60}"#,
+        )
+        .unwrap();
+        let now = super::super::heartbeat::now_ms();
+        std::fs::write(
+            atc_dir.join("heartbeat-state.json"),
+            format!(r#"{{"last_heartbeat_ms":{},"last_active_ms":{},"continue_counts":{{}}}}"#, now - 1000, now - 2000),
+        )
+        .unwrap();
+        let s = probe_atc(home.path(), now);
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(s.connected);
+        assert!(s.channel.as_deref().unwrap().contains("primary"));
+    }
+
+    #[test]
+    fn probe_atc_old_heartbeat_is_stale_stopped() {
+        let home = TempDir::new().unwrap();
+        let atc_dir = home.path().join("atc").join("primary");
+        std::fs::create_dir_all(&atc_dir).unwrap();
+        std::fs::write(
+            atc_dir.join("meta.json"),
+            r#"{"name":"primary","heartbeat_enabled":true,"heartbeat_interval_min":15,"idle_pause_min":60}"#,
+        )
+        .unwrap();
+        let now = super::super::heartbeat::now_ms();
+        // last beat hours ago — well past 2*15m + grace.
+        std::fs::write(
+            atc_dir.join("heartbeat-state.json"),
+            format!(r#"{{"last_heartbeat_ms":{},"continue_counts":{{}}}}"#, now - 10 * 3_600_000),
+        )
+        .unwrap();
+        let s = probe_atc(home.path(), now);
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(s.reason.contains("stale"));
+    }
+
+    #[test]
+    fn collect_in_returns_all_four_in_stable_order() {
+        let home = TempDir::new().unwrap();
+        let notifyd = TempDir::new().unwrap();
+        let rows = collect_in(home.path(), notifyd.path(), super::super::heartbeat::now_ms());
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[0].kind, DaemonKind::Bridge);
+        assert_eq!(rows[1].kind, DaemonKind::Notifyd);
+        assert_eq!(rows[2].kind, DaemonKind::Atc);
+        assert_eq!(rows[3].kind, DaemonKind::FleetDaemon);
+        // Empty homes → everything stopped, never a false running.
+        assert!(rows.iter().all(|r| r.state == DaemonState::Stopped));
+    }
+
+    #[test]
+    fn collect_in_flips_bridge_to_running_when_heartbeat_present() {
+        let home = TempDir::new().unwrap();
+        let notifyd = TempDir::new().unwrap();
+        let mut h = DaemonHeartbeat::starting();
+        h.set_connected(true, Some("Telegram (@bot)".into()));
+        h.record_activity();
+        h.write_in(home.path(), DaemonKind::Bridge.id()).unwrap();
+        let rows = collect_in(home.path(), notifyd.path(), super::super::heartbeat::now_ms());
+        assert_eq!(rows[0].kind, DaemonKind::Bridge);
+        assert_eq!(rows[0].state, DaemonState::Running);
+        assert!(rows[0].connected);
+        assert_eq!(rows[0].channel.as_deref(), Some("Telegram (@bot)"));
+    }
+
+    #[test]
+    fn kind_ids_are_stable_and_distinct() {
+        let ids = [
+            DaemonKind::Bridge.id(),
+            DaemonKind::Notifyd.id(),
+            DaemonKind::Atc.id(),
+            DaemonKind::FleetDaemon.id(),
+        ];
+        assert_eq!(ids, ["bridge", "notifyd", "atc", "fleet-daemon"]);
+        // No duplicates → no heartbeat-file collisions.
+        let mut sorted = ids.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), 4);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod atc;
 pub mod bridge;
+pub mod daemons;
 pub mod discover;
 pub mod enrich_cache;
 pub mod plumbing;

--- a/ainb-tui/crates/ainb-core/tests/tripwire_daemons_opens_and_renders.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_daemons_opens_and_renders.rs
@@ -1,0 +1,203 @@
+//! Tripwire: the Daemons observability screen opens via `d` from the home
+//! menu and renders the four-daemon runtime-health table, with a seeded bridge
+//! heartbeat flipping the phone-bridge row to "running" + "Telegram".
+//!
+//! Drives the real `ainb` binary inside a tmux pane (genuine ratatui frames),
+//! pre-seeds an isolated `$HOME`/`$AINB_HOME` with:
+//!
+//! 1. A completed-onboarding marker + a dismissed ainb-hooks install record so
+//!    no dialog intercepts the first key press.
+//! 2. A `daemons/bridge.json` heartbeat for the CURRENT test process pid
+//!    (alive → the aggregator's pid cross-check reports it running, not stale),
+//!    connected to "Telegram (@tripwire_bot)".
+//!
+//! Then sends `d`, polls the pane for the Daemons chrome + all four daemon rows
+//! + the running bridge's channel label.
+//!
+//! Skips gracefully if `tmux` isn't on `$PATH`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed_isolated_home(home: &Path) {
+    let base = home.join(".agents-in-a-box");
+    let cfg = base.join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+
+    // Skip onboarding so the first keystroke lands on the HomeScreen.
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "{ts}"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ts = "2026-05-27T00:00:00+00:00",
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    // Suppress the ainb-hooks first-run install dialog (it overlays home and
+    // would swallow the `d` keystroke).
+    let install_record = r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#;
+    fs::write(base.join("install.json"), install_record).expect("seed install.json");
+
+    // Seed a LIVE bridge heartbeat: pid = this test process (definitely alive),
+    // a fresh last_heartbeat_at, connected to Telegram. The aggregator's pid
+    // cross-check then reports the bridge running + connected (not stale).
+    let daemons = base.join("daemons");
+    fs::create_dir_all(&daemons).expect("create daemons dir");
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let bridge = format!(
+        r#"{{"pid":{pid},"started_at":{started},"last_heartbeat_at":{beat},"last_activity_at":{act},"connected":true,"channel":"Telegram (@tripwire_bot)","error_count":0}}"#,
+        pid = std::process::id(),
+        started = now_ms - 600_000,
+        beat = now_ms - 1_000,
+        act = now_ms - 5_000,
+    );
+    fs::write(daemons.join("bridge.json"), bridge).expect("seed bridge heartbeat");
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+
+fn kill_session(session: &str) {
+    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
+}
+
+#[test]
+fn daemons_opens_and_renders_four_rows() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+
+    let session = format!("tripwire-daemons-{}", std::process::id());
+    let ainb = ainb_bin();
+
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "180", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    // Point both HOME and AINB_HOME at the isolated tmp so the daemons
+    // aggregator reads the seeded heartbeat (bridge/fleet/ATC honour
+    // $AINB_HOME; notifyd reads $HOME — both land in the tmp here).
+    let cmd = format!(
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box exec {bin} tui",
+        home = home_tmp.path().display(),
+        bin = ainb.display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("send launch cmd");
+
+    // Wait for HomeScreen — same marker the other tripwire tests use.
+    let home_deadline = Instant::now() + Duration::from_secs(90);
+    let pre_cap = poll_capture(&session, home_deadline, |c| {
+        c.contains("Stats") && c.contains("[i]")
+    });
+    let Some(pre) = pre_cap else {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
+    };
+
+    // Pre-assertion: must not already be on the Daemons screen.
+    assert!(
+        !pre.contains("runtime health"),
+        "pre-key capture already on daemons — state leaked.\n{pre}"
+    );
+
+    // Discoverability gate: the HomeScreen V2 sidebar MUST list the Daemons
+    // tile with its `[d]` shortcut, else the screen is unreachable by a fresh
+    // user who can't see it.
+    assert!(
+        pre.contains("Daemons") && pre.contains("[d]"),
+        "HomeScreen V2 sidebar missing Daemons tile — discoverability regression.\n{pre}"
+    );
+
+    // Drive the daemons-open shortcut.
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, "d"])
+        .status()
+        .expect("send-keys d");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let post_cap = poll_capture(&session, deadline, |c| {
+        c.contains("Daemons")
+            && c.contains("phone bridge")
+            && c.contains("notifyd")
+            && c.contains("fleet daemon")
+    });
+    if post_cap.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!(
+            "Daemons screen didn't render all four rows after pressing d; \
+             last capture:\n---\n{last}\n---"
+        );
+    }
+    let post = post_cap.unwrap();
+
+    // The four daemon rows are present.
+    assert!(post.contains("phone bridge"), "bridge row missing:\n{post}");
+    assert!(post.contains("notifyd"), "notifyd row missing:\n{post}");
+    assert!(post.contains("ATC"), "ATC row missing:\n{post}");
+    assert!(
+        post.contains("fleet daemon"),
+        "fleet daemon row missing:\n{post}"
+    );
+
+    // The seeded live bridge heartbeat flips the bridge to running + connected,
+    // surfacing the Telegram channel label — the original blind spot, closed.
+    assert!(
+        post.contains("running"),
+        "no running daemon shown despite seeded live heartbeat:\n{post}"
+    );
+    assert!(
+        post.contains("Telegram (@tripwire_bot)"),
+        "bridge channel label missing — heartbeat not surfaced:\n{post}"
+    );
+
+    kill_session(&session);
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_daemons_opens_and_renders.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_daemons_opens_and_renders.rs
@@ -60,13 +60,20 @@ git_directories = []
     // Seed a LIVE bridge heartbeat: pid = this test process (definitely alive),
     // a fresh last_heartbeat_at, connected to Telegram. The aggregator's pid
     // cross-check then reports the bridge running + connected (not stale).
+    //
+    // The H1 identity guard matches `started_at` against the live process's REAL
+    // OS start time, so the seed must use the test process's actual start time
+    // (not an arbitrary "10 minutes ago") — otherwise the live-but-mismatched
+    // pid would correctly classify as a recycled-pid tombstone (Stopped).
     let daemons = base.join("daemons");
     fs::create_dir_all(&daemons).expect("create daemons dir");
     let now_ms = chrono::Utc::now().timestamp_millis();
+    let started_at = ainb::fleet::daemons::heartbeat::process_start_ms(std::process::id())
+        .expect("test process start time readable");
     let bridge = format!(
         r#"{{"pid":{pid},"started_at":{started},"last_heartbeat_at":{beat},"last_activity_at":{act},"connected":true,"channel":"Telegram (@tripwire_bot)","error_count":0}}"#,
         pid = std::process::id(),
-        started = now_ms - 600_000,
+        started = started_at,
         beat = now_ms - 1_000,
         act = now_ms - 5_000,
     );


### PR DESCRIPTION
## Unified "Daemons" observability surface

Closes the live-debugging blind spot: there was **no runtime observability** for the phone bridge — `ainb fleet bridge status` only reported launchd *install* state, so a running, Telegram-connected, relaying bridge looked identical to a dead one. notifyd / ATC / the fleet daemon had ad-hoc or no aggregated health. This adds a single source of truth surfaced two ways.

### What's here
- **Core aggregator** `fleet::daemons` — a typed `Vec<DaemonStatus>` from one `collect()` function, behind both surfaces (no logic duplicated in the view).
- **Heartbeat convention** `~/.agents-in-a-box/daemons/<name>.json` (atomic-write, honours `$AINB_HOME`): `{pid, started_at, last_heartbeat_at, last_activity_at, connected, channel?, last_error?, error_count}`.
- **Per-daemon wiring (minimal, in-module):**
  - **bridge** + **fleet daemon** now *emit* the heartbeat (they had zero observability). The bridge records "Telegram channel online" + last-relay + error count — the blind spot, closed.
  - **notifyd** + **ATC** are *read* from the signals they already maintain (notifyd: PID file + socket + sqlite DB; ATC: its `heartbeat-state.json`) — no duplicate state.
- **Stale-heartbeat cross-check:** a heartbeat whose `pid` is dead, or whose beat is older than the window, reports `stopped` with a "crashed / wedged" reason — never a false `running`.
- **CLI** `ainb fleet daemons [--format text|json]`.
- **TUI** read-only Daemons screen, reachable from the home menu (`d`), refreshing live on tick — renders from the same `collect()`.

### Proof — `ainb fleet daemons`

Running + connected:
```
DAEMON         STATE     PID      UPTIME     LAST ACTIVITY ERRORS  HEALTH
--------------------------------------------------------------------------------------
phone bridge   ● running 49569    1h         15s ago      0       Telegram (@mybot) — running + connected
notifyd        ● running 49569    -          just now     0       unix socket + sqlite — running + connected (socket bound, db reachable)
ATC            ● running -        -          2m ago       0       primary (every 15m) — heartbeat alive — last beat 1m ago
fleet daemon   ● running 49569    10m        45s ago      1       broker 127.0.0.1:7899 — running + connected
```

Stopped:
```
DAEMON         STATE     PID      UPTIME     LAST ACTIVITY ERRORS  HEALTH
--------------------------------------------------------------------------------------
phone bridge   ○ stopped -        -          -            0       no heartbeat — not running this session
notifyd        ○ stopped -        -          -            0       no pid file — not running
ATC            ○ stopped -        -          -            0       no ATC instance provisioned
fleet daemon   ○ stopped -        -          -            0       no heartbeat — not running this session
```

Stale detection (dead-pid bridge, wedged fleet daemon):
```
phone bridge   ○ stopped 2147483647 -        -            0       stale heartbeat — pid 2147483647 not alive (crashed)
fleet daemon   ○ stopped 55515      10m      -            0       stale heartbeat — last beat 120s ago (wedged?)
```

### TUI screen
```
╭ ⚙ Daemons  runtime health ──────────────────────────────────────────────────╮
│DAEMON         STATE      PID    UPTIME  LAST ACTIVITY  ERR  HEALTH            │
│phone bridge   ● running  98232  1h      24s ago        0    Telegram (@mybot) — running + connected
│notifyd        ● running  98232  -       1s ago         0    unix socket + sqlite — running + connected …
│ATC            ● running  -      -       2m ago         0    primary (every 15m) — heartbeat alive …
│fleet daemon   ● running  98232  5m      1m ago         0    broker 127.0.0.1:7899 — running + connected
│read-only • live  │  q/Esc back                                               │
╰──────────────────────────────────────────────────────────────────────────────╯
```

### Tests (all green via targeted runs)
- `fleet::daemons::` — 33 (heartbeat, aggregation, stale detection, each probe)
- `fleet::bridge::heartbeat::` — 4 · `cli::fleet::daemons::` — 4 · `components::daemons::` — 2 (TestBackend render tripwire)
- `cli::registry::tests::fleet_*` — 2 (fleet-subcommand surface guard incl. `daemons`)
- `components::sidebar::` — 9 (incl. `[d]` tile guard) · `components::home_screen_v2::` — 8
- tmux tripwire `tripwire_daemons_opens_and_renders` — passes (menu `d` → screen renders 4 rows + live bridge channel)
- `cargo build -p ainb` ✓ · `cargo fmt -p ainb --check` exit 0 ✓ · new code clippy-clean

Not chased (per the goal): the ~47 pre-existing UI-rot failures in #286 (the broken `tests/test_events.rs` predates this branch) and the `renders_large_diff_within_budget` perf flake — both verified unrelated.

### Notes / limitations
- ATC is timer-driven (no resident pid); v1 surfaces the most-recently-beating instance as one row with the instance name + cadence in the channel label.
- notifyd does not honour `$AINB_HOME` in production (it keys off `$HOME`); `collect()` mirrors that exactly, and points at the ainb home when `$AINB_HOME` is set so isolated runs stay coherent.
- Fleet daemon "connected" = broker reachability (the closest signal until real `ainb-fleet-cp` peer registration lands).
- Read-only in v1 (no start/stop controls), matching the app's other observability panels.
