### PR TITLE
docs(illustration): add example gallery to plugin README

### DIFF
--- a/plugins/illustration/README.md
+++ b/plugins/illustration/README.md
@@ -12,6 +12,38 @@ A shared workflow engine — **digest → shot list → per-image generation →
 | `illustration:sporthead-alex` | **Alex** — ShotClubhouse Sport Head (soccer-ball head, black cap, no glasses) | Sketchnote — hand-drawn visual notes (banners/arrows/icons) on white, optional gold accent | ShotClubhouse brand/marketing, sport, explainers, how-it-works |
 | `illustration:popa` | **Popa** — pink blob, green sprout, notepad | Crude hand-drawn on soft pastel, deadpan-absurd | Dev/product/system explainers, how-it-works, architecture, friendly social |
 
+## Examples
+
+### `illustration:sporthead-alex` — sketchnotes (gold accent or mono)
+
+<table>
+  <tr>
+    <td align="center"><img src="skills/sporthead-alex/assets/examples/01-sporthead-gold.png" width="420"><br><sub>“What is a Sport Head?” — gold accent</sub></td>
+    <td align="center"><img src="skills/sporthead-alex/assets/examples/02-sporthead-mono.png" width="420"><br><sub>“What is a Sport Head?” — mono</sub></td>
+  </tr>
+  <tr>
+    <td align="center"><img src="skills/sporthead-alex/assets/examples/03-agents-box-gold.png" width="420"><br><sub>“Agents in a box” — gold accent</sub></td>
+    <td align="center"><img src="skills/sporthead-alex/assets/examples/04-agents-box-mono.png" width="420"><br><sub>“Agents in a box” — mono</sub></td>
+  </tr>
+</table>
+
+### `illustration:popa` — hand-drawn pastel
+
+<table>
+  <tr>
+    <td align="center"><img src="skills/popa/assets/examples/01-idea-pipeline.png" width="270"><br><sub>idea pipeline</sub></td>
+    <td align="center"><img src="skills/popa/assets/examples/02-chaos-vs-system.png" width="270"><br><sub>chaos vs system</sub></td>
+    <td align="center"><img src="skills/popa/assets/examples/03-urgent-vs-important.png" width="270"><br><sub>urgent vs important</sub></td>
+  </tr>
+  <tr>
+    <td align="center"><img src="skills/popa/assets/examples/04-architecture-tour.png" width="270"><br><sub>architecture tour</sub></td>
+    <td align="center"><img src="skills/popa/assets/examples/05-three-states.png" width="270"><br><sub>three states</sub></td>
+    <td align="center"><img src="skills/popa/assets/examples/06-idea-to-prod-route.png" width="270"><br><sub>idea → prod route</sub></td>
+  </tr>
+</table>
+
+> These are the bundled calibration examples (also in each skill's `assets/examples/`). They show the style only — the skills invent a fresh composition per request and don't reuse them.
+
 ## How it works
 
 - Shared engine: `references/workflow-engine.md`


### PR DESCRIPTION
Adds an **Examples** section to `plugins/illustration/README.md` embedding the bundled calibration images:

- **illustration:sporthead-alex** — 4 sketchnotes (gold + mono, sport + dev)
- **illustration:popa** — 6 hand-drawn pastel examples

Images use relative paths into each skill's `assets/examples/` (all verified to resolve), so they render on the GitHub README. Docs-only.

Commit unsigned (no interactive GPG here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Examples" section to the illustration plugin README demonstrating sporthead-alex and popa illustration styles with various aesthetic options: gold-accent, mono sketchnote, and hand-drawn pastel variants.
  * Included clarification explaining that bundled calibration examples provide style parameters only, with fresh unique compositions generated per request rather than reusing bundled images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->