### PR TITLE
onboarding: auto-copy the generated installer command (OSC 52)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -6388,12 +6388,18 @@ impl EventHandler {
                 match generate_install_script(agent, &RealEnv) {
                     Ok(path) => {
                         tracing::info!("Generated installer at {}", path.display());
+                        // Auto-copy the run command to the clipboard (OSC 52) —
+                        // you can't mouse-select in the TUI. Best-effort.
+                        let run_cmd = format!("bash {}", path.display());
+                        let copied = crate::clipboard::copy_osc52(&run_cmd).is_ok();
                         if let Some(os) = &mut state.onboarding_state {
                             os.error_message = None;
+                            let suffix = if copied { " (copied to clipboard)" } else { "" };
                             os.status_message = Some(format!(
-                                "✓ Wrote {} installer — run:  bash {}",
+                                "✓ Wrote {} installer{} — run:  {}",
                                 agent.label(),
-                                path.display()
+                                suffix,
+                                run_cmd
                             ));
                         }
                     }

--- a/ainb-tui/crates/ainb-core/src/clipboard.rs
+++ b/ainb-tui/crates/ainb-core/src/clipboard.rs
@@ -1,0 +1,66 @@
+// ABOUTME: Copy text to the terminal clipboard via the OSC 52 escape sequence.
+// OSC 52 is handled by the terminal emulator itself, so it reaches the USER's
+// machine through tmux (set-clipboard on), zellij, and ssh — unlike pbcopy /
+// xclip / wl-copy, which would target the remote host. Best-effort: returns Err
+// only on a stdout write failure; a terminal that ignores OSC 52 is a silent
+// no-op (the text is still shown on screen).
+
+use std::io::Write;
+
+/// Copy `text` to the terminal clipboard via OSC 52.
+pub fn copy_osc52(text: &str) -> std::io::Result<()> {
+    let seq = format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()));
+    let mut out = std::io::stdout();
+    out.write_all(seq.as_bytes())?;
+    out.flush()
+}
+
+/// Standard base64 (no line breaks). Inlined to avoid a crate dependency for the
+/// handful of bytes a clipboard payload needs.
+fn base64_encode(input: &[u8]) -> String {
+    const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(T[((n >> 18) & 63) as usize] as char);
+        out.push(T[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            T[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            T[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_matches_known_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn base64_path_roundtrips_shape() {
+        // A realistic path encodes without padding errors / panics.
+        let s = base64_encode(b"/home/claude/.agents-in-a-box/installer/install-claude.sh");
+        assert!(!s.contains(' '));
+        assert_eq!(s.len() % 4, 0);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/clipboard.rs
+++ b/ainb-tui/crates/ainb-core/src/clipboard.rs
@@ -9,10 +9,14 @@ use std::io::Write;
 
 /// Copy `text` to the terminal clipboard via OSC 52.
 pub fn copy_osc52(text: &str) -> std::io::Result<()> {
-    let seq = format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()));
     let mut out = std::io::stdout();
-    out.write_all(seq.as_bytes())?;
+    out.write_all(osc52_sequence(text).as_bytes())?;
     out.flush()
+}
+
+/// The OSC 52 "set clipboard" escape for `text` (pure — testable without a tty).
+fn osc52_sequence(text: &str) -> String {
+    format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()))
 }
 
 /// Standard base64 (no line breaks). Inlined to avoid a crate dependency for the
@@ -54,6 +58,11 @@ mod tests {
         assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
         assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
         assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn osc52_sequence_wraps_base64_in_escape() {
+        assert_eq!(osc52_sequence("foo"), "\x1b]52;c;Zm9v\x07");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod app;
 pub mod audit;
 pub mod claude;
 pub mod cli;
+pub mod clipboard;
 pub mod components;
 pub mod config;
 pub mod credentials;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -34,6 +34,7 @@ mod app;
 mod audit;
 mod claude;
 mod cli;
+mod clipboard;
 mod components;
 mod config;
 mod credentials;


### PR DESCRIPTION
Follow-up to the G installer button: after generating, the run command (`bash <path>`) is copied to the terminal clipboard via OSC 52 — works through tmux/zellij/ssh (you can't mouse-select in the TUI). Footer shows '(copied to clipboard)'; best-effort no-op if the terminal ignores OSC 52. New crate::clipboard (inlined base64, no new dep), 2 unit tests; verified in tmux.

https://claude.ai/code/session_012BMaP4fZ8ff8idHMJgXcVh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now shows the full command to run the generated installer.
  * The command is automatically copied to the clipboard when possible, with a clear confirmation message.

* **Bug Fixes**
  * Improved the onboarding flow so the next step is easier to complete by reducing manual copy/paste.

* **Tests**
  * Added coverage for clipboard text encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->