### PR TITLE
feat: per-session Headroom proxy + RTK token optimisation (fault-tolerant, observable)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -48,7 +48,11 @@ pub enum AppEvent {
     McpOverlayStopServer,
     McpOverlayStopDaemon,
     McpOverlayImport, // Import cwd .mcp.json + Claude user-scope into the global user config
-    RefreshWorkspaces, // Manual refresh of workspace data
+    // Daemons overlay (MCP pool + Headroom, read-only)
+    DaemonsOverlayOpen,
+    DaemonsOverlayClose,
+    DaemonsOverlayRefresh,
+    RefreshWorkspaces,  // Manual refresh of workspace data
     CycleSessionFilter, // Cycle Interactive session filter (Shift+F): All → ActiveOnly → StoppedOnly
     ToggleClaudeChat,   // Toggle Claude chat visibility
     NewSession,         // Create session in current directory
@@ -1230,6 +1234,17 @@ impl EventHandler {
                 KeyCode::Char('s') => Some(AppEvent::McpOverlayStopServer),
                 KeyCode::Char('X') => Some(AppEvent::McpOverlayStopDaemon),
                 KeyCode::Char('i') => Some(AppEvent::McpOverlayImport),
+                _ => None,
+            };
+        }
+
+        // Daemons overlay captures all keys while open (read-only: only r and esc/q).
+        if state.daemons_overlay.is_some() {
+            return match key_event.code {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('d') => {
+                    Some(AppEvent::DaemonsOverlayClose)
+                }
+                KeyCode::Char('r') => Some(AppEvent::DaemonsOverlayRefresh),
                 _ => None,
             };
         }
@@ -2630,6 +2645,8 @@ impl EventHandler {
             // overlay. `m` is taken by the learnings/Memory browser, so the
             // pool tile + global keybind use `p` instead.
             KeyCode::Char('p') => return Some(AppEvent::McpOverlayOpen),
+            // `d` for "daemons" — opens the MCP pool + Headroom status overlay.
+            KeyCode::Char('d') => return Some(AppEvent::DaemonsOverlayOpen),
             KeyCode::Char('v') => return Some(AppEvent::ShowChangelog),
             KeyCode::Char('?') => return Some(AppEvent::ToggleHelp),
             KeyCode::Char('q') => return Some(AppEvent::Quit),
@@ -2899,6 +2916,9 @@ impl EventHandler {
             // from anywhere. cwd's .mcp.json is still pulled in as a source.
             // Additive (never overwrites), so it fires without a confirmation.
             AppEvent::McpOverlayImport => state.mcp_import(true),
+            AppEvent::DaemonsOverlayOpen => state.toggle_daemons_overlay(),
+            AppEvent::DaemonsOverlayClose => state.close_daemons_overlay(),
+            AppEvent::DaemonsOverlayRefresh => state.spawn_daemons_fetch(),
             AppEvent::ToggleClaudeChat => state.toggle_claude_chat(),
             AppEvent::ToggleExpandAll => state.toggle_expand_all_workspaces(),
             AppEvent::ToggleSessionsSidebar => {
@@ -4127,6 +4147,9 @@ impl EventHandler {
                         // Opens the overlay on top of the current screen (not a
                         // screen switch) and fires the first lazy fetch.
                         state.toggle_mcp_overlay();
+                    }
+                    SidebarItem::Daemons => {
+                        state.toggle_daemons_overlay();
                     }
                     SidebarItem::Logs => {
                         // Initialize log history viewer with log directory

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -62,6 +62,10 @@ pub enum AppEvent {
     KillContainer,
     ReauthenticateCredentials,
     RestartSession,
+    /// Flip headroom off for the selected running session and respawn its CLI
+    /// process directly (no proxy env). Only valid for Claude/Codex sessions
+    /// that currently have headroom_enabled=true in the SessionStore.
+    DowngradeHeadroom,
     DeleteSession,
     ResumeSession(String), // Resume a Stopped interactive session (carries trigger key: "Enter" or "r")
     ResumeSelectedSessions(String), // Resume all multi-selected Stopped interactive sessions (carries trigger key)
@@ -1334,6 +1338,30 @@ impl EventHandler {
         }
 
         if !in_text_input {
+            // Session-list-specific intercept for `H`: downgrade Headroom
+            // routing on the selected running session. Must be checked before
+            // the global `H` → ToggleHelp handler below because the global
+            // handler fires first and the session-list has no early-return
+            // path of its own. Only intercepts on the SESSION_LIST screen when
+            // the selected session is a Headroom-capable agent (Claude/Codex).
+            if matches!(key_event.code, KeyCode::Char('H'))
+                && state.current_screen == screen_ids::SESSION_LIST
+            {
+                use crate::models::session::SessionAgentType;
+                let is_headroom_capable = state
+                    .selected_session()
+                    .map(|s| {
+                        matches!(
+                            s.agent_type,
+                            SessionAgentType::Claude | SessionAgentType::Codex
+                        )
+                    })
+                    .unwrap_or(false);
+                if is_headroom_capable {
+                    return Some(AppEvent::DowngradeHeadroom);
+                }
+            }
+
             // Global help toggle: `?` or `Shift+H` from any non-text view.
             if matches!(key_event.code, KeyCode::Char('?' | 'H')) {
                 return Some(AppEvent::ToggleHelp);
@@ -3280,6 +3308,11 @@ impl EventHandler {
             AppEvent::RestartSession => {
                 if let Some(session_id) = state.get_selected_session_id() {
                     state.pending_async_action = Some(AsyncAction::RestartSession(session_id));
+                }
+            }
+            AppEvent::DowngradeHeadroom => {
+                if let Some(session_id) = state.get_selected_session_id() {
+                    state.pending_async_action = Some(AsyncAction::DowngradeHeadroom(session_id));
                 }
             }
             AppEvent::DeleteSession => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3333,6 +3333,7 @@ struct ConfigureLaunchSnapshot {
     /// The base-branch popup pick (2026-06). `None` = legacy base policy:
     /// HEAD for local repos, origin/HEAD for remote/star launches.
     base: Option<crate::components::new_session::configure::BaseSelection>,
+    headroom_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7047,6 +7048,7 @@ impl AppState {
             session_model,
             codex_model,
             base: spec.base.clone(),
+            headroom_enabled: spec.headroom_enabled,
         };
 
         // Boss mode builds its own Docker workspace from `repo_path` and
@@ -7201,6 +7203,7 @@ impl AppState {
                 snapshot.codex_model,
                 existing_worktree,
                 base_start_point,
+                snapshot.headroom_enabled,
             )
             .await;
 
@@ -7823,6 +7826,7 @@ impl AppState {
         codex_model: Option<crate::models::CodexModel>,
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
         base_start_point: Option<String>,
+        headroom_enabled: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Branch based on session mode
         match mode {
@@ -7837,6 +7841,7 @@ impl AppState {
                     codex_model,
                     existing_worktree,
                     base_start_point,
+                    headroom_enabled,
                 )
                 .await
             }
@@ -7877,6 +7882,7 @@ impl AppState {
         codex_model: Option<crate::models::CodexModel>,
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
         base_start_point: Option<String>,
+        headroom_enabled: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::interactive::InteractiveSessionManager;
 
@@ -7936,6 +7942,7 @@ impl AppState {
                     agent_type,
                     model,
                     codex_model,
+                    headroom_enabled,
                 )
                 .await
         } else {
@@ -7952,6 +7959,7 @@ impl AppState {
                     agent_type,
                     model,
                     codex_model,
+                    headroom_enabled,
                 )
                 .await
         };
@@ -8654,6 +8662,7 @@ impl AppState {
                     codex_model,
                     metadata.agent_type,
                     transcript.clone(),
+                    metadata.headroom_enabled,
                 )
                 .await?;
 
@@ -10147,7 +10156,21 @@ impl AppState {
         if skip_permissions {
             cmd_parts.push(provider.skip_permissions_flag().to_string());
         }
-        let cli_cmd = cmd_parts.join(" ");
+        // Preserve per-session Headroom routing across restart. `send-keys`
+        // bypasses build_env_setup_for_provider, so re-derive the proxy export
+        // from the persisted SessionMetadata (keyed by tmux name) and prepend
+        // it — otherwise a restarted HR session would silently stop routing
+        // through the proxy.
+        let headroom_enabled = crate::interactive::SessionStore::load()
+            .sessions
+            .get(&tmux_session_name)
+            .map(|m| m.headroom_enabled)
+            .unwrap_or(false);
+        let cli_cmd = format!(
+            "{}{}",
+            crate::interactive::session_manager::headroom_env_prefix(agent_type, headroom_enabled),
+            cmd_parts.join(" ")
+        );
 
         info!(
             "Restarting {} in tmux session '{}' for workspace '{}' (cmd: {})",

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -4968,9 +4968,14 @@ impl AppState {
 
     /// Headroom proxy watchdog. If a Headroom-enabled session is live but the
     /// shared proxy went down, re-ensure it. Throttled to ~10s, async, and
-    /// best-effort so it never blocks the render loop. Self-healing: claude's
-    /// Anthropic SDK retries connection errors with backoff, so a respawn
-    /// inside the retry window is transparent to the session.
+    /// best-effort so it never blocks the render loop.
+    ///
+    /// This is a self-heal, not a zero-loss guarantee: a request a session
+    /// makes while the proxy is down (before the next ~10s tick respawns it)
+    /// fails at the CLI and is retried by the agent/user — recovery is "the
+    /// next request succeeds", not "the in-flight request is rescued". The
+    /// statusline reflects actual routing, so an outage surfaces rather than
+    /// silently dropping compression.
     ///
     /// In-loop tick, NOT a separate daemon — surfaced as the "watched" marker
     /// on the Headroom row of the Daemons screen, per the daemons-screen rule.
@@ -10339,14 +10344,32 @@ impl AppState {
         // from the persisted SessionMetadata (keyed by tmux name) and prepend
         // it — otherwise a restarted HR session would silently stop routing
         // through the proxy.
-        let headroom_enabled = crate::interactive::SessionStore::load()
+        //
+        // Mirror the launch path (`start_cli_in_tmux`): the stored flag is
+        // *intent*; only inject the base URL when the proxy is actually
+        // healthy. Injecting a dead-port URL would brick the restarted CLI on
+        // connection-refused. Ensure the proxy first; degrade to direct on
+        // failure rather than pointing the session at a closed port.
+        let mut headroom_active = crate::interactive::SessionStore::load()
             .sessions
             .get(&tmux_session_name)
             .map(|m| m.headroom_enabled)
-            .unwrap_or(false);
+            .unwrap_or(false)
+            && matches!(
+                agent_type,
+                SessionAgentType::Claude | SessionAgentType::Codex
+            );
+        if headroom_active {
+            if let Err(e) = crate::headroom::ensure_proxy_running().await {
+                warn!(
+                    "headroom proxy unavailable on restart — running DIRECT, no compression: {e}"
+                );
+                headroom_active = false;
+            }
+        }
         let cli_cmd = format!(
             "{}{}",
-            crate::interactive::session_manager::headroom_env_prefix(agent_type, headroom_enabled),
+            crate::interactive::session_manager::headroom_env_prefix(agent_type, headroom_active),
             cmd_parts.join(" ")
         );
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3423,8 +3423,13 @@ pub enum AsyncAction {
     AuthSetupApiKey,                       // Save API key authentication
     ReauthenticateCredentials,             // Re-authenticate Claude credentials
     RestartSession(Uuid),                  // Restart a stopped session with new container
-    CleanupOrphaned,                       // Clean up orphaned containers without worktrees
-    AttachToOtherTmux(String),             // Attach to a non-agents-in-a-box tmux session by name
+    /// Flip headroom off in the SessionStore, then respawn the session's CLI
+    /// process with `tmux respawn-pane -k` (no proxy env) so the running
+    /// process is replaced. Claude gets `--continue` to preserve the
+    /// conversation; Codex restarts fresh (no continue flag exists).
+    DowngradeHeadroom(Uuid),
+    CleanupOrphaned,           // Clean up orphaned containers without worktrees
+    AttachToOtherTmux(String), // Attach to a non-agents-in-a-box tmux session by name
     AttachWitr, // Launch `witr -i` (process-causality browser) in a dedicated tmux session and attach full-screen
     AttachAbtop, // Launch `abtop --exit-on-jump` (top-for-agents monitor) in a dedicated tmux session and attach full-screen
     SetupAbtopRateLimits, // Run `abtop --setup` (rate-limit StatusLine hook) in a detached tmux pane, then queue AttachAbtop
@@ -9143,6 +9148,16 @@ impl AppState {
                         error!("Failed to restart session: {}", e);
                     }
                 }
+                AsyncAction::DowngradeHeadroom(session_id) => {
+                    info!("Downgrading Headroom for session {}", session_id);
+                    if let Err(e) = self.downgrade_headroom_session(session_id).await {
+                        error!(
+                            "Failed to downgrade Headroom for session {}: {}",
+                            session_id, e
+                        );
+                        self.add_error_notification(format!("Failed to downgrade Headroom: {}", e));
+                    }
+                }
                 AsyncAction::CleanupOrphaned => {
                     info!("Starting cleanup of orphaned containers");
                     if let Err(e) = self.cleanup_orphaned_containers().await {
@@ -10355,6 +10370,167 @@ impl AppState {
             tmux_session_name
         );
         Ok(provider.display_name().to_string())
+    }
+
+    /// Flip headroom off for a running session and replace its CLI process.
+    ///
+    /// Steps:
+    /// 1. Resolve the session and validate it is Claude or Codex.
+    /// 2. Load the SessionStore; check that headroom_enabled is true.
+    /// 3. Set headroom_enabled = false and save the store.
+    /// 4. Build the resume command: `[provider] [--skip-perms] [--continue for Claude]`.
+    ///    No env prefix (headroom is now off → `headroom_env_prefix(…, false)` == "").
+    /// 5. Replace the running CLI with `tmux respawn-pane -k` using the same
+    ///    `sh -c '…exec cli …'` shape as `start_cli_in_tmux`.
+    ///    `respawn-pane -k` kills the running process and starts fresh in-place,
+    ///    which is the only way to clear env vars from a running process.
+    ///    Codex has no `--continue` flag — it restarts fresh (noted in notification).
+    async fn downgrade_headroom_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
+        use crate::config::CliProvider;
+        use crate::models::session::SessionAgentType;
+        use anyhow::Context;
+        use tokio::process::Command;
+
+        // --- 1. Resolve session ---
+        let session = self
+            .find_session(session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        let tmux_session_name = session
+            .tmux_session_name
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No tmux session associated with this session"))?
+            .clone();
+
+        let agent_type = session.agent_type;
+        let skip_permissions = session.skip_permissions;
+
+        // --- 1a. Only Claude/Codex are Headroom-capable ---
+        let provider = match agent_type {
+            SessionAgentType::Claude => CliProvider::Claude,
+            SessionAgentType::Codex => CliProvider::Codex,
+            other => {
+                self.add_warning_notification(format!(
+                    "Headroom is Claude/Codex only — {:?} does not use the proxy",
+                    other
+                ));
+                return Ok(());
+            }
+        };
+
+        // --- 2. Check and flip headroom_enabled in SessionStore ---
+        let mut store = crate::interactive::SessionStore::load();
+        match store.sessions.get(&tmux_session_name) {
+            None => {
+                self.add_warning_notification(
+                    "Session not found in store — Headroom state unknown".to_string(),
+                );
+                return Ok(());
+            }
+            Some(meta) if !meta.headroom_enabled => {
+                self.add_info_notification("Session is already direct (Headroom off)".to_string());
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        // --- 3. Persist headroom_enabled = false ---
+        if let Some(meta) = store.sessions.get_mut(&tmux_session_name) {
+            meta.headroom_enabled = false;
+        }
+        if let Err(e) = store.save() {
+            // Non-fatal: we still attempt the respawn; the flag will be
+            // re-read from a stale store on the next restart, so log clearly.
+            warn!(
+                "Failed to persist headroom_enabled=false for {}: {}",
+                tmux_session_name, e
+            );
+        }
+
+        // --- 4. Build the resume command (no env prefix — headroom is off) ---
+        //
+        // env_setup is intentionally empty: `headroom_env_prefix(…, false)` == ""
+        // and we are not injecting an API key here (the original launch path
+        // already injected it into the pane's environment; `respawn-pane -k`
+        // inherits from the ainb-tui process which has the correct key).
+        let mut cmd_parts: Vec<String> = vec![provider.command().to_string()];
+        if skip_permissions {
+            cmd_parts.push(provider.skip_permissions_flag().to_string());
+        }
+        // Claude: `--continue` (-c) resumes the most recent conversation in the cwd.
+        // Codex: no continue/resume flag exists — restarts fresh.
+        let codex_fresh_note = if agent_type == SessionAgentType::Claude {
+            cmd_parts.push("--continue".to_string());
+            ""
+        } else {
+            " (Codex restarted fresh — no --continue flag)"
+        };
+
+        let cli_cmd = cmd_parts.join(" ");
+
+        info!(
+            "Downgrading Headroom for {} in '{}': cmd={}",
+            provider.display_name(),
+            tmux_session_name,
+            cli_cmd
+        );
+
+        // --- 5. Replace the running CLI via tmux respawn-pane -k ---
+        //
+        // Mirrors `start_cli_in_tmux` exactly:
+        //   - `remain-on-exit on` first so any startup error stays visible.
+        //   - `respawn-pane -k -t <name> sh -c 'exec <cmd>'`
+        //     The `exec` replaces `sh` itself; the pane ends up running only
+        //     the CLI binary (same as the original launch). Because env_setup
+        //     is empty we could use the argv path, but wrapping in `sh -c 'exec …'`
+        //     is consistent with start_cli_in_tmux and future-proof.
+        let target = tmux_session_name.clone();
+
+        // Set remain-on-exit so startup errors stay visible (best-effort).
+        let _ = Command::new("tmux")
+            .args(["set-option", "-w", "-t", &target, "remain-on-exit", "on"])
+            .output()
+            .await;
+
+        let full_line = format!("exec {cli_cmd}");
+        let output = Command::new("tmux")
+            .args(["respawn-pane", "-k", "-t", &target, "sh", "-c", &full_line])
+            .output()
+            .await
+            .context("Failed to invoke tmux respawn-pane for Headroom downgrade")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Restore the headroom flag in the store so the next manual
+            // restart picks it back up (best-effort).
+            let mut store2 = crate::interactive::SessionStore::load();
+            if let Some(meta) = store2.sessions.get_mut(&tmux_session_name) {
+                meta.headroom_enabled = true;
+            }
+            let _ = store2.save();
+            anyhow::bail!(
+                "tmux respawn-pane failed for {}: {}",
+                tmux_session_name,
+                stderr
+            );
+        }
+
+        // Update in-memory status.
+        if let Some(session) = self.find_session_mut(session_id) {
+            session.set_status(crate::models::SessionStatus::Running);
+        }
+
+        self.add_success_notification(format!(
+            "Headroom OFF for this session — resumed direct (no compression){}",
+            codex_fresh_note
+        ));
+
+        info!(
+            "Headroom downgraded for {} in tmux session '{}'",
+            provider.display_name(),
+            tmux_session_name
+        );
+        Ok(())
     }
 
     /// Helper to find a session by ID across all workspaces

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -988,6 +988,44 @@ pub(crate) fn mcp_import_blocking(to_user: bool) -> McpFetchResult {
 }
 
 // ============================================================================
+// Daemons overlay (MCP pool + Headroom proxy — read-only status)
+// ============================================================================
+
+/// Fetched snapshot delivered through the daemons overlay channel.
+#[derive(Debug, Clone)]
+pub struct DaemonsFetchResult {
+    pub mcp_alive: bool,
+    pub headroom: crate::headroom::ProxyStatus,
+    pub headroom_consumers: Vec<String>,
+}
+
+/// Live, lazily-refreshed snapshot for the Daemons overlay. Present only while
+/// the overlay is open; dropping it stops all refresh activity.
+#[derive(Debug)]
+pub struct DaemonsOverlayState {
+    pub mcp_alive: bool,
+    pub headroom: crate::headroom::ProxyStatus,
+    pub headroom_consumers: Vec<String>,
+    pub loading: bool,
+    pub last_refreshed: Option<std::time::Instant>,
+    /// Receiver for the in-flight fetch (None = no fetch pending).
+    pub fetch_rx: Option<mpsc::UnboundedReceiver<DaemonsFetchResult>>,
+}
+
+/// Blocking portion of the daemons fetch: MCP alive probe + SessionStore read.
+/// These are sync calls so they run on the blocking thread pool.
+pub(crate) fn daemons_sync_probe() -> (bool, Vec<String>) {
+    let mcp_alive = crate::mcp_pool::client::daemon_alive();
+    let headroom_consumers = crate::interactive::SessionStore::load()
+        .sessions
+        .into_values()
+        .filter(|m| m.headroom_enabled)
+        .map(|m| m.tmux_session_name.clone())
+        .collect::<Vec<_>>();
+    (mcp_alive, headroom_consumers)
+}
+
+// ============================================================================
 // Home Screen State
 // ============================================================================
 
@@ -2848,6 +2886,8 @@ pub struct AppState {
     pub confirmation_dialog: Option<ConfirmationDialog>,
     // Shared MCP pool observability overlay (None = closed; no refresh runs).
     pub mcp_overlay: Option<McpOverlayState>,
+    // Daemons status overlay (MCP pool + Headroom proxy, read-only).
+    pub daemons_overlay: Option<DaemonsOverlayState>,
     // Flag to force UI refresh after workspace changes
     pub ui_needs_refresh: bool,
 
@@ -3433,6 +3473,7 @@ impl Default for AppState {
             async_operation_cancelled: false,
             confirmation_dialog: None,
             mcp_overlay: None,
+            daemons_overlay: None,
             ui_needs_refresh: false,
             claude_chat_visible: false,
             focused_pane: FocusedPane::Sessions,
@@ -4839,6 +4880,80 @@ impl AppState {
                 });
             let _ = tx.send(result);
         });
+    }
+
+    // ── Daemons overlay ──────────────────────────────────────────────────────
+
+    /// Open the Daemons overlay and fire the first fetch; idempotent (toggle).
+    pub fn toggle_daemons_overlay(&mut self) {
+        if self.daemons_overlay.is_some() {
+            self.daemons_overlay = None;
+            return;
+        }
+        self.daemons_overlay = Some(DaemonsOverlayState {
+            mcp_alive: false,
+            headroom: crate::headroom::ProxyStatus {
+                running: false,
+                port: crate::headroom::proxy_port(),
+                pid: None,
+                tokens_saved: None,
+            },
+            headroom_consumers: Vec::new(),
+            loading: true,
+            last_refreshed: None,
+            fetch_rx: None,
+        });
+        self.spawn_daemons_fetch();
+    }
+
+    pub fn close_daemons_overlay(&mut self) {
+        self.daemons_overlay = None;
+    }
+
+    /// Spawn one off-thread fetch of both daemon statuses (one-outstanding guard).
+    /// Runs MCP + SessionStore probes on the blocking pool; headroom::status()
+    /// is async so it runs directly in the spawned task.
+    pub fn spawn_daemons_fetch(&mut self) {
+        let Some(o) = self.daemons_overlay.as_mut() else {
+            return;
+        };
+        if o.fetch_rx.is_some() {
+            return;
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        o.fetch_rx = Some(rx);
+        o.loading = true;
+        tokio::spawn(async move {
+            // Blocking I/O (control socket + file read) on the blocking pool.
+            let (mcp_alive, headroom_consumers) = tokio::task::spawn_blocking(daemons_sync_probe)
+                .await
+                .unwrap_or((false, Vec::new()));
+            // Async HTTP probe of the Headroom /health + /stats endpoints.
+            let headroom = crate::headroom::status().await;
+            let result = DaemonsFetchResult {
+                mcp_alive,
+                headroom,
+                headroom_consumers,
+            };
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Drain a completed daemons fetch. Called from the 250ms app tick.
+    pub fn check_daemons_overlay(&mut self) {
+        let Some(o) = self.daemons_overlay.as_mut() else {
+            return;
+        };
+        if let Some(rx) = o.fetch_rx.as_mut() {
+            if let Ok(result) = rx.try_recv() {
+                o.fetch_rx = None;
+                o.loading = false;
+                o.mcp_alive = result.mcp_alive;
+                o.headroom = result.headroom;
+                o.headroom_consumers = result.headroom_consumers;
+                o.last_refreshed = Some(std::time::Instant::now());
+            }
+        }
     }
 
     /// Open the Configure screen's base-branch popup: seed entries from
@@ -10703,6 +10818,8 @@ impl App {
 
         // Drain + lazily refresh the MCP pool overlay (no-op when closed).
         self.state.check_mcp_overlay();
+        // Drain completed daemons overlay fetch (no-op when closed).
+        self.state.check_daemons_overlay();
 
         // Periodic OAuth token refresh check (every 5 minutes)
         let now = Instant::now();

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3377,6 +3377,7 @@ struct ConfigureLaunchSnapshot {
     /// HEAD for local repos, origin/HEAD for remote/star launches.
     base: Option<crate::components::new_session::configure::BaseSelection>,
     headroom_enabled: bool,
+    rtk_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7209,6 +7210,7 @@ impl AppState {
             codex_model,
             base: spec.base.clone(),
             headroom_enabled: spec.headroom_enabled,
+            rtk_enabled: spec.rtk_enabled,
         };
 
         // Boss mode builds its own Docker workspace from `repo_path` and
@@ -7364,6 +7366,7 @@ impl AppState {
                 existing_worktree,
                 base_start_point,
                 snapshot.headroom_enabled,
+                snapshot.rtk_enabled,
             )
             .await;
 
@@ -7987,6 +7990,7 @@ impl AppState {
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
         base_start_point: Option<String>,
         headroom_enabled: bool,
+        rtk_enabled: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Branch based on session mode
         match mode {
@@ -8002,6 +8006,7 @@ impl AppState {
                     existing_worktree,
                     base_start_point,
                     headroom_enabled,
+                    rtk_enabled,
                 )
                 .await
             }
@@ -8043,6 +8048,7 @@ impl AppState {
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
         base_start_point: Option<String>,
         headroom_enabled: bool,
+        rtk_enabled: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::interactive::InteractiveSessionManager;
 
@@ -8103,6 +8109,7 @@ impl AppState {
                     model,
                     codex_model,
                     headroom_enabled,
+                    rtk_enabled,
                 )
                 .await
         } else {
@@ -8120,6 +8127,7 @@ impl AppState {
                     model,
                     codex_model,
                     headroom_enabled,
+                    rtk_enabled,
                 )
                 .await
         };

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2932,6 +2932,9 @@ pub struct AppState {
     pub last_log_check: Option<std::time::Instant>,
     // Track the last time we checked for OAuth token refresh
     pub last_token_refresh_check: Option<std::time::Instant>,
+    // Track the last Headroom proxy watchdog tick (re-ensure if a Headroom
+    // session is live but the proxy died).
+    pub last_headroom_watchdog: Option<std::time::Instant>,
     // Claude chat integration
     pub claude_chat_state: Option<ClaudeChatState>,
     // Live logs from Docker containers
@@ -3488,6 +3491,7 @@ impl Default for AppState {
             log_last_updated: HashMap::new(),
             last_log_check: None,
             last_token_refresh_check: None,
+            last_headroom_watchdog: None,
             claude_chat_state: None,
             live_logs: HashMap::new(),
             claude_manager: None,
@@ -4954,6 +4958,42 @@ impl AppState {
                 o.last_refreshed = Some(std::time::Instant::now());
             }
         }
+    }
+
+    /// Headroom proxy watchdog. If a Headroom-enabled session is live but the
+    /// shared proxy went down, re-ensure it. Throttled to ~10s, async, and
+    /// best-effort so it never blocks the render loop. Self-healing: claude's
+    /// Anthropic SDK retries connection errors with backoff, so a respawn
+    /// inside the retry window is transparent to the session.
+    ///
+    /// In-loop tick, NOT a separate daemon — surfaced as the "watched" marker
+    /// on the Headroom row of the Daemons screen, per the daemons-screen rule.
+    pub fn headroom_watchdog(&mut self) {
+        const INTERVAL_SECS: u64 = 10;
+        let now = std::time::Instant::now();
+        let due = self
+            .last_headroom_watchdog
+            .map(|last| now.duration_since(last).as_secs() >= INTERVAL_SECS)
+            .unwrap_or(true);
+        if !due {
+            return;
+        }
+        self.last_headroom_watchdog = Some(now);
+
+        let has_headroom_session = crate::interactive::SessionStore::load()
+            .sessions
+            .values()
+            .any(|m| m.headroom_enabled);
+        if !has_headroom_session {
+            return;
+        }
+
+        tokio::spawn(async {
+            if !crate::headroom::is_healthy().await {
+                warn!("Headroom proxy down with a live session — watchdog respawning");
+                let _ = crate::headroom::ensure_proxy_running().await;
+            }
+        });
     }
 
     /// Open the Configure screen's base-branch popup: seed entries from
@@ -10820,6 +10860,9 @@ impl App {
         self.state.check_mcp_overlay();
         // Drain completed daemons overlay fetch (no-op when closed).
         self.state.check_daemons_overlay();
+        // Re-ensure the Headroom proxy if a Headroom session is live but the
+        // proxy died (throttled, async, best-effort).
+        self.state.headroom_watchdog();
 
         // Periodic OAuth token refresh check (every 5 minutes)
         let now = Instant::now();

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -283,6 +283,7 @@ mod tests {
             workspace_name: "ws".to_string(),
             created_at: chrono::Utc::now(),
             agent_type: SessionAgentType::Claude,
+            headroom_enabled: false,
         };
 
         let session = AppState::stopped_session_from_metadata(&metadata);

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -284,6 +284,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             agent_type: SessionAgentType::Claude,
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let session = AppState::stopped_session_from_metadata(&metadata);

--- a/ainb-tui/crates/ainb-core/src/cli/deps.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/deps.rs
@@ -33,6 +33,8 @@ pub enum Consumer {
     Usage,
     /// OpenTelemetry export to Grafana Cloud (`ainb otel setup`).
     Otel,
+    /// Token-optimisation tooling (rtk output compression, headroom proxy).
+    TokenOpt,
 }
 
 impl Consumer {
@@ -44,6 +46,7 @@ impl Consumer {
             Consumer::Beads => "beads",
             Consumer::Usage => "usage",
             Consumer::Otel => "otel",
+            Consumer::TokenOpt => "token-opt",
         }
     }
 
@@ -56,6 +59,7 @@ impl Consumer {
             Consumer::Beads,
             Consumer::Usage,
             Consumer::Otel,
+            Consumer::TokenOpt,
         ]
     }
 }
@@ -250,6 +254,22 @@ pub fn catalog() -> &'static [DepSpec] {
             required: false,
             why: "Grafana Alloy: forwards local OTLP telemetry to Grafana Cloud (run `ainb otel setup`)",
             install_hint: "brew install grafana/grafana/alloy   # macOS · then: ainb otel setup",
+        },
+        DepSpec {
+            name: "rtk",
+            kind: System,
+            consumers: &[TokenOpt],
+            required: false,
+            why: "compress CLI tool output (Bash/test/diff) via PreToolUse hooks — opt-in token savings",
+            install_hint: "brew install rtk        # macOS  ·  curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh  ·  then `rtk init -g`",
+        },
+        DepSpec {
+            name: "headroom",
+            kind: System,
+            consumers: &[TokenOpt],
+            required: false,
+            why: "per-session LLM-API compression proxy (ANTHROPIC_BASE_URL / OPENAI_BASE_URL) — opt-in token savings",
+            install_hint: "uv tool install 'headroom-ai[proxy]'   # or: pipx install 'headroom-ai[proxy]'",
         },
     ]
 }

--- a/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
@@ -462,6 +462,7 @@ mod tests {
             workspace_name: workspace.to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
@@ -463,6 +463,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/headroom.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/headroom.rs
@@ -1,0 +1,54 @@
+// ABOUTME: `ainb headroom` namespace — proxy lifecycle inspection.
+//   status  query the Headroom proxy (running / port / pid / tokens_saved)
+//   stop    send SIGTERM to the ainb-managed proxy
+
+use anyhow::Result;
+use clap::ArgMatches;
+
+use crate::cli::OutputFormat;
+use crate::headroom;
+
+pub async fn execute(matches: &ArgMatches, format: OutputFormat) -> Result<()> {
+    match matches.subcommand() {
+        Some(("status", _)) => cmd_status(format).await,
+        Some(("stop", _)) => cmd_stop(),
+        _ => unreachable!("clap subcommand_required"),
+    }
+}
+
+async fn cmd_status(format: OutputFormat) -> Result<()> {
+    let s = headroom::status().await;
+    match format {
+        OutputFormat::Json => {
+            // Emit a minimal JSON object — enough for scripting.
+            let tokens_saved = s.tokens_saved.map_or_else(|| "null".to_string(), |n| n.to_string());
+            let pid_str = s.pid.map_or_else(|| "null".to_string(), |n| n.to_string());
+            println!(
+                r#"{{"running":{running},"port":{port},"pid":{pid},"tokens_saved":{tokens_saved}}}"#,
+                running = s.running,
+                port = s.port,
+                pid = pid_str,
+            );
+        }
+        _ => {
+            let running_str = if s.running { "running" } else { "stopped" };
+            println!("headroom proxy: {running_str}");
+            println!("  port:         {}", s.port);
+            match s.pid {
+                Some(pid) => println!("  pid:          {pid}"),
+                None => println!("  pid:          (none)"),
+            }
+            match s.tokens_saved {
+                Some(n) => println!("  tokens_saved: {n}"),
+                None => println!("  tokens_saved: (unavailable)"),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_stop() -> Result<()> {
+    headroom::stop();
+    println!("headroom proxy stopped");
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/cli/headroom.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/headroom.rs
@@ -48,7 +48,12 @@ async fn cmd_status(format: OutputFormat) -> Result<()> {
 }
 
 fn cmd_stop() -> Result<()> {
-    headroom::stop();
-    println!("headroom proxy stopped");
+    if headroom::stop() {
+        println!("headroom proxy stopped");
+    } else {
+        println!(
+            "no ainb-managed headroom proxy is running (a proxy you started yourself is left untouched)"
+        );
+    }
     Ok(())
 }

--- a/ainb-tui/crates/ainb-core/src/cli/list.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/list.rs
@@ -190,6 +190,7 @@ mod tests {
             workspace_name: "test-workspace".to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);
@@ -205,6 +206,7 @@ mod tests {
             workspace_name: "test-workspace".to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, false);
@@ -220,6 +222,7 @@ mod tests {
             workspace_name: "test-workspace".to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, false, false);
@@ -250,6 +253,7 @@ mod tests {
             workspace_name: "my-workspace".to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);

--- a/ainb-tui/crates/ainb-core/src/cli/list.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/list.rs
@@ -191,6 +191,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);
@@ -207,6 +208,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, false);
@@ -223,6 +225,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, false, false);
@@ -254,6 +257,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -17,6 +17,7 @@ pub mod favorites;
 pub mod fleet;
 pub mod git_cmd;
 pub mod hangar;
+pub mod headroom;
 pub mod init;
 pub mod list;
 pub mod logs;

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -28,6 +28,7 @@ pub mod presets;
 pub mod recover;
 pub mod reflect;
 pub mod registry;
+pub mod rtk;
 pub mod run;
 pub mod status;
 pub mod statusline;

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -392,6 +392,7 @@ fn execute_resume(session: &str) -> Result<()> {
         workspace_name: workspace.clone(),
         created_at: matched.created_at.unwrap_or_else(Utc::now),
         agent_type: SessionAgentType::default(),
+        headroom_enabled: false,
     };
 
     let mut store = SessionStore::load();
@@ -612,6 +613,7 @@ mod tests {
             workspace_name: workspace.to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -393,6 +393,7 @@ fn execute_resume(session: &str) -> Result<()> {
         created_at: matched.created_at.unwrap_or_else(Utc::now),
         agent_type: SessionAgentType::default(),
         headroom_enabled: false,
+        rtk_enabled: false,
     };
 
     let mut store = SessionStore::load();
@@ -614,6 +615,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -116,6 +116,7 @@ impl CommandRegistry {
         r.register(McpCommand);
         r.register(NotifydCommand); // hidden — ainb-hooks daemon alias
         r.register(HangarCommand); // Hangar control plane (issue / task / beads / daemon)
+        r.register(RtkCommand); // RTK token-killer: install/uninstall/status
         r
     }
 
@@ -2012,6 +2013,58 @@ impl CliCommand for HangarCommand {
     }
 }
 
+/// `ainb rtk {status,install,uninstall}` — RTK (Rust Token Killer) lifecycle.
+///
+/// RTK compresses CLI tool output (Bash/test/diff) before it reaches the model
+/// context window via a Claude Code PreToolUse hook. It is NOT an ainb
+/// marketplace plugin — it wires directly into `~/.claude/settings.json`
+/// via `rtk init -g`.
+///
+/// - `status`    detect install + wiring state + total tokens saved
+/// - `install`   brew install rtk + rtk init -g [--codex]
+/// - `uninstall` rtk init -g --uninstall (leaves binary, removes hook)
+pub struct RtkCommand;
+impl CliCommand for RtkCommand {
+    fn name(&self) -> &'static str {
+        "rtk"
+    }
+    fn build(&self, app: Command) -> Command {
+        let status = Command::new("status")
+            .about("Show RTK install state, hook wiring, and total tokens saved");
+        let install = Command::new("install")
+            .about(
+                "Install rtk (brew install rtk) and wire the Claude Code PreToolUse hook \
+                 (rtk init -g)",
+            )
+            .arg(
+                clap::Arg::new("codex").long("codex").action(clap::ArgAction::SetTrue).help(
+                    "Also wire Codex AGENTS.md prompt injection (rtk init -g --codex). \
+                         Best-effort; weaker than the Claude Code hook path.",
+                ),
+            );
+        let uninstall = Command::new("uninstall").about(
+            "Remove the Claude Code hook from ~/.claude/settings.json \
+             (rtk init -g --uninstall). Leaves the rtk binary installed.",
+        );
+        app.subcommand(
+            Command::new(self.name())
+                .about(
+                    "RTK (Rust Token Killer): compress CLI output in Claude Code via \
+                     PreToolUse hook",
+                )
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(status)
+                .subcommand(install)
+                .subcommand(uninstall),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        let matches = matches.clone();
+        Box::pin(async move { crate::cli::rtk::execute(&matches, ctx.format).await })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2026,9 +2079,10 @@ mod tests {
         let names = r.names();
         // main's 30 (built-ins + doctor + reflect + claudecode + codex + tmux +
         // otel + abtop + witr + learnings + plugin stub + fleet + mcp + hidden
-        // notifyd + hangar) + the headroom namespace = 31. The TUI is NOT in the
-        // registry — main.rs handles `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 31, "expected 31 entries, got {names:?}");
+        // notifyd + hangar) + the headroom namespace + the rtk namespace = 32.
+        // The TUI is NOT in the registry — main.rs handles `tui` /
+        // no-subcommand inline.
+        assert_eq!(names.len(), 32, "expected 32 entries, got {names:?}");
         for required in [
             "run",
             "list",
@@ -2061,6 +2115,7 @@ mod tests {
             "notifyd",
             "hangar",
             "headroom",
+            "rtk",
         ] {
             assert!(
                 names.contains(&required),

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -112,6 +112,7 @@ impl CommandRegistry {
         r.register(LearningsCommand); // headless KB search via the learnings plugin
         r.register(PluginCommand); // Phase 4 stub — surface reserved now
         r.register(FleetCommand);
+        r.register(HeadroomCommand);
         r.register(McpCommand);
         r.register(NotifydCommand); // hidden — ainb-hooks daemon alias
         r.register(HangarCommand); // Hangar control plane (issue / task / beads / daemon)
@@ -1868,6 +1869,33 @@ impl CliCommand for FleetCommand {
     }
 }
 
+/// `ainb headroom {status,stop}` — inspect and control the ainb-managed
+/// Headroom compression proxy. `status` prints running / port / pid /
+/// tokens_saved (with `--format json` support). `stop` sends SIGTERM.
+pub struct HeadroomCommand;
+impl CliCommand for HeadroomCommand {
+    fn name(&self) -> &'static str {
+        "headroom"
+    }
+    fn build(&self, app: Command) -> Command {
+        let status = Command::new("status")
+            .about("Query the Headroom proxy (running, port, pid, tokens saved)");
+        let stop = Command::new("stop").about("Stop the ainb-managed Headroom proxy");
+        app.subcommand(
+            Command::new(self.name())
+                .about("Manage the ainb-managed Headroom compression proxy")
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(status)
+                .subcommand(stop),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        let matches = matches.clone();
+        Box::pin(async move { crate::cli::headroom::execute(&matches, ctx.format).await })
+    }
+}
+
 pub struct McpCommand;
 impl CliCommand for McpCommand {
     fn name(&self) -> &'static str {
@@ -1993,14 +2021,14 @@ mod tests {
     }
 
     #[test]
-    fn built_ins_registers_thirty_commands() {
+    fn built_ins_registers_all_commands() {
         let r = CommandRegistry::built_ins();
         let names = r.names();
-        // built-ins + doctor + reflect + claudecode + codex + tmux + otel +
-        // abtop + witr + learnings + plugin stub + fleet + mcp + hidden notifyd
-        // + hangar = 30. The TUI is NOT in the registry — main.rs handles `tui`
-        // / no-subcommand inline.
-        assert_eq!(names.len(), 30, "expected 30 entries, got {names:?}");
+        // main's 30 (built-ins + doctor + reflect + claudecode + codex + tmux +
+        // otel + abtop + witr + learnings + plugin stub + fleet + mcp + hidden
+        // notifyd + hangar) + the headroom namespace = 31. The TUI is NOT in the
+        // registry — main.rs handles `tui` / no-subcommand inline.
+        assert_eq!(names.len(), 31, "expected 31 entries, got {names:?}");
         for required in [
             "run",
             "list",
@@ -2032,6 +2060,7 @@ mod tests {
             "mcp",
             "notifyd",
             "hangar",
+            "headroom",
         ] {
             assert!(
                 names.contains(&required),

--- a/ainb-tui/crates/ainb-core/src/cli/rtk.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/rtk.rs
@@ -1,0 +1,66 @@
+// ABOUTME: `ainb rtk` namespace — RTK (Rust Token Killer) lifecycle management.
+//   status     detect install + wiring state + total tokens saved
+//   install    brew install rtk + rtk init -g [--codex]
+//   uninstall  rtk init -g --uninstall (removes hook; leaves binary)
+
+use anyhow::Result;
+use clap::ArgMatches;
+
+use crate::cli::OutputFormat;
+use crate::rtk;
+
+pub async fn execute(matches: &ArgMatches, format: OutputFormat) -> Result<()> {
+    match matches.subcommand() {
+        Some(("status", _)) => cmd_status(format),
+        Some(("install", m)) => cmd_install(m.get_flag("codex")),
+        Some(("uninstall", _)) => cmd_uninstall(),
+        _ => unreachable!("clap subcommand_required"),
+    }
+}
+
+fn cmd_status(format: OutputFormat) -> Result<()> {
+    let s = rtk::status();
+    match format {
+        OutputFormat::Json => {
+            let total_saved = s.total_saved.map_or_else(|| "null".to_string(), |n| n.to_string());
+            println!(
+                r#"{{"installed":{installed},"wired":{wired},"total_saved":{total_saved}}}"#,
+                installed = s.installed,
+                wired = s.wired,
+            );
+        }
+        _ => {
+            let installed_str = if s.installed { "yes" } else { "no" };
+            let wired_str = if s.wired {
+                "yes"
+            } else {
+                "no (run `ainb rtk install`)"
+            };
+            println!("rtk installed:  {installed_str}");
+            println!("hook wired:     {wired_str}");
+            match s.total_saved {
+                Some(n) => println!("tokens saved:   {n}"),
+                None => println!("tokens saved:   (unavailable)"),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_install(also_codex: bool) -> Result<()> {
+    rtk::install()?;
+    println!("rtk installed and Claude Code hook wired.");
+    if also_codex {
+        rtk::install_codex()?;
+        println!("Codex AGENTS.md prompt injection wired (best-effort).");
+    }
+    println!("Verify with: ainb rtk status");
+    Ok(())
+}
+
+fn cmd_uninstall() -> Result<()> {
+    rtk::uninstall()?;
+    println!("RTK hook removed from ~/.claude/settings.json.");
+    println!("The rtk binary is still installed; remove with: brew uninstall rtk");
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -116,6 +116,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         workspace_name: workspace_name.clone(),
         created_at: Utc::now(),
         agent_type,
+        headroom_enabled: false,
     };
 
     let mut store = SessionStore::load();

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -117,6 +117,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         created_at: Utc::now(),
         agent_type,
         headroom_enabled: false,
+        rtk_enabled: false,
     };
 
     let mut store = SessionStore::load();

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -205,6 +205,7 @@ mod tests {
             workspace_name: workspace.to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -206,6 +206,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/statusline.rs
@@ -212,7 +212,41 @@ pub fn render_powerline(cache: &LiveCache) -> String {
         parts.push(ansi_fg(GOLD, &format!("${cost:.2}")));
     }
 
+    if let Some(hr) = headroom_segment() {
+        parts.push(hr);
+    }
+
     parts.join(&format!(" {} ", ansi_fg(MUTED, "·")))
+}
+
+/// A compact `HR` segment when this session's CLI is routed through the local
+/// Headroom proxy.
+///
+/// Detection reads the base-URL env var the statusline process actually
+/// inherited (`ANTHROPIC_BASE_URL` for Claude, `OPENAI_BASE_URL` for Codex). A
+/// `#951`-bypassed child that never received the var shows nothing — so the
+/// badge reflects ACTUAL routing, not the stored toggle. A fast localhost TCP
+/// probe distinguishes a live proxy (green `HR`) from a configured-but-down one
+/// (amber `HR`).
+fn headroom_segment() -> Option<String> {
+    let port = crate::headroom::proxy_port();
+    let needle_ip = format!("127.0.0.1:{port}");
+    let needle_localhost = format!("localhost:{port}");
+
+    let routed = ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"].iter().any(|var| {
+        std::env::var(var)
+            .map(|v| v.contains(&needle_ip) || v.contains(&needle_localhost))
+            .unwrap_or(false)
+    });
+    if !routed {
+        return None;
+    }
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let live =
+        std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(40)).is_ok();
+    let color = if live { GREEN } else { AMBER };
+    Some(ansi_fg(color, "HR"))
 }
 
 // Hand-rolled ANSI 24-bit escape sequences. Avoid pulling in a colored
@@ -532,6 +566,38 @@ mod tests {
         };
         // Just don't panic; result may be empty string.
         let _ = render_powerline(&cache);
+    }
+
+    #[test]
+    fn headroom_segment_reflects_base_url_routing() {
+        // Shared lock: this test mutates ANTHROPIC_BASE_URL + AINB_HEADROOM_PORT,
+        // which other tests read in parallel (cargo runs tests in-process).
+        let _guard = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let key = "ANTHROPIC_BASE_URL";
+        let old = std::env::var_os(key);
+        let port_old = std::env::var_os("AINB_HEADROOM_PORT");
+        std::env::remove_var("AINB_HEADROOM_PORT"); // force default 8787
+
+        // Not routed → no segment.
+        std::env::remove_var(key);
+        assert!(headroom_segment().is_none());
+
+        // Pointed at the real Anthropic endpoint → no segment.
+        std::env::set_var(key, "https://api.anthropic.com");
+        assert!(headroom_segment().is_none());
+
+        // Pointed at the local proxy → segment present (proxy is down in tests,
+        // so it renders, just amber — we only assert the "HR" label is there).
+        std::env::set_var(key, "http://127.0.0.1:8787");
+        assert!(headroom_segment().as_deref().unwrap_or("").contains("HR"));
+
+        match old {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        if let Some(v) = port_old {
+            std::env::set_var("AINB_HEADROOM_PORT", v);
+        }
     }
 
     /// `--cache-only`: cache is written, stdout payload is `None`

--- a/ainb-tui/crates/ainb-core/src/cli/usage.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/usage.rs
@@ -41,6 +41,8 @@ pub enum UsageCommands {
     ModelAlias(UsageModelAliasArgs),
     /// Show read-only optimization findings
     Optimize(UsageReportArgs),
+    /// Token-savings rollup (Headroom proxy + RTK + caveman estimate)
+    Savings(UsageReportArgs),
     /// Compare models
     Compare(UsageReportArgs),
     /// Estimate usage yield from session signals
@@ -282,6 +284,7 @@ pub async fn execute(command: UsageCommands, format: OutputFormat) -> Result<()>
         | UsageCommands::Month(_)
         | UsageCommands::Export(_)
         | UsageCommands::Optimize(_)
+        | UsageCommands::Savings(_)
         | UsageCommands::Compare(_)
         | UsageCommands::Yield(_)
         | UsageCommands::ModelAlias(_)

--- a/ainb-tui/crates/ainb-core/src/cli/util.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/util.rs
@@ -140,6 +140,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let session2 = SessionMetadata {
@@ -150,6 +151,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         store.sessions.insert(session1.tmux_session_name.clone(), session1);

--- a/ainb-tui/crates/ainb-core/src/cli/util.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/util.rs
@@ -139,6 +139,7 @@ mod tests {
             workspace_name: "project-alpha".to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         };
 
         let session2 = SessionMetadata {
@@ -148,6 +149,7 @@ mod tests {
             workspace_name: "project-beta".to_string(),
             created_at: Utc::now(),
             agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
         };
 
         store.sessions.insert(session1.tmux_session_name.clone(), session1);

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -132,8 +132,11 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
         .tokens_saved
         .map(|t| format!("saved {t} tokens"))
         .unwrap_or_else(|| "—".to_string());
+    // "watched" = a live Headroom session exists, so the in-loop watchdog is
+    // re-ensuring this proxy if it drops. Surfaced here, not as its own daemon.
+    let watched = state.headroom.running && !state.headroom_consumers.is_empty();
 
-    let headroom_line = Line::from(vec![
+    let mut headroom_spans = vec![
         Span::styled(
             format!("  Headroom :{port:<5}"),
             Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
@@ -143,7 +146,14 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
             format!("    {pid_str}   {tokens_str}"),
             Style::default().fg(MUTED_GRAY),
         ),
-    ]);
+    ];
+    if watched {
+        headroom_spans.push(Span::styled(
+            "  · watched",
+            Style::default().fg(SELECTION_GREEN),
+        ));
+    }
+    let headroom_line = Line::from(headroom_spans);
     frame.render_widget(Paragraph::new(headroom_line), rows[2]);
 
     // ── Headroom consumers ────────────────────────────────────────────────────
@@ -296,6 +306,11 @@ mod tests {
         assert!(
             text.contains("worktree-abc"),
             "missing consumer name in:\n{text}"
+        );
+        // A running proxy with a live consumer is watched by the in-loop watchdog.
+        assert!(
+            text.contains("watched"),
+            "missing 'watched' marker in:\n{text}"
         );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -1,0 +1,301 @@
+// ABOUTME: Read-only overlay showing the status of ainb-managed background
+// daemons: the shared MCP pool and the Headroom compression proxy. Opened via
+// `d` / SidebarItem::Daemons. No start/stop actions — control is via CLI
+// (`ainb mcp stop`, `ainb headroom stop`). Mirrors mcp_overlay.rs structure.
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+};
+
+use crate::app::state::DaemonsOverlayState;
+
+const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
+const GOLD: Color = Color::Rgb(255, 215, 0);
+const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
+const DARK_BG: Color = Color::Rgb(25, 25, 35);
+const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
+const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+const CLAY: Color = Color::Rgb(217, 119, 87);
+
+/// Centered popup rect sized as a percentage of the area.
+fn centered(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let v = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(v[1])[1]
+}
+
+pub fn render(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
+    let popup = centered(70, 55, area);
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(Span::styled(
+            " ⚙ Daemons — MCP pool · Headroom proxy ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(3),    // daemon cards
+            Constraint::Length(1), // help bar
+        ])
+        .split(inner);
+
+    render_cards(frame, chunks[0], state);
+    render_help_bar(frame, chunks[1], state);
+}
+
+fn status_dot(running: bool) -> Span<'static> {
+    if running {
+        Span::styled(
+            "● up",
+            Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::styled("○ down", Style::default().fg(CLAY))
+    }
+}
+
+fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
+    if state.loading {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "Loading…",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )))
+            .alignment(Alignment::Center),
+            area,
+        );
+        return;
+    }
+
+    // Two rows: MCP, Headroom.
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // MCP row
+            Constraint::Length(1), // spacer
+            Constraint::Length(2), // Headroom row
+            Constraint::Length(1), // spacer
+            Constraint::Length(2), // Headroom consumers
+            Constraint::Min(0),    // rest
+        ])
+        .split(area);
+
+    // ── MCP pool ──────────────────────────────────────────────────────────────
+    let mcp_line = Line::from(vec![
+        Span::styled(
+            "  MCP pool     ",
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+        status_dot(state.mcp_alive),
+        Span::styled(
+            "    (use `ainb mcp stop` to stop)",
+            Style::default().fg(MUTED_GRAY),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(mcp_line), rows[0]);
+
+    // ── Headroom proxy ────────────────────────────────────────────────────────
+    let port = state.headroom.port;
+    let pid_str = state
+        .headroom
+        .pid
+        .map(|p| format!("pid {p}"))
+        .unwrap_or_else(|| "—".to_string());
+    let tokens_str = state
+        .headroom
+        .tokens_saved
+        .map(|t| format!("saved {t} tokens"))
+        .unwrap_or_else(|| "—".to_string());
+
+    let headroom_line = Line::from(vec![
+        Span::styled(
+            format!("  Headroom :{port:<5}"),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+        status_dot(state.headroom.running),
+        Span::styled(
+            format!("    {pid_str}   {tokens_str}"),
+            Style::default().fg(MUTED_GRAY),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(headroom_line), rows[2]);
+
+    // ── Headroom consumers ────────────────────────────────────────────────────
+    let consumers_text = if state.headroom_consumers.is_empty() {
+        "  Sessions using Headroom: no sessions routed".to_string()
+    } else {
+        format!(
+            "  Sessions using Headroom ({}): {}",
+            state.headroom_consumers.len(),
+            state.headroom_consumers.join(", ")
+        )
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            consumers_text,
+            Style::default().fg(MUTED_GRAY),
+        ))),
+        rows[4],
+    );
+}
+
+fn render_help_bar(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
+    let refreshed = match state.last_refreshed.map(|t| t.elapsed().as_secs()) {
+        Some(0) => "just now".to_string(),
+        Some(n) => format!("{n}s ago"),
+        None => "—".to_string(),
+    };
+    let spans = vec![
+        Span::styled("r", Style::default().fg(GOLD)),
+        Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("esc", Style::default().fg(GOLD)),
+        Span::styled(" close", Style::default().fg(MUTED_GRAY)),
+        Span::styled(
+            format!("    · refreshed {refreshed}"),
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ),
+    ];
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).alignment(Alignment::Center),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::headroom::ProxyStatus;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn make_state(
+        running: bool,
+        port: u16,
+        pid: Option<u32>,
+        tokens: Option<u64>,
+    ) -> DaemonsOverlayState {
+        DaemonsOverlayState {
+            mcp_alive: true,
+            headroom: ProxyStatus {
+                running,
+                port,
+                pid,
+                tokens_saved: tokens,
+            },
+            headroom_consumers: vec!["agents/worktree-abc".to_string()],
+            loading: false,
+            last_refreshed: Some(std::time::Instant::now()),
+            fetch_rx: None,
+        }
+    }
+
+    fn buffer_text(term: &Terminal<TestBackend>) -> String {
+        let buf = term.backend().buffer().clone();
+        (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf.get(x, y).symbol().chars().next().unwrap_or(' '))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn daemons_overlay_renders_headroom_port() {
+        let state = make_state(true, 8787, Some(12345), Some(9876));
+        let backend = TestBackend::new(120, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.size();
+            render(f, area, &state);
+        })
+        .unwrap();
+        let text = buffer_text(&term);
+        assert!(!text.is_empty(), "buffer should not be empty");
+        assert!(text.contains("Headroom"), "missing 'Headroom' in:\n{text}");
+        assert!(text.contains("8787"), "missing port 8787 in:\n{text}");
+    }
+
+    #[test]
+    fn daemons_overlay_renders_mcp_status() {
+        let state = make_state(false, 8787, None, None);
+        let backend = TestBackend::new(120, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.size();
+            render(f, area, &state);
+        })
+        .unwrap();
+        let text = buffer_text(&term);
+        assert!(text.contains("MCP"), "missing 'MCP' in:\n{text}");
+    }
+
+    #[test]
+    fn daemons_overlay_renders_loading_state() {
+        let state = DaemonsOverlayState {
+            mcp_alive: false,
+            headroom: ProxyStatus {
+                running: false,
+                port: 8787,
+                pid: None,
+                tokens_saved: None,
+            },
+            headroom_consumers: Vec::new(),
+            loading: true,
+            last_refreshed: None,
+            fetch_rx: None,
+        };
+        let backend = TestBackend::new(120, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.size();
+            render(f, area, &state);
+        })
+        .unwrap();
+        let text = buffer_text(&term);
+        assert!(text.contains("Loading"), "missing 'Loading' in:\n{text}");
+    }
+
+    #[test]
+    fn daemons_overlay_renders_consumer_list() {
+        let state = make_state(true, 8787, Some(1), Some(0));
+        let backend = TestBackend::new(120, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.size();
+            render(f, area, &state);
+        })
+        .unwrap();
+        let text = buffer_text(&term);
+        assert!(
+            text.contains("worktree-abc"),
+            "missing consumer name in:\n{text}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -383,7 +383,9 @@ impl LayoutComponent {
             desc(" cleanup"),
             sep(),
             key("u", MUTED_GRAY),
-            desc(" re-auth"),
+            desc(" re-auth "),
+            key("H", MUTED_GRAY),
+            desc(" headroom off"),
         ];
 
         // Line 4: Panels + System. Every panel screen mirrors its
@@ -522,7 +524,9 @@ impl LayoutComponent {
                 cleanup_key,
                 cleanup_desc,
                 key("u", MUTED_GRAY),
-                desc(" re-auth"),
+                desc(" re-auth  "),
+                key("H", MUTED_GRAY),
+                desc(" headroom off"),
             ]),
         ];
 

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -384,8 +384,6 @@ impl LayoutComponent {
             sep(),
             key("u", MUTED_GRAY),
             desc(" re-auth "),
-            key("H", MUTED_GRAY),
-            desc(" headroom off"),
         ];
 
         // Line 4: Panels + System. Every panel screen mirrors its
@@ -525,8 +523,6 @@ impl LayoutComponent {
                 cleanup_desc,
                 key("u", MUTED_GRAY),
                 desc(" re-auth  "),
-                key("H", MUTED_GRAY),
-                desc(" headroom off"),
             ]),
         ];
 

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -111,6 +111,10 @@ impl LayoutComponent {
             if let Some(ref overlay) = state.mcp_overlay {
                 crate::components::mcp_overlay::render(frame, frame_size, overlay);
             }
+            // Daemons overlay (read-only; same z-order as MCP overlay).
+            if let Some(ref overlay) = state.daemons_overlay {
+                crate::components::daemons_overlay::render(frame, frame_size, overlay);
+            }
             if state.confirmation_dialog.is_some() {
                 self.confirmation_dialog.render(frame, frame_size, state);
             }
@@ -211,6 +215,10 @@ impl LayoutComponent {
         // MCP pool overlay (above the screen, below the confirmation dialog).
         if let Some(ref overlay) = state.mcp_overlay {
             crate::components::mcp_overlay::render(frame, frame.size(), overlay);
+        }
+        // Daemons overlay (read-only; same z-order as MCP overlay).
+        if let Some(ref overlay) = state.daemons_overlay {
+            crate::components::daemons_overlay::render(frame, frame.size(), overlay);
         }
 
         // Render confirmation dialog if visible (highest priority overlay)

--- a/ainb-tui/crates/ainb-core/src/components/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/components/mod.rs
@@ -11,6 +11,7 @@ pub mod code_review;
 pub mod config_popup;
 pub mod config_screen;
 pub mod confirmation_dialog;
+pub mod daemons_overlay;
 pub mod fuzzy_file_finder;
 pub mod git_view;
 pub mod help;

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -567,6 +567,10 @@ impl ConfigureState {
                 rows.push(ConfigureRow::Yolo);
                 if preset.agent_provider == "claude" || preset.agent_provider == "codex" {
                     rows.push(ConfigureRow::HeadroomProxy);
+                }
+                // RTK is a Claude Code hook (`.claude/settings.json`) — Claude
+                // only. Codex/Gemini/Copilot never read it, so don't offer it.
+                if preset.agent_provider == "claude" {
                     rows.push(ConfigureRow::Rtk);
                 }
             }
@@ -578,6 +582,10 @@ impl ConfigureState {
                 rows.push(ConfigureRow::Yolo);
                 if preset.agent_provider == "claude" || preset.agent_provider == "codex" {
                     rows.push(ConfigureRow::HeadroomProxy);
+                }
+                // RTK is a Claude Code hook (`.claude/settings.json`) — Claude
+                // only. Codex/Gemini/Copilot never read it, so don't offer it.
+                if preset.agent_provider == "claude" {
                     rows.push(ConfigureRow::Rtk);
                 }
             }

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -213,6 +213,7 @@ pub enum ConfigureRow {
     Mode,
     Yolo,
     HeadroomProxy,
+    Rtk,
     Host,
     User,
     Port,
@@ -295,6 +296,12 @@ pub struct ConfigureState {
     /// Detected once at construction (cheap PATH lookup) — gates the toggle so
     /// we never offer routing through a proxy that can't run.
     pub headroom_available: bool,
+    /// Wire RTK as a project-local Claude Code PreToolUse hook in the session's
+    /// worktree. Claude only (Codex path is AGENTS.md prompt-injection, out of
+    /// scope for this phase).
+    pub rtk_enabled: bool,
+    /// Whether the `rtk` binary was found on PATH when this screen opened.
+    pub rtk_available: bool,
 }
 
 impl ConfigureState {
@@ -388,6 +395,8 @@ impl ConfigureState {
             branch_picker: None,
             headroom_enabled: false,
             headroom_available: crate::headroom::is_installed(),
+            rtk_enabled: false,
+            rtk_available: crate::rtk::is_installed(),
         }
     }
 
@@ -558,6 +567,7 @@ impl ConfigureState {
                 rows.push(ConfigureRow::Yolo);
                 if preset.agent_provider == "claude" || preset.agent_provider == "codex" {
                     rows.push(ConfigureRow::HeadroomProxy);
+                    rows.push(ConfigureRow::Rtk);
                 }
             }
         } else {
@@ -568,6 +578,7 @@ impl ConfigureState {
                 rows.push(ConfigureRow::Yolo);
                 if preset.agent_provider == "claude" || preset.agent_provider == "codex" {
                     rows.push(ConfigureRow::HeadroomProxy);
+                    rows.push(ConfigureRow::Rtk);
                 }
             }
         }
@@ -643,6 +654,8 @@ pub struct LaunchSpec {
     pub base: Option<BaseSelection>,
     pub prompt: Option<String>,
     pub headroom_enabled: bool,
+    /// Wire RTK project-local PreToolUse hook in this session's worktree.
+    pub rtk_enabled: bool,
 }
 
 impl LaunchSpec {
@@ -729,6 +742,9 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
             ConfigureRow::HeadroomProxy => {
                 render_headroom_row(f, state, area_for_row, focused);
             }
+            ConfigureRow::Rtk => {
+                render_rtk_row(f, state, area_for_row, focused);
+            }
             ConfigureRow::Host | ConfigureRow::User | ConfigureRow::Port | ConfigureRow::Key => {
                 render_ssh_field(f, state, area_for_row, *row);
             }
@@ -744,6 +760,8 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
     let filler_chunk = chunks[rows.len()];
     if state.focused_row == ConfigureRow::HeadroomProxy && state.headroom_available {
         render_headroom_guide(f, filler_chunk);
+    } else if state.focused_row == ConfigureRow::Rtk && state.rtk_available {
+        render_rtk_guide(f, filler_chunk);
     }
 
     // Help bar — always last chunk.
@@ -1154,6 +1172,60 @@ fn render_headroom_guide(f: &mut Frame, area: Rect) {
         )),
         Line::from(Span::styled(
             "  Off = straight to the provider \u{00b7} fastest \u{00b7} no savings",
+            Style::default().fg(MUTED_GRAY),
+        )),
+    ];
+    f.render_widget(Paragraph::new(lines), area);
+}
+
+fn render_rtk_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
+    if !state.rtk_available {
+        let line = Line::from(vec![
+            focus_indicator(focused),
+            label_span("RTK:      "),
+            Span::styled(
+                "unavailable \u{2014} install: brew install rtk",
+                Style::default().fg(MUTED_GRAY),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(line), area);
+        return;
+    }
+    let current = if state.rtk_enabled {
+        "on".to_string()
+    } else {
+        "off".to_string()
+    };
+    let options = vec!["on".to_string(), "off".to_string()];
+    let mut line = build_pills_line("RTK:      ", &options, &current, focused, &[], area.width);
+    line.spans.push(Span::styled(
+        "  \u{2014} compress tool output via hooks \u{00b7} Claude only \u{00b7} github.com/rtk-ai/rtk",
+        Style::default().fg(MUTED_GRAY),
+    ));
+    f.render_widget(Paragraph::new(line), area);
+}
+
+/// Contextual RTK guide card, shown while the RTK row is focused.
+fn render_rtk_guide(f: &mut Frame, area: Rect) {
+    let lines = vec![
+        Line::from(Span::styled(
+            "  RTK \u{00b7} project-local Claude Code hook",
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "  Wires a PreToolUse hook into this session's worktree .claude/settings.json.",
+            Style::default().fg(MUTED_GRAY),
+        )),
+        Line::from(Span::styled(
+            "    \u{2713} compresses Bash/test/diff output \u{2192} fewer tokens",
+            Style::default().fg(SELECTION_GREEN),
+        )),
+        Line::from(Span::styled(
+            "    \u{2713} hook-based \u{2014} zero latency overhead",
+            Style::default().fg(SELECTION_GREEN),
+        )),
+        Line::from(Span::styled(
+            "    \u{2717} Claude only \u{2014} Codex hook path out of scope for this phase",
             Style::default().fg(MUTED_GRAY),
         )),
     ];
@@ -1980,6 +2052,8 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
         // Defensive: never launch with Headroom on if the binary isn't there,
         // even if some stale state slipped through.
         headroom_enabled: state.headroom_enabled && state.headroom_available,
+        // Same guard for RTK.
+        rtk_enabled: state.rtk_enabled && state.rtk_available,
     })
 }
 
@@ -2012,6 +2086,12 @@ fn cycle_value_in_focused_row(state: &mut ConfigureState, delta: i32) {
             // No-op when headroom isn't installed — the row is informational only.
             if state.headroom_available {
                 state.headroom_enabled = !state.headroom_enabled;
+            }
+        }
+        ConfigureRow::Rtk => {
+            // No-op when rtk isn't installed — the row is informational only.
+            if state.rtk_available {
+                state.rtk_enabled = !state.rtk_enabled;
             }
         }
         ConfigureRow::Branch => {
@@ -2398,6 +2478,8 @@ mod tests {
             branch_picker: None,
             headroom_enabled: false,
             headroom_available: true,
+            rtk_enabled: false,
+            rtk_available: true,
         }
     }
 
@@ -2762,10 +2844,27 @@ mod tests {
     }
 
     #[test]
+    fn rtk_toggle_gated_when_unavailable() {
+        let mut s = mk_state();
+        s.rtk_available = false;
+        s.focused_row = ConfigureRow::Rtk;
+        // Cycling the row must NOT enable RTK when the binary is absent.
+        cycle_value_in_focused_row(&mut s, 1);
+        assert!(!s.rtk_enabled, "toggle must not flip when rtk unavailable");
+        cycle_value_in_focused_row(&mut s, -1);
+        assert!(!s.rtk_enabled);
+
+        // And when available it flips normally.
+        s.rtk_available = true;
+        cycle_value_in_focused_row(&mut s, 1);
+        assert!(s.rtk_enabled, "toggle flips when rtk is available");
+    }
+
+    #[test]
     fn tab_cycles_focus_through_visible_rows() {
         let mut s = mk_state();
         // Named preset, default mode = Boss, Claude/Codex provider → rows =
-        // [Preset, Mode, Yolo, HeadroomProxy, Branch, Prompt, Launch].
+        // [Preset, Mode, Yolo, HeadroomProxy, Rtk, Branch, Prompt, Launch].
         assert_eq!(s.focused_row, ConfigureRow::Preset);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Mode);
@@ -2773,6 +2872,8 @@ mod tests {
         assert_eq!(s.focused_row, ConfigureRow::Yolo);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::HeadroomProxy);
+        s.cycle_focus(1);
+        assert_eq!(s.focused_row, ConfigureRow::Rtk);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Branch);
         s.cycle_focus(1);

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -212,6 +212,7 @@ pub enum ConfigureRow {
     Model,
     Mode,
     Yolo,
+    HeadroomProxy,
     Host,
     User,
     Port,
@@ -287,6 +288,9 @@ pub struct ConfigureState {
     pub base_selection: Option<BaseSelection>,
     /// Base-branch popup state — `Some` while the popup is open.
     pub branch_picker: Option<BranchPickerState>,
+    /// Route this session's CLI through the local Headroom compression proxy.
+    /// Only active for Claude and Codex agents.
+    pub headroom_enabled: bool,
 }
 
 impl ConfigureState {
@@ -378,6 +382,7 @@ impl ConfigureState {
             branch_segment: BranchSegment::Source,
             base_selection: None,
             branch_picker: None,
+            headroom_enabled: false,
         }
     }
 
@@ -546,6 +551,9 @@ impl ConfigureState {
             if preset.agent_provider != "shell" {
                 rows.push(ConfigureRow::Mode);
                 rows.push(ConfigureRow::Yolo);
+                if preset.agent_provider == "claude" || preset.agent_provider == "codex" {
+                    rows.push(ConfigureRow::HeadroomProxy);
+                }
             }
         } else {
             // Real preset — Mode/Yolo are shown locked, but only when the
@@ -553,6 +561,9 @@ impl ConfigureState {
             if preset.agent_provider != "shell" {
                 rows.push(ConfigureRow::Mode);
                 rows.push(ConfigureRow::Yolo);
+                if preset.agent_provider == "claude" || preset.agent_provider == "codex" {
+                    rows.push(ConfigureRow::HeadroomProxy);
+                }
             }
         }
         // Branch row visible for everything that isn't SSH.
@@ -626,6 +637,7 @@ pub struct LaunchSpec {
     /// (HEAD for local repos, origin/HEAD for remote/star launches).
     pub base: Option<BaseSelection>,
     pub prompt: Option<String>,
+    pub headroom_enabled: bool,
 }
 
 impl LaunchSpec {
@@ -708,6 +720,9 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
             }
             ConfigureRow::Yolo => {
                 render_yolo_row(f, state, area_for_row, focused);
+            }
+            ConfigureRow::HeadroomProxy => {
+                render_headroom_row(f, state, area_for_row, focused);
             }
             ConfigureRow::Host | ConfigureRow::User | ConfigureRow::Port | ConfigureRow::Key => {
                 render_ssh_field(f, state, area_for_row, *row);
@@ -1065,6 +1080,17 @@ fn render_yolo_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: b
     }
     let options = vec!["ON".to_string(), "OFF".to_string()];
     let line = build_pills_line("Yolo:    ", &options, &current, focused, &[], area.width);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn render_headroom_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
+    let current = if state.headroom_enabled {
+        "on".to_string()
+    } else {
+        "off".to_string()
+    };
+    let options = vec!["on".to_string(), "off".to_string()];
+    let line = build_pills_line("Headroom: ", &options, &current, focused, &[], area.width);
     f.render_widget(Paragraph::new(line), area);
 }
 
@@ -1885,6 +1911,7 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
         branch_override: state.branch_override.clone(),
         base: state.base_selection.clone(),
         prompt,
+        headroom_enabled: state.headroom_enabled,
     })
 }
 
@@ -1912,6 +1939,9 @@ fn cycle_value_in_focused_row(state: &mut ConfigureState, delta: i32) {
             if state.preset_selection == PresetSelection::Custom {
                 cycle_yolo(state);
             }
+        }
+        ConfigureRow::HeadroomProxy => {
+            state.headroom_enabled = !state.headroom_enabled;
         }
         ConfigureRow::Branch => {
             // ←/→ on the Branch row toggles the targeted segment
@@ -2295,6 +2325,7 @@ mod tests {
             branch_segment: BranchSegment::Source,
             base_selection: None,
             branch_picker: None,
+            headroom_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -738,6 +738,14 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
         }
     }
 
+    // Contextual help in the filler space (the Min(1) chunk between the rows
+    // and the help bar), keyed to the focused row. Headroom card for now — the
+    // pattern extends to other rows when they need it.
+    let filler_chunk = chunks[rows.len()];
+    if state.focused_row == ConfigureRow::HeadroomProxy && state.headroom_available {
+        render_headroom_guide(f, filler_chunk);
+    }
+
     // Help bar — always last chunk.
     let help_chunk = *chunks.last().expect("layout always emits help row");
     let in_prompt =
@@ -1117,6 +1125,39 @@ fn render_headroom_row(f: &mut Frame, state: &ConfigureState, area: Rect, focuse
         Style::default().fg(MUTED_GRAY),
     ));
     f.render_widget(Paragraph::new(line), area);
+}
+
+/// Contextual "when to use Headroom" card, shown in the new-session filler
+/// space while the Headroom row is focused. Honest pros/cons at the point of
+/// choice — token savings vs. latency + a proxy dependency that auto-degrades.
+fn render_headroom_guide(f: &mut Frame, area: Rect) {
+    let lines = vec![
+        Line::from(Span::styled(
+            "  Headroom \u{00b7} local compression proxy",
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "  Use when token budget matters more than speed.",
+            Style::default().fg(MUTED_GRAY),
+        )),
+        Line::from(Span::styled(
+            "    \u{2713} trims context \u{2192} fewer tokens billed",
+            Style::default().fg(SELECTION_GREEN),
+        )),
+        Line::from(Span::styled(
+            "    \u{2717} ~100ms latency per call",
+            Style::default().fg(MUTED_GRAY),
+        )),
+        Line::from(Span::styled(
+            "    \u{2717} proxy dependency \u{2014} auto-degrades to direct on failure",
+            Style::default().fg(MUTED_GRAY),
+        )),
+        Line::from(Span::styled(
+            "  Off = straight to the provider \u{00b7} fastest \u{00b7} no savings",
+            Style::default().fg(MUTED_GRAY),
+        )),
+    ];
+    f.render_widget(Paragraph::new(lines), area);
 }
 
 /// Inline marker + guidance sub-line for a Branch-row problem. Returns

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -291,6 +291,10 @@ pub struct ConfigureState {
     /// Route this session's CLI through the local Headroom compression proxy.
     /// Only active for Claude and Codex agents.
     pub headroom_enabled: bool,
+    /// Whether the `headroom` binary was found on PATH when this screen opened.
+    /// Detected once at construction (cheap PATH lookup) — gates the toggle so
+    /// we never offer routing through a proxy that can't run.
+    pub headroom_available: bool,
 }
 
 impl ConfigureState {
@@ -383,6 +387,7 @@ impl ConfigureState {
             base_selection: None,
             branch_picker: None,
             headroom_enabled: false,
+            headroom_available: crate::headroom::is_installed(),
         }
     }
 
@@ -1084,6 +1089,20 @@ fn render_yolo_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: b
 }
 
 fn render_headroom_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
+    // Gate: if the headroom binary isn't on PATH, the toggle can't work — show
+    // a muted, non-interactive row with the install command instead of pills.
+    if !state.headroom_available {
+        let line = Line::from(vec![
+            focus_indicator(focused),
+            label_span("Headroom: "),
+            Span::styled(
+                "unavailable \u{2014} install: uv tool install 'headroom-ai[proxy]'",
+                Style::default().fg(MUTED_GRAY),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(line), area);
+        return;
+    }
     let current = if state.headroom_enabled {
         "on".to_string()
     } else {
@@ -1917,7 +1936,9 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
         branch_override: state.branch_override.clone(),
         base: state.base_selection.clone(),
         prompt,
-        headroom_enabled: state.headroom_enabled,
+        // Defensive: never launch with Headroom on if the binary isn't there,
+        // even if some stale state slipped through.
+        headroom_enabled: state.headroom_enabled && state.headroom_available,
     })
 }
 
@@ -1947,7 +1968,10 @@ fn cycle_value_in_focused_row(state: &mut ConfigureState, delta: i32) {
             }
         }
         ConfigureRow::HeadroomProxy => {
-            state.headroom_enabled = !state.headroom_enabled;
+            // No-op when headroom isn't installed — the row is informational only.
+            if state.headroom_available {
+                state.headroom_enabled = !state.headroom_enabled;
+            }
         }
         ConfigureRow::Branch => {
             // ←/→ on the Branch row toggles the targeted segment
@@ -2332,6 +2356,7 @@ mod tests {
             base_selection: None,
             branch_picker: None,
             headroom_enabled: false,
+            headroom_available: true,
         }
     }
 
@@ -2670,6 +2695,29 @@ mod tests {
         // Still no overrides, still on Named(0).
         assert!(s.custom_overrides.is_none());
         assert!(matches!(s.preset_selection, PresetSelection::Named(0)));
+    }
+
+    #[test]
+    fn headroom_toggle_gated_when_unavailable() {
+        let mut s = mk_state();
+        s.headroom_available = false;
+        s.focused_row = ConfigureRow::HeadroomProxy;
+        // Cycling the row must NOT enable Headroom when the binary is absent.
+        cycle_value_in_focused_row(&mut s, 1);
+        assert!(
+            !s.headroom_enabled,
+            "toggle must not flip when headroom unavailable"
+        );
+        cycle_value_in_focused_row(&mut s, -1);
+        assert!(!s.headroom_enabled);
+
+        // And when available it flips normally.
+        s.headroom_available = true;
+        cycle_value_in_focused_row(&mut s, 1);
+        assert!(
+            s.headroom_enabled,
+            "toggle flips when headroom is available"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -2669,13 +2669,15 @@ mod tests {
     #[test]
     fn tab_cycles_focus_through_visible_rows() {
         let mut s = mk_state();
-        // Named preset, default mode = Boss → rows =
-        // [Preset, Mode, Yolo, Branch, Prompt, Launch].
+        // Named preset, default mode = Boss, Claude/Codex provider → rows =
+        // [Preset, Mode, Yolo, HeadroomProxy, Branch, Prompt, Launch].
         assert_eq!(s.focused_row, ConfigureRow::Preset);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Mode);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Yolo);
+        s.cycle_focus(1);
+        assert_eq!(s.focused_row, ConfigureRow::HeadroomProxy);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Branch);
         s.cycle_focus(1);

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -1090,7 +1090,13 @@ fn render_headroom_row(f: &mut Frame, state: &ConfigureState, area: Rect, focuse
         "off".to_string()
     };
     let options = vec!["on".to_string(), "off".to_string()];
-    let line = build_pills_line("Headroom: ", &options, &current, focused, &[], area.width);
+    let mut line = build_pills_line("Headroom: ", &options, &current, focused, &[], area.width);
+    // Brief muted explainer + link. Terminals auto-linkify the bare URL, so a
+    // cmd/ctrl-click opens it — no OSC-8 escape juggling needed.
+    line.spans.push(Span::styled(
+        "  \u{2014} proxy that trims token usage \u{00b7} github.com/chopratejas/headroom",
+        Style::default().fg(MUTED_GRAY),
+    ));
     f.render_widget(Paragraph::new(line), area);
 }
 

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -818,6 +818,7 @@ impl SessionRecoveryState {
             created_at: chrono::Utc::now(),
             agent_type,
             headroom_enabled: false,
+            rtk_enabled: false,
         };
 
         let mut store = SessionStore::load();

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -817,6 +817,7 @@ impl SessionRecoveryState {
             workspace_name: worktree.source_repo.clone().unwrap_or_else(|| worktree.name.clone()),
             created_at: chrono::Utc::now(),
             agent_type,
+            headroom_enabled: false,
         };
 
         let mut store = SessionStore::load();

--- a/ainb-tui/crates/ainb-core/src/components/sidebar.rs
+++ b/ainb-tui/crates/ainb-core/src/components/sidebar.rs
@@ -38,6 +38,7 @@ pub enum SidebarItem {
     Inbox,        // ainb-hooks notification inbox
     Recovery,     // Recover orphaned sessions
     Mcp,          // Shared MCP pool overlay
+    Daemons,      // MCP pool + Headroom proxy status (read-only)
     Logs,         // Log history viewer
     Stats,        // Analytics & usage
     Witr,         // Process causality (witr plugin)
@@ -61,6 +62,7 @@ impl SidebarItem {
             Self::Inbox => "📥",
             Self::Recovery => "🔄",
             Self::Mcp => "🧬",
+            Self::Daemons => "⚙",
             Self::Logs => "📋",
             Self::Stats => "📊",
             Self::Witr => "🌳",
@@ -84,6 +86,7 @@ impl SidebarItem {
             Self::Inbox => "Inbox",
             Self::Recovery => "Recovery",
             Self::Mcp => "MCP",
+            Self::Daemons => "Daemons",
             Self::Logs => "Logs",
             Self::Stats => "Stats",
             Self::Witr => "Witr",
@@ -107,6 +110,7 @@ impl SidebarItem {
             Self::Inbox => "Hook Notifications",
             Self::Recovery => "Resume Orphaned",
             Self::Mcp => "Shared Pool",
+            Self::Daemons => "MCP + Headroom",
             Self::Logs => "View Log History",
             Self::Stats => "Usage & Analytics",
             Self::Witr => "Process Causality",
@@ -130,6 +134,7 @@ impl SidebarItem {
             Self::Inbox => "b",
             Self::Recovery => "R",
             Self::Mcp => "p",
+            Self::Daemons => "d",
             Self::Logs => "l",
             Self::Stats => "i",
             Self::Witr => "w",
@@ -154,6 +159,7 @@ impl SidebarItem {
             Self::Inbox,
             Self::Recovery,
             Self::Mcp,
+            Self::Daemons,
             Self::Logs,
             Self::Stats,
             Self::Witr,
@@ -564,6 +570,26 @@ mod tests {
         let collisions =
             all.iter().filter(|i| **i != SidebarItem::Memory && i.shortcut() == "m").count();
         assert_eq!(collisions, 0, "sidebar shortcut 'm' collides");
+    }
+
+    #[test]
+    fn daemons_tile_registered_with_non_colliding_shortcut() {
+        let all = SidebarItem::all();
+        let pos = all
+            .iter()
+            .position(|i| *i == SidebarItem::Daemons)
+            .expect("SidebarItem::Daemons missing from all()");
+        assert!(pos > 0, "Daemons shouldn't be first sidebar item");
+        assert_eq!(SidebarItem::Daemons.icon(), "⚙");
+        assert_eq!(SidebarItem::Daemons.label(), "Daemons");
+        assert_eq!(SidebarItem::Daemons.shortcut(), "d");
+        assert_eq!(SidebarItem::Daemons.description(), "MCP + Headroom");
+        // 'd' must not collide with any other sidebar shortcut.
+        let collisions = all
+            .iter()
+            .filter(|i| **i != SidebarItem::Daemons && i.shortcut() == "d")
+            .count();
+        assert_eq!(collisions, 0, "sidebar shortcut 'd' collides");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -30,6 +30,15 @@ fn log_file() -> PathBuf {
     headroom_dir().join("proxy.log")
 }
 
+// ── Availability ───────────────────────────────────────────────────────────
+
+/// Whether the `headroom` binary is on `PATH`. Cheap (one PATH lookup) — call
+/// it once when a screen opens, not per render. Used to gate the per-session
+/// toggle: no point offering Headroom if it can't be run.
+pub fn is_installed() -> bool {
+    which::which("headroom").is_ok()
+}
+
 // ── Port resolution ──────────────────────────────────────────────────────────
 
 /// Effective port for the Headroom proxy.

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -177,7 +177,7 @@ pub async fn stats() -> Option<HeadroomStats> {
 // ── Status ───────────────────────────────────────────────────────────────────
 
 /// Combined status of the ainb-managed Headroom proxy.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProxyStatus {
     pub running: bool,
     pub port: u16,

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -26,6 +26,11 @@ fn pid_file() -> PathBuf {
     headroom_dir().join("proxy.pid")
 }
 
+/// Serializes `ensure_proxy_running` so concurrent callers can't double-spawn
+/// the proxy on the same port (and clobber `proxy.pid`). Real runtime lock —
+/// distinct from the test-only `HEADROOM_ENV_LOCK`.
+static SPAWN_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 fn log_file() -> PathBuf {
     headroom_dir().join("proxy.log")
 }
@@ -75,6 +80,19 @@ pub async fn is_healthy() -> bool {
 /// 3. Writes the child PID to `proxy.pid`.
 /// 4. Polls `is_healthy()` for up to 5 s (50 × 100ms); returns `Ok` when live.
 pub async fn ensure_proxy_running() -> Result<()> {
+    if is_healthy().await {
+        return Ok(());
+    }
+
+    // Serialize the spawn. Two concurrent callers — a session launch and the
+    // 10s watchdog tick, or two overlapping watchdog ticks — could otherwise
+    // both observe `is_healthy() == false` and both `cmd.spawn()` a proxy on
+    // the same port. The loser exits on bind failure but still overwrites
+    // `proxy.pid` (below), orphaning the real proxy from `stop()`/idle-reap.
+    let _spawn_guard = SPAWN_LOCK.lock().await;
+
+    // Re-check under the lock: a racing caller may have brought the proxy up
+    // while we waited for the guard, in which case there is nothing to do.
     if is_healthy().await {
         return Ok(());
     }

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -1,0 +1,318 @@
+// ABOUTME: ainb-managed shared Headroom compression proxy.
+// One `headroom proxy --port <N>` process shared by all Headroom-enabled
+// sessions. Lazily started on first opt-in session, reaped on quit.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use crate::interactive::session_manager::HEADROOM_DEFAULT_PORT;
+
+// ── Directory helpers ────────────────────────────────────────────────────────
+
+/// Root directory for headroom runtime files (pid + log).
+/// Honors `AINB_HOME` just like `SessionStore::storage_path()`.
+fn headroom_dir() -> PathBuf {
+    let base = std::env::var_os("AINB_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")));
+    base.join(".agents-in-a-box").join("headroom")
+}
+
+fn pid_file() -> PathBuf {
+    headroom_dir().join("proxy.pid")
+}
+
+fn log_file() -> PathBuf {
+    headroom_dir().join("proxy.log")
+}
+
+// ── Port resolution ──────────────────────────────────────────────────────────
+
+/// Effective port for the Headroom proxy.
+/// Reads `AINB_HEADROOM_PORT`; falls back to `HEADROOM_DEFAULT_PORT` (8787).
+pub fn proxy_port() -> u16 {
+    std::env::var("AINB_HEADROOM_PORT")
+        .ok()
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(HEADROOM_DEFAULT_PORT)
+}
+
+// ── Liveness probe ───────────────────────────────────────────────────────────
+
+/// Returns `true` when the Headroom proxy answers `GET /health` within 500ms.
+/// Never panics; any error maps to `false`.
+pub async fn is_healthy() -> bool {
+    let port = proxy_port();
+    let url = format!("http://127.0.0.1:{port}/health");
+    let client = match reqwest::Client::builder().timeout(Duration::from_millis(500)).build() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    client.get(&url).send().await.map(|r| r.status().is_success()).unwrap_or(false)
+}
+
+// ── Proxy lifecycle ──────────────────────────────────────────────────────────
+
+/// Ensure the Headroom proxy is running.
+///
+/// If already healthy, returns immediately. Otherwise:
+/// 1. Locates the `headroom` binary via `which` (bail with install hint if absent).
+/// 2. Spawns `headroom proxy --port <N>` detached into its own process group,
+///    stdout+stderr → `~/.agents-in-a-box/headroom/proxy.log`.
+/// 3. Writes the child PID to `proxy.pid`.
+/// 4. Polls `is_healthy()` for up to 5 s (50 × 100ms); returns `Ok` when live.
+pub async fn ensure_proxy_running() -> Result<()> {
+    if is_healthy().await {
+        return Ok(());
+    }
+
+    // Locate binary — descriptive error if not on PATH.
+    let headroom_bin = which::which("headroom").map_err(|_| {
+        anyhow::anyhow!(
+            "headroom binary not found on PATH — install it with:\n  \
+             uv tool install 'headroom-ai[proxy]'"
+        )
+    })?;
+
+    let dir = headroom_dir();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create headroom dir {}", dir.display()))?;
+
+    let log_path = log_file();
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("open headroom log {}", log_path.display()))?;
+
+    let port = proxy_port();
+    let mut cmd = std::process::Command::new(&headroom_bin);
+    cmd.args(["proxy", "--port", &port.to_string()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(log.try_clone()?))
+        .stderr(std::process::Stdio::from(log));
+
+    // Detach into its own process group so terminal signals (ctrl-c aimed at
+    // the spawning CLI/TUI) never reach the proxy.
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
+    let child = cmd.spawn().context("spawn headroom proxy")?;
+    let pid = child.id();
+
+    // Persist PID for stop() to use.
+    std::fs::write(pid_file(), pid.to_string())
+        .with_context(|| format!("write pid file {}", pid_file().display()))?;
+
+    info!(
+        "spawned headroom proxy (pid={pid}, port={port}, log={})",
+        log_path.display()
+    );
+
+    // Poll up to ~5 s for the health endpoint. Async sleep so we yield the
+    // tokio worker instead of blocking it during session creation.
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if is_healthy().await {
+            info!("headroom proxy is healthy on port {port}");
+            return Ok(());
+        }
+    }
+
+    anyhow::bail!(
+        "headroom proxy did not come up within 5s (see {})",
+        log_path.display()
+    )
+}
+
+// ── Stats ────────────────────────────────────────────────────────────────────
+
+/// Summary statistics reported by the Headroom proxy `/stats` endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HeadroomStats {
+    #[serde(default)]
+    pub tokens_saved: u64,
+    #[serde(default)]
+    pub requests_total: u64,
+}
+
+/// Intermediate shape for deserializing `/stats` JSON:
+/// `{"summary":{"tokens_saved_total":N,"requests_total":N}}`.
+#[derive(Debug, Deserialize)]
+struct StatsResponse {
+    #[serde(default)]
+    summary: StatsSummary,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct StatsSummary {
+    #[serde(default)]
+    tokens_saved_total: u64,
+    #[serde(default)]
+    requests_total: u64,
+}
+
+/// Fetch `/stats` from the Headroom proxy; returns `None` on any error.
+pub async fn stats() -> Option<HeadroomStats> {
+    let port = proxy_port();
+    let url = format!("http://127.0.0.1:{port}/stats");
+    let client = reqwest::Client::builder().timeout(Duration::from_millis(500)).build().ok()?;
+    let resp = client.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: StatsResponse = resp.json().await.ok()?;
+    Some(HeadroomStats {
+        tokens_saved: body.summary.tokens_saved_total,
+        requests_total: body.summary.requests_total,
+    })
+}
+
+// ── Status ───────────────────────────────────────────────────────────────────
+
+/// Combined status of the ainb-managed Headroom proxy.
+#[derive(Debug)]
+pub struct ProxyStatus {
+    pub running: bool,
+    pub port: u16,
+    pub pid: Option<u32>,
+    pub tokens_saved: Option<u64>,
+}
+
+/// Query the proxy for a combined status snapshot.
+pub async fn status() -> ProxyStatus {
+    let port = proxy_port();
+    let running = is_healthy().await;
+    let pid = read_pid();
+    let tokens_saved = if running {
+        stats().await.map(|s| s.tokens_saved)
+    } else {
+        None
+    };
+    ProxyStatus {
+        running,
+        port,
+        pid,
+        tokens_saved,
+    }
+}
+
+// ── Stop ─────────────────────────────────────────────────────────────────────
+
+/// Stop the ainb-managed Headroom proxy.
+///
+/// Reads the PID file, sends SIGTERM to the process, removes the PID file.
+/// Best-effort — never panics.
+pub fn stop() {
+    let Some(pid) = read_pid() else {
+        return;
+    };
+
+    // Use nix::sys::signal::kill if available (nix is in the workspace).
+    let killed = try_kill(pid);
+    if killed {
+        info!("sent SIGTERM to headroom proxy (pid={pid})");
+    } else {
+        warn!("could not kill headroom proxy (pid={pid}): process may have already exited");
+    }
+
+    // Remove pid file regardless of kill outcome.
+    let _ = std::fs::remove_file(pid_file());
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn read_pid() -> Option<u32> {
+    std::fs::read_to_string(pid_file())
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+/// Send SIGTERM to `pid`. Returns `true` if the signal was sent (or the process
+/// was already gone — both are fine outcomes).
+fn try_kill(pid: u32) -> bool {
+    use nix::sys::signal::{Signal, kill as nix_kill};
+    use nix::unistd::Pid;
+    match nix_kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+        Ok(()) => true,
+        Err(nix::errno::Errno::ESRCH) => {
+            // Process already gone — not an error.
+            true
+        }
+        Err(e) => {
+            warn!("nix::kill({pid}, SIGTERM) failed: {e}");
+            false
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// Serializes every test that reads or mutates `AINB_HEADROOM_PORT`. Cargo runs
+/// tests in-process in parallel, so a setter in one test races a reader in
+/// another (e.g. `headroom_base_url()` in the session_manager tests). All such
+/// tests — in this module AND others — must hold this lock. See
+/// [reference: ENV_LOCK for parallel tests].
+#[cfg(test)]
+pub(crate) static HEADROOM_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `proxy_port()` must honor `AINB_HEADROOM_PORT` override.
+    #[test]
+    fn proxy_port_honors_override() {
+        let _guard = HEADROOM_ENV_LOCK.lock().unwrap();
+        // Isolate: stash any existing value, set ours, restore after.
+        let key = "AINB_HEADROOM_PORT";
+        let old = std::env::var_os(key);
+
+        std::env::set_var(key, "9999");
+        assert_eq!(proxy_port(), 9999);
+
+        // Restore env.
+        match old {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        // Default restored: should be HEADROOM_DEFAULT_PORT.
+        assert_eq!(proxy_port(), HEADROOM_DEFAULT_PORT);
+    }
+
+    /// Parsing the Headroom `/stats` JSON shape into `HeadroomStats`.
+    #[test]
+    fn headroom_stats_parses_summary() {
+        let json = r#"{"summary":{"tokens_saved_total":1220217,"requests_total":196}}"#;
+        let raw: StatsResponse = serde_json::from_str(json).expect("parses");
+        let s = HeadroomStats {
+            tokens_saved: raw.summary.tokens_saved_total,
+            requests_total: raw.summary.requests_total,
+        };
+        assert_eq!(s.tokens_saved, 1_220_217);
+        assert_eq!(s.requests_total, 196);
+    }
+
+    /// Missing or empty summary fields must default to 0 (no panic).
+    #[test]
+    fn headroom_stats_defaults_on_absent_fields() {
+        let json = r#"{"summary":{}}"#;
+        let raw: StatsResponse = serde_json::from_str(json).expect("parses");
+        assert_eq!(raw.summary.tokens_saved_total, 0);
+        assert_eq!(raw.summary.requests_total, 0);
+    }
+
+    /// Entirely missing `summary` key must also work (default-deriving outer struct).
+    #[test]
+    fn headroom_stats_defaults_on_no_summary() {
+        let json = r#"{}"#;
+        let raw: StatsResponse = serde_json::from_str(json).expect("parses");
+        assert_eq!(raw.summary.tokens_saved_total, 0);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -142,20 +142,30 @@ pub struct HeadroomStats {
     pub requests_total: u64,
 }
 
-/// Intermediate shape for deserializing `/stats` JSON:
-/// `{"summary":{"tokens_saved_total":N,"requests_total":N}}`.
-#[derive(Debug, Deserialize)]
+/// Intermediate shape for deserializing the Headroom `/stats` JSON. The real
+/// payload (headroom 0.26) is large; we only pull the two canonical figures:
+/// `savings.total_tokens` (total tokens saved across all layers) and
+/// `summary.api_requests` (requests seen by the proxy). Verified against a live
+/// proxy on 2026-06-19 — an earlier guess at `summary.tokens_saved_total`
+/// silently parsed to 0 because that key does not exist.
+#[derive(Debug, Default, Deserialize)]
 struct StatsResponse {
     #[serde(default)]
     summary: StatsSummary,
+    #[serde(default)]
+    savings: StatsSavings,
 }
 
 #[derive(Debug, Default, Deserialize)]
 struct StatsSummary {
     #[serde(default)]
-    tokens_saved_total: u64,
+    api_requests: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct StatsSavings {
     #[serde(default)]
-    requests_total: u64,
+    total_tokens: u64,
 }
 
 /// Fetch `/stats` from the Headroom proxy; returns `None` on any error.
@@ -169,8 +179,8 @@ pub async fn stats() -> Option<HeadroomStats> {
     }
     let body: StatsResponse = resp.json().await.ok()?;
     Some(HeadroomStats {
-        tokens_saved: body.summary.tokens_saved_total,
-        requests_total: body.summary.requests_total,
+        tokens_saved: body.savings.total_tokens,
+        requests_total: body.summary.api_requests,
     })
 }
 
@@ -286,33 +296,42 @@ mod tests {
         assert_eq!(proxy_port(), HEADROOM_DEFAULT_PORT);
     }
 
-    /// Parsing the Headroom `/stats` JSON shape into `HeadroomStats`.
+    /// Parse the REAL Headroom `/stats` shape (headroom 0.26, captured from a
+    /// live proxy) — `savings.total_tokens` + `summary.api_requests`, nested
+    /// among many sibling keys we ignore.
     #[test]
-    fn headroom_stats_parses_summary() {
-        let json = r#"{"summary":{"tokens_saved_total":1220217,"requests_total":196}}"#;
+    fn headroom_stats_parses_real_shape() {
+        let json = r#"{
+            "summary":{"mode":"token","api_requests":196,
+                "compression":{"total_tokens_removed":12345}},
+            "agent_usage":{"totals":{"tokens_saved":999}},
+            "savings":{"total_tokens":1220217,"per_project":{}}
+        }"#;
         let raw: StatsResponse = serde_json::from_str(json).expect("parses");
         let s = HeadroomStats {
-            tokens_saved: raw.summary.tokens_saved_total,
-            requests_total: raw.summary.requests_total,
+            tokens_saved: raw.savings.total_tokens,
+            requests_total: raw.summary.api_requests,
         };
         assert_eq!(s.tokens_saved, 1_220_217);
         assert_eq!(s.requests_total, 196);
     }
 
-    /// Missing or empty summary fields must default to 0 (no panic).
+    /// Missing nested fields must default to 0 (no panic) — the real payload
+    /// reports zeros before any traffic.
     #[test]
     fn headroom_stats_defaults_on_absent_fields() {
-        let json = r#"{"summary":{}}"#;
+        let json = r#"{"summary":{},"savings":{}}"#;
         let raw: StatsResponse = serde_json::from_str(json).expect("parses");
-        assert_eq!(raw.summary.tokens_saved_total, 0);
-        assert_eq!(raw.summary.requests_total, 0);
+        assert_eq!(raw.savings.total_tokens, 0);
+        assert_eq!(raw.summary.api_requests, 0);
     }
 
-    /// Entirely missing `summary` key must also work (default-deriving outer struct).
+    /// Entirely missing `summary`/`savings` keys must also work.
     #[test]
-    fn headroom_stats_defaults_on_no_summary() {
+    fn headroom_stats_defaults_on_empty_object() {
         let json = r#"{}"#;
         let raw: StatsResponse = serde_json::from_str(json).expect("parses");
-        assert_eq!(raw.summary.tokens_saved_total, 0);
+        assert_eq!(raw.savings.total_tokens, 0);
+        assert_eq!(raw.summary.api_requests, 0);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -218,10 +218,13 @@ pub async fn status() -> ProxyStatus {
 /// Stop the ainb-managed Headroom proxy.
 ///
 /// Reads the PID file, sends SIGTERM to the process, removes the PID file.
-/// Best-effort — never panics.
-pub fn stop() {
+/// Returns `true` when there was an ainb-managed proxy to stop (a pid file
+/// existed), `false` when there was nothing to do — e.g. the user is running
+/// their own `headroom proxy`, which we must NOT kill. Best-effort, never
+/// panics.
+pub fn stop() -> bool {
     let Some(pid) = read_pid() else {
-        return;
+        return false;
     };
 
     // Use nix::sys::signal::kill if available (nix is in the workspace).
@@ -234,6 +237,7 @@ pub fn stop() {
 
     // Remove pid file regardless of kill outcome.
     let _ = std::fs::remove_file(pid_file());
+    true
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -136,7 +136,16 @@ impl SessionStore {
         let content = serde_json::to_string_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
-        std::fs::write(&path, content)?;
+        // Atomic write: tmp + rename so a crash / full disk mid-write can't
+        // truncate the store and lose every tracked session. With the proxy
+        // watchdog, session-create and the `H` downgrade all writing here,
+        // an in-place truncating write would widen the corruption window.
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, content)?;
+        if let Err(e) = std::fs::rename(&tmp, &path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e);
+        }
         debug!("Saved {} sessions to {:?}", self.sessions.len(), path);
         Ok(())
     }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -292,8 +292,11 @@ impl InteractiveSessionManager {
 
         info!("Created worktree at: {}", worktree_info.path.display());
 
-        // Step 1b: Wire RTK project-local hook (best-effort — failure is non-fatal).
-        if rtk_enabled {
+        // Step 1b: Wire RTK project-local hook (best-effort — failure is
+        // non-fatal). Claude only: the hook lives in `.claude/settings.json`,
+        // which Codex/Gemini/Copilot never read — wiring it for them writes a
+        // file nothing consumes.
+        if rtk_enabled && agent_type == SessionAgentType::Claude {
             if let Err(e) = wire_rtk_project_hook(&worktree_info.path) {
                 warn!(
                     "Failed to wire RTK hook in worktree: {} — session launches without RTK",
@@ -455,8 +458,10 @@ impl InteractiveSessionManager {
             std::os::unix::fs::symlink(&existing_worktree_path, &session_path).ok();
         }
 
-        // Step 0b: Wire RTK project-local hook (best-effort — failure is non-fatal).
-        if rtk_enabled {
+        // Step 0b: Wire RTK project-local hook (best-effort — failure is
+        // non-fatal). Claude only: see create_session — `.claude/settings.json`
+        // is a Claude Code surface, ignored by other agents.
+        if rtk_enabled && agent_type == SessionAgentType::Claude {
             if let Err(e) = wire_rtk_project_hook(&existing_worktree_path) {
                 warn!(
                     "Failed to wire RTK hook in worktree: {} — session launches without RTK",
@@ -1530,12 +1535,17 @@ impl InteractiveSession {
 /// is already present, and preserves all other settings (never clobbers).
 /// Best-effort — call sites log warn on error but must not propagate it.
 fn wire_rtk_project_hook(worktree: &std::path::Path) -> anyhow::Result<()> {
-    use anyhow::Context as _;
-
     let Some(cmd) = crate::rtk::project_hook_command() else {
         warn!("rtk binary not found — skipping project hook wiring");
         return Ok(());
     };
+    wire_rtk_project_hook_with_cmd(worktree, &cmd)
+}
+
+/// Inner merge, parameterised on the resolved hook `cmd` so tests can exercise
+/// the real read-merge-write path without rtk on PATH.
+fn wire_rtk_project_hook_with_cmd(worktree: &std::path::Path, cmd: &str) -> anyhow::Result<()> {
+    use anyhow::Context as _;
 
     let claude_dir = worktree.join(".claude");
     let settings_path = claude_dir.join("settings.json");
@@ -1543,7 +1553,19 @@ fn wire_rtk_project_hook(worktree: &std::path::Path) -> anyhow::Result<()> {
     let mut root: serde_json::Value = if settings_path.exists() {
         let raw = std::fs::read_to_string(&settings_path)
             .with_context(|| format!("read {}", settings_path.display()))?;
-        serde_json::from_str(&raw).unwrap_or(serde_json::Value::Object(serde_json::Map::new()))
+        match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            // Never overwrite a settings.json we couldn't parse — it may hold
+            // the user's own hooks/config. Leave it untouched; the session
+            // just launches without the rtk hook.
+            Err(e) => {
+                warn!(
+                    "{} is not valid JSON ({e}) — leaving it untouched, session launches without rtk hook",
+                    settings_path.display()
+                );
+                return Ok(());
+            }
+        }
     } else {
         serde_json::Value::Object(serde_json::Map::new())
     };
@@ -1561,30 +1583,44 @@ fn wire_rtk_project_hook(worktree: &std::path::Path) -> anyhow::Result<()> {
 
     let arr = pre_tool_use.as_array_mut().context("PreToolUse is not an array")?;
 
-    // Idempotent: only append if no existing rtk hook command is present.
+    // Idempotent: skip if an rtk hook is already wired. Match the exact command
+    // or any command containing `rtk hook claude` (the install path may differ)
+    // — tighter than a bare "hook claude" substring, which would false-match
+    // unrelated user commands.
     let already_present = arr.iter().any(|entry| {
         entry.get("hooks").and_then(|h| h.as_array()).map_or(false, |hooks| {
             hooks.iter().any(|h| {
                 h.get("command")
                     .and_then(|c| c.as_str())
-                    .map_or(false, |c| c.contains("hook claude"))
+                    .map_or(false, |c| c == cmd || c.contains("rtk hook claude"))
             })
         })
     });
 
-    if !already_present {
-        arr.push(serde_json::json!({
-            "matcher": "Bash",
-            "hooks": [{"type": "command", "command": cmd}]
-        }));
+    // Nothing to add → don't touch the file (avoids mtime churn / reformatting
+    // a user's compact JSON on every launch).
+    if already_present {
+        return Ok(());
     }
+
+    arr.push(serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": cmd}]
+    }));
 
     std::fs::create_dir_all(&claude_dir)
         .with_context(|| format!("create dir {}", claude_dir.display()))?;
 
     let content = serde_json::to_string_pretty(&root).context("serialize settings.json")?;
 
-    if let Err(e) = std::fs::write(&settings_path, &content) {
+    // Atomic write: tmp in the same dir + rename, so a crash / full disk
+    // mid-write can't truncate a settings.json that may hold unrelated user
+    // hooks. rename(2) is atomic on POSIX within a filesystem.
+    let tmp = settings_path.with_extension("json.tmp");
+    if let Err(e) =
+        std::fs::write(&tmp, &content).and_then(|_| std::fs::rename(&tmp, &settings_path))
+    {
+        let _ = std::fs::remove_file(&tmp);
         warn!(
             "failed to write {}: {} — session launches without rtk hook",
             settings_path.display(),
@@ -1809,61 +1845,25 @@ mod tests {
         std::env::remove_var("AINB_HOME");
     }
 
-    /// wire_rtk_project_hook is idempotent: calling twice yields exactly one hook entry.
+    /// Two wires yield exactly one rtk entry — exercises the real function.
     #[test]
     fn wire_rtk_project_hook_merges_idempotently() {
         use tempfile::TempDir;
         let dir = TempDir::new().expect("tempdir");
+        let cmd = "/usr/local/bin/rtk hook claude";
 
-        // First call — creates .claude/settings.json with one entry.
-        // wire_rtk_project_hook degrades gracefully when rtk not on PATH, so we
-        // pre-seed settings.json with a synthetic hook to test the idempotency
-        // logic directly.
-        let claude_dir = dir.path().join(".claude");
-        std::fs::create_dir_all(&claude_dir).unwrap();
-        let settings_path = claude_dir.join("settings.json");
-        let initial = serde_json::json!({
-            "hooks": {
-                "PreToolUse": [
-                    {
-                        "matcher": "Bash",
-                        "hooks": [{"type": "command", "command": "/usr/local/bin/rtk hook claude"}]
-                    }
-                ]
-            }
-        });
-        std::fs::write(
-            &settings_path,
-            serde_json::to_string_pretty(&initial).unwrap(),
-        )
-        .unwrap();
+        wire_rtk_project_hook_with_cmd(dir.path(), cmd).expect("first wire");
+        wire_rtk_project_hook_with_cmd(dir.path(), cmd).expect("second wire");
 
-        // Manually invoke the merge logic by calling wire_rtk_project_hook.
-        // Since rtk may not be installed in CI, we patch the path inline by
-        // verifying the idempotency guard in isolation: read back the file and
-        // assert still one entry.
+        let settings_path = dir.path().join(".claude/settings.json");
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
         let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(arr.len(), 1, "should have exactly one PreToolUse entry");
-
-        // Simulate a second wire call: re-parse + check already_present guard.
-        let already_present = arr.iter().any(|entry| {
-            entry.get("hooks").and_then(|h| h.as_array()).map_or(false, |hooks| {
-                hooks.iter().any(|h| {
-                    h.get("command")
-                        .and_then(|c| c.as_str())
-                        .map_or(false, |c| c.contains("hook claude"))
-                })
-            })
-        });
-        assert!(
-            already_present,
-            "idempotency guard must fire on second call"
-        );
+        assert_eq!(arr.len(), 1, "two wires must produce exactly one rtk entry");
+        assert_eq!(arr[0]["hooks"][0]["command"], cmd);
     }
 
-    /// wire_rtk_project_hook preserves unrelated hooks already in settings.json.
+    /// The real function appends rtk while preserving unrelated hooks + settings.
     #[test]
     fn wire_rtk_project_hook_merge_preserves_existing() {
         use tempfile::TempDir;
@@ -1872,7 +1872,6 @@ mod tests {
         std::fs::create_dir_all(&claude_dir).unwrap();
         let settings_path = claude_dir.join("settings.json");
 
-        // Pre-seed an unrelated hook.
         let initial = serde_json::json!({
             "hooks": {
                 "PreToolUse": [
@@ -1890,12 +1889,36 @@ mod tests {
         )
         .unwrap();
 
-        // Verify existing hook is intact after reading back.
+        wire_rtk_project_hook_with_cmd(dir.path(), "/opt/rtk hook claude").expect("wire");
+
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
         assert_eq!(root["someOtherSetting"], serde_json::Value::Bool(true));
         let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(arr.len(), 1, "one pre-existing hook");
+        assert_eq!(arr.len(), 2, "pre-existing hook kept + rtk appended");
         assert_eq!(arr[0]["matcher"], "Read");
+        assert_eq!(arr[1]["matcher"], "Bash");
+    }
+
+    /// A settings.json we can't parse is left byte-for-byte untouched — we must
+    /// never clobber a file that may hold the user's own hooks/config.
+    #[test]
+    fn wire_rtk_project_hook_preserves_unparseable_settings() {
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings_path = claude_dir.join("settings.json");
+
+        let garbage = "{ not valid json, // with a comment\n";
+        std::fs::write(&settings_path, garbage).unwrap();
+
+        wire_rtk_project_hook_with_cmd(dir.path(), "/opt/rtk hook claude").expect("must not error");
+
+        let after = std::fs::read_to_string(&settings_path).unwrap();
+        assert_eq!(
+            after, garbage,
+            "unparseable settings must be left untouched"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -63,6 +63,7 @@ pub struct InteractiveSession {
     pub agent_type: SessionAgentType, // The AI agent or shell for this session
     pub model: Option<ClaudeModel>,   // Claude model for this session (only for Claude agent)
     pub headroom_enabled: bool,       // Route this session's CLI through the local Headroom proxy
+    pub rtk_enabled: bool,            // RTK PreToolUse hook wired in session's worktree
 }
 
 /// Persisted session metadata for discovery across restarts
@@ -82,6 +83,8 @@ pub struct SessionMetadata {
     pub agent_type: SessionAgentType,
     #[serde(default)]
     pub headroom_enabled: bool,
+    #[serde(default)]
+    pub rtk_enabled: bool,
 }
 
 /// Storage for all persisted session metadata
@@ -260,6 +263,7 @@ impl InteractiveSessionManager {
         model: Option<ClaudeModel>,
         codex_model: Option<CodexModel>,
         headroom_enabled: bool,
+        rtk_enabled: bool,
     ) -> Result<InteractiveSession, InteractiveSessionError> {
         info!(
             "Creating Interactive session {} for branch '{}' in workspace '{}' (agent={:?}, model={:?}, codex_model={:?}, skip_permissions={})",
@@ -287,6 +291,16 @@ impl InteractiveSessionManager {
         )?;
 
         info!("Created worktree at: {}", worktree_info.path.display());
+
+        // Step 1b: Wire RTK project-local hook (best-effort — failure is non-fatal).
+        if rtk_enabled {
+            if let Err(e) = wire_rtk_project_hook(&worktree_info.path) {
+                warn!(
+                    "Failed to wire RTK hook in worktree: {} — session launches without RTK",
+                    e
+                );
+            }
+        }
 
         // Step 2: Create tmux session name (format: tmux_{folder}_{branch})
         let worktree_folder = Self::extract_worktree_folder(&worktree_info.path);
@@ -335,6 +349,7 @@ impl InteractiveSessionManager {
             agent_type,
             model,
             headroom_enabled,
+            rtk_enabled,
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -348,6 +363,7 @@ impl InteractiveSessionManager {
             created_at,
             agent_type,
             headroom_enabled,
+            rtk_enabled,
         };
         let mut store = SessionStore::load();
         store.upsert(metadata);
@@ -400,6 +416,7 @@ impl InteractiveSessionManager {
         model: Option<ClaudeModel>,
         codex_model: Option<CodexModel>,
         headroom_enabled: bool,
+        rtk_enabled: bool,
     ) -> Result<InteractiveSession, InteractiveSessionError> {
         info!(
             "Creating Interactive session {} with existing worktree at '{}' (agent={:?}, model={:?}, codex_model={:?})",
@@ -436,6 +453,16 @@ impl InteractiveSessionManager {
             }
             #[cfg(unix)]
             std::os::unix::fs::symlink(&existing_worktree_path, &session_path).ok();
+        }
+
+        // Step 0b: Wire RTK project-local hook (best-effort — failure is non-fatal).
+        if rtk_enabled {
+            if let Err(e) = wire_rtk_project_hook(&existing_worktree_path) {
+                warn!(
+                    "Failed to wire RTK hook in worktree: {} — session launches without RTK",
+                    e
+                );
+            }
         }
 
         // Step 1: Create tmux session name (format: tmux_{folder}_{branch})
@@ -486,6 +513,7 @@ impl InteractiveSessionManager {
             agent_type,
             model,
             headroom_enabled,
+            rtk_enabled,
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -499,6 +527,7 @@ impl InteractiveSessionManager {
             created_at,
             agent_type,
             headroom_enabled,
+            rtk_enabled,
         };
         let mut store = SessionStore::load();
         store.upsert(metadata);
@@ -626,6 +655,7 @@ impl InteractiveSessionManager {
                     agent_type,
                     model: None,
                     headroom_enabled: metadata.headroom_enabled,
+                    rtk_enabled: metadata.rtk_enabled,
                 });
             } else {
                 debug!(
@@ -675,6 +705,7 @@ impl InteractiveSessionManager {
                     agent_type,
                     model: None,
                     headroom_enabled: false,
+                    rtk_enabled: false,
                 });
             }
         }
@@ -1493,6 +1524,76 @@ impl InteractiveSession {
     }
 }
 
+/// Write an RTK `PreToolUse` hook entry into `<worktree>/.claude/settings.json`.
+///
+/// Merge-only, idempotent: reads existing JSON, appends only when no rtk hook
+/// is already present, and preserves all other settings (never clobbers).
+/// Best-effort — call sites log warn on error but must not propagate it.
+fn wire_rtk_project_hook(worktree: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    let Some(cmd) = crate::rtk::project_hook_command() else {
+        warn!("rtk binary not found — skipping project hook wiring");
+        return Ok(());
+    };
+
+    let claude_dir = worktree.join(".claude");
+    let settings_path = claude_dir.join("settings.json");
+
+    let mut root: serde_json::Value = if settings_path.exists() {
+        let raw = std::fs::read_to_string(&settings_path)
+            .with_context(|| format!("read {}", settings_path.display()))?;
+        serde_json::from_str(&raw).unwrap_or(serde_json::Value::Object(serde_json::Map::new()))
+    } else {
+        serde_json::Value::Object(serde_json::Map::new())
+    };
+
+    // Ensure hooks.PreToolUse is an array.
+    let pre_tool_use = root
+        .as_object_mut()
+        .context("settings.json root is not an object")?
+        .entry("hooks")
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+        .context("hooks is not an object")?
+        .entry("PreToolUse")
+        .or_insert_with(|| serde_json::Value::Array(vec![]));
+
+    let arr = pre_tool_use.as_array_mut().context("PreToolUse is not an array")?;
+
+    // Idempotent: only append if no existing rtk hook command is present.
+    let already_present = arr.iter().any(|entry| {
+        entry.get("hooks").and_then(|h| h.as_array()).map_or(false, |hooks| {
+            hooks.iter().any(|h| {
+                h.get("command")
+                    .and_then(|c| c.as_str())
+                    .map_or(false, |c| c.contains("hook claude"))
+            })
+        })
+    });
+
+    if !already_present {
+        arr.push(serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": cmd}]
+        }));
+    }
+
+    std::fs::create_dir_all(&claude_dir)
+        .with_context(|| format!("create dir {}", claude_dir.display()))?;
+
+    let content = serde_json::to_string_pretty(&root).context("serialize settings.json")?;
+
+    if let Err(e) = std::fs::write(&settings_path, &content) {
+        warn!(
+            "failed to write {}: {} — session launches without rtk hook",
+            settings_path.display(),
+            e
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1685,6 +1786,7 @@ mod tests {
             created_at: Utc::now(),
             agent_type: SessionAgentType::Claude,
             headroom_enabled: true,
+            rtk_enabled: false,
         });
         store.save().expect("save");
 
@@ -1705,5 +1807,95 @@ mod tests {
 
         // Cleanup env
         std::env::remove_var("AINB_HOME");
+    }
+
+    /// wire_rtk_project_hook is idempotent: calling twice yields exactly one hook entry.
+    #[test]
+    fn wire_rtk_project_hook_merges_idempotently() {
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+
+        // First call — creates .claude/settings.json with one entry.
+        // wire_rtk_project_hook degrades gracefully when rtk not on PATH, so we
+        // pre-seed settings.json with a synthetic hook to test the idempotency
+        // logic directly.
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings_path = claude_dir.join("settings.json");
+        let initial = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/usr/local/bin/rtk hook claude"}]
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        // Manually invoke the merge logic by calling wire_rtk_project_hook.
+        // Since rtk may not be installed in CI, we patch the path inline by
+        // verifying the idempotency guard in isolation: read back the file and
+        // assert still one entry.
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1, "should have exactly one PreToolUse entry");
+
+        // Simulate a second wire call: re-parse + check already_present guard.
+        let already_present = arr.iter().any(|entry| {
+            entry.get("hooks").and_then(|h| h.as_array()).map_or(false, |hooks| {
+                hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map_or(false, |c| c.contains("hook claude"))
+                })
+            })
+        });
+        assert!(
+            already_present,
+            "idempotency guard must fire on second call"
+        );
+    }
+
+    /// wire_rtk_project_hook preserves unrelated hooks already in settings.json.
+    #[test]
+    fn wire_rtk_project_hook_merge_preserves_existing() {
+        use tempfile::TempDir;
+        let dir = TempDir::new().expect("tempdir");
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings_path = claude_dir.join("settings.json");
+
+        // Pre-seed an unrelated hook.
+        let initial = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Read",
+                        "hooks": [{"type": "command", "command": "/usr/local/bin/other hook"}]
+                    }
+                ]
+            },
+            "someOtherSetting": true
+        });
+        std::fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        // Verify existing hook is intact after reading back.
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(root["someOtherSetting"], serde_json::Value::Bool(true));
+        let arr = root["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1, "one pre-existing hook");
+        assert_eq!(arr[0]["matcher"], "Read");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -62,6 +62,7 @@ pub struct InteractiveSession {
     pub created_at: DateTime<Utc>,
     pub agent_type: SessionAgentType, // The AI agent or shell for this session
     pub model: Option<ClaudeModel>,   // Claude model for this session (only for Claude agent)
+    pub headroom_enabled: bool,       // Route this session's CLI through the local Headroom proxy
 }
 
 /// Persisted session metadata for discovery across restarts
@@ -79,6 +80,8 @@ pub struct SessionMetadata {
     pub created_at: DateTime<Utc>,
     #[serde(default)]
     pub agent_type: SessionAgentType,
+    #[serde(default)]
+    pub headroom_enabled: bool,
 }
 
 /// Storage for all persisted session metadata
@@ -179,6 +182,37 @@ impl SessionStore {
     }
 }
 
+/// Default port for the ainb-managed Headroom compression proxy.
+pub const HEADROOM_DEFAULT_PORT: u16 = 8787;
+
+/// Base URL of the local Headroom proxy. Port overridable via `AINB_HEADROOM_PORT`.
+pub fn headroom_base_url() -> String {
+    let port = std::env::var("AINB_HEADROOM_PORT")
+        .ok()
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(HEADROOM_DEFAULT_PORT);
+    format!("http://127.0.0.1:{port}")
+}
+
+/// Shell `export … && ` prefix that routes a session's CLI through the local
+/// Headroom proxy. Empty when disabled or for providers that can't be proxied
+/// (Gemini/Copilot). One source of truth for both initial launch
+/// (`build_env_setup_for_provider`) and restart, so the two never drift.
+pub fn headroom_env_prefix(agent_type: SessionAgentType, enabled: bool) -> String {
+    if !enabled {
+        return String::new();
+    }
+    match agent_type {
+        SessionAgentType::Claude => {
+            format!("export ANTHROPIC_BASE_URL='{}' && ", headroom_base_url())
+        }
+        SessionAgentType::Codex => {
+            format!("export OPENAI_BASE_URL='{}/v1' && ", headroom_base_url())
+        }
+        _ => String::new(),
+    }
+}
+
 /// Manager for Interactive mode sessions (host-based, no Docker)
 pub struct InteractiveSessionManager {
     worktree_manager: WorktreeManager,
@@ -225,6 +259,7 @@ impl InteractiveSessionManager {
         agent_type: SessionAgentType,
         model: Option<ClaudeModel>,
         codex_model: Option<CodexModel>,
+        headroom_enabled: bool,
     ) -> Result<InteractiveSession, InteractiveSessionError> {
         info!(
             "Creating Interactive session {} for branch '{}' in workspace '{}' (agent={:?}, model={:?}, codex_model={:?}, skip_permissions={})",
@@ -278,6 +313,7 @@ impl InteractiveSessionManager {
                     codex_model,
                     agent_type,
                     None,
+                    headroom_enabled,
                 )
                 .await?;
             }
@@ -298,6 +334,7 @@ impl InteractiveSessionManager {
             created_at,
             agent_type,
             model,
+            headroom_enabled,
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -310,6 +347,7 @@ impl InteractiveSessionManager {
             workspace_name: workspace_name.clone(),
             created_at,
             agent_type,
+            headroom_enabled,
         };
         let mut store = SessionStore::load();
         store.upsert(metadata);
@@ -361,6 +399,7 @@ impl InteractiveSessionManager {
         agent_type: SessionAgentType,
         model: Option<ClaudeModel>,
         codex_model: Option<CodexModel>,
+        headroom_enabled: bool,
     ) -> Result<InteractiveSession, InteractiveSessionError> {
         info!(
             "Creating Interactive session {} with existing worktree at '{}' (agent={:?}, model={:?}, codex_model={:?})",
@@ -424,6 +463,7 @@ impl InteractiveSessionManager {
                     codex_model,
                     agent_type,
                     None,
+                    headroom_enabled,
                 )
                 .await?;
             }
@@ -445,6 +485,7 @@ impl InteractiveSessionManager {
             created_at,
             agent_type,
             model,
+            headroom_enabled,
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -457,6 +498,7 @@ impl InteractiveSessionManager {
             workspace_name: workspace_name.clone(),
             created_at,
             agent_type,
+            headroom_enabled,
         };
         let mut store = SessionStore::load();
         store.upsert(metadata);
@@ -583,6 +625,7 @@ impl InteractiveSessionManager {
                     created_at: metadata.created_at,
                     agent_type,
                     model: None,
+                    headroom_enabled: metadata.headroom_enabled,
                 });
             } else {
                 debug!(
@@ -631,6 +674,7 @@ impl InteractiveSessionManager {
                     created_at: Utc::now(),
                     agent_type,
                     model: None,
+                    headroom_enabled: false,
                 });
             }
         }
@@ -1171,6 +1215,7 @@ impl InteractiveSessionManager {
         codex_model: Option<CodexModel>,
         agent_type: SessionAgentType,
         resume_transcript: Option<PathBuf>,
+        headroom_enabled: bool,
     ) -> Result<(), InteractiveSessionError> {
         use crate::config::CliProvider;
 
@@ -1192,7 +1237,7 @@ impl InteractiveSessionManager {
         };
 
         // Build environment setup for API key injection
-        let env_setup = Self::build_env_setup_for_provider(agent_type);
+        let env_setup = Self::build_env_setup_for_provider(agent_type, headroom_enabled);
 
         // Build the CLI command with appropriate flags
         let mut cmd_parts = vec![provider.command().to_string()];
@@ -1346,37 +1391,37 @@ impl InteractiveSessionManager {
     }
 
     /// Build environment setup for injecting API key based on provider
-    fn build_env_setup_for_provider(agent_type: SessionAgentType) -> String {
+    fn build_env_setup_for_provider(
+        agent_type: SessionAgentType,
+        headroom_enabled: bool,
+    ) -> String {
         use crate::credentials;
 
-        match agent_type {
-            SessionAgentType::Claude => {
-                // Use existing logic for Claude
-                Self::build_env_setup()
-            }
+        let headroom_prefix = headroom_env_prefix(agent_type, headroom_enabled);
+
+        let base = match agent_type {
+            SessionAgentType::Claude => Self::build_env_setup(),
             SessionAgentType::Codex => {
-                // Inject OpenAI API key if available
                 if let Ok(Some(api_key)) = credentials::get_openai_api_key() {
                     info!("Injecting OPENAI_API_KEY for Codex CLI");
-                    return format!("export OPENAI_API_KEY='{}' && ", api_key);
+                    format!("export OPENAI_API_KEY='{}' && ", api_key)
+                } else {
+                    String::new()
                 }
-                String::new()
             }
             SessionAgentType::Gemini => {
-                // Inject Gemini API key if available
                 if let Ok(Some(api_key)) = credentials::get_gemini_api_key() {
                     info!("Injecting GEMINI_API_KEY for Gemini CLI");
-                    return format!("export GEMINI_API_KEY='{}' && ", api_key);
+                    format!("export GEMINI_API_KEY='{}' && ", api_key)
+                } else {
+                    String::new()
                 }
-                String::new()
             }
-            SessionAgentType::Copilot => {
-                // Copilot uses gh OAuth — no API key injection needed
-                // gh auth handles authentication transparently
-                String::new()
-            }
+            SessionAgentType::Copilot => String::new(),
             _ => String::new(),
-        }
+        };
+
+        format!("{headroom_prefix}{base}")
     }
 }
 
@@ -1407,6 +1452,36 @@ impl InteractiveSession {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn headroom_env_prefix_routes_claude_and_codex_only() {
+        use crate::models::session::SessionAgentType;
+
+        // Disabled → no injection for any provider.
+        assert_eq!(headroom_env_prefix(SessionAgentType::Claude, false), "");
+        assert_eq!(headroom_env_prefix(SessionAgentType::Codex, false), "");
+
+        // Enabled → Claude routes via ANTHROPIC_BASE_URL, Codex via OPENAI_BASE_URL/v1.
+        let base = headroom_base_url();
+        assert_eq!(
+            headroom_env_prefix(SessionAgentType::Claude, true),
+            format!("export ANTHROPIC_BASE_URL='{base}' && ")
+        );
+        assert_eq!(
+            headroom_env_prefix(SessionAgentType::Codex, true),
+            format!("export OPENAI_BASE_URL='{base}/v1' && ")
+        );
+
+        // Providers Headroom can't proxy → empty even when enabled (gating).
+        assert_eq!(headroom_env_prefix(SessionAgentType::Gemini, true), "");
+        assert_eq!(headroom_env_prefix(SessionAgentType::Copilot, true), "");
+    }
+
+    #[test]
+    fn headroom_base_url_honors_port_override() {
+        // Default port when unset is the documented 8787.
+        assert!(headroom_base_url().ends_with(&HEADROOM_DEFAULT_PORT.to_string()));
+    }
 
     #[test]
     fn test_derive_workspace_name() {

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -949,6 +949,16 @@ impl InteractiveSessionManager {
             // Continue anyway - removal was successful
         }
 
+        // Idle-reap: if no Headroom-enabled sessions remain, stop the shared
+        // proxy so it doesn't linger after the last consumer is gone.
+        // `headroom::stop()` is a no-op when the proxy wasn't ainb-spawned (no
+        // pid file), so a user's own `headroom proxy` is never touched.
+        let remaining_headroom = store.sessions.values().filter(|m| m.headroom_enabled).count();
+        if remaining_headroom == 0 {
+            info!("No Headroom sessions remain — reaping shared proxy");
+            crate::headroom::stop();
+        }
+
         info!(
             "<<< InteractiveSessionManager::remove_session() COMPLETE: {}",
             session_id
@@ -1239,8 +1249,19 @@ impl InteractiveSessionManager {
         // Ensure the shared Headroom proxy is running before we build the env
         // that points the CLI at it. On error we log a warning and continue —
         // the session still launches, just without working compression.
-        // TODO(P2-followup #951): respawn Claude Code daemon under proxy env
-        // TODO(idle-reap): reap proxy when no Headroom-enabled sessions remain
+        //
+        // #951 (Claude Code daemon bypass): NOT reproduced in ainb's launch
+        // model. We respawn the pane with `export ANTHROPIC_BASE_URL=… && exec
+        // claude`, so the CLI process inherits the override directly. Live-
+        // verified 2026-06-19: routing a call through the proxy incremented its
+        // request counter, so the env reaches the upstream request. The
+        // headroom-issue fix (killing Claude Code's global daemon) is
+        // deliberately NOT done here — it would disrupt unrelated sessions to
+        // solve a problem we cannot reproduce. The statusline reflects ACTUAL
+        // routing, so any real bypass would surface there rather than silently.
+        //
+        // Idle-reap is handled in `remove_session()` (stops the shared proxy
+        // when the last Headroom session closes).
         if headroom_enabled
             && matches!(
                 agent_type,

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1236,6 +1236,22 @@ impl InteractiveSessionManager {
             _ => return Ok(()), // Shell and other types don't need CLI
         };
 
+        // Ensure the shared Headroom proxy is running before we build the env
+        // that points the CLI at it. On error we log a warning and continue —
+        // the session still launches, just without working compression.
+        // TODO(P2-followup #951): respawn Claude Code daemon under proxy env
+        // TODO(idle-reap): reap proxy when no Headroom-enabled sessions remain
+        if headroom_enabled
+            && matches!(
+                agent_type,
+                SessionAgentType::Claude | SessionAgentType::Codex
+            )
+        {
+            if let Err(e) = crate::headroom::ensure_proxy_running().await {
+                warn!("headroom proxy unavailable — session will start without compression: {e}");
+            }
+        }
+
         // Build environment setup for API key injection
         let env_setup = Self::build_env_setup_for_provider(agent_type, headroom_enabled);
 
@@ -1457,6 +1473,12 @@ mod tests {
     fn headroom_env_prefix_routes_claude_and_codex_only() {
         use crate::models::session::SessionAgentType;
 
+        // Hold the shared env lock + force the default port so the base URL is
+        // deterministic regardless of other tests mutating AINB_HEADROOM_PORT.
+        let _guard = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os("AINB_HEADROOM_PORT");
+        std::env::remove_var("AINB_HEADROOM_PORT");
+
         // Disabled → no injection for any provider.
         assert_eq!(headroom_env_prefix(SessionAgentType::Claude, false), "");
         assert_eq!(headroom_env_prefix(SessionAgentType::Codex, false), "");
@@ -1475,12 +1497,30 @@ mod tests {
         // Providers Headroom can't proxy → empty even when enabled (gating).
         assert_eq!(headroom_env_prefix(SessionAgentType::Gemini, true), "");
         assert_eq!(headroom_env_prefix(SessionAgentType::Copilot, true), "");
+
+        if let Some(v) = old {
+            std::env::set_var("AINB_HEADROOM_PORT", v);
+        }
     }
 
     #[test]
     fn headroom_base_url_honors_port_override() {
-        // Default port when unset is the documented 8787.
+        let _guard = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let key = "AINB_HEADROOM_PORT";
+        let old = std::env::var_os(key);
+
+        // Unset → documented default 8787.
+        std::env::remove_var(key);
         assert!(headroom_base_url().ends_with(&HEADROOM_DEFAULT_PORT.to_string()));
+
+        // Override → reflected in the base URL.
+        std::env::set_var(key, "9191");
+        assert!(headroom_base_url().ends_with(":9191"));
+
+        match old {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1656,4 +1656,54 @@ mod tests {
         let manager = InteractiveSessionManager::new();
         assert!(manager.is_ok(), "Should create manager without Docker");
     }
+
+    /// Verify the SessionStore headroom flip: if a session has headroom_enabled=true,
+    /// mutating the field to false and saving results in false when re-loaded.
+    /// This covers the pure store-manipulation leg of `downgrade_headroom_session`
+    /// without requiring tmux.
+    #[test]
+    fn session_store_headroom_flip_persists() {
+        use crate::models::session::SessionAgentType;
+        use chrono::Utc;
+        use std::path::PathBuf;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().expect("tempdir");
+        // Point AINB_HOME at our temp dir so SessionStore::storage_path() uses it.
+        std::env::set_var("AINB_HOME", dir.path());
+
+        let tmux_name = "ainb-test-headroom-flip".to_string();
+        let session_id = uuid::Uuid::new_v4();
+
+        // Seed: headroom_enabled = true
+        let mut store = SessionStore::load();
+        store.upsert(SessionMetadata {
+            session_id,
+            tmux_session_name: tmux_name.clone(),
+            worktree_path: PathBuf::from("/tmp/fake"),
+            workspace_name: "test".to_string(),
+            created_at: Utc::now(),
+            agent_type: SessionAgentType::Claude,
+            headroom_enabled: true,
+        });
+        store.save().expect("save");
+
+        // Flip: headroom_enabled = false (mirrors downgrade_headroom_session step 3)
+        let mut store2 = SessionStore::load();
+        let meta = store2.sessions.get(&tmux_name).expect("meta present");
+        assert!(meta.headroom_enabled, "precondition: headroom was on");
+        store2.sessions.get_mut(&tmux_name).unwrap().headroom_enabled = false;
+        store2.save().expect("save after flip");
+
+        // Reload and verify persistence
+        let store3 = SessionStore::load();
+        let reloaded = store3.sessions.get(&tmux_name).expect("still present");
+        assert!(
+            !reloaded.headroom_enabled,
+            "headroom should be off after flip"
+        );
+
+        // Cleanup env
+        std::env::remove_var("AINB_HOME");
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1262,19 +1262,26 @@ impl InteractiveSessionManager {
         //
         // Idle-reap is handled in `remove_session()` (stops the shared proxy
         // when the last Headroom session closes).
-        if headroom_enabled
+        // The toggle being on is *intent*; routing only happens if the proxy is
+        // actually healthy. If ensure fails (binary missing, port 8787 taken,
+        // crash), DEGRADE to direct — do NOT inject a base URL pointing at a
+        // dead port, which would brick the session with connection-refused.
+        let mut headroom_active = headroom_enabled
             && matches!(
                 agent_type,
                 SessionAgentType::Claude | SessionAgentType::Codex
-            )
-        {
+            );
+        if headroom_active {
             if let Err(e) = crate::headroom::ensure_proxy_running().await {
-                warn!("headroom proxy unavailable — session will start without compression: {e}");
+                warn!("headroom proxy unavailable — running DIRECT, no compression: {e}");
+                headroom_active = false;
             }
         }
 
-        // Build environment setup for API key injection
-        let env_setup = Self::build_env_setup_for_provider(agent_type, headroom_enabled);
+        // Build environment setup for API key injection. `headroom_active`
+        // (not the raw toggle) decides injection, so a failed proxy degrades to
+        // direct rather than a dead-port URL.
+        let env_setup = Self::build_env_setup_for_provider(agent_type, headroom_active);
 
         // Build the CLI command with appropriate flags
         let mut cmd_parts = vec![provider.command().to_string()];

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod docker;
 pub mod editors;
 pub mod fleet;
 pub mod git;
+pub mod headroom;
 pub mod interactive;
 pub mod mcp_pool;
 pub mod models;

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod otel;
 pub mod perf;
 pub mod plugins;
 pub mod providers;
+pub mod rtk;
 pub mod tmux;
 pub mod usage_cache;
 pub mod widgets;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -49,6 +49,7 @@ mod otel;
 mod perf;
 mod plugins;
 mod providers;
+mod rtk;
 mod tmux;
 mod usage_cache;
 mod widgets;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -41,6 +41,7 @@ mod docker;
 mod editors;
 mod fleet;
 mod git;
+mod headroom;
 mod interactive;
 mod mcp_pool;
 mod models;
@@ -258,6 +259,10 @@ async fn tokio_main() -> Result<()> {
             if let Some(rt) = app_state.take_plugin_runtime() {
                 rt.shutdown();
             }
+
+            // Best-effort: stop the shared Headroom proxy so it does not
+            // orphan after the TUI exits.
+            headroom::stop();
 
             tui_result
         }

--- a/ainb-tui/crates/ainb-core/src/rtk/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/rtk/mod.rs
@@ -1,0 +1,276 @@
+// ABOUTME: RTK (Rust Token Killer) detect + install/uninstall lifecycle.
+//
+// RTK is a Claude Code plugin that uses PreToolUse hooks (wired via
+// ~/.claude/settings.json) to compress CLI tool output (Bash/test/diff)
+// before it reaches the model context window — opt-in, per-project.
+//
+// Wire model: NOT a marketplace plugin. RTK owns its own Claude Code hook
+// registration via `rtk init -g`, which writes a PreToolUse hook entry
+// into ~/.claude/settings.json and a companion ~/.claude/RTK.md.
+//
+// Bug #685 note: Homebrew may put the rtk binary at a path not on Claude
+// Code's hook execution PATH. rtk v1.x embeds the absolute binary path
+// in the hook it writes, so this is self-healing once `rtk init -g` has
+// run. ainb surfaces the detection result so the user knows the current
+// wiring state; remediation is always `rtk init -g`.
+
+use std::process::{Command, Stdio};
+
+// ── Detection ────────────────────────────────────────────────────────────────
+
+/// Returns `true` when the `rtk` binary is resolvable on `$PATH`.
+/// Never panics.
+pub fn is_installed() -> bool {
+    which::which("rtk").is_ok()
+}
+
+/// Returns `true` when the Claude Code PreToolUse hook for rtk is wired.
+///
+/// Runs `rtk init --show` and checks for the presence of the hook command
+/// in its output. Best-effort: returns `false` on any execution error,
+/// missing binary, or ambiguous output. Guards against bug #1821 (hook
+/// silently removed from settings.json after a Claude Code upgrade).
+pub fn is_wired() -> bool {
+    let out = Command::new("rtk").args(["init", "--show"]).output();
+    match out {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // `rtk init --show` prints the current hook config. If the hook
+            // is present the output contains a "Hook:" section or the rtk
+            // command string. Any non-empty successful output that mentions
+            // the hook is a positive signal.
+            let combined = format!("{stdout}{stderr}");
+            output.status.success()
+                && !combined.is_empty()
+                && (combined.contains("Hook:") || combined.contains("rtk"))
+                && !combined.to_lowercase().contains("no hook")
+                && !combined.to_lowercase().contains("not installed")
+                && !combined.to_lowercase().contains("not wired")
+        }
+        Err(_) => false,
+    }
+}
+
+// ── Install / uninstall lifecycle ────────────────────────────────────────────
+
+/// Install RTK and wire its Claude Code hook.
+///
+/// Steps:
+/// 1. If `rtk` is not on PATH, install via `brew install rtk`. Falls back
+///    to the curl installer if Homebrew is absent. Bails on any failure.
+/// 2. Runs `rtk init -g` to write the PreToolUse hook into
+///    `~/.claude/settings.json`.
+///
+/// Inherits stdio so the user sees Homebrew progress output directly.
+pub fn install() -> anyhow::Result<()> {
+    if !is_installed() {
+        run_install_binary()?;
+    }
+    wire_claude_hook()?;
+    Ok(())
+}
+
+/// Wire the Codex AGENTS.md prompt injection in addition to the Claude Code
+/// hook. Assumes the `rtk` binary is already present (call `install()` first
+/// or guard with `is_installed()`).
+///
+/// Runs `rtk init -g --codex`. This is best-effort (Codex support is weaker
+/// than the Claude Code PreToolUse hook path).
+pub fn install_codex() -> anyhow::Result<()> {
+    let status = Command::new("rtk")
+        .args(["init", "-g", "--codex"])
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to run `rtk init -g --codex`: {e}"))?;
+    if !status.success() {
+        anyhow::bail!(
+            "`rtk init -g --codex` exited with status {status} — \
+             check `rtk init --show` and try again"
+        );
+    }
+    Ok(())
+}
+
+/// Remove the RTK Claude Code hook from `~/.claude/settings.json` and
+/// delete `~/.claude/RTK.md`. Leaves the `rtk` binary installed.
+///
+/// Runs `rtk init -g --uninstall`.
+pub fn uninstall() -> anyhow::Result<()> {
+    let status = Command::new("rtk")
+        .args(["init", "-g", "--uninstall"])
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to run `rtk init -g --uninstall`: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("`rtk init -g --uninstall` exited with status {status}");
+    }
+    Ok(())
+}
+
+// ── Savings ──────────────────────────────────────────────────────────────────
+
+/// Query total tokens saved across all sessions via `rtk gain --all --format json`.
+///
+/// Returns `None` on any error (binary absent, parse failure, non-zero exit).
+///
+/// The JSON shape is `{"summary":{"total_saved":N,"avg_savings_pct":F,...}}`.
+pub fn gain_total_saved() -> Option<u64> {
+    let out = Command::new("rtk")
+        .args(["gain", "--all", "--format", "json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_total_saved(&out.stdout)
+}
+
+// ── Status ───────────────────────────────────────────────────────────────────
+
+/// Combined RTK status snapshot.
+#[derive(Debug)]
+pub struct RtkStatus {
+    /// `rtk` binary is on `$PATH`.
+    pub installed: bool,
+    /// Claude Code PreToolUse hook is wired in `~/.claude/settings.json`.
+    pub wired: bool,
+    /// Total tokens saved across all sessions, if queryable.
+    pub total_saved: Option<u64>,
+}
+
+/// Collect a combined status snapshot.
+///
+/// Wiring and savings are only queried when the binary is installed to avoid
+/// pointless subprocesses on machines where rtk is absent.
+pub fn status() -> RtkStatus {
+    let installed = is_installed();
+    let wired = if installed { is_wired() } else { false };
+    let total_saved = if installed { gain_total_saved() } else { None };
+    RtkStatus {
+        installed,
+        wired,
+        total_saved,
+    }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Install the `rtk` binary via Homebrew (primary) or the curl fallback.
+/// Inherits the caller's stdio so Homebrew progress is visible.
+fn run_install_binary() -> anyhow::Result<()> {
+    if which::which("brew").is_ok() {
+        let status = Command::new("brew")
+            .args(["install", "rtk"])
+            .status()
+            .map_err(|e| anyhow::anyhow!("failed to run `brew install rtk`: {e}"))?;
+        if status.success() {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "`brew install rtk` failed (exit {status}).\n\n\
+             Fallback — run manually:\n  \
+             curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh\n  \
+             then: rtk init -g"
+        );
+    }
+
+    // Homebrew absent — print the curl fallback and bail (ainb never
+    // auto-runs curl-pipe-to-sh on behalf of the user).
+    anyhow::bail!(
+        "Homebrew not found. Install `rtk` manually:\n  \
+         curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh\n  \
+         then run: ainb rtk install"
+    )
+}
+
+/// Wire the Claude Code PreToolUse hook via `rtk init -g`.
+fn wire_claude_hook() -> anyhow::Result<()> {
+    let status = Command::new("rtk")
+        .args(["init", "-g"])
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to run `rtk init -g`: {e}"))?;
+    if !status.success() {
+        anyhow::bail!(
+            "`rtk init -g` exited with status {status} — \
+             check `rtk init --show` and try again"
+        );
+    }
+    Ok(())
+}
+
+/// Parse `total_saved` from `rtk gain --all --format json` stdout bytes.
+///
+/// Expected shape: `{"summary":{"total_saved":N,"avg_savings_pct":F}}`.
+fn parse_total_saved(bytes: &[u8]) -> Option<u64> {
+    // Use a minimal hand-rolled path rather than a full serde derive so this
+    // module stays dependency-light (serde_json is already in the workspace
+    // via lib, but explicit parse keeps the shape obvious).
+    let text = std::str::from_utf8(bytes).ok()?;
+    let v: serde_json::Value = serde_json::from_str(text).ok()?;
+    v.get("summary")?.get("total_saved")?.as_u64()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse the documented `rtk gain --format json` payload shape.
+    #[test]
+    fn parse_total_saved_from_sample_json() {
+        let json = br#"{"summary":{"total_saved":1220217,"avg_savings_pct":95.6}}"#;
+        assert_eq!(parse_total_saved(json), Some(1_220_217));
+    }
+
+    /// Additional fields and missing optional fields must not break parsing.
+    #[test]
+    fn parse_total_saved_extra_fields() {
+        let json = br#"{"summary":{"total_saved":42,"avg_savings_pct":80.0,"sessions":10}}"#;
+        assert_eq!(parse_total_saved(json), Some(42));
+    }
+
+    /// Malformed JSON returns None without panicking.
+    #[test]
+    fn parse_total_saved_bad_json() {
+        assert_eq!(parse_total_saved(b"not json"), None);
+    }
+
+    /// Missing `total_saved` key returns None.
+    #[test]
+    fn parse_total_saved_missing_key() {
+        let json = br#"{"summary":{"avg_savings_pct":80.0}}"#;
+        assert_eq!(parse_total_saved(json), None);
+    }
+
+    /// `RtkStatus` smoke test: fields are constructible and readable.
+    #[test]
+    fn rtk_status_struct_fields() {
+        let s = RtkStatus {
+            installed: true,
+            wired: false,
+            total_saved: Some(1_220_217),
+        };
+        assert!(s.installed);
+        assert!(!s.wired);
+        assert_eq!(s.total_saved, Some(1_220_217));
+    }
+
+    /// `status()` returns `wired = false` and `total_saved = None` when
+    /// `installed` is false (avoids spinning up subprocesses for absent binary).
+    /// This only verifies the short-circuit logic; live detection is integration-tested.
+    #[test]
+    fn status_does_not_query_when_not_installed() {
+        // We can't intercept `is_installed()` here without a testable seam, but
+        // we can at least assert the struct is valid when constructed manually.
+        let s = RtkStatus {
+            installed: false,
+            wired: false,
+            total_saved: None,
+        };
+        assert!(!s.installed);
+        assert!(!s.wired);
+        assert!(s.total_saved.is_none());
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/rtk/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/rtk/mod.rs
@@ -52,6 +52,15 @@ pub fn is_wired() -> bool {
     }
 }
 
+/// Returns the absolute-path hook command for project-local hook wiring.
+///
+/// Uses `which::which` so the returned path is absolute, sidestepping Claude
+/// Code's restricted hook execution PATH (bug #685).  Returns `None` when rtk
+/// is not installed.
+pub fn project_hook_command() -> Option<String> {
+    which::which("rtk").ok().map(|p| format!("{} hook claude", p.display()))
+}
+
 // ── Install / uninstall lifecycle ────────────────────────────────────────────
 
 /// Install RTK and wire its Claude Code hook.

--- a/ainb-tui/crates/ainb-core/tests/behavioral/session_persistence.rs
+++ b/ainb-tui/crates/ainb-core/tests/behavioral/session_persistence.rs
@@ -21,6 +21,8 @@ fn create_session_metadata(
         workspace_name: workspace_name.to_string(),
         created_at: Utc::now(),
         agent_type: SessionAgentType::default(),
+        headroom_enabled: false,
+        rtk_enabled: false,
     }
 }
 
@@ -38,6 +40,8 @@ fn create_session_metadata_with_id(
         workspace_name: workspace_name.to_string(),
         created_at: Utc::now(),
         agent_type: SessionAgentType::default(),
+        headroom_enabled: false,
+        rtk_enabled: false,
     }
 }
 

--- a/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
+++ b/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
@@ -53,6 +53,8 @@ async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
         workspace_name: "orphan-workspace".to_string(),
         created_at: Utc::now(),
         agent_type: SessionAgentType::default(),
+        headroom_enabled: false,
+        rtk_enabled: false,
     });
     store.upsert(SessionMetadata {
         session_id: keep_id,
@@ -61,6 +63,8 @@ async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
         workspace_name: "keep-workspace".to_string(),
         created_at: Utc::now(),
         agent_type: SessionAgentType::default(),
+        headroom_enabled: false,
+        rtk_enabled: false,
     });
     store.save()?;
     assert_eq!(SessionStore::load().sessions().len(), 2);

--- a/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
@@ -40,6 +40,7 @@ async-trait = "0.1"
 nucleo-matcher = "0.3"
 dirs = { workspace = true }
 arboard = { workspace = true }
+reqwest = { workspace = true }
 
 # UI: ratatui without termion/crossterm backends — we paint into a
 # ratatui Buffer and convert to a WireBuffer cell stream for the host.

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -50,6 +50,8 @@ pub enum UsageCommands {
     },
     /// Per-model rollup or per-model × per-activity-category matrix
     Models(UsageModelsArgs),
+    /// Token-savings summary (Headroom, RTK, Caveman estimate)
+    Savings(UsageReportArgs),
 }
 
 #[derive(Args, Clone, Default)]
@@ -282,6 +284,7 @@ pub fn execute_for_plugin(
         UsageCommands::Yield(args) => print_yield_with_data(data, &args, format),
         UsageCommands::ModelAlias(args) => model_alias_command_plugin(args),
         UsageCommands::Models(args) => print_models_with_data(data, &args, format),
+        UsageCommands::Savings(_args) => print_savings_with_data(data, format),
         // Plan / Currency / Cache stay in the host-side `cli/usage.rs`
         // shim — they're config admin, not analytics.
         UsageCommands::Plan { .. } | UsageCommands::Currency(_) | UsageCommands::Cache { .. } => {
@@ -660,6 +663,79 @@ fn print_yield_with_data(
     Ok(())
 }
 
+/// Plugin-mode `savings` — prints the same three figures as the TUI
+/// Savings tab: Headroom (fetched live), RTK (shelled out), and the
+/// Caveman estimate (output_tokens × 0.74). Operates on the
+/// pre-loaded usage snapshot for the Caveman figure; the other two
+/// are fetched synchronously via a single-shot tokio runtime so the
+/// CLI path doesn't block the plugin mutex for I/O.
+fn print_savings_with_data(data: &UsageData, format: OutputFormat) -> Result<()> {
+    use crate::data::savings::{CAVEMAN_OUTPUT_RATIO, fetch_savings};
+    // The plugin binary has a tokio runtime already, but cli_dispatch is
+    // synchronous once we're inside capture_stdout. We spawn a one-shot
+    // runtime for the fetch rather than holding the async mutex.
+    let output_tokens = data.grand_total.output_tokens;
+    let sd = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map(|rt| rt.block_on(fetch_savings(output_tokens)))
+        .unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "headroom": {
+                        "running": sd.headroom_running,
+                        "tokens_saved": sd.headroom_tokens_saved,
+                    },
+                    "rtk": {
+                        "installed": sd.rtk_installed,
+                        "tokens_saved": sd.rtk_total_saved,
+                    },
+                    "caveman": {
+                        "tokens_est": sd.caveman_est,
+                        "ratio": CAVEMAN_OUTPUT_RATIO,
+                        "note": "modelled potential, not measured",
+                    },
+                    "net_real": sd.net_real(),
+                }))?
+            );
+        }
+        _ => {
+            println!("Token Savings");
+            println!(
+                "  Headroom   {:>10} tokens  {}",
+                sd.headroom_tokens_saved,
+                if sd.headroom_running {
+                    "● live"
+                } else {
+                    "○ proxy down"
+                }
+            );
+            println!(
+                "  RTK        {:>10} tokens  {}",
+                sd.rtk_total_saved,
+                if sd.rtk_installed {
+                    "● installed"
+                } else {
+                    "○ not installed"
+                }
+            );
+            println!(
+                "  Caveman    {:>10} tokens  modelled ×{:.2} (est)",
+                sd.caveman_est, CAVEMAN_OUTPUT_RATIO
+            );
+            println!("  ---");
+            println!("  NET        {:>10} tokens  Headroom + RTK", sd.net_real());
+            println!();
+            println!("  (est) = modelled potential; install Headroom/RTK for real data.");
+        }
+    }
+    Ok(())
+}
+
 /// Plugin-mode `model-alias`. The host-side path persists aliases via
 /// `AppConfig::save()` — filesystem write through the plugin's config
 /// dir. Inside wasmi we have no arbitrary fs path access, so the
@@ -715,6 +791,10 @@ pub async fn execute(command: UsageCommands, format: OutputFormat) -> Result<()>
         UsageCommands::Models(args) => {
             let data = load_usage(&args.report)?;
             print_models_with_data(&data, &args, format)
+        }
+        UsageCommands::Savings(_args) => {
+            let data = load_usage(&_args)?;
+            print_savings_with_data(&data, format)
         }
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/cli.rs
@@ -675,11 +675,21 @@ fn print_savings_with_data(data: &UsageData, format: OutputFormat) -> Result<()>
     // synchronous once we're inside capture_stdout. We spawn a one-shot
     // runtime for the fetch rather than holding the async mutex.
     let output_tokens = data.grand_total.output_tokens;
-    let sd = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map(|rt| rt.block_on(fetch_savings(output_tokens)))
-        .unwrap_or_default();
+    // Run on a DEDICATED OS thread with its own runtime. cli_dispatch already
+    // runs on the plugin's tokio runtime, so a nested current-thread runtime
+    // here deadlocks `tokio::process` child-reaping (rtk gain never returns).
+    // A fresh runtime on its own thread owns its I/O+signal driver, so the
+    // subprocess fetch completes. ponytail: own thread, the standard
+    // block-on-from-within-async escape hatch.
+    let sd = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map(|rt| rt.block_on(fetch_savings(output_tokens)))
+            .unwrap_or_default()
+    })
+    .join()
+    .unwrap_or_default();
 
     match format {
         OutputFormat::Json => {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/mod.rs
@@ -6,6 +6,7 @@
 //! unchanged from the pre-Phase-3 core implementation.
 
 pub mod repo_lookup;
+pub mod savings;
 pub mod usage;
 
 // Re-export the surface that `crate::models::*` provided in core, so

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
@@ -8,9 +8,18 @@
 use serde::Deserialize;
 use std::time::Duration;
 
-/// Caveman multiplier: fraction of output tokens estimated as savings.
-/// 74 % is a modelled potential, NOT measured throughput. Rendered
-/// explicitly as `(est)` so users understand it is an approximation.
+/// Caveman multiplier: fraction of output tokens modelled as savings.
+///
+/// This is a BLANKET MODEL, not a measurement, and cannot be made into one:
+/// caveman savings are counterfactual (the tokens the model *would* have
+/// emitted without terse mode) so there is nothing to measure against in
+/// production. It also can't be scoped to only the turns where caveman was
+/// active — no caveman marker is recorded in the session/JSONL data the
+/// reader sees. So the figure is `total_output_tokens * 0.74` across all
+/// output, rendered explicitly as `(est)` so it reads as an upper-bound
+/// model, never as realised savings. A true per-session caveman metric would
+/// require instrumenting the caveman skill to emit an on/off signal per turn
+/// — tracked as a separate follow-up, not bodged in here.
 pub const CAVEMAN_OUTPUT_RATIO: f64 = 0.74;
 
 /// Aggregated savings figures fetched by the plugin.

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
@@ -38,16 +38,28 @@ impl SavingsData {
 
 // ── Headroom /stats response shape ───────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+// Real headroom 0.26 `/stats` shape (verified against a live proxy 2026-06-19):
+// the canonical total is `savings.total_tokens`; request count is
+// `summary.api_requests`. An earlier guess at `summary.tokens_saved_total`
+// silently parsed to 0 because that key does not exist.
+#[derive(Debug, Default, Deserialize)]
 pub struct HeadroomStats {
+    #[serde(default)]
     pub summary: HeadroomSummary,
+    #[serde(default)]
+    pub savings: HeadroomSavings,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct HeadroomSummary {
-    pub tokens_saved_total: u64,
-    #[allow(dead_code)]
-    pub requests_total: u64,
+    #[serde(default)]
+    pub api_requests: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct HeadroomSavings {
+    #[serde(default)]
+    pub total_tokens: u64,
 }
 
 // ── RTK gain response shape ───────────────────────────────────────────────────
@@ -104,7 +116,7 @@ async fn fetch_headroom() -> (bool, u64) {
 
     match client.get(&url).send().await {
         Ok(resp) if resp.status().is_success() => match resp.json::<HeadroomStats>().await {
-            Ok(stats) => (true, stats.summary.tokens_saved_total),
+            Ok(stats) => (true, stats.savings.total_tokens),
             Err(_) => (false, 0),
         },
         _ => (false, 0),
@@ -137,11 +149,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn headroom_stats_deserialises_from_sample_json() {
-        let json = r#"{"summary":{"tokens_saved_total":42000,"requests_total":120}}"#;
+    fn headroom_stats_deserialises_from_real_shape() {
+        // Real headroom 0.26 /stats shape (live-verified): savings.total_tokens
+        // is the canonical total; summary.api_requests is the request count.
+        let json = r#"{
+            "summary":{"api_requests":120,"compression":{"total_tokens_removed":1}},
+            "savings":{"total_tokens":42000,"per_project":{}}
+        }"#;
         let stats: HeadroomStats = serde_json::from_str(json).expect("parse HeadroomStats");
-        assert_eq!(stats.summary.tokens_saved_total, 42000);
-        assert_eq!(stats.summary.requests_total, 120);
+        assert_eq!(stats.savings.total_tokens, 42000);
+        assert_eq!(stats.summary.api_requests, 120);
+    }
+
+    #[test]
+    fn headroom_stats_defaults_to_zero_on_empty() {
+        let stats: HeadroomStats = serde_json::from_str("{}").expect("parse empty");
+        assert_eq!(stats.savings.total_tokens, 0);
+        assert_eq!(stats.summary.api_requests, 0);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
@@ -1,0 +1,191 @@
+// ABOUTME: Token-savings aggregation from three sources: Headroom proxy,
+// RTK tool, and a caveman estimate from local output-token totals.
+//
+// Fetched asynchronously; stored in BurndownPlugin state and handed to
+// the renderer via UsageViewState. All sources degrade gracefully —
+// unavailable sources contribute 0 and are flagged as inactive.
+
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Caveman multiplier: fraction of output tokens estimated as savings.
+/// 74 % is a modelled potential, NOT measured throughput. Rendered
+/// explicitly as `(est)` so users understand it is an approximation.
+pub const CAVEMAN_OUTPUT_RATIO: f64 = 0.74;
+
+/// Aggregated savings figures fetched by the plugin.
+#[derive(Debug, Clone, Default)]
+pub struct SavingsData {
+    /// Whether the Headroom proxy responded successfully.
+    pub headroom_running: bool,
+    /// `summary.tokens_saved_total` from Headroom /stats.
+    pub headroom_tokens_saved: u64,
+    /// Whether `rtk` was found on PATH and exited successfully.
+    pub rtk_installed: bool,
+    /// `summary.total_saved` from `rtk gain --all --format json`.
+    pub rtk_total_saved: u64,
+    /// Modelled estimate: `grand_total.output_tokens * CAVEMAN_OUTPUT_RATIO`.
+    /// Always present; always marked as an estimate in the renderer.
+    pub caveman_est: u64,
+}
+
+impl SavingsData {
+    /// Net tokens saved across all real (non-estimated) sources.
+    pub fn net_real(&self) -> u64 {
+        self.headroom_tokens_saved + self.rtk_total_saved
+    }
+}
+
+// ── Headroom /stats response shape ───────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct HeadroomStats {
+    pub summary: HeadroomSummary,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HeadroomSummary {
+    pub tokens_saved_total: u64,
+    #[allow(dead_code)]
+    pub requests_total: u64,
+}
+
+// ── RTK gain response shape ───────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct RtkGain {
+    pub summary: RtkSummary,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RtkSummary {
+    pub total_saved: u64,
+    #[allow(dead_code)]
+    pub avg_savings_pct: f64,
+}
+
+// ── Fetch helpers ─────────────────────────────────────────────────────────────
+
+/// Fetch token-savings figures from all three sources and return a
+/// [`SavingsData`] snapshot. Safe to call from an async context —
+/// both I/O operations are awaited, not blocked.
+///
+/// `output_tokens` is the `grand_total.output_tokens` from the latest
+/// [`UsageData`] snapshot; used to compute `caveman_est`.
+pub async fn fetch_savings(output_tokens: u64) -> SavingsData {
+    let caveman_est = (output_tokens as f64 * CAVEMAN_OUTPUT_RATIO).round() as u64;
+
+    let (headroom_running, headroom_tokens_saved) = fetch_headroom().await;
+    let (rtk_installed, rtk_total_saved) = fetch_rtk().await;
+
+    SavingsData {
+        headroom_running,
+        headroom_tokens_saved,
+        rtk_installed,
+        rtk_total_saved,
+        caveman_est,
+    }
+}
+
+/// GET `http://127.0.0.1:<port>/stats` where port is `AINB_HEADROOM_PORT`
+/// or 8787. Returns `(true, tokens_saved_total)` on success, `(false, 0)`
+/// on any error (proxy down, parse failure, network issue).
+async fn fetch_headroom() -> (bool, u64) {
+    let port = std::env::var("AINB_HEADROOM_PORT")
+        .ok()
+        .and_then(|v| v.parse::<u16>().ok())
+        .unwrap_or(8787);
+
+    let url = format!("http://127.0.0.1:{port}/stats");
+    let client = match reqwest::Client::builder().timeout(Duration::from_millis(500)).build() {
+        Ok(c) => c,
+        Err(_) => return (false, 0),
+    };
+
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => match resp.json::<HeadroomStats>().await {
+            Ok(stats) => (true, stats.summary.tokens_saved_total),
+            Err(_) => (false, 0),
+        },
+        _ => (false, 0),
+    }
+}
+
+/// Run `rtk gain --all --format json`. Returns `(true, total_saved)` when
+/// `rtk` is on PATH and exits successfully, `(false, 0)` otherwise.
+async fn fetch_rtk() -> (bool, u64) {
+    use tokio::process::Command;
+
+    let output =
+        match Command::new("rtk").args(["gain", "--all", "--format", "json"]).output().await {
+            Ok(o) => o,
+            Err(_) => return (false, 0), // rtk not on PATH
+        };
+
+    if !output.status.success() {
+        return (false, 0);
+    }
+
+    match serde_json::from_slice::<RtkGain>(&output.stdout) {
+        Ok(gain) => (true, gain.summary.total_saved),
+        Err(_) => (false, 0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headroom_stats_deserialises_from_sample_json() {
+        let json = r#"{"summary":{"tokens_saved_total":42000,"requests_total":120}}"#;
+        let stats: HeadroomStats = serde_json::from_str(json).expect("parse HeadroomStats");
+        assert_eq!(stats.summary.tokens_saved_total, 42000);
+        assert_eq!(stats.summary.requests_total, 120);
+    }
+
+    #[test]
+    fn rtk_gain_deserialises_from_sample_json() {
+        let json = r#"{"summary":{"total_saved":8000,"avg_savings_pct":18.5}}"#;
+        let gain: RtkGain = serde_json::from_str(json).expect("parse RtkGain");
+        assert_eq!(gain.summary.total_saved, 8000);
+    }
+
+    #[test]
+    fn caveman_estimate_rounds_correctly() {
+        // 1000 output tokens * 0.74 = 740
+        let est = (1000_f64 * CAVEMAN_OUTPUT_RATIO).round() as u64;
+        assert_eq!(est, 740);
+    }
+
+    #[test]
+    fn caveman_estimate_zero_for_zero_output_tokens() {
+        let est = (0_f64 * CAVEMAN_OUTPUT_RATIO).round() as u64;
+        assert_eq!(est, 0);
+    }
+
+    #[test]
+    fn savings_data_net_real_sums_headroom_and_rtk() {
+        let sd = SavingsData {
+            headroom_running: true,
+            headroom_tokens_saved: 10_000,
+            rtk_installed: true,
+            rtk_total_saved: 5_000,
+            caveman_est: 7_000,
+        };
+        assert_eq!(sd.net_real(), 15_000);
+    }
+
+    #[test]
+    fn savings_data_net_real_excludes_caveman() {
+        // caveman is an estimate; it must not inflate net_real
+        let sd = SavingsData {
+            headroom_running: false,
+            headroom_tokens_saved: 0,
+            rtk_installed: false,
+            rtk_total_saved: 0,
+            caveman_est: 999_999,
+        };
+        assert_eq!(sd.net_real(), 0);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -21,6 +21,7 @@ use ratatui::layout::Rect as RRect;
 use ratatui::style::{Color as RColor, Modifier as RModifier};
 
 use crate::cli::{UsageCommands, execute_for_plugin};
+use crate::data::savings::{SavingsData, fetch_savings};
 use crate::data::usage::UsageData;
 use crate::output_format::OutputFormat;
 use crate::ui::{UsageTab, UsageViewState, render as render_ui};
@@ -114,6 +115,10 @@ pub struct BurndownPlugin {
     /// wall-clock compute was fast enough that the only visible
     /// change is a few panel numbers.
     pivot_seq: u64,
+    /// Latest token-savings snapshot. Populated asynchronously after
+    /// each `sessions.usage_data` finalise — the Savings tab renders
+    /// whatever is here (or a "fetching" placeholder while `None`).
+    savings_data: Option<SavingsData>,
 }
 
 /// One-deep filter-cache slot. A single entry is enough because
@@ -391,6 +396,7 @@ impl Plugin for BurndownPlugin {
             ui.data = self.data.clone();
             ui.scan_progress = self.scan_progress.clone();
             ui.cached_filtered = cached_filtered;
+            ui.savings_data = self.savings_data.clone();
             // True iff `cached_filtered` ran an actual recompute this
             // frame (cache miss). The chip strip uses this to flash a
             // brief `↻ updated` badge so the user sees confirmation
@@ -531,15 +537,31 @@ impl BurndownPlugin {
     /// (follow-on chunk with no in-flight publish); calls into the
     /// pure [`Self::apply_chunk_pure`] for the actual state transition
     /// so unit tests can hit every branch without a `HostClient`.
+    ///
+    /// On `Finalised`, kicks off an async savings fetch so the Savings
+    /// tab has fresh data shortly after each usage snapshot lands.
     async fn apply_chunk(&mut self, event: UsageDataEvent, host: &HostClient) {
         let chunk_index = event.chunk_index;
         let outcome = self.apply_chunk_pure(event);
-        if matches!(outcome, ChunkOutcome::DroppedFollowOn) {
-            let _ = host
-                .log_info(format!(
-                    "burndown: dropped follow-on chunk {chunk_index} (no in-flight publish)"
-                ))
-                .await;
+        match outcome {
+            ChunkOutcome::DroppedFollowOn => {
+                let _ = host
+                    .log_info(format!(
+                        "burndown: dropped follow-on chunk {chunk_index} (no in-flight publish)"
+                    ))
+                    .await;
+            }
+            ChunkOutcome::Finalised => {
+                // Refresh the savings snapshot from all three sources.
+                // The output_tokens total lives on grand_total after
+                // the wire→local conversion has completed; safe to read
+                // here because apply_chunk_pure already moved the
+                // assembled data into self.data.
+                let output_tokens =
+                    self.data.as_ref().map(|d| d.grand_total.output_tokens).unwrap_or(0);
+                self.savings_data = Some(fetch_savings(output_tokens).await);
+            }
+            ChunkOutcome::Buffered => {}
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -12,6 +12,7 @@ use ratatui::{
 
 use ainb_plugin_types_sessions::ScanProgressEvent;
 
+use crate::data::savings::SavingsData;
 use crate::data::usage::{
     BranchUsage, current_quarter, first_of_month, next_month_first, next_quarter,
     previous_month_first, previous_quarter,
@@ -54,6 +55,7 @@ pub enum UsageTab {
     Weekly,
     Projects,
     Optimize,
+    Savings,
 }
 
 impl UsageTab {
@@ -64,6 +66,7 @@ impl UsageTab {
             UsageTab::Weekly,
             UsageTab::Projects,
             UsageTab::Optimize,
+            UsageTab::Savings,
         ]
     }
 
@@ -74,6 +77,7 @@ impl UsageTab {
             UsageTab::Weekly => "Weekly",
             UsageTab::Projects => "By Project",
             UsageTab::Optimize => "Optimize",
+            UsageTab::Savings => "Savings",
         }
     }
 
@@ -83,17 +87,19 @@ impl UsageTab {
             UsageTab::Daily => UsageTab::Weekly,
             UsageTab::Weekly => UsageTab::Projects,
             UsageTab::Projects => UsageTab::Optimize,
-            UsageTab::Optimize => UsageTab::Burndown,
+            UsageTab::Optimize => UsageTab::Savings,
+            UsageTab::Savings => UsageTab::Burndown,
         }
     }
 
     fn prev(&self) -> Self {
         match self {
-            UsageTab::Burndown => UsageTab::Optimize,
+            UsageTab::Burndown => UsageTab::Savings,
             UsageTab::Daily => UsageTab::Burndown,
             UsageTab::Weekly => UsageTab::Daily,
             UsageTab::Projects => UsageTab::Weekly,
             UsageTab::Optimize => UsageTab::Projects,
+            UsageTab::Savings => UsageTab::Optimize,
         }
     }
 }
@@ -316,6 +322,12 @@ pub struct UsageViewState {
     /// behind a confirm because a hard refresh re-parses ALL session
     /// history from source — the CPU-heavy path.
     pub confirm_hard: bool,
+    /// Latest token-savings snapshot, populated asynchronously whenever
+    /// a new `sessions.usage_data` chunk finalises. `None` until the
+    /// first fetch completes. The renderer shows a brief loading state
+    /// while this is absent; after that it renders the last-known figures
+    /// (the fetch runs off the render path so stale data is fine).
+    pub savings_data: Option<SavingsData>,
 }
 
 /// Per-column width step applied by `<` / `>` in the zoom table.
@@ -353,6 +365,7 @@ impl Default for UsageViewState {
             zoom_cols_panel: None,
             copy_flash: None,
             confirm_hard: false,
+            savings_data: None,
         }
     }
 }
@@ -507,6 +520,8 @@ impl UsageViewState {
                         + data.models.len()
                 }
                 UsageTab::Optimize => optimize_usage(data).findings.len(),
+                // Savings renders a fixed 4-row summary card (3 sources + net).
+                UsageTab::Savings => 4,
             },
         }
     }
@@ -1009,6 +1024,9 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
                 }
                 UsageTab::Burndown => render_burndown(buf, layout[content_idx], data, state),
                 UsageTab::Optimize => render_optimize(buf, layout[content_idx], data),
+                UsageTab::Savings => {
+                    render_savings(buf, layout[content_idx], state.savings_data.as_ref())
+                }
             }
         }
     }
@@ -3887,6 +3905,177 @@ fn render_optimize(buf: &mut Buffer, area: Rect, data: &UsageData) {
         }
     }
     render_panel(buf, area, "Optimize Findings", lines);
+}
+
+/// Render the Savings tab.
+///
+/// Three source rows (Headroom, RTK, Caveman) plus a NET total line.
+/// Each row shows: source name, saved token count, and a status badge.
+/// The Caveman row is always marked `(est)` — it is a modelled
+/// potential, not a measured figure.
+///
+/// When `savings_data` is `None` the panel shows a single "Fetching…"
+/// line — this is only visible for the brief window before the first
+/// async fetch completes after a data load.
+fn render_savings(
+    buf: &mut Buffer,
+    area: Rect,
+    savings: Option<&crate::data::savings::SavingsData>,
+) {
+    use crate::data::savings::CAVEMAN_OUTPUT_RATIO;
+
+    let block = ratatui::widgets::Block::default()
+        .title(ratatui::text::Span::styled(
+            " Token Savings ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG));
+
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let Some(sd) = savings else {
+        let fetching = Line::from(Span::styled(
+            "  ⏳ Fetching savings data…",
+            Style::default().fg(MUTED_GRAY),
+        ));
+        ratatui::widgets::Widget::render(Paragraph::new(fetching), inner, buf);
+        return;
+    };
+
+    // ── Row builders ──────────────────────────────────────────────────────
+
+    // Status dot: ● (live/installed) or ○ (down/not installed)
+    let headroom_dot = if sd.headroom_running {
+        Span::styled(
+            "● ",
+            Style::default().fg(TERMINAL_GOOD).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::styled("○ ", Style::default().fg(MUTED_GRAY))
+    };
+    let headroom_status = if sd.headroom_running {
+        Span::styled("live", Style::default().fg(TERMINAL_GOOD))
+    } else {
+        Span::styled("proxy down", Style::default().fg(MUTED_GRAY))
+    };
+
+    let rtk_dot = if sd.rtk_installed {
+        Span::styled(
+            "● ",
+            Style::default().fg(TERMINAL_GOOD).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::styled("○ ", Style::default().fg(MUTED_GRAY))
+    };
+    let rtk_status = if sd.rtk_installed {
+        Span::styled("installed", Style::default().fg(TERMINAL_GOOD))
+    } else {
+        Span::styled("not installed", Style::default().fg(MUTED_GRAY))
+    };
+
+    let pct_label = format!("×{:.2}", CAVEMAN_OUTPUT_RATIO);
+
+    // Column widths: source(14) + tokens(16) + status
+    let src_w = 14_usize;
+
+    let pad_source = |s: &str| -> String {
+        let mut out = s.to_string();
+        while out.len() < src_w {
+            out.push(' ');
+        }
+        out
+    };
+
+    let lines: Vec<Line> = vec![
+        // ── Header ────────────────────────────────────────────────────────
+        Line::from(vec![
+            Span::styled(
+                format!("  {:<src_w$}", "Source"),
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("{:<16}", "Tokens Saved"),
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Status",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(Span::styled(
+            format!("  {}", "─".repeat((inner.width.saturating_sub(2)) as usize)),
+            Style::default().fg(CORNFLOWER_BLUE),
+        )),
+        // ── Headroom row ──────────────────────────────────────────────────
+        Line::from(vec![
+            Span::raw("  "),
+            headroom_dot,
+            Span::styled(pad_source("Headroom"), Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                format!("{:<16}", format_tokens_short(sd.headroom_tokens_saved)),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            headroom_status,
+        ]),
+        // ── RTK row ───────────────────────────────────────────────────────
+        Line::from(vec![
+            Span::raw("  "),
+            rtk_dot,
+            Span::styled(pad_source("RTK"), Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                format!("{:<16}", format_tokens_short(sd.rtk_total_saved)),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            rtk_status,
+        ]),
+        // ── Caveman row ───────────────────────────────────────────────────
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("~ ", Style::default().fg(TERMINAL_ACCENT)),
+            Span::styled(pad_source("Caveman (est)"), Style::default().fg(SOFT_WHITE)),
+            Span::styled(
+                format!("{:<16}", format_tokens_short(sd.caveman_est)),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("modelled {pct_label}"),
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            ),
+        ]),
+        Line::from(Span::styled(
+            format!("  {}", "─".repeat((inner.width.saturating_sub(2)) as usize)),
+            Style::default().fg(CORNFLOWER_BLUE),
+        )),
+        // ── NET (real sources only) ───────────────────────────────────────
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                format!("  {}", pad_source("NET (measured)")),
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("{:<16}", format_tokens_short(sd.net_real())),
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("Headroom + RTK", Style::default().fg(MUTED_GRAY)),
+        ]),
+        Line::from(""),
+        // ── Caveman disclaimer ────────────────────────────────────────────
+        Line::from(Span::styled(
+            "  (est) = modelled potential, not measured. Install Headroom/RTK for real data.",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        )),
+    ];
+
+    ratatui::widgets::Widget::render(Paragraph::new(lines), inner, buf);
 }
 
 fn render_panel(buf: &mut Buffer, area: Rect, title: &str, rows: Vec<String>) {


### PR DESCRIPTION
## Token optimisation: per-session Headroom proxy + RTK + savings surface

Adds **opt-in, per-session** token optimisation to ainb — never global, fault-tolerant, and observable.

### What ships
- **Headroom** — an ainb-managed shared compression proxy. Per-session toggle on the Configure screen routes that session's Claude/Codex CLI through `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`. One session ON + another OFF verified live (OFF goes direct to Anthropic).
- **RTK** — detect + install/uninstall, plus **per-session** wiring via a project-local `.claude/settings.json` PreToolUse hook in the worktree (no global mutation).
- **Savings surface** — burndown Savings tab (Headroom live tokens · RTK · caveman blanket estimate) + CLI `ainb usage savings`, `ainb headroom status/stop`, `ainb rtk status`, and `ainb doctor` listing both as `token-opt` deps.

### Fault tolerance (v2)
- **Availability gating** — toggles show `unavailable + install hint` when the binary is absent; can't arm a proxy that can't exist.
- **Degrade-to-direct** — if the proxy can't come up at launch, the session runs DIRECT (no bricked env injection).
- **In-loop watchdog** — re-ensures the proxy if a Headroom session is live but the proxy died; transparent self-heal. Surfaced on the Daemons overlay (`d`).
- **Mid-session downgrade** — `H` flips a session back to direct (`claude --continue`) when the proxy misbehaves.
- **Idle-reap** — shared proxy reaped when the last Headroom session closes.

### Verification
Live-validated end-to-end (TUI + CLI, tmux). This caught **3 real bugs unit tests missed**:
1. `/stats` parser read non-existent keys → observability silently 0 forever (`45fa5125`).
2. `ainb headroom stop` reported "stopped" when it stopped nothing (`52d1f1ee`).
3. `ainb usage savings` was unreachable + hung on a nested-runtime deadlock (`0c280a25`).

Fault-injection harness passes 4/4 (watchdog respawn, availability gating). Explainer with full-journey recordings: **https://explainers.stevengonsalvez.com/headroom-rtk-verified/**

### Tests
- `ainb` core: **1158 pass**, burndown: **203 pass**.
- Rebased onto current `main` (215 commits); fmt clean.

### Pre-existing reds (NOT introduced here, disclosed honestly)
- **9 × `docker::agents_dev_tests::*`** — require a Docker daemon; environmental.
- **1 × `ainb-plugin-burndown` `init_render_shutdown_round_trip`** — `plugin.rs` subscribes `sessions.refresh_request` in `on_init`, but the stdio_smoke test still expects a publish at reverse #3. **Verified failing identically on a clean `origin/main` worktree** — a pre-existing main bug, untouched by this branch. Happy to fix as a one-line drive-by if wanted.

https://claude.ai/code/session_01FwQC25huAxcpeKoA1umEZb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Headroom proxy support for token-efficient routing of Claude/Codex CLI traffic.
  * Added RTK (Rust Token Killer) for token output compression in Claude sessions.
  * Added per-session toggles to enable/disable Headroom and RTK in session configuration.
  * Added Daemons overlay (sidebar shortcut "d") displaying MCP pool and Headroom proxy status.
  * Added `ainb headroom` and `ainb rtk` CLI commands for proxy and compression management.
  * Added Token Savings analytics tab showing real and estimated token savings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->