### PR TITLE
fix(docs): unblock the docsite build (otel-grafana frontmatter)

### DIFF
--- a/docs/reference/otel-grafana.md
+++ b/docs/reference/otel-grafana.md
@@ -1,4 +1,6 @@
-# OpenTelemetry → Grafana Cloud
+---
+title: "OpenTelemetry → Grafana Cloud"
+---
 
 Ship Claude Code (and Codex) metrics, logs, and traces to Grafana Cloud via a
 local [Grafana Alloy](https://grafana.com/docs/alloy/) collector. Wired into


### PR DESCRIPTION
The GitHub Pages deploy has been **failing since before #304** — `docs/reference/otel-grafana.md` has no frontmatter, but Starlight's `reference/` collection requires a `title` (`InvalidContentEntryDataError: title Required`). So the docsite never redeployed (which is why recent doc changes — incl. the reflect-extraction refresh — aren't live yet).

Fix: add the `title` frontmatter. Verified locally: `astro build` now green (59 pages). Merging this lets the whole site (including the refreshed knowledge/overview + its new SVG) deploy.

https://claude.ai/code/session_01223aCWFSQkJZjQ7GN2hxv5