### PR TITLE
docs(site): CLI reference as its own top-level heading + top-nav link

### DIFF
--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -76,11 +76,16 @@ export default defineConfig({
             { label: 'Starting a new session', slug: 'tui/start-session' },
             { label: 'Code Review (diff)', slug: 'tui/code-review' },
             { label: 'Shared MCP pool', slug: 'tui/mcp-pool' },
-            { label: 'CLI reference', slug: 'tui/cli' },
             { label: 'Keyboard shortcuts', slug: 'tui/keyboard-shortcuts' },
             { label: 'Inbox & notifications', slug: 'tui/inbox-notifications' },
             { label: 'Architecture', slug: 'tui/architecture' },
             { label: 'FAQ', slug: 'tui/faq' },
+          ],
+        },
+        {
+          label: 'CLI',
+          items: [
+            { label: 'Full CLI reference', slug: 'tui/cli' },
           ],
         },
         {

--- a/website/site/src/pages/index.astro
+++ b/website/site/src/pages/index.astro
@@ -35,6 +35,7 @@ const docs = (path: string) => `${BASE}/${path.replace(/^\//, '')}`;
       <a class="nav__brand" href={`${BASE}/`}>ainb<span class="ainb-cursor" aria-hidden="true"></span></a>
       <nav class="nav__links">
         <a href={docs('product/what-is-ainb')}>Docs</a>
+        <a href={docs('tui/cli')}>CLI</a>
         <a href={docs('plugins/overview')}>Plugins</a>
         <a href={docs('toolkit/overview')}>Toolkit</a>
         <a href={REPO}>GitHub →</a>


### PR DESCRIPTION
Makes the generated CLI reference discoverable as a first-class page.

- **Own sidebar heading** — pulled `CLI reference` out of the **TUI** group into a dedicated top-level **CLI** section (between TUI and Skill manager).
- **Top-nav link** — added a **CLI** link to the landing-page nav (Docs · CLI · Plugins · Toolkit · GitHub).

Page slug is unchanged (`tui/cli`), so no links break. Docsite-only (`astro.config.mjs` sidebar + `index.astro` nav).

Verified: `npm run build` green (59 pages); built sidebar shows the dedicated `CLI` group → "Full CLI reference", and the page renders (615 KB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized sidebar navigation with a dedicated CLI section
  * Added CLI link to landing page navigation menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->