### PR TITLE
docs/site: light mode + 'why build, not adopt' comparison page

### DIFF
--- a/docs/assets/reflect-session-timeline.svg
+++ b/docs/assets/reflect-session-timeline.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 520" width="1040" height="520" font-family="system-ui,-apple-system,Segoe UI,Roboto,sans-serif">
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#141413"/>
+    </marker>
+    <marker id="ahb" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#5B7FA6"/>
+    </marker>
+    <marker id="ahg" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#788C5D"/>
+    </marker>
+    <marker id="aho" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" fill="#D97757"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1040" height="520" fill="#FAF9F5"/>
+
+  <!-- title -->
+  <text x="40" y="44" font-size="23" font-weight="700" fill="#141413">How reflect operates across one coding session</text>
+  <text x="40" y="68" font-size="13.5" fill="#87867F">Reads inject prior knowledge into context · writes capture new signals · the index closes the loop to the next session.</text>
+
+  <!-- lane labels -->
+  <text x="40" y="120" font-size="12" font-weight="700" fill="#5B7FA6" letter-spacing="0.5">READ → INTO CONTEXT</text>
+  <text x="40" y="404" font-size="12" font-weight="700" fill="#788C5D" letter-spacing="0.5">WRITE ← FROM SESSION</text>
+
+  <!-- ============ SESSION AXIS ============ -->
+  <line x1="70" y1="258" x2="980" y2="258" stroke="#141413" stroke-width="2" marker-end="url(#ah)"/>
+  <!-- phase ticks -->
+  <g font-size="12" fill="#141413" text-anchor="middle">
+    <!-- col1 -->
+    <circle cx="150" cy="258" r="5" fill="#D97757"/>
+    <text x="150" y="282" font-weight="600">SessionStart</text>
+    <!-- col2 -->
+    <circle cx="400" cy="258" r="5" fill="#141413"/>
+    <text x="400" y="282" font-weight="600">UserPromptSubmit</text>
+    <text x="400" y="298" font-size="10.5" fill="#87867F">→ tool calls (Bash/Edit/Todo…)</text>
+    <!-- col3 -->
+    <circle cx="640" cy="258" r="5" fill="#141413"/>
+    <text x="640" y="282" font-weight="600">UserPromptSubmit</text>
+    <text x="640" y="298" font-size="10.5" fill="#87867F">→ more tool calls</text>
+    <!-- col4 -->
+    <circle cx="820" cy="258" r="5" fill="#141413"/>
+    <text x="820" y="282" font-weight="600">Stop</text>
+    <text x="820" y="298" font-size="10.5" fill="#87867F">turn ends</text>
+    <!-- col5 -->
+    <circle cx="935" cy="258" r="5" fill="#D97757"/>
+    <text x="935" y="282" font-weight="600">PreCompact</text>
+  </g>
+
+  <!-- ============ READ LANE (blue, top) ============ -->
+  <g>
+    <!-- SessionStart recall -->
+    <rect x="78" y="132" width="200" height="62" rx="8" fill="#EAF0F6" stroke="#5B7FA6" stroke-width="1.5"/>
+    <text x="90" y="153" font-size="12.5" font-weight="700" fill="#1F3A5F">Recall</text>
+    <text x="90" y="170" font-size="11" fill="#141413">inject relevant prior learnings</text>
+    <text x="90" y="185" font-size="11" fill="#141413">+ drain queued captures</text>
+    <line x1="150" y1="194" x2="150" y2="252" stroke="#5B7FA6" stroke-width="1.5" marker-end="url(#ahb)"/>
+
+    <!-- per-prompt recall col2 -->
+    <rect x="318" y="140" width="172" height="54" rx="8" fill="#EAF0F6" stroke="#5B7FA6" stroke-width="1.5"/>
+    <text x="330" y="161" font-size="12.5" font-weight="700" fill="#1F3A5F">Recall (intent-sharp)</text>
+    <text x="330" y="178" font-size="11" fill="#141413">per prompt · de-duped</text>
+    <line x1="400" y1="194" x2="400" y2="252" stroke="#5B7FA6" stroke-width="1.5" marker-end="url(#ahb)"/>
+
+    <!-- per-prompt recall col3 -->
+    <rect x="566" y="140" width="148" height="54" rx="8" fill="#EAF0F6" stroke="#5B7FA6" stroke-width="1.5"/>
+    <text x="578" y="161" font-size="12.5" font-weight="700" fill="#1F3A5F">Recall</text>
+    <text x="578" y="178" font-size="11" fill="#141413">RRF · rerank · OOD gate</text>
+    <line x1="640" y1="194" x2="640" y2="252" stroke="#5B7FA6" stroke-width="1.5" marker-end="url(#ahb)"/>
+  </g>
+
+  <!-- ============ WRITE LANE (green, bottom) ============ -->
+  <g>
+    <!-- PostToolUse signals (spans col2-col3) -->
+    <rect x="318" y="324" width="396" height="62" rx="8" fill="#EEF1E8" stroke="#788C5D" stroke-width="1.5"/>
+    <text x="330" y="345" font-size="12.5" font-weight="700" fill="#3E4A2E">PostToolUse · signals</text>
+    <text x="330" y="362" font-size="11" fill="#141413">test pass/fail · tool-loop · git event · todo done</text>
+    <text x="330" y="377" font-size="11" fill="#141413">correction (“no — don’t…”) · permission reply</text>
+    <line x1="460" y1="264" x2="460" y2="322" stroke="#788C5D" stroke-width="1.5" marker-end="url(#ahg)"/>
+
+    <!-- Stop capture -->
+    <rect x="742" y="324" width="170" height="62" rx="8" fill="#EEF1E8" stroke="#788C5D" stroke-width="1.5"/>
+    <text x="754" y="345" font-size="12.5" font-weight="700" fill="#3E4A2E">Capture</text>
+    <text x="754" y="362" font-size="11" fill="#141413">slice window →</text>
+    <text x="754" y="377" font-size="11" fill="#141413">learning + sidecar</text>
+    <line x1="820" y1="264" x2="820" y2="322" stroke="#788C5D" stroke-width="1.5" marker-end="url(#ahg)"/>
+
+    <!-- PreCompact flush -->
+    <rect x="862" y="150" width="150" height="48" rx="8" fill="#FBEEE8" stroke="#D97757" stroke-width="1.5"/>
+    <text x="874" y="170" font-size="12" font-weight="700" fill="#9A4D2E">Flush</text>
+    <text x="874" y="186" font-size="10.5" fill="#141413">capture before compact</text>
+    <line x1="935" y1="252" x2="935" y2="198" stroke="#D97757" stroke-width="1.5" marker-end="url(#aho)"/>
+  </g>
+
+  <!-- ============ INDEX + LOOP ============ -->
+  <rect x="318" y="430" width="396" height="46" rx="8" fill="#FBEEE8" stroke="#D97757" stroke-width="1.5"/>
+  <text x="338" y="451" font-size="12.5" font-weight="700" fill="#9A4D2E">Index</text>
+  <text x="338" y="468" font-size="11" fill="#141413">QMD (BM25) + nano-graphrag (vector + entity graph) · local model, no extra key</text>
+  <!-- signals/capture feed the index -->
+  <line x1="516" y1="386" x2="516" y2="428" stroke="#D97757" stroke-width="1.5" marker-end="url(#aho)"/>
+
+  <!-- loop arrow: index back up to next-session recall -->
+  <path d="M714 453 C 980 453, 1006 360, 1006 220 C 1006 150, 660 150, 494 156" fill="none" stroke="#87867F" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#ah)"/>
+  <text x="780" y="430" font-size="11" font-style="italic" fill="#87867F">recalled in the next session →</text>
+
+  <!-- idle sweep (detached, lower-left) -->
+  <rect x="78" y="430" width="200" height="46" rx="8" fill="#F0EEE6" stroke="#D1CFC5" stroke-width="1.5"/>
+  <text x="90" y="451" font-size="12" font-weight="700" fill="#57564F">Idle sweep</text>
+  <text x="90" y="468" font-size="10.5" fill="#87867F">quiet transcripts → speculative (down-ranked)</text>
+</svg>

--- a/docs/knowledge/reflect-memory/comparison.md
+++ b/docs/knowledge/reflect-memory/comparison.md
@@ -1,0 +1,144 @@
+---
+title: "Why build, not adopt — the agent-memory landscape"
+description: "Eight coding-agent memory systems (Hindsight, Mem0, ByteRover, claude-mem, agentmemory, Honcho, OpenViking) compared on four deciding axes, with an honest build-vs-adopt verdict for reflect."
+---
+
+> Eight coding-agent memory systems, four deciding axes, and an honest build-vs-adopt verdict. The
+> short version: the tools that need no second API key tend to hoard noise; the ones that curate well
+> make you run a server and pay a second provider; and none capture corrections, tests, git events or
+> skill upgrades as typed signals. reflect is the row that holds all four.
+
+:::tip[Interactive version]
+A richer, standalone version of this page (option cards, scored matrix, the full critique) is published at
+**[explainers.stevengonsalvez.com/agent-memory-landscape](https://explainers.stevengonsalvez.com/agent-memory-landscape/)**.
+For the newcomer framing see [Problem & fit](/knowledge/reflect-memory/problem-and-fit/).
+:::
+
+## The problem: context engineering, not a bigger file
+
+Every coding harness gives you one persistent-memory primitive: a static instructions file you
+maintain by hand (`CLAUDE.md`, `AGENTS.md`, `MEMORY.md`), front-loaded into the context window every
+session. The window is finite and **shared with the task** — every line you front-load "just in case"
+is bloat the moment this session doesn't need it. The real problem is **retrieval**: store the
+signal-bearing moments and query the right one at the right time. That's why a class of "agent memory"
+products exists. This page compares them and explains why we built rather than adopted.
+
+## The four deciding axes
+
+1. **Store everything vs selectively** — whole-session / fire-hose capture is useful but accretes
+   noise and unbounded data over time.
+2. **Separate LLM/embedding key** — your coding agent already has a model + subscription; most memory
+   tools make you configure and pay for a *second* provider just for memory.
+3. **Infrastructure** — an always-on server (Postgres, Redis, a Rust/Bun daemon, a vector DB) is
+   operational weight, and often cloud-bound.
+4. **First-class coding-signal capture** — corrections, test outcomes, git events, skill upgrades
+   captured *structurally*, or only as prose an LLM might (or might not) extract?
+
+## The eight systems
+
+| Tool | What it stores | Extra LLM/embed key? | Runs as | First-class coding signals | License |
+|---|---|---|---|---|---|
+| **reflect** | **selective** learnings; markdown = source of truth | **No** — reuses the agent's own model + local embeddings | **local files** (sqlite + graphml); optional shared Postgres | **Yes** — corrections, tests, tool-loops, git, todos, permissions, contradictions, skill-refresh | MIT |
+| [Hindsight](https://github.com/vectorize-io/hindsight) | LLM-extracted facts + mental models | Yes for writes¹ | local daemon → Docker (FastAPI+Postgres) → cloud | No — extracted from prose; skill capture is a logged bug | MIT |
+| [Mem0](https://github.com/mem0ai/mem0) | LLM-extracted facts | **Yes** — OpenAI by default at ingest | library → Docker (Postgres+Neo4j); graph = Pro $249/mo | No — hooks, but no correction/git/test capture | Apache-2.0 + SaaS |
+| [ByteRover](https://github.com/campfirein/byterover-cli) | curated markdown tree | curation makes its own LLM calls | local files + node daemon; optional cloud sync | No — curation is agent-*directed*, not passive | Elastic 2.0 (not OSS) |
+| [claude-mem](https://github.com/thedotmack/claude-mem) | every tool call → compressed observations | **No** — reuses Claude auth + local embeddings | always-on Bun daemon + optional ChromaDB | No — probabilistic Haiku extraction | Apache-2.0 |
+| [agentmemory](https://github.com/rohitg00/agentmemory) | **fire-hose** — every tool call, verbatim | optional (value degrades without it) | always-on Rust daemon (4 ports) | No — raw events; little structure without LLM | Apache-2.0 |
+| [Honcho](https://github.com/plastic-labs/honcho) | user/peer models (theory-of-mind) | Yes (self-host); cloud is per-token | Postgres + Redis + deriver worker; or cloud | No — built for end-user personalization, not coding | AGPL-3.0 |
+| [OpenViking](https://github.com/volcengine/OpenViking) | LLM-extracted memories/skills (tiered) | **Yes** — OpenAI/Volcengine by default | Rust+Go+C++ server, always-on | No — git/test/skill not first-class | AGPL-3.0 |
+
+¹ Hindsight's `retain` needs an LLM; its "reuse your Claude subscription" loopback is documented as
+**personal-use-only per Anthropic's terms** — not shippable as a default.
+
+The pattern: the only other system that matches reflect on *no extra key* (claude-mem) collapses on
+*selective/noise*; the systems that curate well (Hindsight, OpenViking, ByteRover) lose on *no extra
+key* or *local-first*; and **first-class signal capture is a wall of "no"** — nobody else treats
+corrections, tests, git or skills as typed events.
+
+## How reflect works
+
+![Timeline of one coding session and where reflect operates — recall at SessionStart and each prompt; typed signals + capture at tool calls, Stop and PreCompact; the index closing the loop to the next session](../../assets/reflect-session-timeline.svg)
+
+![reflect component topology — local by default (QMD sqlite + nano-graphrag), optional shared Postgres; the markdown KB stays the source of truth either way](../../assets/reflect-topology.svg)
+
+## Token economics — both sides of the ledger
+
+Memory looks cheap if you only price retrieval. The real cost is the **write side** (LLM
+extraction/consolidation) plus the **read side** (context injection).
+
+| System | Write side | Read side | Net extra spend |
+|---|---|---|---|
+| **reflect** | reuses harness LLM (`claude -p`), gated + queued; local embed | local — vector + BM25 + graph, no LLM | **$0 extra** (rides your existing sub) |
+| claude-mem | Haiku on your Claude auth, per tool-call batch | FTS5 + local ONNX vectors | $0 extra, but high write volume |
+| Hindsight | `retain` = LLM extraction; cloud $15/M tokens | vector/graph; `reflect` synthesis costs | separate key or $15/M retain |
+| Mem0 | OpenAI extraction at ingest | vector/BM25; graph = Pro $249/mo | separate OpenAI key + tier |
+| OpenViking | VLM extraction + L0/L1 summaries | vector recursive (no LLM) | separate provider key |
+| Honcho | deriver LLM ("dreaming") per batch | `context()` free; dialectic up to $0.50/query | 1–3 keys (self-host) or per-query |
+| agentmemory | optional LLM compression (off by default) | local embed; triple-stream RRF | $0 if LLM off — value degrades |
+| ByteRover | curation = own LLM calls | BM25 → LLM fallback | own key tokens or Pro $19/mo |
+
+:::caution[Dangerous default to watch]
+**Auto-retain every turn + large auto-recall** is how memory tools quietly burn a subscription —
+agentmemory has documented incidents of exhausting a Claude Pro quota in a handful of messages.
+reflect's capture is **gated and queued** (not every turn), and recall is **OOD-gated +
+token-budgeted** — it injects nothing when nothing fits.
+:::
+
+## Observability & correction
+
+When the memory is wrong, can you see it, edit it, delete it, and trace where it came from?
+
+- **reflect** — learnings are plain markdown you open, edit or delete in your editor; volatile signals
+  live in a DB sidecar (clean git diffs); each learning links back to its source transcript + chunk;
+  per-row TTL + contradiction handling expire stale beliefs.
+- **Most others** — facts live in Postgres + vector DBs, inspected via API or SQL, not your editor.
+  claude-mem ships a web viewer but observations are DB rows; ByteRover is the exception (an editable
+  markdown tree). Correcting a wrong memory usually means an API call or a re-curation pass, not a
+  one-line file edit + commit.
+
+## Self-improvement — how a correction becomes behaviour
+
+This is the wedge. In every other system a correction is, at best, a sentence in a transcript an
+extraction LLM *might* turn into a fact — Hindsight literally files capturing a skill update as a
+*bug*. reflect routes it as **typed signals** at hook time (`SG1`–`SG8`: contradiction, git
+commit/revert, test pass/fail, tool-loop, permission reply, idle sweep, negative-recall gaps) and
+**auto-refreshes the skills those learnings affect** (`R13`/`R14`). A correction isn't hoping to be
+extracted from prose; it's a structured event that can revise a belief or promote a skill.
+
+> Everyone else remembers **what was said**. reflect captures **what changed** — and turns it into the
+> next session's behaviour.
+
+## Recommendation & decision rule
+
+:::note[Decision rule]
+Adopt an external memory provider **only if** it (a) needs no second API key or subscription, (b) runs
+without a mandatory always-on server, and (c) captures coding signals as typed events. **No single
+external tool clears all three.** So: build the thin, differentiated layer (capture + typed signals +
+local-first), and **port — don't re-invent forever — the commodity retrieval**, keeping it behind a
+seam so a stronger backend can be swapped in later.
+:::
+
+**Verdict: build + port, with eyes open.** reflect ported Hindsight's retrieval ideas
+(graph-expansion arm, RRF fusion, cross-encoder rerank, temporal arm) across a
+[57-port effort](/knowledge/reflect-memory/recall/) — so it has the retrieval brains without the
+infra/LLM/ToS baggage, at the cost of owning that code.
+
+:::caution[Honest sensitivity note]
+These weights favour self-improvement and zero-friction operation — reflect's strengths. Re-weight
+toward **pure retrieval quality and ecosystem maturity** and **Hindsight wins**: MIT, production-grade,
+94.6% LongMemEval, ~48 integrations, 62 releases. If your priority is "best recall, least code I
+maintain," adopting Hindsight (as a retrieval backend) is the smarter call. The build case rests on
+valuing *no-extra-key capture* and *typed signals* — which is why retrieval is kept swappable, not
+sacred.
+:::
+
+## If you'd adopt instead — four pilot acceptance tests
+
+1. **Zero extra credentials** — install on a fresh machine with only the coding agent's existing auth.
+   Does capture + recall work with no new key or account? *(reflect / claude-mem: pass · most: fail)*
+2. **No always-on server** — reboot. Does memory work with nothing running in the background?
+   *(reflect: pass · daemon-based tools: fail)*
+3. **Correction → behaviour** — correct the agent once; next session, does the rule resurface
+   *without* manual curation? *(the typed-signal test — reflect's wedge)*
+4. **Noise over 30 days** — run daily for a month. Is recall still sharp, or flooded with stale /
+   duplicate / fire-hosed entries? *(fire-hose tools degrade here)*

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -152,6 +152,7 @@ export default defineConfig({
             { label: 'Problem & fit', slug: 'knowledge/reflect-memory/problem-and-fit' },
             { label: 'The construct', slug: 'knowledge/reflect-memory/construct' },
             { label: 'Recall reference (57 ports)', slug: 'knowledge/reflect-memory/recall' },
+            { label: 'Why build, not adopt', slug: 'knowledge/reflect-memory/comparison' },
           ],
         },
         {

--- a/website/site/src/styles/tokens.css
+++ b/website/site/src/styles/tokens.css
@@ -1,14 +1,15 @@
 /*
  * agents-in-a-box — design tokens
  *
- * Locked to the TUI palette (see ../../../BRIEF.md §5.2). No light mode in v1.
+ * Locked to the TUI palette (see ../../../BRIEF.md §5.2).
  * Override Starlight's CSS variables to project the TUI identity through the
- * docs hub.
+ * docs hub. Dark is the default; the light palette below re-points only the
+ * `--ainb-*` leaf tokens (every `--sl-*` mapping lives on `:root`, which always
+ * matches, so the leaf override cascades through them).
  */
 
 :root,
-:root[data-theme='dark'],
-:root[data-theme='light'] {
+:root[data-theme='dark'] {
   /* ---- Palette ---- */
   --ainb-bg-deep:        #0F0F18;
   --ainb-bg-panel:       #191923;
@@ -79,6 +80,32 @@
 
   /* Spacing rhythm */
   --sl-content-width:            48rem;
+}
+
+/*
+ * Light mode — same TUI identity (cornflower frame, goldenrod accent, green),
+ * re-toned for a light surface. Only the `--ainb-*` leaves change; the
+ * `--sl-*` mappings on `:root` above pick these up automatically. Code blocks
+ * intentionally stay on a dark surface (a readable dark island on a light page).
+ */
+:root[data-theme='light'] {
+  --ainb-bg-deep:        #FAFAFC;
+  --ainb-bg-panel:       #EEEEF4;
+  --ainb-bg-raised:      #E4E4EE;
+  --ainb-bg-highlight:   #DCDCEC;
+
+  --ainb-border:         #2F5C99;  /* darker cornflower — contrast on light */
+  --ainb-accent-gold:    #9A6B00;  /* dark goldenrod — gold is unreadable on light */
+  --ainb-accent-green:   #2E7D32;
+
+  --ainb-text-primary:   #16161E;
+  --ainb-text-muted:     #54546A;
+  --ainb-text-faint:     #8C8CA0;
+
+  --ainb-syntax-keyword: #9A6B00;
+  --ainb-syntax-string:  #2E7D32;
+  --ainb-syntax-comment: #54546A;
+  --ainb-syntax-number:  #2F5C99;
 }
 
 /* Headings: use display font and a touch more presence. */


### PR DESCRIPTION
Two things requested: publish the agent-memory landscape explainer in the docsite, and add a light mode.

## Light mode
The docsite shipped a custom dark CRT theme; `[data-theme='light']` *shared the dark palette* ("no light mode in v1"), so the Starlight toggle was inert. This gives light a real palette — same TUI identity (cornflower frame, goldenrod accent, green) re-toned for a light surface. Only the `--ainb-*` leaf tokens change; the `--sl-*` mappings on `:root` pick them up. Verified in-browser: light is readable, dark is unchanged. (Code blocks intentionally stay dark — a readable island on a light page. CRT scanlines are light-on-light at 1.5% opacity → invisible in light mode, no change needed.)

| | |
|---|---|
| Toggle | ships with Starlight; now functional |
| Files | `website/site/src/styles/tokens.css` |

## Comparison page
Native-docsite port of the published [agent-memory landscape explainer](https://explainers.stevengonsalvez.com/agent-memory-landscape/), at `knowledge/reflect-memory/comparison` ("Why build, not adopt") — context-engineering thesis, four deciding axes, the 8-system table (Hindsight, Mem0, ByteRover, claude-mem, agentmemory, Honcho, OpenViking), token economics, observability, self-improvement, and the build-vs-adopt verdict + honest sensitivity note. Both architecture SVGs inline; linked in the Reflect Memory sidebar.

`astro build` passes (62 pages); page renders, SVGs resolve, light + dark both screenshotted.

> Note: this branch also adds `reflect-session-timeline.svg`, shared with #326 (identical file — merge-safe).

https://claude.ai/code/session_01KZHPj7CGYkjXbo7bJZN7iP