### PR TITLE
docs: reframe reflect problem-and-fit around context engineering + memory-product comparison

### DIFF
--- a/docs/assets/reflect-session-timeline.svg
+++ b/docs/assets/reflect-session-timeline.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 520" width="1040" height="520" font-family="system-ui,-apple-system,Segoe UI,Roboto,sans-serif">
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#141413"/>
+    </marker>
+    <marker id="ahb" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#5B7FA6"/>
+    </marker>
+    <marker id="ahg" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#788C5D"/>
+    </marker>
+    <marker id="aho" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#D97757"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1040" height="520" fill="#FAF9F5"/>
+
+  <!-- title -->
+  <text x="40" y="44" font-size="23" font-weight="700" fill="#141413">How reflect operates across one coding session</text>
+  <text x="40" y="68" font-size="13.5" fill="#87867F">Reads inject prior knowledge into context · writes capture new signals · the index closes the loop to the next session.</text>
+
+  <!-- lane labels -->
+  <text x="40" y="120" font-size="12" font-weight="700" fill="#5B7FA6" letter-spacing="0.5">READ → INTO CONTEXT</text>
+  <text x="40" y="404" font-size="12" font-weight="700" fill="#788C5D" letter-spacing="0.5">WRITE ← FROM SESSION</text>
+
+  <!-- ============ SESSION AXIS ============ -->
+  <line x1="70" y1="258" x2="980" y2="258" stroke="#141413" stroke-width="2" marker-end="url(#ah)"/>
+  <!-- phase ticks -->
+  <g font-size="12" fill="#141413" text-anchor="middle">
+    <!-- col1 -->
+    <circle cx="150" cy="258" r="5" fill="#D97757"/>
+    <text x="150" y="282" font-weight="600">SessionStart</text>
+    <!-- col2 -->
+    <circle cx="400" cy="258" r="5" fill="#141413"/>
+    <text x="400" y="282" font-weight="600">UserPromptSubmit</text>
+    <text x="400" y="298" font-size="10.5" fill="#87867F">→ tool calls (Bash/Edit/Todo…)</text>
+    <!-- col3 -->
+    <circle cx="640" cy="258" r="5" fill="#141413"/>
+    <text x="640" y="282" font-weight="600">UserPromptSubmit</text>
+    <text x="640" y="298" font-size="10.5" fill="#87867F">→ more tool calls</text>
+    <!-- col4 -->
+    <circle cx="820" cy="258" r="5" fill="#141413"/>
+    <text x="820" y="282" font-weight="600">Stop</text>
+    <text x="820" y="298" font-size="10.5" fill="#87867F">turn ends</text>
+    <!-- col5 -->
+    <circle cx="935" cy="258" r="5" fill="#D97757"/>
+    <text x="935" y="282" font-weight="600">PreCompact</text>
+  </g>
+
+  <!-- ============ READ LANE (blue, top) ============ -->
+  <g>
+    <!-- SessionStart recall -->
+    <rect x="78" y="132" width="200" height="62" rx="8" fill="#EAF0F6" stroke="#5B7FA6" stroke-width="1.5"/>
+    <text x="90" y="153" font-size="12.5" font-weight="700" fill="#1F3A5F">Recall</text>
+    <text x="90" y="170" font-size="11" fill="#141413">inject relevant prior learnings</text>
+    <text x="90" y="185" font-size="11" fill="#141413">+ drain queued captures</text>
+    <line x1="150" y1="194" x2="150" y2="252" stroke="#5B7FA6" stroke-width="1.5" marker-end="url(#ahb)"/>
+
+    <!-- per-prompt recall col2 -->
+    <rect x="318" y="140" width="172" height="54" rx="8" fill="#EAF0F6" stroke="#5B7FA6" stroke-width="1.5"/>
+    <text x="330" y="161" font-size="12.5" font-weight="700" fill="#1F3A5F">Recall (intent-sharp)</text>
+    <text x="330" y="178" font-size="11" fill="#141413">per prompt · de-duped</text>
+    <line x1="400" y1="194" x2="400" y2="252" stroke="#5B7FA6" stroke-width="1.5" marker-end="url(#ahb)"/>
+
+    <!-- per-prompt recall col3 -->
+    <rect x="566" y="140" width="148" height="54" rx="8" fill="#EAF0F6" stroke="#5B7FA6" stroke-width="1.5"/>
+    <text x="578" y="161" font-size="12.5" font-weight="700" fill="#1F3A5F">Recall</text>
+    <text x="578" y="178" font-size="11" fill="#141413">RRF · rerank · OOD gate</text>
+    <line x1="640" y1="194" x2="640" y2="252" stroke="#5B7FA6" stroke-width="1.5" marker-end="url(#ahb)"/>
+  </g>
+
+  <!-- ============ WRITE LANE (green, bottom) ============ -->
+  <g>
+    <!-- PostToolUse signals (spans col2-col3) -->
+    <rect x="318" y="324" width="396" height="62" rx="8" fill="#EEF1E8" stroke="#788C5D" stroke-width="1.5"/>
+    <text x="330" y="345" font-size="12.5" font-weight="700" fill="#3E4A2E">PostToolUse · signals</text>
+    <text x="330" y="362" font-size="11" fill="#141413">test pass/fail · tool-loop · git event · todo done</text>
+    <text x="330" y="377" font-size="11" fill="#141413">correction (“no — don’t…”) · permission reply</text>
+    <line x1="460" y1="264" x2="460" y2="322" stroke="#788C5D" stroke-width="1.5" marker-end="url(#ahg)"/>
+
+    <!-- Stop capture -->
+    <rect x="742" y="324" width="170" height="62" rx="8" fill="#EEF1E8" stroke="#788C5D" stroke-width="1.5"/>
+    <text x="754" y="345" font-size="12.5" font-weight="700" fill="#3E4A2E">Capture</text>
+    <text x="754" y="362" font-size="11" fill="#141413">slice window →</text>
+    <text x="754" y="377" font-size="11" fill="#141413">learning + sidecar</text>
+    <line x1="820" y1="264" x2="820" y2="322" stroke="#788C5D" stroke-width="1.5" marker-end="url(#ahg)"/>
+
+    <!-- PreCompact flush -->
+    <rect x="862" y="150" width="150" height="48" rx="8" fill="#FBEEE8" stroke="#D97757" stroke-width="1.5"/>
+    <text x="874" y="170" font-size="12" font-weight="700" fill="#9A4D2E">Flush</text>
+    <text x="874" y="186" font-size="10.5" fill="#141413">capture before compact</text>
+    <line x1="935" y1="252" x2="935" y2="198" stroke="#D97757" stroke-width="1.5" marker-end="url(#aho)"/>
+  </g>
+
+  <!-- ============ INDEX + LOOP ============ -->
+  <rect x="318" y="430" width="396" height="46" rx="8" fill="#FBEEE8" stroke="#D97757" stroke-width="1.5"/>
+  <text x="338" y="451" font-size="12.5" font-weight="700" fill="#9A4D2E">Index</text>
+  <text x="338" y="468" font-size="11" fill="#141413">QMD (BM25) + nano-graphrag (vector + entity graph) · local model, no extra key</text>
+  <!-- signals/capture feed the index -->
+  <line x1="516" y1="386" x2="516" y2="428" stroke="#D97757" stroke-width="1.5" marker-end="url(#aho)"/>
+
+  <!-- loop arrow: index back up to next-session recall -->
+  <path d="M714 453 C 980 453, 1006 360, 1006 220 C 1006 150, 660 150, 494 156" fill="none" stroke="#87867F" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#ah)"/>
+  <text x="780" y="430" font-size="11" font-style="italic" fill="#87867F">recalled in the next session →</text>
+
+  <!-- idle sweep (detached, lower-left) -->
+  <rect x="78" y="430" width="200" height="46" rx="8" fill="#F0EEE6" stroke="#D1CFC5" stroke-width="1.5"/>
+  <text x="90" y="451" font-size="12" font-weight="700" fill="#57564F">Idle sweep</text>
+  <text x="90" y="468" font-size="10.5" fill="#87867F">quiet transcripts → speculative (down-ranked)</text>
+</svg>

--- a/docs/knowledge/reflect-memory/problem-and-fit.md
+++ b/docs/knowledge/reflect-memory/problem-and-fit.md
@@ -1,89 +1,110 @@
 ---
 title: "reflect-memory — the problem & where it fits"
-description: "What Claude Code, Codex, and Copilot give you out of the box, the memory gap they all share, and how reflect-memory fills it without an extra API key."
+description: "Context engineering, not a bigger instructions file: why front-loading CLAUDE.md/AGENTS.md hits a wall, how reflect captures and recalls the right knowledge at the right time, and how it compares to Mem0, Hindsight, ByteRover, claude-mem, agentmemory, Honcho and OpenViking."
 ---
 
-> **reflect-memory** is a cross-harness memory layer for AI coding agents: it captures what you
-> teach the agent, indexes it (semantic + lexical + graph), and recalls the right prior art into
-> the next session — across machines, with **no extra LLM or embedding key**.
+> **reflect-memory** captures what you teach a coding agent — corrections, decisions, the architecture
+> reasons you keep re-explaining — and recalls the *right* piece into the *right* moment of the next
+> session. Across machines and harnesses, reusing the agent's own model, with **no extra API key**.
 
-This page is the newcomer's entry point: the problem, what your harness already does, and the gap
-reflect fills. For the mental model see [Construct](/knowledge/reflect-memory/construct/); for the
-full per-feature reference see [Recall reference](/knowledge/reflect-memory/recall/).
+![Timeline of one coding session and where reflect operates — recall injects prior learnings at SessionStart and each prompt; signals + capture write out at tool calls, Stop and PreCompact; the index closes the loop to the next session](../../assets/reflect-session-timeline.svg)
 
-## The problem: every session starts amnesiac
+## The real problem: context engineering, not a bigger file
 
-```
-Day 1   you: "regen the gRPC clients after editing payments.proto — broke staging"
-        agent: fixes it ✓
-   ...new session, 3 weeks later, different machine, maybe a teammate...
-Day 22  agent: edits payments.proto, skips regen ──▶ staging breaks again ✗
-```
+Every harness gives you one persistent memory primitive: a **static instructions file you maintain by
+hand** — `CLAUDE.md`, `AGENTS.md`, `MEMORY.md`, `copilot-instructions.md`. It is front-loaded into the
+context window at the start of every session.
 
-Out of the box, an agent's only persistent memory is a **static instructions file you maintain by
-hand** (`CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`). It does not *learn* from a session,
-it cannot *search* what happened in past sessions by meaning, and it never *connects* one fact to
-another. So you re-fix the same bug, re-explain the same convention, and re-research the same
-problem — the cost the agent was supposed to remove.
-
-reflect's promise is the inverse: **correct once, never again.**
-
-## What each harness gives out of the box
+That has a hard ceiling. The context window is finite and **shared with the actual task**. Every line
+you front-load "just in case" is bloat the moment this particular session doesn't need it — and it
+crowds out the files, diffs, and reasoning the task *does* need.
 
 ```
-┌──────────────┐   ┌──────────────┐   ┌──────────────┐
-│ Claude Code  │   │  Codex CLI   │   │   Copilot    │   ◀── static file
-│  CLAUDE.md   │   │  AGENTS.md   │   │ *-instr.md   │      you hand-edit
-└──────┬───────┘   └──────┬───────┘   └──────┬───────┘
-       └──────────────────┼──────────────────┘
-                          ▼
-              ┌───────────────────────┐
-              │     reflect-memory     │  ◀── auto-capture + semantic/
-              │  capture·index·recall  │      lexical/graph recall,
-              └───────────────────────┘      shared across all three
+   context window  =  [ task: files · diffs · plan · tool output ]  +  [ memory ]
+                                                          ▲                    ▲
+                            this is the work ─────────────┘                    │
+                            front-loaded "just in case" — bloat when ──────────┘
+                            irrelevant, and you can only fit so much
 ```
 
-| Capability | Claude Code | Codex CLI | Copilot | **reflect-memory** |
-|---|:---:|:---:|:---:|:---:|
-| Persistent static instructions | `CLAUDE.md` | `AGENTS.md` | `*-instructions.md` | uses them **+** a live KB |
-| Maintained by | you, by hand | you, by hand | you, by hand | **auto-captured** from sessions |
-| Auto-capture corrections → structured learnings | ✗ | ✗ | ✗ | ✓ |
-| Semantic (vector) recall of past learnings | ✗ | ✗ | ✗ | ✓ |
-| Lexical / BM25 exact-term recall | ✗ | ✗ | ✗ | ✓ |
-| Graph (multi-hop) recall — "what caused / depends on X" | ✗ | ✗ | ✗ | ✓ |
-| Recency / temporal awareness | ✗ | ✗ | ✗ | ✓ |
-| Relevance gate (inject nothing when nothing fits) | ✗ | ✗ | ✗ | ✓ |
-| Shared across **harnesses** (Codex writes, Claude reads) | ✗ | ✗ | ✗ | ✓ |
-| Shared across **machines** | ✗ | ✗ | ✗ | ✓ (Postgres backend) |
-| Extra API / embedding key for memory | — | — | — | **none** (local model) |
-| Hook integration | native | 0.129+ hooks | native hooks¹ | wires all three |
+So a bigger instructions file is the wrong axis. The questions that actually matter:
 
-¹ Copilot drops `userPromptSubmitted` hook output, so per-prompt recall there is manual `/recall`;
-SessionStart auto-recall works. See [Hooks & platform](/knowledge/hooks-and-platform/).
+- A correction you made three weeks ago ("don't bump the shared proto without regenerating clients")
+  — how does it reach the agent *only* in the session that's about to touch that proto?
+- The architecture *reason* behind a non-obvious choice ("the double `recalcTax` call fixes an EU-VAT
+  rounding bug") — how is it recalled when someone questions that code, and stays invisible otherwise?
+- A hard-won veering ("we migrated off JWT to server-side sessions in June") — how does it override the
+  stale fact, instead of sitting in a file nobody re-reads?
 
-The static file isn't useless — it's the right place for *rules you already know you want every
-time*. The gap is everything you **discover mid-session**: that knowledge has nowhere to go and no
-way back. reflect is that path.
+The goal isn't to store *more* — it's to store the signal-bearing moments and **query the right one at
+the right time**, spending context only when it pays. That is a retrieval problem, not a file-size
+problem. It's why a class of "agent memory" products exists.
+
+## The memory-product landscape — and where each one pinches
+
+Several tools attack this. They differ on four axes that decide whether they actually fit a
+coding-agent workflow:
+
+1. **Do they store everything, or selectively?** Whole-session / fire-hose capture is useful but
+   accretes noise and unbounded data over time.
+2. **Do they need a separate LLM/embedding key?** Your coding agent already has a model+subscription.
+   Most memory tools make you configure and *pay for a second provider* just for memory.
+3. **What infrastructure do they run?** A always-on server (Postgres, Redis, a Rust/Bun daemon, a
+   vector DB) is operational weight — and often cloud-dependent.
+4. **Do they capture coding signals as first-class events?** Corrections, test outcomes, git events,
+   skill upgrades — captured *structurally*, or only as prose an LLM might (or might not) extract?
+
+```
+        store selectively    no extra key     local, no server    first-class signals
+reflect       ✓                  ✓                  ✓                    ✓
+others        varies          mostly ✗           mostly ✗           ✗ (probabilistic)
+```
+
+| Tool | What it stores | Extra LLM/embed key? | Runs as | First-class coding signals | License |
+|---|---|---|---|---|---|
+| **reflect** | **selective** learnings; markdown = source of truth | **No** — reuses the agent's own model + local embeddings | **local files** (sqlite + graphml); optional shared Postgres | **Yes** — corrections, tests, tool-loops, git, todos, permissions, contradictions, skill-refresh | MIT |
+| Hindsight | LLM-extracted facts + mental models | Yes for writes¹ | local daemon → Docker (FastAPI+Postgres) → cloud | No — extracted from prose (skill-capture is a logged bug) | MIT |
+| Mem0 | LLM-extracted facts | **Yes** — OpenAI by default at ingest | library → Docker (Postgres+Neo4j); graph = Pro $249/mo | No — hooks, but no correction/git/test capture | Apache-2.0 + SaaS |
+| ByteRover | curated markdown tree | curation makes its own LLM calls | local files + node daemon; optional cloud sync | No — curation is agent-*directed*, not passive | Elastic 2.0 (not OSS) |
+| claude-mem | every tool call → compressed observations | **No** — reuses Claude auth + local embeddings | always-on Bun daemon + optional ChromaDB | No — probabilistic Haiku extraction | Apache-2.0 |
+| agentmemory | **fire-hose** — every tool call, verbatim | optional (value degrades without) | always-on Rust daemon (4 ports) | No — raw events; little structure without LLM | Apache-2.0 |
+| Honcho | user/peer models (theory-of-mind) | Yes (self-host); cloud is per-token | Postgres + Redis + deriver worker; or cloud | No — built for end-user personalization, not coding | AGPL-3.0 |
+| OpenViking | LLM-extracted memories/skills (tiered) | **Yes** — OpenAI/Volcengine by default | Rust+Go+C++ server, always-on | No — git/test/skill not first-class | AGPL-3.0 |
+
+¹ Hindsight's `retain` needs an LLM; its "reuse your Claude subscription" loopback is documented as
+**personal-use-only per Anthropic's terms** — not shippable. See the
+[adopt-vs-build critique](https://github.com/stevengonsalvez/ainb-reflect-memory#why-build-not-adopt).
+
+The pattern: the tools that *don't* need a second key (claude-mem) tend to **store everything and grow
+noisy**; the tools that *do* curate well (Hindsight, Mem0, OpenViking) make you **stand up a server and
+pay a second provider**; and **none** of them capture corrections, test outcomes, git events, or skill
+upgrades as typed signals — they hope an LLM extracts them from the transcript.
 
 ## Where reflect fits
 
+reflect is the row that holds all four columns at once. Its design line: **the brain is client-side,
+the store is dumb, and the signals are typed.**
+
 ```
    harness hooks ──▶ reflect (capture)  ──▶ markdown KB (source of truth)
-        ▲                                         │
-        │                                   index (QMD + nano-graphrag)
-   harness LLM  ◀── reflect (recall) ◀────────────┘
-   (capture reuses your harness's own model — no extra key)
+        ▲              ▲ typed signals              │
+        │              │ (corrections, tests,  index (QMD + nano-graphrag)
+   harness LLM  ◀── reflect (recall) ◀──── git, skills, contradictions)
+   (capture reuses the agent's OWN model — no extra key, no separate sub)
 ```
 
-| It plugs into | How |
+| reflect's answer | to the problem |
 |---|---|
-| Your harness's hooks | SessionStart recall, Stop/PostToolUse capture, PreCompact flush |
-| Your harness's own LLM | capture summarisation runs via `claude -p` — no new provider, no new key |
-| A local embedding model | `all-mpnet-base-v2` on CPU/MPS for vector recall — no cloud call |
-| Your existing files | learnings are plain markdown; `CLAUDE.md`/`AGENTS.md` stay as-is |
+| **Selective capture** — only signal-bearing moments become learnings; TTL, dedup and contradiction-handling built in | whole-session noise + unbounded growth |
+| **Reuses the agent's own model** (`claude -p`) + a local embedding model | no second API key, no separate subscription, no ToS loophole |
+| **Local files** (QMD sqlite + nano-graphrag graphml) — optional shared Postgres only if you *want* cross-machine | no mandatory server / cloud dependency |
+| **First-class typed signals** — corrections, test pass/fail, tool-loops, git commit/revert, todo completions, permission replies, cross-turn contradictions, idle sweeps, plus auto **skill-refresh** | the gap every other tool leaves to probabilistic extraction |
+| **Cross-harness by design** — Codex writes a learning, a later Claude session reads it | single-harness / MCP-bolted memory |
+| **Markdown source of truth**, volatile signals in a DB sidecar → clean git diffs, reviewable in a PR | opaque DB/vector blobs |
 
-The deliberate design line: **the brain is client-side, the store is dumb.** reflect never adds an
-LLM provider you have to configure — it borrows the one your harness already authenticated.
+The honest line: on the *no-extra-key* axis alone, claude-mem ties reflect (it also reuses Claude's
+auth). reflect's separation is the **combination** — selective + no-key + local + typed-signals +
+cross-harness + MIT — which no single competitor matches.
 
 ## Next
 


### PR DESCRIPTION
Follow-up to the reflect-memory section (#324). Reframes the **problem-and-fit** page per feedback: the point isn't a harness feature table, it's context engineering.

## Changes
- **Drops the Claude/Codex/Copilot harness comparison table.** Leads instead with the context-engineering thesis: static instruction files (`CLAUDE.md`/`AGENTS.md`/`MEMORY.md`) front-load bloat into a finite, task-shared window — the real problem is storing signal-bearing moments and querying the right one at the right time.
- **New hero: a session-timeline SVG** showing where reflect operates across one coding session (recall at SessionStart + each prompt; typed signals + capture at tool calls / Stop / PreCompact; the index closing the loop to the next session).
- **New comparison is against memory *products*** — Mem0, Hindsight, ByteRover, claude-mem, agentmemory, Honcho, OpenViking — on four deciding axes (selective vs whole-session · extra LLM key · infra · first-class signal capture), with reflect's wedge.

Grounded in per-tool research + the porting epic (#227). Full treatment published at https://explainers.stevengonsalvez.com/agent-memory-landscape/ and the reflect repo README.

`astro build` passes; timeline SVG bundles + renders.

https://claude.ai/code/session_01KZHPj7CGYkjXbo7bJZN7iP