### PR TITLE
docs(site): clean up cramped markdown table styling

### DIFF
--- a/website/site/src/styles/tokens.css
+++ b/website/site/src/styles/tokens.css
@@ -136,20 +136,44 @@ a:not(.sl-link-card):not([class*='sl-flex']):hover {
   font-size: 0.875em;
 }
 
-/* Tables — cornflower borders, zebra body. */
+/* Tables — cornflower frame, padded cells, subtle zebra + hover. */
 .sl-markdown-content table {
+  width: 100%;
+  margin: 1.15rem 0;
   border: 1px solid color-mix(in srgb, var(--ainb-border) 40%, transparent);
-  border-collapse: collapse;
+  border-radius: 8px;
+  border-collapse: separate; /* separate so border-radius clips cleanly */
+  border-spacing: 0;
   overflow: hidden;
+}
+/* Consistent breathing room so content never touches the cell edges. */
+.sl-markdown-content th,
+.sl-markdown-content td {
+  padding: 0.55rem 0.9rem;
+  text-align: left;
+  vertical-align: middle;
+  border-bottom: 1px solid color-mix(in srgb, var(--ainb-border) 18%, transparent);
 }
 .sl-markdown-content th {
   background: var(--ainb-bg-panel);
   color: var(--ainb-accent-gold);
   font-weight: 700;
-  border-bottom: 2px solid color-mix(in srgb, var(--ainb-border) 60%, transparent);
+  border-bottom: 2px solid color-mix(in srgb, var(--ainb-border) 55%, transparent);
 }
-.sl-markdown-content tr:nth-child(even) td {
+/* Drop the last row's separator so it doesn't double up with the frame. */
+.sl-markdown-content tbody tr:last-child td {
+  border-bottom: none;
+}
+.sl-markdown-content tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--ainb-bg-panel) 45%, transparent);
+}
+.sl-markdown-content tbody tr:hover td {
   background: var(--ainb-bg-panel);
+}
+/* Keep inline <kbd> chips off the cell edge / each other. */
+.sl-markdown-content td kbd,
+.sl-markdown-content th kbd {
+  vertical-align: baseline;
 }
 
 /* Blockquotes — cornflower bar, muted text. */


### PR DESCRIPTION
Tables across the docsite looked cramped — cells had no padding, so text and inline `<kbd>` chips touched the borders, and the zebra rows read as overlapping boxes (reported on the keyboard-shortcuts page).

`src/styles/tokens.css` table rules now add:
- consistent cell padding (`0.55rem 0.9rem`) so nothing touches the edges
- a rounded framed border (`border-collapse: separate` so the radius clips cleanly)
- subtle, consistent row separators (last-row separator dropped to avoid doubling with the frame)
- a lighter zebra + a row hover state
- full width for a consistent shape

Applies to every markdown table in the docsite. Verified with `npm run build` (green) + a headless screenshot of the rendered keyboard-shortcuts table (padded, framed, no edge-touching).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced table styling with improved borders, spacing, and visual hierarchy. Added alternating row backgrounds and hover effects for better readability. Improved alignment and presentation of inline code elements within tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->