### PR TITLE
feat(notifyd): `notifyd reap` to clear orphan daemons

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1205,6 +1205,10 @@ impl CliCommand for NotifydCommand {
                 .hide(true)
                 .subcommand(Command::new("run").about("Run the daemon in the foreground (default)"))
                 .subcommand(Command::new("stop").about("Stop a running daemon via its PID file"))
+                .subcommand(
+                    Command::new("reap")
+                        .about("Kill orphan / wedged notifyd processes, sparing the live owner"),
+                )
                 .subcommand(agent_flags(
                     Command::new("install").about("Install the ainb-hooks hook"),
                 ))
@@ -1253,6 +1257,9 @@ impl CliCommand for NotifydCommand {
         enum Verb {
             Run,
             Stop,
+            Reap {
+                json: bool,
+            },
             Install(Vec<ainb_plugin_notifyd::Agent>),
             Uninstall(Vec<ainb_plugin_notifyd::Agent>),
             Status,
@@ -1277,6 +1284,9 @@ impl CliCommand for NotifydCommand {
         let verb = match matches.subcommand() {
             Some(("run", _)) | None => Verb::Run,
             Some(("stop", _)) => Verb::Stop,
+            Some(("reap", _)) => Verb::Reap {
+                json: matches!(ctx.format, crate::cli::OutputFormat::Json),
+            },
             Some(("install", m)) => Verb::Install(agents(m)),
             Some(("uninstall", m)) => Verb::Uninstall(agents(m)),
             Some(("status", _)) => Verb::Status,
@@ -1298,6 +1308,7 @@ impl CliCommand for NotifydCommand {
             match verb {
                 Verb::Run => cli::cmd_run().await,
                 Verb::Stop => cli::cmd_stop(),
+                Verb::Reap { json } => cli::cmd_reap(json),
                 Verb::Install(a) => cli::cmd_install(&a),
                 Verb::Uninstall(a) => cli::cmd_uninstall(&a),
                 Verb::Status => cli::cmd_status(),

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -208,7 +208,7 @@ fn build_notifyd_lines(
     )];
     if orphan_count > 0 {
         header.push(Span::styled(
-            format!("   · {orphan_count} to clean up (kill <pid>)"),
+            format!("   · {orphan_count} to clean up (run `ainb notifyd reap`)"),
             Style::default().fg(CLAY),
         ));
     }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/bin/ainb-notifyd.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/bin/ainb-notifyd.rs
@@ -30,6 +30,8 @@ enum Cmd {
     Run,
     /// Stop a running daemon by PID file.
     Stop,
+    /// Kill orphan / wedged notifyd processes, sparing the live owner.
+    Reap,
     /// Install the ainb-hooks plugin for one or more agents.
     Install(AgentArgs),
     /// Uninstall the ainb-hooks plugin for one or more agents.
@@ -68,6 +70,7 @@ async fn main() -> ExitCode {
     let result: Result<()> = match cli.cmd.unwrap_or(Cmd::Run) {
         Cmd::Run => cli::cmd_run().await,
         Cmd::Stop => cli::cmd_stop(),
+        Cmd::Reap => cli::cmd_reap(false),
         Cmd::Install(a) => {
             cli::cmd_install(&cli::agents_from_flags(a.claude, a.codex, a.copilot, a.all))
         }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
@@ -65,6 +65,42 @@ pub fn cmd_stop() -> Result<()> {
     Ok(())
 }
 
+/// `reap` — kill every notifyd process that isn't the healthy live owner
+/// (orphans + a wedged stale owner). The live daemon is left running. This
+/// is the typed verb behind the Daemons overlay's "to clean up" hint —
+/// safer than a hand-typed `kill <pid>` against a possibly-recycled pid.
+pub fn cmd_reap(json: bool) -> Result<()> {
+    let report = crate::procs::reap();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+    if report.killed.is_empty() && report.failed.is_empty() {
+        println!("no orphan notifyd processes to reap");
+    } else {
+        for pid in &report.killed {
+            println!("reaped pid {pid}");
+        }
+        for (pid, why) in &report.failed {
+            println!("could not reap pid {pid}: {why}");
+        }
+        println!(
+            "reaped {} orphan(s){}",
+            report.killed.len(),
+            if report.failed.is_empty() {
+                String::new()
+            } else {
+                format!(", {} failed", report.failed.len())
+            }
+        );
+    }
+    match report.spared {
+        Some(p) => println!("left live daemon running (pid {p})"),
+        None => println!("no live daemon remains — next hook event will lazy-spawn one"),
+    }
+    Ok(())
+}
+
 /// `install` — wire the ainb-hooks hook into the chosen agents and
 /// print the resolved on-disk paths.
 pub fn cmd_install(agents: &[Agent]) -> Result<()> {

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
@@ -190,6 +190,76 @@ fn socket_accepting(path: &std::path::Path) -> bool {
     std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
+/// Outcome of a [`reap`] sweep.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ReapReport {
+    /// Pids that were signalled and confirmed gone.
+    pub killed: Vec<u32>,
+    /// Pids that could not be reaped, with the reason (e.g. `EPERM` —
+    /// another user's process — or survival past `SIGKILL`).
+    pub failed: Vec<(u32, String)>,
+    /// The healthy live owner left untouched, if one was found.
+    pub spared: Option<u32>,
+}
+
+/// The pids worth reaping from a classified set: everything that is not a
+/// healthy live owner (orphans plus a wedged stale owner). Pure — the
+/// selection is the part worth testing; the killing is not.
+pub(crate) fn reapable(daemons: &[ClassifiedDaemon]) -> Vec<u32> {
+    daemons.iter().filter(|d| !d.class.is_healthy()).map(|d| d.proc.pid).collect()
+}
+
+fn signal_pid(pid: u32, sig: nix::sys::signal::Signal) -> nix::Result<()> {
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), sig)
+}
+
+/// Kill every notifyd process that isn't the healthy live owner — the
+/// orphans (and a wedged stale owner) the TUI flags. Sends `SIGTERM`,
+/// waits briefly, then `SIGKILL`s any survivor: wedged daemons don't
+/// always honour `SIGTERM`. The live owner is spared, and this very
+/// process can't be hit because its `notifyd reap` command line is
+/// excluded by the scan filter. Kills by exact pid only — never a name
+/// match or signal broadcast.
+pub fn reap() -> ReapReport {
+    use nix::errno::Errno;
+    use nix::sys::signal::Signal;
+
+    let daemons = scan();
+    let spared = daemons.iter().find(|d| d.class.is_healthy()).map(|d| d.proc.pid);
+    let mut report = ReapReport {
+        spared,
+        ..Default::default()
+    };
+
+    // Phase 1 — SIGTERM each target; collect the ones that took the signal.
+    let mut pending = Vec::new();
+    for pid in reapable(&daemons) {
+        match signal_pid(pid, Signal::SIGTERM) {
+            Ok(()) => pending.push(pid),
+            Err(Errno::ESRCH) => report.killed.push(pid), // already gone
+            Err(e) => report.failed.push((pid, e.to_string())), // EPERM, etc.
+        }
+    }
+
+    // Phase 2 — give them a moment, then SIGKILL any survivor and confirm.
+    if !pending.is_empty() {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        for pid in pending {
+            if crate::pid::is_running(pid) {
+                let _ = signal_pid(pid, Signal::SIGKILL);
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            if crate::pid::is_running(pid) {
+                report.failed.push((pid, "survived SIGKILL".to_string()));
+            } else {
+                report.killed.push(pid);
+            }
+        }
+    }
+
+    report
+}
+
 /// One-shot scan: enumerate notifyd processes and classify them against
 /// the on-disk owner pid, the live socket, and this process's own binary.
 /// Used by the TUI's Daemons overlay.
@@ -218,6 +288,31 @@ mod tests {
             cmd: format!("{bin} notifyd run"),
             etime: "01:23".to_string(),
         }
+    }
+
+    fn classified(class: DaemonClass, pid: u32) -> ClassifiedDaemon {
+        ClassifiedDaemon {
+            proc: proc(pid, "/x/ainb"),
+            class,
+            binary_drift: false,
+        }
+    }
+
+    #[test]
+    fn reapable_selects_everything_but_the_live_owner() {
+        let ds = vec![
+            classified(DaemonClass::LiveOwner, 1),
+            classified(DaemonClass::Orphan, 2),
+            classified(DaemonClass::StaleOwner, 3),
+            classified(DaemonClass::Orphan, 4),
+        ];
+        assert_eq!(reapable(&ds), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn reapable_empty_when_only_live_owner() {
+        let ds = vec![classified(DaemonClass::LiveOwner, 1)];
+        assert!(reapable(&ds).is_empty());
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
@@ -36,14 +36,14 @@ pub struct NotifydProc {
 /// How a discovered notifyd process relates to the canonical daemon.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DaemonClass {
-    /// Pid recorded in `notify.pid` *and* the socket is present — the
-    /// process actually serving notifications.
+    /// Holds the live, accepting socket — the process actually serving
+    /// notifications. Spared from a reap, whatever `notify.pid` says.
     LiveOwner,
-    /// Pid recorded in `notify.pid` but the socket is missing — the owner
-    /// is wedged / not listening.
+    /// The pid recorded in `notify.pid`, but it is not the live socket
+    /// holder — a wedged / superseded owner. Reapable.
     StaleOwner,
-    /// A running notifyd whose pid is **not** the recorded owner — an
-    /// orphan that should be reaped.
+    /// A running notifyd that is neither the live socket holder nor the
+    /// recorded owner — an orphan that should be reaped.
     Orphan,
 }
 
@@ -134,30 +134,29 @@ fn is_notifyd(p: &NotifydProc) -> bool {
     matches!(sub, None | Some("run"))
 }
 
-/// Classify each discovered process against the canonical owner pid +
-/// whether the socket is actually accepting + the currently-running binary.
-/// Pure — the testable core. `socket_accepting` must reflect a real connect
-/// probe, not mere file presence: a wedged owner that left a stale socket
-/// file behind is the failure this surface exists to show, so it must land
-/// as `StaleOwner`, not `LiveOwner`.
+/// Classify each discovered process. `live_pids` is the set of pids that
+/// actually hold an **accepting** socket (lsof ∩ a successful connect probe)
+/// — the authoritative liveness signal. A process is the live owner iff it
+/// holds that socket, *regardless of what `notify.pid` records*: in a spawn
+/// race the pid that won the socket can differ from the one in the file, and
+/// reaping must never kill whoever is actually serving. The pid file only
+/// distinguishes a wedged recorded owner (`StaleOwner`) from a plain orphan
+/// when nothing is serving. Pure — the testable core.
 pub(crate) fn classify(
     procs: Vec<NotifydProc>,
     owner_pid: Option<u32>,
-    socket_accepting: bool,
+    live_pids: &[u32],
     current_bin: Option<&str>,
 ) -> Vec<ClassifiedDaemon> {
     procs
         .into_iter()
         .map(|p| {
-            let class = match owner_pid {
-                Some(owner) if owner == p.pid => {
-                    if socket_accepting {
-                        DaemonClass::LiveOwner
-                    } else {
-                        DaemonClass::StaleOwner
-                    }
-                }
-                _ => DaemonClass::Orphan,
+            let class = if live_pids.contains(&p.pid) {
+                DaemonClass::LiveOwner
+            } else if owner_pid == Some(p.pid) {
+                DaemonClass::StaleOwner
+            } else {
+                DaemonClass::Orphan
             };
             let binary_drift = current_bin.is_some_and(|cur| !same_binary(&p.bin, cur));
             ClassifiedDaemon {
@@ -188,6 +187,21 @@ fn same_binary(a: &str, b: &str) -> bool {
 /// it, same as the hook script's `nc` probe.
 fn socket_accepting(path: &std::path::Path) -> bool {
     std::os::unix::net::UnixStream::connect(path).is_ok()
+}
+
+/// Pids holding the unix socket, via `lsof -t`. Empty when `lsof` is absent
+/// or nothing holds the path. Used only once the socket is confirmed
+/// accepting, so the result identifies the live listener to spare from a
+/// reap. Best-effort: if `lsof` can't be run we fall back to pid-file-only
+/// liveness (the historical behaviour).
+fn socket_listener_pids(path: &std::path::Path) -> Vec<u32> {
+    let Ok(out) = Command::new("lsof").arg("-t").arg(path).output() else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.trim().parse::<u32>().ok())
+        .collect()
 }
 
 /// Outcome of a [`reap`] sweep.
@@ -257,6 +271,16 @@ pub fn reap() -> ReapReport {
         }
     }
 
+    // If nothing live remains, the recorded owner (if any) is now a dead pid
+    // — drop the dangling pid file so `status` / the next lazy-spawn don't
+    // read a stale owner, mirroring what `cmd_stop` does. A SIGKILL'd owner
+    // never runs its `PidFile::Drop`, so this is the only cleanup point.
+    if report.spared.is_none() && !report.killed.is_empty() {
+        if let Ok(paths) = Paths::from_home() {
+            let _ = std::fs::remove_file(&paths.pid);
+        }
+    }
+
     report
 }
 
@@ -269,12 +293,16 @@ pub fn scan() -> Vec<ClassifiedDaemon> {
     };
     let owner_pid = crate::pid::read(&paths.pid).ok().flatten();
     let current_bin = std::env::current_exe().ok().and_then(|p| p.to_str().map(String::from));
-    classify(
-        enumerate(),
-        owner_pid,
-        socket_accepting(&paths.socket),
-        current_bin.as_deref(),
-    )
+    // Authoritative liveness: who actually holds an *accepting* socket. The
+    // connect probe proves something is serving; lsof names the listener to
+    // spare. A wedged listener that bound but hung fails the connect probe,
+    // so it stays reapable.
+    let live_pids = if socket_accepting(&paths.socket) {
+        socket_listener_pids(&paths.socket)
+    } else {
+        Vec::new()
+    };
+    classify(enumerate(), owner_pid, &live_pids, current_bin.as_deref())
 }
 
 #[cfg(test)]
@@ -316,24 +344,19 @@ mod tests {
     }
 
     #[test]
-    fn owner_with_socket_is_live() {
+    fn owner_holding_live_socket_is_live() {
         let out = classify(
             vec![proc(100, "/usr/local/bin/ainb")],
             Some(100),
-            true,
+            &[100],
             None,
         );
         assert_eq!(out[0].class, DaemonClass::LiveOwner);
     }
 
     #[test]
-    fn owner_without_socket_is_stale() {
-        let out = classify(
-            vec![proc(100, "/usr/local/bin/ainb")],
-            Some(100),
-            false,
-            None,
-        );
+    fn owner_not_serving_is_stale() {
+        let out = classify(vec![proc(100, "/usr/local/bin/ainb")], Some(100), &[], None);
         assert_eq!(out[0].class, DaemonClass::StaleOwner);
     }
 
@@ -342,18 +365,31 @@ mod tests {
         let out = classify(
             vec![proc(200, "/usr/local/bin/ainb")],
             Some(100),
-            true,
+            &[100],
             None,
         );
         assert_eq!(out[0].class, DaemonClass::Orphan);
     }
 
     #[test]
-    fn no_owner_pid_makes_everything_orphan() {
+    fn live_socket_holder_is_spared_even_when_pid_file_points_elsewhere() {
+        // Spawn race: the process that won the socket (200) is not the pid
+        // the file records (100, now dead). The live server must classify as
+        // LiveOwner and never be reaped — the bug this guards against.
+        let out = classify(vec![proc(200, "/x/ainb")], Some(100), &[200], None);
+        assert_eq!(out[0].class, DaemonClass::LiveOwner);
+        assert!(
+            reapable(&out).is_empty(),
+            "must not reap the live socket holder"
+        );
+    }
+
+    #[test]
+    fn no_owner_and_nothing_serving_makes_everything_orphan() {
         let out = classify(
             vec![proc(100, "/a/ainb"), proc(200, "/b/ainb")],
             None,
-            true,
+            &[],
             None,
         );
         assert!(out.iter().all(|d| d.class == DaemonClass::Orphan));
@@ -365,7 +401,7 @@ mod tests {
         let out = classify(
             vec![proc(100, "/opt/homebrew/Cellar/ainb/1.7.4/libexec/ainb")],
             Some(100),
-            true,
+            &[100],
             Some("/opt/homebrew/Cellar/ainb/1.9.4/libexec/ainb"),
         );
         assert!(out[0].binary_drift);
@@ -377,7 +413,7 @@ mod tests {
         let out = classify(
             vec![proc(100, "/same/path/ainb")],
             Some(100),
-            true,
+            &[100],
             Some("/same/path/ainb"),
         );
         assert!(!out[0].binary_drift);


### PR DESCRIPTION
## Why

Follow-up to #358. The Daemons overlay now flags orphan/wedged `notifyd` processes, but the only cleanup it offered was a raw `kill <pid>` — inconsistent with the overlay's "control via CLI verb" convention and unsafe against a recycled pid. This adds a typed verb to do it correctly.

## What

`ainb notifyd reap` (and `ainb-notifyd reap`): scan every notifyd process, then SIGTERM → (SIGKILL survivors) every one that isn't the healthy live owner. The live daemon is spared; the reap process excludes itself via the scan's CLI-subcommand filter. Kills by exact pid only — never a name match or signal broadcast.

- `procs::reap()` + `ReapReport`; the selection (`reapable`) is a pure, tested fn.
- Wired into both entrypoints through one shared `cmd_reap` body (standalone binary + hidden `ainb notifyd` alias).
- `--format json` emits the ReapReport; text lists each reaped pid + the spared owner.
- Overlay hint now reads `(run \`ainb notifyd reap\`)`.

## Live verification

On the dev box, 5 fresh orphans had already accumulated (the *deployed* pre-hardening notify.sh still races — the hardened hook ships only on the next binary release):

```
$ ainb notifyd reap
reaped pid 29473
reaped pid 29904
reaped pid 37968
reaped pid 41523
reaped pid 94285
reaped 5 orphan(s)
left live daemon running (pid 10244)
$ ainb --format json notifyd reap
{ "killed": [], "failed": [], "spared": 10244 }
```

The live owner (10244) survived both runs.

## Tests
- `reapable` selection: 2 unit tests (spares live owner; empty when only owner).
- notifyd lib 73/73, ainb registry 22/22, `cargo fmt --check` clean, no new clippy warnings.

## Pre-existing failure (NOT introduced here)
`tests/end_to_end.rs::hook_falls_back_when_daemon_down_then_daemon_replays` fails on **clean `origin/main`** too (verified via worktree: `left: 0, right: 1` — the replayed row isn't persisted). It's unrelated to this change and not gated by CI (CI runs `cargo nextest --lib`, which skips `tests/*.rs`). Filed for separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `ainb notifyd reap` command to clean up orphaned or wedged `notifyd` processes while preserving the active owner.
  * Added a report output that can be shown as either readable text or JSON.
* **Bug Fixes**
  * Updated the daemon status guidance to point users to the new cleanup command instead of manual process killing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->