### PR TITLE
fix(hooks): isolate uv-run hooks from the cwd project with --no-project

### DIFF
--- a/toolkit/claude-code-4.5/settings.json
+++ b/toolkit/claude-code-4.5/settings.json
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/notification.py --notify"
+            "command": "uv run --no-project ~/.claude/hooks/notification.py --notify"
           }
         ]
       }
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/dev_server_tmux.py"
+            "command": "uv run --no-project ~/.claude/hooks/dev_server_tmux.py"
           }
         ]
       },
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/pre_tool_use.py"
+            "command": "uv run --no-project ~/.claude/hooks/pre_tool_use.py"
           }
         ]
       }
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/post_tool_use.py"
+            "command": "uv run --no-project ~/.claude/hooks/post_tool_use.py"
           }
         ]
       },
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/stop.py --chat"
+            "command": "uv run --no-project ~/.claude/hooks/stop.py --chat"
           }
         ]
       },
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/cost_tracker.py",
+            "command": "uv run --no-project ~/.claude/hooks/cost_tracker.py",
             "timeout": 10,
             "async": true
           }
@@ -129,7 +129,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/subagent_stop.py"
+            "command": "uv run --no-project ~/.claude/hooks/subagent_stop.py"
           }
         ]
       }
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/user_prompt_submit.py --log-only"
+            "command": "uv run --no-project ~/.claude/hooks/user_prompt_submit.py --log-only"
           }
         ]
       },
@@ -158,7 +158,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/pre_compact.py --handover --backup --verbose"
+            "command": "uv run --no-project ~/.claude/hooks/pre_compact.py --handover --backup --verbose"
           }
         ]
       }
@@ -169,7 +169,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ~/.claude/hooks/session_start.py --git-status --load-context"
+            "command": "uv run --no-project ~/.claude/hooks/session_start.py --git-status --load-context"
           }
         ]
       },


### PR DESCRIPTION
## Problem

Every Claude Code hook in `toolkit/claude-code-4.5/settings.json` shells out via bare `uv run ~/.claude/hooks/<X>.py`. `uv run` resolves and **builds the current working directory's uv project** before executing the target script.

So when a session is editing a uv package that is mid-migration / otherwise unbuildable (e.g. a freshly-scaffolded `ainb-reflect-memory`), *every* tool call fires the project build first and fails:

```
PreToolUse:Bash hook error
  Failed with non-blocking status code: × Failed to build `ainb-reflect-memory @ ...`
```

The errors are non-blocking but spam every Bash/Stop/SessionStart hook for the whole session. The hook scripts are stdlib-only and never needed the local project at all.

## Fix

Add `--no-project` to all 10 `uv run` hook commands. Hooks now ignore the cwd project entirely while still honouring PEP-723 inline script deps. The `SUPERSET_HOME_DIR` notify shell hooks are untouched (not `uv run`).

```
uv run ~/.claude/hooks/X.py   ->   uv run --no-project ~/.claude/hooks/X.py
```

This file is the master copied into local `~/.claude/settings.json`; the live copy has been patched in lockstep.

## Scope

- `toolkit/claude-code-4.5/settings.json` only — 10 line changes, no behaviour change beyond dropping the local-project build coupling.

https://claude.ai/code/session_01R8RtuefaG8d6tQiR5Zpogq