### PR TITLE
onboarding: one-button install-script generator (TUI G / ainb init --script / doctor)

### DIFF
--- a/ainb-tui/crates/ainb-cli/src/doctor.rs
+++ b/ainb-tui/crates/ainb-cli/src/doctor.rs
@@ -256,6 +256,19 @@ pub fn dispatch(home: &Path, args: DoctorArgs, out: &mut dyn io::Write) -> Resul
 }
 
 fn finalize(out: &mut dyn io::Write, issues: Vec<String>) -> Result<()> {
+    // Point at the dependency catalog + installer (lives in the ainb-core setup
+    // engine, not this crate — so surface the commands rather than re-render it).
+    writeln!(out, "\nDependencies (tools the agents + plugins need):")?;
+    writeln!(
+        out,
+        "  ainb init --check                    # full topic/dependency status"
+    )?;
+    writeln!(
+        out,
+        "  ainb init --script --agent <claude|codex|copilot>   # write an installer for what's missing"
+    )?;
+    writeln!(out)?;
+
     if issues.is_empty() {
         writeln!(out, "doctor: all checks passed")?;
         return Ok(());

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -443,26 +443,29 @@ pub enum AppEvent {
     LogHistoryScrollHome,    // Reset horizontal scroll to start (Home)
     LogHistoryCleanup,       // Delete all log files (C)
     // Onboarding wizard events
-    OnboardingNext,            // Go to next step (Enter/Right Arrow)
-    OnboardingBack,            // Go to previous step (Backspace/Left Arrow)
-    OnboardingToMenu,          // Leave wizard for the Setup menu (Esc)
-    OnboardingInputChar(char), // Input character for git directories
-    OnboardingBackspace,       // Backspace in git directories input
-    OnboardingDelete,          // Delete character in input
-    OnboardingCursorLeft,      // Move cursor left in input
-    OnboardingCursorRight,     // Move cursor right in input
-    OnboardingCursorHome,      // Move cursor to start of input
-    OnboardingCursorEnd,       // Move cursor to end of input
-    OnboardingCheckDeps,       // Run dependency check
-    OnboardingSkipAuth,        // Skip authentication step
-    OnboardingEditorUp,        // Move editor selection up
-    OnboardingEditorDown,      // Move editor selection down
-    OnboardingFinish,          // Complete onboarding
-    OnboardingInstallConfig,   // Install recommended config (I key)
-    OnboardingOtelChar(char),  // Type into the focused OTEL field
-    OnboardingOtelBackspace,   // Backspace the focused OTEL field
-    OnboardingOtelNextField,   // Focus next OTEL field (Tab/Down)
-    OnboardingOtelPrevField,   // Focus previous OTEL field (Shift-Tab/Up)
+    OnboardingNext,               // Go to next step (Enter/Right Arrow)
+    OnboardingBack,               // Go to previous step (Backspace/Left Arrow)
+    OnboardingToMenu,             // Leave wizard for the Setup menu (Esc)
+    OnboardingInputChar(char),    // Input character for git directories
+    OnboardingBackspace,          // Backspace in git directories input
+    OnboardingDelete,             // Delete character in input
+    OnboardingCursorLeft,         // Move cursor left in input
+    OnboardingCursorRight,        // Move cursor right in input
+    OnboardingCursorHome,         // Move cursor to start of input
+    OnboardingCursorEnd,          // Move cursor to end of input
+    OnboardingCheckDeps,          // Run dependency check
+    OnboardingSkipAuth,           // Skip authentication step
+    OnboardingEditorUp,           // Move editor selection up
+    OnboardingEditorDown,         // Move editor selection down
+    OnboardingFinish,             // Complete onboarding
+    OnboardingInstallConfig,      // Install recommended config (I key)
+    OnboardingScriptPrompt,       // G key: ask which agent to generate a script for
+    OnboardingCancelScriptPrompt, // Esc out of the agent picker
+    OnboardingGenerateScript(crate::setup::Agent), // Generate installer for agent
+    OnboardingOtelChar(char),     // Type into the focused OTEL field
+    OnboardingOtelBackspace,      // Backspace the focused OTEL field
+    OnboardingOtelNextField,      // Focus next OTEL field (Tab/Down)
+    OnboardingOtelPrevField,      // Focus previous OTEL field (Shift-Tab/Up)
     // Setup menu events
     SetupMenuBack,   // Return to home screen (Esc)
     SetupMenuSelect, // Select menu item (Enter)
@@ -2263,24 +2266,44 @@ impl EventHandler {
                     }
                 }
                 OnboardingStep::DependencyCheck => {
-                    match key_event.code {
-                        KeyCode::Enter | KeyCode::Right => {
-                            // If deps not checked yet, check them; otherwise advance
-                            if onboarding_state.dependency_status.is_none() {
-                                Some(AppEvent::OnboardingCheckDeps)
-                            } else {
-                                Some(AppEvent::OnboardingNext)
+                    if onboarding_state.agent_pick_open {
+                        // Agent picker (after G): choose which agent's installer to write.
+                        match key_event.code {
+                            KeyCode::Char('c') | KeyCode::Char('C') => Some(
+                                AppEvent::OnboardingGenerateScript(crate::setup::Agent::Claude),
+                            ),
+                            KeyCode::Char('x') | KeyCode::Char('X') => Some(
+                                AppEvent::OnboardingGenerateScript(crate::setup::Agent::Codex),
+                            ),
+                            KeyCode::Char('p') | KeyCode::Char('P') => Some(
+                                AppEvent::OnboardingGenerateScript(crate::setup::Agent::Copilot),
+                            ),
+                            KeyCode::Esc => Some(AppEvent::OnboardingCancelScriptPrompt),
+                            _ => None,
+                        }
+                    } else {
+                        match key_event.code {
+                            KeyCode::Enter | KeyCode::Right => {
+                                // If deps not checked yet, check them; otherwise advance
+                                if onboarding_state.dependency_status.is_none() {
+                                    Some(AppEvent::OnboardingCheckDeps)
+                                } else {
+                                    Some(AppEvent::OnboardingNext)
+                                }
                             }
+                            KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
+                            KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
+                                Some(AppEvent::OnboardingBack)
+                            }
+                            KeyCode::Char('r') => Some(AppEvent::OnboardingCheckDeps), // Re-check
+                            KeyCode::Char('i') | KeyCode::Char('I') => {
+                                Some(AppEvent::OnboardingInstallConfig)
+                            } // Install tmux config
+                            KeyCode::Char('g') | KeyCode::Char('G') => {
+                                Some(AppEvent::OnboardingScriptPrompt)
+                            } // Generate install script
+                            _ => None,
                         }
-                        KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
-                        KeyCode::Left | KeyCode::Backspace | KeyCode::Up => {
-                            Some(AppEvent::OnboardingBack)
-                        }
-                        KeyCode::Char('r') => Some(AppEvent::OnboardingCheckDeps), // Re-check
-                        KeyCode::Char('i') | KeyCode::Char('I') => {
-                            Some(AppEvent::OnboardingInstallConfig)
-                        } // Install config
-                        _ => None,
                     }
                 }
                 OnboardingStep::Authentication => match key_event.code {
@@ -6341,6 +6364,44 @@ impl EventHandler {
                             onboarding_state.status_message = None;
                             onboarding_state.error_message =
                                 Some(format!("✗ tmux.conf install failed: {e}"));
+                        }
+                    }
+                }
+            }
+            AppEvent::OnboardingScriptPrompt => {
+                if let Some(os) = &mut state.onboarding_state {
+                    os.agent_pick_open = true;
+                    os.error_message = None;
+                    os.status_message = None;
+                }
+            }
+            AppEvent::OnboardingCancelScriptPrompt => {
+                if let Some(os) = &mut state.onboarding_state {
+                    os.agent_pick_open = false;
+                }
+            }
+            AppEvent::OnboardingGenerateScript(agent) => {
+                use crate::setup::{RealEnv, generate_install_script};
+                if let Some(os) = &mut state.onboarding_state {
+                    os.agent_pick_open = false;
+                }
+                match generate_install_script(agent, &RealEnv) {
+                    Ok(path) => {
+                        tracing::info!("Generated installer at {}", path.display());
+                        if let Some(os) = &mut state.onboarding_state {
+                            os.error_message = None;
+                            os.status_message = Some(format!(
+                                "✓ Wrote {} installer — run:  bash {}",
+                                agent.label(),
+                                path.display()
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to generate installer: {}", e);
+                        if let Some(os) = &mut state.onboarding_state {
+                            os.status_message = None;
+                            os.error_message = Some(format!("✗ installer generation failed: {e}"));
                         }
                     }
                 }

--- a/ainb-tui/crates/ainb-core/src/cli/init.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/init.rs
@@ -14,8 +14,8 @@ use std::io::{self, Write as _};
 use super::OutputFormat;
 use crate::config::{AppConfig, OnboardingConfig};
 use crate::setup::{
-    DepState, ProvisionMode, ProvisionOutcome, RealEnv, SetupStatus, catalog, detect_all,
-    detect_dep, provision,
+    Agent, DepState, ProvisionMode, ProvisionOutcome, RealEnv, SetupStatus, catalog, detect_all,
+    detect_dep, generate_install_script, provision,
 };
 
 #[derive(clap::Args)]
@@ -40,6 +40,15 @@ pub struct InitArgs {
     /// ainb/claude-plugin). brew/curl still need explicit per-item consent.
     #[arg(long, short = 'y')]
     pub yes: bool,
+
+    /// Generate an idempotent install script for what's missing (writes
+    /// ~/.agents-in-a-box/installer/install-<agent>.sh) instead of installing.
+    #[arg(long)]
+    pub script: bool,
+
+    /// Target agent for --script: claude | codex | copilot (default: claude).
+    #[arg(long)]
+    pub agent: Option<String>,
 }
 
 /// Output structure for `--status`
@@ -59,11 +68,11 @@ struct StatusReport {
 }
 
 /// Validate that at most one mode flag is set
-fn validate_flags(check: bool, status: bool, reset: bool) -> Result<()> {
-    let count = [check, status, reset].iter().filter(|x| **x).count();
+fn validate_flags(check: bool, status: bool, reset: bool, script: bool) -> Result<()> {
+    let count = [check, status, reset, script].iter().filter(|x| **x).count();
     if count > 1 {
         return Err(anyhow!(
-            "--check, --status, and --reset are mutually exclusive"
+            "--check, --status, --reset, and --script are mutually exclusive"
         ));
     }
     Ok(())
@@ -72,7 +81,7 @@ fn validate_flags(check: bool, status: bool, reset: bool) -> Result<()> {
 /// Entry point for `ainb init`
 #[allow(clippy::unused_async)]
 pub async fn execute(args: InitArgs, format: OutputFormat) -> Result<()> {
-    validate_flags(args.check, args.status, args.reset)?;
+    validate_flags(args.check, args.status, args.reset, args.script)?;
 
     if args.reset {
         cmd_reset(args.force, format)
@@ -80,9 +89,36 @@ pub async fn execute(args: InitArgs, format: OutputFormat) -> Result<()> {
         cmd_status(format)
     } else if args.check {
         cmd_check(format)
+    } else if args.script {
+        cmd_script(args.agent.as_deref(), format)
     } else {
         cmd_setup(format, args.yes)
     }
+}
+
+/// `ainb init --script` — generate an install script for the chosen agent.
+fn cmd_script(agent_arg: Option<&str>, format: OutputFormat) -> Result<()> {
+    let agent = match agent_arg {
+        Some(a) => Agent::parse(a)
+            .ok_or_else(|| anyhow!("unknown --agent '{a}' (use claude | codex | copilot)"))?,
+        None => Agent::Claude,
+    };
+    let path = generate_install_script(agent, &RealEnv)?;
+
+    match format {
+        OutputFormat::Json => {
+            let out = serde_json::json!({
+                "agent": agent.slug(),
+                "script_path": path.display().to_string(),
+            });
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
+            println!("Wrote {} installer:\n  {}", agent.label(), path.display());
+            println!("\nReview it, then run:\n  bash {}", path.display());
+        }
+    }
+    Ok(())
 }
 
 // --- Catalog rendering (shared with the TUI via crate::setup) ----------------
@@ -675,26 +711,28 @@ mod tests {
 
     #[test]
     fn test_validate_flags_none_set() {
-        assert!(validate_flags(false, false, false).is_ok());
+        assert!(validate_flags(false, false, false, false).is_ok());
     }
 
     #[test]
     fn test_validate_flags_single_set() {
-        assert!(validate_flags(true, false, false).is_ok());
-        assert!(validate_flags(false, true, false).is_ok());
-        assert!(validate_flags(false, false, true).is_ok());
+        assert!(validate_flags(true, false, false, false).is_ok());
+        assert!(validate_flags(false, true, false, false).is_ok());
+        assert!(validate_flags(false, false, true, false).is_ok());
+        assert!(validate_flags(false, false, false, true).is_ok());
     }
 
     #[test]
     fn test_validate_flags_two_set_rejected() {
-        assert!(validate_flags(true, true, false).is_err());
-        assert!(validate_flags(true, false, true).is_err());
-        assert!(validate_flags(false, true, true).is_err());
+        assert!(validate_flags(true, true, false, false).is_err());
+        assert!(validate_flags(true, false, true, false).is_err());
+        assert!(validate_flags(false, true, true, false).is_err());
+        assert!(validate_flags(false, false, true, true).is_err());
     }
 
     #[test]
     fn test_validate_flags_all_three_rejected() {
-        let err = validate_flags(true, true, true).unwrap_err();
+        let err = validate_flags(true, true, true, false).unwrap_err();
         assert!(err.to_string().contains("mutually exclusive"));
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -365,9 +365,14 @@ impl OnboardingComponent {
             frame.render_widget(list, *area);
         }
 
-        // Show the last action's result if there is one (e.g. the I-key tmux
-        // install), otherwise the key hints. Errors take priority over success.
-        let instr_span = if let Some(err) = &state.error_message {
+        // Footer priority: agent picker (after G) > last action result (error >
+        // success) > key hints.
+        let instr_span = if state.agent_pick_open {
+            Span::styled(
+                "Generate installer for:   [c] Claude    [x] Codex    [p] Copilot       Esc cancel",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            )
+        } else if let Some(err) = &state.error_message {
             Span::styled(
                 err.clone(),
                 Style::default().fg(ERROR_RED).add_modifier(Modifier::BOLD),
@@ -379,12 +384,12 @@ impl OnboardingComponent {
             )
         } else if status.required_met() {
             Span::styled(
-                "Press Enter to continue • I to install tmux config • R to re-check",
+                "Enter continue • G generate install script • I tmux config • R re-check",
                 Style::default().fg(MUTED_GRAY),
             )
         } else {
             Span::styled(
-                "Install required dependencies • I to install tmux config • R to re-check",
+                "Install required deps • G generate install script • I tmux config • R re-check",
                 Style::default().fg(MUTED_GRAY),
             )
         };

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -248,6 +248,9 @@ pub struct OnboardingState {
     pub error_message: Option<String>,
     /// Transient success/status message (e.g. after the `I` tmux-config install)
     pub status_message: Option<String>,
+    /// After pressing `G`: waiting for the user to pick an agent for the
+    /// generated install script (c/x/p), or Esc to cancel.
+    pub agent_pick_open: bool,
     /// Dependencies user chose to skip
     pub skipped_dependencies: Vec<String>,
     /// Available editor options (detected on EditorSelection step)
@@ -282,6 +285,7 @@ impl OnboardingState {
             show_cursor: true,
             error_message: None,
             status_message: None,
+            agent_pick_open: false,
             skipped_dependencies: Vec::new(),
             available_editors: Vec::new(),
             selected_editor_index: 0,
@@ -436,6 +440,7 @@ impl OnboardingState {
                 self.focus = OnboardingFocus::Content;
                 self.error_message = None;
                 self.status_message = None;
+                self.agent_pick_open = false;
 
                 // Auto-trigger dependency check when entering DependencyCheck step
                 let trigger_dep_check =
@@ -454,6 +459,7 @@ impl OnboardingState {
             self.focus = OnboardingFocus::Content;
             self.error_message = None;
             self.status_message = None;
+            self.agent_pick_open = false;
             return true;
         }
         false

--- a/ainb-tui/crates/ainb-core/src/setup/installer.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/installer.rs
@@ -1,0 +1,371 @@
+// ABOUTME: Generates a single, idempotent, agent-specific install script from the
+// setup catalog. The onboarding `G` key, `ainb init --script`, and `ainb doctor`
+// all point users at this — instead of installing inline (consent-gated, can fail
+// mid-wizard), we write a reviewable shell script the user runs once. A script
+// the user runs themselves can safely bootstrap brew + run brew/curl/sudo.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use crate::setup::catalog::{Detect, Install, Tier, catalog};
+use crate::setup::detect::{Env, detect_dep};
+
+/// The AI agent the generated script targets — decides which CLI + statusline +
+/// hooks get wired (the shared deps are the same for all).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Agent {
+    Claude,
+    Codex,
+    Copilot,
+}
+
+impl Agent {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Agent::Claude => "claude",
+            Agent::Codex => "codex",
+            Agent::Copilot => "copilot",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Agent::Claude => "Claude Code",
+            Agent::Codex => "Codex",
+            Agent::Copilot => "GitHub Copilot",
+        }
+    }
+
+    /// Parse from a CLI flag value.
+    pub fn parse(s: &str) -> Option<Agent> {
+        match s.trim().to_lowercase().as_str() {
+            "claude" | "c" | "claude-code" | "claudecode" => Some(Agent::Claude),
+            "codex" | "x" => Some(Agent::Codex),
+            "copilot" | "p" | "gh-copilot" => Some(Agent::Copilot),
+            _ => None,
+        }
+    }
+
+    /// The catalog dep id of this agent's CLI.
+    fn cli_id(self) -> &'static str {
+        match self {
+            Agent::Claude => "claude",
+            Agent::Codex => "codex",
+            Agent::Copilot => "copilot",
+        }
+    }
+
+    /// This agent's statusline dep id, if it has one.
+    fn statusline_id(self) -> Option<&'static str> {
+        match self {
+            Agent::Claude => Some("claudecode-statusline"),
+            Agent::Codex => Some("codex-statusline"),
+            Agent::Copilot => None,
+        }
+    }
+}
+
+/// All AI-CLI dep ids — used to keep only the chosen agent's CLI in the script.
+const AI_CLI_IDS: &[&str] = &["claude", "codex", "gemini", "copilot"];
+/// All statusline dep ids — keep only the chosen agent's.
+const STATUSLINE_IDS: &[&str] = &["claudecode-statusline", "codex-statusline"];
+
+/// The binary to guard an install on (`command -v <bin> || install`), if any.
+fn probe_bin(detect: &Detect) -> Option<&'static str> {
+    match detect {
+        Detect::Bin(n) => Some(n),
+        Detect::BinAlt { primary, .. } => Some(primary),
+        Detect::MinVersion { bin, .. } => Some(bin),
+        Detect::CommandOk { cmd, .. } => Some(cmd),
+        Detect::Custom("reflect-kb") => Some("reflect"),
+        Detect::Custom("brew") => Some("brew"),
+        Detect::Custom("ainb-self") => Some("ainb"),
+        Detect::Custom("rtk-wired") => Some("rtk"),
+        Detect::Custom(_) => None,
+    }
+}
+
+/// The runnable install command for a dep, or `None` if it's manual/bundled/
+/// multi-step (emitted as a comment instead). `ainb-hooks` is rewritten to the
+/// chosen agent's notifyd target.
+fn install_cmd(id: &str, install: &Install, agent: Agent) -> Option<String> {
+    if id == "ainb-hooks" {
+        return Some(format!("ainb notifyd install --{}", agent.slug()));
+    }
+    match install {
+        Install::Brew(_)
+        | Install::Npm(_)
+        | Install::Uv(_)
+        | Install::Cargo(_)
+        | Install::Curl(_)
+        | Install::Ainb(_)
+        | Install::ClaudePlugin(_) => Some(install.hint()),
+        // Multi-step / no automatic installer — comment only.
+        Install::Toolkit | Install::Manual(_) | Install::BundledWith(_) => None,
+    }
+}
+
+/// Whether a dep should appear, and whether ACTIVE (uncommented) or commented.
+enum Inclusion {
+    /// Active install line.
+    Active,
+    /// Commented-out (optional/suggested — uncomment to install).
+    Commented,
+    /// Skip entirely (other agents' CLI/statusline, or satisfied).
+    Skip,
+}
+
+fn classify(id: &str, tier: Tier, agent: Agent) -> Inclusion {
+    // Keep only the chosen agent's CLI; drop the others.
+    if AI_CLI_IDS.contains(&id) {
+        return if id == agent.cli_id() {
+            Inclusion::Active
+        } else {
+            Inclusion::Skip
+        };
+    }
+    // Keep only the chosen agent's statusline.
+    if STATUSLINE_IDS.contains(&id) {
+        return if Some(id) == agent.statusline_id() {
+            Inclusion::Active
+        } else {
+            Inclusion::Skip
+        };
+    }
+    // reflect's Claude Code plugin only applies to Claude.
+    if id == "reflect-plugin" && agent != Agent::Claude {
+        return Inclusion::Skip;
+    }
+    match tier {
+        Tier::Required | Tier::Recommended => Inclusion::Active,
+        Tier::Optional | Tier::Suggested => Inclusion::Commented,
+    }
+}
+
+/// Build the install script for `agent`, including only deps unsatisfied on the
+/// host (`env`). Pure (no IO) so it's unit-testable.
+pub fn build_script(agent: Agent, env: &dyn Env) -> String {
+    let mut required = String::new();
+    let mut optional = String::new();
+    let mut brew_missing = false;
+
+    for topic in catalog() {
+        let mut topic_header_written = (false, false); // (required, optional)
+        for dep in &topic.deps {
+            if !dep.applies_here() {
+                continue;
+            }
+            // Only install what's missing.
+            if detect_dep(dep, env).satisfied() {
+                continue;
+            }
+            // brew is bootstrapped specially at the top.
+            if dep.id == "brew" {
+                brew_missing = true;
+                continue;
+            }
+            match classify(dep.id, dep.tier, agent) {
+                Inclusion::Skip => continue,
+                Inclusion::Active => {
+                    let (buf, flag) = (&mut required, &mut topic_header_written.0);
+                    if !*flag {
+                        buf.push_str(&format!("\n# --- {} ---\n", topic.label));
+                        *flag = true;
+                    }
+                    buf.push_str(&dep_line(dep, agent, false));
+                }
+                Inclusion::Commented => {
+                    let (buf, flag) = (&mut optional, &mut topic_header_written.1);
+                    if !*flag {
+                        buf.push_str(&format!("\n# --- {} (optional) ---\n", topic.label));
+                        *flag = true;
+                    }
+                    buf.push_str(&dep_line(dep, agent, true));
+                }
+            }
+        }
+    }
+
+    let mut s = String::new();
+    s.push_str("#!/usr/bin/env bash\n");
+    s.push_str(&format!(
+        "# ainb installer for {} — generated by `ainb`.\n",
+        agent.label()
+    ));
+    s.push_str("# Idempotent: safe to re-run. Installs what ainb needs that's missing.\n");
+    s.push_str("set -euo pipefail\n\n");
+
+    // Homebrew bootstrap — most install lines below use brew.
+    s.push_str("# --- Homebrew (bootstrap if missing) ---\n");
+    if brew_missing {
+        s.push_str("if ! command -v brew >/dev/null 2>&1; then\n");
+        s.push_str("  /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n");
+        s.push_str("fi\n");
+    } else {
+        s.push_str("# brew already installed.\n");
+    }
+    // Load brew into this script's environment regardless (covers a fresh install
+    // and shells that haven't sourced shellenv yet).
+    s.push_str("for p in /opt/homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/brew /usr/local/bin/brew; do\n");
+    s.push_str("  [ -x \"$p\" ] && eval \"$(\"$p\" shellenv)\" && break\n");
+    s.push_str("done\n");
+
+    if required.is_empty() {
+        s.push_str("\n# Nothing required/recommended is missing — you're set.\n");
+    } else {
+        s.push_str(&required);
+    }
+
+    if !optional.is_empty() {
+        s.push_str("\n# ===== Optional / suggested — uncomment to install =====\n");
+        s.push_str(&optional);
+    }
+
+    s.push_str("\necho \"\u{2713} ainb installer finished. Run 'ainb init --check' to verify.\"\n");
+    s
+}
+
+/// One script line for a dep — guarded `command -v` when a probe binary exists,
+/// the raw idempotent installer otherwise, or a `#` comment for manual deps.
+fn dep_line(dep: &crate::setup::catalog::Dep, agent: Agent, commented: bool) -> String {
+    let prefix = if commented { "# " } else { "" };
+    match install_cmd(dep.id, &dep.install, agent) {
+        Some(cmd) => match probe_bin(&dep.detect) {
+            Some(bin) => format!(
+                "{prefix}command -v {bin} >/dev/null 2>&1 || {cmd}   # {}\n",
+                dep.why
+            ),
+            // No simple binary to guard on (ainb subcommands, plugins) — the
+            // installer is itself idempotent.
+            None => format!("{prefix}{cmd}   # {}\n", dep.why),
+        },
+        // Manual / multi-step — always a comment with the hint.
+        None => format!("# {} — {}: {}\n", dep.name, dep.why, dep.install.hint()),
+    }
+}
+
+/// Generate the script for `agent` and write it to
+/// `~/.agents-in-a-box/installer/install-<agent>.sh` (executable). Returns the path.
+pub fn generate(agent: Agent, env: &dyn Env) -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let dir = home.join(".agents-in-a-box/installer");
+    fs::create_dir_all(&dir).with_context(|| format!("Failed to create {}", dir.display()))?;
+    let path = dir.join(format!("install-{}.sh", agent.slug()));
+    fs::write(&path, build_script(agent, env))
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms)?;
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockEnv {
+        present: Vec<&'static str>,
+    }
+    impl Env for MockEnv {
+        fn which(&self, name: &str) -> bool {
+            self.present.contains(&name)
+        }
+        fn run(&self, _cmd: &str, _args: &[&str]) -> Option<String> {
+            None
+        }
+    }
+
+    #[test]
+    fn agent_parse() {
+        assert_eq!(Agent::parse("claude"), Some(Agent::Claude));
+        assert_eq!(Agent::parse("x"), Some(Agent::Codex));
+        assert_eq!(Agent::parse("copilot"), Some(Agent::Copilot));
+        assert_eq!(Agent::parse("nope"), None);
+    }
+
+    #[test]
+    fn empty_host_script_installs_required_guarded_and_picks_agent_cli() {
+        // NOTE: brew/notifyd/statusline are Custom probes against the real FS,
+        // so MockEnv can't force them missing — assert only on mock-controlled
+        // (Bin/CommandOk) deps here.
+        let env = MockEnv { present: vec![] };
+        let s = build_script(Agent::Claude, &env);
+        assert!(s.starts_with("#!/usr/bin/env bash"));
+        assert!(s.contains("# --- Homebrew (bootstrap if missing) ---"));
+        // required deps present + guarded
+        assert!(s.contains("command -v git >/dev/null 2>&1 || brew install git"));
+        assert!(s.contains("command -v tmux >/dev/null 2>&1 || brew install tmux"));
+        // chosen agent's CLI in, others out
+        assert!(s.contains("@anthropic-ai/claude-code"));
+        assert!(!s.contains("@openai/codex"));
+        assert!(!s.contains("@google/gemini-cli"));
+    }
+
+    #[test]
+    fn codex_script_picks_codex_cli_not_claude() {
+        let env = MockEnv { present: vec![] };
+        let s = build_script(Agent::Codex, &env);
+        assert!(s.contains("@openai/codex"));
+        assert!(!s.contains("@anthropic-ai/claude-code"));
+        // reflect Claude plugin is excluded for non-Claude agents (deterministic,
+        // independent of host state).
+        assert!(!s.contains("claude plugin install reflect@agents-in-a-box"));
+    }
+
+    #[test]
+    fn satisfied_deps_are_skipped_and_brew_not_bootstrapped() {
+        // Everything the script would install is already present.
+        let env = MockEnv {
+            present: vec![
+                "brew",
+                "git",
+                "tmux",
+                "jq",
+                "bash",
+                "timeout",
+                "gtimeout",
+                "node",
+                "npm",
+                "gh",
+                "ainb",
+                "uv",
+                "reflect",
+                "claude",
+                "rtk",
+                "headroom",
+                "witr",
+                "abtop",
+                "alloy",
+                "ccusage",
+                "docker",
+                "colima",
+                "reattach-to-user-namespace",
+                "bd",
+                "gemini",
+                "codex",
+                "copilot",
+            ],
+        };
+        let s = build_script(Agent::Claude, &env);
+        assert!(s.contains("brew already installed."));
+        assert!(!s.contains("brew install git"));
+    }
+
+    #[test]
+    fn optional_deps_are_commented_not_active() {
+        let env = MockEnv { present: vec![] };
+        let s = build_script(Agent::Claude, &env);
+        // headroom is optional -> commented
+        let line = s.lines().find(|l| l.contains("headroom")).unwrap_or("");
+        assert!(
+            line.trim_start().starts_with('#'),
+            "optional dep should be commented: {line}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/setup/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/mod.rs
@@ -5,12 +5,14 @@
 
 pub mod catalog;
 pub mod detect;
+pub mod installer;
 pub mod provision;
 
 pub use catalog::{Consumer, Dep, Detect, Install, Platform, Tier, Topic, catalog};
 pub use detect::{
     DepReport, DepState, Env, RealEnv, SetupStatus, TopicReport, detect_all, detect_dep,
 };
+pub use installer::{Agent, build_script, generate as generate_install_script};
 pub use provision::{
     ConsentLevel, ProvisionMode, ProvisionOutcome, install_tmux_config, provision,
 };

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -639,6 +639,8 @@ Options:
       --reset            Factory reset: remove ~/.agents-in-a-box entirely
   -f, --force            Skip interactive confirmation (required for non-interactive --reset)
   -y, --yes              Auto-install missing dependencies ainb can install safely (npm/uv/cargo/ ainb/claude-plugin). brew/curl still need explicit per-item consent
+      --script           Generate an idempotent install script for what's missing (writes ~/.agents-in-a-box/installer/install-<agent>.sh) instead of installing
+      --agent <AGENT>    Target agent for --script: claude | codex | copilot (default: claude)
   -h, --help             Print help
 
 EXAMPLES:


### PR DESCRIPTION
Adds the "generate an installer for everything missing" button you asked for. Instead of installing inline (consent-gated, can fail mid-wizard), it writes a single idempotent, reviewable shell script from the catalog and tells you to run it.

## What
`setup::installer` builds an agent-specific script:
- brew bootstrap if missing, then every **missing required+recommended** dep, guarded `command -v X || <install>`
- the **chosen agent**'s CLI + statusline + hooks wired (codex → `notifyd install --codex`, codex statusline; claude → reflect plugin; etc)
- optional/suggested emitted **commented-out** to uncomment
- written to `~/.agents-in-a-box/installer/install-<agent>.sh` (executable)

## Three surfaces
- **TUI**: `G` on the dependency step → agent picker (`[c]/[x]/[p]`, Esc) → writes the script → green "✓ Wrote … run: bash …" footer.
- **CLI**: `ainb init --script [--agent claude|codex|copilot]`.
- **doctor**: `ainb doctor` points at `ainb init --check` + `--script`.

## Tests
5 installer unit tests (agent filtering, guards, skip-satisfied) + 9 init + 13 onboarding + tripwire green; verified the G flow in tmux (picker → c → script written). fmt clean.

https://claude.ai/code/session_012BMaP4fZ8ff8idHMJgXcVh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided onboarding path for generating installer scripts for supported AI agents.
  - `ainb init` now supports a script-generation mode and can show the script location plus a ready-to-run command.
  - Onboarding help text now includes clearer options for re-checking dependencies, installing config, and generating install scripts.

- **Bug Fixes**
  - Improved onboarding state handling so script-selection prompts close correctly when moving between steps.
  - Dependency checks now provide clearer next-step guidance before finishing or reporting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->