### PR TITLE
feat(otel): OpenTelemetry → Grafana Cloud setup (CLI + TUI onboarding)

### DIFF
--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -122,6 +122,8 @@ bytes = "1.6"
 
 # Fleet — filesystem watch for JSONL transcript tail (assistant-turn detection).
 notify = { workspace = true }
+# No-echo terminal read for the Grafana Cloud API token in `ainb otel setup`.
+rpassword = "7"
 
 [features]
 default = []

--- a/ainb-tui/crates/ainb-core/assets/otel/config.alloy
+++ b/ainb-tui/crates/ainb-core/assets/otel/config.alloy
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// Grafana Alloy: local OTLP fan-in for AI coding CLIs -> Grafana Cloud
+//
+//   Claude Code (env-driven)  ─┐                                  ┌─ logs
+//                              ├─ OTLP :4318/:4317 ─▶ Alloy ──────┼─ traces
+//   Codex CLI (config.toml)   ─┘                                  └─ metrics*
+//
+//   *metrics pass through deltatocumulative: Grafana Cloud/Mimir rejects
+//    Delta-temporality sums ("invalid temporality and type combination"),
+//    so we convert Delta->Cumulative before export. (Claude is also set to
+//    emit cumulative at source; Codex has no such knob, hence this processor.)
+//
+// Secrets from env (set in grafana-cloud.env, sourced by start-alloy.sh):
+//   GRAFANA_INSTANCE_ID, GRAFANA_API_TOKEN, GRAFANA_OTLP_ENDPOINT
+// ---------------------------------------------------------------------------
+
+otelcol.receiver.otlp "default" {
+  grpc { endpoint = "127.0.0.1:4317" }
+  http { endpoint = "127.0.0.1:4318" }
+
+  output {
+    metrics = [otelcol.processor.deltatocumulative.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Delta -> Cumulative for monotonic sums (Mimir requirement).
+otelcol.processor.deltatocumulative "default" {
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.otlphttp.grafanacloud.input]
+    logs    = [otelcol.exporter.otlphttp.grafanacloud.input]
+    traces  = [otelcol.exporter.otlphttp.grafanacloud.input]
+  }
+}
+
+otelcol.auth.basic "grafanacloud" {
+  username = sys.env("GRAFANA_INSTANCE_ID")
+  password = sys.env("GRAFANA_API_TOKEN")
+}
+
+otelcol.exporter.otlphttp "grafanacloud" {
+  client {
+    // otlphttp appends /v1/metrics|logs|traces, so give the base .../otlp URL.
+    endpoint = sys.env("GRAFANA_OTLP_ENDPOINT")
+    auth     = otelcol.auth.basic.grafanacloud.handler
+  }
+}

--- a/ainb-tui/crates/ainb-core/assets/otel/dashboards/claude-code.json
+++ b/ainb-tui/crates/ainb-core/assets/otel/dashboards/claude-code.json
@@ -1,0 +1,405 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus (Grafana Cloud)",
+      "description": "Your Grafana Cloud Prometheus / Mimir data source",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "claude-code",
+    "otel",
+    "ai-coding"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "model",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "query": "label_values(claude_code_cost_usage_USD_total, model)",
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "title": "Claude Code — Usage & Cost",
+  "uid": "claude-code-otel",
+  "panels": [
+    {
+      "title": "Total cost (USD)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(claude_code_cost_usage_USD_total{model=~\"$model\"})"
+        }
+      ]
+    },
+    {
+      "title": "Total tokens",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(claude_code_token_usage_tokens_total{model=~\"$model\"})"
+        }
+      ]
+    },
+    {
+      "title": "Sessions started",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(claude_code_session_count_total)"
+        }
+      ]
+    },
+    {
+      "title": "Active time (hours)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(claude_code_active_time_seconds_total) / 3600"
+        }
+      ]
+    },
+    {
+      "title": "Cost rate by model (USD/interval)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (model) (rate(claude_code_cost_usage_USD_total{model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+    {
+      "title": "Tokens by type (rate)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (type) (rate(claude_code_token_usage_tokens_total{model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{type}}"
+        }
+      ]
+    },
+    {
+      "title": "Cost by skill (USD)",
+      "type": "barchart",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sort_desc(sum by (skill_name) (claude_code_cost_usage_USD_total{skill_name!=\"\"}))",
+          "legendFormat": "{{skill_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "title": "Cost by model (share)",
+      "type": "piechart",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (model) (claude_code_cost_usage_USD_total{model=~\"$model\"})",
+          "legendFormat": "{{model}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "title": "Recent traces (claude-code)",
+      "type": "traces",
+      "datasource": {
+        "type": "tempo",
+        "uid": "grafanacloud-traces"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "tempo",
+            "uid": "grafanacloud-traces"
+          },
+          "queryType": "traceql",
+          "query": "{resource.service.name=\"claude-code\"}",
+          "limit": 20,
+          "tableType": "traces"
+        }
+      ]
+    },
+    {
+      "title": "User prompts (text)",
+      "type": "logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "grafanacloud-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "grafanacloud-logs"
+          },
+          "expr": "{service_name=\"claude-code\"} | prompt != `` | line_format `{{.prompt}}`"
+        }
+      ]
+    },
+    {
+      "title": "Event stream (all claude-code logs)",
+      "type": "logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "grafanacloud-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "grafanacloud-logs"
+          },
+          "expr": "{service_name=\"claude-code\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/ainb-tui/crates/ainb-core/assets/otel/dashboards/codex.json
+++ b/ainb-tui/crates/ainb-core/assets/otel/dashboards/codex.json
@@ -1,0 +1,390 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus (Grafana Cloud)",
+      "description": "Your Grafana Cloud Prometheus / Mimir data source",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "codex",
+    "otel",
+    "ai-coding"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "title": "Codex CLI — Usage & Telemetry",
+  "uid": "codex-cli-otel",
+  "panels": [
+    {
+      "title": "Total tokens (sum of per-turn usage)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(codex_turn_token_usage_sum)"
+        }
+      ]
+    },
+    {
+      "title": "Conversation turns",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(codex_conversation_turn_count_total)"
+        }
+      ]
+    },
+    {
+      "title": "Tool calls (total)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(codex_turn_tool_call_sum)"
+        }
+      ]
+    },
+    {
+      "title": "Hook runs",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(codex_hooks_run_total)"
+        }
+      ]
+    },
+    {
+      "title": "WebSocket requests",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(codex_websocket_request_total)"
+        }
+      ]
+    },
+    {
+      "title": "Tokens per turn (rate)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(codex_turn_token_usage_sum[$__rate_interval]))",
+          "legendFormat": "tokens/s"
+        }
+      ]
+    },
+    {
+      "title": "Turn latency p95 (TTFT vs end-to-end)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(codex_turn_ttft_duration_ms_milliseconds_bucket[$__rate_interval])))",
+          "legendFormat": "TTFT p95"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(codex_turn_e2e_duration_ms_milliseconds_bucket[$__rate_interval])))",
+          "legendFormat": "end-to-end p95"
+        }
+      ]
+    },
+    {
+      "title": "MCP tool list latency p95",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(codex_mcp_tools_list_duration_ms_milliseconds_bucket[$__rate_interval])))",
+          "legendFormat": "mcp tools list p95"
+        }
+      ]
+    },
+    {
+      "title": "All codex_* series (discovery — full catalog)",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "group by (__name__) ({__name__=~\"codex.*\"})",
+          "format": "table",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "title": "Recent traces (codex)",
+      "type": "traces",
+      "datasource": {
+        "type": "tempo",
+        "uid": "grafanacloud-traces"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "tempo",
+            "uid": "grafanacloud-traces"
+          },
+          "queryType": "traceql",
+          "query": "{resource.service.name=~\"codex.*\"}",
+          "limit": 20,
+          "tableType": "traces"
+        }
+      ]
+    },
+    {
+      "title": "Event stream (codex logs, prompts incl.)",
+      "type": "logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "grafanacloud-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "grafanacloud-logs"
+          },
+          "expr": "{service_name=\"codex_exec\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/ainb-tui/crates/ainb-core/assets/otel/grafana-cloud.env.template
+++ b/ainb-tui/crates/ainb-core/assets/otel/grafana-cloud.env.template
@@ -1,0 +1,25 @@
+# Claude Code OTEL — full telemetry config (machine-specific).
+# Generic OTEL config (exporter/protocol/intervals/log flags) lives in the
+# ~/.claude/settings.json env block (committed copy:
+# toolkit/claude-code-4.5/settings.json). Shell env WINS over the settings.json
+# env block, so these values are authoritative per-machine.
+#
+# Source this from your shell rc (e.g. ~/.zshrc):
+#   [ -f "$HOME/.agents-in-a-box/otel/grafana-cloud.env" ] && source "$HOME/.agents-in-a-box/otel/grafana-cloud.env"
+#
+# Telemetry pipeline:
+#   Claude Code --OTLP http://localhost:4318--> Grafana Alloy --> Grafana Cloud
+#   Alloy (start-alloy.sh) reads the GRAFANA_* vars from this same file.
+
+# Machine-specific OTLP exporter (Claude Code -> local Alloy)
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+export OTEL_RESOURCE_ATTRIBUTES="host.name=__HOST_NAME__"
+
+# Grafana Cloud OTLP credentials for Alloy.
+# Where to get these: Grafana Cloud -> Connections -> "OpenTelemetry (OTLP)".
+#   GRAFANA_OTLP_ENDPOINT  = the OTLP endpoint URL shown there (ends in /otlp)
+#   GRAFANA_INSTANCE_ID    = the "Instance ID" / Basic-auth username on that page
+#   GRAFANA_API_TOKEN      = an API/Access token with metrics+logs+traces write
+export GRAFANA_OTLP_ENDPOINT="__GRAFANA_OTLP_ENDPOINT__"
+export GRAFANA_INSTANCE_ID="__GRAFANA_INSTANCE_ID__"
+export GRAFANA_API_TOKEN="__GRAFANA_API_TOKEN__"

--- a/ainb-tui/crates/ainb-core/assets/otel/grafana-cloud.env.template
+++ b/ainb-tui/crates/ainb-core/assets/otel/grafana-cloud.env.template
@@ -10,16 +10,19 @@
 # Telemetry pipeline:
 #   Claude Code --OTLP http://localhost:4318--> Grafana Alloy --> Grafana Cloud
 #   Alloy (start-alloy.sh) reads the GRAFANA_* vars from this same file.
+#
+# Values are single-quoted and shell-escaped by `ainb otel setup`; do not
+# hand-edit the quoting.
 
 # Machine-specific OTLP exporter (Claude Code -> local Alloy)
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
-export OTEL_RESOURCE_ATTRIBUTES="host.name=__HOST_NAME__"
+export OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:4318'
+export OTEL_RESOURCE_ATTRIBUTES='host.name=__HOST_NAME__'
 
 # Grafana Cloud OTLP credentials for Alloy.
 # Where to get these: Grafana Cloud -> Connections -> "OpenTelemetry (OTLP)".
 #   GRAFANA_OTLP_ENDPOINT  = the OTLP endpoint URL shown there (ends in /otlp)
 #   GRAFANA_INSTANCE_ID    = the "Instance ID" / Basic-auth username on that page
 #   GRAFANA_API_TOKEN      = an API/Access token with metrics+logs+traces write
-export GRAFANA_OTLP_ENDPOINT="__GRAFANA_OTLP_ENDPOINT__"
-export GRAFANA_INSTANCE_ID="__GRAFANA_INSTANCE_ID__"
-export GRAFANA_API_TOKEN="__GRAFANA_API_TOKEN__"
+export GRAFANA_OTLP_ENDPOINT='__GRAFANA_OTLP_ENDPOINT__'
+export GRAFANA_INSTANCE_ID='__GRAFANA_INSTANCE_ID__'
+export GRAFANA_API_TOKEN='__GRAFANA_API_TOKEN__'

--- a/ainb-tui/crates/ainb-core/assets/otel/start-alloy.sh
+++ b/ainb-tui/crates/ainb-core/assets/otel/start-alloy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Start Grafana Alloy in a dedicated tmux session, forwarding local OTLP
+# (Claude Code + Codex) to Grafana Cloud. Idempotent: re-running restarts it.
+#
+# Written by `ainb otel setup`. Reads creds + endpoint from grafana-cloud.env
+# (same directory) and the OTLP fan-in pipeline from config.alloy (same
+# directory). Override the config path with ALLOY_CONFIG=... if you keep a
+# custom one.
+set -euo pipefail
+
+OTEL_DIR="$HOME/.agents-in-a-box/otel"
+ENV_FILE="$OTEL_DIR/grafana-cloud.env"
+CONFIG="${ALLOY_CONFIG:-$OTEL_DIR/config.alloy}"
+SESSION="otel-alloy"
+LOG="$HOME/.agents-in-a-box/logs/alloy.log"
+
+[ -f "$ENV_FILE" ] || { echo "missing $ENV_FILE — run 'ainb otel setup' first"; exit 1; }
+[ -f "$CONFIG" ] || { echo "missing $CONFIG — run 'ainb otel setup' first"; exit 1; }
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+case "${GRAFANA_API_TOKEN:-}" in ""|REPLACE_*) echo "fill creds in $ENV_FILE first (run 'ainb otel setup')"; exit 1;; esac
+
+command -v alloy >/dev/null || { echo "alloy not installed — brew install grafana/grafana/alloy"; exit 1; }
+
+mkdir -p "$(dirname "$LOG")"
+
+# Kill only our own named session, never the server.
+tmux has-session -t "$SESSION" 2>/dev/null && tmux kill-session -t "$SESSION"
+
+tmux new-session -d -s "$SESSION" -n alloy
+tmux send-keys -t "$SESSION:alloy" \
+  "export GRAFANA_OTLP_ENDPOINT='$GRAFANA_OTLP_ENDPOINT' GRAFANA_INSTANCE_ID='$GRAFANA_INSTANCE_ID' GRAFANA_API_TOKEN='$GRAFANA_API_TOKEN'; alloy run --stability.level=experimental --server.http.listen-addr=127.0.0.1:12345 '$CONFIG' 2>&1 | tee '$LOG'" C-m
+
+echo "Alloy starting in tmux session '$SESSION'"
+echo "  config:  $CONFIG"
+echo "  logs:    $LOG"
+echo "  health:  http://127.0.0.1:12345  (Alloy UI)"
+echo "  attach:  tmux attach -t $SESSION"

--- a/ainb-tui/crates/ainb-core/assets/otel/start-alloy.sh
+++ b/ainb-tui/crates/ainb-core/assets/otel/start-alloy.sh
@@ -18,7 +18,7 @@ LOG="$HOME/.agents-in-a-box/logs/alloy.log"
 [ -f "$CONFIG" ] || { echo "missing $CONFIG — run 'ainb otel setup' first"; exit 1; }
 # shellcheck disable=SC1090
 source "$ENV_FILE"
-case "${GRAFANA_API_TOKEN:-}" in ""|REPLACE_*) echo "fill creds in $ENV_FILE first (run 'ainb otel setup')"; exit 1;; esac
+case "${GRAFANA_API_TOKEN:-}" in ""|__GRAFANA_*|REPLACE_*) echo "fill creds in $ENV_FILE first (run 'ainb otel setup')"; exit 1;; esac
 
 command -v alloy >/dev/null || { echo "alloy not installed — brew install grafana/grafana/alloy"; exit 1; }
 

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -451,6 +451,10 @@ pub enum AppEvent {
     OnboardingEditorDown,      // Move editor selection down
     OnboardingFinish,          // Complete onboarding
     OnboardingInstallConfig,   // Install recommended config (I key)
+    OnboardingOtelChar(char),  // Type into the focused OTEL field
+    OnboardingOtelBackspace,   // Backspace the focused OTEL field
+    OnboardingOtelNextField,   // Focus next OTEL field (Tab/Down)
+    OnboardingOtelPrevField,   // Focus previous OTEL field (Shift-Tab/Up)
     // Setup menu events
     SetupMenuBack,   // Return to home screen (Esc)
     SetupMenuSelect, // Select menu item (Enter)
@@ -2243,6 +2247,18 @@ impl EventHandler {
                         Some(AppEvent::OnboardingBack)
                     }
                     KeyCode::Char('s') | KeyCode::Char('S') => Some(AppEvent::OnboardingSkipAuth),
+                    _ => None,
+                },
+                OnboardingStep::OtelSetup => match key_event.code {
+                    // Enter advances; if all 3 creds are filled, finish-time
+                    // setup runs, otherwise the step is effectively skipped.
+                    KeyCode::Enter => Some(AppEvent::OnboardingNext),
+                    KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
+                    KeyCode::Left => Some(AppEvent::OnboardingBack),
+                    KeyCode::Tab | KeyCode::Down => Some(AppEvent::OnboardingOtelNextField),
+                    KeyCode::BackTab | KeyCode::Up => Some(AppEvent::OnboardingOtelPrevField),
+                    KeyCode::Backspace => Some(AppEvent::OnboardingOtelBackspace),
+                    KeyCode::Char(ch) => Some(AppEvent::OnboardingOtelChar(ch)),
                     _ => None,
                 },
                 OnboardingStep::EditorSelection => match key_event.code {
@@ -6226,6 +6242,26 @@ impl EventHandler {
                     if onboarding_state.selected_editor_index < max_idx {
                         onboarding_state.selected_editor_index += 1;
                     }
+                }
+            }
+            AppEvent::OnboardingOtelChar(ch) => {
+                if let Some(ref mut onboarding_state) = state.onboarding_state {
+                    onboarding_state.otel_input_char(ch);
+                }
+            }
+            AppEvent::OnboardingOtelBackspace => {
+                if let Some(ref mut onboarding_state) = state.onboarding_state {
+                    onboarding_state.otel_backspace();
+                }
+            }
+            AppEvent::OnboardingOtelNextField => {
+                if let Some(ref mut onboarding_state) = state.onboarding_state {
+                    onboarding_state.otel_next_field();
+                }
+            }
+            AppEvent::OnboardingOtelPrevField => {
+                if let Some(ref mut onboarding_state) = state.onboarding_state {
+                    onboarding_state.otel_prev_field();
                 }
             }
             AppEvent::OnboardingInstallConfig => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3994,6 +3994,34 @@ impl AppState {
                 self.app_config.ui_preferences.preferred_editor = Some(editor);
             }
 
+            // Optional OpenTelemetry -> Grafana Cloud setup. Best-effort: a
+            // failure here must never block finishing onboarding. The TUI does
+            // NOT brew-install Alloy (interactive brew in the alt-screen is
+            // hostile) — if Alloy is missing we still write the config and the
+            // user finishes with `ainb otel setup` / `ainb otel start` later.
+            if state.otel_should_setup() {
+                let creds = crate::otel::GrafanaCloudCreds {
+                    otlp_endpoint: state.otel_otlp_endpoint.trim().to_string(),
+                    instance_id: state.otel_instance_id.trim().to_string(),
+                    api_token: state.otel_api_token.trim().to_string(),
+                };
+                let host = crate::otel::detect_host_name();
+                let result = (|| -> anyhow::Result<()> {
+                    crate::otel::write_assets()?;
+                    crate::otel::write_env_file(&creds, &host)?;
+                    crate::otel::ensure_settings_env()?;
+                    let _ = crate::otel::ensure_shell_rc_sources_env();
+                    if crate::otel::alloy_installed() {
+                        let _ = crate::otel::start_alloy();
+                    }
+                    Ok(())
+                })();
+                match result {
+                    Ok(()) => info!("OTEL setup written (host.name={host})"),
+                    Err(e) => warn!("OTEL setup during onboarding failed (non-fatal): {e}"),
+                }
+            }
+
             if let Err(e) = self.app_config.save() {
                 warn!(
                     "Failed to save app config during onboarding completion: {}",

--- a/ainb-tui/crates/ainb-core/src/cli/deps.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/deps.rs
@@ -31,6 +31,8 @@ pub enum Consumer {
     Beads,
     /// ccusage-backed 5h / weekly usage bars.
     Usage,
+    /// OpenTelemetry export to Grafana Cloud (`ainb otel setup`).
+    Otel,
 }
 
 impl Consumer {
@@ -41,6 +43,7 @@ impl Consumer {
             Consumer::Statusline => "statusline",
             Consumer::Beads => "beads",
             Consumer::Usage => "usage",
+            Consumer::Otel => "otel",
         }
     }
 
@@ -52,6 +55,7 @@ impl Consumer {
             Consumer::Statusline,
             Consumer::Beads,
             Consumer::Usage,
+            Consumer::Otel,
         ]
     }
 }
@@ -238,6 +242,14 @@ pub fn catalog() -> &'static [DepSpec] {
             required: false,
             why: "the Claude Code CLI the reflect drainer shells out to",
             install_hint: "# install Claude Code: https://claude.com/claude-code",
+        },
+        DepSpec {
+            name: "alloy",
+            kind: System,
+            consumers: &[Otel],
+            required: false,
+            why: "Grafana Alloy: forwards local OTLP telemetry to Grafana Cloud (run `ainb otel setup`)",
+            install_hint: "brew install grafana/grafana/alloy   # macOS · then: ainb otel setup",
         },
     ]
 }

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod init;
 pub mod list;
 pub mod logs;
 pub mod mcp;
+pub mod otel;
 pub mod plugin;
 pub mod presets;
 pub mod recover;

--- a/ainb-tui/crates/ainb-core/src/cli/otel.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/otel.rs
@@ -1,0 +1,279 @@
+// ABOUTME: `ainb otel` — set up OpenTelemetry export to Grafana Cloud.
+//
+// Full-auto `setup`: vendors the Alloy assets into ~/.agents-in-a-box/otel/,
+// prompts for the three Grafana Cloud values (with how-to-get instructions),
+// writes grafana-cloud.env (0600), ensures the generic OTEL keys are in
+// ~/.claude/settings.json, wires the shell rc to source the env file,
+// optionally `brew install`s Alloy (with consent), and starts Alloy in tmux.
+//
+// Secrets never touch settings.json (that file syncs to a public repo) — they
+// live only in grafana-cloud.env, read by Alloy's launcher.
+
+use std::io::{self, Write};
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::cli::OutputFormat;
+use crate::otel;
+
+#[derive(Subcommand, Debug)]
+pub enum OtelCommands {
+    /// Set up OpenTelemetry export to Grafana Cloud (assets, creds, Alloy).
+    Setup(SetupArgs),
+    /// Show local OTEL pipeline state (env file, Alloy install, tmux session).
+    Status,
+    /// (Re)start Grafana Alloy in its tmux session.
+    Start,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SetupArgs {
+    /// host.name resource attribute (defaults to the short hostname).
+    #[arg(long)]
+    pub host_name: Option<String>,
+
+    /// Don't start Alloy after writing config.
+    #[arg(long)]
+    pub no_start: bool,
+
+    /// Don't offer to `brew install` Alloy if it's missing.
+    #[arg(long)]
+    pub no_install: bool,
+
+    /// Telemetry provider (only grafana-cloud today).
+    #[arg(long, default_value = "grafana-cloud")]
+    pub provider: String,
+}
+
+/// Dispatch `ainb otel <sub>`.
+pub async fn execute(cmd: OtelCommands, format: OutputFormat) -> Result<()> {
+    match cmd {
+        OtelCommands::Setup(args) => setup(args).await,
+        OtelCommands::Status => status(format),
+        OtelCommands::Start => start(),
+    }
+}
+
+// ── setup ───────────────────────────────────────────────────────────────────
+
+async fn setup(args: SetupArgs) -> Result<()> {
+    if args.provider != "grafana-cloud" {
+        anyhow::bail!(
+            "unknown provider '{}' — only 'grafana-cloud' is supported today",
+            args.provider
+        );
+    }
+
+    println!("OpenTelemetry setup — provider: Grafana Cloud");
+    println!("{}", "\u{2501}".repeat(64));
+    println!(
+        "Pipeline:  Claude Code --OTLP {}--> Grafana Alloy --> Grafana Cloud\n",
+        otel::LOCAL_OTLP_ENDPOINT
+    );
+
+    // 1. Vendor the generic assets (config.alloy, start-alloy.sh, dashboards).
+    otel::write_assets()?;
+    println!(
+        "[1/6] wrote Alloy config + launcher + dashboards to {}",
+        otel::otel_dir()?.display()
+    );
+
+    // 2. Collect Grafana Cloud creds — with how-to-get instructions.
+    println!("\n[2/6] Grafana Cloud credentials");
+    println!(
+        "      Where to find these: Grafana Cloud \u{2192} Connections \u{2192} \"OpenTelemetry (OTLP)\"."
+    );
+    println!("      That page shows the OTLP endpoint URL, an Instance ID (Basic-auth");
+    println!("      username), and lets you generate an API token (needs metrics+logs+traces");
+    println!("      write). Values can also be preset via the GRAFANA_OTLP_ENDPOINT,");
+    println!("      GRAFANA_INSTANCE_ID and GRAFANA_API_TOKEN env vars.\n");
+
+    let otlp_endpoint = resolve_value(
+        "GRAFANA_OTLP_ENDPOINT",
+        "      OTLP endpoint URL (ends in /otlp)",
+    )?;
+    let instance_id = resolve_value("GRAFANA_INSTANCE_ID", "      Instance ID (Basic-auth user)")?;
+    let api_token = resolve_value("GRAFANA_API_TOKEN", "      API token (input visible)")?;
+
+    let creds = otel::GrafanaCloudCreds {
+        otlp_endpoint,
+        instance_id,
+        api_token,
+    };
+    if !creds.is_complete() {
+        anyhow::bail!("all three Grafana Cloud values are required — aborting");
+    }
+
+    // 3. host.name resource attr.
+    let host_name = match args.host_name {
+        Some(h) => h,
+        None => {
+            let detected = otel::detect_host_name();
+            let answer = prompt(&format!("      host.name [{detected}]"))?;
+            if answer.trim().is_empty() {
+                detected
+            } else {
+                answer.trim().to_string()
+            }
+        }
+    };
+
+    // 4. Write the secret env file (0600).
+    let env_path = otel::write_env_file(&creds, &host_name)?;
+    println!(
+        "\n[3/6] wrote {} (0600, secrets — never committed)",
+        env_path.display()
+    );
+
+    // 5. Ensure the generic, non-secret OTEL keys are in settings.json.
+    let added = otel::ensure_settings_env()?;
+    if added.is_empty() {
+        println!("[4/6] ~/.claude/settings.json already has the generic OTEL env");
+    } else {
+        println!(
+            "[4/6] added {} generic OTEL key(s) to ~/.claude/settings.json (no secrets)",
+            added.len()
+        );
+    }
+
+    // 6. Wire the shell rc to source the env file.
+    match otel::ensure_shell_rc_sources_env() {
+        Ok(true) => println!(
+            "[5/6] wired {} to source the OTEL env (backup at <rc>.bak) \u{2014} open a new shell to load it",
+            otel::shell_rc_path()?.display()
+        ),
+        Ok(false) => println!("[5/6] shell rc already sources the OTEL env"),
+        Err(e) => eprintln!("[5/6] could not wire shell rc: {e} (add the source line manually)"),
+    }
+
+    // 7. Alloy: install (consent) + start.
+    if !otel::alloy_installed() {
+        if args.no_install {
+            println!(
+                "[6/6] alloy not installed \u{2014} install it then run `ainb otel start`:\n        brew install {}",
+                otel::ALLOY_BREW_FORMULA
+            );
+            print_done(&host_name)?;
+            return Ok(());
+        }
+        let yes = prompt_yes_no(&format!(
+            "[6/6] alloy not installed. brew install {}?",
+            otel::ALLOY_BREW_FORMULA
+        ))?;
+        if yes {
+            otel::brew_install_alloy()?;
+        } else {
+            println!(
+                "      skipped. install later then run `ainb otel start`:\n        brew install {}",
+                otel::ALLOY_BREW_FORMULA
+            );
+            print_done(&host_name)?;
+            return Ok(());
+        }
+    }
+
+    if args.no_start {
+        println!("[6/6] alloy installed \u{2014} start it with: ainb otel start");
+    } else {
+        otel::start_alloy()?;
+    }
+
+    print_done(&host_name)?;
+    Ok(())
+}
+
+fn print_done(host_name: &str) -> Result<()> {
+    let dash = otel::otel_dir()?.join("dashboards");
+    println!("\n{}", "\u{2501}".repeat(64));
+    println!("DONE. host.name={host_name}");
+    println!("  Alloy UI/health:  {}", otel::ALLOY_HEALTH_URL);
+    println!(
+        "  Dashboards to import in Grafana Cloud:  {}",
+        dash.display()
+    );
+    println!("  Verify:  ainb otel status   (or: ainb doctor)");
+    Ok(())
+}
+
+// ── status ────────────────────────────────────────────────────────────────
+
+fn status(format: OutputFormat) -> Result<()> {
+    let s = otel::status();
+    if matches!(format, OutputFormat::Json) {
+        let v = serde_json::json!({
+            "env_file_present": s.env_file_present,
+            "config_present": s.config_present,
+            "alloy_installed": s.alloy_installed,
+            "alloy_running": s.alloy_running,
+            "settings_env_present": s.settings_env_present,
+        });
+        println!("{}", serde_json::to_string_pretty(&v)?);
+        return Ok(());
+    }
+
+    let mark = |b: bool| if b { "\u{2713}" } else { "\u{2717}" };
+    println!("OpenTelemetry / Grafana Cloud status");
+    println!("{}", "\u{2501}".repeat(48));
+    println!("  {} grafana-cloud.env present", mark(s.env_file_present));
+    println!("  {} config.alloy present", mark(s.config_present));
+    println!(
+        "  {} generic OTEL env in settings.json",
+        mark(s.settings_env_present)
+    );
+    println!("  {} alloy installed", mark(s.alloy_installed));
+    println!(
+        "  {} alloy running (tmux: {})",
+        mark(s.alloy_running),
+        otel::ALLOY_TMUX_SESSION
+    );
+    if !s.env_file_present || !s.config_present {
+        println!("\nRun `ainb otel setup` to configure.");
+    } else if !s.alloy_running {
+        println!("\nRun `ainb otel start` to launch Alloy.");
+    }
+    Ok(())
+}
+
+// ── start ─────────────────────────────────────────────────────────────────
+
+fn start() -> Result<()> {
+    if !otel::alloy_installed() {
+        anyhow::bail!(
+            "alloy not installed — brew install {} (or run `ainb otel setup`)",
+            otel::ALLOY_BREW_FORMULA
+        );
+    }
+    otel::start_alloy()
+}
+
+// ── prompt helpers ──────────────────────────────────────────────────────────
+
+/// Use the env var if set+non-empty, else prompt.
+fn resolve_value(env_key: &str, label: &str) -> Result<String> {
+    if let Ok(v) = std::env::var(env_key) {
+        if !v.trim().is_empty() {
+            println!("{label}: (from ${env_key})");
+            return Ok(v.trim().to_string());
+        }
+    }
+    let v = prompt(label)?;
+    Ok(v.trim().to_string())
+}
+
+fn prompt(label: &str) -> Result<String> {
+    print!("{label}: ");
+    io::stdout().flush()?;
+    let mut buf = String::new();
+    io::stdin().read_line(&mut buf)?;
+    Ok(buf.trim_end_matches(['\n', '\r']).to_string())
+}
+
+fn prompt_yes_no(label: &str) -> Result<bool> {
+    print!("{label} [Y/n] ");
+    io::stdout().flush()?;
+    let mut buf = String::new();
+    io::stdin().read_line(&mut buf)?;
+    let a = buf.trim().to_lowercase();
+    Ok(a.is_empty() || a == "y" || a == "yes")
+}

--- a/ainb-tui/crates/ainb-core/src/cli/otel.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/otel.rs
@@ -94,7 +94,20 @@ async fn setup(args: SetupArgs) -> Result<()> {
         "      OTLP endpoint URL (ends in /otlp)",
     )?;
     let instance_id = resolve_value("GRAFANA_INSTANCE_ID", "      Instance ID (Basic-auth user)")?;
-    let api_token = resolve_value("GRAFANA_API_TOKEN", "      API token (input visible)")?;
+    // Token is a secret — read it without echoing to the terminal.
+    let api_token = resolve_secret("GRAFANA_API_TOKEN", "      API token (hidden)")?;
+
+    // Light sanity check: the endpoint should be an http(s) URL ending in /otlp.
+    // Warn (don't bail) — a common mistake is swapping the endpoint and instance
+    // fields, which otherwise only surfaces as a confusing Alloy auth error.
+    let ep = otlp_endpoint.trim();
+    if !ep.starts_with("http://") && !ep.starts_with("https://") {
+        eprintln!(
+            "      warning: OTLP endpoint doesn't start with http(s):// — did you paste the right field?"
+        );
+    } else if !ep.ends_with("/otlp") {
+        eprintln!("      warning: OTLP endpoint usually ends in /otlp — double-check the value.");
+    }
 
     let creds = otel::GrafanaCloudCreds {
         otlp_endpoint,
@@ -249,16 +262,40 @@ fn start() -> Result<()> {
 
 // ── prompt helpers ──────────────────────────────────────────────────────────
 
-/// Use the env var if set+non-empty, else prompt.
+/// Use the env var if set+non-empty, else prompt (echoed).
 fn resolve_value(env_key: &str, label: &str) -> Result<String> {
-    if let Ok(v) = std::env::var(env_key) {
-        if !v.trim().is_empty() {
-            println!("{label}: (from ${env_key})");
-            return Ok(v.trim().to_string());
-        }
+    if let Some(v) = from_env(env_key, label) {
+        return Ok(v);
     }
     let v = prompt(label)?;
     Ok(v.trim().to_string())
+}
+
+/// Like `resolve_value` but reads the prompt without echoing (secrets). Falls
+/// back to an echoed read if there is no TTY (e.g. piped input in CI).
+fn resolve_secret(env_key: &str, label: &str) -> Result<String> {
+    if let Some(v) = from_env(env_key, label) {
+        return Ok(v);
+    }
+    match rpassword::prompt_password(format!("{label}: ")) {
+        Ok(v) => Ok(v.trim().to_string()),
+        // No TTY (piped stdin) — rpassword errors; fall back to a plain read.
+        Err(_) => {
+            let v = prompt(label)?;
+            Ok(v.trim().to_string())
+        }
+    }
+}
+
+/// Return the env var value if set+non-empty, announcing the source.
+fn from_env(env_key: &str, label: &str) -> Option<String> {
+    std::env::var(env_key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .inspect(|_| {
+            println!("{label}: (from ${env_key})");
+        })
 }
 
 fn prompt(label: &str) -> Result<String> {

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -105,6 +105,7 @@ impl CommandRegistry {
         r.register(ClaudecodeCommand);
         r.register(CodexCommand);
         r.register(TmuxCommand);
+        r.register(OtelCommand);
         r.register(CompletionCommand);
         r.register(AbtopCommand);
         r.register(PluginCommand); // Phase 4 stub — surface reserved now
@@ -1141,6 +1142,30 @@ impl CliCommand for NotifydCommand {
     }
 }
 
+/// `ainb otel {setup,status,start}` — OpenTelemetry export to Grafana Cloud.
+/// See `crate::cli::otel` for the setup flow.
+pub struct OtelCommand;
+impl CliCommand for OtelCommand {
+    fn name(&self) -> &'static str {
+        "otel"
+    }
+    fn build(&self, app: Command) -> Command {
+        app.subcommand(
+            <crate::cli::otel::OtelCommands as Subcommand>::augment_subcommands(
+                Command::new(self.name())
+                    .about("Set up OpenTelemetry export to Grafana Cloud (Grafana Alloy pipeline)")
+                    .subcommand_required(true),
+            ),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        match crate::cli::otel::OtelCommands::from_arg_matches(matches) {
+            Ok(c) => Box::pin(async move { crate::cli::otel::execute(c, ctx.format).await }),
+            Err(e) => boxed_err(e),
+        }
+    }
+}
+
 pub struct CompletionCommand;
 impl CliCommand for CompletionCommand {
     fn name(&self) -> &'static str {
@@ -1581,14 +1606,14 @@ mod tests {
     }
 
     #[test]
-    fn built_ins_registers_twenty_seven_commands() {
+    fn built_ins_registers_twenty_eight_commands() {
         let r = CommandRegistry::built_ins();
         let names = r.names();
-        // main's 26 (built-ins + doctor + reflect + claudecode + codex + tmux
-        // + abtop + plugin stub + fleet + hidden notifyd + hangar) + the mcp
-        // namespace = 27. The TUI is NOT in the registry — main.rs handles
+        // main's built-ins + doctor + reflect + claudecode + codex + tmux + otel
+        // + abtop + plugin stub + fleet + hidden notifyd + hangar + the mcp
+        // namespace = 28. The TUI is NOT in the registry — main.rs handles
         // `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 27, "expected 27 entries, got {names:?}");
+        assert_eq!(names.len(), 28, "expected 28 entries, got {names:?}");
         for required in [
             "run",
             "list",
@@ -1610,6 +1635,7 @@ mod tests {
             "claudecode",
             "codex",
             "tmux",
+            "otel",
             "completion",
             "abtop",
             "plugin",

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -141,6 +141,7 @@ impl OnboardingComponent {
             OnboardingStep::DependencyCheck => self.render_dependencies(frame, area, state),
             OnboardingStep::GitDirectories => self.render_git_directories(frame, area, state),
             OnboardingStep::Authentication => self.render_authentication(frame, area, state),
+            OnboardingStep::OtelSetup => self.render_otel_setup(frame, area, state),
             OnboardingStep::EditorSelection => self.render_editor_selection(frame, area, state),
             OnboardingStep::Summary => self.render_summary(frame, area, state),
         }
@@ -588,6 +589,137 @@ impl OnboardingComponent {
         frame.render_widget(text, inner);
     }
 
+    /// Render the OpenTelemetry (Grafana Cloud) setup step
+    fn render_otel_setup(&self, frame: &mut Frame, area: Rect, state: &OnboardingState) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(CORNFLOWER_BLUE))
+            .style(Style::default().bg(PANEL_BG))
+            .title(" OpenTelemetry → Grafana Cloud ")
+            .title_style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let content_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Length(5), // What + how-to-get
+                Constraint::Length(3), // endpoint field
+                Constraint::Length(3), // instance id field
+                Constraint::Length(3), // token field
+                Constraint::Min(2),    // instructions
+            ])
+            .split(inner);
+
+        // What this does + where to get the creds.
+        let intro = Paragraph::new(vec![
+            Line::from(Span::styled(
+                "Optional: ship Claude Code metrics/logs/traces to Grafana Cloud",
+                Style::default().fg(SOFT_WHITE),
+            )),
+            Line::from(Span::styled(
+                "via a local Grafana Alloy collector (started for you).",
+                Style::default().fg(MUTED_GRAY),
+            )),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Get creds: ", Style::default().fg(GOLD)),
+                Span::styled(
+                    "Grafana Cloud → Connections → \"OpenTelemetry (OTLP)\"",
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ]),
+        ])
+        .alignment(Alignment::Center);
+        frame.render_widget(intro, content_layout[0]);
+
+        // Field renderer with focus + token masking.
+        let field =
+            |frame: &mut Frame, area: Rect, idx: usize, label: &str, value: &str, mask: bool| {
+                let focused = state.otel_field == idx && !state.otel_skip;
+                let shown = if mask {
+                    "•".repeat(value.chars().count())
+                } else {
+                    value.to_string()
+                };
+                let display = if focused && state.show_cursor {
+                    format!("{shown}│")
+                } else {
+                    shown
+                };
+                let border = if focused { GOLD } else { SUBDUED_BORDER };
+                let para = Paragraph::new(display).style(Style::default().fg(SOFT_WHITE)).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(border))
+                        .title(format!(" {label} "))
+                        .title_style(Style::default().fg(if focused { GOLD } else { MUTED_GRAY }))
+                        .style(Style::default().bg(DARK_BG)),
+                );
+                frame.render_widget(para, area);
+            };
+
+        field(
+            frame,
+            content_layout[1],
+            0,
+            "OTLP endpoint (…/otlp)",
+            &state.otel_otlp_endpoint,
+            false,
+        );
+        field(
+            frame,
+            content_layout[2],
+            1,
+            "Instance ID",
+            &state.otel_instance_id,
+            false,
+        );
+        field(
+            frame,
+            content_layout[3],
+            2,
+            "API token",
+            &state.otel_api_token,
+            true,
+        );
+
+        // Instructions / status line.
+        let status = if state.otel_skip {
+            Line::from(vec![
+                Span::styled("Optional. ", Style::default().fg(WARNING_YELLOW)),
+                Span::styled("Type to configure · ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("Tab", Style::default().fg(GOLD)),
+                Span::styled(" next field · ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("Enter", Style::default().fg(GOLD)),
+                Span::styled(" skip", Style::default().fg(MUTED_GRAY)),
+            ])
+        } else if state.otel_creds_complete() {
+            Line::from(vec![
+                Span::styled("✓ ready ", Style::default().fg(SELECTION_GREEN)),
+                Span::styled("· Tab next field · ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("Enter", Style::default().fg(GOLD)),
+                Span::styled(" set up & continue", Style::default().fg(MUTED_GRAY)),
+            ])
+        } else {
+            Line::from(vec![
+                Span::styled("Tab", Style::default().fg(GOLD)),
+                Span::styled(
+                    " next field · fill all 3 to enable · ",
+                    Style::default().fg(MUTED_GRAY),
+                ),
+                Span::styled("Enter", Style::default().fg(GOLD)),
+                Span::styled(" skips", Style::default().fg(MUTED_GRAY)),
+            ])
+        };
+        let instr = Paragraph::new(status).alignment(Alignment::Center);
+        frame.render_widget(instr, content_layout[4]);
+    }
+
     /// Render editor selection step
     fn render_editor_selection(&self, frame: &mut Frame, area: Rect, state: &OnboardingState) {
         let block = Block::default()
@@ -804,6 +936,28 @@ impl OnboardingComponent {
             ),
             Span::styled("Authentication: ", Style::default().fg(SOFT_WHITE)),
             Span::styled(auth_status, Style::default().fg(MUTED_GRAY)),
+        ]));
+
+        // Telemetry (OTEL -> Grafana Cloud)
+        let otel_on = state.otel_should_setup();
+        summary_items.push(Line::from(vec![
+            Span::styled(
+                if otel_on { "  ✓ " } else { "  ○ " },
+                Style::default().fg(if otel_on {
+                    SELECTION_GREEN
+                } else {
+                    WARNING_YELLOW
+                }),
+            ),
+            Span::styled("Telemetry: ", Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                if otel_on {
+                    "Grafana Cloud (Alloy)".to_string()
+                } else {
+                    "skipped (run `ainb otel setup` later)".to_string()
+                },
+                Style::default().fg(MUTED_GRAY),
+            ),
         ]));
 
         // Editor

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -12,6 +12,7 @@ pub enum OnboardingStep {
     DependencyCheck,
     GitDirectories,
     Authentication,
+    OtelSetup,
     EditorSelection,
     Summary,
 }
@@ -35,6 +36,7 @@ impl OnboardingStep {
             Self::DependencyCheck,
             Self::GitDirectories,
             Self::Authentication,
+            Self::OtelSetup,
             Self::EditorSelection,
             Self::Summary,
         ]
@@ -47,14 +49,15 @@ impl OnboardingStep {
             Self::DependencyCheck => 2,
             Self::GitDirectories => 3,
             Self::Authentication => 4,
-            Self::EditorSelection => 5,
-            Self::Summary => 6,
+            Self::OtelSetup => 5,
+            Self::EditorSelection => 6,
+            Self::Summary => 7,
         }
     }
 
     /// Get the total number of steps
     pub fn total() -> usize {
-        6
+        7
     }
 
     /// Get display title for this step
@@ -64,6 +67,7 @@ impl OnboardingStep {
             Self::DependencyCheck => "Dependencies",
             Self::GitDirectories => "Git Directories",
             Self::Authentication => "Authentication",
+            Self::OtelSetup => "Telemetry",
             Self::EditorSelection => "Editor",
             Self::Summary => "Summary",
         }
@@ -76,6 +80,7 @@ impl OnboardingStep {
             Self::DependencyCheck => "Checking required tools",
             Self::GitDirectories => "Where are your projects?",
             Self::Authentication => "Set up AI agent authentication",
+            Self::OtelSetup => "Optional: ship metrics to Grafana Cloud",
             Self::EditorSelection => "Choose your preferred editor",
             Self::Summary => "You're all set!",
         }
@@ -97,6 +102,10 @@ impl OnboardingStep {
                 // Auth can be skipped
                 true
             }
+            Self::OtelSetup => {
+                // OTEL is optional — always advanceable (fill creds or skip)
+                true
+            }
             Self::EditorSelection => {
                 // Editor selection can be skipped (will use fallback)
                 true
@@ -114,7 +123,8 @@ impl OnboardingStep {
             Self::Welcome => Some(Self::DependencyCheck),
             Self::DependencyCheck => Some(Self::GitDirectories),
             Self::GitDirectories => Some(Self::Authentication),
-            Self::Authentication => Some(Self::EditorSelection),
+            Self::Authentication => Some(Self::OtelSetup),
+            Self::OtelSetup => Some(Self::EditorSelection),
             Self::EditorSelection => Some(Self::Summary),
             Self::Summary => None,
         }
@@ -127,7 +137,8 @@ impl OnboardingStep {
             Self::DependencyCheck => Some(Self::Welcome),
             Self::GitDirectories => Some(Self::DependencyCheck),
             Self::Authentication => Some(Self::GitDirectories),
-            Self::EditorSelection => Some(Self::Authentication),
+            Self::OtelSetup => Some(Self::Authentication),
+            Self::EditorSelection => Some(Self::OtelSetup),
             Self::Summary => Some(Self::EditorSelection),
         }
     }
@@ -243,6 +254,16 @@ pub struct OnboardingState {
     pub available_editors: Vec<EditorOption>,
     /// Currently selected editor index
     pub selected_editor_index: usize,
+    /// OTEL: user chose to skip the OpenTelemetry step (no setup on finish)
+    pub otel_skip: bool,
+    /// OTEL: Grafana Cloud OTLP endpoint URL (ends in /otlp)
+    pub otel_otlp_endpoint: String,
+    /// OTEL: Grafana Cloud Instance ID (Basic-auth username)
+    pub otel_instance_id: String,
+    /// OTEL: Grafana Cloud API token (secret)
+    pub otel_api_token: String,
+    /// OTEL: focused form field (0=endpoint, 1=instance, 2=token)
+    pub otel_field: usize,
 }
 
 impl OnboardingState {
@@ -264,7 +285,54 @@ impl OnboardingState {
             skipped_dependencies: Vec::new(),
             available_editors: Vec::new(),
             selected_editor_index: 0,
+            otel_skip: true,
+            otel_otlp_endpoint: String::new(),
+            otel_instance_id: String::new(),
+            otel_api_token: String::new(),
+            otel_field: 0,
         }
+    }
+
+    /// Mutable handle to the currently focused OTEL field's string.
+    fn otel_field_mut(&mut self) -> &mut String {
+        match self.otel_field {
+            0 => &mut self.otel_otlp_endpoint,
+            1 => &mut self.otel_instance_id,
+            _ => &mut self.otel_api_token,
+        }
+    }
+
+    /// Type a character into the focused OTEL field (entering data un-skips).
+    pub fn otel_input_char(&mut self, c: char) {
+        self.otel_skip = false;
+        self.otel_field_mut().push(c);
+    }
+
+    /// Backspace the focused OTEL field.
+    pub fn otel_backspace(&mut self) {
+        self.otel_field_mut().pop();
+    }
+
+    /// Move focus to the next OTEL field (wraps).
+    pub fn otel_next_field(&mut self) {
+        self.otel_field = (self.otel_field + 1) % 3;
+    }
+
+    /// Move focus to the previous OTEL field (wraps).
+    pub fn otel_prev_field(&mut self) {
+        self.otel_field = (self.otel_field + 2) % 3;
+    }
+
+    /// True when all three OTEL fields are filled (after trim).
+    pub fn otel_creds_complete(&self) -> bool {
+        !self.otel_otlp_endpoint.trim().is_empty()
+            && !self.otel_instance_id.trim().is_empty()
+            && !self.otel_api_token.trim().is_empty()
+    }
+
+    /// Whether OTEL setup should run on finish (not skipped + creds complete).
+    pub fn otel_should_setup(&self) -> bool {
+        !self.otel_skip && self.otel_creds_complete()
     }
 
     /// Detect available editors on the system
@@ -479,15 +547,37 @@ mod tests {
 
         let step = OnboardingStep::EditorSelection;
         assert_eq!(step.next(), Some(OnboardingStep::Summary));
+        assert_eq!(step.previous(), Some(OnboardingStep::OtelSetup));
+
+        let step = OnboardingStep::OtelSetup;
+        assert_eq!(step.next(), Some(OnboardingStep::EditorSelection));
         assert_eq!(step.previous(), Some(OnboardingStep::Authentication));
     }
 
     #[test]
     fn test_step_numbers() {
         assert_eq!(OnboardingStep::Welcome.number(), 1);
-        assert_eq!(OnboardingStep::EditorSelection.number(), 5);
-        assert_eq!(OnboardingStep::Summary.number(), 6);
-        assert_eq!(OnboardingStep::total(), 6);
+        assert_eq!(OnboardingStep::OtelSetup.number(), 5);
+        assert_eq!(OnboardingStep::EditorSelection.number(), 6);
+        assert_eq!(OnboardingStep::Summary.number(), 7);
+        assert_eq!(OnboardingStep::total(), 7);
+    }
+
+    #[test]
+    fn test_otel_field_input() {
+        let mut state = OnboardingState::new();
+        assert!(state.otel_skip);
+        state.current_step = OnboardingStep::OtelSetup;
+        state.otel_input_char('h');
+        state.otel_input_char('i');
+        assert_eq!(state.otel_otlp_endpoint, "hi");
+        assert!(!state.otel_skip);
+        state.otel_next_field();
+        state.otel_input_char('7');
+        assert_eq!(state.otel_instance_id, "7");
+        state.otel_backspace();
+        assert_eq!(state.otel_instance_id, "");
+        assert!(!state.otel_creds_complete());
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod git;
 pub mod interactive;
 pub mod mcp_pool;
 pub mod models;
+pub mod otel;
 pub mod perf;
 pub mod plugins;
 pub mod providers;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -44,6 +44,7 @@ mod git;
 mod interactive;
 mod mcp_pool;
 mod models;
+mod otel;
 mod perf;
 mod plugins;
 mod providers;

--- a/ainb-tui/crates/ainb-core/src/otel/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/otel/mod.rs
@@ -129,16 +129,28 @@ pub fn claude_settings_path() -> Result<PathBuf> {
         .join(".claude/settings.json"))
 }
 
-/// Short machine hostname (`hostname -s`), falling back to `localhost`.
+/// Short machine hostname (`hostname -s`), then `$HOSTNAME`, then `localhost`.
+/// The `$HOSTNAME` fallback matters on minimal Linux containers where the
+/// `hostname` binary is often absent (otherwise every host reads `localhost`).
 pub fn detect_host_name() -> String {
-    Command::new("hostname")
+    if let Some(h) = Command::new("hostname")
         .arg("-s")
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "localhost".to_string())
+    {
+        return h;
+    }
+    if let Ok(h) = std::env::var("HOSTNAME") {
+        // `$HOSTNAME` is usually the FQDN; keep just the short label.
+        let short = h.split('.').next().unwrap_or(&h).trim();
+        if !short.is_empty() {
+            return short.to_string();
+        }
+    }
+    "localhost".to_string()
 }
 
 // ── Asset writing ─────────────────────────────────────────────────────────
@@ -164,32 +176,72 @@ pub fn write_assets() -> Result<()> {
     Ok(())
 }
 
+/// Escape a value for safe inclusion inside a single-quoted POSIX shell string.
+/// The template wraps every value in `'...'`; this returns the inner content
+/// with each `'` rewritten as `'\''` (close-quote, escaped quote, reopen). The
+/// rendered file is `source`d by the user's shell + start-alloy.sh, so anything
+/// less leaves a shell-injection hole (a token containing `"`, `` ` ``, `$`, or
+/// `'` could otherwise execute arbitrary code at every shell startup).
+fn sh_squote_inner(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
+/// Reject values that can't be safely represented on a single shell line.
+fn validate_cred_value(label: &str, v: &str) -> Result<()> {
+    if v.contains('\n') || v.contains('\r') {
+        anyhow::bail!("{label} contains a newline — paste the value on a single line");
+    }
+    Ok(())
+}
+
 /// Render the env template with creds + host and write it to grafana-cloud.env
 /// with 0600 perms. Returns the path written.
 pub fn write_env_file(creds: &GrafanaCloudCreds, host_name: &str) -> Result<PathBuf> {
     let dir = otel_dir()?;
     fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    write_env_file_to(&env_file_path()?, creds, host_name)
+}
+
+/// `write_env_file` against an explicit path (testable; no `$HOME` dependency).
+/// The caller is responsible for the parent directory existing.
+pub fn write_env_file_to(
+    path: &std::path::Path,
+    creds: &GrafanaCloudCreds,
+    host_name: &str,
+) -> Result<PathBuf> {
+    validate_cred_value("host.name", host_name.trim())?;
+    validate_cred_value("OTLP endpoint", creds.otlp_endpoint.trim())?;
+    validate_cred_value("Instance ID", creds.instance_id.trim())?;
+    validate_cred_value("API token", creds.api_token.trim())?;
 
     let rendered = ASSET_ENV_TEMPLATE
-        .replace("__HOST_NAME__", host_name.trim())
-        .replace("__GRAFANA_OTLP_ENDPOINT__", creds.otlp_endpoint.trim())
-        .replace("__GRAFANA_INSTANCE_ID__", creds.instance_id.trim())
-        .replace("__GRAFANA_API_TOKEN__", creds.api_token.trim());
+        .replace("__HOST_NAME__", &sh_squote_inner(host_name.trim()))
+        .replace(
+            "__GRAFANA_OTLP_ENDPOINT__",
+            &sh_squote_inner(creds.otlp_endpoint.trim()),
+        )
+        .replace(
+            "__GRAFANA_INSTANCE_ID__",
+            &sh_squote_inner(creds.instance_id.trim()),
+        )
+        .replace(
+            "__GRAFANA_API_TOKEN__",
+            &sh_squote_inner(creds.api_token.trim()),
+        );
 
-    let path = env_file_path()?;
     // Create with 0600 from the start so the token is never briefly world-readable.
     let mut f = fs::OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
         .mode(0o600)
-        .open(&path)
+        .open(path)
         .with_context(|| format!("opening {}", path.display()))?;
     f.write_all(rendered.as_bytes()).context("writing grafana-cloud.env")?;
     // Re-assert perms in case the file pre-existed with looser bits.
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
         .context("chmod grafana-cloud.env")?;
-    Ok(path)
+    Ok(path.to_path_buf())
 }
 
 /// Merge the generic (non-secret) OTEL keys into ~/.claude/settings.json's
@@ -201,10 +253,14 @@ pub fn ensure_settings_env() -> Result<Vec<String>> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
+    ensure_settings_env_at(&path)
+}
 
+/// `ensure_settings_env` against an explicit path (testable; no `$HOME`).
+pub fn ensure_settings_env_at(path: &std::path::Path) -> Result<Vec<String>> {
     let mut root: serde_json::Value = if path.exists() {
         let raw =
-            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         if raw.trim().is_empty() {
             serde_json::json!({})
         } else {
@@ -216,17 +272,30 @@ pub fn ensure_settings_env() -> Result<Vec<String>> {
     };
 
     if !root.is_object() {
-        anyhow::bail!("{} is not a JSON object", path.display());
+        anyhow::bail!(
+            "{} is not a JSON object — fix or remove it, then re-run",
+            path.display()
+        );
     }
+    let obj = root.as_object_mut().unwrap();
 
-    let env = root
-        .as_object_mut()
-        .unwrap()
-        .entry("env")
-        .or_insert_with(|| serde_json::json!({}));
-    let env = env
-        .as_object_mut()
-        .context("the `env` field in settings.json is not an object")?;
+    // A null `env` is treated as absent (safe to replace). A non-null,
+    // non-object `env` (array/string/number/bool) is a user value we must NOT
+    // clobber — bail with an actionable message instead of overwriting.
+    match obj.get("env") {
+        None | Some(serde_json::Value::Null) => {
+            obj.insert("env".to_string(), serde_json::json!({}));
+        }
+        Some(v) if v.is_object() => {}
+        Some(_) => anyhow::bail!(
+            "the `env` field in {} is not an object — fix or remove it, then re-run",
+            path.display()
+        ),
+    }
+    let env = obj
+        .get_mut("env")
+        .and_then(|e| e.as_object_mut())
+        .expect("env normalized to an object above");
 
     let mut added = Vec::new();
     for (k, v) in SETTINGS_ENV {
@@ -242,7 +311,7 @@ pub fn ensure_settings_env() -> Result<Vec<String>> {
     if !added.is_empty() {
         let mut out = serde_json::to_string_pretty(&root).context("serializing settings.json")?;
         out.push('\n');
-        fs::write(&path, out).with_context(|| format!("writing {}", path.display()))?;
+        fs::write(path, out).with_context(|| format!("writing {}", path.display()))?;
     }
     Ok(added)
 }
@@ -272,16 +341,35 @@ pub fn shell_rc_path() -> Result<PathBuf> {
 /// the marker is already present. Backs up the rc to `<rc>.bak` before the first
 /// append. Returns `true` if it appended (rc was modified).
 pub fn ensure_shell_rc_sources_env() -> Result<bool> {
-    let rc = shell_rc_path()?;
-    let env_file = env_file_path()?;
+    ensure_shell_rc_at(&shell_rc_path()?, &env_file_path()?)
+}
 
-    let existing = fs::read_to_string(&rc).unwrap_or_default();
+/// `ensure_shell_rc_sources_env` against explicit paths (testable).
+///
+/// Note: this read-check-append is not atomic across concurrent processes —
+/// two simultaneous setups could both pass the marker check and append twice.
+/// That race is acceptable for a single-user, interactive onboarding tool; if
+/// it ever matters, guard with an advisory file lock.
+pub fn ensure_shell_rc_at(rc: &std::path::Path, env_file: &std::path::Path) -> Result<bool> {
+    // NotFound -> treat as empty (we'll create it). Any other read error
+    // (permission denied, rc is a directory) is real — surface it rather than
+    // silently masking it as an empty file.
+    let existing = match fs::read_to_string(rc) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", rc.display())),
+    };
     if existing.contains(RC_MARKER) || existing.contains("otel/grafana-cloud.env") {
         return Ok(false);
     }
 
     if rc.exists() {
-        let _ = fs::copy(&rc, rc.with_extension("bak"));
+        // Build "<name>.bak" from the full file name — `with_extension` would
+        // turn `.zshrc` into `.zsh.bak` (and `.profile` into `.bak`).
+        if let Some(name) = rc.file_name() {
+            let bak = rc.with_file_name(format!("{}.bak", name.to_string_lossy()));
+            let _ = fs::copy(rc, bak);
+        }
     }
 
     let block = format!(
@@ -291,7 +379,7 @@ pub fn ensure_shell_rc_sources_env() -> Result<bool> {
     let mut f = fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&rc)
+        .open(rc)
         .with_context(|| format!("opening {}", rc.display()))?;
     f.write_all(block.as_bytes())
         .with_context(|| format!("appending to {}", rc.display()))?;
@@ -454,5 +542,134 @@ mod tests {
     fn config_alloy_asset_is_the_fan_in_pipeline() {
         assert!(ASSET_CONFIG_ALLOY.contains("otelcol.receiver.otlp"));
         assert!(ASSET_CONFIG_ALLOY.contains("deltatocumulative"));
+    }
+
+    #[test]
+    fn sh_squote_neutralizes_injection() {
+        // A single quote becomes '\'' so the value can't break out of '...'.
+        assert_eq!(sh_squote_inner("a'b$c`x`"), "a'\\''b$c`x`");
+    }
+
+    #[test]
+    fn write_env_file_is_0600_and_shell_safe() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grafana-cloud.env");
+        let creds = GrafanaCloudCreds {
+            otlp_endpoint: "https://e/otlp".into(),
+            instance_id: "12345".into(),
+            // Hostile token: quote + command-substitution + backticks.
+            api_token: "a'b$(rm -rf ~)`x`".into(),
+        };
+        write_env_file_to(&path, &creds, "my-host").unwrap();
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "env file must be 0600, got {mode:o}");
+
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(!body.contains("__"), "unresolved placeholder:\n{body}");
+        // The token stays inside single quotes with the embedded ' escaped, so
+        // $(...) / backticks are inert.
+        assert!(
+            body.contains("export GRAFANA_API_TOKEN='a'\\''b$(rm -rf ~)`x`'"),
+            "token not safely single-quoted:\n{body}"
+        );
+        assert!(body.contains("host.name=my-host"));
+    }
+
+    #[test]
+    fn write_env_file_rejects_newline_in_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("env");
+        let creds = GrafanaCloudCreds {
+            otlp_endpoint: "https://e/otlp".into(),
+            instance_id: "1".into(),
+            api_token: "line1\nexport EVIL=1".into(),
+        };
+        assert!(write_env_file_to(&path, &creds, "h").is_err());
+    }
+
+    #[test]
+    fn settings_env_merge_preserves_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(
+            &path,
+            r#"{"foo":"bar","env":{"EXISTING":"keep","OTEL_LOG_USER_PROMPTS":"0"}}"#,
+        )
+        .unwrap();
+
+        let added = ensure_settings_env_at(&path).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["foo"], "bar", "unrelated top-level key dropped");
+        assert_eq!(v["env"]["EXISTING"], "keep", "unrelated env key dropped");
+        // Must NOT clobber a user's existing value for one of our keys.
+        assert_eq!(v["env"]["OTEL_LOG_USER_PROMPTS"], "0");
+        assert!(!added.contains(&"OTEL_LOG_USER_PROMPTS".to_string()));
+        assert!(added.contains(&"CLAUDE_CODE_ENABLE_TELEMETRY".to_string()));
+
+        // Second run is a no-op.
+        assert!(ensure_settings_env_at(&path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn settings_env_creates_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let added = ensure_settings_env_at(&path).unwrap();
+        assert_eq!(added.len(), SETTINGS_ENV.len());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn settings_env_bails_on_non_object_env_without_clobber() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let original = r#"{"env":["x"]}"#;
+        fs::write(&path, original).unwrap();
+        assert!(ensure_settings_env_at(&path).is_err());
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            original,
+            "must not modify a file it refuses to merge"
+        );
+    }
+
+    #[test]
+    fn settings_env_treats_null_env_as_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, r#"{"env":null}"#).unwrap();
+        let added = ensure_settings_env_at(&path).unwrap();
+        assert_eq!(added.len(), SETTINGS_ENV.len());
+    }
+
+    #[test]
+    fn shell_rc_backup_name_is_full_filename_and_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let rc = dir.path().join(".zshrc");
+        fs::write(&rc, "# my rc\nexport FOO=1\n").unwrap();
+        let env_file = dir.path().join("grafana-cloud.env");
+
+        assert!(ensure_shell_rc_at(&rc, &env_file).unwrap());
+        // Backup must be `.zshrc.bak`, NOT `.zsh.bak`.
+        let bak = dir.path().join(".zshrc.bak");
+        assert!(bak.exists(), "backup not at .zshrc.bak");
+        assert_eq!(fs::read_to_string(&bak).unwrap(), "# my rc\nexport FOO=1\n");
+        assert!(fs::read_to_string(&rc).unwrap().contains("grafana-cloud.env"));
+
+        // Idempotent: second run does nothing, no duplicate source block.
+        assert!(!ensure_shell_rc_at(&rc, &env_file).unwrap());
+        let sources = fs::read_to_string(&rc).unwrap().matches("source").count();
+        assert_eq!(sources, 1, "duplicate source block appended");
+    }
+
+    #[test]
+    fn shell_rc_created_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let rc = dir.path().join(".bashrc");
+        let env_file = dir.path().join("grafana-cloud.env");
+        assert!(ensure_shell_rc_at(&rc, &env_file).unwrap());
+        assert!(rc.exists());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/otel/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/otel/mod.rs
@@ -1,0 +1,458 @@
+// ABOUTME: OpenTelemetry / Grafana Cloud setup — shared logic for the
+// `ainb otel` CLI and the TUI onboarding "OpenTelemetry" step.
+//
+// Pipeline this wires up:
+//   Claude Code --OTLP http://localhost:4318--> Grafana Alloy --> Grafana Cloud
+//
+// Split of where things live (the ONE rule that keeps secrets out of synced
+// files): ~/.claude/settings.json carries ONLY the generic, non-secret OTEL
+// env (exporter/protocol/intervals/log flags) — that file is synced back to a
+// PUBLIC repo, so nothing machine-specific or secret may land there. Everything
+// machine-specific (the local OTLP endpoint, the host.name resource attr) and
+// every secret (the Grafana Cloud creds) lives in
+// ~/.agents-in-a-box/otel/grafana-cloud.env (0600), which is sourced from the
+// user's shell rc and read directly by start-alloy.sh. Shell env wins over the
+// settings.json env block, so the shell file is authoritative per-machine.
+
+use std::fs;
+use std::io::Write as _;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+// ── Embedded assets (vendored from the hand-built setup) ────────────────────
+
+/// Grafana Alloy OTLP fan-in pipeline (Delta->Cumulative + Basic auth export).
+pub const ASSET_CONFIG_ALLOY: &str = include_str!("../../assets/otel/config.alloy");
+/// tmux launcher for Alloy. Reads grafana-cloud.env + config.alloy beside it.
+pub const ASSET_START_ALLOY: &str = include_str!("../../assets/otel/start-alloy.sh");
+/// grafana-cloud.env template with `__PLACEHOLDER__` tokens.
+pub const ASSET_ENV_TEMPLATE: &str = include_str!("../../assets/otel/grafana-cloud.env.template");
+/// Grafana dashboard JSON for Claude Code metrics (import into Grafana Cloud).
+pub const ASSET_DASH_CLAUDE: &str = include_str!("../../assets/otel/dashboards/claude-code.json");
+/// Grafana dashboard JSON for Codex metrics.
+pub const ASSET_DASH_CODEX: &str = include_str!("../../assets/otel/dashboards/codex.json");
+
+/// Generic, non-secret OTEL env merged into ~/.claude/settings.json. Safe to
+/// sync to a public repo — no endpoint, host, or credential lives here.
+pub const SETTINGS_ENV: &[(&str, &str)] = &[
+    ("CLAUDE_CODE_ENABLE_TELEMETRY", "1"),
+    ("CLAUDE_CODE_ENHANCED_TELEMETRY_BETA", "1"),
+    ("OTEL_METRICS_EXPORTER", "otlp"),
+    ("OTEL_LOGS_EXPORTER", "otlp"),
+    ("OTEL_TRACES_EXPORTER", "otlp"),
+    ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
+    (
+        "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+        "cumulative",
+    ),
+    ("OTEL_METRIC_EXPORT_INTERVAL", "10000"),
+    ("OTEL_LOGS_EXPORT_INTERVAL", "5000"),
+    ("OTEL_TRACES_EXPORT_INTERVAL", "5000"),
+    ("OTEL_LOG_USER_PROMPTS", "1"),
+    ("OTEL_LOG_TOOL_DETAILS", "1"),
+    ("OTEL_LOG_TOOL_CONTENT", "1"),
+    ("OTEL_METRICS_INCLUDE_VERSION", "1"),
+    ("OTEL_METRICS_INCLUDE_ENTRYPOINT", "1"),
+];
+
+/// Local OTLP endpoint every machine's Claude Code points at (the local Alloy).
+pub const LOCAL_OTLP_ENDPOINT: &str = "http://localhost:4318";
+/// Homebrew formula for Grafana Alloy.
+pub const ALLOY_BREW_FORMULA: &str = "grafana/grafana/alloy";
+/// tmux session name the launcher uses.
+pub const ALLOY_TMUX_SESSION: &str = "otel-alloy";
+/// Alloy local UI / health endpoint.
+pub const ALLOY_HEALTH_URL: &str = "http://127.0.0.1:12345";
+
+/// Telemetry provider. Only Grafana Cloud today; the enum reserves room.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelProvider {
+    GrafanaCloud,
+}
+
+/// Grafana Cloud OTLP credentials (the three values from the OTLP page).
+#[derive(Debug, Clone)]
+pub struct GrafanaCloudCreds {
+    /// OTLP endpoint URL (ends in `/otlp`).
+    pub otlp_endpoint: String,
+    /// Instance ID — the Basic-auth username on the OTLP page.
+    pub instance_id: String,
+    /// API/access token with metrics+logs+traces write scope.
+    pub api_token: String,
+}
+
+impl GrafanaCloudCreds {
+    /// True when all three fields are non-empty (after trim).
+    pub fn is_complete(&self) -> bool {
+        !self.otlp_endpoint.trim().is_empty()
+            && !self.instance_id.trim().is_empty()
+            && !self.api_token.trim().is_empty()
+    }
+}
+
+// ── Paths ───────────────────────────────────────────────────────────────────
+
+/// `~/.agents-in-a-box`.
+pub fn base_dir() -> Result<PathBuf> {
+    Ok(dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".agents-in-a-box"))
+}
+
+/// `~/.agents-in-a-box/otel`.
+pub fn otel_dir() -> Result<PathBuf> {
+    Ok(base_dir()?.join("otel"))
+}
+
+/// `~/.agents-in-a-box/otel/grafana-cloud.env`.
+pub fn env_file_path() -> Result<PathBuf> {
+    Ok(otel_dir()?.join("grafana-cloud.env"))
+}
+
+/// `~/.agents-in-a-box/otel/config.alloy`.
+pub fn config_path() -> Result<PathBuf> {
+    Ok(otel_dir()?.join("config.alloy"))
+}
+
+/// `~/.agents-in-a-box/otel/start-alloy.sh`.
+pub fn start_script_path() -> Result<PathBuf> {
+    Ok(otel_dir()?.join("start-alloy.sh"))
+}
+
+/// `~/.claude/settings.json`.
+pub fn claude_settings_path() -> Result<PathBuf> {
+    Ok(dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".claude/settings.json"))
+}
+
+/// Short machine hostname (`hostname -s`), falling back to `localhost`.
+pub fn detect_host_name() -> String {
+    Command::new("hostname")
+        .arg("-s")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "localhost".to_string())
+}
+
+// ── Asset writing ─────────────────────────────────────────────────────────
+
+/// Write the generic (non-secret) assets into `~/.agents-in-a-box/otel/`:
+/// config.alloy, start-alloy.sh (executable), and the two dashboards. Safe to
+/// re-run; overwrites with the embedded canonical copy.
+pub fn write_assets() -> Result<()> {
+    let dir = otel_dir()?;
+    let dash_dir = dir.join("dashboards");
+    fs::create_dir_all(&dash_dir).with_context(|| format!("creating {}", dash_dir.display()))?;
+
+    fs::write(config_path()?, ASSET_CONFIG_ALLOY).context("writing config.alloy")?;
+
+    let script = start_script_path()?;
+    fs::write(&script, ASSET_START_ALLOY).context("writing start-alloy.sh")?;
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+        .context("chmod start-alloy.sh")?;
+
+    fs::write(dash_dir.join("claude-code.json"), ASSET_DASH_CLAUDE)
+        .context("writing claude-code dashboard")?;
+    fs::write(dash_dir.join("codex.json"), ASSET_DASH_CODEX).context("writing codex dashboard")?;
+    Ok(())
+}
+
+/// Render the env template with creds + host and write it to grafana-cloud.env
+/// with 0600 perms. Returns the path written.
+pub fn write_env_file(creds: &GrafanaCloudCreds, host_name: &str) -> Result<PathBuf> {
+    let dir = otel_dir()?;
+    fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+
+    let rendered = ASSET_ENV_TEMPLATE
+        .replace("__HOST_NAME__", host_name.trim())
+        .replace("__GRAFANA_OTLP_ENDPOINT__", creds.otlp_endpoint.trim())
+        .replace("__GRAFANA_INSTANCE_ID__", creds.instance_id.trim())
+        .replace("__GRAFANA_API_TOKEN__", creds.api_token.trim());
+
+    let path = env_file_path()?;
+    // Create with 0600 from the start so the token is never briefly world-readable.
+    let mut f = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    f.write_all(rendered.as_bytes()).context("writing grafana-cloud.env")?;
+    // Re-assert perms in case the file pre-existed with looser bits.
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+        .context("chmod grafana-cloud.env")?;
+    Ok(path)
+}
+
+/// Merge the generic (non-secret) OTEL keys into ~/.claude/settings.json's
+/// `env` block. Adds only missing keys (never clobbers a user override), and
+/// only rewrites the file when something actually changed. Returns the keys
+/// that were added.
+pub fn ensure_settings_env() -> Result<Vec<String>> {
+    let path = claude_settings_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+
+    let mut root: serde_json::Value = if path.exists() {
+        let raw =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        if raw.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&raw)
+                .with_context(|| format!("parsing {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if !root.is_object() {
+        anyhow::bail!("{} is not a JSON object", path.display());
+    }
+
+    let env = root
+        .as_object_mut()
+        .unwrap()
+        .entry("env")
+        .or_insert_with(|| serde_json::json!({}));
+    let env = env
+        .as_object_mut()
+        .context("the `env` field in settings.json is not an object")?;
+
+    let mut added = Vec::new();
+    for (k, v) in SETTINGS_ENV {
+        if !env.contains_key(*k) {
+            env.insert(
+                (*k).to_string(),
+                serde_json::Value::String((*v).to_string()),
+            );
+            added.push((*k).to_string());
+        }
+    }
+
+    if !added.is_empty() {
+        let mut out = serde_json::to_string_pretty(&root).context("serializing settings.json")?;
+        out.push('\n');
+        fs::write(&path, out).with_context(|| format!("writing {}", path.display()))?;
+    }
+    Ok(added)
+}
+
+// ── Shell rc wiring ─────────────────────────────────────────────────────────
+
+/// Marker line that precedes the source line in the user's rc — used to detect
+/// (idempotency) and to label the block.
+const RC_MARKER: &str =
+    "# agents-in-a-box: Claude Code OTEL env (machine-specific + Grafana Cloud creds)";
+
+/// Pick the shell rc to wire based on `$SHELL`.
+pub fn shell_rc_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let file = if shell.ends_with("zsh") {
+        ".zshrc"
+    } else if shell.ends_with("bash") {
+        ".bashrc"
+    } else {
+        ".profile"
+    };
+    Ok(home.join(file))
+}
+
+/// Ensure the user's shell rc sources grafana-cloud.env. Idempotent: a no-op if
+/// the marker is already present. Backs up the rc to `<rc>.bak` before the first
+/// append. Returns `true` if it appended (rc was modified).
+pub fn ensure_shell_rc_sources_env() -> Result<bool> {
+    let rc = shell_rc_path()?;
+    let env_file = env_file_path()?;
+
+    let existing = fs::read_to_string(&rc).unwrap_or_default();
+    if existing.contains(RC_MARKER) || existing.contains("otel/grafana-cloud.env") {
+        return Ok(false);
+    }
+
+    if rc.exists() {
+        let _ = fs::copy(&rc, rc.with_extension("bak"));
+    }
+
+    let block = format!(
+        "\n{RC_MARKER}\n[ -f \"{ef}\" ] && source \"{ef}\"\n",
+        ef = env_file.display()
+    );
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&rc)
+        .with_context(|| format!("opening {}", rc.display()))?;
+    f.write_all(block.as_bytes())
+        .with_context(|| format!("appending to {}", rc.display()))?;
+    Ok(true)
+}
+
+// ── Alloy lifecycle ─────────────────────────────────────────────────────────
+
+/// Is the `alloy` binary on PATH?
+pub fn alloy_installed() -> bool {
+    which::which("alloy").is_ok()
+}
+
+/// Best-effort `brew install grafana/grafana/alloy`. Inherits stdio so the user
+/// sees brew's progress. Errors if brew is missing or the install fails.
+pub fn brew_install_alloy() -> Result<()> {
+    if which::which("brew").is_err() {
+        anyhow::bail!(
+            "Homebrew not found — install alloy yourself: brew install {ALLOY_BREW_FORMULA}"
+        );
+    }
+    let status = Command::new("brew")
+        .args(["install", ALLOY_BREW_FORMULA])
+        .status()
+        .context("running brew install")?;
+    if !status.success() {
+        anyhow::bail!("brew install {ALLOY_BREW_FORMULA} failed");
+    }
+    Ok(())
+}
+
+/// Is the Alloy tmux session running?
+pub fn alloy_session_running() -> bool {
+    // `tmux has-session` writes "can't find session" to stderr on a miss —
+    // silence it; the exit status is the signal we care about.
+    Command::new("tmux")
+        .args(["has-session", "-t", ALLOY_TMUX_SESSION])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Run start-alloy.sh (launches Alloy in its own tmux session). Inherits stdio.
+pub fn start_alloy() -> Result<()> {
+    let script = start_script_path()?;
+    if !script.exists() {
+        anyhow::bail!("{} missing — run write_assets() first", script.display());
+    }
+    let status = Command::new("bash")
+        .arg(&script)
+        .status()
+        .with_context(|| format!("running {}", script.display()))?;
+    if !status.success() {
+        anyhow::bail!("start-alloy.sh exited with failure");
+    }
+    Ok(())
+}
+
+/// A snapshot of the OTEL pipeline's local state, for `ainb otel status` /
+/// `ainb doctor`.
+#[derive(Debug, Clone)]
+pub struct OtelStatus {
+    pub env_file_present: bool,
+    pub config_present: bool,
+    pub alloy_installed: bool,
+    pub alloy_running: bool,
+    pub settings_env_present: bool,
+}
+
+/// Probe local OTEL state without mutating anything.
+pub fn status() -> OtelStatus {
+    let env_file_present = env_file_path().map(|p| p.exists()).unwrap_or(false);
+    let config_present = config_path().map(|p| p.exists()).unwrap_or(false);
+    let settings_env_present = claude_settings_path()
+        .ok()
+        .and_then(|p| fs::read_to_string(p).ok())
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|v| {
+            v.get("env").and_then(|e| e.get("CLAUDE_CODE_ENABLE_TELEMETRY")).map(|_| true)
+        })
+        .unwrap_or(false);
+    OtelStatus {
+        env_file_present,
+        config_present,
+        alloy_installed: alloy_installed(),
+        alloy_running: alloy_session_running(),
+        settings_env_present,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_env_has_no_secret_or_machine_keys() {
+        // The settings.json set must stay public-repo-safe: no endpoint, host,
+        // or credential keys.
+        for (k, v) in SETTINGS_ENV {
+            assert!(
+                !k.contains("ENDPOINT"),
+                "endpoint key leaked into settings env: {k}"
+            );
+            assert!(!k.contains("RESOURCE_ATTRIBUTES"), "host attr leaked: {k}");
+            assert!(!k.contains("GRAFANA"), "grafana cred leaked: {k}");
+            assert!(!v.contains("grafana.net"), "endpoint value leaked: {v}");
+        }
+    }
+
+    #[test]
+    fn env_template_has_all_placeholders() {
+        for token in [
+            "__HOST_NAME__",
+            "__GRAFANA_OTLP_ENDPOINT__",
+            "__GRAFANA_INSTANCE_ID__",
+            "__GRAFANA_API_TOKEN__",
+        ] {
+            assert!(
+                ASSET_ENV_TEMPLATE.contains(token),
+                "template missing {token}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_replaces_every_placeholder() {
+        let creds = GrafanaCloudCreds {
+            otlp_endpoint: "https://otlp-gateway-test.grafana.net/otlp".to_string(),
+            instance_id: "123456".to_string(),
+            api_token: "glc_secret".to_string(),
+        };
+        let rendered = ASSET_ENV_TEMPLATE
+            .replace("__HOST_NAME__", "my-host")
+            .replace("__GRAFANA_OTLP_ENDPOINT__", &creds.otlp_endpoint)
+            .replace("__GRAFANA_INSTANCE_ID__", &creds.instance_id)
+            .replace("__GRAFANA_API_TOKEN__", &creds.api_token);
+        assert!(
+            !rendered.contains("__"),
+            "unresolved placeholder remains:\n{rendered}"
+        );
+        assert!(rendered.contains("host.name=my-host"));
+        assert!(rendered.contains("glc_secret"));
+    }
+
+    #[test]
+    fn creds_completeness() {
+        let mut c = GrafanaCloudCreds {
+            otlp_endpoint: " ".to_string(),
+            instance_id: "x".to_string(),
+            api_token: "y".to_string(),
+        };
+        assert!(!c.is_complete());
+        c.otlp_endpoint = "https://e/otlp".to_string();
+        assert!(c.is_complete());
+    }
+
+    #[test]
+    fn config_alloy_asset_is_the_fan_in_pipeline() {
+        assert!(ASSET_CONFIG_ALLOY.contains("otelcol.receiver.otlp"));
+        assert!(ASSET_CONFIG_ALLOY.contains("deltatocumulative"));
+    }
+}

--- a/docs/reference/otel-grafana.md
+++ b/docs/reference/otel-grafana.md
@@ -1,0 +1,78 @@
+# OpenTelemetry → Grafana Cloud
+
+Ship Claude Code (and Codex) metrics, logs, and traces to Grafana Cloud via a
+local [Grafana Alloy](https://grafana.com/docs/alloy/) collector. Wired into
+both the `ainb` CLI and the first-run TUI onboarding wizard.
+
+```
+┌────────────┐  OTLP            ┌──────────────┐            ┌──────────────┐
+│ Claude Code│ ──:4318/:4317──▶ │ Grafana Alloy│ ──OTLP───▶ │ Grafana Cloud│
+│  (+ Codex) │                  │  (local tmux)│  + auth    │              │
+└────────────┘                  └──────────────┘            └──────────────┘
+```
+
+## What you need
+
+| Thing | Why | How to get it |
+|-------|-----|---------------|
+| Grafana Cloud account | Destination for telemetry | Free tier at grafana.com |
+| OTLP endpoint URL | Where Alloy ships data | Grafana Cloud → **Connections → OpenTelemetry (OTLP)** (ends in `/otlp`) |
+| Instance ID | Basic-auth username | Same OTLP page ("Instance ID") |
+| API token | Basic-auth password | Same page → generate a token with **metrics + logs + traces** write scope |
+| `alloy` binary | The local collector | `brew install grafana/grafana/alloy` (the CLI offers to install it) |
+
+> The three Grafana values come from one screen: **Connections → OpenTelemetry
+> (OTLP)** in your Grafana Cloud stack. The "Instance ID" there is the Basic-auth
+> username — it is NOT your org id.
+
+## Setup (CLI)
+
+```bash
+ainb otel setup            # interactive, full-auto
+ainb otel status           # check the local pipeline
+ainb otel start            # (re)start Alloy in its tmux session
+```
+
+`ainb otel setup` will:
+
+1. Write the Alloy config + launcher + dashboards to `~/.agents-in-a-box/otel/`.
+2. Prompt for the three Grafana Cloud values (or read them from
+   `GRAFANA_OTLP_ENDPOINT` / `GRAFANA_INSTANCE_ID` / `GRAFANA_API_TOKEN` env
+   vars if set).
+3. Write `~/.agents-in-a-box/otel/grafana-cloud.env` (mode `0600` — secrets).
+4. Ensure the generic, non-secret OTEL keys are in `~/.claude/settings.json`.
+5. Wire your shell rc to `source` the env file (backed up to `<rc>.bak`).
+6. Offer to `brew install` Alloy if missing, then start it in tmux.
+
+## Setup (TUI)
+
+The onboarding wizard has an optional **Telemetry** step. Fill the three fields
+(Tab to move between them) and press Enter to set up, or press Enter with the
+fields empty to skip. Re-run later any time with `ainb otel setup`.
+
+The TUI does not `brew install` Alloy — if it's missing the config is still
+written; finish with `ainb otel setup` or `brew install grafana/grafana/alloy`
+then `ainb otel start`.
+
+## Where things live (and why)
+
+| File | Contents | Secret? |
+|------|----------|---------|
+| `~/.claude/settings.json` (`env`) | Generic OTEL flags (exporter/protocol/intervals/log toggles) | **No** — this file syncs to a public repo, so nothing machine-specific or secret goes here |
+| `~/.agents-in-a-box/otel/grafana-cloud.env` | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES` (host.name), `GRAFANA_*` creds | **Yes** — `0600`, never committed, sourced by your shell + read by Alloy |
+| `~/.agents-in-a-box/otel/config.alloy` | Alloy OTLP fan-in pipeline (Delta→Cumulative for Mimir) | No |
+| `~/.agents-in-a-box/otel/dashboards/*.json` | Grafana dashboards to import (Claude Code + Codex) | No |
+
+Shell env wins over the `settings.json` env block, so the machine-specific
+values in `grafana-cloud.env` are authoritative per machine.
+
+## Verify
+
+```bash
+ainb otel status        # env file / config / alloy install + tmux session
+ainb doctor             # alloy shows under the "otel" consumer group
+```
+
+Alloy's local UI/health is at <http://127.0.0.1:12345>. Import the dashboards
+under `~/.agents-in-a-box/otel/dashboards/` into your Grafana Cloud stack to see
+the data.


### PR DESCRIPTION
## What

Wire OpenTelemetry → Grafana Cloud setup into both the `ainb` CLI and the
first-run TUI onboarding wizard.

```
Claude Code (+ Codex) --OTLP :4318--> Grafana Alloy --Basic auth--> Grafana Cloud
```

## Surfaces

- **CLI**: `ainb otel {setup,status,start}`
  - `setup` (full-auto): writes the Alloy pipeline to `~/.agents-in-a-box/otel/`,
    prompts for the 3 Grafana Cloud values (or reads `GRAFANA_*` env), writes
    `grafana-cloud.env` (0600), ensures the generic OTEL keys in
    `~/.claude/settings.json`, wires the shell rc to source the env file, offers
    to `brew install` Alloy (consent), then starts it in tmux.
  - `status` probes local pipeline state; `start` (re)launches Alloy.
- **TUI**: optional **Telemetry** step in onboarding (after Authentication).
  3-field form (OTLP endpoint, instance id, masked token) with where-to-get
  guidance. Enter with empty fields skips; filling all three writes the pipeline
  on finish. The TUI does NOT brew-install (deferred — see follow-up bead).
- **doctor**: new `Consumer::Otel` + optional `alloy` dep.
- **docs**: `docs/reference/otel-grafana.md`.

## Design: secrets never touch settings.json

`~/.claude/settings.json` syncs to this public repo, so it carries ONLY the 15
generic, non-secret OTEL keys. The OTLP endpoint, `host.name` resource attr, and
the Grafana Cloud credentials live exclusively in `grafana-cloud.env` (0600),
sourced from the shell rc and read by Alloy. Shell env wins over the settings.json
env block, so the shell file is authoritative per-machine. A unit test
(`settings_env_has_no_secret_or_machine_keys`) enforces the split.

## Tests / checks

- `cargo build` + `cargo fmt --check` clean.
- New unit tests: otel module (5), onboarding state OTEL field input (1),
  registry count updated (27 → 28).
- Clippy `-D warnings` debt is pre-existing in untouched files; CI gates on
  `cargo fmt --check`, not clippy (see ci.yml).

## Follow-up

Bead filed for deferred TUI-onboarding polish (brew-install in TUI, live
post-setup status, tmux-verify tripwire).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Grafana Cloud telemetry integration with new `ainb otel` CLI commands for setup, status, and monitoring
  * Telemetry configuration now available as an optional step in the onboarding wizard
  * Pre-configured Grafana dashboards for monitoring Claude Code and Codex usage, costs, and performance metrics

* **Documentation**
  * New guide for setting up and managing Grafana Cloud telemetry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->