### PR TITLE
docs(site): tables hug content width (fix blank right region)

### DIFF
--- a/website/site/src/styles/tokens.css
+++ b/website/site/src/styles/tokens.css
@@ -138,7 +138,11 @@ a:not(.sl-link-card):not([class*='sl-flex']):hover {
 
 /* Tables — cornflower frame, padded cells, subtle zebra + hover. */
 .sl-markdown-content table {
-  width: 100%;
+  /* Hug the content (capped at the container) instead of stretching to 100%:
+     narrow 2-column tables otherwise leave a large blank region on the right
+     inside the frame. Wide tables still grow up to max-width. */
+  width: fit-content;
+  max-width: 100%;
   margin: 1.15rem 0;
   border: 1px solid color-mix(in srgb, var(--ainb-border) 40%, transparent);
   border-radius: 8px;


### PR DESCRIPTION
Follow-up to the table styling pass: `width:100%` left a large blank region on the right of short 2-column tables (frame full-width, columns ~45%). Switch to `width:fit-content; max-width:100%` so the frame wraps the content; wide tables still grow to the container. Verified with a headless screenshot of the keyboard-shortcuts table.