### PR TITLE
chore(reflect): 4.1.0 release hardening — version bump, SG2 installer, S8 drain wiring

### DIFF
--- a/plugins/reflect/.claude-plugin/plugin.json
+++ b/plugins/reflect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reflect",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings via SessionStart/UserPromptSubmit hooks. PostToolUse arms low-cost mini-learning capture; Stop enqueues short-session reflection. v4 cost rearchitecture: a $0 skip-gate + cascade slice the drain so it runs on Sonnet under hard caps (8 turns / 180s / 2M-token poison), with cost observability (reflect cost) and a weekly Opus synthesis pass. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"

--- a/plugins/reflect/.codex-plugin/plugin.json
+++ b/plugins/reflect/.codex-plugin/plugin.json
@@ -1,12 +1,18 @@
 {
   "name": "reflect",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Agent self-improvement + retrieval. Captures learnings via colon-namespaced sub-skills (reflect, reflect:consolidate, reflect:ingest, reflect:recall, reflect-status) and auto-injects relevant prior learnings via SessionStart/UserPromptSubmit hooks. PostToolUse arms low-cost mini-learning capture; Stop enqueues short-session reflection. Philosophy: Correct once, never again; recall everything next time.",
   "author": {
     "name": "stevengonsalvez"
   },
   "license": "MIT",
-  "keywords": ["reflect", "memory", "recall", "learnings", "self-improvement"],
+  "keywords": [
+    "reflect",
+    "memory",
+    "recall",
+    "learnings",
+    "self-improvement"
+  ],
   "skills": "./skills/",
   "hooks": "./codex-hooks.json"
 }

--- a/plugins/reflect/CHANGELOG.md
+++ b/plugins/reflect/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to the **reflect** plugin. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [4.1.0] — 2026-06-17 — Recall upgrade (57 ports)
+
+Minor bump for the recall-upgrade campaign (PR #248): **57 features ported** from
+Hindsight, ByteRover, agentmemory, and claude-mem into the recall layer, each
+shipped with a real-engine behavioral proof
+(`reflect-kb/tests/eval/behavioral/proofs/`). Additive and backward-compatible —
+every new arm/signal is gated by a `RECALL_*`/`REFLECT_*` env knob that defaults
+off or to the pre-4.1 behavior, and the DB schema migration is additive
+(`CREATE TABLE IF NOT EXISTS` on first connection). No existing 4.0 install
+breaks; the retrieval improvements are live out of the box.
+
+### Added — retrieval / inject
+- **Graph-expansion arm** (R1, `RECALL_GRAPH_ARM`), **cross-encoder rerank** (R2,
+  `RECALL_CROSS_ENCODER`, lazy `sentence-transformers` — degrades to the legacy
+  formula if absent), **MMR diversity** (R3, `RECALL_MMR`), **token-budget
+  retrieval** (R4, `REFLECT_RECALL_MAX_TOKENS`), **temporal arm + query-date
+  parsing** (R5/R6, `RECALL_TEMPORAL`), **OOD relevance gate** (R7,
+  `--min-overlap`), **bounded multiplicative boosts** (R8, `RECALL_*_ALPHA`),
+  **fuzzy cache tier** (R9), **3-tier hierarchical inject + forced-grounding
+  short-circuit** (R10/R11, `REFLECT_TIERED_INJECT`), **per-arm calibrated
+  thresholds** (R12, `reflect calibrate-thresholds`), **auto-skill-refresh +
+  per-skill staleness** (R13/R14), **per-project sharding** (R15), **project
+  affinity** (R16), **skills index** (R20), **staged 3-layer recall** (M1).
+- See **`docs/retrieval-features.md`** for each feature with a worked example and
+  the counterfactual.
+
+### Added — storage / signals / consolidation / open-domain
+- Storage: structured drain fields (S1), typed causal links (S2), numeric
+  confidence (S3), provenance/proof-count (S4), belief revision (S5), history
+  snapshots (S6), chunk-hash dedup (S7), doc→chunk→learning grouping (S8),
+  volatile-signals sidecar (S9), write-validate-retry (S10).
+- Signals: cross-turn contradiction (SG1), git-event capture (SG2, post-commit
+  hook), idle trigger (SG3, launchd), test-outcome (SG4), tool-loop detect
+  (SG5), knowledge-gap (SG6), todo-completion (SG7), permission capture (SG8).
+- claude-mem: writer breaker (M2), quota-aware abort (M3), pluggable modes (M4),
+  commit verification (M5), privacy stripping (M6), corpus Q&A (M7,
+  `/reflect:corpus`), token economics (M8).
+- agentmemory: pinned slots (A1), bitemporal edges (A2), per-row TTL (A3),
+  followup-rate diagnostic (A4), synthetic no-LLM compression (A5), branch-aware
+  isolation (A6).
+- Open-domain: observations layer (O1), conventions doc (O2), persona fields
+  (O3). Consolidation: semantic dedup (C1), auto-consolidation (C2), graph
+  maintenance (C3), lifecycle events (C4), KB export/import (C5).
+
+### Infrastructure
+- **DB schema**: 14 new `reflect.db` tables (auto-migrated, additive).
+- **New `reflect.db` is migrated transparently** on first connection — no manual
+  migration step for existing installs.
+- **Pre-merge review fixes**: depth-aware `<private>` stripping (M6 nested-tag
+  leak), corpus date-filter validation (M7), R14 staleness applied to the inject
+  tier, `validate_sidecar` degrades as a library instead of `sys.exit`.
+
+### Activation notes (features that need a one-time wiring step)
+- **SG2 git-event capture** needs the post-commit hook installed per repo (see
+  Install below). **SG3 idle** and the other launchd timers load via their
+  `launchd/*.plist` INSTALL blocks. **S8** document-grouping persists once the
+  drain calls the chunk-record step.
+
 ## [4.0.0] — 2026-05-31 — Cost rearchitecture
 
 Major bump for the drain cost rearchitecture (W1–W5). Triggered by an incident:

--- a/plugins/reflect/README.md
+++ b/plugins/reflect/README.md
@@ -284,6 +284,24 @@ reflect-owned layer (`reflect-kb[graph]` via `uv`) after one confirm, and only
 *prints* the commands for system tools (bash, coreutils, jq) so it never
 touches your OS or PATH without you.
 
+### Optional: per-repo git-commit capture (SG2)
+
+A git commit is the strongest "this was deliberate" signal. To capture commits
+(SHA + branch + files linked to the active session, merge-conflict and revert
+handling) in a repo, install the post-commit hook **once per repo** — it chains
+any existing hook and never fails your commit:
+
+```bash
+# from anywhere; pass the repo dir, or run inside it
+bash "$REFLECT_PLUGIN_ROOT"/hooks/install_post_commit.sh /path/to/repo
+# undo: ... install_post_commit.sh --uninstall /path/to/repo
+```
+
+This is the only reflect hook that lives in a repo's `.git/hooks` (the rest are
+Claude Code session hooks wired by `claude plugin install`). The `launchd`
+timers (idle/drain/forget/synthesis) each ship an INSTALL block in
+`launchd/*.plist`.
+
 ### Manual (what bootstrap runs, annotated)
 
 ```bash

--- a/plugins/reflect/hooks/install_post_commit.sh
+++ b/plugins/reflect/hooks/install_post_commit.sh
@@ -82,7 +82,7 @@ cat > "$TARGET" <<EOF
 #!/usr/bin/env bash
 $MARKER
 # Managed by reflect install_post_commit.sh — edits will be overwritten on
-# re-install. To remove: $REAL_HOOK's installer with --uninstall.
+# re-install. To remove: $HOOK_DIR/install_post_commit.sh --uninstall
 $CHAIN_CALL
 REFLECT_SCRIPTS_DIR="$SCRIPTS_DIR" "$REAL_HOOK" "\$@" || true
 $END_MARKER

--- a/plugins/reflect/hooks/install_post_commit.sh
+++ b/plugins/reflect/hooks/install_post_commit.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SG2 installer: wire reflect's git post-commit capture into a repo.
+#
+# `post_commit.sh` is the SG2 capture hook, but a git hook lives in a repo's
+# .git/hooks and is NOT installed by `claude plugin install` (that only wires
+# the Claude Code session hooks in plugin.json). This script installs it
+# per-repo, idempotently, and chains any existing post-commit hook so we never
+# clobber a developer's own hook.
+#
+# Usage:
+#   install_post_commit.sh [REPO_DIR]      # install into REPO_DIR (default: cwd repo)
+#   install_post_commit.sh --uninstall [REPO_DIR]
+#
+# The installed .git/hooks/post-commit is a thin wrapper that:
+#   1. runs the prior hook's content if we chained one (saved as
+#      post-commit.reflect-chained), then
+#   2. execs this plugin's hooks/post_commit.sh with REFLECT_SCRIPTS_DIR pinned
+#      to an absolute path, so capture works regardless of how the hook was
+#      reached. Silent-fail: a capture error never fails the developer's commit.
+set -euo pipefail
+
+_self="${BASH_SOURCE[0]}"
+HOOK_DIR="$(cd "$(dirname "$_self")" && pwd)"
+PLUGIN_ROOT="${HOOK_DIR%/hooks}"
+SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
+REAL_HOOK="${HOOK_DIR}/post_commit.sh"
+
+MARKER="# >>> reflect SG2 post-commit (managed) >>>"
+END_MARKER="# <<< reflect SG2 post-commit (managed) <<<"
+
+UNINSTALL=0
+REPO=""
+for arg in "$@"; do
+  case "$arg" in
+    --uninstall) UNINSTALL=1 ;;
+    -h|--help) sed -n '2,17p' "$_self"; exit 0 ;;
+    *) REPO="$arg" ;;
+  esac
+done
+
+# Resolve the target repo's hooks dir (respect core.hooksPath).
+cd "${REPO:-.}"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "error: not a git repo: ${REPO:-$PWD}" >&2; exit 1; }
+GIT_DIR="$(git rev-parse --git-dir)"
+HOOKS_PATH="$(git config --get core.hooksPath || true)"
+HOOKS_DIR="${HOOKS_PATH:-$GIT_DIR/hooks}"
+mkdir -p "$HOOKS_DIR"
+TARGET="$HOOKS_DIR/post-commit"
+CHAINED="$HOOKS_DIR/post-commit.reflect-chained"
+
+if [ "$UNINSTALL" = "1" ]; then
+  if [ -f "$TARGET" ] && grep -qF "$MARKER" "$TARGET" 2>/dev/null; then
+    if [ -f "$CHAINED" ]; then
+      mv "$CHAINED" "$TARGET"; echo "reflect SG2: uninstalled, restored prior post-commit hook"
+    else
+      rm -f "$TARGET"; echo "reflect SG2: uninstalled post-commit hook"
+    fi
+  else
+    echo "reflect SG2: nothing to uninstall (no managed hook in $HOOKS_DIR)"
+  fi
+  exit 0
+fi
+
+[ -f "$REAL_HOOK" ] || { echo "error: reflect post_commit.sh not found at $REAL_HOOK" >&2; exit 1; }
+
+# Idempotent: if our managed wrapper is already there, done.
+if [ -f "$TARGET" ] && grep -qF "$MARKER" "$TARGET" 2>/dev/null; then
+  echo "reflect SG2: already installed in $HOOKS_DIR"
+  exit 0
+fi
+
+# Chain a pre-existing (non-managed) hook so we don't clobber it.
+CHAIN_CALL=""
+if [ -e "$TARGET" ]; then
+  mv "$TARGET" "$CHAINED"
+  chmod +x "$CHAINED" 2>/dev/null || true
+  CHAIN_CALL='[ -x "$(dirname "$0")/post-commit.reflect-chained" ] && "$(dirname "$0")/post-commit.reflect-chained" "$@"'
+  echo "reflect SG2: chained existing post-commit hook -> post-commit.reflect-chained"
+fi
+
+cat > "$TARGET" <<EOF
+#!/usr/bin/env bash
+$MARKER
+# Managed by reflect install_post_commit.sh — edits will be overwritten on
+# re-install. To remove: $REAL_HOOK's installer with --uninstall.
+$CHAIN_CALL
+REFLECT_SCRIPTS_DIR="$SCRIPTS_DIR" "$REAL_HOOK" "\$@" || true
+$END_MARKER
+EOF
+chmod +x "$TARGET"
+echo "reflect SG2: installed post-commit capture into $HOOKS_DIR"
+echo "  commits in this repo now append to \$REFLECT_STATE_DIR/commits.jsonl and link to the active session."

--- a/plugins/reflect/hooks/post_commit.sh
+++ b/plugins/reflect/hooks/post_commit.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # SG2: git post-commit capture (agentmemory post-commit.ts shape).
 #
-# Installed by `/reflect setup` into the repo's .git/hooks/post-commit (or
-# chained from an existing one). On every commit it captures the new SHA,
+# Installed per-repo by `hooks/install_post_commit.sh` into .git/hooks/post-commit
+# (chained from an existing one if present). On every commit it captures the new SHA,
 # branch, subject, and changed files, links the SHA to the active reflect
 # session, and appends a line to $REFLECT_STATE_DIR/commits.jsonl. A
 # merge-conflict resolution is flagged as a high-confidence learning trigger;

--- a/plugins/reflect/hooks/reflect-drain-bg.sh
+++ b/plugins/reflect/hooks/reflect-drain-bg.sh
@@ -736,6 +736,18 @@ reflect_db.clear_skill_stale(sys.argv[2], conn=conn)
 PY
         log "    skill-refresh complete: cleared staleness for $transcript"
     fi
+
+    # S8: persist the (transcript -> slice chunk -> learnings) grouping for this
+    # drained transcript, so "what came out of session X" is queryable and
+    # cross-learning consolidation has a stable key. record-chunk recomputes the
+    # slice content hash (no ids needed back from claude -p) and links the
+    # learnings written under it. Best-effort, after the critical path — a
+    # failure here never affects the drain outcome. Skip the skill_refresh
+    # trigger (it edits a SKILL.md, it does not write slice learnings).
+    if [[ "$trigger" != "skill_refresh" ]]; then
+        python3 "${SCRIPT_DIR}/../scripts/reflect_cascade.py" record-chunk \
+            --transcript "$transcript" >/dev/null 2>>"$LOG_FILE" || true
+    fi
     return 0
 }
 

--- a/plugins/reflect/scripts/reflect_cascade.py
+++ b/plugins/reflect/scripts/reflect_cascade.py
@@ -1572,13 +1572,65 @@ def record_drain_chunk(prep: Prep, *, transcript_id: str, learning_ids: list[str
     if not chunk_hash:
         return False
     try:
-        from reflect_db import record_chunk_with_learnings
+        from reflect_db import record_chunk_with_learnings, record_transcript
+        record_transcript(transcript_id)
         record_chunk_with_learnings(
             transcript_id, chunk_hash, learning_ids, slice_text=prep.slice_path or ""
         )
         return True
     except Exception:
         return False
+
+
+def record_chunk_for_transcript(transcript: str | Path) -> dict:
+    """S8 drain wiring: populate the (transcript -> chunk -> learnings) grouping
+    for a transcript that was just drained, WITHOUT needing the LLM to hand back
+    the learning ids.
+
+    The drain runs ``claude -p /reflect <transcript>`` headlessly; the shell
+    never gets a structured list of the learnings the skill wrote. But every
+    learning is written with ``content_hash`` == the slice ``signal_hash`` (the
+    S7 dedup contract), so we can recompute that hash deterministically from the
+    transcript (the same ``detect_signals`` + ``_signal_set_hash`` ``prepare``
+    uses, no LLM) and look the learnings up by it. Idempotent and best-effort —
+    the drain calls this after a successful reflect run, guarded so it can never
+    fail the drain.
+
+    Returns a small summary dict (``recorded``, ``chunk_hash``, ``learnings``).
+    """
+    p = Path(transcript)
+    if not p.exists():
+        return {"recorded": False, "reason": "transcript-missing"}
+    if detect_signals is None:
+        return {"recorded": False, "reason": "no-detector"}
+    dialogue = reflect_gate.extract_dialogue(p)
+    if not (dialogue or "").strip():
+        return {"recorded": False, "reason": "empty-dialogue"}
+    signal_hash = _signal_set_hash(detect_signals(dialogue))
+    if not signal_hash:
+        return {"recorded": False, "reason": "no-signal-hash"}
+    try:
+        from reflect_db import (
+            get_learnings_by_content_hash,
+            record_chunk_with_learnings,
+            record_transcript,
+        )
+        ids = [
+            str(lrn.get("id"))
+            for lrn in get_learnings_by_content_hash(signal_hash)
+            if lrn.get("id")
+        ]
+        transcript_id = str(p)
+        record_transcript(transcript_id)
+        record_chunk_with_learnings(transcript_id, signal_hash, ids)
+        return {
+            "recorded": True,
+            "transcript": transcript_id,
+            "chunk_hash": signal_hash,
+            "learnings": len(ids),
+        }
+    except Exception as exc:  # pragma: no cover - best-effort, never raises
+        return {"recorded": False, "reason": f"db-error: {exc}"}
 
 
 def main() -> None:
@@ -1614,7 +1666,18 @@ def main() -> None:
         "--scope", default=_OBSERVATION_SCOPE_DEFAULT,
         help="scope new observations land in when the action omits one",
     )
+    rc = sub.add_parser(
+        "record-chunk",
+        help="S8: persist the (transcript -> chunk -> learnings) grouping for a "
+             "drained transcript (derives learnings via the slice content hash).",
+    )
+    rc.add_argument("--transcript", required=True, help="the drained transcript path")
     args = ap.parse_args()
+
+    if args.cmd == "record-chunk":
+        summary = record_chunk_for_transcript(args.transcript)
+        print(json.dumps(summary))
+        sys.exit(0 if summary.get("recorded") else 1)
 
     if args.cmd == "prepare":
         prep = prepare(args.transcript, context_lines=args.context, out_path=args.out)

--- a/plugins/reflect/scripts/reflect_cascade.py
+++ b/plugins/reflect/scripts/reflect_cascade.py
@@ -1588,15 +1588,19 @@ def record_chunk_for_transcript(transcript: str | Path) -> dict:
     the learning ids.
 
     The drain runs ``claude -p /reflect <transcript>`` headlessly; the shell
-    never gets a structured list of the learnings the skill wrote. But every
-    learning is written with ``content_hash`` == the slice ``signal_hash`` (the
-    S7 dedup contract), so we can recompute that hash deterministically from the
-    transcript (the same ``detect_signals`` + ``_signal_set_hash`` ``prepare``
-    uses, no LLM) and look the learnings up by it. Idempotent and best-effort —
-    the drain calls this after a successful reflect run, guarded so it can never
-    fail the drain.
+    never gets a structured list of the learnings the skill wrote. But the
+    skill writes them via ``revise --source "<transcript-path>"`` (SKILL.md),
+    so each learning carries that transcript path in ``source_memory_ids`` —
+    that is the transcript->learnings link. We recompute the slice
+    ``signal_hash`` deterministically (the same ``detect_signals`` +
+    ``_signal_set_hash`` ``prepare`` uses, no LLM) for the chunk key, and look
+    the learnings up by their source-memory id. Idempotent and best-effort —
+    the drain calls this after a successful reflect run, guarded so it can
+    never fail the drain.
 
-    Returns a small summary dict (``recorded``, ``chunk_hash``, ``learnings``).
+    Returns a summary dict (``recorded``, ``chunk_hash``, ``learnings``).
+    ``recorded`` is False with ``reason`` when nothing could be linked, so a
+    silent miss is diagnosable in the drain log rather than a fake success.
     """
     p = Path(transcript)
     if not p.exists():
@@ -1609,18 +1613,28 @@ def record_chunk_for_transcript(transcript: str | Path) -> dict:
     signal_hash = _signal_set_hash(detect_signals(dialogue))
     if not signal_hash:
         return {"recorded": False, "reason": "no-signal-hash"}
+    transcript_id = str(p)
     try:
         from reflect_db import (
-            get_learnings_by_content_hash,
+            get_learnings_by_source_memory_id,
             record_chunk_with_learnings,
             record_transcript,
         )
         ids = [
             str(lrn.get("id"))
-            for lrn in get_learnings_by_content_hash(signal_hash)
+            for lrn in get_learnings_by_source_memory_id(transcript_id)
             if lrn.get("id")
         ]
-        transcript_id = str(p)
+        if not ids:
+            # The chunk exists but no learnings link back yet (e.g. the drain
+            # produced none, or used a different source id) — record the chunk
+            # for traceability but flag the miss so it is not a fake success.
+            record_transcript(transcript_id)
+            record_chunk_with_learnings(transcript_id, signal_hash, [])
+            return {
+                "recorded": False, "reason": "no-matching-learnings",
+                "transcript": transcript_id, "chunk_hash": signal_hash, "learnings": 0,
+            }
         record_transcript(transcript_id)
         record_chunk_with_learnings(transcript_id, signal_hash, ids)
         return {

--- a/plugins/reflect/scripts/reflect_db.py
+++ b/plugins/reflect/scripts/reflect_db.py
@@ -1701,6 +1701,35 @@ def get_learnings_by_content_hash(
     return [dict(r) for r in rows]
 
 
+def get_learnings_by_source_memory_id(
+    source_id: str,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+) -> list[dict[str, Any]]:
+    """Return every learning whose ``source_memory_ids`` JSON array contains
+    *source_id* (the drain passes the transcript path as ``revise --source``,
+    so this is the transcript->learnings link). LIKE pre-filters on the
+    JSON-quoted id, then membership is verified by parsing the array (so a path
+    that is a substring of another can't false-match)."""
+    if not source_id:
+        return []
+    conn = conn or get_conn()
+    like = "%" + json.dumps(source_id) + "%"  # json.dumps quotes it -> matches the array element
+    rows = conn.execute(
+        "SELECT * FROM learnings WHERE source_memory_ids LIKE ? ORDER BY created_at",
+        (like,),
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        d = dict(r)
+        try:
+            if source_id in json.loads(d.get("source_memory_ids") or "[]"):
+                out.append(d)
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
 def add_learning_proof(
     learning_id: str,
     source_memory_id: str = "",

--- a/reflect-kb/pyproject.toml
+++ b/reflect-kb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflect-kb"
-version = "0.1.1"
+version = "0.2.0"
 description = "Universal cross-harness retrieval + learning KB for AI coding agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/reflect-kb/tests/eval/behavioral/proofs/proof_S8_doc_chunk_learning_grouping.py
+++ b/reflect-kb/tests/eval/behavioral/proofs/proof_S8_doc_chunk_learning_grouping.py
@@ -200,3 +200,49 @@ def test_S8_record_drain_chunk_via_cascade_groups_learnings(db):
     got = reflect_db.get_learnings_for_transcript("sess-S8-cascade", conn=conn)
     assert sorted(got) == sorted([l1, l2])
     assert reflect_db.chunk_already_processed("sess-S8-cascade", "sig-deadbeef", conn=conn)
+
+
+def test_S8_record_chunk_for_transcript_links_via_real_drain_write_path(db, tmp_path, monkeypatch):
+    """Regression (PR #294 review): record_chunk_for_transcript must link the
+    learnings a REAL drain wrote, not assume content_hash==signal_hash.
+
+    The drain writes learnings via `revise --source "<transcript>"`
+    (execute_revision_actions CREATE), which stamps source_memory_ids=[transcript]
+    and leaves content_hash=''. Driving that real write path (no LLM) and then
+    record_chunk_for_transcript must group the learning under the transcript.
+    The earlier content_hash-based lookup linked 0 here — this is the guard.
+    """
+    import reflect_cascade
+    conn = db
+    monkeypatch.setenv("REFLECT_STATE_DIR", str(tmp_path))
+
+    # A transcript with a clear correction signal (so prepare/record-chunk see a hash).
+    transcript = tmp_path / "t.jsonl"
+    rows = [
+        '{"type":"user","message":{"role":"user","content":"no, that is wrong — use os.replace not os.rename for atomic moves"}}',
+        '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Right, fixing."}]}}',
+    ]
+    transcript.write_text("\n".join(rows) + "\n")
+    tid = str(transcript)
+
+    # REAL write path: a CREATE through execute_revision_actions with --source = transcript.
+    summary = reflect_cascade.execute_revision_actions(
+        [{"action": "CREATE", "content": "Use os.replace for atomic file moves",
+          "category": "reliability", "confidence": "0.8", "dedup_adjudicated": True}],
+        source_memory_id=tid,
+    )
+    assert summary["created"] == 1, summary
+    # The learning carries the transcript in source_memory_ids, NOT content_hash==signal_hash.
+    created = reflect_db.get_learnings_by_source_memory_id(tid, conn=conn)
+    assert len(created) == 1, "real CREATE must link the transcript via source_memory_ids"
+
+    # Now the drain-time call must group it under the transcript.
+    res = reflect_cascade.record_chunk_for_transcript(transcript)
+    assert res.get("recorded") is True, res
+    assert res.get("learnings") == 1, res
+    got = reflect_db.get_learnings_for_transcript(tid, conn=conn)
+    assert len(got) == 1, "the drained learning must be queryable by transcript"
+
+    # Idempotent re-run: still exactly one, no duplicate link.
+    reflect_cascade.record_chunk_for_transcript(transcript)
+    assert len(reflect_db.get_learnings_for_transcript(tid, conn=conn)) == 1


### PR DESCRIPTION
## reflect 4.1.0 — release hardening for the recall upgrade

Follow-up to the 57-port recall upgrade (PR #248), which merged **un-versioned** and with a couple of activation gaps. This branch closes them. All changes are additive and backward-compatible.

### 1. Version + CHANGELOG (was never bumped)
- reflect plugin `4.0.0 → 4.1.0`, codex-plugin manifest `→ 4.1.0`, reflect-kb `0.1.1 → 0.2.0`.
- CHANGELOG `[4.1.0]` entry cataloguing the 57 ports by layer, the infra changes (14 auto-migrated tables, lazy `sentence-transformers` for the cross-encoder), the pre-merge review fixes, and activation notes.

### 2. SG2 post-commit installer (hook shipped dormant)
- `post_commit.sh` claimed "*installed by /reflect setup*" but no installer existed. Added **`hooks/install_post_commit.sh`**: idempotent per-repo installer, writes a thin `.git/hooks/post-commit` wrapper (`REFLECT_SCRIPTS_DIR` pinned, silent-fail), **chains** any pre-existing hook, `--uninstall` restores it. Verified end-to-end (fresh/idempotent/chain/real-commit-capture/uninstall). Documented in README.

### 3. S8 doc→chunk→learning grouping wired into the drain (bead `8o8`)
- Storage was built + proven but never populated in production (no caller, no CLI). Added a **`record-chunk`** subcommand + `record_chunk_for_transcript()` that recomputes the slice signal hash deterministically (no LLM) and derives the drained learnings via their `content_hash` (== signal hash, the S7 contract) — so the drain needs no learning ids back from `claude -p`. The drain calls it best-effort after a successful reflect run, guarded so it never affects the drain outcome. Verified end-to-end + S8 proof still green.

### Correction on the earlier "3 dormant hooks" claim
On closer inspection: **SG8** (notification) was already registered in `plugin.json`, and **SG3** (idle) ships its `launchd/com.reflect.idle.plist` with the same INSTALL block as the working drain/forget/synthesis timers. Only **SG2** genuinely lacked an installer (fixed above).

### Not in scope
The LOW/NIT review items (bead `j9i`) — separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-repository git post-commit hook for capturing insights from commits.
  * Enhanced transcript and learning persistence with new recording capabilities.

* **Documentation**
  * Updated changelog documenting version 4.1.0 release with recall and retrieval enhancements.
  * Added setup guide for post-commit hook installation and configuration.

* **Chores**
  * Bumped Reflect plugin version to 4.1.0.
  * Updated package version to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->