### PR TITLE
style(setup): satisfy stable rustfmt in catalog/provision

### DIFF
--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -159,10 +159,16 @@ impl Install {
             Install::Curl(url) => format!("curl -LsSf {url} | sh"),
             Install::Cargo(c) => format!("cargo install {c}"),
             Install::Ainb(a) => format!("ainb {}", a.join(" ")),
-            Install::ClaudePlugin { spec, marketplace: Some(url) } => format!(
+            Install::ClaudePlugin {
+                spec,
+                marketplace: Some(url),
+            } => format!(
                 "claude plugin marketplace add {url} 2>/dev/null || true\nclaude plugin install {spec}"
             ),
-            Install::ClaudePlugin { spec, marketplace: None } => {
+            Install::ClaudePlugin {
+                spec,
+                marketplace: None,
+            } => {
                 format!("claude plugin install {spec}")
             }
             Install::Toolkit => "ainb migrate --from-bootstrap --toolkit-root ./ainb-toolkit \
@@ -647,7 +653,10 @@ pub fn catalog() -> Vec<Topic> {
                     Custom("claude-plugin:caveman"),
                     // External marketplace (not stevengonsalvez/*) — no known HTTPS
                     // URL to pin, so leave the bare install; user adds it themselves.
-                    ClaudePlugin { spec: "caveman@caveman", marketplace: None },
+                    ClaudePlugin {
+                        spec: "caveman@caveman",
+                        marketplace: None,
+                    },
                     &[],
                     &[],
                 ),

--- a/ainb-tui/crates/ainb-core/src/setup/provision.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/provision.rs
@@ -124,7 +124,10 @@ pub fn plan(install: &Install) -> InstallPlan {
         // Add the marketplace over HTTPS first (shorthand defaults to SSH and
         // fails without GitHub SSH keys), then install. `|| true` keeps the
         // already-added case from aborting.
-        Install::ClaudePlugin { spec, marketplace: Some(url) } => InstallPlan {
+        Install::ClaudePlugin {
+            spec,
+            marketplace: Some(url),
+        } => InstallPlan {
             argv: Some(vec![
                 s("sh"),
                 s("-c"),
@@ -136,7 +139,10 @@ pub fn plan(install: &Install) -> InstallPlan {
             consent: ConsentLevel::Auto,
             display,
         },
-        Install::ClaudePlugin { spec, marketplace: None } => InstallPlan {
+        Install::ClaudePlugin {
+            spec,
+            marketplace: None,
+        } => InstallPlan {
             argv: Some(vec![s("claude"), s("plugin"), s("install"), s(spec)]),
             consent: ConsentLevel::Auto,
             display,


### PR DESCRIPTION
Pre-existing rustfmt drift in `catalog.rs`/`provision.rs` (from 22c8d792) that CI's stable rustfmt now flags — `cargo fmt --all --check` was red on main, unrelated to #362 (whose own files are fmt-clean). Whitespace only. Greens the `Rustfmt` job.