### PR TITLE
feat(bridge): add Discord as a third native phone-bridge channel

### DIFF
--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/config.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/config.rs
@@ -25,6 +25,13 @@
 //   listen_mode = "mentions"         # "mentions" (default) | "all"
 //   response_timeout = 300           # optional
 //
+//   [fleet.bridge.discord]
+//   token = "$DISCORD_BOT_TOKEN"      # Bot token (gateway + REST), secret ref
+//   user_id = "123456789012345678"   # authorized Discord user id (snowflake, string)
+//   default_target = "conductor"     # optional
+//   channel_id = "123456789012345678"# optional fallback channel for replies
+//   response_timeout = 300           # optional
+//
 // At least ONE channel table must be present and valid.
 
 use std::path::{Path, PathBuf};
@@ -68,18 +75,33 @@ pub struct SlackConfig {
     pub response_timeout: u64,
 }
 
+/// Resolved, validated Discord channel config.
+#[derive(Debug, Clone)]
+pub struct DiscordConfig {
+    /// Discord Bot token (used for both the gateway IDENTIFY and REST posts).
+    pub token: String,
+    /// Authorized Discord user id (snowflake, kept as a string).
+    pub authorized_user_id: String,
+    pub default_target: Option<String>,
+    /// Fallback channel to post a reply to when the inbound message carries no
+    /// originating channel id.
+    pub channel_id: Option<String>,
+    pub response_timeout: u64,
+}
+
 /// Resolved bridge config — at least one channel is present.
 #[derive(Debug, Clone)]
 pub struct BridgeConfig {
     pub telegram: Option<TelegramConfig>,
     pub slack: Option<SlackConfig>,
+    pub discord: Option<DiscordConfig>,
 }
 
 impl BridgeConfig {
     /// Whether any channel is configured to run.
     #[must_use]
     pub fn any_channel(&self) -> bool {
-        self.telegram.is_some() || self.slack.is_some()
+        self.telegram.is_some() || self.slack.is_some() || self.discord.is_some()
     }
 }
 
@@ -100,6 +122,7 @@ struct RawBridge {
     response_timeout: Option<toml::Value>,
     telegram: Option<RawTelegram>,
     slack: Option<RawSlack>,
+    discord: Option<RawDiscord>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -118,6 +141,15 @@ struct RawSlack {
     user_id: Option<String>,
     default_target: Option<String>,
     listen_mode: Option<String>,
+    response_timeout: Option<toml::Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawDiscord {
+    token: Option<String>,
+    user_id: Option<String>,
+    default_target: Option<String>,
+    channel_id: Option<String>,
     response_timeout: Option<toml::Value>,
 }
 
@@ -243,6 +275,39 @@ fn parse_slack(raw: RawSlack, shared_timeout: u64) -> Result<SlackConfig> {
     })
 }
 
+fn parse_discord(raw: RawDiscord, shared_timeout: u64) -> Result<DiscordConfig> {
+    let token_ref =
+        raw.token.ok_or_else(|| anyhow!("[fleet.bridge.discord] is missing `token`"))?;
+    let token = resolve_secret(&token_ref).trim().to_string();
+    if token.is_empty() {
+        bail!("discord token resolved to empty — check the env var / keychain ref");
+    }
+    let user_ref = raw
+        .user_id
+        .ok_or_else(|| anyhow!("[fleet.bridge.discord] is missing `user_id`"))?;
+    let authorized_user_id = resolve_secret(&user_ref).trim().to_string();
+    if authorized_user_id.is_empty() {
+        bail!("discord user_id resolved to empty");
+    }
+    let default_target = raw.default_target.and_then(|s| {
+        let t = s.trim().to_string();
+        (!t.is_empty()).then_some(t)
+    });
+    let channel_id = raw.channel_id.and_then(|s| {
+        let t = s.trim().to_string();
+        (!t.is_empty()).then_some(t)
+    });
+    let response_timeout = coerce_timeout(raw.response_timeout.as_ref(), shared_timeout)
+        .context("[fleet.bridge.discord] `response_timeout`")?;
+    Ok(DiscordConfig {
+        token,
+        authorized_user_id,
+        default_target,
+        channel_id,
+        response_timeout,
+    })
+}
+
 /// Build a [`BridgeConfig`] from a parsed TOML string. Split out so it can be
 /// unit-tested without touching the filesystem.
 pub fn parse_config(toml_text: &str) -> Result<BridgeConfig> {
@@ -257,14 +322,19 @@ pub fn parse_config(toml_text: &str) -> Result<BridgeConfig> {
 
     let telegram = bridge.telegram.map(|t| parse_telegram(t, shared_timeout)).transpose()?;
     let slack = bridge.slack.map(|s| parse_slack(s, shared_timeout)).transpose()?;
+    let discord = bridge.discord.map(|d| parse_discord(d, shared_timeout)).transpose()?;
 
-    if telegram.is_none() && slack.is_none() {
+    if telegram.is_none() && slack.is_none() && discord.is_none() {
         bail!(
-            "[fleet.bridge] has neither a [fleet.bridge.telegram] nor a \
-             [fleet.bridge.slack] channel — configure at least one"
+            "[fleet.bridge] has no channel — configure at least one of \
+             [fleet.bridge.telegram], [fleet.bridge.slack], or [fleet.bridge.discord]"
         );
     }
-    Ok(BridgeConfig { telegram, slack })
+    Ok(BridgeConfig {
+        telegram,
+        slack,
+        discord,
+    })
 }
 
 /// Load and validate the bridge config from disk.
@@ -378,6 +448,96 @@ mod tests {
     fn no_channel_errors() {
         let err = parse_config("[fleet.bridge]\nresponse_timeout = 60\n").unwrap_err();
         assert!(err.to_string().contains("at least one"));
+    }
+
+    #[test]
+    fn parses_discord_only() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge.discord]
+            token = "bot-literal"
+            user_id = "123456789012345678"
+            default_target = "conductor"
+            channel_id = "987654321098765432"
+            "#,
+        )
+        .unwrap();
+        let dc = cfg.discord.unwrap();
+        assert_eq!(dc.token, "bot-literal");
+        assert_eq!(dc.authorized_user_id, "123456789012345678");
+        assert_eq!(dc.default_target.as_deref(), Some("conductor"));
+        assert_eq!(dc.channel_id.as_deref(), Some("987654321098765432"));
+        assert_eq!(dc.response_timeout, RESPONSE_TIMEOUT);
+        assert!(cfg.telegram.is_none());
+        assert!(cfg.slack.is_none());
+    }
+
+    #[test]
+    fn discord_channel_id_is_optional() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge.discord]
+            token = "bot"
+            user_id = "1"
+            "#,
+        )
+        .unwrap();
+        let dc = cfg.discord.unwrap();
+        assert!(dc.channel_id.is_none());
+        assert!(dc.default_target.is_none());
+    }
+
+    #[test]
+    fn discord_missing_token_errors() {
+        let err = parse_config(
+            r#"
+            [fleet.bridge.discord]
+            user_id = "1"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("token"));
+    }
+
+    #[test]
+    fn discord_missing_user_id_errors() {
+        let err = parse_config(
+            r#"
+            [fleet.bridge.discord]
+            token = "bot"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("user_id"));
+    }
+
+    #[test]
+    fn discord_empty_token_after_resolution_errors() {
+        let err = parse_config(
+            r#"
+            [fleet.bridge.discord]
+            token = "$AINB_BRIDGE_DISCORD_UNSET_TOKEN_VAR"
+            user_id = "1"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("resolved to empty"));
+    }
+
+    #[test]
+    fn discord_shares_bridge_timeout() {
+        let cfg = parse_config(
+            r#"
+            [fleet.bridge]
+            response_timeout = 120
+
+            [fleet.bridge.discord]
+            token = "bot"
+            user_id = "1"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.discord.unwrap().response_timeout, 120);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
@@ -1,0 +1,536 @@
+// ABOUTME: The Discord channel — raw Gateway WebSocket, two-way relay.
+//
+// Flow: connect to the Discord Gateway (`wss://gateway.discord.gg/?v=10&
+// encoding=json`) with tokio-tungstenite, complete the documented handshake
+// (receive HELLO → start a heartbeat loop → IDENTIFY), receive `MESSAGE_CREATE`
+// dispatches, run authorized messages through the SHARED relay core, and post
+// the reply via the REST `POST /channels/{id}/messages` (Bot token).
+//
+// Parity with the Telegram + Slack channels' policy:
+//   * Authorization by Discord user id (unknown senders silently ignored).
+//   * The bot's own messages (and other bots) are ignored to avoid reply loops.
+//   * Routing honours a leading `name:` prefix (shared `relay` core), else the
+//     configured `default_target`.
+//   * Replies are split at Discord's 2000-char limit; markdown passes through
+//     verbatim (Discord renders **bold**/`code`/```fences``` natively).
+//
+// We use the RAW gateway rather than a heavyweight SDK (serenity/twilight) to
+// match slack.rs's lightweight `tokio_tungstenite` + `reqwest` style and to
+// avoid pulling a large dependency tree into the single `ainb` binary. The
+// gateway surface the bridge needs is small: HELLO/heartbeat/IDENTIFY plus the
+// MESSAGE_CREATE dispatch, all hand-rolled here.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio_tungstenite::tungstenite::Message;
+
+use super::config::DiscordConfig;
+use super::redact::scrub_token;
+use super::relay::{FleetTransport, RelayParams, relay};
+
+const GATEWAY_URL: &str = "wss://gateway.discord.gg/?v=10&encoding=json";
+const API_BASE: &str = "https://discord.com/api/v10";
+
+/// Discord message-content limit (`POST /channels/{id}/messages`). We split below it.
+const DISCORD_MAX_LENGTH: usize = 2000;
+
+/// Gateway opcodes we handle (subset of the documented set).
+mod op {
+    pub const DISPATCH: u64 = 0;
+    pub const HEARTBEAT: u64 = 1;
+    pub const IDENTIFY: u64 = 2;
+    pub const RECONNECT: u64 = 7;
+    pub const INVALID_SESSION: u64 = 9;
+    pub const HELLO: u64 = 10;
+    pub const HEARTBEAT_ACK: u64 = 11;
+}
+
+/// Gateway intents: `GUILD_MESSAGES` | `MESSAGE_CONTENT` | `DIRECT_MESSAGES`.
+/// `(1 << 9) | (1 << 15) | (1 << 12)` = 512 | 32768 | 4096.
+const INTENTS: u64 = (1 << 9) | (1 << 15) | (1 << 12);
+
+/// Run the Discord channel forever (reconnecting on disconnect).
+pub async fn run<T: FleetTransport>(cfg: DiscordConfig, transport: &T) -> Result<()> {
+    let client =
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "building Discord HTTP client: {}",
+                    scrub_token(&e.to_string())
+                )
+            })?;
+
+    tracing::info!(
+        authorized_user = %cfg.authorized_user_id,
+        "ainb phone bridge: Discord channel online (gateway)"
+    );
+
+    loop {
+        match connect_and_serve(&client, &cfg, transport).await {
+            Ok(()) => tracing::info!("Discord gateway closed; reconnecting"),
+            Err(e) => {
+                // Build the diagnostic from the error's text, then scrub any
+                // token-shaped substring so a Bot token can never leak into logs.
+                tracing::warn!(
+                    error = %scrub_token(&e.to_string()),
+                    "Discord gateway error; reconnecting in 5s"
+                );
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+}
+
+/// One gateway connection: handshake, then pump dispatches until the socket
+/// closes or Discord asks us to reconnect.
+async fn connect_and_serve<T: FleetTransport>(
+    client: &reqwest::Client,
+    cfg: &DiscordConfig,
+    transport: &T,
+) -> Result<()> {
+    let (ws, _resp) = tokio_tungstenite::connect_async(GATEWAY_URL)
+        .await
+        .context("connecting to Discord gateway WSS")?;
+    let (mut write, mut read) = ws.split();
+
+    // ── HELLO (op 10) — carries the heartbeat interval ──────────────────────
+    let hello = next_payload(&mut read).await.context("waiting for Discord HELLO")?;
+    if hello.op != op::HELLO {
+        anyhow::bail!("expected HELLO (op 10), got op {}", hello.op);
+    }
+    let heartbeat_ms = hello
+        .d
+        .as_ref()
+        .and_then(|d| d.get("heartbeat_interval"))
+        .and_then(Value::as_u64)
+        .context("HELLO missing heartbeat_interval")?;
+
+    // ── IDENTIFY (op 2) ─────────────────────────────────────────────────────
+    let identify = json!({
+        "op": op::IDENTIFY,
+        "d": {
+            "token": cfg.token,
+            "intents": INTENTS,
+            "properties": { "os": "linux", "browser": "ainb", "device": "ainb" }
+        }
+    });
+    write
+        .send(Message::Text(identify.to_string()))
+        .await
+        .context("sending Discord IDENTIFY")?;
+
+    // Last received sequence number, shared with the heartbeat loop.
+    let last_seq = Arc::new(AtomicU64::new(0));
+    let mut heartbeat = tokio::time::interval(Duration::from_millis(heartbeat_ms));
+    // The first tick fires immediately; skip it so we don't double-send before
+    // the gateway is ready (Discord tolerates an early beat, but this is tidy).
+    heartbeat.tick().await;
+
+    loop {
+        tokio::select! {
+            // Periodic heartbeat (op 1 with the last seq, or null if none yet).
+            _ = heartbeat.tick() => {
+                let seq = last_seq.load(Ordering::Relaxed);
+                let d = if seq == 0 { Value::Null } else { json!(seq) };
+                let beat = json!({ "op": op::HEARTBEAT, "d": d }).to_string();
+                if write.send(Message::Text(beat)).await.is_err() {
+                    break; // socket gone — outer loop reconnects
+                }
+            }
+            frame = read.next() => {
+                let Some(frame) = frame else { break };
+                let payload = match frame.context("reading Discord gateway frame")? {
+                    Message::Text(t) => match serde_json::from_str::<GatewayPayload>(&t) {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    },
+                    Message::Ping(p) => { write.send(Message::Pong(p)).await.ok(); continue; }
+                    Message::Close(_) => break,
+                    _ => continue,
+                };
+
+                if let Some(s) = payload.s {
+                    last_seq.store(s, Ordering::Relaxed);
+                }
+
+                match payload.op {
+                    op::HEARTBEAT => {
+                        // Server asked for an immediate beat.
+                        let seq = last_seq.load(Ordering::Relaxed);
+                        let d = if seq == 0 { Value::Null } else { json!(seq) };
+                        let beat = json!({ "op": op::HEARTBEAT, "d": d }).to_string();
+                        write.send(Message::Text(beat)).await.ok();
+                    }
+                    op::HEARTBEAT_ACK => tracing::trace!("Discord heartbeat ack"),
+                    op::RECONNECT => {
+                        tracing::info!("Discord requested reconnect");
+                        break;
+                    }
+                    op::INVALID_SESSION => {
+                        // We never persist a session for RESUME, so a fresh
+                        // reconnect (new IDENTIFY) is the correct minimal handling.
+                        tracing::info!("Discord invalidated session; reconnecting fresh");
+                        break;
+                    }
+                    op::DISPATCH => {
+                        if payload.t.as_deref() == Some("MESSAGE_CREATE") {
+                            if let Some(d) = payload.d {
+                                if let Ok(msg) = serde_json::from_value::<DiscordMessage>(d) {
+                                    handle_message(client, cfg, transport, msg).await;
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read frames until the next JSON gateway payload (skipping ping/pong/binary).
+async fn next_payload<S>(read: &mut S) -> Result<GatewayPayload>
+where
+    S: StreamExt<Item = tokio_tungstenite::tungstenite::Result<Message>> + Unpin,
+{
+    while let Some(frame) = read.next().await {
+        match frame.context("reading Discord gateway frame")? {
+            Message::Text(t) => {
+                if let Ok(p) = serde_json::from_str::<GatewayPayload>(&t) {
+                    return Ok(p);
+                }
+            }
+            Message::Close(_) => anyhow::bail!("gateway closed before payload"),
+            _ => {}
+        }
+    }
+    anyhow::bail!("gateway stream ended before a payload")
+}
+
+/// Process one `MESSAGE_CREATE`: authorize, relay through the shared core, and
+/// post the reply back to the originating (or configured) channel.
+async fn handle_message<T: FleetTransport>(
+    client: &reqwest::Client,
+    cfg: &DiscordConfig,
+    transport: &T,
+    msg: DiscordMessage,
+) {
+    if !authorize(cfg, &msg) {
+        return;
+    }
+
+    let text = msg.content.trim();
+    if text.is_empty() {
+        return;
+    }
+
+    let params = RelayParams {
+        default_target: cfg.default_target.as_deref(),
+        response_timeout: Duration::from_secs(cfg.response_timeout),
+    };
+    let reply = relay(transport, &params, text).await;
+
+    // Reply to the message's channel; fall back to the configured channel_id.
+    let channel = msg.channel_id.as_deref().or(cfg.channel_id.as_deref());
+    let Some(channel) = channel else {
+        tracing::warn!(
+            "Discord reply has no channel (no originating channel_id and no configured channel_id)"
+        );
+        return;
+    };
+
+    for chunk in split_for_discord(&reply) {
+        if let Err(e) = post_message(client, &cfg.token, channel, &chunk).await {
+            // Scrub before logging: the error may echo the Authorization header.
+            tracing::warn!(error = %scrub_token(&e.to_string()), "Discord post message failed");
+        }
+    }
+}
+
+/// Decide whether to act on a message. Returns `true` to act, `false` to skip.
+/// Pure — exercised directly in tests.
+///
+/// Skips the bot's own posts and other bots (`author.bot`), and any author whose
+/// id is not the single authorized user.
+fn authorize(cfg: &DiscordConfig, msg: &DiscordMessage) -> bool {
+    let Some(author) = msg.author.as_ref() else {
+        return false;
+    };
+    // Ignore bot authors (including ourselves) to avoid reply loops.
+    if author.bot.unwrap_or(false) {
+        return false;
+    }
+    if author.id != cfg.authorized_user_id {
+        tracing::warn!(user = %author.id, "ignoring Discord message from unauthorized user");
+        return false;
+    }
+    true
+}
+
+/// Split a reply for Discord's message-length limit on newline boundaries (with
+/// a hard char cut for oversized lines). Markdown passes through (Discord renders
+/// it natively).
+fn split_for_discord(text: &str) -> Vec<String> {
+    super::format::split_message(text, DISCORD_MAX_LENGTH)
+}
+
+/// Post a message to a channel via the REST API (`Authorization: Bot <token>`).
+async fn post_message(
+    client: &reqwest::Client,
+    token: &str,
+    channel_id: &str,
+    text: &str,
+) -> Result<()> {
+    let resp = client
+        .post(format!("{API_BASE}/channels/{channel_id}/messages"))
+        .header("Authorization", format!("Bot {token}"))
+        .json(&json!({ "content": text }))
+        .send()
+        .await
+        .context("POST /channels/{id}/messages request")?;
+    let status = resp.status();
+    if !status.is_success() {
+        // Surface status + the API error code/message, never the token.
+        let body: Value = resp.json().await.unwrap_or(Value::Null);
+        let code = body.get("code").and_then(Value::as_i64);
+        let message = body.get("message").and_then(Value::as_str).unwrap_or("");
+        anyhow::bail!(
+            "Discord message post failed: HTTP {} (code {:?}: {})",
+            status.as_u16(),
+            code,
+            message
+        );
+    }
+    Ok(())
+}
+
+// ── Gateway / REST wire types ───────────────────────────────────────────────
+
+/// A gateway frame: `{ op, d, s, t }`. `d`/`s`/`t` are present only on some ops.
+#[derive(Debug, Deserialize)]
+struct GatewayPayload {
+    op: u64,
+    #[serde(default)]
+    d: Option<Value>,
+    #[serde(default)]
+    s: Option<u64>,
+    #[serde(default)]
+    t: Option<String>,
+}
+
+/// A `MESSAGE_CREATE` dispatch payload (the fields the bridge reads).
+#[derive(Debug, Default, Deserialize)]
+struct DiscordMessage {
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    channel_id: Option<String>,
+    #[serde(default)]
+    author: Option<DiscordAuthor>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DiscordAuthor {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    bot: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> DiscordConfig {
+        DiscordConfig {
+            token: "bot-token".into(),
+            authorized_user_id: "123456789".into(),
+            default_target: None,
+            channel_id: None,
+            response_timeout: 300,
+        }
+    }
+
+    fn msg(user_id: &str) -> DiscordMessage {
+        DiscordMessage {
+            content: "hello".into(),
+            channel_id: Some("C1".into()),
+            author: Some(DiscordAuthor {
+                id: user_id.into(),
+                bot: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn authorizes_the_configured_user() {
+        assert!(authorize(&cfg(), &msg("123456789")));
+    }
+
+    #[test]
+    fn ignores_unauthorized_user() {
+        assert!(!authorize(&cfg(), &msg("999")));
+    }
+
+    #[test]
+    fn ignores_bot_authors() {
+        // Even the authorized id is ignored if the message is flagged as a bot
+        // post (this is how the bot's own messages are filtered — no reply loop).
+        let mut m = msg("123456789");
+        m.author.as_mut().unwrap().bot = Some(true);
+        assert!(!authorize(&cfg(), &m));
+    }
+
+    #[test]
+    fn ignores_message_with_no_author() {
+        let mut m = msg("123456789");
+        m.author = None;
+        assert!(!authorize(&cfg(), &m));
+    }
+
+    #[test]
+    fn intents_cover_guild_messages_message_content_and_dms() {
+        // GUILD_MESSAGES (1<<9), DIRECT_MESSAGES (1<<12), MESSAGE_CONTENT (1<<15).
+        assert_eq!(INTENTS & (1 << 9), 1 << 9);
+        assert_eq!(INTENTS & (1 << 12), 1 << 12);
+        assert_eq!(INTENTS & (1 << 15), 1 << 15);
+    }
+
+    #[test]
+    fn split_respects_discord_limit() {
+        let big = "x".repeat(5000);
+        for chunk in split_for_discord(&big) {
+            assert!(chunk.chars().count() <= DISCORD_MAX_LENGTH);
+        }
+    }
+
+    #[test]
+    fn parses_hello_payload() {
+        let raw = r#"{"op":10,"d":{"heartbeat_interval":41250},"s":null,"t":null}"#;
+        let p: GatewayPayload = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.op, op::HELLO);
+        assert_eq!(
+            p.d.unwrap().get("heartbeat_interval").and_then(Value::as_u64),
+            Some(41250)
+        );
+    }
+
+    #[test]
+    fn parses_message_create_dispatch() {
+        let raw = r#"{
+            "op":0,"s":42,"t":"MESSAGE_CREATE",
+            "d":{"content":"backend: run tests","channel_id":"C9","author":{"id":"123456789","bot":false}}
+        }"#;
+        let p: GatewayPayload = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.op, op::DISPATCH);
+        assert_eq!(p.s, Some(42));
+        assert_eq!(p.t.as_deref(), Some("MESSAGE_CREATE"));
+        let m: DiscordMessage = serde_json::from_value(p.d.unwrap()).unwrap();
+        assert_eq!(m.content, "backend: run tests");
+        assert_eq!(m.channel_id.as_deref(), Some("C9"));
+        assert_eq!(m.author.as_ref().unwrap().id, "123456789");
+        assert_eq!(m.author.as_ref().unwrap().bot, Some(false));
+    }
+
+    #[test]
+    fn message_without_bot_flag_defaults_to_human() {
+        // `author.bot` absent → treated as a human author (not filtered).
+        let raw = r#"{"content":"hi","channel_id":"C1","author":{"id":"123456789"}}"#;
+        let m: DiscordMessage = serde_json::from_str(raw).unwrap();
+        assert_eq!(m.author.unwrap().bot, None);
+    }
+
+    // ── Relay-path tests over an in-memory mock FleetTransport ───────────────
+    // These exercise the same shared `relay` core the live channel calls, so the
+    // routing/degrade behaviour is verified without a live Discord connection.
+
+    use std::sync::Mutex;
+
+    use super::super::relay::FleetTransport;
+    use super::super::routing::TargetSession;
+
+    struct FakeTransport {
+        sessions: Vec<TargetSession>,
+        last_send: Mutex<Option<(String, String)>>,
+        reply: Option<String>,
+    }
+
+    impl FakeTransport {
+        fn new(sessions: Vec<TargetSession>, reply: Option<String>) -> Self {
+            Self {
+                sessions,
+                last_send: Mutex::new(None),
+                reply,
+            }
+        }
+    }
+
+    impl FleetTransport for FakeTransport {
+        async fn discover(&self) -> Vec<TargetSession> {
+            self.sessions.clone()
+        }
+        async fn send_and_capture(
+            &self,
+            session: &TargetSession,
+            text: &str,
+            _timeout: Duration,
+        ) -> Option<String> {
+            *self.last_send.lock().unwrap() = Some((session.name.clone(), text.to_string()));
+            self.reply.clone()
+        }
+    }
+
+    fn sess(name: &str) -> TargetSession {
+        TargetSession::new(
+            name,
+            format!("tmux-{name}"),
+            format!("/cwd/{name}"),
+            format!("id-{name}"),
+        )
+    }
+
+    fn relay_params() -> RelayParams<'static> {
+        RelayParams {
+            default_target: None,
+            response_timeout: Duration::from_secs(300),
+        }
+    }
+
+    #[tokio::test]
+    async fn relay_routes_name_prefix_to_session() {
+        let t = FakeTransport::new(vec![sess("backend"), sess("frontend")], Some("ok".into()));
+        let out = relay(&t, &relay_params(), "backend: run tests").await;
+        assert_eq!(out, "ok");
+        let (target, msg) = t.last_send.lock().unwrap().clone().unwrap();
+        assert_eq!(target, "backend");
+        assert_eq!(msg, "run tests");
+    }
+
+    #[tokio::test]
+    async fn relay_uses_configured_default_target() {
+        let t = FakeTransport::new(vec![sess("alpha"), sess("beta")], Some("hi".into()));
+        let p = RelayParams {
+            default_target: Some("beta"),
+            response_timeout: Duration::from_secs(5),
+        };
+        let out = relay(&t, &p, "do it").await;
+        assert_eq!(out, "hi");
+        assert_eq!(t.last_send.lock().unwrap().clone().unwrap().0, "beta");
+    }
+
+    #[tokio::test]
+    async fn relay_reports_empty_fleet() {
+        let t = FakeTransport::new(vec![], Some("x".into()));
+        let out = relay(&t, &relay_params(), "hello").await;
+        assert_eq!(out, "No running ainb sessions to relay to.");
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
@@ -84,6 +84,48 @@ fn backoff_delay(attempt: u32) -> Duration {
     Duration::from_millis(u64::try_from(capped).unwrap_or(u64::MAX))
 }
 
+/// ACK-zombie detection state (M2). The gateway must acknowledge (`op-11`) every
+/// heartbeat; a half-open socket silently stops acknowledging while
+/// `read.next()` blocks forever. We require the previous beat to be acknowledged
+/// before sending the next — an unacknowledged beat means the connection is dead.
+#[derive(Debug)]
+struct HeartbeatTracker {
+    /// Whether the most recent beat we sent has been acknowledged. Starts `true`
+    /// so the very first beat is allowed to send.
+    acked: bool,
+}
+
+impl HeartbeatTracker {
+    const fn new() -> Self {
+        Self { acked: true }
+    }
+
+    /// Called when an `op-11` acknowledgement arrives.
+    const fn on_ack(&mut self) {
+        self.acked = true;
+    }
+
+    /// Called on a heartbeat tick. Returns `true` if it's safe to send the beat,
+    /// or `false` if the previous beat was never acknowledged (zombie →
+    /// reconnect). Records that a fresh beat is now outstanding when it returns
+    /// `true`.
+    const fn on_tick(&mut self) -> bool {
+        if !self.acked {
+            return false;
+        }
+        self.acked = false;
+        true
+    }
+}
+
+/// Build an `op-1` heartbeat frame carrying the last received sequence (or
+/// `null` if none yet).
+fn heartbeat_frame(last_seq: &AtomicU64) -> String {
+    let seq = last_seq.load(Ordering::Relaxed);
+    let d = if seq == 0 { Value::Null } else { json!(seq) };
+    json!({ "op": op::HEARTBEAT, "d": d }).to_string()
+}
+
 /// Gateway opcodes we handle (subset of the documented set).
 mod op {
     pub const DISPATCH: u64 = 0;
@@ -194,14 +236,19 @@ async fn connect_and_serve<T: FleetTransport + 'static>(
     // the gateway is ready (Discord tolerates an early beat, but this is tidy).
     heartbeat.tick().await;
 
+    // M2: ACK-zombie detection — require each beat to be ACKed before the next.
+    let mut hb = HeartbeatTracker::new();
+
     loop {
         tokio::select! {
             // Periodic heartbeat (op 1 with the last seq, or null if none yet).
             _ = heartbeat.tick() => {
-                let seq = last_seq.load(Ordering::Relaxed);
-                let d = if seq == 0 { Value::Null } else { json!(seq) };
-                let beat = json!({ "op": op::HEARTBEAT, "d": d }).to_string();
-                if write.send(Message::Text(beat)).await.is_err() {
+                if !hb.on_tick() {
+                    // Previous beat was never ACKed → zombie connection.
+                    tracing::warn!("Discord heartbeat not ACKed; treating socket as dead");
+                    break;
+                }
+                if write.send(Message::Text(heartbeat_frame(&last_seq))).await.is_err() {
                     break; // socket gone — outer loop reconnects
                 }
             }
@@ -224,13 +271,12 @@ async fn connect_and_serve<T: FleetTransport + 'static>(
                 match payload.op {
                     op::HEARTBEAT => {
                         // Server asked for an immediate beat.
-                        let seq = last_seq.load(Ordering::Relaxed);
-                        let d = if seq == 0 { Value::Null } else { json!(seq) };
-                        let beat = json!({ "op": op::HEARTBEAT, "d": d }).to_string();
-                        write.send(Message::Text(beat)).await.ok();
+                        write.send(Message::Text(heartbeat_frame(&last_seq))).await.ok();
                     }
                     op::HEARTBEAT_ACK => {
                         tracing::trace!("Discord heartbeat ack");
+                        // M2: mark this beat ACKed so the next tick may send.
+                        hb.on_ack();
                         // M1: a two-way-confirmed connection is healthy — reset
                         // the reconnect streak so the next blip starts cheap.
                         backoff.reset();
@@ -661,6 +707,30 @@ mod tests {
         // A healthy (ACKed) connection resets the streak → next blip starts cheap.
         b.reset();
         assert_eq!(b.next_delay(), Duration::from_secs(1));
+    }
+
+    // ── M2: ACK-zombie state machine ─────────────────────────────────────────
+
+    #[test]
+    fn heartbeat_beat_without_ack_triggers_reconnect() {
+        let mut hb = HeartbeatTracker::new();
+        // First beat may send (starts ACKed=true), leaving a beat outstanding.
+        assert!(hb.on_tick(), "first beat should be allowed");
+        // Next tick with NO intervening ACK → unhealthy → reconnect signal.
+        assert!(
+            !hb.on_tick(),
+            "un-ACKed beat before next tick must signal a zombie connection"
+        );
+    }
+
+    #[test]
+    fn heartbeat_beat_then_ack_stays_healthy() {
+        let mut hb = HeartbeatTracker::new();
+        assert!(hb.on_tick(), "first beat allowed");
+        hb.on_ack();
+        assert!(hb.on_tick(), "ACKed beat → next beat allowed");
+        hb.on_ack();
+        assert!(hb.on_tick(), "still healthy after repeated ack/beat cycles");
     }
 
     // ── H1: relay runs OFF the socket task; heartbeat is never starved ───────

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
@@ -118,6 +118,14 @@ impl HeartbeatTracker {
     }
 }
 
+/// Jittered delay for the FIRST heartbeat (L1, Discord spec): the gateway tells
+/// clients to send the first beat after `heartbeat_interval * rand[0, 1)` so a
+/// fleet of bots doesn't beat in lockstep. Pure in `frac` for testability.
+fn first_beat_delay(interval: Duration, frac: f64) -> Duration {
+    let frac = frac.clamp(0.0, 1.0);
+    interval.mul_f64(frac)
+}
+
 /// Build an `op-1` heartbeat frame carrying the last received sequence (or
 /// `null` if none yet).
 fn heartbeat_frame(last_seq: &AtomicU64) -> String {
@@ -231,10 +239,13 @@ async fn connect_and_serve<T: FleetTransport + 'static>(
 
     // Last received sequence number, shared with the heartbeat loop.
     let last_seq = Arc::new(AtomicU64::new(0));
-    let mut heartbeat = tokio::time::interval(Duration::from_millis(heartbeat_ms));
-    // The first tick fires immediately; skip it so we don't double-send before
-    // the gateway is ready (Discord tolerates an early beat, but this is tidy).
-    heartbeat.tick().await;
+    let interval = Duration::from_millis(heartbeat_ms);
+
+    // L1: jitter the FIRST beat by `interval * rand[0, 1)` per the Discord spec,
+    // so a fleet of bots reconnecting together don't all beat in lockstep.
+    let first_delay = first_beat_delay(interval, rand::random::<f64>());
+    let start = tokio::time::Instant::now() + first_delay;
+    let mut heartbeat = tokio::time::interval_at(start, interval);
 
     // M2: ACK-zombie detection — require each beat to be ACKed before the next.
     let mut hb = HeartbeatTracker::new();
@@ -731,6 +742,20 @@ mod tests {
         assert!(hb.on_tick(), "ACKed beat → next beat allowed");
         hb.on_ack();
         assert!(hb.on_tick(), "still healthy after repeated ack/beat cycles");
+    }
+
+    // ── L1: first-heartbeat jitter ───────────────────────────────────────────
+
+    #[test]
+    fn first_beat_delay_is_jittered_within_one_interval() {
+        let interval = Duration::from_millis(41250);
+        assert_eq!(first_beat_delay(interval, 0.0), Duration::ZERO);
+        assert_eq!(first_beat_delay(interval, 0.5), interval.mul_f64(0.5));
+        // frac approaching 1.0 stays strictly under a full interval.
+        assert!(first_beat_delay(interval, 0.999) < interval);
+        // Out-of-range fractions are clamped, never panic or overshoot.
+        assert_eq!(first_beat_delay(interval, 1.5), interval);
+        assert_eq!(first_beat_delay(interval, -0.5), Duration::ZERO);
     }
 
     // ── H1: relay runs OFF the socket task; heartbeat is never starved ───────

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
@@ -40,6 +40,50 @@ const API_BASE: &str = "https://discord.com/api/v10";
 /// Discord message-content limit (`POST /channels/{id}/messages`). We split below it.
 const DISCORD_MAX_LENGTH: usize = 2000;
 
+/// Reconnect backoff bounds (M1). Discord's spec says wait 1–5s after an
+/// `INVALID_SESSION` before re-`IDENTIFY`ing; we apply the same floor to every
+/// non-clean reconnect and grow it exponentially on *consecutive* reconnects so
+/// a server that immediately drops us doesn't get hammered.
+const RECONNECT_BACKOFF_MIN: Duration = Duration::from_secs(1);
+const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+/// Exponential reconnect backoff with reset-on-health (M1).
+///
+/// Each consecutive reconnect doubles the delay from [`RECONNECT_BACKOFF_MIN`]
+/// (capped at [`RECONNECT_BACKOFF_MAX`]); a connection that lived long enough to
+/// be considered healthy resets the streak so the next blip starts cheap again.
+#[derive(Debug, Default)]
+struct ReconnectBackoff {
+    consecutive: u32,
+}
+
+impl ReconnectBackoff {
+    const fn new() -> Self {
+        Self { consecutive: 0 }
+    }
+
+    /// The delay to wait before the next reconnect, advancing the streak.
+    fn next_delay(&mut self) -> Duration {
+        let delay = backoff_delay(self.consecutive);
+        self.consecutive = self.consecutive.saturating_add(1);
+        delay
+    }
+
+    /// A connection proved healthy — forget the streak.
+    const fn reset(&mut self) {
+        self.consecutive = 0;
+    }
+}
+
+/// Pure backoff schedule: `min * 2^attempt`, saturating, clamped to `max`.
+fn backoff_delay(attempt: u32) -> Duration {
+    let factor = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+    let millis = RECONNECT_BACKOFF_MIN.as_millis().saturating_mul(u128::from(factor));
+    let capped = millis.min(RECONNECT_BACKOFF_MAX.as_millis());
+    // `capped <= RECONNECT_BACKOFF_MAX` (60_000ms) so this never truncates.
+    Duration::from_millis(u64::try_from(capped).unwrap_or(u64::MAX))
+}
+
 /// Gateway opcodes we handle (subset of the documented set).
 mod op {
     pub const DISPATCH: u64 = 0;
@@ -81,19 +125,26 @@ pub async fn run<T: FleetTransport + 'static>(
         "ainb phone bridge: Discord channel online (gateway)"
     );
 
+    let mut backoff = ReconnectBackoff::new();
     loop {
-        match connect_and_serve(&client, &cfg, transport).await {
+        match connect_and_serve(&client, &cfg, transport, &mut backoff).await {
             Ok(()) => tracing::info!("Discord gateway closed; reconnecting"),
             Err(e) => {
                 // Build the diagnostic from the error's text, then scrub any
                 // token-shaped substring so a Bot token can never leak into logs.
                 tracing::warn!(
                     error = %scrub_token(&e.to_string()),
-                    "Discord gateway error; reconnecting in 5s"
+                    "Discord gateway error; reconnecting"
                 );
-                tokio::time::sleep(Duration::from_secs(5)).await;
             }
         }
+        // M1: never reconnect with zero delay — a server that drops us
+        // immediately (clean op-7/op-9 close OR an error) would otherwise spin a
+        // hot reconnect loop. The streak is reset inside `connect_and_serve` once
+        // a connection proves healthy.
+        let delay = backoff.next_delay();
+        tracing::debug!(?delay, "Discord reconnect backoff");
+        tokio::time::sleep(delay).await;
     }
 }
 
@@ -103,6 +154,7 @@ async fn connect_and_serve<T: FleetTransport + 'static>(
     client: &reqwest::Client,
     cfg: &DiscordConfig,
     transport: &'static T,
+    backoff: &mut ReconnectBackoff,
 ) -> Result<()> {
     let (ws, _resp) = tokio_tungstenite::connect_async(GATEWAY_URL)
         .await
@@ -177,7 +229,12 @@ async fn connect_and_serve<T: FleetTransport + 'static>(
                         let beat = json!({ "op": op::HEARTBEAT, "d": d }).to_string();
                         write.send(Message::Text(beat)).await.ok();
                     }
-                    op::HEARTBEAT_ACK => tracing::trace!("Discord heartbeat ack"),
+                    op::HEARTBEAT_ACK => {
+                        tracing::trace!("Discord heartbeat ack");
+                        // M1: a two-way-confirmed connection is healthy — reset
+                        // the reconnect streak so the next blip starts cheap.
+                        backoff.reset();
+                    }
                     op::RECONNECT => {
                         tracing::info!("Discord requested reconnect");
                         break;
@@ -575,6 +632,35 @@ mod tests {
         let t = FakeTransport::new(vec![], Some("x".into()));
         let out = relay(&t, &relay_params(), "hello").await;
         assert_eq!(out, "No running ainb sessions to relay to.");
+    }
+
+    // ── M1: reconnect backoff ────────────────────────────────────────────────
+
+    #[test]
+    fn backoff_delay_grows_exponentially_and_caps() {
+        // min * 2^attempt, clamped to RECONNECT_BACKOFF_MAX (60s).
+        assert_eq!(backoff_delay(0), Duration::from_secs(1));
+        assert_eq!(backoff_delay(1), Duration::from_secs(2));
+        assert_eq!(backoff_delay(2), Duration::from_secs(4));
+        assert_eq!(backoff_delay(5), Duration::from_secs(32));
+        // 2^6 = 64s > cap → clamped to 60s.
+        assert_eq!(backoff_delay(6), RECONNECT_BACKOFF_MAX);
+        // Absurd attempt counts saturate, never panic or wrap.
+        assert_eq!(backoff_delay(64), RECONNECT_BACKOFF_MAX);
+        assert_eq!(backoff_delay(u32::MAX), RECONNECT_BACKOFF_MAX);
+    }
+
+    #[test]
+    fn consecutive_reconnects_increase_delay_then_reset_when_healthy() {
+        let mut b = ReconnectBackoff::new();
+        // First reconnect is never zero (fixes the zero-backoff hammer).
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
+        assert!(b.next_delay() >= Duration::from_secs(1));
+        let third = b.next_delay();
+        assert_eq!(third, Duration::from_secs(4));
+        // A healthy (ACKed) connection resets the streak → next blip starts cheap.
+        b.reset();
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
     }
 
     // ── H1: relay runs OFF the socket task; heartbeat is never starved ───────

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
@@ -440,13 +440,50 @@ fn split_for_discord(text: &str) -> Vec<String> {
     super::format::split_message(text, DISCORD_MAX_LENGTH)
 }
 
+/// Cap on a single honoured `Retry-After` sleep (L2). Discord rate limits are
+/// short; an absurd value (or a hostile one) must not wedge the reply task.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
+
+/// Parse a Discord `Retry-After` header (seconds, possibly fractional) into a
+/// bounded sleep duration. Returns `None` for missing/garbage values. Pure.
+fn parse_retry_after(raw: Option<&str>) -> Option<Duration> {
+    let secs: f64 = raw?.trim().parse().ok()?;
+    if !secs.is_finite() || secs < 0.0 {
+        return None;
+    }
+    Some(Duration::from_secs_f64(secs).min(MAX_RETRY_AFTER))
+}
+
 /// Post a message to a channel via the REST API (`Authorization: Bot <token>`).
+///
+/// On HTTP 429 (rate limited) the chunk is retried ONCE after sleeping for the
+/// `Retry-After` the gateway returns (L2); any other failure — or a second 429 —
+/// surfaces an error so the caller drops the chunk as before.
 async fn post_message(
     client: &reqwest::Client,
     token: &str,
     channel_id: &str,
     text: &str,
 ) -> Result<()> {
+    if let Some(retry_after) = post_message_once(client, token, channel_id, text).await? {
+        // 429: honour Retry-After once, then try a single resend.
+        tracing::warn!(?retry_after, "Discord rate limited; retrying chunk once");
+        tokio::time::sleep(retry_after).await;
+        if let Some(_again) = post_message_once(client, token, channel_id, text).await? {
+            anyhow::bail!("Discord message post rate limited (429) twice; dropping chunk");
+        }
+    }
+    Ok(())
+}
+
+/// Single POST attempt. Returns `Ok(Some(retry_after))` on a 429 (so the caller
+/// may retry), `Ok(None)` on success, and `Err` on any other failure.
+async fn post_message_once(
+    client: &reqwest::Client,
+    token: &str,
+    channel_id: &str,
+    text: &str,
+) -> Result<Option<Duration>> {
     let resp = client
         .post(format!("{API_BASE}/channels/{channel_id}/messages"))
         .header("Authorization", format!("Bot {token}"))
@@ -455,19 +492,28 @@ async fn post_message(
         .await
         .context("POST /channels/{id}/messages request")?;
     let status = resp.status();
-    if !status.is_success() {
-        // Surface status + the API error code/message, never the token.
-        let body: Value = resp.json().await.unwrap_or(Value::Null);
-        let code = body.get("code").and_then(Value::as_i64);
-        let message = body.get("message").and_then(Value::as_str).unwrap_or("");
-        anyhow::bail!(
-            "Discord message post failed: HTTP {} (code {:?}: {})",
-            status.as_u16(),
-            code,
-            message
-        );
+    if status.is_success() {
+        return Ok(None);
     }
-    Ok(())
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| parse_retry_after(Some(s)))
+            .unwrap_or(RECONNECT_BACKOFF_MIN);
+        return Ok(Some(retry_after));
+    }
+    // Surface status + the API error code/message, never the token.
+    let body: Value = resp.json().await.unwrap_or(Value::Null);
+    let code = body.get("code").and_then(Value::as_i64);
+    let message = body.get("message").and_then(Value::as_str).unwrap_or("");
+    anyhow::bail!(
+        "Discord message post failed: HTTP {} (code {:?}: {})",
+        status.as_u16(),
+        code,
+        message
+    );
 }
 
 // ── Gateway / REST wire types ───────────────────────────────────────────────
@@ -756,6 +802,22 @@ mod tests {
         // Out-of-range fractions are clamped, never panic or overshoot.
         assert_eq!(first_beat_delay(interval, 1.5), interval);
         assert_eq!(first_beat_delay(interval, -0.5), Duration::ZERO);
+    }
+
+    // ── L2: Retry-After parsing for the 429 retry ────────────────────────────
+
+    #[test]
+    fn parse_retry_after_reads_seconds_and_bounds_garbage() {
+        assert_eq!(
+            parse_retry_after(Some("1.5")),
+            Some(Duration::from_secs_f64(1.5))
+        );
+        assert_eq!(parse_retry_after(Some("0")), Some(Duration::ZERO));
+        assert_eq!(parse_retry_after(None), None);
+        assert_eq!(parse_retry_after(Some("not-a-number")), None);
+        assert_eq!(parse_retry_after(Some("-3")), None);
+        // An absurd value is capped so a hostile header can't wedge the task.
+        assert_eq!(parse_retry_after(Some("99999")), Some(MAX_RETRY_AFTER));
     }
 
     // ── H1: relay runs OFF the socket task; heartbeat is never starved ───────

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/discord.rs
@@ -56,7 +56,15 @@ mod op {
 const INTENTS: u64 = (1 << 9) | (1 << 15) | (1 << 12);
 
 /// Run the Discord channel forever (reconnecting on disconnect).
-pub async fn run<T: FleetTransport>(cfg: DiscordConfig, transport: &T) -> Result<()> {
+///
+/// `transport` is `&'static` because the relay for each inbound message runs in
+/// its own `tokio::spawn` task (H1) so a slow reply can never starve the gateway
+/// heartbeat; the spawned future must therefore not borrow a non-`'static`
+/// transport. The daemon leaks a single shared transport, so this costs nothing.
+pub async fn run<T: FleetTransport + 'static>(
+    cfg: DiscordConfig,
+    transport: &'static T,
+) -> Result<()> {
     let client =
         reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
@@ -91,10 +99,10 @@ pub async fn run<T: FleetTransport>(cfg: DiscordConfig, transport: &T) -> Result
 
 /// One gateway connection: handshake, then pump dispatches until the socket
 /// closes or Discord asks us to reconnect.
-async fn connect_and_serve<T: FleetTransport>(
+async fn connect_and_serve<T: FleetTransport + 'static>(
     client: &reqwest::Client,
     cfg: &DiscordConfig,
-    transport: &T,
+    transport: &'static T,
 ) -> Result<()> {
     let (ws, _resp) = tokio_tungstenite::connect_async(GATEWAY_URL)
         .await
@@ -184,7 +192,26 @@ async fn connect_and_serve<T: FleetTransport>(
                         if payload.t.as_deref() == Some("MESSAGE_CREATE") {
                             if let Some(d) = payload.d {
                                 if let Ok(msg) = serde_json::from_value::<DiscordMessage>(d) {
-                                    handle_message(client, cfg, transport, msg).await;
+                                    // H1: the relay polls the agent for up to
+                                    // `response_timeout` (300s default). Doing that
+                                    // inline here would block `heartbeat.tick()`,
+                                    // starve the op-1 beat, and make Discord
+                                    // force-close the socket — under exactly the
+                                    // slow-reply workload the bridge exists for. So
+                                    // dispatch the handle-and-reply work to its own
+                                    // task: the `reqwest::Client` is `Arc` inside
+                                    // (cheap clone), the config is cloned, and the
+                                    // transport is `&'static` (shared, not the WSS
+                                    // socket). The REST reply uses its own HTTPS
+                                    // connection and never touches the gateway
+                                    // `write` half, so there's no shared-socket
+                                    // contention with the heartbeat.
+                                    spawn_handle_message(
+                                        client.clone(),
+                                        cfg.clone(),
+                                        transport,
+                                        msg,
+                                    );
                                 }
                             }
                         }
@@ -214,6 +241,22 @@ where
         }
     }
     anyhow::bail!("gateway stream ended before a payload")
+}
+
+/// Dispatch one `MESSAGE_CREATE` to its own task (H1) so the relay + REST reply
+/// run OFF the gateway socket task and can never starve the heartbeat.
+///
+/// Owns everything it needs: a cloned `reqwest::Client` (cheap — `Arc` inside),
+/// a cloned [`DiscordConfig`], and the `&'static` shared transport.
+fn spawn_handle_message<T: FleetTransport + 'static>(
+    client: reqwest::Client,
+    cfg: DiscordConfig,
+    transport: &'static T,
+    msg: DiscordMessage,
+) {
+    tokio::spawn(async move {
+        handle_message(&client, &cfg, transport, msg).await;
+    });
 }
 
 /// Process one `MESSAGE_CREATE`: authorize, relay through the shared core, and
@@ -532,5 +575,70 @@ mod tests {
         let t = FakeTransport::new(vec![], Some("x".into()));
         let out = relay(&t, &relay_params(), "hello").await;
         assert_eq!(out, "No running ainb sessions to relay to.");
+    }
+
+    // ── H1: relay runs OFF the socket task; heartbeat is never starved ───────
+
+    /// A transport whose `send_and_capture` blocks for a long time, modelling a
+    /// slow agent reply (the exact workload the bridge exists for).
+    struct SlowTransport {
+        sessions: Vec<TargetSession>,
+    }
+
+    impl FleetTransport for SlowTransport {
+        async fn discover(&self) -> Vec<TargetSession> {
+            self.sessions.clone()
+        }
+        async fn send_and_capture(
+            &self,
+            _session: &TargetSession,
+            _text: &str,
+            _timeout: Duration,
+        ) -> Option<String> {
+            // Far longer than the test runs — if this ran inline on the socket
+            // task it would starve the beat. Real wall-clock so the test needs no
+            // tokio `test-util` feature (not enabled for this target).
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Some("late reply".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn relay_runs_off_task_so_heartbeat_keeps_firing() {
+        // Leak a slow transport to get the `&'static` the spawned relay needs,
+        // mirroring how the daemon leaks its shared transport.
+        let transport: &'static SlowTransport = Box::leak(Box::new(SlowTransport {
+            sessions: vec![sess("conductor")],
+        }));
+
+        // Kick off a relay exactly the way the socket task does — in a spawned
+        // task — then prove the socket task's own loop keeps ticking while the
+        // relay (an hour-long sleep) is still outstanding.
+        let relay_done = Arc::new(AtomicU64::new(0));
+        let rd = relay_done.clone();
+        tokio::spawn(async move {
+            let params = relay_params();
+            let _ = relay(transport, &params, "status?").await;
+            rd.store(1, Ordering::SeqCst);
+        });
+
+        // Stand-in for the gateway heartbeat: a fast interval the socket task
+        // services. With the relay OFF-task these keep firing; if the relay were
+        // awaited inline they would all be blocked behind the 1h sleep.
+        let mut beats: u64 = 0;
+        let mut heartbeat = tokio::time::interval(Duration::from_millis(5));
+        heartbeat.tick().await; // immediate first tick
+        for _ in 0..5 {
+            heartbeat.tick().await;
+            beats += 1;
+        }
+
+        // Five beats fired while the relay is still pending.
+        assert_eq!(beats, 5, "heartbeat must keep firing during a slow relay");
+        assert_eq!(
+            relay_done.load(Ordering::SeqCst),
+            0,
+            "the relay should still be in flight — proving it did not block the beats"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -5,6 +5,7 @@
 //
 //   * Telegram (long-polling getUpdates over reqwest) — `telegram.rs`
 //   * Slack    (socket-mode WebSocket via tokio-tungstenite) — `slack.rs`
+//   * Discord  (raw Gateway WebSocket via tokio-tungstenite) — `discord.rs`
 //
 // Both channels share ONE relay/routing core (`relay.rs`) over one transport
 // (`transport.rs`: discover via `ainb list`, deliver via tmux send-keys with the
@@ -18,7 +19,9 @@
 // unit-tested without a live fleet or network.
 
 pub mod config;
+pub mod discord;
 pub mod format;
+pub mod redact;
 pub mod relay;
 pub mod routing;
 pub mod secrets;
@@ -43,7 +46,10 @@ pub async fn run() -> Result<()> {
 /// Run with an already-loaded config (the testable seam — no disk access).
 pub async fn run_with_config(cfg: BridgeConfig) -> Result<()> {
     if !cfg.any_channel() {
-        bail!("no bridge channel configured — add [fleet.bridge.telegram] or [fleet.bridge.slack]");
+        bail!(
+            "no bridge channel configured — add [fleet.bridge.telegram], \
+             [fleet.bridge.slack], or [fleet.bridge.discord]"
+        );
     }
 
     // The shared transport is cheap (a zero-sized marker); each channel borrows
@@ -64,6 +70,13 @@ pub async fn run_with_config(cfg: BridgeConfig) -> Result<()> {
         tasks.push(tokio::spawn(async move {
             if let Err(e) = slack::run(sl, transport).await {
                 tracing::error!(error = %e, "Slack channel exited with error");
+            }
+        }));
+    }
+    if let Some(dc) = cfg.discord {
+        tasks.push(tokio::spawn(async move {
+            if let Err(e) = discord::run(dc, transport).await {
+                tracing::error!(error = %e, "Discord channel exited with error");
             }
         }));
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/redact.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/redact.rs
@@ -1,0 +1,72 @@
+// ABOUTME: Token redaction for bridge diagnostics — keep secrets out of logs.
+//
+// Channel error paths build their diagnostics from HTTP status / flags rather
+// than echoing raw transport errors, but as defence-in-depth we also scrub any
+// token-shaped substring before logging. A Discord *bot* token has the shape
+//   <base64 user-id>.<base64 timestamp>.<base64 hmac>
+// — three dot-separated base64url segments of roughly ~24+/~6/~27+ chars. We
+// replace any such run with `[redacted]` so a token can never leak through an
+// error string. (The tests below use obviously-synthetic placeholders rather
+// than a realistic token so secret scanners don't flag this source file.)
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Matches a Discord-bot-token-shaped substring: three base64url segments of
+/// roughly 24+ / 6 / 27+ chars. Deliberately conservative on the boundaries so
+/// it does not eat ordinary dotted identifiers.
+static TOKEN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[\w-]{24,}\.[\w-]{6}\.[\w-]{27,}").expect("valid token regex"));
+
+/// Replace any token-shaped substring in `text` with `[redacted]`.
+///
+/// Pure; safe to call on every diagnostic string before logging.
+#[must_use]
+pub fn scrub_token(text: &str) -> String {
+    TOKEN_RE.replace_all(text, "[redacted]").into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic placeholders: each matches the redaction regex (three
+    // `[\w-]{24+}.{6}.{27+}` segments) but is obviously not a real token, so
+    // secret scanners don't flag this file.
+    #[test]
+    fn redacts_a_discord_bot_token() {
+        let token = "fake-user-id-segment-xxxx.tttttt.fake-hmac-segment-yyyyyyyyyy";
+        let msg = format!("auth failed with Bot {token} (401)");
+        let scrubbed = scrub_token(&msg);
+        assert!(
+            !scrubbed.contains(token),
+            "token must not survive scrubbing"
+        );
+        assert!(scrubbed.contains("[redacted]"));
+        assert!(scrubbed.contains("(401)"), "non-token text is preserved");
+    }
+
+    #[test]
+    fn redacts_token_anywhere_in_the_string() {
+        let token = "placeholder-first-segment-zz.midseg.placeholder-third-segment-w";
+        let scrubbed = scrub_token(&format!("prefix {token} suffix"));
+        assert_eq!(scrubbed, "prefix [redacted] suffix");
+    }
+
+    #[test]
+    fn leaves_ordinary_text_untouched() {
+        let msg = "HTTP 500 (code 50001: Missing Access)";
+        assert_eq!(scrub_token(msg), msg);
+        // A short dotted identifier (e.g. a version) is not token-shaped.
+        assert_eq!(scrub_token("v10.0.1"), "v10.0.1");
+    }
+
+    #[test]
+    fn redacts_multiple_tokens() {
+        let t1 = "AAAAAAAAAAAAAAAAAAAAAAAAA.BBBBBB.CCCCCCCCCCCCCCCCCCCCCCCCCCC";
+        let t2 = "DDDDDDDDDDDDDDDDDDDDDDDDD.EEEEEE.FFFFFFFFFFFFFFFFFFFFFFFFFFF";
+        let scrubbed = scrub_token(&format!("{t1} and {t2}"));
+        assert_eq!(scrubbed, "[redacted] and [redacted]");
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/relay.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/relay.rs
@@ -15,22 +15,23 @@ use super::routing::{TargetSession, parse_target_prefix, resolve_target};
 /// `ainb`/tmux (`transport.rs`); tests substitute an in-memory fake so the
 /// routing + degrade logic is verified without a live fleet.
 ///
-/// Uses native `async fn` in traits (stable since Rust 1.75) — the relay only
-/// ever calls it through a generic `&T`, never a `dyn` object, so the
-/// `async_fn_in_trait` auto-trait caveat does not apply here (the returned
-/// futures are awaited inline in `Send` channel tasks).
-#[allow(async_fn_in_trait)]
+/// Uses native `async fn` in traits (stable since Rust 1.75). The methods spell
+/// out `impl Future<…> + Send` explicitly (rather than bare `async fn`) so the
+/// returned futures are guaranteed `Send`: the Discord channel runs the relay in
+/// its own `tokio::spawn` task (so a slow agent reply can't starve the gateway
+/// heartbeat), and `tokio::spawn` requires a `Send` future. The relay is still
+/// only ever called through a generic `&T`, never a `dyn` object.
 pub trait FleetTransport: Send + Sync {
     /// Currently-running relay targets.
-    async fn discover(&self) -> Vec<TargetSession>;
+    fn discover(&self) -> impl std::future::Future<Output = Vec<TargetSession>> + Send;
     /// Send `text` to `session` and capture its end-of-turn reply (or `None`
     /// on send failure / timeout).
-    async fn send_and_capture(
+    fn send_and_capture(
         &self,
         session: &TargetSession,
         text: &str,
         timeout: Duration,
-    ) -> Option<String>;
+    ) -> impl std::future::Future<Output = Option<String>> + Send;
 }
 
 /// Parameters that shape a single relay, supplied per-channel.

--- a/docs/fleet-bridge.md
+++ b/docs/fleet-bridge.md
@@ -1,4 +1,4 @@
-# `ainb fleet bridge` — native phone bridge (Telegram + Slack)
+# `ainb fleet bridge` — native phone bridge (Telegram + Slack + Discord)
 
 A single-binary Rust daemon, built into `ainb`, that relays messages **two-way**
 between a chat app and a named `ainb` session — a conductor/ATC session when one
@@ -7,12 +7,12 @@ session from your phone while away from the keyboard, with **no separate Python
 runtime** to install or manage.
 
 It ports the proven logic of the Python `ainb_phone_bridge` (now deprecated) and
-adds a **Slack** channel. Both channels share one relay/routing core.
+adds **Slack** and **Discord** channels. All channels share one relay/routing core.
 
 ```
   Telegram ─long-poll─▶                                  ┌─▶ ainb session
-                        ainb fleet bridge ─tmux send-keys─┤
-  Slack ─socket-mode─▶  (shared relay core)              └─ read JSONL transcript
+  Slack ───socket-mode─▶ ainb fleet bridge ─tmux send-keys┤
+  Discord ─gateway-wss─▶  (shared relay core)            └─ read JSONL transcript
      ▲                          │                              │
      └──── reply (split) ───────┴──── wait for assistant end_turn ◀──┘
 ```
@@ -59,6 +59,9 @@ across restarts). An unknown `name:` prefix is treated as plain text.
   (`mentions` default, or `all`) decides whether the bot acts only on
   app-mentions/DMs or on every message in subscribed channels. The bot ignores
   its own and other bots' messages (no reply loops).
+- **Discord** — by Discord `user_id` (snowflake); unknown senders ignored. The
+  bot ignores any message flagged `author.bot` (its own and every other bot),
+  so it never relays its own replies.
 
 Tokens are resolved through the **secret resolver** and are **never** placed on
 argv or written into the launchd/systemd unit:
@@ -92,6 +95,13 @@ user_id = "U0123ABC"               # authorized Slack user id (string)
 default_target = "conductor"        # optional
 listen_mode = "mentions"            # "mentions" (default) | "all"
 response_timeout = 300              # optional
+
+[fleet.bridge.discord]
+token = "$DISCORD_BOT_TOKEN"        # Bot token (gateway IDENTIFY + REST posts)
+user_id = "123456789012345678"     # authorized Discord user id (snowflake, string)
+default_target = "conductor"        # optional
+channel_id = "123456789012345678"  # optional: fallback channel for replies
+response_timeout = 300              # optional
 ```
 
 ### Slack app setup (socket-mode)
@@ -102,6 +112,26 @@ response_timeout = 300              # optional
 3. Event subscriptions (over socket mode): `app_mention`, `message.im` (and
    `message.channels` if you use `listen_mode = "all"`).
 4. App-level token (`xapp-…`) with `connections:write`.
+
+### Discord bot setup (gateway)
+
+1. Create an application at <https://discord.com/developers/applications>.
+2. Under **Bot**, click **Add Bot**, then **Reset Token** to reveal the bot
+   token — this is the `token` value (store it as an env/keychain ref, never a
+   literal in prod).
+3. On the same **Bot** page, enable the **MESSAGE CONTENT INTENT** (privileged).
+   Without it the gateway delivers empty `content`, so the bridge has nothing to
+   relay. (The bridge requests the `GUILD_MESSAGES`, `MESSAGE_CONTENT`, and
+   `DIRECT_MESSAGES` intents.)
+4. Invite the bot to your server: **OAuth2 → URL Generator**, scopes `bot`,
+   bot permissions `View Channels` + `Send Messages` + `Read Message History`,
+   then open the generated URL and add it to a server. For DM-only use, no
+   server invite is needed once the bot shares a server with you.
+5. Get your **own** Discord user id: enable **Settings → Advanced → Developer
+   Mode**, then right-click your name → **Copy User ID**. That snowflake is the
+   `user_id` value (messages from anyone else are ignored).
+6. Optional `channel_id`: a fallback channel the bot posts to if a reply has no
+   originating channel. Right-click a channel → **Copy Channel ID**.
 
 ## Running
 
@@ -152,10 +182,13 @@ cargo test -p ainb --lib fleet::bridge
 
 Coverage: prefix routing + conductor-first default + degrade; markdown→HTML and
 4096-char split (split-before-convert); secret resolution (`$ENV`/`${ENV}`/
-`keychain:`/literal); config parsing/validation for both channel tables; the
+`keychain:`/literal); config parsing/validation for all three channel tables; the
 shared relay core (every outcome, via an in-memory transport fake); the JSONL
 reply scan (complete-line-only, send-time guard accept/reject, no-timestamp
 rejection, multi-block concat); Telegram mention-gating + mention-strip; Slack
 event classification (mentions vs all, auth, self/bot/subtype filtering) +
-envelope parsing; and launchd/systemd unit rendering (argv correct, no token
+envelope parsing; Discord message authorization (auth, self/bot filtering) +
+gateway HELLO/MESSAGE_CREATE payload parsing + the relay path over the mock
+transport; token redaction (a bot-token-shaped substring is scrubbed from any
+diagnostic); and launchd/systemd unit rendering (argv correct, no token
 leakage). A live-token end-to-end run is manual.

--- a/plugins/ainb-fleet/bridge/README.md
+++ b/plugins/ainb-fleet/bridge/README.md
@@ -2,8 +2,9 @@
 
 > **Deprecated — superseded by the native Rust bridge `ainb fleet bridge`.**
 > The single-binary Rust daemon (in `ainb-core`, run via `ainb fleet bridge run`)
-> ports this bridge's verified behaviour AND adds a Slack (socket-mode) channel,
-> with no separate Python runtime to install or manage. Prefer it for new setups.
+> ports this bridge's verified behaviour AND adds Slack (socket-mode) and Discord
+> (gateway) channels, with no separate Python runtime to install or manage. Prefer
+> it for new setups.
 > See [`docs/fleet-bridge.md`](../../../docs/fleet-bridge.md) for config + a
 > Python→Rust migration guide. This Python implementation is retained (not
 > deleted) for existing installs and as the behavioral reference spec; it will be
@@ -173,8 +174,10 @@ token — every external boundary is mocked or driven through a temp transcript.
 
 ## Known limitations / follow-ups
 
-- **Slack / Discord deferred** — Telegram only for this cut; the routing, format,
-  and capture layers are platform-agnostic so a Slack adapter slots in cleanly.
+- **Slack / Discord** — landed in the native Rust bridge (`ainb fleet bridge`),
+  not this Python daemon. The routing, format, and capture layers are
+  platform-agnostic, which is what let the Slack and Discord adapters slot in
+  cleanly there. This Python bridge remains Telegram-only.
 - **No busy-queue / hooks** — agent-deck's per-conductor busy queue and
   pre/post-message hooks are not ported (they depend on the conductor track).
 - **No heartbeat / NEED: escalation** — those belong to the conductor track.

--- a/plugins/ainb-fleet/bridge/config.example.toml
+++ b/plugins/ainb-fleet/bridge/config.example.toml
@@ -29,3 +29,50 @@ response_timeout = 300
 
 # Optional: HTTP/SOCKS proxy for the Telegram API (SOCKS needs aiohttp-socks).
 # proxy_url = "http://127.0.0.1:8080"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Native Rust bridge (`ainb fleet bridge`) config blocks.
+#
+# The native single-binary daemon reads `[fleet.bridge.*]` tables (NOT the
+# `[fleet.telegram]` table above, which is the deprecated Python bridge). Merge
+# the blocks you want into ~/.agents-in-a-box/config/config.toml. At least one
+# channel must be present. All tokens resolve through the secret resolver
+# ("$ENV" / "${ENV}" / "keychain:svc" / literal) and are NEVER passed on argv.
+# See docs/fleet-bridge.md for the full setup guide.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# [fleet.bridge]
+# response_timeout = 300              # optional shared default (seconds)
+
+# [fleet.bridge.telegram]
+# token = "$TELEGRAM_BOT_TOKEN"
+# user_id = 123456789
+# default_target = "conductor"
+# require_mention_in_groups = true
+# response_timeout = 300
+
+# [fleet.bridge.slack]
+# bot_token = "$SLACK_BOT_TOKEN"      # xoxb-… (Web API)
+# app_token = "$SLACK_APP_TOKEN"      # xapp-… (socket-mode)
+# user_id = "U0123ABC"
+# default_target = "conductor"
+# listen_mode = "mentions"            # "mentions" (default) | "all"
+# response_timeout = 300
+
+# [fleet.bridge.discord]
+# token = "$DISCORD_BOT_TOKEN"        # Bot token (gateway IDENTIFY + REST posts)
+# user_id = "123456789012345678"     # authorized Discord user id (snowflake, string)
+# default_target = "conductor"        # optional
+# channel_id = "123456789012345678"  # optional: fallback channel to post replies to
+# response_timeout = 300              # optional
+#
+# Discord bot setup:
+#   1. Create an app at https://discord.com/developers/applications
+#   2. Bot → Add Bot → Reset Token  → use as `token` (env/keychain ref in prod).
+#   3. Bot → enable the **MESSAGE CONTENT INTENT** (privileged) — without it the
+#      gateway delivers empty content and there is nothing to relay.
+#   4. OAuth2 → URL Generator: scope `bot`; permissions View Channels +
+#      Send Messages + Read Message History; open the URL to invite the bot.
+#   5. Your user id: Settings → Advanced → Developer Mode, then right-click your
+#      name → Copy User ID  → use as `user_id`.


### PR DESCRIPTION
## What

Adds **Discord** as a third channel to the native `ainb fleet bridge`, alongside Telegram and Slack, mirroring the Slack channel's structure and quality. Two-way relay: phone/chat <-> ainb session.

## How it works

- **`fleet/bridge/discord.rs`** — `run<T: FleetTransport>(cfg, transport)` mirroring `slack.rs`. Connects to the **raw Discord Gateway** over WSS (`wss://gateway.discord.gg/?v=10&encoding=json`) with `tokio_tungstenite`, completes the documented handshake: receive HELLO (op 10) -> start a heartbeat loop (op 1 with the last seq, via `tokio::select!`) -> IDENTIFY (op 2) with intents `GUILD_MESSAGES | MESSAGE_CONTENT | DIRECT_MESSAGES`. On `MESSAGE_CREATE`, authorizes by `author.id == authorized_user_id` (ignoring its own and other bots' posts), relays through the **shared relay/routing core** (honoring a `name:` prefix, else `default_target`), and posts the reply via REST `POST /channels/{id}/messages` with `Authorization: Bot <token>`. Reconnects on disconnect; handles RECONNECT / INVALID_SESSION with a fresh reconnect.
- **Raw gateway, no SDK** — matches `slack.rs`'s lightweight `tokio_tungstenite` + `reqwest` style and avoids pulling serenity/twilight into the single `ainb` binary. **No new dependency.**
- **`DiscordConfig` + `[fleet.bridge.discord]`** parsing in `config.rs`: `token` (secret ref), `user_id` (snowflake string), optional `default_target`, optional `channel_id` (reply fallback), `response_timeout`. Added `discord: Option<DiscordConfig>` to `BridgeConfig` and spawned the task in `run_with_config` alongside Telegram + Slack.
- **Token redaction** — new `fleet/bridge/redact.rs` scrubs any token-shaped substring (`[\w-]{24,}\.[\w-]{6}\.[\w-]{27,}`) from diagnostics; the Discord error paths build diagnostics from HTTP status/flags and run them through the scrubber, so a bot token can never leak to logs.

## Tests

Mirror the Slack tests, no live connection required: config parse (Discord-only, optional channel_id, missing token/user_id, empty-after-resolution, shared timeout), authorization (configured user, unauthorized ignored, bot/self ignored, no-author ignored), intents bitmask, HELLO + MESSAGE_CREATE payload parsing, the relay path over the in-crate mock `FleetTransport`, and token redaction. `cargo test -p ainb --bin ainb fleet::bridge` -> **104 passed; 0 failed**.

## Docs

`docs/fleet-bridge.md`, `plugins/ainb-fleet/bridge/config.example.toml`, and the bridge README document the `[fleet.bridge.discord]` block and the bot setup (create app -> bot token -> enable MESSAGE CONTENT intent -> invite with `bot` scope -> get your user id via Developer Mode).

## To test live

Provide a Discord **bot token** (`token`), your Discord **user id** (`user_id`, snowflake), and enable the **MESSAGE CONTENT INTENT** on the bot. Invite the bot to a server (or share one for DMs). Then `ainb fleet bridge run`.

## Gates

- `cargo build -p ainb` — clean
- `cargo test -p ainb --bin ainb fleet::bridge` — 104 passed, 0 failed
- `cargo fmt -p ainb --check` — exit 0
- New code is clippy-clean