### PR TITLE
chore: set teammateMode in-process, register ponytail plugin

### DIFF
--- a/toolkit/claude-code-4.5/settings.json
+++ b/toolkit/claude-code-4.5/settings.json
@@ -227,7 +227,8 @@
     "ainb-fleet@agents-in-a-box": true,
     "ainb-hooks@agents-in-a-box": true,
     "caveman-stats@agents-in-a-box": true,
-    "caveman@caveman": true
+    "caveman@caveman": true,
+    "ponytail@ponytail": true
   },
   "extraKnownMarketplaces": {
     "agents-in-a-box": {
@@ -241,10 +242,16 @@
         "source": "github",
         "repo": "JuliusBrussee/caveman"
       }
+    },
+    "ponytail": {
+      "source": {
+        "source": "github",
+        "repo": "DietrichGebert/ponytail"
+      }
     }
   },
   "skipDangerousModePermissionPrompt": true,
-  "teammateMode": "auto",
+  "teammateMode": "in-process",
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
   "inputNeededNotifEnabled": true,


### PR DESCRIPTION
## What

Sync two Claude Code config changes into the canonical toolkit settings.

- `teammateMode`: `auto` → `in-process` — spawned teammates run in-process rather than tmux.
- Register the `ponytail` plugin: `ponytail@ponytail` in `enabledPlugins` + `DietrichGebert/ponytail` github marketplace.

## Deliberately excluded (machine-local / not portable)

- `OTEL_RESOURCE_ATTRIBUTES=host.name=...` and `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` — per the OTEL→Grafana design these live in `~/.agents-in-a-box/otel/grafana-cloud.env` (shell-sourced, 0600), not in the synced settings file.
- `agents-in-a-box` marketplace local `directory` path — repo keeps the `github` source.

## Scope

Single file: `toolkit/claude-code-4.5/settings.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to enable new plugin integration
  * Added new marketplace source to toolkit resources
  * Modified teammate mode operational behavior setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->