### PR TITLE
fix(notifyd): orphan daemon view + spawn hardening

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -997,6 +997,8 @@ pub struct DaemonsFetchResult {
     pub mcp_alive: bool,
     pub headroom: crate::headroom::ProxyStatus,
     pub headroom_consumers: Vec<String>,
+    /// Every running `notifyd` process, classified live / stale / orphan.
+    pub notifyd: Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
 }
 
 /// Live, lazily-refreshed snapshot for the Daemons overlay. Present only while
@@ -1006,15 +1008,22 @@ pub struct DaemonsOverlayState {
     pub mcp_alive: bool,
     pub headroom: crate::headroom::ProxyStatus,
     pub headroom_consumers: Vec<String>,
+    /// Every running `notifyd` process, classified live / stale / orphan.
+    pub notifyd: Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
     pub loading: bool,
     pub last_refreshed: Option<std::time::Instant>,
     /// Receiver for the in-flight fetch (None = no fetch pending).
     pub fetch_rx: Option<mpsc::UnboundedReceiver<DaemonsFetchResult>>,
 }
 
-/// Blocking portion of the daemons fetch: MCP alive probe + SessionStore read.
-/// These are sync calls so they run on the blocking thread pool.
-pub(crate) fn daemons_sync_probe() -> (bool, Vec<String>) {
+/// Blocking portion of the daemons fetch: MCP alive probe + SessionStore read
+/// + notifyd process scan. These are sync calls (the notifyd scan shells out
+/// to `ps`) so they run on the blocking thread pool.
+pub(crate) fn daemons_sync_probe() -> (
+    bool,
+    Vec<String>,
+    Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
+) {
     let mcp_alive = crate::mcp_pool::client::daemon_alive();
     let headroom_consumers = crate::interactive::SessionStore::load()
         .sessions
@@ -1022,7 +1031,8 @@ pub(crate) fn daemons_sync_probe() -> (bool, Vec<String>) {
         .filter(|m| m.headroom_enabled)
         .map(|m| m.tmux_session_name.clone())
         .collect::<Vec<_>>();
-    (mcp_alive, headroom_consumers)
+    let notifyd = ainb_plugin_notifyd::scan_daemons();
+    (mcp_alive, headroom_consumers, notifyd)
 }
 
 // ============================================================================
@@ -4909,6 +4919,7 @@ impl AppState {
                 tokens_saved: None,
             },
             headroom_consumers: Vec::new(),
+            notifyd: Vec::new(),
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
@@ -4934,16 +4945,20 @@ impl AppState {
         o.fetch_rx = Some(rx);
         o.loading = true;
         tokio::spawn(async move {
-            // Blocking I/O (control socket + file read) on the blocking pool.
-            let (mcp_alive, headroom_consumers) = tokio::task::spawn_blocking(daemons_sync_probe)
-                .await
-                .unwrap_or((false, Vec::new()));
+            // Blocking I/O (control socket + file read + `ps` scan) on the
+            // blocking pool.
+            let (mcp_alive, headroom_consumers, notifyd) = tokio::task::spawn_blocking(
+                daemons_sync_probe,
+            )
+            .await
+            .unwrap_or((false, Vec::new(), Vec::new()));
             // Async HTTP probe of the Headroom /health + /stats endpoints.
             let headroom = crate::headroom::status().await;
             let result = DaemonsFetchResult {
                 mcp_alive,
                 headroom,
                 headroom_consumers,
+                notifyd,
             };
             let _ = tx.send(result);
         });
@@ -4961,6 +4976,7 @@ impl AppState {
                 o.mcp_alive = result.mcp_alive;
                 o.headroom = result.headroom;
                 o.headroom_consumers = result.headroom_consumers;
+                o.notifyd = result.notifyd;
                 o.last_refreshed = Some(std::time::Instant::now());
             }
         }

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -184,15 +184,26 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
 /// This is the only daemon surface that enumerates *every* process rather
 /// than a single pid — orphans are invisible to a pid-file-only view.
 fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
-    use ainb_plugin_notifyd::DaemonClass;
+    let lines = build_notifyd_lines(&state.notifyd, area.height as usize);
+    frame.render_widget(Paragraph::new(lines), area);
+}
 
-    let orphan_count = state.notifyd.iter().filter(|d| d.class != DaemonClass::LiveOwner).count();
+/// Build the notifyd section's lines, bounded to `capacity` rows. The
+/// `Paragraph` doesn't scroll, so without a cap a host with many orphans
+/// (the very case this surface exists for) would have rows silently clipped
+/// — and the user would think they'd seen them all. When the list overflows,
+/// the last visible row becomes a "… +N more" pointer instead.
+fn build_notifyd_lines(
+    notifyd: &[ainb_plugin_notifyd::ClassifiedDaemon],
+    capacity: usize,
+) -> Vec<Line<'static>> {
+    let orphan_count = notifyd.iter().filter(|d| !d.class.is_healthy()).count();
 
-    let mut lines: Vec<Line> = Vec::new();
+    let mut lines: Vec<Line<'static>> = Vec::new();
 
-    // Header: "notifyd processes (N)  · M need attention".
+    // Header: "notifyd processes (N)  · M to clean up".
     let mut header = vec![Span::styled(
-        format!("  notifyd processes ({})", state.notifyd.len()),
+        format!("  notifyd processes ({})", notifyd.len()),
         Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
     )];
     if orphan_count > 0 {
@@ -203,44 +214,63 @@ fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayS
     }
     lines.push(Line::from(header));
 
-    if state.notifyd.is_empty() {
+    if notifyd.is_empty() {
         lines.push(Line::from(Span::styled(
             "    none running — a hook event will lazy-spawn one",
             Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
         )));
-    } else {
-        for d in &state.notifyd {
-            let (glyph, color) = match d.class {
-                DaemonClass::LiveOwner => ("●", SELECTION_GREEN),
-                DaemonClass::StaleOwner | DaemonClass::Orphan => ("○", CLAY),
-            };
-            let mut spans = vec![
-                Span::styled(format!("    {glyph} "), Style::default().fg(color)),
-                Span::styled(
-                    format!("{:<11}", d.class.label()),
-                    Style::default().fg(color).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!("pid {:<7}", d.proc.pid),
-                    Style::default().fg(SOFT_WHITE),
-                ),
-                Span::styled(
-                    format!("up {:<10}", d.proc.etime),
-                    Style::default().fg(MUTED_GRAY),
-                ),
-                Span::styled(d.proc.bin.clone(), Style::default().fg(MUTED_GRAY)),
-            ];
-            if d.binary_drift {
-                spans.push(Span::styled(
-                    "  ⚠ old binary",
-                    Style::default().fg(CLAY).add_modifier(Modifier::BOLD),
-                ));
-            }
-            lines.push(Line::from(spans));
-        }
+        return lines;
     }
 
-    frame.render_widget(Paragraph::new(lines), area);
+    // Header consumed one row; if the rest don't fit, reserve one row for the
+    // overflow pointer and fill the remainder with daemon rows.
+    let body_cap = capacity.saturating_sub(1);
+    let (shown, overflow) = if notifyd.len() <= body_cap {
+        (notifyd.len(), 0)
+    } else {
+        let shown = body_cap.saturating_sub(1);
+        (shown, notifyd.len() - shown)
+    };
+
+    for d in notifyd.iter().take(shown) {
+        let (glyph, color) = if d.class.is_healthy() {
+            ("●", SELECTION_GREEN)
+        } else {
+            ("○", CLAY)
+        };
+        let mut spans = vec![
+            Span::styled(format!("    {glyph} "), Style::default().fg(color)),
+            Span::styled(
+                format!("{:<11}", d.class.label()),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("pid {:<7}", d.proc.pid),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled(
+                format!("up {:<10}", d.proc.etime),
+                Style::default().fg(MUTED_GRAY),
+            ),
+            Span::styled(d.proc.bin.clone(), Style::default().fg(MUTED_GRAY)),
+        ];
+        if d.binary_drift {
+            spans.push(Span::styled(
+                "  ⚠ old binary",
+                Style::default().fg(CLAY).add_modifier(Modifier::BOLD),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    if overflow > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("    … +{overflow} more — see `ainb notifyd list`"),
+            Style::default().fg(MUTED_GRAY),
+        )));
+    }
+
+    lines
 }
 
 fn render_help_bar(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
@@ -410,6 +440,38 @@ mod tests {
         assert!(
             text.contains("to clean up"),
             "missing cleanup hint in:\n{text}"
+        );
+    }
+
+    #[test]
+    fn notifyd_lines_cap_to_capacity_with_overflow_pointer() {
+        use ainb_plugin_notifyd::{ClassifiedDaemon, DaemonClass, NotifydProc};
+        let many: Vec<ClassifiedDaemon> = (0..7)
+            .map(|i| ClassifiedDaemon {
+                proc: NotifydProc {
+                    pid: 1000 + i,
+                    bin: "/x/ainb".to_string(),
+                    cmd: "ainb notifyd".to_string(),
+                    etime: "01:00".to_string(),
+                },
+                class: DaemonClass::Orphan,
+                binary_drift: false,
+            })
+            .collect();
+        // capacity 4 → header + 2 rows + "… +5 more"
+        let lines = build_notifyd_lines(&many, 4);
+        assert!(lines.len() <= 4, "exceeded capacity: {}", lines.len());
+        let last: String = lines.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();
+        assert!(last.contains("more"), "no overflow pointer in: {last}");
+
+        // Ample capacity → all 7 rows, no overflow line.
+        let full = build_notifyd_lines(&many, 30);
+        assert_eq!(full.len(), 8); // header + 7
+        let full_last: String =
+            full.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();
+        assert!(
+            !full_last.contains("more"),
+            "unexpected overflow: {full_last}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -47,7 +47,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
 
     let block = Block::default()
         .title(Span::styled(
-            " ⚙ Daemons — MCP pool · Headroom proxy ",
+            " ⚙ Daemons — MCP pool · Headroom proxy · notifyd ",
             Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
@@ -93,7 +93,7 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
         return;
     }
 
-    // Two rows: MCP, Headroom.
+    // Rows: MCP, Headroom, Headroom consumers, then the notifyd section.
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -102,7 +102,8 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
             Constraint::Length(2), // Headroom row
             Constraint::Length(1), // spacer
             Constraint::Length(2), // Headroom consumers
-            Constraint::Min(0),    // rest
+            Constraint::Length(1), // spacer
+            Constraint::Min(3),    // notifyd section
         ])
         .split(area);
 
@@ -173,6 +174,73 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
         ))),
         rows[4],
     );
+
+    // ── notifyd processes ───────────────────────────────────────────────────────
+    render_notifyd_section(frame, rows[6], state);
+}
+
+/// Render every running `notifyd` process, one line each, with its
+/// classification (live owner / stale / orphan) and a binary-drift flag.
+/// This is the only daemon surface that enumerates *every* process rather
+/// than a single pid — orphans are invisible to a pid-file-only view.
+fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
+    use ainb_plugin_notifyd::DaemonClass;
+
+    let orphan_count = state.notifyd.iter().filter(|d| d.class != DaemonClass::LiveOwner).count();
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Header: "notifyd processes (N)  · M need attention".
+    let mut header = vec![Span::styled(
+        format!("  notifyd processes ({})", state.notifyd.len()),
+        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+    )];
+    if orphan_count > 0 {
+        header.push(Span::styled(
+            format!("   · {orphan_count} to clean up (kill <pid>)"),
+            Style::default().fg(CLAY),
+        ));
+    }
+    lines.push(Line::from(header));
+
+    if state.notifyd.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "    none running — a hook event will lazy-spawn one",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        )));
+    } else {
+        for d in &state.notifyd {
+            let (glyph, color) = match d.class {
+                DaemonClass::LiveOwner => ("●", SELECTION_GREEN),
+                DaemonClass::StaleOwner | DaemonClass::Orphan => ("○", CLAY),
+            };
+            let mut spans = vec![
+                Span::styled(format!("    {glyph} "), Style::default().fg(color)),
+                Span::styled(
+                    format!("{:<11}", d.class.label()),
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("pid {:<7}", d.proc.pid),
+                    Style::default().fg(SOFT_WHITE),
+                ),
+                Span::styled(
+                    format!("up {:<10}", d.proc.etime),
+                    Style::default().fg(MUTED_GRAY),
+                ),
+                Span::styled(d.proc.bin.clone(), Style::default().fg(MUTED_GRAY)),
+            ];
+            if d.binary_drift {
+                spans.push(Span::styled(
+                    "  ⚠ old binary",
+                    Style::default().fg(CLAY).add_modifier(Modifier::BOLD),
+                ));
+            }
+            lines.push(Line::from(spans));
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
 }
 
 fn render_help_bar(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
@@ -218,6 +286,7 @@ mod tests {
                 tokens_saved: tokens,
             },
             headroom_consumers: vec!["agents/worktree-abc".to_string()],
+            notifyd: Vec::new(),
             loading: false,
             last_refreshed: Some(std::time::Instant::now()),
             fetch_rx: None,
@@ -277,6 +346,7 @@ mod tests {
                 tokens_saved: None,
             },
             headroom_consumers: Vec::new(),
+            notifyd: Vec::new(),
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
@@ -290,6 +360,57 @@ mod tests {
         .unwrap();
         let text = buffer_text(&term);
         assert!(text.contains("Loading"), "missing 'Loading' in:\n{text}");
+    }
+
+    #[test]
+    fn daemons_overlay_flags_notifyd_orphans() {
+        use ainb_plugin_notifyd::{ClassifiedDaemon, DaemonClass, NotifydProc};
+        let mut state = make_state(true, 8787, Some(1), Some(0));
+        state.notifyd = vec![
+            ClassifiedDaemon {
+                proc: NotifydProc {
+                    pid: 10244,
+                    bin: "/opt/homebrew/Cellar/ainb/1.9.4/libexec/ainb".to_string(),
+                    cmd: "ainb notifyd run".to_string(),
+                    etime: "01:23".to_string(),
+                },
+                class: DaemonClass::LiveOwner,
+                binary_drift: false,
+            },
+            ClassifiedDaemon {
+                proc: NotifydProc {
+                    pid: 41530,
+                    bin: "/opt/homebrew/Cellar/ainb/1.7.4/libexec/ainb".to_string(),
+                    cmd: "ainb notifyd".to_string(),
+                    etime: "06-04:04:24".to_string(),
+                },
+                class: DaemonClass::Orphan,
+                binary_drift: true,
+            },
+        ];
+        let backend = TestBackend::new(120, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.size();
+            render(f, area, &state);
+        })
+        .unwrap();
+        let text = buffer_text(&term);
+        assert!(
+            text.contains("notifyd processes (2)"),
+            "missing header in:\n{text}"
+        );
+        assert!(
+            text.contains("LIVE owner"),
+            "missing live label in:\n{text}"
+        );
+        assert!(text.contains("ORPHAN"), "missing orphan label in:\n{text}");
+        assert!(text.contains("10244"), "missing live pid in:\n{text}");
+        assert!(text.contains("41530"), "missing orphan pid in:\n{text}");
+        assert!(
+            text.contains("to clean up"),
+            "missing cleanup hint in:\n{text}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/sidebar.rs
+++ b/ainb-tui/crates/ainb-core/src/components/sidebar.rs
@@ -110,7 +110,7 @@ impl SidebarItem {
             Self::Inbox => "Hook Notifications",
             Self::Recovery => "Resume Orphaned",
             Self::Mcp => "Shared Pool",
-            Self::Daemons => "MCP + Headroom",
+            Self::Daemons => "MCP · Headroom · notifyd",
             Self::Logs => "View Log History",
             Self::Stats => "Usage & Analytics",
             Self::Witr => "Process Causality",

--- a/ainb-tui/crates/ainb-core/src/components/sidebar.rs
+++ b/ainb-tui/crates/ainb-core/src/components/sidebar.rs
@@ -676,7 +676,10 @@ mod tests {
         assert_eq!(SidebarItem::Daemons.icon(), "⚙");
         assert_eq!(SidebarItem::Daemons.label(), "Daemons");
         assert_eq!(SidebarItem::Daemons.shortcut(), "d");
-        assert_eq!(SidebarItem::Daemons.description(), "MCP + Headroom");
+        assert_eq!(
+            SidebarItem::Daemons.description(),
+            "MCP · Headroom · notifyd"
+        );
         // 'd' must not collide with any other sidebar shortcut.
         let collisions = all
             .iter()

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -46,7 +46,5 @@ pub use listener::{RunConfig, run_daemon};
 pub use osnotify::{AlertKind, classify_attention};
 pub use paths::Paths;
 pub use pid::PidFile;
-pub use procs::{
-    ClassifiedDaemon, DaemonClass, NotifydProc, classify as classify_daemons, scan as scan_daemons,
-};
+pub use procs::{ClassifiedDaemon, DaemonClass, NotifydProc, scan as scan_daemons};
 pub use store::{NotificationRecord, RetentionPolicy, Store, StoreError};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -30,6 +30,7 @@ pub mod install;
 pub mod osnotify;
 pub mod paths;
 pub mod pid;
+pub mod procs;
 pub mod store;
 
 mod listener;
@@ -45,4 +46,7 @@ pub use listener::{RunConfig, run_daemon};
 pub use osnotify::{AlertKind, classify_attention};
 pub use paths::Paths;
 pub use pid::PidFile;
+pub use procs::{
+    ClassifiedDaemon, DaemonClass, NotifydProc, classify as classify_daemons, scan as scan_daemons,
+};
 pub use store::{NotificationRecord, RetentionPolicy, Store, StoreError};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
@@ -78,7 +78,7 @@ pub struct ClassifiedDaemon {
 
 /// Enumerate every running notifyd-family process. Returns an empty vec
 /// if `ps` is unavailable or fails — discovery is best-effort.
-pub fn enumerate() -> Vec<NotifydProc> {
+pub(crate) fn enumerate() -> Vec<NotifydProc> {
     let output = match Command::new("ps").args(["-axo", "pid=,etime=,args="]).output() {
         Ok(o) if o.status.success() => o.stdout,
         _ => return Vec::new(),
@@ -112,22 +112,38 @@ fn parse_ps_line(line: &str) -> Option<NotifydProc> {
     })
 }
 
-/// Does this process look like a notifyd? Matches either `ainb notifyd …`
-/// (the subcommand form the hook lazy-spawns) or the slim `ainb-notifyd`
-/// binary. The `ainb` TUI itself never carries a `notifyd` token, so it is
-/// not matched.
+/// Does this process look like a *daemon* notifyd? Matches the long-running
+/// forms — `ainb notifyd` / `ainb notifyd run`, or the slim `ainb-notifyd`
+/// (`run`) binary — but NOT the transient CLI subcommands (`status`, `stop`,
+/// `install`, `uninstall`, `list`): those are short-lived invocations, and
+/// labelling one ORPHAN with a "kill it" hint would be actively wrong. The
+/// `ainb` TUI itself never carries a `notifyd` token, so it is not matched.
 fn is_notifyd(p: &NotifydProc) -> bool {
     let base = p.bin.rsplit('/').next().unwrap_or(&p.bin);
-    (base == "ainb" && p.cmd.split_whitespace().any(|t| t == "notifyd")) || base == "ainb-notifyd"
+    let toks: Vec<&str> = p.cmd.split_whitespace().collect();
+    // The subcommand token that selects daemon mode, if any.
+    let sub = match base {
+        "ainb" => match toks.iter().position(|t| *t == "notifyd") {
+            Some(i) => toks.get(i + 1).copied(),
+            None => return false,
+        },
+        "ainb-notifyd" => toks.get(1).copied(),
+        _ => return false,
+    };
+    // Daemon mode is the bare command or an explicit `run`.
+    matches!(sub, None | Some("run"))
 }
 
 /// Classify each discovered process against the canonical owner pid +
-/// socket presence + the currently-running binary. Pure — the testable
-/// core.
-pub fn classify(
+/// whether the socket is actually accepting + the currently-running binary.
+/// Pure — the testable core. `socket_accepting` must reflect a real connect
+/// probe, not mere file presence: a wedged owner that left a stale socket
+/// file behind is the failure this surface exists to show, so it must land
+/// as `StaleOwner`, not `LiveOwner`.
+pub(crate) fn classify(
     procs: Vec<NotifydProc>,
     owner_pid: Option<u32>,
-    socket_present: bool,
+    socket_accepting: bool,
     current_bin: Option<&str>,
 ) -> Vec<ClassifiedDaemon> {
     procs
@@ -135,7 +151,7 @@ pub fn classify(
         .map(|p| {
             let class = match owner_pid {
                 Some(owner) if owner == p.pid => {
-                    if socket_present {
+                    if socket_accepting {
                         DaemonClass::LiveOwner
                     } else {
                         DaemonClass::StaleOwner
@@ -165,20 +181,28 @@ fn same_binary(a: &str, b: &str) -> bool {
     }
 }
 
+/// True when a daemon is actually accepting on the unix socket. A bare
+/// socket *file* left by a crashed daemon connects with `ECONNREFUSED`, so
+/// this correctly returns false for a wedged owner — unlike `Path::exists`.
+/// The throwaway connection sends nothing; the daemon reads EOF and skips
+/// it, same as the hook script's `nc` probe.
+fn socket_accepting(path: &std::path::Path) -> bool {
+    std::os::unix::net::UnixStream::connect(path).is_ok()
+}
+
 /// One-shot scan: enumerate notifyd processes and classify them against
-/// the on-disk owner pid, socket, and this process's own binary. Used by
-/// the TUI's Daemons overlay.
+/// the on-disk owner pid, the live socket, and this process's own binary.
+/// Used by the TUI's Daemons overlay.
 pub fn scan() -> Vec<ClassifiedDaemon> {
     let Ok(paths) = Paths::from_home() else {
         return Vec::new();
     };
     let owner_pid = crate::pid::read(&paths.pid).ok().flatten();
-    let socket_present = paths.socket.exists();
     let current_bin = std::env::current_exe().ok().and_then(|p| p.to_str().map(String::from));
     classify(
         enumerate(),
         owner_pid,
-        socket_present,
+        socket_accepting(&paths.socket),
         current_bin.as_deref(),
     )
 }
@@ -296,5 +320,31 @@ mod tests {
             etime: "01:00".to_string(),
         };
         assert!(is_notifyd(&p));
+    }
+
+    #[test]
+    fn is_notifyd_accepts_bare_subcommand() {
+        let p = NotifydProc {
+            pid: 1,
+            bin: "/usr/local/bin/ainb".to_string(),
+            cmd: "/usr/local/bin/ainb notifyd".to_string(),
+            etime: "01:00".to_string(),
+        };
+        assert!(is_notifyd(&p));
+    }
+
+    #[test]
+    fn is_notifyd_rejects_transient_cli_subcommands() {
+        // `ainb notifyd status|stop|install|...` are short-lived CLI calls,
+        // not daemons — labelling one ORPHAN with a kill hint would be wrong.
+        for sub in ["status", "stop", "install", "uninstall", "list"] {
+            let p = NotifydProc {
+                pid: 1,
+                bin: "/usr/local/bin/ainb".to_string(),
+                cmd: format!("/usr/local/bin/ainb notifyd {sub}"),
+                etime: "00:01".to_string(),
+            };
+            assert!(!is_notifyd(&p), "should reject `ainb notifyd {sub}`");
+        }
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
@@ -1,0 +1,300 @@
+//! Discovery + classification of running `notifyd` processes.
+//!
+//! The daemon's own [`crate::pid`] / [`crate::install::status`] surfaces
+//! only know about the single pid recorded in `notify.pid`. That is
+//! structurally blind to *orphans* — extra `ainb notifyd` processes left
+//! behind by a spawn race or a `brew upgrade` that never bound the socket.
+//! This module enumerates every notifyd-family process on the host and
+//! classifies each against the canonical owner so the TUI can show — and
+//! the user can reap — orphans.
+//!
+//! Enumeration shells out to `ps` rather than pulling in a process-table
+//! crate: it runs only on demand (when the Daemons overlay is open), the
+//! two supported targets (macOS, Linux) both ship a `ps` that accepts
+//! `-axo pid=,etime=,args=`, and the classification logic — the part worth
+//! testing — is a pure function over the parsed rows.
+
+use std::process::Command;
+
+use crate::Paths;
+
+/// One running notifyd-family process discovered on the host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotifydProc {
+    /// Process id.
+    pub pid: u32,
+    /// Resolved binary path from `argv[0]` — e.g.
+    /// `/opt/homebrew/Cellar/ainb/1.7.4/libexec/ainb`. The version often
+    /// reads straight off this path.
+    pub bin: String,
+    /// Full command line as reported by `ps`.
+    pub cmd: String,
+    /// Elapsed-time string from `ps` (`[[DD-]HH:]MM:SS`), best-effort.
+    pub etime: String,
+}
+
+/// How a discovered notifyd process relates to the canonical daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonClass {
+    /// Pid recorded in `notify.pid` *and* the socket is present — the
+    /// process actually serving notifications.
+    LiveOwner,
+    /// Pid recorded in `notify.pid` but the socket is missing — the owner
+    /// is wedged / not listening.
+    StaleOwner,
+    /// A running notifyd whose pid is **not** the recorded owner — an
+    /// orphan that should be reaped.
+    Orphan,
+}
+
+impl DaemonClass {
+    /// Short human label for the TUI.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::LiveOwner => "LIVE owner",
+            Self::StaleOwner => "STALE owner",
+            Self::Orphan => "ORPHAN",
+        }
+    }
+
+    /// Whether this class is healthy (the one we want) vs something the
+    /// user probably wants to clean up.
+    pub fn is_healthy(self) -> bool {
+        matches!(self, Self::LiveOwner)
+    }
+}
+
+/// A discovered process plus its relationship to the canonical daemon.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassifiedDaemon {
+    /// The underlying process.
+    pub proc: NotifydProc,
+    /// Live owner / stale owner / orphan.
+    pub class: DaemonClass,
+    /// True when this process's binary differs from the currently-running
+    /// `ainb` binary — i.e. a stale install lingering after an upgrade.
+    pub binary_drift: bool,
+}
+
+/// Enumerate every running notifyd-family process. Returns an empty vec
+/// if `ps` is unavailable or fails — discovery is best-effort.
+pub fn enumerate() -> Vec<NotifydProc> {
+    let output = match Command::new("ps").args(["-axo", "pid=,etime=,args="]).output() {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return Vec::new(),
+    };
+    String::from_utf8_lossy(&output)
+        .lines()
+        .filter_map(parse_ps_line)
+        .filter(is_notifyd)
+        .collect()
+}
+
+/// Parse one `pid etime args...` line from `ps`. `ps` right-justifies the
+/// pid and pads between columns, so split on whitespace runs and rejoin
+/// the command remainder (original spacing is irrelevant for matching and
+/// display).
+fn parse_ps_line(line: &str) -> Option<NotifydProc> {
+    let mut toks = line.split_whitespace();
+    let pid: u32 = toks.next()?.parse().ok()?;
+    let etime = toks.next()?.to_string();
+    let rest: Vec<&str> = toks.collect();
+    if rest.is_empty() {
+        return None;
+    }
+    let cmd = rest.join(" ");
+    let bin = rest[0].to_string();
+    Some(NotifydProc {
+        pid,
+        bin,
+        cmd,
+        etime,
+    })
+}
+
+/// Does this process look like a notifyd? Matches either `ainb notifyd …`
+/// (the subcommand form the hook lazy-spawns) or the slim `ainb-notifyd`
+/// binary. The `ainb` TUI itself never carries a `notifyd` token, so it is
+/// not matched.
+fn is_notifyd(p: &NotifydProc) -> bool {
+    let base = p.bin.rsplit('/').next().unwrap_or(&p.bin);
+    (base == "ainb" && p.cmd.split_whitespace().any(|t| t == "notifyd")) || base == "ainb-notifyd"
+}
+
+/// Classify each discovered process against the canonical owner pid +
+/// socket presence + the currently-running binary. Pure — the testable
+/// core.
+pub fn classify(
+    procs: Vec<NotifydProc>,
+    owner_pid: Option<u32>,
+    socket_present: bool,
+    current_bin: Option<&str>,
+) -> Vec<ClassifiedDaemon> {
+    procs
+        .into_iter()
+        .map(|p| {
+            let class = match owner_pid {
+                Some(owner) if owner == p.pid => {
+                    if socket_present {
+                        DaemonClass::LiveOwner
+                    } else {
+                        DaemonClass::StaleOwner
+                    }
+                }
+                _ => DaemonClass::Orphan,
+            };
+            let binary_drift = current_bin.is_some_and(|cur| !same_binary(&p.bin, cur));
+            ClassifiedDaemon {
+                proc: p,
+                class,
+                binary_drift,
+            }
+        })
+        .collect()
+}
+
+/// Compare two binary paths for identity, canonicalizing both so a
+/// symlinked install (e.g. a `~/.cargo/bin` or Homebrew shim) doesn't read
+/// as drift. A path that no longer resolves (old install removed by an
+/// upgrade) falls back to a string compare — which correctly reports
+/// drift.
+fn same_binary(a: &str, b: &str) -> bool {
+    match (std::fs::canonicalize(a).ok(), std::fs::canonicalize(b).ok()) {
+        (Some(x), Some(y)) => x == y,
+        _ => a == b,
+    }
+}
+
+/// One-shot scan: enumerate notifyd processes and classify them against
+/// the on-disk owner pid, socket, and this process's own binary. Used by
+/// the TUI's Daemons overlay.
+pub fn scan() -> Vec<ClassifiedDaemon> {
+    let Ok(paths) = Paths::from_home() else {
+        return Vec::new();
+    };
+    let owner_pid = crate::pid::read(&paths.pid).ok().flatten();
+    let socket_present = paths.socket.exists();
+    let current_bin = std::env::current_exe().ok().and_then(|p| p.to_str().map(String::from));
+    classify(
+        enumerate(),
+        owner_pid,
+        socket_present,
+        current_bin.as_deref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proc(pid: u32, bin: &str) -> NotifydProc {
+        NotifydProc {
+            pid,
+            bin: bin.to_string(),
+            cmd: format!("{bin} notifyd run"),
+            etime: "01:23".to_string(),
+        }
+    }
+
+    #[test]
+    fn owner_with_socket_is_live() {
+        let out = classify(
+            vec![proc(100, "/usr/local/bin/ainb")],
+            Some(100),
+            true,
+            None,
+        );
+        assert_eq!(out[0].class, DaemonClass::LiveOwner);
+    }
+
+    #[test]
+    fn owner_without_socket_is_stale() {
+        let out = classify(
+            vec![proc(100, "/usr/local/bin/ainb")],
+            Some(100),
+            false,
+            None,
+        );
+        assert_eq!(out[0].class, DaemonClass::StaleOwner);
+    }
+
+    #[test]
+    fn non_owner_is_orphan() {
+        let out = classify(
+            vec![proc(200, "/usr/local/bin/ainb")],
+            Some(100),
+            true,
+            None,
+        );
+        assert_eq!(out[0].class, DaemonClass::Orphan);
+    }
+
+    #[test]
+    fn no_owner_pid_makes_everything_orphan() {
+        let out = classify(
+            vec![proc(100, "/a/ainb"), proc(200, "/b/ainb")],
+            None,
+            true,
+            None,
+        );
+        assert!(out.iter().all(|d| d.class == DaemonClass::Orphan));
+    }
+
+    #[test]
+    fn binary_drift_flagged_for_nonexistent_mismatched_path() {
+        // Neither path resolves, so falls back to string compare → drift.
+        let out = classify(
+            vec![proc(100, "/opt/homebrew/Cellar/ainb/1.7.4/libexec/ainb")],
+            Some(100),
+            true,
+            Some("/opt/homebrew/Cellar/ainb/1.9.4/libexec/ainb"),
+        );
+        assert!(out[0].binary_drift);
+        assert_eq!(out[0].class, DaemonClass::LiveOwner);
+    }
+
+    #[test]
+    fn no_drift_when_paths_match() {
+        let out = classify(
+            vec![proc(100, "/same/path/ainb")],
+            Some(100),
+            true,
+            Some("/same/path/ainb"),
+        );
+        assert!(!out[0].binary_drift);
+    }
+
+    #[test]
+    fn parse_ps_line_extracts_fields() {
+        let p = parse_ps_line(
+            "  41530 06-04:04:24 /opt/homebrew/Cellar/ainb/1.7.4/libexec/ainb notifyd",
+        )
+        .unwrap();
+        assert_eq!(p.pid, 41530);
+        assert_eq!(p.etime, "06-04:04:24");
+        assert_eq!(p.bin, "/opt/homebrew/Cellar/ainb/1.7.4/libexec/ainb");
+        assert!(is_notifyd(&p));
+    }
+
+    #[test]
+    fn is_notifyd_rejects_plain_ainb_tui() {
+        let p = NotifydProc {
+            pid: 1,
+            bin: "/usr/local/bin/ainb".to_string(),
+            cmd: "/usr/local/bin/ainb".to_string(),
+            etime: "01:00".to_string(),
+        };
+        assert!(!is_notifyd(&p));
+    }
+
+    #[test]
+    fn is_notifyd_accepts_slim_binary() {
+        let p = NotifydProc {
+            pid: 1,
+            bin: "/usr/local/bin/ainb-notifyd".to_string(),
+            cmd: "/usr/local/bin/ainb-notifyd run".to_string(),
+            etime: "01:00".to_string(),
+        };
+        assert!(is_notifyd(&p));
+    }
+}

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -149,7 +149,9 @@ ainb_socket_alive() {
   # `[ -S ]` alone is what let a stale socket block respawn for days.
   [ -S "${AINB_SOCK}" ] || return 1
   if command -v nc >/dev/null 2>&1; then
-    : | nc -U -w 1 "${AINB_SOCK}" >/dev/null 2>&1
+    # `-N` closes the socket after stdin EOF so an accepting daemon answers
+    # instantly; without it BSD/macOS nc waits out the full `-w` timeout.
+    : | nc -U -N -w 1 "${AINB_SOCK}" >/dev/null 2>&1
     return $?
   fi
   if command -v socat >/dev/null 2>&1; then

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -143,35 +143,66 @@ ainb_send() {
   return 2
 }
 
+ainb_socket_alive() {
+  # True only when a daemon is actually ACCEPTING on the socket. A bare
+  # socket *file* left behind by a crashed daemon must NOT count — testing
+  # `[ -S ]` alone is what let a stale socket block respawn for days.
+  [ -S "${AINB_SOCK}" ] || return 1
+  if command -v nc >/dev/null 2>&1; then
+    : | nc -U -w 1 "${AINB_SOCK}" >/dev/null 2>&1
+    return $?
+  fi
+  if command -v socat >/dev/null 2>&1; then
+    : | socat - UNIX-CONNECT:"${AINB_SOCK}" >/dev/null 2>&1
+    return $?
+  fi
+  # No probe client available — assume present to avoid spawn storms.
+  return 0
+}
+
 ainb_lazy_spawn() {
-  # Best-effort lazy spawn of ainb notifyd. Uses a flock to avoid races
-  # when multiple hooks fire concurrently. Silent on success and failure;
+  # Best-effort lazy spawn of ainb notifyd. Silent on success and failure;
   # the fallback file is the safety net.
-  if [ -S "${AINB_SOCK}" ]; then
+  if ainb_socket_alive; then
     return 0
   fi
   if ! command -v ainb >/dev/null 2>&1; then
     return 1
   fi
-  # flock acquisition is non-blocking — concurrent first-fires let the
-  # winner spawn and the others fall through to the fallback file.
-  if command -v flock >/dev/null 2>&1; then
-    (
-      flock -n 9 || exit 1
-      nohup ainb notifyd >/dev/null 2>&1 &
-    ) 9>"${AINB_SPAWN_LOCK}"
-  else
-    nohup ainb notifyd >/dev/null 2>&1 &
+  # Mutual exclusion across concurrent first-fires. `mkdir` is atomic on
+  # POSIX *and* present on macOS — unlike `flock`, whose absence on macOS
+  # silently disabled the old guard and let every fire spawn its own
+  # daemon. The winner spawns; everyone else falls through to the fallback
+  # file. A distinct `.d` path is used (not the old flock lock *file*) so a
+  # leftover regular file from a previous version can't make mkdir fail
+  # forever. A lock dir older than 60s (spawner crashed mid-flight) is
+  # reclaimed so a stale lock can't wedge spawning permanently.
+  ainb_lock_dir="${AINB_SPAWN_LOCK}.d"
+  if [ -d "${ainb_lock_dir}" ] && command -v find >/dev/null 2>&1; then
+    if [ -z "$(find "${ainb_lock_dir}" -maxdepth 0 -mmin -1 2>/dev/null)" ]; then
+      rmdir "${ainb_lock_dir}" 2>/dev/null || true
+    fi
   fi
-  # Wait up to 500ms for the socket to appear.
+  if ! mkdir "${ainb_lock_dir}" 2>/dev/null; then
+    # Another fire is already spawning — let it win, we fall back.
+    return 1
+  fi
+  # Detach hard: stdin from /dev/null (an inherited hook pipe on stdin is
+  # the suspected cause of daemons wedging in startup before they ever
+  # bind), stdout/stderr discarded, nohup so a closing pane/tmux can't
+  # SIGHUP it.
+  nohup ainb notifyd </dev/null >/dev/null 2>&1 &
+  # Wait up to 1s for the socket to come up, then release the lock.
   ainb_attempts=0
-  while [ "${ainb_attempts}" -lt 50 ]; do
-    if [ -S "${AINB_SOCK}" ]; then
+  while [ "${ainb_attempts}" -lt 100 ]; do
+    if ainb_socket_alive; then
+      rmdir "${ainb_lock_dir}" 2>/dev/null || true
       return 0
     fi
     sleep 0.01 2>/dev/null || sleep 1
     ainb_attempts=$((ainb_attempts + 1))
   done
+  rmdir "${ainb_lock_dir}" 2>/dev/null || true
   return 1
 }
 


### PR DESCRIPTION
## Why

The session-list attention markers (`[?]` / `[!]` / `[✓]`) silently stopped rendering. Root cause: the notifyd daemon died and was never re-bound to its socket; six idle daemons orphaned (spawned in a 3-minute race, none listening) and survived a `brew upgrade`, while every hook event spilled to the fallback JSONL instead of the SQLite DB the TUI reads. Two confirmed defects:

1. **No spawn mutex on macOS** — the hook's `flock` guard is a no-op (macOS ships no `flock`), so concurrent first-fires each spawned a daemon.
2. **Spawned daemons wedged in startup before binding** (proven: none ever wrote the pid file), then nothing reaped them — no idle timeout, `nohup` is SIGHUP-immune, no version self-retire on upgrade.

## What

**Spawn hardening** (`notify.sh`)
- Atomic `mkdir` lock (works on macOS) + 60s stale reclaim, on a distinct `.d` path so a leftover flock lock file can't wedge it.
- Detach spawn from stdin (`</dev/null`) to kill the startup wedge.
- Real connect-probe before spawn/retry instead of a bare socket-file test, so a stale socket no longer blocks respawn.

**Orphan visibility** (Daemons overlay, opened with `d`)
- New `procs` module in `ainb-plugin-notifyd`: enumerate every running notifyd process via `ps`, classify LIVE owner / STALE / ORPHAN + binary-drift flag. Pure, unit-tested classifier; no new dependency.
- Overlay now renders a notifyd section — pid, uptime, binary path, classification, and a header count of how many need cleanup. Sidebar subtitle updated.

## Out of scope (follow-up)
- `k`-to-kill action in the overlay (display-only for now; pid shown so you can `kill` from CLI).
- Durable `listener.rs` bind-as-singleton + idle self-timeout (the deeper prevention layer).

## Tests
- `procs` classifier: 9 unit tests (live/stale/orphan/drift/parse).
- Daemons overlay: orphan-render test added; 5/5 pass.
- `cargo build`, `cargo fmt --check`, `bash -n notify.sh` all green; no new clippy warnings in changed files.

Note: the hardened hook ships only when a new `ainb` binary is built+installed (it's `include_str!`'d).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Daemons view now includes `notifyd` process information alongside MCP and Headroom.
  * Each detected process shows its status, PID, runtime, path, and warning indicators for stale or mismatched binaries.
  * The sidebar label was updated to reflect the expanded daemon view.

* **Bug Fixes**
  * Improved daemon detection so the notification service is checked by actual connection health, reducing false positives.
  * Better handled concurrent startup of the notification service, helping prevent duplicate launches and startup race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->