### PR TITLE
onboarding: confirm the I tmux-config install (success/failure feedback)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -6328,6 +6328,9 @@ impl EventHandler {
                         tracing::info!("Successfully installed tmux.conf");
                         // Re-run dependency check to update status
                         if let Some(ref mut onboarding_state) = state.onboarding_state {
+                            onboarding_state.error_message = None;
+                            onboarding_state.status_message =
+                                Some("✓ Installed optimized tmux.conf → ~/.tmux.conf (backup saved if one existed)".to_string());
                             onboarding_state.dependency_check_running = true;
                         }
                         state.pending_async_action = Some(AsyncAction::OnboardingCheckDeps);
@@ -6335,7 +6338,9 @@ impl EventHandler {
                     Err(e) => {
                         tracing::error!("Failed to install tmux.conf: {}", e);
                         if let Some(ref mut onboarding_state) = state.onboarding_state {
-                            onboarding_state.error_message = Some(format!("Install failed: {}", e));
+                            onboarding_state.status_message = None;
+                            onboarding_state.error_message =
+                                Some(format!("✗ tmux.conf install failed: {e}"));
                         }
                     }
                 }

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -365,15 +365,31 @@ impl OnboardingComponent {
             frame.render_widget(list, *area);
         }
 
-        let instructions = if status.required_met() {
-            "Press Enter to continue • I to install tmux config • R to re-check"
+        // Show the last action's result if there is one (e.g. the I-key tmux
+        // install), otherwise the key hints. Errors take priority over success.
+        let instr_span = if let Some(err) = &state.error_message {
+            Span::styled(
+                err.clone(),
+                Style::default().fg(ERROR_RED).add_modifier(Modifier::BOLD),
+            )
+        } else if let Some(msg) = &state.status_message {
+            Span::styled(
+                msg.clone(),
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            )
+        } else if status.required_met() {
+            Span::styled(
+                "Press Enter to continue • I to install tmux config • R to re-check",
+                Style::default().fg(MUTED_GRAY),
+            )
         } else {
-            "Install required dependencies • I to install tmux config • R to re-check"
+            Span::styled(
+                "Install required dependencies • I to install tmux config • R to re-check",
+                Style::default().fg(MUTED_GRAY),
+            )
         };
 
-        let instr_widget =
-            Paragraph::new(Span::styled(instructions, Style::default().fg(MUTED_GRAY)))
-                .alignment(Alignment::Center);
+        let instr_widget = Paragraph::new(instr_span).alignment(Alignment::Center);
         frame.render_widget(instr_widget, content_layout[2]);
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -246,6 +246,8 @@ pub struct OnboardingState {
     pub show_cursor: bool,
     /// Error message to display
     pub error_message: Option<String>,
+    /// Transient success/status message (e.g. after the `I` tmux-config install)
+    pub status_message: Option<String>,
     /// Dependencies user chose to skip
     pub skipped_dependencies: Vec<String>,
     /// Available editor options (detected on EditorSelection step)
@@ -279,6 +281,7 @@ impl OnboardingState {
             cursor_position: 0,
             show_cursor: true,
             error_message: None,
+            status_message: None,
             skipped_dependencies: Vec::new(),
             available_editors: Vec::new(),
             selected_editor_index: 0,
@@ -432,6 +435,7 @@ impl OnboardingState {
                 self.current_step = next;
                 self.focus = OnboardingFocus::Content;
                 self.error_message = None;
+                self.status_message = None;
 
                 // Auto-trigger dependency check when entering DependencyCheck step
                 let trigger_dep_check =
@@ -449,6 +453,7 @@ impl OnboardingState {
             self.current_step = prev;
             self.focus = OnboardingFocus::Content;
             self.error_message = None;
+            self.status_message = None;
             return true;
         }
         false


### PR DESCRIPTION
Pressing **I** on the dependency step installs ~/.tmux.conf but gave no feedback — the user couldn't tell if it worked. Now the footer shows a green `✓ Installed optimized tmux.conf → ~/.tmux.conf` on success or a red `✗ … failed: <err>` on failure (new `status_message` field; error > status > hints; cleared on navigation).

Verified in tmux: pressing I renders the success line and writes the 12.9KB conf. 13 onboarding unit tests + tripwire green; fmt clean.

https://claude.ai/code/session_012BMaP4fZ8ff8idHMJgXcVh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The onboarding flow now shows clearer success and error feedback after installing the terminal configuration.
  * Success messages are displayed in green, while failures are shown prominently in red.

* **Bug Fixes**
  * Improved how onboarding messages reset when moving between steps, so old success or error text no longer lingers.
  * Install failures now include more specific details to help identify what went wrong.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->