### PR TITLE
fix(new-session): surface exact git-auth error in dismissible modal

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7633,19 +7633,18 @@ impl AppState {
                 ),
             }
         });
-        let (auth_ok, auth_msg) = match tokio::time::timeout(Duration::from_secs(5), auth_check)
-            .await
-        {
-            Ok(Ok(res)) => res,
-            Ok(Err(join_err)) => {
-                tracing::warn!(error = %join_err, "GitHub auth check task panicked");
-                (false, format!("auth check task panicked: {join_err}"))
-            }
-            Err(_) => {
-                tracing::warn!("GitHub auth check timed out after 5s");
-                (false, "`gh auth status` timed out after 5s".to_string())
-            }
-        };
+        let (auth_ok, auth_msg) =
+            match tokio::time::timeout(Duration::from_secs(5), auth_check).await {
+                Ok(Ok(res)) => res,
+                Ok(Err(join_err)) => {
+                    tracing::warn!(error = %join_err, "GitHub auth check task panicked");
+                    (false, format!("auth check task panicked: {join_err}"))
+                }
+                Err(_) => {
+                    tracing::warn!("GitHub auth check timed out after 5s");
+                    (false, "`gh auth status` timed out after 5s".to_string())
+                }
+            };
 
         if let Some(pick) =
             self.new_session_state.as_mut().and_then(|ns| ns.pick_repo_state.as_mut())

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7603,27 +7603,47 @@ impl AppState {
 
         // Bound the probe: a hung `gh` (network stall, credential helper
         // wedged) must not leave the picker stuck in `Checking` forever.
-        // Timeout and task-panic both fail closed → NotAuthenticated, with a
-        // warning so the cause is visible in the logs.
+        // Timeout and task-panic both fail closed → NotAuthenticated. Capture
+        // the EXACT `gh auth status` output (stderr+stdout) so the failure
+        // modal can show the real reason instead of a generic "auth failed".
         let auth_check = tokio::task::spawn_blocking(|| {
-            std::process::Command::new("gh")
+            match std::process::Command::new("gh")
                 .args(["auth", "status", "--hostname", "github.com"])
                 .env("GIT_TERMINAL_PROMPT", "0")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false)
+                .output()
+            {
+                Ok(out) => {
+                    // gh writes its human status to stderr; fold in stdout too
+                    // in case a future version moves it.
+                    let mut msg = String::from_utf8_lossy(&out.stderr).into_owned();
+                    let stdout = String::from_utf8_lossy(&out.stdout);
+                    if !stdout.trim().is_empty() {
+                        if !msg.is_empty() && !msg.ends_with('\n') {
+                            msg.push('\n');
+                        }
+                        msg.push_str(&stdout);
+                    }
+                    (out.status.success(), msg.trim().to_string())
+                }
+                Err(e) => (
+                    false,
+                    format!(
+                        "could not run `gh`: {e}\nInstall the GitHub CLI: https://cli.github.com"
+                    ),
+                ),
+            }
         });
-        let auth_ok = match tokio::time::timeout(Duration::from_secs(5), auth_check).await {
-            Ok(Ok(ok)) => ok,
+        let (auth_ok, auth_msg) = match tokio::time::timeout(Duration::from_secs(5), auth_check)
+            .await
+        {
+            Ok(Ok(res)) => res,
             Ok(Err(join_err)) => {
                 tracing::warn!(error = %join_err, "GitHub auth check task panicked");
-                false
+                (false, format!("auth check task panicked: {join_err}"))
             }
             Err(_) => {
                 tracing::warn!("GitHub auth check timed out after 5s");
-                false
+                (false, "`gh auth status` timed out after 5s".to_string())
             }
         };
 
@@ -7633,6 +7653,7 @@ impl AppState {
             if auth_ok {
                 tracing::info!("GitHub auth check passed");
                 pick.git_auth_status = Some(GitAuthStatus::Authenticated);
+                pick.git_auth_error = None;
                 // Auto-advance: take the pending source and emit StartClone
                 // via the advance-to-configure path. We replicate the
                 // AdvanceTo → Configure transition inline here.
@@ -7641,8 +7662,9 @@ impl AppState {
                     self.advance_pick_repo_to_configure(source);
                 }
             } else {
-                tracing::warn!("GitHub auth check failed");
+                tracing::warn!(error = %auth_msg, "GitHub auth check failed");
                 pick.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+                pick.git_auth_error = Some(auth_msg);
             }
         }
         self.ui_needs_refresh = true;

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -600,49 +600,63 @@ fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
         GitAuthStatus::Authenticated => return,
     };
 
-    let mut lines: Vec<Line> = Vec::new();
+    // Body holds everything above the CTA. The CTA is rendered into a pinned
+    // 1-row footer below, so Dismiss/Retry stays visible no matter how long
+    // the error is — a chatty `gh` must never push the CTA off-screen (the
+    // very symptom this modal exists to fix).
+    const MAX_ERR_LINES: usize = 8;
+    let mut body: Vec<Line> = Vec::new();
     match status {
         GitAuthStatus::Checking => {
-            lines.push(Line::from(Span::styled(
+            body.push(Line::from(Span::styled(
                 "\u{1f504} Running `gh auth status`\u{2026}",
                 Style::default().fg(Color::Rgb(100, 200, 230)),
             )));
         }
         GitAuthStatus::NotAuthenticated => {
-            lines.push(Line::from(Span::styled(
+            body.push(Line::from(Span::styled(
                 "\u{1f511} Can't clone this repo without GitHub auth.",
                 Style::default().fg(amber),
             )));
             // The verbatim probe output — the specific error, not a generic
-            // "auth failed". Empty only if the probe produced no output.
-            if let Some(err) = state.git_auth_error.as_deref().map(str::trim).filter(|s| !s.is_empty())
+            // "auth failed". Capped to keep the modal bounded.
+            if let Some(err) =
+                state.git_auth_error.as_deref().map(str::trim).filter(|s| !s.is_empty())
             {
-                lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
+                body.push(Line::from(""));
+                body.push(Line::from(Span::styled(
                     "gh auth status:",
                     Style::default().fg(MUTED_GRAY),
                 )));
-                for l in err.lines() {
-                    lines.push(Line::from(Span::styled(
-                        l.to_string(),
+                let err_lines: Vec<&str> = err.lines().collect();
+                for l in err_lines.iter().take(MAX_ERR_LINES) {
+                    body.push(Line::from(Span::styled(
+                        (*l).to_string(),
                         Style::default().fg(red),
                     )));
                 }
+                if err_lines.len() > MAX_ERR_LINES {
+                    body.push(Line::from(Span::styled(
+                        format!("\u{2026} ({} more lines)", err_lines.len() - MAX_ERR_LINES),
+                        Style::default().fg(MUTED_GRAY),
+                    )));
+                }
             }
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
+            body.push(Line::from(""));
+            body.push(Line::from(Span::styled(
                 "Fix \u{2014} in another terminal run:",
                 Style::default().fg(MUTED_GRAY),
             )));
-            lines.push(Line::from(Span::styled(
+            body.push(Line::from(Span::styled(
                 "  gh auth login && gh auth setup-git",
                 Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
             )));
         }
-        GitAuthStatus::Authenticated => unreachable!(),
+        // Returned early above; kept exhaustive without a panic landmine.
+        GitAuthStatus::Authenticated => return,
     }
+    body.push(Line::from("")); // gap before the pinned CTA footer
 
-    lines.push(Line::from(""));
     let cta = match status {
         GitAuthStatus::Checking => Line::from(vec![
             Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
@@ -657,11 +671,11 @@ fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
             Span::styled(" Dismiss", Style::default().fg(MUTED_GRAY)),
         ]),
     };
-    lines.push(cta);
 
-    // Size to content, clamped to the available area (+2 for the border).
-    let height = (lines.len() as u16 + 2).min(area.height.max(3));
-    let width = area.width.saturating_sub(4).clamp(20, 76);
+    // Size to content: body + 1 CTA row + 2 border rows, clamped to the area.
+    // Width never exceeds the area (centred when it fits).
+    let height = (body.len() as u16 + 3).min(area.height.max(3));
+    let width = area.width.saturating_sub(4).clamp(20, 76).min(area.width);
     let modal = Rect {
         x: area.x + area.width.saturating_sub(width) / 2,
         y: area.y + area.height.saturating_sub(height) / 2,
@@ -676,13 +690,21 @@ fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
         .title(Span::styled(title, Style::default().fg(GOLD).add_modifier(Modifier::BOLD)))
         .title_alignment(Alignment::Center)
         .style(Style::default().bg(DARK_BG));
-    let para = Paragraph::new(lines)
-        .block(block)
-        .wrap(Wrap { trim: false })
-        .style(Style::default().fg(SOFT_WHITE));
-
+    let inner = block.inner(modal);
     f.render_widget(Clear, modal);
-    f.render_widget(para, modal);
+    f.render_widget(block, modal);
+
+    // Body takes all rows but the last; the CTA is pinned to the final row so
+    // it survives even when the body is clipped on a short terminal.
+    let parts = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner);
+    f.render_widget(
+        Paragraph::new(body).wrap(Wrap { trim: false }).style(Style::default().fg(SOFT_WHITE)),
+        parts[0],
+    );
+    f.render_widget(Paragraph::new(cta).alignment(Alignment::Center), parts[1]);
 }
 
 /// Handle a single key event. Mutates state in place; returns the outcome
@@ -1268,6 +1290,33 @@ mod tests {
             "exact gh error not surfaced:\n{text}"
         );
         assert!(text.contains("Dismiss"), "missing Dismiss CTA:\n{text}");
+    }
+
+    #[test]
+    fn modal_keeps_dismiss_cta_visible_with_a_long_error() {
+        // A chatty `gh` must not push the CTA off the bottom of the modal — the
+        // footer is pinned. Constrained viewport: the pre-fix layout clipped it.
+        let mut s = mk_state_with_rows(vec![]);
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        s.pending_clone_source = Some(github_source());
+        let long = (0..30).map(|i| format!("error line {i}")).collect::<Vec<_>>().join("\n");
+        s.git_auth_error = Some(long);
+
+        let text = render_to_string(&s, 100, 16);
+
+        assert!(text.contains("Dismiss"), "Dismiss CTA clipped on long error:\n{text}");
+    }
+
+    #[test]
+    fn modal_caps_a_chatty_gh_error() {
+        let mut s = mk_state_with_rows(vec![]);
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        let long = (0..30).map(|i| format!("noisy line {i}")).collect::<Vec<_>>().join("\n");
+        s.git_auth_error = Some(long);
+
+        let text = render_to_string(&s, 100, 40);
+
+        assert!(text.contains("more lines"), "error body not capped:\n{text}");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -659,15 +659,24 @@ fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
 
     let cta = match status {
         GitAuthStatus::Checking => Line::from(vec![
-            Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Esc",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" Cancel", Style::default().fg(MUTED_GRAY)),
         ]),
         _ => Line::from(vec![
-            Span::styled("Enter", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Enter",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" Retry   ", Style::default().fg(MUTED_GRAY)),
             Span::styled("s", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled(" Skip auth   ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Esc",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" Dismiss", Style::default().fg(MUTED_GRAY)),
         ]),
     };
@@ -687,7 +696,10 @@ fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(border))
-        .title(Span::styled(title, Style::default().fg(GOLD).add_modifier(Modifier::BOLD)))
+        .title(Span::styled(
+            title,
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
         .title_alignment(Alignment::Center)
         .style(Style::default().bg(DARK_BG));
     let inner = block.inner(modal);
@@ -701,7 +713,9 @@ fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
         .constraints([Constraint::Min(0), Constraint::Length(1)])
         .split(inner);
     f.render_widget(
-        Paragraph::new(body).wrap(Wrap { trim: false }).style(Style::default().fg(SOFT_WHITE)),
+        Paragraph::new(body)
+            .wrap(Wrap { trim: false })
+            .style(Style::default().fg(SOFT_WHITE)),
         parts[0],
     );
     f.render_widget(Paragraph::new(cta).alignment(Alignment::Center), parts[1]);
@@ -1284,7 +1298,10 @@ mod tests {
 
         let text = render_to_string(&s, 100, 24);
 
-        assert!(text.contains("auth required"), "modal not shown on empty list:\n{text}");
+        assert!(
+            text.contains("auth required"),
+            "modal not shown on empty list:\n{text}"
+        );
         assert!(
             text.contains("not logged into any GitHub hosts"),
             "exact gh error not surfaced:\n{text}"
@@ -1304,7 +1321,10 @@ mod tests {
 
         let text = render_to_string(&s, 100, 16);
 
-        assert!(text.contains("Dismiss"), "Dismiss CTA clipped on long error:\n{text}");
+        assert!(
+            text.contains("Dismiss"),
+            "Dismiss CTA clipped on long error:\n{text}"
+        );
     }
 
     #[test]
@@ -1316,7 +1336,10 @@ mod tests {
 
         let text = render_to_string(&s, 100, 40);
 
-        assert!(text.contains("more lines"), "error body not capped:\n{text}");
+        assert!(
+            text.contains("more lines"),
+            "error body not capped:\n{text}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/pick_repo.rs
@@ -14,7 +14,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
@@ -146,6 +146,10 @@ pub struct PickRepoState {
     pub git_auth_status: Option<GitAuthStatus>,
     /// Source that triggered the auth check, held until auth passes or user skips.
     pub pending_clone_source: Option<RepoSource>,
+    /// Exact, verbatim output of the failed `gh auth status` probe (stderr +
+    /// stdout). Shown in the `NotAuthenticated` modal so the user sees the real
+    /// reason instead of a generic "auth failed". `None` until a probe fails.
+    pub git_auth_error: Option<String>,
     /// Snapshot of session-defaults — read on open, updated on `^R`.
     pub defaults: SessionDefaults,
     /// Snapshot of favorites — read on open, updated on `^F`.
@@ -170,6 +174,7 @@ impl PickRepoState {
             clone_progress: None,
             git_auth_status: None,
             pending_clone_source: None,
+            git_auth_error: None,
             defaults,
             favorites,
         }
@@ -500,71 +505,13 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
             // Inline status shown directly under the highlighted row
             // by appending extra lines. Works inside ListItem::new(vec![…]).
             let mut lines = vec![Line::from(spans)];
+            // Auth status (Checking / NotAuthenticated) renders as a standalone
+            // modal after the list (see `render_git_auth_modal`) so it stays
+            // visible even when the filter matches no rows — a typed
+            // `owner/repo` clone has no local row to attach an inline message
+            // to. Only clone progress stays inline on the selected row.
             if is_selected {
-                if let Some(auth) = &state.git_auth_status {
-                    match auth {
-                        GitAuthStatus::Checking => {
-                            lines.push(Line::from(vec![
-                                Span::raw("    "),
-                                Span::styled(
-                                    "\u{1f504} Checking GitHub auth...",
-                                    Style::default().fg(Color::Rgb(100, 200, 230)),
-                                ),
-                            ]));
-                        }
-                        GitAuthStatus::NotAuthenticated => {
-                            // The `gh`-specific copy is intentional: the auth
-                            // pre-check only fires for GitHub sources (see
-                            // `is_github_host` gating in events.rs StartClone),
-                            // so this branch never renders for GitLab /
-                            // self-hosted HTTPS remotes.
-                            let amber = Color::Rgb(255, 191, 0);
-                            lines.push(Line::from(vec![
-                                Span::raw("    "),
-                                Span::styled(
-                                    "\u{1f511} GitHub auth required. In another terminal run:",
-                                    Style::default().fg(amber),
-                                ),
-                            ]));
-                            lines.push(Line::from(vec![
-                                Span::raw("      "),
-                                Span::styled(
-                                    "gh auth login && gh auth setup-git",
-                                    Style::default()
-                                        .fg(SELECTION_GREEN)
-                                        .add_modifier(Modifier::BOLD),
-                                ),
-                            ]));
-                            lines.push(Line::from(vec![
-                                Span::raw("    "),
-                                Span::styled(
-                                    "Enter",
-                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-                                ),
-                                Span::styled("=Retry  ", Style::default().fg(MUTED_GRAY)),
-                                Span::styled(
-                                    "s",
-                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-                                ),
-                                Span::styled("=Skip auth  ", Style::default().fg(MUTED_GRAY)),
-                                Span::styled(
-                                    "Esc",
-                                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-                                ),
-                                Span::styled("=Back", Style::default().fg(MUTED_GRAY)),
-                            ]));
-                        }
-                        GitAuthStatus::Authenticated => {
-                            lines.push(Line::from(vec![
-                                Span::raw("    "),
-                                Span::styled(
-                                    "\u{2705} Authenticated",
-                                    Style::default().fg(SELECTION_GREEN),
-                                ),
-                            ]));
-                        }
-                    }
-                } else if let Some(progress) = &state.clone_progress {
+                if let Some(progress) = &state.clone_progress {
                     if let Some(err) = &progress.error {
                         lines.push(Line::from(vec![
                             Span::raw("    "),
@@ -605,6 +552,12 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
     });
     f.render_stateful_widget(list, chunks[1], &mut list_state);
 
+    // Auth pre-check feedback as a centered overlay on the list area. Drawn
+    // here (not inline under a row) so a typed `owner/repo` with no local
+    // match — empty list, no selection — still shows the spinner / the exact
+    // failure + CTA instead of silently hanging.
+    render_git_auth_modal(f, state, chunks[1]);
+
     // Help bar — gold keys + muted descriptions, single line.
     let help = Line::from(vec![
         Span::styled(
@@ -624,6 +577,112 @@ pub fn render(f: &mut Frame, state: &PickRepoState, area: Rect) {
     ]);
     let help_p = Paragraph::new(help).alignment(Alignment::Center);
     f.render_widget(help_p, chunks[2]);
+}
+
+/// Centered overlay reporting GitHub auth pre-check state. Renders for
+/// `Checking` (spinner) and `NotAuthenticated` (the EXACT `gh auth status`
+/// output + the fix command + CTAs); `Authenticated` is transient and draws
+/// nothing. Drawn over the list area so it is visible even when the filter
+/// matches no rows — the case that previously hung silently. The overlay is
+/// persistent: it clears only on an explicit key (Enter/s/Esc), never on a
+/// timer.
+fn render_git_auth_modal(f: &mut Frame, state: &PickRepoState, area: Rect) {
+    let Some(status) = &state.git_auth_status else {
+        return;
+    };
+    let amber = Color::Rgb(255, 191, 0);
+    let red = Color::Rgb(230, 100, 100);
+
+    let (title, border) = match status {
+        GitAuthStatus::Checking => (" Checking GitHub auth ", Color::Rgb(100, 200, 230)),
+        GitAuthStatus::NotAuthenticated => (" GitHub auth required ", amber),
+        // Transient — auto-advances to Configure, no overlay needed.
+        GitAuthStatus::Authenticated => return,
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    match status {
+        GitAuthStatus::Checking => {
+            lines.push(Line::from(Span::styled(
+                "\u{1f504} Running `gh auth status`\u{2026}",
+                Style::default().fg(Color::Rgb(100, 200, 230)),
+            )));
+        }
+        GitAuthStatus::NotAuthenticated => {
+            lines.push(Line::from(Span::styled(
+                "\u{1f511} Can't clone this repo without GitHub auth.",
+                Style::default().fg(amber),
+            )));
+            // The verbatim probe output — the specific error, not a generic
+            // "auth failed". Empty only if the probe produced no output.
+            if let Some(err) = state.git_auth_error.as_deref().map(str::trim).filter(|s| !s.is_empty())
+            {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "gh auth status:",
+                    Style::default().fg(MUTED_GRAY),
+                )));
+                for l in err.lines() {
+                    lines.push(Line::from(Span::styled(
+                        l.to_string(),
+                        Style::default().fg(red),
+                    )));
+                }
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Fix \u{2014} in another terminal run:",
+                Style::default().fg(MUTED_GRAY),
+            )));
+            lines.push(Line::from(Span::styled(
+                "  gh auth login && gh auth setup-git",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            )));
+        }
+        GitAuthStatus::Authenticated => unreachable!(),
+    }
+
+    lines.push(Line::from(""));
+    let cta = match status {
+        GitAuthStatus::Checking => Line::from(vec![
+            Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" Cancel", Style::default().fg(MUTED_GRAY)),
+        ]),
+        _ => Line::from(vec![
+            Span::styled("Enter", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" Retry   ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("s", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" Skip auth   ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("Esc", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" Dismiss", Style::default().fg(MUTED_GRAY)),
+        ]),
+    };
+    lines.push(cta);
+
+    // Size to content, clamped to the available area (+2 for the border).
+    let height = (lines.len() as u16 + 2).min(area.height.max(3));
+    let width = area.width.saturating_sub(4).clamp(20, 76);
+    let modal = Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(border))
+        .title(Span::styled(title, Style::default().fg(GOLD).add_modifier(Modifier::BOLD)))
+        .title_alignment(Alignment::Center)
+        .style(Style::default().bg(DARK_BG));
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .style(Style::default().fg(SOFT_WHITE));
+
+    f.render_widget(Clear, modal);
+    f.render_widget(para, modal);
 }
 
 /// Handle a single key event. Mutates state in place; returns the outcome
@@ -649,18 +708,23 @@ pub fn handle_key(state: &mut PickRepoState, key: KeyEvent) -> PickRepoOutcome {
                 if matches!(key.code, KeyCode::Esc) {
                     state.git_auth_status = None;
                     state.pending_clone_source = None;
+                    state.git_auth_error = None;
                 }
                 return PickRepoOutcome::Stay;
             }
             GitAuthStatus::NotAuthenticated => {
                 match key.code {
                     KeyCode::Enter => {
+                        // Re-probe: drop the stale error so the modal shows the
+                        // spinner, not last attempt's failure, while it re-runs.
+                        state.git_auth_error = None;
                         state.git_auth_status = Some(GitAuthStatus::Checking);
                         return PickRepoOutcome::Stay; // dispatcher sees Checking → re-runs check
                     }
                     KeyCode::Char('s' | 'S') => {
                         let source = state.pending_clone_source.take();
                         state.git_auth_status = None;
+                        state.git_auth_error = None;
                         if let Some(src) = source {
                             return PickRepoOutcome::StartClone(src);
                         }
@@ -669,6 +733,7 @@ pub fn handle_key(state: &mut PickRepoState, key: KeyEvent) -> PickRepoOutcome {
                     KeyCode::Esc => {
                         state.git_auth_status = None;
                         state.pending_clone_source = None;
+                        state.git_auth_error = None;
                         return PickRepoOutcome::Stay;
                     }
                     _ => return PickRepoOutcome::Stay,
@@ -914,6 +979,7 @@ mod tests {
             clone_progress: None,
             git_auth_status: None,
             pending_clone_source: None,
+            git_auth_error: None,
             defaults: SessionDefaults::default(),
             favorites: FavoritesStore::default(),
         }
@@ -1180,7 +1246,28 @@ mod tests {
         // The three key hints the user can act on.
         assert!(text.contains("Retry"), "missing Retry hint in:\n{text}");
         assert!(text.contains("Skip"), "missing Skip hint in:\n{text}");
-        assert!(text.contains("Back"), "missing Back hint in:\n{text}");
+        assert!(text.contains("Dismiss"), "missing Dismiss hint in:\n{text}");
+    }
+
+    #[test]
+    fn not_authenticated_modal_shows_exact_error_even_with_no_rows() {
+        // The regression: a typed `owner/repo` with no local match leaves the
+        // filtered list empty (no selected row). The auth failure must still
+        // render — with the EXACT gh output — instead of hanging silently.
+        let mut s = mk_state_with_rows(vec![]);
+        s.git_auth_status = Some(GitAuthStatus::NotAuthenticated);
+        s.pending_clone_source = Some(github_source());
+        s.git_auth_error =
+            Some("You are not logged into any GitHub hosts. To log in, run: gh auth login".into());
+
+        let text = render_to_string(&s, 100, 24);
+
+        assert!(text.contains("auth required"), "modal not shown on empty list:\n{text}");
+        assert!(
+            text.contains("not logged into any GitHub hosts"),
+            "exact gh error not surfaced:\n{text}"
+        );
+        assert!(text.contains("Dismiss"), "missing Dismiss CTA:\n{text}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Typing `owner/repo` in the new-session repo picker for a repo with no local match left the fuzzy-filtered list empty. The GitHub auth pre-check failure (`NotAuthenticated`) was rendered **only inline under the selected row** — but with zero rows there is no selection, so the clone hung with **no error and no CTA**. The exact `gh auth status` output was also piped to `/dev/null` and lost.

Repro: open new session, type `stevengonsalvez/cerebro` on a host without `gh` auth, press Enter → nothing happens.

## Fix

- **Capture the exact error**: `check_git_auth` now uses `.output()` instead of `Stdio::null()`, folding `gh auth status` stderr+stdout into a new `git_auth_error` field (and logging the verbatim text).
- **Render standalone**: auth status moves out of the per-row `if is_selected` block into `render_git_auth_modal` — a centered overlay that draws even when the list is empty, showing the exact error, the `gh auth login && gh auth setup-git` remediation, and `Enter Retry / s Skip / Esc Dismiss`.
- **Persistent + dismissible**: no timer — clears only on an explicit key. `Back` CTA relabelled `Dismiss`.

## Tests

`cargo test -p ainb --bin ainb` — 6 picker auth tests green, including a new `not_authenticated_modal_shows_exact_error_even_with_no_rows` regression (empty list + verbatim error visible). Bin compiles.

## Out of scope

The post-auth clone failure at the Configure→Creating step still fires a 5s auto-expiring toast + cancels the flow — a separate "vanish" surface, flagged for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer GitHub authentication prompt with a centered modal and status-specific messaging.
  * When authentication checks fail, the app now shows the full command output and a dismiss option.
  * Skipping the auth prompt now continues cloning with the selected source.

* **Bug Fixes**
  * Improved handling of authentication check failures, including timeouts and command errors.
  * Auth messages are now cleared and refreshed more reliably when retrying or dismissing the prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->