### PR TITLE
feat(mcp-pool): daemon self-shuts down when idle

### DIFF
--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -146,9 +146,13 @@ show_git_status = true
 #
 # [mcp_pool]
 # enabled = true          # Master switch (default: true)
-# idle_grace_secs = 300   # Reap a pooled server this many seconds after its
-#                         # last client detaches (default: 300)
-# monitor_refresh_secs = 2 # TUI pool overlay (sidebar MCP / `m`) auto-refresh
+# idle_grace_secs = 300   # Reap a pooled server's child process this many
+#                         # seconds after its last client detaches (default: 300)
+# daemon_idle_grace_secs = 900 # Exit the whole daemon after this long with NO
+#                         # clients attached anywhere (default: 900; 0 = never).
+#                         # `ainb run`/import restart it on demand, so this just
+#                         # stops an unused or orphaned pool lingering forever.
+# monitor_refresh_secs = 2 # TUI pool overlay (sidebar MCP / `p`) auto-refresh
 #                         # cadence while OPEN (default: 2; 0 = on-open + manual).
 #                         # The overlay never polls when closed.
 

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1908,8 +1908,22 @@ impl CliCommand for McpCommand {
         "mcp"
     }
     fn build(&self, app: Command) -> Command {
-        let daemon =
-            Command::new("daemon").about("Run the shared MCP pool daemon (foreground)").arg(
+        let daemon = Command::new("daemon")
+            .about("Run the shared MCP pool daemon (foreground)")
+            .long_about(
+                "Run the shared MCP pool daemon (foreground).\n\n\
+                 You rarely run this directly — `ainb run` and the TUI overlay's import \
+                 auto-start it detached. There is exactly ONE daemon per user, keyed by the \
+                 control socket at ~/.agents-in-a-box/mcp/sockets/control.sock: every `ainb` \
+                 instance (and Codex/Copilot sessions wired via `ainb mcp install`) shares it, \
+                 so N sessions share ONE child process per server. A second start is a no-op — \
+                 it detects the live socket (or loses the bind race) and exits.\n\n\
+                 Lifecycle: servers spawn lazily on first attach; a server's child is reaped \
+                 [mcp_pool].idle_grace_secs after its last client detaches (default 300); and \
+                 the whole daemon exits after [mcp_pool].daemon_idle_grace_secs with no clients \
+                 anywhere (default 900, 0 = never) so an unused or orphaned pool can't linger.",
+            )
+            .arg(
                 clap::Arg::new("idle-grace")
                     .long("idle-grace")
                     .value_parser(clap::value_parser!(u64))

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -297,6 +297,14 @@ pub struct McpPoolConfig {
     /// polls when closed, so this only affects an actively-watched view.
     #[serde(default = "default_monitor_refresh_secs")]
     pub monitor_refresh_secs: u64,
+
+    /// Seconds the daemon itself stays up with ZERO attached clients (across
+    /// all servers) before it exits cleanly — removing its sockets and
+    /// freeing the process. `ainb run` / import restart it on demand, so this
+    /// just stops an unused (or orphaned) pool from lingering forever. `0`
+    /// disables self-shutdown (the daemon runs until explicitly stopped).
+    #[serde(default = "default_daemon_idle_grace_secs")]
+    pub daemon_idle_grace_secs: u64,
 }
 
 impl Default for McpPoolConfig {
@@ -305,6 +313,7 @@ impl Default for McpPoolConfig {
             enabled: true,
             idle_grace_secs: default_idle_grace_secs(),
             monitor_refresh_secs: default_monitor_refresh_secs(),
+            daemon_idle_grace_secs: default_daemon_idle_grace_secs(),
         }
     }
 }
@@ -315,6 +324,10 @@ fn default_idle_grace_secs() -> u64 {
 
 fn default_monitor_refresh_secs() -> u64 {
     2
+}
+
+fn default_daemon_idle_grace_secs() -> u64 {
+    900
 }
 
 /// Where the single `presets.toml` file lives.
@@ -1353,6 +1366,18 @@ mod tests {
         let parsed: AppConfig = toml::from_str("version = \"1.0.0\"").unwrap();
         assert!(parsed.mcp_pool.enabled);
         assert_eq!(parsed.mcp_pool.idle_grace_secs, 300);
+        // Daemon self-shutdown is on by default (15 min idle) so an unused or
+        // orphaned pool can't linger forever; 0 would disable it.
+        assert_eq!(parsed.mcp_pool.daemon_idle_grace_secs, 900);
+    }
+
+    #[test]
+    fn mcp_pool_daemon_idle_grace_round_trips() {
+        let mut config = AppConfig::default();
+        config.mcp_pool.daemon_idle_grace_secs = 0; // disable self-shutdown
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: AppConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.mcp_pool.daemon_idle_grace_secs, 0);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/mcp_pool/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/mcp_pool/daemon.rs
@@ -9,7 +9,7 @@
 use anyhow::{Context, Result};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
 use tokio::sync::{Mutex, mpsc};
@@ -61,6 +61,10 @@ pub async fn execute(idle_grace_override: Option<u64>) -> Result<()> {
 
     let idle_grace =
         Duration::from_secs(idle_grace_override.unwrap_or(config.mcp_pool.idle_grace_secs));
+    // Daemon-level idle shutdown: exit after this long with ZERO attached
+    // clients across all servers (0 = never). Stops an unused or orphaned
+    // pool from lingering forever; `ainb run`/import restart it on demand.
+    let daemon_idle_grace = config.mcp_pool.daemon_idle_grace_secs;
     let status: StatusMap = Arc::new(Mutex::new(HashMap::new()));
     let (register_tx, mut register_rx) = mpsc::unbounded_channel::<Vec<PooledServer>>();
     let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<DaemonCmd>();
@@ -112,10 +116,37 @@ pub async fn execute(idle_grace_override: Option<u64>) -> Result<()> {
     );
 
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+
+    // Idle-shutdown bookkeeping. We poll the live client count on a coarse
+    // tick (a fraction of the grace, clamped) and remember when the pool went
+    // quiet; once it's been quiet for `daemon_idle_grace` we break into the
+    // teardown below. The daemon starts idle, so a pool nobody ever attaches
+    // to also reaps itself.
+    let mut idle_since: Option<Instant> = None;
+    let idle_tick = (daemon_idle_grace / 4).clamp(2, 30);
+    let mut idle_check = tokio::time::interval(Duration::from_secs(idle_tick.max(1)));
+
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => break,
             _ = sigterm.recv() => break,
+            _ = idle_check.tick(), if daemon_idle_grace > 0 => {
+                let clients: usize = {
+                    let map = status.lock().await;
+                    map.values().map(|s| s.clients).sum()
+                };
+                if clients == 0 {
+                    let since = *idle_since.get_or_insert_with(Instant::now);
+                    if since.elapsed().as_secs() >= daemon_idle_grace {
+                        eprintln!(
+                            "mcp daemon: idle {daemon_idle_grace}s with no clients — shutting down"
+                        );
+                        break;
+                    }
+                } else {
+                    idle_since = None;
+                }
+            }
             registered = register_rx.recv() => {
                 let Some(servers) = registered else { continue };
                 for server in servers {

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2230,18 +2230,30 @@ EXAMPLES:
 
 ### `ainb mcp daemon`
 
-Run the shared MCP pool daemon (foreground)
+Run the shared MCP pool daemon (foreground).
 
 ```console
 $ ainb mcp daemon --help
-Run the shared MCP pool daemon (foreground)
+Run the shared MCP pool daemon (foreground).
+
+You rarely run this directly — `ainb run` and the TUI overlay's import auto-start it detached. There is exactly ONE daemon per user, keyed by the control socket at ~/.agents-in-a-box/mcp/sockets/control.sock: every `ainb` instance (and Codex/Copilot sessions wired via `ainb mcp install`) shares it, so N sessions share ONE child process per server. A second start is a no-op — it detects the live socket (or loses the bind race) and exits.
+
+Lifecycle: servers spawn lazily on first attach; a server's child is reaped [mcp_pool].idle_grace_secs after its last client detaches (default 300); and the whole daemon exits after [mcp_pool].daemon_idle_grace_secs with no clients anywhere (default 900, 0 = never) so an unused or orphaned pool can't linger.
 
 Usage: ainb mcp daemon [OPTIONS]
 
 Options:
-      --format <format>          Output format [default: text] [possible values: text, json, csv, markdown]
-      --idle-grace <idle-grace>  Override [mcp_pool].idle_grace_secs (seconds)
-  -h, --help                     Print help
+      --format <format>
+          Output format
+          
+          [default: text]
+          [possible values: text, json, csv, markdown]
+
+      --idle-grace <idle-grace>
+          Override [mcp_pool].idle_grace_secs (seconds)
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 ### `ainb mcp proxy`

--- a/docs/tui/mcp-pool.mdx
+++ b/docs/tui/mcp-pool.mdx
@@ -158,8 +158,9 @@ Pool settings and per-server opt-out live in `config.toml` (user-level `~/.agent
 # …or  ./.ainb/config.toml                (per-repo override)
 
 [mcp_pool]
-enabled = true          # default true
-idle_grace_secs = 300   # reap a pooled server N seconds after its last session detaches
+enabled = true               # default true
+idle_grace_secs = 300        # reap a pooled server's child N seconds after its last session detaches
+daemon_idle_grace_secs = 900 # exit the whole daemon after N seconds with NO clients (0 = never)
 
 [mcp_servers.context7]
 name = "context7"
@@ -279,6 +280,35 @@ A tool call fans in: many stdio shims, one socket, one child.
 </Steps>
 
 If anything fails — daemon down, server not on PATH — the session silently falls back to spawning its own MCP, so a session never fails to start because of the pool. Host/tmux sessions only; Docker sessions keep their per-container MCP init.
+
+## One daemon per machine — lifecycle &amp; scaling
+
+**Running several `ainb` windows does *not* start several daemons.** There is exactly **one daemon per user**, keyed by the control socket at `~/.agents-in-a-box/mcp/sockets/control.sock`. Every `ainb` instance — and every Codex/Copilot session wired with `ainb mcp install` — discovers and shares that one daemon, which in turn keeps one child process per server. Ten windows all using context7 = **one** `context7` process, not ten.
+
+The singleton is enforced by two independent guards, so even a dead heat collapses to one survivor:
+
+<Steps>
+
+1. **Discover before spawn.** Before starting a daemon, `ensure_daemon()` (what `ainb run` and the overlay's import call) connects to the control socket and `ping`s it. If it answers, nothing is spawned.
+
+2. **Exclusive bind.** If a daemon *is* spawned, it re-checks the socket and then `bind()`s it — an OS-exclusive operation. If two instances race past step 1 simultaneously, the first binds and the second's bind fails, so it logs and exits. A crashed daemon's stale socket fails the liveness `connect` and is cleaned up automatically, so a fresh start is never blocked.
+
+</Steps>
+
+Scope is **per `$HOME`**: same user → same daemon. (Sandboxes with a custom `$HOME` get their own pool — that's how the test harnesses stay isolated.)
+
+### What it costs at rest
+
+| Mechanism | Effect |
+|---|---|
+| **Lazy spawn** | At daemon start only lightweight listener tasks exist; the child process spawns on **first attach**. An idle pool is essentially free. |
+| **Refcounted sharing** | N session shims → **1 child** per server. The win scales with how many sessions you run. |
+| **Per-server reap** | `idle_grace_secs` (default 300) after the last client detaches, the **child** is killed but the listener stays — the next attach respawns it. |
+| **Daemon self-shutdown** | `daemon_idle_grace_secs` (default 900; `0` = never) with **zero** clients anywhere, the **whole daemon** exits and removes its sockets. `ainb run` / import restart it on demand, so an unused — or orphaned — pool never lingers. |
+
+<Aside type="tip" title="Why the daemon can exit on its own">
+The daemon is spawned detached so it survives the TUI closing — useful for a persistent pool, but it means a daemon whose `$HOME`/sandbox was deleted would otherwise run forever. `daemon_idle_grace_secs` closes that: no clients for the grace window → clean exit. Because startup is lazy and cheap, the next session just brings it back.
+</Aside>
 
 ## The hard parts the mux had to solve
 


### PR DESCRIPTION
## Why

The pool daemon never self-terminated — only its **per-server children** were reaped on idle, so the daemon process itself ran forever as an idle event loop. A daemon whose `$HOME`/sandbox was deleted out from under it (or that nobody ever attaches to) lingered indefinitely. In practice this surfaced as orphaned `ainb mcp daemon` processes piling up from throwaway test sandboxes (4 found and reaped during review).

## Change

New `[mcp_pool].daemon_idle_grace_secs` (default **900**, `0` = never): with **zero attached clients across all servers** for that window, the daemon exits cleanly and removes its sockets. `ensure_daemon` restarts it on demand and startup is lazy, so this only reaps unused or orphaned pools — a live session keeps it up.

Implemented as a coarse idle-check tick in the daemon's `select!` loop that remembers when the pool went quiet and breaks into the existing teardown once it's been quiet long enough.

## Verification

Smoke-tested against the real binary:
- **self-exits** at the grace with no clients (`idle Ns with no clients — shutting down`, socket removed)
- **stays up** while a client is attached (`clients:1` well past the grace)
- **exits** after the client detaches

Plus config round-trip unit tests, `fmt` (rustfmt 1.96.0) and `clippy` clean.

## Docs

- **TUI page** (`docs/tui/mcp-pool.mdx`): new *"One daemon per machine — lifecycle & scaling"* section — one daemon per user (multiple `ainb` instances share it, not one-per-window), how the singleton is enforced (discover-before-spawn + exclusive socket bind), and the at-rest cost table (lazy spawn / refcount / per-server reap / daemon self-shutdown).
- **CLI ref** (`docs/tui/cli.md`): regenerated from an enriched `ainb mcp daemon --help` `long_about` describing the singleton model + lifecycle (edited `registry.rs`, not the generated file).
- `config/example.config.toml`: documented the new field (+ fixed a stale `m`→`p` overlay-key reference).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daemon idle timeout configuration option to automatically shut down the MCP pool daemon after remaining idle with no connected clients.

* **Documentation**
  * Expanded CLI help text and guides for the MCP daemon with detailed lifecycle and behavior explanations.
  * Improved MCP pool configuration documentation with new daemon shutdown settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->