### PR TITLE
fix(burndown): make the Savings observability tab keyboard-reachable + verify

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/savings.rs
@@ -27,7 +27,8 @@ pub const CAVEMAN_OUTPUT_RATIO: f64 = 0.74;
 pub struct SavingsData {
     /// Whether the Headroom proxy responded successfully.
     pub headroom_running: bool,
-    /// `summary.tokens_saved_total` from Headroom /stats.
+    /// `savings.total_tokens` from Headroom /stats (NOT `summary.tokens_saved_total`,
+    /// which does not exist and silently parsed to 0 — see HeadroomStats below).
     pub headroom_tokens_saved: u64,
     /// Whether `rtk` was found on PATH and exited successfully.
     pub rtk_installed: bool,

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -1038,6 +1038,13 @@ impl BurndownPlugin {
                 self.ui.zoom_reset_cols()
             }
 
+            // ── Outer tab switch (Burndown ↔ … ↔ Savings). While zoomed,
+            // `[`/`]` focus table columns (handled above); when NOT zoomed
+            // they cycle the outer UsageTab so every tab — including the
+            // Savings observability card — is keyboard-reachable.
+            KeyCode::Char { ch: '[' } => self.ui.prev_tab(),
+            KeyCode::Char { ch: ']' } => self.ui.next_tab(),
+
             // ── Zoom-table row navigation (zoomed only). Arrows are safe
             // even while searching; `j` is guarded like the resize keys
             // so it can be typed into the search box.
@@ -1188,6 +1195,47 @@ mod handle_key_dispatch_tests {
         assert!(p.dispatch_key_pure(&KeyCode::Tab));
         let after = p.ui.focused_panel;
         assert_ne!(before, after, "Tab must change focused panel");
+    }
+
+    #[test]
+    fn bracket_keys_cycle_outer_tabs_and_reach_savings() {
+        use crate::ui::UsageTab;
+        // Regression: `[`/`]` were zoom-only, so the outer tabs (incl. the
+        // Savings observability card) were keyboard-unreachable — active_tab
+        // was stuck on Burndown. They now cycle the outer tab when not zoomed.
+        let mut p = BurndownPlugin::default();
+        assert_eq!(p.ui.active_tab, UsageTab::Burndown, "starts on Burndown");
+
+        // `]` walks forward: Burndown → Daily → Weekly → Projects → Optimize → Savings.
+        for expect in [
+            UsageTab::Daily,
+            UsageTab::Weekly,
+            UsageTab::Projects,
+            UsageTab::Optimize,
+            UsageTab::Savings,
+        ] {
+            assert!(
+                p.dispatch_key_pure(&KeyCode::Char { ch: ']' }),
+                "] must be consumed"
+            );
+            assert_eq!(p.ui.active_tab, expect, "] advances the outer tab");
+        }
+        assert_eq!(
+            p.ui.active_tab,
+            UsageTab::Savings,
+            "Savings is now reachable"
+        );
+
+        // `[` walks back off Savings.
+        assert!(
+            p.dispatch_key_pure(&KeyCode::Char { ch: '[' }),
+            "[ must be consumed"
+        );
+        assert_eq!(
+            p.ui.active_tab,
+            UsageTab::Optimize,
+            "[ retreats the outer tab"
+        );
     }
 
     #[test]
@@ -1471,12 +1519,14 @@ mod handle_key_dispatch_tests {
     }
 
     #[test]
-    fn resize_keys_unbound_on_dashboard() {
-        // Not zoomed: the column keys must fall through (return false)
-        // so they keep their no-op behavior on the dashboard.
+    fn resize_col_keys_unbound_on_dashboard() {
+        // Not zoomed: the column resize keys `< > =` must fall through (return
+        // false) so they keep their no-op behavior on the dashboard. (`[`/`]`
+        // ARE bound off-zoom now — they switch the outer tab; see
+        // bracket_keys_cycle_outer_tabs_and_reach_savings.)
         let mut p = BurndownPlugin::default();
         assert!(!p.ui.is_zoomed());
-        for k in ['[', ']', '<', '>', '='] {
+        for k in ['<', '>', '='] {
             assert!(
                 !p.dispatch_key_pure(&ch(k)),
                 "`{k}` must be unhandled on the dashboard"

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -1305,7 +1305,14 @@ fn render_tab_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(CORNFLOWER_BLUE))
-                .style(Style::default().bg(DARK_BG)),
+                .style(Style::default().bg(DARK_BG))
+                .title(
+                    Line::from(Span::styled(
+                        " [ ] switch tab ",
+                        Style::default().fg(MUTED_GRAY),
+                    ))
+                    .right_aligned(),
+                ),
         );
 
     ratatui::widgets::Widget::render(tabs, area, buf);

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -6332,4 +6332,113 @@ mod zoom_table_tests {
         state.zoom_row_up();
         assert_eq!(state.focus_row, 0);
     }
+
+    // ── Savings tab observability (G1 tripwire for the Headroom/RTK card) ──
+    // These render the real `render_savings` into a TestBackend buffer and
+    // assert the VT100 truth the user sees — proving the proxy /stats figures
+    // (savings.total_tokens → headroom_tokens_saved) actually reach the screen,
+    // the gap that earlier let observability read 0 forever.
+
+    fn render_savings_flat(
+        sd: Option<&crate::data::savings::SavingsData>,
+        w: u16,
+        h: u16,
+    ) -> String {
+        use ratatui::{Terminal, backend::TestBackend};
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).expect("test backend");
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                render_savings(frame.buffer_mut(), area, sd);
+            })
+            .expect("render_savings must not panic");
+        flatten(terminal.backend().buffer())
+    }
+
+    #[test]
+    fn savings_tab_surfaces_live_headroom_tokens() {
+        use crate::data::savings::{CAVEMAN_OUTPUT_RATIO, SavingsData};
+        let sd = SavingsData {
+            headroom_running: true,
+            headroom_tokens_saved: 12_345,
+            rtk_installed: true,
+            rtk_total_saved: 6_789,
+            caveman_est: 1_000_000,
+        };
+        let flat = render_savings_flat(Some(&sd), 120, 16);
+
+        // Card chrome + columns.
+        assert!(flat.contains("Token Savings"), "card title:\n{flat}");
+        assert!(
+            flat.contains("Source") && flat.contains("Tokens Saved") && flat.contains("Status"),
+            "header row:\n{flat}"
+        );
+        // Headroom observability: live dot, "live" status, and the ACTUAL
+        // saved-token figure from /stats — the whole point of this tab.
+        assert!(flat.contains('●'), "live status dot:\n{flat}");
+        assert!(
+            flat.contains("Headroom") && flat.contains("live"),
+            "headroom row:\n{flat}"
+        );
+        assert!(
+            flat.contains(&format_tokens_short(12_345)),
+            "headroom tokens {} must render:\n{flat}",
+            format_tokens_short(12_345)
+        );
+        // RTK row.
+        assert!(
+            flat.contains("RTK") && flat.contains("installed"),
+            "rtk row:\n{flat}"
+        );
+        assert!(
+            flat.contains(&format_tokens_short(6_789)),
+            "rtk tokens:\n{flat}"
+        );
+        // Caveman is labelled a modelled estimate, never counted as real.
+        assert!(flat.contains("Caveman (est)"), "caveman row:\n{flat}");
+        assert!(
+            flat.contains(&format!("×{CAVEMAN_OUTPUT_RATIO:.2}")),
+            "caveman ratio label:\n{flat}"
+        );
+        // NET = real sources only (Headroom + RTK), not the estimate.
+        assert!(flat.contains("NET (measured)"), "net row:\n{flat}");
+        assert!(
+            flat.contains(&format_tokens_short(12_345 + 6_789)),
+            "net = headroom + rtk = {}:\n{flat}",
+            format_tokens_short(12_345 + 6_789)
+        );
+        assert!(
+            flat.contains("not measured"),
+            "estimate disclaimer:\n{flat}"
+        );
+    }
+
+    #[test]
+    fn savings_tab_shows_offline_state_when_proxy_down() {
+        use crate::data::savings::SavingsData;
+        let sd = SavingsData {
+            headroom_running: false,
+            headroom_tokens_saved: 0,
+            rtk_installed: false,
+            rtk_total_saved: 0,
+            caveman_est: 0,
+        };
+        let flat = render_savings_flat(Some(&sd), 120, 16);
+        assert!(flat.contains('○'), "offline status dot:\n{flat}");
+        assert!(flat.contains("proxy down"), "headroom down status:\n{flat}");
+        assert!(
+            flat.contains("not installed"),
+            "rtk not-installed status:\n{flat}"
+        );
+    }
+
+    #[test]
+    fn savings_tab_shows_fetching_placeholder_before_data_lands() {
+        let flat = render_savings_flat(None, 120, 6);
+        assert!(
+            flat.contains("Fetching savings"),
+            "fetching placeholder:\n{flat}"
+        );
+    }
 }


### PR DESCRIPTION
Started as "is the Headroom/RTK savings observability in burndown actually tested
with /tmux-verify?" — it wasn't, and verifying it surfaced a real bug.

## What this does
1. **docs** — corrects `savings.rs` doc-comment that claimed `headroom_tokens_saved`
   comes from `summary.tokens_saved_total` (the exact non-existent key that made
   savings read 0 forever). It's `savings.total_tokens`.
2. **test (G1)** — a TestBackend render tripwire on `render_savings`: live ●
   Headroom row with the real saved-token figure, RTK row, caveman estimate
   labelled `modelled ×0.74`, and NET = Headroom + RTK. Plus the proxy-down ○
   state and the pre-data "Fetching" placeholder. The render had no automated
   coverage before — only the shared `ainb usage savings` CLI path did.
3. **fix** — the outer usage tabs (Burndown … **Savings**) were
   **keyboard-unreachable**: `active_tab` was stuck on Burndown because
   `next_tab`/`prev_tab`/`set_active_tab` existed but had no key or host binding.
   So the Savings card could never be opened in the TUI. Bind `[`/`]` to prev/next
   outer tab when not zoomed (they stay column-focus while zoomed) + a
   ` [ ] switch tab ` hint on the tab bar.

## /tmux-verify (the point of the exercise)
Empirically confirmed the tab was dead (active tab never left Burndown through
Tab/arrows/numbers), wired `[`/`]`, rebuilt + re-staged the plugin, and
frame-read the live result:

```
╭ Token Savings ──────────────────────────────╮
│  ● Headroom      907K            live         │  ← real proxy /stats
│  ○ RTK           0               not installed │
│  ~ Caveman (est) 0               modelled ×0.74│
│    NET (measured)907K            Headroom + RTK│
╰──────────────────────────────────────────────╯
```

`907K` is the live local proxy figure rendered end-to-end (proxy /stats →
fetch_savings → render_savings → screen). GIF recorded for the explainer.

## Tests
`ainb-plugin-burndown`: **207 pass** (3 new render + 1 new dispatch). fmt clean.

https://claude.ai/code/session_01FwQC25huAxcpeKoA1umEZb