### PR TITLE
fix(tui): survive transient EINTR from terminal I/O on flaky links

### DIFF
--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -430,28 +430,52 @@ async fn run_tui_loop(
 
         if needs_redraw {
             let draw_start = Instant::now();
-            terminal.draw(|frame| {
+            match terminal.draw(|frame| {
                 layout.render(frame, &mut app.state);
-            })?;
-            crate::perf::record_draw(draw_start.elapsed());
-            // This paint is the first one to reflect any key read in the
-            // previous iteration, so it marks the end of the key-to-render
-            // interval.
-            if let Some(key_at) = pending_key_at.take() {
-                crate::perf::record_key_to_render(key_at.elapsed());
+            }) {
+                Ok(_) => {
+                    crate::perf::record_draw(draw_start.elapsed());
+                    // This paint is the first one to reflect any key read in the
+                    // previous iteration, so it marks the end of the key-to-render
+                    // interval.
+                    if let Some(key_at) = pending_key_at.take() {
+                        crate::perf::record_key_to_render(key_at.elapsed());
+                    }
+                    needs_redraw = false;
+                }
+                // Transient frame-write failure (e.g. EINTR over a flaky SSH
+                // link) — keep the TUI alive and repaint next iteration instead
+                // of tearing the whole session down. Only genuinely fatal I/O
+                // errors propagate.
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {
+                    needs_redraw = true;
+                }
+                Err(e) => return Err(e.into()),
             }
-            needs_redraw = false;
         }
 
         let timeout = tick_rate
             .checked_sub(last_tick.elapsed())
             .unwrap_or_else(|| Duration::from_secs(0));
 
-        if crossterm::event::poll(timeout)? {
+        // Tolerate transient terminal-read failures: EINTR (e.g. SIGWINCH on
+        // resize, common over SSH) must not crash the session. Only fatal I/O
+        // errors propagate.
+        let has_event = match crossterm::event::poll(timeout) {
+            Ok(v) => v,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => false,
+            Err(e) => return Err(e.into()),
+        };
+        if has_event {
             // Any input (key/mouse/paste/resize) warrants a repaint on the next
             // loop iteration (perf: bead `wai` dirty-gate).
             needs_redraw = true;
-            match event::read()? {
+            let read_event = match event::read() {
+                Ok(ev) => ev,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e.into()),
+            };
+            match read_event {
                 Event::Key(key_event) => {
                     // Windows fires Press + Release for every key; macOS/Linux fire only Press.
                     // Drop Release so Enter doesn't immediately re-trigger and close popups.


### PR DESCRIPTION
## Problem

Reported as an intermittent ainb TUI crash on an SSH box (not local):
`Error: The cursor position could not be read within a normal duration`.

Research findings (full write-up was local-only):
- That exact string is emitted **only** by crossterm `cursor::position()` (a `\x1b[6n` DSR query that times out after 2s). ainb itself **never** calls it — proven across this branch, `origin/main`, and full git history. The crossterm 0.29 `size()` path falls back to `tput`, not the cursor. So the cursor-string crash originates in a spawned crossterm **child** (e.g. the codex CLI, a known emitter of this exact error when idle — openai/codex#2805, #4415), whose DSR query round-trips over SSH and times out. The durable fix for that is to run the remote session under a multiplexer (tmux or zellij both answer `\x1b[6n` locally).

## What this PR changes

Separately, the main event loop propagated **any** `io::Error` from `terminal.draw`, `event::poll`, and `event::read` straight to `main()`, tearing down the whole TUI. Over a flaky link (SSH), a transient `EINTR` — e.g. `SIGWINCH` on window resize — would crash the session.

This treats `ErrorKind::Interrupted` as transient: repaint / retry on the next loop iteration instead of exiting. Only genuinely fatal I/O still propagates. Terminal restoration on exit is unchanged (already handled on both Ok and Err paths plus the panic hook).

## Scope / honesty

This hardens the **broad SSH-transient crash class**. It does **not** by itself stop the specific `cursor position` string, which is a child process — see above.

## Test

`cargo check -p ainb` clean (pre-existing warnings only).