### PR TITLE
docs/site: impeccable polish — fit ASCII boxes, de-stripe cards, tame highlights

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,33 @@
+# Design Context
+
+### Users
+Developers evaluating or running **agents-in-a-box** / **reflect** — people who live in a terminal,
+read docs to make a build-vs-adopt call or to wire up memory for their coding agent. They skim for
+signal (flags, comparisons, what-breaks-without-it), then dive deep on one section.
+
+### Brand Personality
+Terminal-native, precise, opinionated. Three words: **mechanical · candid · dense**. The docs should
+feel like a well-set technical manual from a 1980s mainframe shop — confident, monospaced, no
+marketing gloss — not a SaaS landing page.
+
+### Aesthetic Direction
+Established CRT / TUI identity — **keep it, polish within it** (do not redesign):
+- Mono everywhere (JetBrains Mono body, IBM Plex Mono display); ligatures only in code.
+- Palette: deep navy `#0F0F18`, cornflower `#6495ED` (frames/links), gold `#FFD700` (h1/accents),
+  green `#64C864`. Light mode = the same identity re-toned (`#2F5C99` / `#9A6B00` / `#2E7D32` on a
+  `#FAFAFC` surface).
+- ASCII section dividers + subtle 1.5%-opacity scanlines are part of the identity.
+- Anti-reference: generic SaaS docs (Inter, soft drop-shadows, purple→blue gradients, glassmorphism).
+
+### Design Principles
+1. **No janky overflow.** Wide comparisons scroll *intentionally* (`.rm-matrix`, sticky first column);
+   ASCII art is sized to fit the column in a clean box — never a default horizontal scrollbar on a
+   code frame.
+2. **No AI-slop tells.** No >1px side-stripe borders on cards/callouts (use full borders + a leading
+   id + a background tint); no gradient text; no bleeding glow highlights — accents are rare and
+   uniform.
+3. **Hierarchy through type + space, not boxes.** Don't wrap everything in cards; vary spacing for
+   rhythm; cap prose at ~70ch.
+4. **Theme-aware always.** Every custom component is built on `--ainb-*`/`--sl-*` tokens so light and
+   dark both render correctly. Verify both in localhost before shipping.
+5. **Don't repeat.** A summary and the full matrix shouldn't restate each other verbatim.

--- a/docs/knowledge/reflect-memory/construct.md
+++ b/docs/knowledge/reflect-memory/construct.md
@@ -12,7 +12,7 @@ For *why* this exists and how it compares to bare-harness memory, see
 
 ## The loop
 
-```
+<pre class="rm-ascii">
    ┌─────────┐  signal   ┌──────────┐  markdown   ┌──────────────┐
    │ session │ ───────▶  │ capture  │ ─────────▶  │  KB (notes)  │ ◀── source of truth
    └─────────┘ "no—don't"└──────────┘  + sidecar  └──────┬───────┘
@@ -27,7 +27,7 @@ For *why* this exists and how it compares to bare-harness memory, see
                                                           │ rerank · gate · budget
                                                           ▼
                                                    inject into next session
-```
+</pre>
 
 | Stage | What happens | Where it lives |
 |---|---|---|

--- a/docs/knowledge/reflect-memory/problem-and-fit.md
+++ b/docs/knowledge/reflect-memory/problem-and-fit.md
@@ -19,13 +19,13 @@ That has a hard ceiling. The context window is finite and **shared with the actu
 you front-load "just in case" is bloat the moment this particular session doesn't need it — and it
 crowds out the files, diffs, and reasoning the task *does* need.
 
-```
+<pre class="rm-ascii">
    context window  =  [ task: files · diffs · plan · tool output ]  +  [ memory ]
                                                           ▲                    ▲
                             this is the work ─────────────┘                    │
                             front-loaded "just in case" — bloat when ──────────┘
                             irrelevant, and you can only fit so much
-```
+</pre>
 
 So a bigger instructions file is the wrong axis. The questions that actually matter:
 
@@ -54,11 +54,11 @@ coding-agent workflow:
 4. **Do they capture coding signals as first-class events?** Corrections, test outcomes, git events,
    skill upgrades — captured *structurally*, or only as prose an LLM might (or might not) extract?
 
-```
-        store selectively    no extra key     local, no server    first-class signals
-reflect       ✓                  ✓                  ✓                    ✓
-others        varies          mostly ✗           mostly ✗           ✗ (probabilistic)
-```
+<pre class="rm-ascii">
+           store selectively   no extra key   local, no server   first-class signals
+reflect           ✓                 ✓                ✓                    ✓
+others          varies          mostly ✗         mostly ✗          ✗ (probabilistic)
+</pre>
 
 <div class="rm-matrix">
 <table>
@@ -93,13 +93,13 @@ upgrades as typed signals — they hope an LLM extracts them from the transcript
 reflect is the row that holds all four columns at once. Its design line: **the brain is client-side,
 the store is dumb, and the signals are typed.**
 
-```
+<pre class="rm-ascii">
    harness hooks ──▶ reflect (capture)  ──▶ markdown KB (source of truth)
         ▲              ▲ typed signals              │
         │              │ (corrections, tests,  index (QMD + nano-graphrag)
    harness LLM  ◀── reflect (recall) ◀──── git, skills, contradictions)
    (capture reuses the agent's OWN model — no extra key, no separate sub)
-```
+</pre>
 
 | reflect's answer | to the problem |
 |---|---|

--- a/docs/knowledge/reflect-memory/recall.md
+++ b/docs/knowledge/reflect-memory/recall.md
@@ -57,12 +57,12 @@ capture → index → fuse → rerank → gate → inject — is what the 57 por
 
 ## The 57 ports at a glance
 
-```
+<pre class="rm-ascii">
             ┌──────────────────────── recall time ───────────────────────┐
  query ─▶ [arms] ─▶ RRF fuse ─▶ [rerank] ─▶ [gate] ─▶ [boosts] ─▶ budget ─▶ inject
             R1·R5·R6           R2·R3        R7·R12      R8·R16
             ─────────────────── scope: R15·A6 · modes: M1·R10·R11 ────────────────
-```
+</pre>
 
 - **Retrieval arms** — R1 R5 R6 R2 R3 R4 → [§ below](#retrieval-arms)
 - **Relevance gates** — R7 R12 → [§ below](#relevance-gates)

--- a/website/site/src/styles/reflect-viz.css
+++ b/website/site/src/styles/reflect-viz.css
@@ -10,7 +10,8 @@
 /* ---- horizontal-scroll matrix (wide comparisons) ---- */
 .sl-markdown-content .rm-matrix {
   overflow-x: auto;
-  margin: 1.25rem 0;
+  max-width: 100%;            /* never spill past the content column / under the TOC */
+  margin: 1.5rem 0;
   border: 1px solid color-mix(in srgb, var(--ainb-border) 40%, transparent);
   border-radius: 10px;
   -webkit-overflow-scrolling: touch;
@@ -63,8 +64,14 @@
   font-weight: 700;
   background: color-mix(in srgb, var(--ainb-bg-panel) 70%, transparent);
 }
-/* the "me" column / row highlight */
-.sl-markdown-content .rm-matrix .me { background: color-mix(in srgb, var(--ainb-accent-gold) 12%, transparent); }
+/* reflect row marker — uniform opaque tint (mixed with the surface, not transparent,
+   so it never bleeds/gradients over the page); never painted over a heatmap cell. */
+.sl-markdown-content .rm-matrix tr.me .rowh {
+  background: color-mix(in srgb, var(--ainb-accent-gold) 15%, var(--ainb-bg-panel));
+}
+.sl-markdown-content .rm-matrix tr.me td:not(.s1):not(.s2):not(.s3):not(.s4):not(.s5) {
+  background: color-mix(in srgb, var(--ainb-accent-gold) 7%, var(--ainb-bg-panel));
+}
 
 /* heatmap score tints — semantic, derived from accent tokens so they theme */
 .sl-markdown-content .rm-matrix td.s5 { background: color-mix(in srgb, var(--ainb-accent-green) 30%, transparent); }
@@ -83,12 +90,18 @@
 @media (min-width: 56rem) {
   .sl-markdown-content .rm-cards.two { grid-template-columns: 1fr 1fr; }
 }
+/* Full border + surface tint + a leading gold id as the visual anchor —
+   deliberately NOT a left side-stripe (the #1 AI-design tell). */
 .sl-markdown-content .rm-card {
-  border: 1px solid color-mix(in srgb, var(--ainb-border) 28%, transparent);
-  border-left: 3px solid var(--ainb-border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--ainb-bg-panel) 55%, transparent);
-  padding: 0.8rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--ainb-border) 30%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--ainb-bg-panel) 50%, transparent);
+  padding: 0.9rem 1.1rem;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.sl-markdown-content .rm-card:hover {
+  border-color: color-mix(in srgb, var(--ainb-border) 55%, transparent);
+  background: color-mix(in srgb, var(--ainb-bg-panel) 70%, transparent);
 }
 .sl-markdown-content .rm-card .h {
   font-family: var(--ainb-font-display);
@@ -112,3 +125,26 @@
   margin-right: 0.5ch;
 }
 .sl-markdown-content .rm-card .without .lbl { color: #C0563E; }
+
+/* ---- fitted ASCII diagram box ----
+   Plain ASCII art, sized down so it fits the content column without the janky
+   default code-frame scrollbar, in a tidy themed box. Use raw <pre class="rm-ascii">
+   instead of a fenced code block for diagrams (keeps the art, drops the overflow). */
+.sl-markdown-content pre.rm-ascii {
+  font-family: var(--ainb-font-mono);
+  font-size: 0.74rem;
+  line-height: 1.5;
+  white-space: pre;
+  overflow-x: auto;
+  max-width: 100%;
+  margin: 1.5rem 0;
+  padding: 1rem 1.1rem;
+  color: var(--ainb-text-primary);
+  background: var(--ainb-bg-panel);   /* theme-aware surface (not the always-dark code bg) so the line-art stays readable in light mode */
+  border: 1px solid color-mix(in srgb, var(--ainb-border) 28%, transparent);
+  border-radius: 10px;
+  font-feature-settings: 'liga' 0;
+}
+@media (max-width: 30rem) {
+  .sl-markdown-content pre.rm-ascii { font-size: 0.62rem; }
+}


### PR DESCRIPTION
Polish pass on the reflect-memory pages to premium quality (ran `/impeccable`, applied within the existing CRT/TUI identity). Fixes the overfull table you flagged + the AI-design tells the audit surfaced.

## Fixes (all verified in localhost, light + dark)
- **Overfull ASCII blocks** → `pre.rm-ascii`: a fitted, **theme-aware** box. ASCII is sized to the column (no janky code-frame horizontal scrollbar), on a panel surface so the line-art is readable in both themes. (Caught + fixed a light-mode bug where the box was dark-on-dark.)
- **Banned side-stripe on cards** → `.rm-card` dropped `border-left: 3px` (the single most recognizable AI-design tell per `/impeccable`); now a full border + surface tint + hover, with the gold id as the anchor.
- **Bleeding reflect-row highlight** → uniform opaque tint mixed with the surface (was a transparent gold that read as a gradient bleed); never painted over a heatmap cell.
- **Matrix vs TOC** → `.rm-matrix` constrained to `max-width:100%` so it can't spill under the right rail.
- Added `.impeccable.md` (design context) for future work.

## Verification
`astro build` passes (62 pages). Served locally and screenshotted the previously-broken areas in **both themes** — summary block fits, ASCII boxes readable light+dark, cards de-striped, reflect-row clean.

https://claude.ai/code/session_01KZHPj7CGYkjXbo7bJZN7iP