### PR TITLE
feat(burndown): mouse on the usage screen + switch-tab legend

### DIFF
--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -9,8 +9,9 @@
 
 use crate::data::usage::UsagePeriod;
 use ainb_plugin_sdk::{
-    Cell, CliOutput, Color, Coord, HandleKeyParams, HostClient, InitContext, KeyCode, Plugin,
-    RenderParams, Result, SdkError, WireBuffer, topics,
+    Cell, CliOutput, Color, Coord, HandleKeyParams, HandleMouseParams, HostClient, InitContext,
+    KeyCode, MouseButton, MouseEvent, MouseKind, Plugin, RenderParams, Result, SdkError,
+    WireBuffer, topics,
 };
 use ainb_plugin_types_sessions::{
     RefreshRequest, ScanProgressEvent, UsageData as WireUsageData, UsageDataEvent, WIRE_VERSION,
@@ -24,7 +25,9 @@ use crate::cli::{UsageCommands, execute_for_plugin};
 use crate::data::savings::{SavingsData, fetch_savings};
 use crate::data::usage::UsageData;
 use crate::output_format::OutputFormat;
-use crate::ui::{UsageTab, UsageViewState, render as render_ui};
+use crate::ui::{
+    TAB_BAR_H, TAB_BAR_TOP, UsageTab, UsageViewState, render as render_ui, tab_at_col,
+};
 use crate::wire::wire_to_local;
 
 /// Static manifest TOML loaded at compile time. The Server uses this on
@@ -362,6 +365,16 @@ impl Plugin for BurndownPlugin {
             if !matches!(params.key.code, KeyCode::Char { ch: 'y' }) {
                 self.ui.copy_flash = None;
             }
+            self.generation = self.generation.wrapping_add(1);
+        }
+        Ok(())
+    }
+
+    async fn handle_mouse(&mut self, _host: &HostClient, params: HandleMouseParams) -> Result<()> {
+        // Same redraw discipline as `handle_key`: only bump the generation
+        // (→ re-render) when the event actually changed something.
+        if self.dispatch_mouse_pure(params.mouse) {
+            self.ui.copy_flash = None;
             self.generation = self.generation.wrapping_add(1);
         }
         Ok(())
@@ -1109,6 +1122,50 @@ impl BurndownPlugin {
         }
         true
     }
+
+    /// Pure mouse dispatch (no host I/O) so it's unit-testable like
+    /// [`Self::dispatch_key_pure`]. Returns true iff it changed visible state.
+    ///
+    /// - **Wheel** scrolls the focused list — the zoomed table row when zoomed
+    ///   (self-clamping), else the dashboard list clamped to the session count
+    ///   so the offset can never run past the data.
+    /// - **Left click on a tab** in the tab bar switches to that tab, so every
+    ///   tab — including the Savings card — is reachable by mouse.
+    fn dispatch_mouse_pure(&mut self, m: MouseEvent) -> bool {
+        match m.kind {
+            MouseKind::ScrollUp => {
+                if self.ui.is_zoomed() {
+                    self.ui.zoom_row_up();
+                } else {
+                    self.ui.scroll_up();
+                }
+                true
+            }
+            MouseKind::ScrollDown => {
+                if self.ui.is_zoomed() {
+                    self.ui.zoom_row_down();
+                } else {
+                    let max_rows = self.data.as_ref().map_or(0, |d| d.sessions.len());
+                    self.ui.scroll_down(max_rows);
+                }
+                true
+            }
+            MouseKind::Down {
+                button: MouseButton::Left,
+            } => {
+                if (TAB_BAR_TOP..TAB_BAR_TOP + TAB_BAR_H).contains(&m.row) {
+                    if let Some(tab) = tab_at_col(m.col) {
+                        if tab != self.ui.active_tab {
+                            self.ui.active_tab = tab;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
 }
 
 /// Copy `text` to the system clipboard via `arboard`.
@@ -1236,6 +1293,71 @@ mod handle_key_dispatch_tests {
             UsageTab::Optimize,
             "[ retreats the outer tab"
         );
+    }
+
+    #[test]
+    fn mouse_left_click_on_savings_tab_switches_to_it() {
+        use crate::ui::{TAB_BAR_TOP, UsageTab, tab_at_col};
+        let mut p = BurndownPlugin::default();
+        assert_eq!(p.ui.active_tab, UsageTab::Burndown);
+        // A column inside the Savings title's hit zone.
+        let col = (0u16..240)
+            .find(|c| tab_at_col(*c) == Some(UsageTab::Savings))
+            .expect("Savings hit zone exists");
+        let ev = MouseEvent {
+            kind: MouseKind::Down {
+                button: MouseButton::Left,
+            },
+            col,
+            row: TAB_BAR_TOP,
+            mods: 0,
+        };
+        assert!(
+            p.dispatch_mouse_pure(ev),
+            "clicking the Savings tab must switch"
+        );
+        assert_eq!(
+            p.ui.active_tab,
+            UsageTab::Savings,
+            "clicked tab is now active"
+        );
+    }
+
+    #[test]
+    fn mouse_click_off_the_tab_bar_is_a_noop() {
+        use crate::ui::TAB_BAR_TOP;
+        let mut p = BurndownPlugin::default();
+        let ev = MouseEvent {
+            kind: MouseKind::Down {
+                button: MouseButton::Left,
+            },
+            col: 4,
+            row: TAB_BAR_TOP + 40, // deep in the content area
+            mods: 0,
+        };
+        assert!(
+            !p.dispatch_mouse_pure(ev),
+            "a click outside the tab bar changes nothing"
+        );
+    }
+
+    #[test]
+    fn mouse_wheel_is_consumed_for_redraw() {
+        let mut p = BurndownPlugin::default();
+        let up = MouseEvent {
+            kind: MouseKind::ScrollUp,
+            col: 0,
+            row: 0,
+            mods: 0,
+        };
+        let down = MouseEvent {
+            kind: MouseKind::ScrollDown,
+            col: 0,
+            row: 0,
+            mods: 0,
+        };
+        assert!(p.dispatch_mouse_pure(up), "wheel up is handled");
+        assert!(p.dispatch_mouse_pure(down), "wheel down is handled");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -1134,21 +1134,32 @@ impl BurndownPlugin {
     fn dispatch_mouse_pure(&mut self, m: MouseEvent) -> bool {
         match m.kind {
             MouseKind::ScrollUp => {
+                // Return the REAL delta so a boundary tick (already at the top)
+                // doesn't force a needless WireBuffer re-serialize — same
+                // redraw discipline as `handle_key`.
+                let before = (self.ui.scroll_offset, self.ui.focus_row);
                 if self.ui.is_zoomed() {
                     self.ui.zoom_row_up();
                 } else {
                     self.ui.scroll_up();
                 }
-                true
+                (self.ui.scroll_offset, self.ui.focus_row) != before
             }
             MouseKind::ScrollDown => {
+                let before = (self.ui.scroll_offset, self.ui.focus_row);
                 if self.ui.is_zoomed() {
                     self.ui.zoom_row_down();
                 } else {
-                    let max_rows = self.data.as_ref().map_or(0, |d| d.sessions.len());
+                    // `row_count()` reads `ui.data`, which the plugin only syncs
+                    // at render time — refresh it first (same sync the Enter
+                    // handler does) so the clamp matches the live snapshot. It
+                    // is tab-aware (Daily=days, Projects=projects, …), so short
+                    // lists can't over-scroll the way a raw session count would.
+                    self.ui.data = self.data.clone();
+                    let max_rows = self.ui.row_count();
                     self.ui.scroll_down(max_rows);
                 }
-                true
+                (self.ui.scroll_offset, self.ui.focus_row) != before
             }
             MouseKind::Down {
                 button: MouseButton::Left,
@@ -1342,8 +1353,7 @@ mod handle_key_dispatch_tests {
     }
 
     #[test]
-    fn mouse_wheel_is_consumed_for_redraw() {
-        let mut p = BurndownPlugin::default();
+    fn mouse_wheel_only_redraws_on_real_movement() {
         let up = MouseEvent {
             kind: MouseKind::ScrollUp,
             col: 0,
@@ -1356,8 +1366,22 @@ mod handle_key_dispatch_tests {
             row: 0,
             mods: 0,
         };
-        assert!(p.dispatch_mouse_pure(up), "wheel up is handled");
-        assert!(p.dispatch_mouse_pure(down), "wheel down is handled");
+        // Fresh plugin: nothing to scroll → wheel is a no-op, so it must NOT
+        // request a redraw (boundary tick discipline, mirroring handle_key).
+        let mut p = BurndownPlugin::default();
+        assert!(!p.dispatch_mouse_pure(up), "wheel up at the top is a no-op");
+        assert!(
+            !p.dispatch_mouse_pure(down),
+            "wheel down with no rows is a no-op"
+        );
+
+        // Zoomed table with rows: wheel-down advances the focused row → real
+        // change → redraw requested.
+        let mut z = zoomed_plugin();
+        assert!(
+            z.dispatch_mouse_pure(down),
+            "wheel down in a zoomed table scrolls and redraws"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Clear, Gauge, Paragraph, Row, Table, Tabs},
+    widgets::{Block, BorderType, Borders, Clear, Gauge, Paragraph, Row, Table},
 };
 
 use ainb_plugin_types_sessions::ScanProgressEvent;
@@ -965,23 +965,23 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
         Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Summary bar
-                Constraint::Length(3), // Provider selector
-                Constraint::Length(3), // Tab bar
-                Constraint::Length(1), // Scan banner (mid-scan only)
-                Constraint::Min(0),    // Table content
-                Constraint::Length(2), // Help bar
+                Constraint::Length(SUMMARY_BAR_H),  // Summary bar
+                Constraint::Length(PROVIDER_BAR_H), // Provider selector
+                Constraint::Length(TAB_BAR_H),      // Tab bar
+                Constraint::Length(1),              // Scan banner (mid-scan only)
+                Constraint::Min(0),                 // Table content
+                Constraint::Length(2),              // Help bar
             ])
             .split(area)
     } else {
         Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Summary bar
-                Constraint::Length(3), // Provider selector
-                Constraint::Length(3), // Tab bar
-                Constraint::Min(0),    // Table content
-                Constraint::Length(2), // Help bar
+                Constraint::Length(SUMMARY_BAR_H),  // Summary bar
+                Constraint::Length(PROVIDER_BAR_H), // Provider selector
+                Constraint::Length(TAB_BAR_H),      // Tab bar
+                Constraint::Min(0),                 // Table content
+                Constraint::Length(2),              // Help bar
             ])
             .split(area)
     };
@@ -1282,40 +1282,82 @@ fn render_no_data(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     ratatui::widgets::Widget::render(paragraph, inner, buf);
 }
 
+// ── Tab-bar geometry (shared by the renderer AND mouse hit-testing) ──────────
+// The usage view stacks fixed-height bars above the tab bar. Mouse hit-testing
+// needs the tab bar's row range, so `TAB_BAR_TOP` / `*_H` MUST match the render
+// layout heights below — guarded by `tab_bar_geometry_matches_render`.
+pub(crate) const SUMMARY_BAR_H: u16 = 3;
+pub(crate) const PROVIDER_BAR_H: u16 = 3;
+pub(crate) const TAB_BAR_H: u16 = 3;
+/// First viewport row occupied by the tab bar (below summary + provider bars).
+pub(crate) const TAB_BAR_TOP: u16 = SUMMARY_BAR_H + PROVIDER_BAR_H;
+/// Inner-left column of the tab-bar block (rounded border = 1 col).
+const TAB_BAR_INNER_X: u16 = 1;
+const TAB_DIVIDER: &str = " │ ";
+
+/// Per-tab hit zones on the tab-bar title row as `(start, end_inclusive, tab)`,
+/// derived from the tab titles + dividers. Single source of truth so the
+/// painted tabs and the clickable zones can never drift apart.
+fn tab_zones(inner_x: u16) -> Vec<(u16, u16, UsageTab)> {
+    let div_w = TAB_DIVIDER.chars().count() as u16;
+    let mut zones = Vec::with_capacity(UsageTab::all().len());
+    let mut x = inner_x;
+    for (i, t) in UsageTab::all().iter().enumerate() {
+        if i > 0 {
+            x += div_w;
+        }
+        let w = t.title().chars().count() as u16;
+        zones.push((x, x + w.saturating_sub(1), *t));
+        x += w;
+    }
+    zones
+}
+
+/// The tab whose title spans `col` on the tab-bar row, if any. Used by mouse
+/// click hit-testing to turn a column into a tab.
+pub(crate) fn tab_at_col(col: u16) -> Option<UsageTab> {
+    tab_zones(TAB_BAR_INNER_X)
+        .into_iter()
+        .find(|(s, e, _)| col >= *s && col <= *e)
+        .map(|(_, _, t)| t)
+}
+
 fn render_tab_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
-    let titles: Vec<Line> = UsageTab::all()
-        .iter()
-        .map(|t| {
-            let style = if *t == state.active_tab {
-                Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-            } else {
-                Style::default().fg(MUTED_GRAY)
-            };
-            Line::from(Span::styled(t.title(), style))
-        })
-        .collect();
-
-    let idx = UsageTab::all().iter().position(|t| *t == state.active_tab).unwrap_or(0);
-    let tabs = Tabs::new(titles)
-        .select(idx)
-        .highlight_style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
-        .divider(Span::styled(" │ ", Style::default().fg(MUTED_GRAY)))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(CORNFLOWER_BLUE))
-                .style(Style::default().bg(DARK_BG))
-                .title(
-                    Line::from(Span::styled(
-                        " [ ] switch tab ",
-                        Style::default().fg(MUTED_GRAY),
-                    ))
-                    .right_aligned(),
-                ),
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .style(Style::default().bg(DARK_BG))
+        .title(
+            Line::from(Span::styled(
+                " [ ] switch tab ",
+                Style::default().fg(MUTED_GRAY),
+            ))
+            .right_aligned(),
         );
+    let inner = block.inner(area);
+    ratatui::widgets::Widget::render(block, area, buf);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
 
-    ratatui::widgets::Widget::render(tabs, area, buf);
+    // Paint titles + dividers at the exact columns `tab_zones` reports, so a
+    // click resolves to the same tab the user sees. We render manually (not the
+    // ratatui Tabs widget) precisely so render and hit-test share one formula.
+    let y = inner.y;
+    let div_w = TAB_DIVIDER.chars().count() as u16;
+    let div_style = Style::default().fg(MUTED_GRAY);
+    for (i, (start, _end, t)) in tab_zones(inner.x).into_iter().enumerate() {
+        if i > 0 {
+            buf.set_string(start.saturating_sub(div_w), y, TAB_DIVIDER, div_style);
+        }
+        let style = if t == state.active_tab {
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else {
+            Style::default().fg(MUTED_GRAY)
+        };
+        buf.set_string(start, y, t.title(), style);
+    }
 }
 
 fn render_loading(buf: &mut Buffer, area: Rect) {
@@ -4518,6 +4560,8 @@ fn render_help_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     let mut spans = vec![
         Span::styled(" ◀/▶ p", Style::default().fg(GOLD)),
         Span::styled(" provider  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("[ ]", Style::default().fg(GOLD)),
+        Span::styled(" switch tab  ", Style::default().fg(MUTED_GRAY)),
         Span::styled(
             "1 Today  2 7d  3 30d  4 90d  5 YTD  m Month  q Quarter  a All  D advanced  ",
             Style::default().fg(MUTED_GRAY),
@@ -6446,6 +6490,86 @@ mod zoom_table_tests {
         assert!(
             flat.contains("Fetching savings"),
             "fetching placeholder:\n{flat}"
+        );
+    }
+
+    // ── Tab-bar mouse geometry (click-to-switch hit zones) ──────────────────
+
+    #[test]
+    fn tab_zones_are_contiguous_with_3col_dividers() {
+        let zones = tab_zones(1);
+        assert_eq!(zones.len(), UsageTab::all().len());
+        assert_eq!(zones[0].0, 1, "first tab starts at inner_x");
+        for (i, (start, end, t)) in zones.iter().enumerate() {
+            let w = t.title().chars().count() as u16;
+            assert_eq!(*end, start + w - 1, "{t:?} zone width must equal its title");
+            if i > 0 {
+                assert_eq!(
+                    *start,
+                    zones[i - 1].1 + 1 + 3,
+                    "3-col ` │ ` divider before {t:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tab_at_col_resolves_tabs_and_divider_gaps() {
+        let zones = tab_zones(1);
+        let b = zones.iter().find(|(_, _, t)| *t == UsageTab::Burndown).unwrap();
+        let s = zones.iter().find(|(_, _, t)| *t == UsageTab::Savings).unwrap();
+        assert_eq!(tab_at_col(b.0), Some(UsageTab::Burndown));
+        assert_eq!(tab_at_col(s.0), Some(UsageTab::Savings));
+        assert_eq!(
+            tab_at_col(s.1),
+            Some(UsageTab::Savings),
+            "end col is inclusive"
+        );
+        assert_eq!(tab_at_col(b.1 + 1), None, "the divider gap is dead space");
+    }
+
+    /// Drift guard: the rendered tab titles must land exactly where
+    /// `tab_at_col` (and `TAB_BAR_TOP`) say they are, so a click resolves to
+    /// the tab the user sees. Catches both layout-height and tab-zone drift.
+    #[test]
+    fn tab_bar_geometry_matches_render() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let state = UsageViewState::default();
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).expect("backend");
+        terminal
+            .draw(|f| {
+                let a = f.size();
+                render(f.buffer_mut(), a, &state);
+            })
+            .expect("render must not panic");
+        let buf = terminal.backend().buffer();
+        // Titles paint on the row just inside the tab-bar block's top border.
+        let row = TAB_BAR_TOP + 1;
+        let bz = tab_zones(1).into_iter().find(|(_, _, t)| *t == UsageTab::Burndown).unwrap();
+        let got: String = (bz.0..=bz.1).map(|x| buf.get(x, row).symbol().to_string()).collect();
+        assert_eq!(
+            got, "Burndown",
+            "tab title must render at its hit-zone on row {row}"
+        );
+    }
+
+    #[test]
+    fn help_bar_advertises_switch_tab_legend() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let state = UsageViewState::default();
+        let backend = TestBackend::new(160, 24);
+        let mut terminal = Terminal::new(backend).expect("backend");
+        terminal
+            .draw(|f| {
+                let a = f.size();
+                render(f.buffer_mut(), a, &state);
+            })
+            .expect("render must not panic");
+        let flat = flatten(terminal.backend().buffer());
+        assert!(
+            flat.contains("switch tab"),
+            "help bar must show the legend:\n{flat}"
         );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -1344,19 +1344,29 @@ fn render_tab_bar(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
     // Paint titles + dividers at the exact columns `tab_zones` reports, so a
     // click resolves to the same tab the user sees. We render manually (not the
     // ratatui Tabs widget) precisely so render and hit-test share one formula.
+    // Every paint is clipped to the block's inner width: `buf.set_string` only
+    // clips at the buffer edge, so without this a long tab strip would overwrite
+    // the right border on a narrow viewport.
     let y = inner.y;
+    let right = inner.x.saturating_add(inner.width); // exclusive inner-right edge
     let div_w = TAB_DIVIDER.chars().count() as u16;
     let div_style = Style::default().fg(MUTED_GRAY);
+    let clip =
+        |s: &str, x: u16| -> String { s.chars().take(right.saturating_sub(x) as usize).collect() };
     for (i, (start, _end, t)) in tab_zones(inner.x).into_iter().enumerate() {
+        if start >= right {
+            break; // this tab — and every tab after it — is off the right edge
+        }
         if i > 0 {
-            buf.set_string(start.saturating_sub(div_w), y, TAB_DIVIDER, div_style);
+            let div_x = start.saturating_sub(div_w);
+            buf.set_string(div_x, y, clip(TAB_DIVIDER, div_x), div_style);
         }
         let style = if t == state.active_tab {
             Style::default().fg(GOLD).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
         } else {
             Style::default().fg(MUTED_GRAY)
         };
-        buf.set_string(start, y, t.title(), style);
+        buf.set_string(start, y, clip(t.title(), start), style);
     }
 }
 
@@ -6534,23 +6544,40 @@ mod zoom_table_tests {
     #[test]
     fn tab_bar_geometry_matches_render() {
         use ratatui::{Terminal, backend::TestBackend};
-        let state = UsageViewState::default();
-        let backend = TestBackend::new(120, 24);
-        let mut terminal = Terminal::new(backend).expect("backend");
-        terminal
-            .draw(|f| {
-                let a = f.size();
-                render(f.buffer_mut(), a, &state);
-            })
-            .expect("render must not panic");
-        let buf = terminal.backend().buffer();
-        // Titles paint on the row just inside the tab-bar block's top border.
         let row = TAB_BAR_TOP + 1;
-        let bz = tab_zones(1).into_iter().find(|(_, _, t)| *t == UsageTab::Burndown).unwrap();
-        let got: String = (bz.0..=bz.1).map(|x| buf.get(x, row).symbol().to_string()).collect();
+        let render_at = |w: u16| {
+            let state = UsageViewState::default();
+            let backend = TestBackend::new(w, 24);
+            let mut terminal = Terminal::new(backend).expect("backend");
+            terminal
+                .draw(|f| {
+                    let a = f.size();
+                    render(f.buffer_mut(), a, &state);
+                })
+                .expect("render must not panic");
+            terminal.backend().buffer().clone()
+        };
+
+        // Wide: BOTH a fixed-position tab (Burndown @ col 1) AND a later tab
+        // whose start depends on every preceding divider (Savings) must render
+        // exactly at their hit zones — so a click resolves to the seen tab.
+        let wide = render_at(120);
+        for tab in [UsageTab::Burndown, UsageTab::Savings] {
+            let z = tab_zones(1).into_iter().find(|(_, _, t)| *t == tab).unwrap();
+            let got: String = (z.0..=z.1).map(|x| wide.get(x, row).symbol().to_string()).collect();
+            assert_eq!(
+                got,
+                tab.title(),
+                "{tab:?} must render at its hit-zone on row {row}"
+            );
+        }
+
+        // Narrow: the tab strip must not overwrite the block's right border.
+        let narrow = render_at(40);
         assert_eq!(
-            got, "Burndown",
-            "tab title must render at its hit-zone on row {row}"
+            narrow.get(40 - 1, row).symbol(),
+            "│",
+            "narrow tab bar must keep its right border (no title overflow)"
         );
     }
 


### PR DESCRIPTION
The burndown plugin ignored the mouse (the SDK `handle_mouse` default is a no-op).
Implement it for the stats screen.

## What
- **Click a tab** → switch to it. Every tab, including the **Savings** card, is
  now reachable without the keyboard.
- **Wheel** scrolls the focused list: the zoomed table row when zoomed (self
  clamping), else the dashboard list clamped to the session count (no runaway
  offset).
- **`[ ] switch tab` legend** added to the bottom help bar so keyboard tab
  switching is discoverable (it was only on the tab-bar title before).

## How it can't drift
The tab bar is now rendered manually from a single `tab_zones` helper, shared by
the renderer and the mouse hit-test, so painted titles and clickable zones use
one formula. Layout heights are named consts (`TAB_BAR_TOP` etc.) used by both
the render layout and the hit-test. `tab_bar_geometry_matches_render` renders the
real view and asserts the title lands exactly where `tab_at_col` expects — so a
click resolves to the tab the user sees.

## Tests
`ainb-plugin-burndown`: **214 pass** (+7: 3 mouse dispatch, tab-zone math,
hit-test, render drift-guard, legend). Live-verified the manual tab bar + legend
render correctly. fmt clean.

Note: `MouseKind`/`MouseButton`/`HandleMouseParams` already existed in the plugin
protocol + SDK (host forwards `plugin/handle_mouse` to the focused screen);
burndown just hadn't implemented the handler. Pattern follows the `learnings`
plugin.

https://claude.ai/code/session_01FwQC25huAxcpeKoA1umEZb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse support in the usage view, including scroll-wheel navigation and clicking tabs to switch sections.
  * Updated the tab bar so clicks align more accurately with the visible tab labels.

* **Bug Fixes**
  * Improved redraw behavior so mouse actions only refresh the screen when state actually changes.
  * Added safeguards so clicking outside the tab bar no longer changes the active tab.

* **Tests**
  * Expanded coverage for tab-click behavior, scroll handling, and tab-bar alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->