### PR TITLE
Onboarding catalog: correctness audit, reflect plugin, Codex, checkbox UI

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/init.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/init.rs
@@ -14,7 +14,7 @@ use std::io::{self, Write as _};
 use super::OutputFormat;
 use crate::config::{AppConfig, OnboardingConfig};
 use crate::setup::{
-    DepState, ProvisionMode, ProvisionOutcome, RealEnv, SetupStatus, Tier, catalog, detect_all,
+    DepState, ProvisionMode, ProvisionOutcome, RealEnv, SetupStatus, catalog, detect_all,
     detect_dep, provision,
 };
 
@@ -107,13 +107,7 @@ fn render_setup_text(status: &SetupStatus) {
     for topic in &status.topics {
         println!("\n  {} — {}", topic.label, topic.description);
         for d in &topic.deps {
-            let marker = if d.satisfied {
-                "\u{2713}" // ✓
-            } else if d.tier == Tier::Required {
-                "\u{2717}" // ✗
-            } else {
-                "\u{26A0}" // ⚠
-            };
+            let marker = if d.satisfied { "[\u{2713}]" } else { "[ ]" };
             let tag = if d.satisfied {
                 String::new()
             } else {

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -331,14 +331,14 @@ impl OnboardingComponent {
                     "First-run setup — the tools ainb, your agents, plugins & memory need.   ",
                     Style::default().fg(MUTED_GRAY),
                 ),
-                Span::styled("✓", Style::default().fg(SELECTION_GREEN)),
-                Span::styled(" ready  ", Style::default().fg(MUTED_GRAY)),
-                Span::styled("✗", Style::default().fg(ERROR_RED)),
-                Span::styled(" required  ", Style::default().fg(MUTED_GRAY)),
-                Span::styled("○", Style::default().fg(WARNING_YELLOW)),
-                Span::styled(" recommended/optional  ", Style::default().fg(MUTED_GRAY)),
-                Span::styled("·", Style::default().fg(MUTED_GRAY)),
-                Span::styled(" suggested", Style::default().fg(MUTED_GRAY)),
+                Span::styled("[✓]", Style::default().fg(SELECTION_GREEN)),
+                Span::styled(" ready   ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("[ ]", Style::default().fg(ERROR_RED)),
+                Span::styled(" required   ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("[ ]", Style::default().fg(WARNING_YELLOW)),
+                Span::styled(" recommended   ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("[ ]", Style::default().fg(MUTED_GRAY)),
+                Span::styled(" optional / suggested", Style::default().fg(MUTED_GRAY)),
             ]),
         ])
         .alignment(Alignment::Center);
@@ -1053,7 +1053,7 @@ fn push_topic_items(items: &mut Vec<ListItem<'static>>, topic: &TopicReport) {
         Span::styled(" ───", Style::default().fg(SUBDUED_BORDER)),
     ])));
     for d in &topic.deps {
-        let (icon, icon_color) = dep_icon(d);
+        let (checkbox, box_color) = dep_checkbox(d);
         let tier_tag = if d.satisfied {
             String::new()
         } else {
@@ -1061,7 +1061,10 @@ fn push_topic_items(items: &mut Vec<ListItem<'static>>, topic: &TopicReport) {
         };
         items.push(ListItem::new(Line::from(vec![
             Span::styled("  ", Style::default()),
-            Span::styled(icon, Style::default().fg(icon_color)),
+            Span::styled(
+                checkbox,
+                Style::default().fg(box_color).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" ", Style::default()),
             Span::styled(
                 d.name,
@@ -1077,24 +1080,26 @@ fn push_topic_items(items: &mut Vec<ListItem<'static>>, topic: &TopicReport) {
         ])));
         if !d.satisfied {
             items.push(ListItem::new(Line::from(vec![
-                Span::styled("      → ", Style::default().fg(CORNFLOWER_BLUE)),
+                Span::styled("       → ", Style::default().fg(CORNFLOWER_BLUE)),
                 Span::styled(d.install_hint.clone(), Style::default().fg(CORNFLOWER_BLUE)),
             ])));
         }
     }
+    // Blank spacer line between sections for visual separation.
+    items.push(ListItem::new(Line::from("")));
 }
 
-/// Icon + color for a dependency report: ✓ when satisfied, otherwise keyed to
-/// its tier (required=✗ red, recommended=○ yellow, optional=○ gray, suggested=· gray).
-fn dep_icon(d: &DepReport) -> (&'static str, Color) {
+/// Checkbox + color for a dependency report: `[✓]` (green) when satisfied,
+/// otherwise an empty `[ ]` coloured by tier urgency (required=red,
+/// recommended=yellow, optional/suggested=gray).
+fn dep_checkbox(d: &DepReport) -> (&'static str, Color) {
     if d.satisfied {
-        return ("✓", SELECTION_GREEN);
+        return ("[✓]", SELECTION_GREEN);
     }
     match d.tier {
-        Tier::Required => ("✗", ERROR_RED),
-        Tier::Recommended => ("○", WARNING_YELLOW),
-        Tier::Optional => ("○", MUTED_GRAY),
-        Tier::Suggested => ("·", MUTED_GRAY),
+        Tier::Required => ("[ ]", ERROR_RED),
+        Tier::Recommended => ("[ ]", WARNING_YELLOW),
+        Tier::Optional | Tier::Suggested => ("[ ]", MUTED_GRAY),
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -352,10 +352,10 @@ pub fn catalog() -> Vec<Topic> {
                 dep(
                     "copilot",
                     "GitHub Copilot CLI",
-                    "GitHub's AI agent (uses gh OAuth)",
+                    "GitHub's agentic CLI (Node 22+)",
                     Optional,
                     Bin("copilot"),
-                    Npm(&["@github/copilot-cli"]),
+                    Npm(&["@github/copilot"]),
                     &[],
                     &[],
                 ),
@@ -440,6 +440,16 @@ pub fn catalog() -> Vec<Topic> {
                     Recommended,
                     Custom("reflect-kb"),
                     Ainb(&["reflect", "bootstrap", "--yes"]),
+                    &[Reflect],
+                    &[],
+                ),
+                dep(
+                    "reflect-plugin",
+                    "reflect plugin",
+                    "Claude Code plugin: SessionStart recall + PreCompact capture hooks (Codex: reflect codex adapter)",
+                    Recommended,
+                    Custom("claude-plugin:reflect"),
+                    ClaudePlugin("reflect@agents-in-a-box"),
                     &[Reflect],
                     &[],
                 ),
@@ -586,7 +596,7 @@ pub fn catalog() -> Vec<Topic> {
         Topic {
             id: "suggested-plugins",
             label: "Suggested plugins",
-            description: "Ecosystem extras — Claude Code marketplace; Codex gets the skill-based ones via the toolkit",
+            description: "Claude: claude plugin install <name>@agents-in-a-box · Codex: ainb skill install <uri> --targets codex",
             deps: vec![
                 dep(
                     "ainb-fleet",
@@ -630,11 +640,13 @@ pub fn catalog() -> Vec<Topic> {
                 ),
                 dep(
                     "bd",
-                    "bd (beads)",
-                    "beads ready-issue count segment",
+                    "beads (bd)",
+                    "git-backed issue tracker agents read/write; powers the beads segment",
                     Suggested,
                     Bin("bd"),
-                    Manual("install per your beads setup: https://github.com/steveyegge/beads"),
+                    Manual(
+                        "brew install beads (or npm i -g @beads/bd), then: bd setup claude · bd setup codex",
+                    ),
                     &[Beads],
                     &[],
                 ),

--- a/ainb-tui/crates/ainb-core/src/setup/detect.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/detect.rs
@@ -215,7 +215,18 @@ fn detect_custom(name: &str, env: &dyn Env) -> DepState {
                 DepState::Missing
             }
         }
-        // Marketplace plugin presence isn't reliably detectable from disk.
+        // The reflect Claude Code plugin extracts into ~/.claude/plugins — detect
+        // it from disk so we don't re-suggest an already-installed plugin.
+        "claude-plugin:reflect" => {
+            if home_path_exists(".claude/plugins/reflect")
+                || home_path_exists(".claude/plugins/cache/reflect")
+            {
+                DepState::Ok(None)
+            } else {
+                DepState::Missing
+            }
+        }
+        // Other marketplace plugins aren't reliably detectable from disk.
         s if s.starts_with("claude-plugin:") => DepState::Unknown,
         _ => DepState::Unknown,
     }


### PR DESCRIPTION
Follow-up to #348. Audited every install command against its real source (no invented commands), added the reflect Claude Code plugin + beads + Codex visibility, and polished the UI.

## Correctness fixes
- **copilot**: `@github/copilot-cli` was a 404 / invented → `@github/copilot` (Node 22+).
- **beads**: real install — `brew install beads` (or `npm i -g @beads/bd`) then `bd setup claude` / `bd setup codex`.
- Verified real, unchanged: witr (brew formula v0.3.3), abtop (crate v0.4.8 + graykode/tap), headroom (PyPI `headroom-ai[proxy]`), ccusage (npm), gemini (`@google/gemini-cli`), and ainb-internal `rtk install` / `reflect bootstrap --yes` / `notifyd install --claude --codex` (checked against the binary).

## Additions
- **reflect plugin**: the Claude Code reflect plugin (`claude plugin install reflect@agents-in-a-box`) alongside the reflect CLI; detected from `~/.claude/plugins/reflect`. Codex wiring noted (reflect codex adapter).
- **Codex**: suggested-plugins header now shows the Codex path (`ainb skill install <uri> --targets codex`) — Codex has no `claude plugin install` equivalent. (Statusline + hooks already had Codex.)

## UI
- Checkbox styling — `[✓]` ready / `[ ]` to-do (coloured by tier) in both the TUI and `ainb init`.
- Blank-line spacer between each topic section; updated legend.

fmt clean; 18 setup + 9 init unit tests + tmux tripwire green.

https://claude.ai/code/session_012BMaP4fZ8ff8idHMJgXcVh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setup dependency entry for the Reflect plugin, including detection and install guidance.
  * Expanded first-time setup guidance for suggested plugins with clearer install steps.

* **Bug Fixes**
  * Improved dependency status display to use consistent checkbox-style markers for satisfied and unsatisfied items.
  * Updated setup messaging and package targets for Copilot and Beads to better match current installation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->