### PR TITLE
fix(reflect): clear PR #248 LOW/NIT review items (j9i)

### DIFF
--- a/plugins/reflect/scripts/graphml_repair.py
+++ b/plugins/reflect/scripts/graphml_repair.py
@@ -317,7 +317,15 @@ def maintain(path: Path, *, quiet: bool = False) -> bool:
         say("  maintenance rewrite did not validate; restored original.")
         return False
 
-    say(f"  MAINTAINED (backed up to {backup.name}): "
+    # Rewrite validated — the rollback path above uses the in-memory `original`,
+    # not this file, so the on-disk backup has served its purpose. Remove it so a
+    # stale .premaint.bak never lingers next to the live graph. Best-effort.
+    try:
+        backup.unlink()
+    except OSError:
+        pass
+
+    say("  MAINTAINED: "
         f"orphans_pruned={stats['orphans_pruned']} "
         f"edges_pruned={stats['edges_pruned']} "
         f"nodes_relinked={stats['nodes_relinked']}")

--- a/plugins/reflect/scripts/output_generator.py
+++ b/plugins/reflect/scripts/output_generator.py
@@ -298,30 +298,39 @@ def create_knowledge_note(
         content_hash=content_hash,
     )
 
-    if yaml:
-        fm_str = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
-    else:
-        # Fallback: manual YAML
-        fm_lines = []
-        for k, v in frontmatter.items():
-            if isinstance(v, list):
-                if any(isinstance(i, (dict, list)) for i in v):
-                    # S1: causal_relations is a list of dicts — JSON is valid
-                    # YAML, unlike str() of a python dict.
-                    fm_lines.append(f"{k}: {json.dumps(v)}")
-                else:
-                    fm_lines.append(f"{k}: [{', '.join(str(i) for i in v)}]")
-            elif isinstance(v, dict):
-                fm_lines.append(f"{k}:")
-                for dk, dv in v.items():
-                    fm_lines.append(f'  {dk}: "{dv}"' if isinstance(dv, str) else f"  {dk}: {dv}")
-            else:
-                fm_lines.append(f'{k}: "{v}"' if isinstance(v, str) else f"{k}: {v}")
-        fm_str = '\n'.join(fm_lines)
+    def _render_note() -> str:
+        """Serialize the current ``frontmatter`` + body to the note text.
 
-    content = f"---\n{fm_str}---\n\n## Problem\n\n{problem}\n\n## Solution\n\n{solution}\n"
-    if context:
-        content += f"\n## Context\n\n{context}\n"
+        Defined as a closure so it can be re-called after a later mutation
+        (e.g. adding ``unverified_refs``) and the change lands in BOTH the
+        pyyaml and the manual-fallback path — not only when pyyaml is present.
+        """
+        if yaml:
+            fm = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
+        else:
+            # Fallback: manual YAML
+            fm_lines = []
+            for k, v in frontmatter.items():
+                if isinstance(v, list):
+                    if any(isinstance(i, (dict, list)) for i in v):
+                        # S1: causal_relations is a list of dicts — JSON is valid
+                        # YAML, unlike str() of a python dict.
+                        fm_lines.append(f"{k}: {json.dumps(v)}")
+                    else:
+                        fm_lines.append(f"{k}: [{', '.join(str(i) for i in v)}]")
+                elif isinstance(v, dict):
+                    fm_lines.append(f"{k}:")
+                    for dk, dv in v.items():
+                        fm_lines.append(f'  {dk}: "{dv}"' if isinstance(dv, str) else f"  {dk}: {dv}")
+                else:
+                    fm_lines.append(f'{k}: "{v}"' if isinstance(v, str) else f"{k}: {v}")
+            fm = '\n'.join(fm_lines)
+        out = f"---\n{fm}---\n\n## Problem\n\n{problem}\n\n## Solution\n\n{solution}\n"
+        if context:
+            out += f"\n## Context\n\n{context}\n"
+        return out
+
+    content = _render_note()
 
     # M5: verify commit-like refs in the LLM-authored body against the local
     # repo before persistence. Hallucinated refs get recorded in frontmatter
@@ -344,11 +353,10 @@ def create_knowledge_note(
             )
         if report.checked and report.unverified:
             frontmatter["unverified_refs"] = report.unverified
-            if yaml:
-                fm_str = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
-                content = f"---\n{fm_str}---\n\n## Problem\n\n{problem}\n\n## Solution\n\n{solution}\n"
-                if context:
-                    content += f"\n## Context\n\n{context}\n"
+            # Rebuild via the shared renderer so the hallucination flag is
+            # serialized in the no-pyyaml fallback path too (previously it was
+            # only re-rendered under `if yaml:`, silently dropping the flag).
+            content = _render_note()
     except ImportError:  # pragma: no cover — verifier is best-effort
         pass
 

--- a/plugins/reflect/skills/recall/hooks/session_start_recall.py
+++ b/plugins/reflect/skills/recall/hooks/session_start_recall.py
@@ -542,17 +542,25 @@ def _rerank_score(rec: dict) -> float:
 
 
 def _age_days(archived_at: str | None) -> float | None:
-    """Days since the skill's archive timestamp; None if unknown/unparseable."""
+    """Days since the skill's archive timestamp; None if unknown/unparseable.
+
+    Handles BOTH tz-aware (``...Z`` / ``+00:00``) and naive timestamps — a
+    tz-aware ``archived_at`` previously raised on the naive-vs-aware subtraction
+    and was swallowed to None (so a tz-aware skill could never short-circuit).
+    """
     if not archived_at:
         return None
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     try:
-        ts = datetime.fromisoformat(str(archived_at).rstrip("Z"))
+        # `Z` -> `+00:00` so fromisoformat keeps the offset (don't rstrip it,
+        # which would silently turn an aware ts into a naive one).
+        ts = datetime.fromisoformat(str(archived_at).strip().replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
+    now = datetime.now(timezone.utc) if ts.tzinfo is not None else datetime.now()
     try:
-        return max(0.0, (datetime.now() - ts).days)
+        return max(0.0, (now - ts).days)
     except (TypeError, ValueError):
         return None
 

--- a/plugins/reflect/skills/recall/scripts/recall_stages.py
+++ b/plugins/reflect/skills/recall/scripts/recall_stages.py
@@ -277,7 +277,10 @@ def reflect_index(query: str, limit: int = DEFAULT_INDEX_LIMIT) -> dict[str, Any
     scan when the reflect CLI is missing so the staged workflow degrades
     instead of breaking.
     """
-    result = recall_mod.recall(query, limit=limit)
+    # gap_log/followup_track OFF: this is an internal staged-recall index probe,
+    # not a genuine user ask — counting it would double-log knowledge gaps (SG6)
+    # and inflate the followup-rate diagnostic (A4).
+    result = recall_mod.recall(query, limit=limit, gap_log=False, followup_track=False)
     if result.error or not result.learnings:
         rows = _lexical_index(query, limit)
         return {"step": 1, "query": query, "count": len(rows), "results": rows}

--- a/reflect-kb/src/reflect_kb/recall/corpus.py
+++ b/reflect-kb/src/reflect_kb/recall/corpus.py
@@ -85,9 +85,21 @@ def documents_root() -> Path:
 
 
 def _safe_name(name: str) -> str:
-    """Restrict a corpus name to a single filesystem-safe path component."""
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", name.strip()).strip("-._")
-    return cleaned or "corpus"
+    """Restrict a corpus name to a single filesystem-safe path component.
+
+    When sanitizing actually changed the name, append a short hash of the RAW
+    name so distinct inputs that collapse to the same cleaned form (e.g.
+    ``auth/sub`` vs ``auth sub`` vs ``auth-sub``) get distinct files instead of
+    silently overwriting one another. Already-safe names are returned unchanged.
+    """
+    raw = name.strip()
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-._")
+    if not cleaned:
+        return "corpus"
+    if cleaned != raw:
+        import hashlib
+        return f"{cleaned}-{hashlib.sha1(raw.encode('utf-8')).hexdigest()[:6]}"
+    return cleaned
 
 
 # --- Filter ---------------------------------------------------------------


### PR DESCRIPTION
## Clear the PR #248 LOW/NIT review items (bead `j9i`)

Five non-blocking findings from the recall-upgrade pre-merge review, all small + verified.

| # | item | fix |
|---|---|---|
| 1 | M5 `unverified_refs` dropped on the no-pyyaml fallback | shared `_render_note()` closure → flag serializes in both paths |
| 2 | `recall_stages` index probe double-counts SG6 gaps + A4 followup | pass `gap_log=False, followup_track=False` (it's an internal, non-user query) |
| 3 | corpus `_safe_name` collision (`auth/sub` ≡ `auth sub` ≡ `auth-sub`) | suffix a short raw-name hash when sanitizing changed the name; clean names unchanged |
| 4 | `_age_days` tz-aware timestamp swallowed to None (skill could never short-circuit) | parse `Z`/offset, match `now`'s awareness |
| 5 | graphml `.premaint.bak` lingered after success | remove it after a validated maintain (rollback uses in-memory `original`) |

Affected behavioral proofs re-run green: **M5, S1, M1, M7, R11, C3 (26 tests)**. Closes `j9i`.
