### PR TITLE
onboarding: add Homebrew to the catalog

### DIFF
--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -243,6 +243,18 @@ pub fn catalog() -> Vec<Topic> {
             description: "Required for ainb to function",
             deps: vec![
                 dep(
+                    "brew",
+                    "Homebrew",
+                    "package manager used to install ainb + most tools here",
+                    Recommended,
+                    Custom("brew"),
+                    Manual(
+                        "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+                    ),
+                    &[Consumer::Core],
+                    &[],
+                ),
+                dep(
                     "git",
                     "git",
                     "branch + worktree/session git ops",

--- a/ainb-tui/crates/ainb-core/src/setup/detect.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/detect.rs
@@ -151,6 +151,19 @@ fn detect_state(detect: &Detect, env: &dyn Env) -> DepState {
 /// Bespoke probes for the `Custom(..)` detection specs.
 fn detect_custom(name: &str, env: &dyn Env) -> DepState {
     match name {
+        // Homebrew — on PATH, or at a standard prefix even when the shell hasn't
+        // loaded `brew shellenv` yet (Linuxbrew / Apple-silicon / Intel mac).
+        "brew" => {
+            if env.which("brew")
+                || std::path::Path::new("/home/linuxbrew/.linuxbrew/bin/brew").exists()
+                || std::path::Path::new("/opt/homebrew/bin/brew").exists()
+                || std::path::Path::new("/usr/local/bin/brew").exists()
+            {
+                DepState::Ok(None)
+            } else {
+                DepState::Missing
+            }
+        }
         // ainb is whatever is running this wizard — always present. A PATH probe
         // would false-negative for an off-PATH / freshly-downloaded binary and
         // trap the user on the dependency step (the only "install" is Manual).


### PR DESCRIPTION
Homebrew is the install backbone for most catalog deps and how you (re)install/upgrade ainb. Onboarding now tracks it as the first Core Tools entry — detect via PATH or a standard brew prefix (Linuxbrew / Apple-silicon / Intel mac), install via the official Homebrew installer.

fmt clean; setup unit tests + tripwire green.

https://claude.ai/code/session_012BMaP4fZ8ff8idHMJgXcVh