### PR TITLE
fix: align Codex notify hook parity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     {
       "name": "ainb-hooks",
       "source": "./plugins/ainb-hooks",
-      "description": "Emit actionable Claude Code lifecycle events to the ainb notification inbox: Notification (awaiting-input / permission) and Stop (turn finished) are delivered to ainb-notifyd over a Unix socket, surfacing as native OS banners, the ainb-tui Inbox screen, and the per-session waiting marker. Telemetry events are intentionally not hooked. Install via `/plugin install ainb-hooks@agents-in-a-box` (Claude); Codex wiring is handled by `ainb notifyd install`.",
+      "description": "Emit actionable host-agent lifecycle events to the ainb notification inbox: Claude/Copilot Notification, Codex PermissionRequest, and Stop/agentStop are delivered to ainb-notifyd over a Unix socket, surfacing as native OS banners, the ainb-tui Inbox screen, and per-session attention markers. Telemetry events are intentionally not hooked. Install via `/plugin install ainb-hooks@agents-in-a-box` (Claude); Codex/Copilot wiring is handled by `ainb notifyd install`.",
       "strict": false,
       "keywords": [
         "ainb",

--- a/ainb-tui/crates/ainb-adapters-tool/src/convention.rs
+++ b/ainb-tui/crates/ainb-adapters-tool/src/convention.rs
@@ -142,10 +142,12 @@ pub fn uninstall(deployed: &DeployedRef, install_root: &Path) -> anyhow::Result<
 fn is_protected(rel: &Path) -> bool {
     use std::path::Component;
     // Reject anything that escapes the install root.
-    if rel
-        .components()
-        .any(|c| matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(_)))
-    {
+    if rel.components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
         return true;
     }
     let segments: Vec<&str> = rel
@@ -315,9 +317,18 @@ mod tests {
         // A corrupt lockfile claims the unit deployed those state files.
         let bad = deployed(&["projects/session.jsonl", "settings.json"]);
         let err = uninstall(&bad, root.path()).unwrap_err();
-        assert!(err.to_string().contains("protected user state"), "got: {err}");
-        assert!(session.exists(), "session history must survive a refused uninstall");
-        assert!(settings.exists(), "settings.json must survive a refused uninstall");
+        assert!(
+            err.to_string().contains("protected user state"),
+            "got: {err}"
+        );
+        assert!(
+            session.exists(),
+            "session history must survive a refused uninstall"
+        );
+        assert!(
+            settings.exists(),
+            "settings.json must survive a refused uninstall"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -10002,11 +10002,12 @@ impl AppState {
 
     /// The ainb-hooks `agent` string a session's events are recorded
     /// under, or `None` for session types that don't emit hook events
-    /// (plain shell / SSH, and the not-yet-wired Gemini/Copilot/Kiro).
+    /// (plain shell / SSH, and the not-yet-wired Gemini/Kiro).
     const fn agent_hook_name(agent: SessionAgentType) -> Option<&'static str> {
         match agent {
             SessionAgentType::Claude => Some("claude"),
             SessionAgentType::Codex => Some("codex"),
+            SessionAgentType::Copilot => Some("copilot"),
             _ => None,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -1061,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_hook_name_maps_claude_and_codex_only() {
+    fn agent_hook_name_maps_supported_hook_agents() {
         assert_eq!(
             AppState::agent_hook_name(SessionAgentType::Claude),
             Some("claude")
@@ -1069,6 +1069,10 @@ mod tests {
         assert_eq!(
             AppState::agent_hook_name(SessionAgentType::Codex),
             Some("codex")
+        );
+        assert_eq!(
+            AppState::agent_hook_name(SessionAgentType::Copilot),
+            Some("copilot")
         );
         assert_eq!(AppState::agent_hook_name(SessionAgentType::Shell), None);
         assert_eq!(AppState::agent_hook_name(SessionAgentType::Gemini), None);

--- a/ainb-tui/crates/ainb-core/src/components/inbox.rs
+++ b/ainb-tui/crates/ainb-core/src/components/inbox.rs
@@ -12,7 +12,7 @@
 //   - d               dismiss selected row
 //   - Shift+C         dismiss every currently-visible row
 //   - a               toggle archived (dismissed) filter
-//   - p               cycle agent filter (all / claude / codex)
+//   - p               cycle agent filter (all / claude / codex / copilot)
 //   - r               force refresh from store
 //   - q / Esc         return to previous screen
 //
@@ -40,22 +40,25 @@ const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 /// Agent filter cycled by the `p` key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AgentFilter {
-    /// Show both agents.
+    /// Show every agent.
     #[default]
     All,
     /// Only Claude rows.
     Claude,
     /// Only Codex rows.
     Codex,
+    /// Only Copilot rows.
+    Copilot,
 }
 
 impl AgentFilter {
-    /// Cycle to the next filter (All → Claude → Codex → All).
+    /// Cycle to the next filter (All → Claude → Codex → Copilot → All).
     pub fn next(self) -> Self {
         match self {
             AgentFilter::All => AgentFilter::Claude,
             AgentFilter::Claude => AgentFilter::Codex,
-            AgentFilter::Codex => AgentFilter::All,
+            AgentFilter::Codex => AgentFilter::Copilot,
+            AgentFilter::Copilot => AgentFilter::All,
         }
     }
 
@@ -65,6 +68,7 @@ impl AgentFilter {
             AgentFilter::All => "all",
             AgentFilter::Claude => "claude",
             AgentFilter::Codex => "codex",
+            AgentFilter::Copilot => "copilot",
         }
     }
 
@@ -74,6 +78,7 @@ impl AgentFilter {
             AgentFilter::All => None,
             AgentFilter::Claude => Some("claude"),
             AgentFilter::Codex => Some("codex"),
+            AgentFilter::Copilot => Some("copilot"),
         }
     }
 }
@@ -534,6 +539,8 @@ mod tests {
         assert_eq!(f, AgentFilter::Claude);
         f = f.next();
         assert_eq!(f, AgentFilter::Codex);
+        f = f.next();
+        assert_eq!(f, AgentFilter::Copilot);
         f = f.next();
         assert_eq!(f, AgentFilter::All);
     }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -5,14 +5,17 @@
 //! [`install`] verb extracts them to known on-disk locations and
 //! wires Claude Code, Codex CLI, and GitHub Copilot CLI to call into `notify.sh`.
 //!
-//! For Claude: a plugin directory at `~/.claude/plugins/ainb-hooks/`
-//! holding the manifest + script (so Claude Code's plugin marketplace
-//! resolves `${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh` correctly).
+//! For Claude: the `claude plugin` marketplace CLI installs
+//! `ainb-hooks@agents-in-a-box`, so Claude resolves the plugin root and
+//! bundled `hooks/notify.sh` itself.
 //!
 //! For Codex: a managed JSON block in `~/.codex/hooks.json`, since
 //! Codex resolves hook commands as absolute paths. The block points
 //! at the canonical `~/.agents-in-a-box/hooks/notify.sh` so the
 //! plugin stays agent-agnostic per Stevie's constraint.
+//!
+//! For Copilot: a standalone drop-in at `~/.copilot/hooks/ainb.json`,
+//! because Copilot combines every hook file in that directory.
 //!
 //! Install state is recorded at `~/.agents-in-a-box/install.json` so
 //! [`uninstall`] is fully reversible.
@@ -784,6 +787,14 @@ mod tests {
         assert!(
             text.contains("notify.sh"),
             "managed block lacks script: {text}"
+        );
+        assert!(
+            text.contains("\"PermissionRequest\""),
+            "Codex managed block should use Codex's native permission hook: {text}"
+        );
+        assert!(
+            !text.contains("\"Notification\""),
+            "Codex managed block should not use Claude/Copilot Notification hook: {text}"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -90,8 +90,8 @@ pub enum AlertKind {
 /// the ainb-tui per-session marker classify through here so the two
 /// surfaces never drift apart.
 ///
-/// Codex and Claude name the same semantic event differently; both
-/// variants map to the same [`AlertKind`]. A matcher suffix
+/// Host agents name the same semantic events differently; every
+/// supported variant maps to the same [`AlertKind`]. A matcher suffix
 /// (e.g. `Notification:idle_prompt`) is stripped before matching.
 pub fn classify_attention(raw_event: &str) -> Option<AlertKind> {
     let head = raw_event.split(':').next().unwrap_or(raw_event);
@@ -102,9 +102,11 @@ pub fn classify_attention(raw_event: &str) -> Option<AlertKind> {
         | "exec_approval_request"
         | "apply_patch_approval_request" => AlertKind::NeedsPermission,
         // Asked the user something / idle awaiting input.
-        "Notification" | "request_user_input" | "wait_for_user" => AlertKind::WaitingOnUser,
+        "Notification" | "notification" | "request_user_input" | "wait_for_user" => {
+            AlertKind::WaitingOnUser
+        }
         // Turn ended — informational.
-        "Stop" | "agent-turn-complete" | "task_complete" => AlertKind::Finished,
+        "Stop" | "agentStop" | "agent-turn-complete" | "task_complete" => AlertKind::Finished,
         // Telemetry / lifecycle (PreToolUse, PostToolUse, UserPromptSubmit, …).
         _ => return None,
     })
@@ -120,10 +122,10 @@ pub fn render_title(env: &Envelope) -> String {
         other => other,
     };
     match head {
-        "Stop" | "agent-turn-complete" | "task_complete" => {
+        "Stop" | "agentStop" | "agent-turn-complete" | "task_complete" => {
             format!("{agent} session finished")
         }
-        "Notification" | "request_user_input" | "wait_for_user" => {
+        "Notification" | "notification" | "request_user_input" | "wait_for_user" => {
             format!("{agent} is waiting for you")
         }
         "PermissionRequest"
@@ -256,6 +258,12 @@ mod tests {
     }
 
     #[test]
+    fn copilot_attention_events_are_user_facing() {
+        assert!(is_user_facing(&env("agentStop", "copilot")));
+        assert!(is_user_facing(&env("notification", "copilot")));
+    }
+
+    #[test]
     fn classify_attention_maps_each_kind() {
         // Permission / approval (Claude + Codex) → NeedsPermission.
         for e in [
@@ -274,13 +282,14 @@ mod tests {
         for e in [
             "Notification",
             "Notification:idle_prompt",
+            "notification",
             "request_user_input",
             "wait_for_user",
         ] {
             assert_eq!(classify_attention(e), Some(AlertKind::WaitingOnUser), "{e}");
         }
         // Turn ended → Finished.
-        for e in ["Stop", "agent-turn-complete", "task_complete"] {
+        for e in ["Stop", "agentStop", "agent-turn-complete", "task_complete"] {
             assert_eq!(classify_attention(e), Some(AlertKind::Finished), "{e}");
         }
         // Telemetry / lifecycle → no marker.

--- a/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
@@ -2,9 +2,9 @@
 //!
 //! Spins up the real `ainb-notifyd` accept loop in a temporary
 //! directory, fires the real `plugins/ainb-hooks/hooks/notify.sh`
-//! bash script against the socket with both a Claude-shaped (stdin
-//! JSON) payload and a Codex-shaped (argv JSON) payload, and asserts
-//! that two rows with the correct `agent` + `raw_event` end up in
+//! bash script against the socket with a Claude-shaped (stdin
+//! JSON) payload and Codex-shaped (argv JSON) payloads, and asserts
+//! that rows with the correct `agent` + `raw_event` end up in
 //! `notifications.db`.
 //!
 //! This is the wiring proof referenced in the spec's success
@@ -42,6 +42,7 @@ fn fire_claude_hook(script: &Path, home: &Path, json: &str) {
         .arg(script)
         .env("HOME", home)
         .env("AINB_AGENT", "claude")
+        .env("AINB_NOTIFY_DISABLE_LAZY_SPAWN", "1")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -68,6 +69,7 @@ fn fire_codex_hook(script: &Path, home: &Path, json: &str) {
         .arg(json)
         .env("HOME", home)
         .env("AINB_AGENT", "codex")
+        .env("AINB_NOTIFY_DISABLE_LAZY_SPAWN", "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -81,8 +83,34 @@ fn fire_codex_hook(script: &Path, home: &Path, json: &str) {
     );
 }
 
+fn fire_copilot_hook(script: &Path, home: &Path, json: &str) {
+    let out = Command::new("bash")
+        .arg(script)
+        .env("HOME", home)
+        .env("AINB_AGENT", "copilot")
+        .env("AINB_NOTIFY_DISABLE_LAZY_SPAWN", "1")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(json.as_bytes()).unwrap();
+            }
+            child.wait_with_output()
+        })
+        .expect("running copilot hook");
+    assert!(
+        out.status.success(),
+        "copilot hook failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 #[tokio::test]
-async fn hook_script_into_real_daemon_persists_both_agents() {
+async fn hook_script_into_real_daemon_persists_supported_agents() {
     // Skip if the bash script is missing — useful when running from
     // a CI matrix entry that hasn't checked out the plugin tree
     // (defensive, not expected).
@@ -121,13 +149,24 @@ async fn hook_script_into_real_daemon_persists_both_agents() {
     let codex_json = r#"{"type":"agent-turn-complete","session_id":"sess-codex-1","cwd":"/Users/example/codex-proj"}"#;
     fire_codex_hook(&script, &home, codex_json);
 
-    // Give the daemon a tick to drain both writes.
+    // Codex approval path: PermissionRequest is the native Codex event
+    // that ainb-hooks registers for blocked approval prompts.
+    let codex_permission_json = r#"{"hook_event_name":"PermissionRequest","session_id":"sess-codex-2","cwd":"/Users/example/codex-proj"}"#;
+    fire_codex_hook(&script, &home, codex_permission_json);
+
+    // Copilot path: JSON on stdin, camelCase/native event names.
+    let copilot_notification_json = r#"{"type":"notification","sessionId":"sess-copilot-1","working_directory":"/Users/example/copilot-proj"}"#;
+    fire_copilot_hook(&script, &home, copilot_notification_json);
+    let copilot_stop_json = r#"{"type":"agentStop","sessionId":"sess-copilot-2","working_directory":"/Users/example/copilot-proj"}"#;
+    fire_copilot_hook(&script, &home, copilot_stop_json);
+
+    // Give the daemon a tick to drain the writes.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Open the same DB the daemon wrote.
     let store = Store::open(&paths.db).unwrap();
     let rows = store.list(false, None, None, 100).unwrap();
-    assert_eq!(rows.len(), 2, "expected 2 rows, got {:?}", rows);
+    assert_eq!(rows.len(), 5, "expected 5 rows, got {:?}", rows);
 
     let mut by_agent: std::collections::HashMap<String, _> = std::collections::HashMap::new();
     for row in &rows {
@@ -139,9 +178,24 @@ async fn hook_script_into_real_daemon_persists_both_agents() {
     assert_eq!(claude_row.session_id, "sess-claude-1");
     assert!(claude_row.project.contains("proj"));
 
-    let codex_row = by_agent.get("codex").expect("codex row missing");
-    assert_eq!(codex_row.raw_event, "agent-turn-complete");
-    assert_eq!(codex_row.session_id, "sess-codex-1");
+    let codex_events: std::collections::HashMap<_, _> = rows
+        .iter()
+        .filter(|row| row.agent == "codex")
+        .map(|row| (row.raw_event.as_str(), row.session_id.as_str()))
+        .collect();
+    assert_eq!(
+        codex_events.get("agent-turn-complete"),
+        Some(&"sess-codex-1")
+    );
+    assert_eq!(codex_events.get("PermissionRequest"), Some(&"sess-codex-2"));
+
+    let copilot_events: std::collections::HashMap<_, _> = rows
+        .iter()
+        .filter(|row| row.agent == "copilot")
+        .map(|row| (row.raw_event.as_str(), row.session_id.as_str()))
+        .collect();
+    assert_eq!(copilot_events.get("notification"), Some(&"sess-copilot-1"));
+    assert_eq!(copilot_events.get("agentStop"), Some(&"sess-copilot-2"));
 
     daemon.abort();
 }
@@ -159,8 +213,8 @@ async fn hook_falls_back_when_daemon_down_then_daemon_replays() {
     paths.ensure_base().unwrap();
 
     // Fire the hook BEFORE the daemon starts. The script should
-    // detect no socket, fail the lazy spawn (because `ainb` is not on
-    // PATH in a test context), and write to the fallback file.
+    // detect no socket, skip lazy spawn via the test env, and write to
+    // the fallback file.
     let claude_json = r#"{"hook_event_name":"Stop","session_id":"sess-fallback","cwd":"/Users/example/proj","payload":{}}"#;
     fire_claude_hook(&script, &home, claude_json);
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -25,16 +25,18 @@ If you want to **add a screen / CLI / dashboard to the TUI**, you want this kind
 - [authoring.md](authoring.md) — write one
 - [spec-v2.md](spec-v2.md) — the wire contract
 
-### 2. **Claude Code plugins** (Anthropic's plugin system)
+### 2. **Host-agent plugins** (Claude Code / Codex / Copilot plugin systems)
 
-A separate system owned by Claude Code itself. The monorepo ships **two** Claude Code plugins under `plugins/<name>/` at the repo root (not inside `ainb-tui/`); the third, `reflect`, was **extracted** into its own repo and ships from there:
+A separate system owned by the host agents themselves. The monorepo ships host-agent plugins under `plugins/<name>/` at the repo root (not inside `ainb-tui/`); `reflect` was **extracted** into its own repo and ships from there:
 
 - **[`reflect`](../toolkit/plugins/reflect.md)** — agent self-improvement + retrieval (skills + SessionStart/PostToolUse/Stop hooks). No longer in this monorepo — it now lives in [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) (plugin under `plugin/`) and is installed from that repo, not via `claude plugin install reflect@agents-in-a-box`.
 - **[`ainb-fleet`](../toolkit/plugins/ainb-fleet.md)** — LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration. `claude plugin install ainb-fleet@agents-in-a-box`
-- **[`ainb-hooks`](../toolkit/plugins/ainb-hooks.md)** — emits Claude Code / Codex lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../tui/inbox-notifications.md) daemon — host code, not a plugin); wired by `ainb-notifyd install`.
+- **[`ainb-hooks`](../toolkit/plugins/ainb-hooks.md)** — emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../tui/inbox-notifications.md) daemon — host code, not a plugin); wired by `ainb-notifyd install`.
+- **`caveman-stats`** — Claude Code statusline + compaction-survival hooks for upstream `caveman@caveman`.
+- **`illustration`** — mascot-driven illustration skill bundle; no lifecycle hooks.
 
-- **Distribution:** the two in-monorepo plugins go through `.claude-plugin/marketplace.json` at the repo root, which the Claude Code CLI reads (reflect was removed from that marketplace and now ships from ainb-reflect-memory)
-- **Runtime:** Claude Code itself loads them as skill/hook bundles; the ainb TUI is not involved
+- **Distribution:** in-monorepo Claude Code plugins go through `.claude-plugin/marketplace.json` at the repo root, which the Claude Code CLI reads (reflect was removed from that marketplace and now ships from ainb-reflect-memory)
+- **Runtime:** host agents load them as skill/hook bundles; the ainb TUI is not involved
 - **Full docs:** [Toolkit → Claude Code plugins](../toolkit/plugins/overview.md) — a page per plugin with how-it-works diagrams
 
 If you want to **add behaviour to Claude Code itself**, you want a Claude Code plugin. Anthropic's authoritative reference is the [Claude Code plugin docs](https://docs.anthropic.com/en/docs/claude-code); the `plugins/*/` directories here (`ainb-fleet`, `ainb-hooks`) are working examples, and `reflect`'s plugin (in [ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) under `plugin/`) is another.

--- a/docs/toolkit/plugins/ainb-hooks.md
+++ b/docs/toolkit/plugins/ainb-hooks.md
@@ -1,21 +1,21 @@
 ---
 title: "ainb-hooks"
-description: "Claude Code / Codex plugin that emits session lifecycle events to the ainb notification inbox over a Unix socket."
+description: "Claude Code / Codex / Copilot plugin that emits session lifecycle events to the ainb notification inbox over a Unix socket."
 ---
 
-`ainb-hooks` (v0.1.0) is a **Claude Code plugin** — it is loaded by the Claude Code (and Codex CLI) host agent, not by the `ainb` TUI. (Contrast with the ainb v2 subprocess plugins such as `burndown` and `witr`, which run inside `ainb`.) It registers lifecycle hooks on the host agent and forwards each event to the **ainb notification inbox** — the `ainb-notifyd` daemon — over a Unix socket, powering session-state badges, the Inbox screen, and optional OS notifications in `ainb-tui`. It pairs with the [Inbox & notifications](../../tui/inbox-notifications.md) daemon (`ainb-notifyd`) — host code compiled into `ainb-core`, not a plugin — which is the consumer on the other end of the socket.
+`ainb-hooks` (v0.2.0) is a **host-agent hook plugin** — it is loaded by Claude Code, Codex CLI, or GitHub Copilot CLI, not by the `ainb` TUI. (Contrast with the ainb v2 subprocess plugins such as `burndown` and `witr`, which run inside `ainb`.) It registers lifecycle hooks on the host agent and forwards each event to the **ainb notification inbox** — the `ainb-notifyd` daemon — over a Unix socket, powering session-state badges, the Inbox screen, and optional OS notifications in `ainb-tui`. It pairs with the [Inbox & notifications](../../tui/inbox-notifications.md) daemon (`ainb-notifyd`) — host code compiled into `ainb-core`, not a plugin — which is the consumer on the other end of the socket.
 
 ## How it works
 
 ![ainb-hooks — how it works](../../assets/diagrams/ainb-hooks.svg)
 
-The plugin's `.claude-plugin/plugin.json` registers only the **actionable** lifecycle events with a single command: `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh`. The same events are registered for Codex via `codex/hooks.json` (with `AINB_AGENT=codex`). Each hook has a 5-second timeout so a slow delivery never stalls the agent.
+The plugin's `.claude-plugin/plugin.json` registers only the **actionable** lifecycle events with a single command: `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh`. Codex is registered via `codex/hooks.json` (with `AINB_AGENT=codex`), and Copilot via `copilot/hooks.json` (with `AINB_AGENT=copilot`). Each hook has a 5-second timeout so a slow delivery never stalls the agent.
 
-**Only events that need the human are hooked** — `Notification` (Claude surfaces both idle/awaiting-input and permission prompts through this event) and `Stop` (turn finished). Telemetry — `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact` — is **not** registered: `PostToolUse` alone fires dozens of times per turn and would bury the signal in the inbox. As a second line of defence, `ainb-notifyd` also drops any non-user-facing event on arrival (see `crates/ainb-plugin-notifyd/src/listener.rs`), so even a stale install never accumulates noise.
+**Only events that need the human are hooked** — Claude/Copilot use `Notification`/`notification` for awaiting input and permission prompts, Codex uses `PermissionRequest` for approvals, and all three use `Stop`/`agentStop` for turn completion. Telemetry — `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop` — is **not** registered: `PostToolUse` alone fires dozens of times per turn and would bury the signal in the inbox. As a second line of defence, `ainb-notifyd` also drops any non-user-facing event on arrival (see `crates/ainb-plugin-notifyd/src/listener.rs`), so even a stale install never accumulates noise.
 
 `hooks/notify.sh` is the universal normalizer. Claude Code pipes the hook payload as JSON on stdin; Codex passes it as `argv[1]`. The script autodetects the source, extracts the event name, session id, and cwd (via `jq`, falling back to `grep` in minimal environments), and wraps the verbatim original payload in a normalized envelope: `{protocol_version, agent, raw_event, session_id, cwd, project, ts, payload}`. The `raw_event` field preserves the original event name (e.g. `Notification:idle_prompt`) so semantic mapping happens in the consumer, not on the wire.
 
-Delivery targets `~/.agents-in-a-box/notify.sock` via `nc` (or `socat`). If the socket is absent, the script attempts a best-effort lazy spawn of `ainb notifyd` (guarded by a `flock`) and retries once. If that still fails, it appends the envelope to `~/.agents-in-a-box/notify.fallback.jsonl`, which `ainb-notifyd` replays and clears on its next startup. The hook always exits 0, so a delivery failure never blocks the host agent.
+Delivery targets `~/.agents-in-a-box/notify.sock` via `nc` (or `socat`). If the socket is absent, the script attempts a best-effort lazy spawn of `ainb notifyd` (guarded by an atomic lock directory) and retries once. If that still fails, it appends the envelope to `~/.agents-in-a-box/notify.fallback.jsonl`, which `ainb-notifyd` replays and clears on its next startup. The hook always exits 0, so a delivery failure never blocks the host agent.
 
 Downstream, `ainb-notifyd` persists envelopes to a SQLite `notifications.db` and broadcasts them to `ainb-tui` for live inbox/badge updates.
 
@@ -23,16 +23,20 @@ Downstream, `ainb-notifyd` persists envelopes to a SQLite `notifications.db` and
 
 This plugin ships only hooks plus the shared `notify.sh` script — no skills, commands, or agents.
 
-### Hooks (registered for both Claude Code and Codex)
+### Hooks
 
 Only the events that need the human are registered:
 
-| Event | What fires | Why it's actionable |
-| --- | --- | --- |
-| `Notification` | Agent notifications, incl. `Notification:idle_prompt` ("awaiting user input") and permission prompts | the agent is blocked on you |
-| `Stop` | Agent turn / session stops | the agent finished — come back |
+| Agent | Event | What fires | Why it's actionable |
+| --- | --- | --- | --- |
+| Claude Code | `Notification` | Agent notifications, incl. `Notification:idle_prompt` and permission prompts | the agent is blocked on you |
+| Claude Code | `Stop` | Agent turn / session stops | the agent finished — come back |
+| Codex CLI | `PermissionRequest` | Exec / patch / permission approval prompts | the agent is blocked on approval |
+| Codex CLI | `Stop` | Agent turn / session stops | the agent finished — come back |
+| GitHub Copilot CLI | `notification` | Agent notifications and permission prompts | the agent is blocked on you |
+| GitHub Copilot CLI | `agentStop` | Agent turn / session stops | the agent finished — come back |
 
-Deliberately **not** registered (telemetry / activity noise — would bury the signal): `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`. `PostToolUse` alone fires once per tool call (dozens per turn). The daemon additionally drops any non-user-facing event on arrival as a safety net.
+Deliberately **not** registered (telemetry / activity noise — would bury the signal): `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop`. `PostToolUse` alone fires once per tool call (dozens per turn). The daemon additionally drops any non-user-facing event on arrival as a safety net.
 
 ### Components
 
@@ -40,6 +44,7 @@ Deliberately **not** registered (telemetry / activity noise — would bury the s
 | --- | --- |
 | `.claude-plugin/plugin.json` | Claude Code plugin manifest (`hooks` block, name, version) |
 | `codex/hooks.json` | Codex `~/.codex/hooks.json` merge template (`__AINB_HOOK_SCRIPT__` placeholder) |
+| `copilot/hooks.json` | Copilot `~/.copilot/hooks/ainb.json` drop-in template |
 | `hooks/notify.sh` | Universal hook script — normalizes the payload and delivers it to the socket |
 
 ## Install
@@ -47,19 +52,19 @@ Deliberately **not** registered (telemetry / activity noise — would bury the s
 `ainb-hooks` is published in the `agents-in-a-box` plugin marketplace, but you don't install it by hand — the `ainb-notifyd` binary's installer wires it for the chosen agents and manages the notifyd lifecycle:
 
 ```bash
-ainb-notifyd install --claude --codex
+ainb-notifyd install --claude --codex --copilot
 ainb-notifyd status
 ainb-notifyd uninstall --all
 ```
 
-For **Claude**, the installer shells out to the `claude` plugin CLI — ensuring the `agents-in-a-box` marketplace is known, then `claude plugin install ainb-hooks@agents-in-a-box` (idempotent; "already installed" counts as success) — so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex**, it merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block, extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh`, and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path. The install method is recorded in `~/.agents-in-a-box/install.json` so uninstall is fully reversible (`claude plugin uninstall` for Claude, managed-block removal for Codex). **Both paths are verified end-to-end; Claude remains the primary, most-exercised integration.**
+For **Claude**, the installer shells out to the `claude` plugin CLI — ensuring the `agents-in-a-box` marketplace is known, then `claude plugin install ainb-hooks@agents-in-a-box` (idempotent; "already installed" counts as success) — so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex**, it merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block, extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh`, and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path. For **Copilot**, it writes `copilot/hooks.json` as a standalone drop-in at `~/.copilot/hooks/ainb.json`. The install method is recorded in `~/.agents-in-a-box/install.json` so uninstall is fully reversible (`claude plugin uninstall` for Claude, managed-block removal for Codex, drop-in deletion for Copilot).
 
 > The plugin's README recommends a higher-level `ainb hooks install` wrapper; that `ainb hooks` CLI is planned but not yet on `main`, so use `ainb-notifyd install` (above) today.
 
 ## Using it
 
-- Once installed, delivery is fully automatic — every registered actionable event on the host agent (`Notification`, `Stop`) is forwarded to the inbox with no user action. Telemetry events are not hooked, so the inbox only ever shows things that need you.
-- `Notification:idle_prompt` events surface in `ainb-tui` as "awaiting input" so you can see which sessions need you.
+- Once installed, delivery is fully automatic — every registered actionable event on the host agent (`Notification`/`notification`, `PermissionRequest`, `Stop`/`agentStop`) is forwarded to the inbox with no user action. Telemetry events are not hooked, so the inbox only ever shows things that need you.
+- `Notification:idle_prompt` and `PermissionRequest` events surface in `ainb-tui` as attention markers so you can see which sessions need you.
 - Events show up as session-state badges and in the dedicated Inbox screen in `ainb-tui`; the inbox detail view exposes the full original hook JSON (carried in `payload`) for forensics.
 - Run `ainb-notifyd status` to confirm the plugin is wired for each agent; if `ainb-notifyd` is not running, the next hook fire lazily spawns it (or buffers to the fallback file).
 

--- a/docs/toolkit/plugins/overview.md
+++ b/docs/toolkit/plugins/overview.md
@@ -1,11 +1,11 @@
 ---
 title: "Claude Code plugins"
-description: "The Claude Code plugins this repo ships — reflect, ainb-fleet, ainb-hooks — installable from the agents-in-a-box marketplace."
+description: "The host-agent plugins this repo ships or documents: reflect, ainb-fleet, ainb-hooks, caveman-stats, and illustration."
 ---
 
-These are **Claude Code plugins** — bundles of skills, hooks, and commands that **Claude Code** (Anthropic's CLI) loads. They are a different system from [ainb v2 plugins](../../plugins/overview.md), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](../../plugins/readme.md) first.
+These are **host-agent plugins** — bundles of skills, hooks, and commands that Claude Code, Codex, or Copilot load. They are a different system from [ainb v2 plugins](../../plugins/overview.md), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](../../plugins/readme.md) first.
 
-The repo publishes them through `.claude-plugin/marketplace.json` at the repo root; the source lives under `plugins/<name>/`. Add the marketplace, then install:
+The repo publishes the in-tree Claude Code plugins through `.claude-plugin/marketplace.json` at the repo root; the source lives under `plugins/<name>/`. Add the marketplace, then install:
 
 ```bash
 claude plugin marketplace add https://github.com/stevengonsalvez/agents-in-a-box.git
@@ -23,6 +23,33 @@ claude plugin install ainb-fleet@agents-in-a-box
 |---|---|---|
 | [reflect](./reflect.md) | Agent self-improvement + retrieval — captures learnings and auto-injects relevant prior ones at session start. **(extracted → [ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory))** | `ainb reflect bootstrap` |
 | [ainb-fleet](./ainb-fleet.md) | LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration (broadcast, sequence, needs, daemon). | `claude plugin install ainb-fleet@agents-in-a-box` |
-| [ainb-hooks](./ainb-hooks.md) | Emits Claude Code / Codex lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../../tui/inbox-notifications.md) daemon — host code, not a plugin). | `ainb-notifyd install --claude --codex` |
+| [ainb-hooks](./ainb-hooks.md) | Emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../../tui/inbox-notifications.md) daemon — host code, not a plugin). | `ainb-notifyd install --claude --codex --copilot` |
+| `caveman-stats` | Lifecycle hooks for caveman mode: statusline token-savings suffix and compaction survival. | `claude plugin install caveman-stats@agents-in-a-box` |
+| `illustration` | Mascot-driven illustration skill bundle; no lifecycle hooks. | `claude plugin install illustration@agents-in-a-box` |
+
+## Hook parity target
+
+Hook names are shown as `PascalCase / camelCase` where Copilot uses a different spelling. `YES` means the harness has a native event shape for the target behavior; `N/A` means no matching hook exists in that harness. Codex column reflects the current Codex CLI hook enum, including `PermissionRequest`, `PreToolUse`, `PostCompact`, and `Subagent*`.
+
+| Plugin / owner | Hook | Claude | Codex | Copilot | Target behavior |
+|---|---|---:|---:|---:|---|
+| `reflect` | `SessionStart / sessionStart` | YES | YES | YES | Recall inject + detached drain |
+| `reflect` | `UserPromptSubmit / userPromptSubmitted` | YES | YES | YES | Prompt recall + mini-learning completion |
+| `ainb-hooks` | `Notification / notification` | YES | N/A | YES | Awaiting-input watcher |
+| `reflect` / policy | `PreToolUse / preToolUse` | YES | YES | YES | Tool policy/context before risky calls |
+| `ainb-hooks` | `PermissionRequest / permissionRequest` | YES | YES | YES | Permission-pattern lookup + watcher |
+| `reflect` / `caveman-stats` | `PostToolUse / postToolUse` | YES | YES | YES | Tool-result signal watcher |
+| `reflect` | `PostToolUseFailure / postToolUseFailure` | YES | N/A | YES | Explicit failure mini-learning watcher |
+| `reflect` / `caveman-stats` | `PreCompact / preCompact` | YES | YES | YES | Silent queue producer |
+| `reflect` | `PostCompact / postCompact` | YES | YES | N/A | Breadcrumb/cleanup only, no drain |
+| `reflect` | `SubagentStart / subagentStart` | YES | YES | YES | Subagent-scoped recall inject |
+| `reflect` | `SubagentStop / subagentStop` | YES | YES | YES | Queue subagent transcript |
+| `ainb-hooks` / `reflect` | `Stop / agentStop` | YES | YES | YES | Slot update + queue fallback |
+| `reflect` | `SessionEnd / sessionEnd` | YES | N/A | YES | Final cleanup + final queue producer |
+| `reflect` | `errorOccurred` | N/A | N/A | YES | Error breadcrumb + optional watcher |
+| `ainb-fleet` | *(none)* | N/A | N/A | N/A | Pure skill/workflow bundle; no lifecycle hooks |
+| `illustration` | *(none)* | N/A | N/A | N/A | Pure illustration skill bundle; no lifecycle hooks |
+
+Key: only the `SessionStart` drain runs `/reflect`. `PreCompact`, `Stop`, `SubagentStop`, and `SessionEnd` only queue. `PostCompact` stays bookkeeping only.
 
 Each page below has a `/fireworks-tech-graph` diagram of how the plugin works, the exact hooks/skills it registers, and how to use it.

--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -1,25 +1,25 @@
 ---
 title: "Inbox & notifications"
-description: "How ainb captures Claude Code / Codex hook events into the Inbox and the per-session [!]/[?]/[✓] status markers, via the ainb-notifyd daemon. Host code, not a plugin."
+description: "How ainb captures host-agent hook events into the Inbox and the per-session [!]/[?]/[✓] status markers, via the ainb-notifyd daemon. Host code, not a plugin."
 ---
 
-The **Inbox** screen, the per-session **status markers** (`[!]` / `[?]` / `[✓]`), and the **`ainb-notifyd`** daemon are all part of the `ainb` host binary — **not** an ainb plugin. This page is the single reference for how notifications work: the daemon captures Claude Code / Codex lifecycle hook events into SQLite, and `ainb-tui` renders them two ways — the Inbox screen (full history) and a live per-session marker (the one row glyph that tells you a session needs you).
+The **Inbox** screen, the per-session **status markers** (`[!]` / `[?]` / `[✓]`), and the **`ainb-notifyd`** daemon are all part of the `ainb` host binary — **not** an ainb plugin. This page is the single reference for how notifications work: the daemon captures Claude Code / Codex / Copilot lifecycle hook events into SQLite, and `ainb-tui` renders them two ways — the Inbox screen (full history) and a live per-session marker (the one row glyph that tells you a session needs you).
 
-> **Agent support.** Claude Code is the primary, most-tested path (registered through the `claude` plugin CLI). Codex is wired via `~/.codex/hooks.json` and verified end-to-end too — its `Stop` / `Notification` events flow into the Inbox and mark Codex sessions (`[✓]` / `[?]`) — though Claude remains the better-exercised integration.
+> **Agent support.** Claude Code is the primary, most-tested path (registered through the `claude` plugin CLI). Codex is wired via `~/.codex/hooks.json`; Copilot is wired via `~/.copilot/hooks/ainb.json`. Their user-facing events flow into the Inbox and mark matching sessions (`[✓]` / `[?]` / `[!]`), though Claude remains the better-exercised integration.
 
-> **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins — `burndown`, `session-reader`, `witr` — which run as spawned child processes over stdio JSON-RPC and are governed by the capability gate. The **only** plugin in this feature is [`ainb-hooks`](../toolkit/plugins/ainb-hooks.md), and that is a plugin of the *host agent* (Claude Code / Codex), installed into their config dirs — not a plugin of `ainb`.
+> **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins — `burndown`, `session-reader`, `witr` — which run as spawned child processes over stdio JSON-RPC and are governed by the capability gate. The **only** plugin in this feature is [`ainb-hooks`](../toolkit/plugins/ainb-hooks.md), and that is a plugin of the *host agent* (Claude Code / Codex / Copilot), installed into their config dirs — not a plugin of `ainb`.
 
 ![The Inbox screen in ainb-tui](../assets/screenshots/notifyd-inbox.png)
 
-*Press `b` in ainb to open the Inbox — captured Claude Code / Codex lifecycle events with a list + detail pane, agent filter, and per-session unread counts.*
+*Press `b` in ainb to open the Inbox — captured Claude Code / Codex / Copilot lifecycle events with a list + detail pane, agent filter, and per-session unread counts.*
 
 ## How it works
 
 ![Inbox & notifications — how it works](../assets/diagrams/notifyd.svg)
 
-The capture path starts outside ainb, in a thin bash hook (`notify.sh`). For **Claude Code** it is registered through the plugin marketplace — `ainb notifyd install` shells out to `claude plugin install ainb-hooks@agents-in-a-box`, so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex** a managed block is merged into `~/.codex/hooks.json` pointing at the canonical `~/.agents-in-a-box/hooks/notify.sh`. Either way only the **actionable** lifecycle events are registered — `Notification` (idle / awaiting-input + permission prompts) and `Stop` (turn finished). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
+The capture path starts outside ainb, in a thin bash hook (`notify.sh`). For **Claude Code** it is registered through the plugin marketplace — `ainb notifyd install` shells out to `claude plugin install ainb-hooks@agents-in-a-box`, so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex** a managed block is merged into `~/.codex/hooks.json` pointing at the canonical `~/.agents-in-a-box/hooks/notify.sh`. For **Copilot**, `ainb-notifyd` writes a standalone drop-in at `~/.copilot/hooks/ainb.json`. Only the **actionable** lifecycle events are registered — Claude uses `Notification` (idle / awaiting-input + permission prompts), Codex uses `PermissionRequest` (approval prompts), Copilot uses `notification`, and all three have a turn-finished hook (`Stop` / `agentStop`). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
 
-Telemetry events (`SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`) are deliberately **not** hooked — `PostToolUse` alone fires dozens of times per turn and would bury the signal. So the inbox only ever contains things that need you.
+Telemetry events (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop`) are deliberately **not** hooked — `PostToolUse` alone fires dozens of times per turn and would bury the signal. So the inbox only ever contains things that need you.
 
 `ainb-notifyd` is a tokio accept-loop daemon. On startup it replays (and clears) any queued `notify.fallback.jsonl`, then binds the `0600` socket and writes a PID file. Each accepted connection is parsed into an `Envelope` and checked against `is_user_facing`: non-actionable events (telemetry like `SessionStart` / `PostToolUse`) are **dropped before persistence** — a defensive second filter on top of the trimmed hook registration, so a stale install never accumulates noise either. User-facing events (`Stop`, `Notification`, `PermissionRequest`, `agent-turn-complete`, approval/wait events, etc.) are persisted via `insert_and_prune` and emitted as a native OS notification, debounced per `(session_id, raw_event)` on a 60s window.
 
@@ -35,7 +35,7 @@ The Inbox is the full history; the **status marker** is the at-a-glance signal. 
 
 *Live markers: a Codex session that just finished its turn shows `[✓]`; a Claude session awaiting input shows `[?]`. Idle sessions with nothing pending stay blank.*
 
-Both agents register the same two hooks (`Notification`, `Stop`), so in practice you see `[?]` and `[✓]`. The mapping (identical for Claude and Codex):
+The agents register the same intent, but not the same raw hook names. The mapping:
 
 ### Claude Code
 
@@ -50,10 +50,17 @@ Both agents register the same two hooks (`Notification`, `Stop`), so in practice
 
 | Hook fired | Marker | Means | Shows until |
 |------------|--------|-------|-------------|
-| `Notification` (aliases `request_user_input`, `wait_for_user`) | `[?]` amber | awaiting input | the agent resumes · you attach · a newer `Stop` supersedes — **no TTL** |
+| *(none — Codex has no `Notification` hook)* | `[?]` amber | awaiting input | **not shown today** — Codex permission prompts use `PermissionRequest`; turn completion uses `Stop` |
 | `Stop` (aliases `agent-turn-complete`, `task_complete`) | `[✓]` green | turn finished | **5-minute TTL** · resumes · attach |
-| `exec_approval_request` · `apply_patch_approval_request` | `[!]` red | blocked on exec/patch approval | mapped, but **not registered today** (only `Notification` + `Stop` are wired) |
-| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry — not hooked | — |
+| `PermissionRequest` | `[!]` red | blocked on exec/patch approval | clears when the agent resumes · attach |
+| `SessionStart` · `UserPromptSubmit` · `PreToolUse` · `PostToolUse` · `PreCompact` · `PostCompact` · `SubagentStart` · `SubagentStop` | *(none)* | telemetry — not hooked | — |
+
+### GitHub Copilot CLI
+
+| Hook fired | Marker | Means | Shows until |
+|------------|--------|-------|-------------|
+| `notification` | `[?]` amber | awaiting input or permission prompt | the agent resumes · you attach · a newer `agentStop` supersedes it — **no TTL** |
+| `agentStop` | `[✓]` green | turn finished | **5-minute TTL** · resumes · attach |
 
 While a session is **actively generating**, the marker is suppressed (the busy state covers it). The marker recomputes every **~5 s** (the preview-refresh tick), so every appear/clear lands on that cadence rather than instantly.
 
@@ -70,7 +77,7 @@ Because this is host code, there is **no manifest and no capability declaration*
 | `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist captured envelopes; back the Inbox list and the unread badge. |
 | `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from the `ainb-hooks` script. |
 | `~/.agents-in-a-box/notify.pid`, `notify.fallback.jsonl` | Single-instance guard; recover events queued while the daemon was down. |
-| `claude` CLI (subprocess), `~/.codex/hooks.json` (read+write), `~/.agents-in-a-box/hooks/notify.sh` | The `install` / `uninstall` verbs wire the hook into the host agents — Claude via `claude plugin install/uninstall`, Codex via a managed `hooks.json` block. |
+| `claude` CLI (subprocess), `~/.codex/hooks.json` (read+write), `~/.copilot/hooks/ainb.json`, `~/.agents-in-a-box/hooks/notify.sh` | The `install` / `uninstall` verbs wire the hook into the host agents — Claude via `claude plugin install/uninstall`, Codex via a managed `hooks.json` block, Copilot via a standalone drop-in. |
 | `osascript` / `notify-send` (subprocess) | Emit the native OS notification for user-facing events. |
 
 ## Using it
@@ -83,12 +90,12 @@ Because this is host code, there is **no manifest and no capability declaration*
   - The home screen sidebar lists `📥 Inbox  [b]` between Sessions and Recovery — press `Enter` on the tile, or `b` globally, to open it. (`b` for "in-**B**ox" — picked to avoid the case-pair confusion between `i` Stats and the earlier `I` Inbox binding.)
   - The bottom menu bar (every split-pane screen) always shows `b inbox`. When the store has unread + non-dismissed events the hint becomes `● N · b inbox`, so the global unread count is visible even when the Inbox screen is closed.
   - The Sessions screen renders a live **status marker** (`[!]` / `[?]` / `[✓]`) on the row of any session with a pending hook event, matched by `cwd` ↔ `workspace_path`. This is the primary surface — notifications are tied to the session that produced them, not a separate destination. See [Per-session status markers](#per-session-status-markers).
-- **Inbox screen** — press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex), `r` force refresh, `q`/`Esc` back.
+- **Inbox screen** — press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex → copilot), `r` force refresh, `q`/`Esc` back.
 - **cwd-based correlation (jump-to-tmux)** — every envelope carries the agent's `cwd` at hook-fire time, and every ainb `Session` carries a `workspace_path`. When the user presses `Enter` on an Inbox row, notifyd resolves the row's `cwd` to the first ainb workspace whose path matches (exact or `workspace_path/`-prefix to cover worktree subdirs), picks a session in that workspace, and queues an `AttachToOtherTmux` action with that session's `tmux_session_name`. There is no shared session-id namespace between the host agents' `session_id` strings and ainb's `Session.id` `Uuid`; the cwd is the bridge.
 - **Daemon + installer CLI** — the documented entrypoint is the standalone `ainb-notifyd` binary. The same verbs are also available as a **hidden `ainb notifyd …` subcommand** on the main `ainb` binary (it delegates to the identical `ainb_plugin_notifyd` functions). The hidden alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd` — the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
   - `ainb-notifyd run` (or `ainb notifyd run` / bare `ainb notifyd`) — run the daemon in the foreground. The hook script lazy-spawns `ainb notifyd` when the socket is missing; if `ainb` is on `PATH` the daemon auto-starts and the event is delivered live (no fallback file).
-  - `ainb-notifyd install --claude --codex` (or `--all`) — install the `ainb-hooks` hook for the chosen agents.
-  - `ainb-notifyd uninstall --claude --codex` (or `--all`) — reverse the install; preserves user-authored Codex hooks.
+  - `ainb-notifyd install --claude --codex --copilot` (or `--all`) — install the `ainb-hooks` hook for the chosen agents.
+  - `ainb-notifyd uninstall --claude --codex --copilot` (or `--all`) — reverse the install; preserves user-authored Codex hooks and other Copilot hook files.
   - `ainb-notifyd status` — report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness.
   - `ainb-notifyd stop` — send `SIGTERM` to a running daemon via its PID file.
   - Every verb accepts `--format text|json|csv|markdown` (default `text`) for scripting — e.g. `ainb notifyd status --format json`.

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -8,9 +8,9 @@ badges, the dedicated Inbox screen, and optional OS notifications in
 ## How it works
 
 ```
-┌─ Claude / Codex session ─────┐
+┌─ Claude / Codex / Copilot ───┐
 │ hook fires (Stop, Notification│
-│   :idle_prompt, ...)         │
+│   / PermissionRequest, ...)  │
 │ ────────────────────────────▶│ notify.sh
 └──────────────────────────────┘    │
                                     ▼
@@ -68,7 +68,7 @@ ainb-notifyd uninstall --all
 
 The CLI:
 
-1. Drops `.claude-plugin/plugin.json` at `~/.claude/plugins/ainb-hooks/` (Claude).
+1. Installs `ainb-hooks@agents-in-a-box` through the Claude plugin marketplace (Claude).
 2. Merges this directory's `codex/hooks.json` into `~/.codex/hooks.json` as a
    managed block (Codex).
 3. Writes this directory's `copilot/hooks.json` to `~/.copilot/hooks/ainb.json`
@@ -82,18 +82,23 @@ The CLI:
 
 ## Hook events
 
-Claude and Codex use identical PascalCase event names: `SessionStart`,
-`UserPromptSubmit`, `PostToolUse`, `Notification`, `Stop`, `PreCompact`.
-Copilot's hook format differs — camelCase events in a `{"version":1,"hooks":…}`
-drop-in — so its template registers `notification` + `agentStop` (the
-human-facing pair). Only the user-facing events are hooked on every agent;
-telemetry events are intentionally left out so they don't bury the signal.
+Claude and Codex both use PascalCase event names, but Codex now exposes a
+separate `PermissionRequest` hook instead of a `Notification` hook. The
+human-facing registrations are:
 
-The matcher `Notification:idle_prompt` (Claude) and Codex's variants
-(`request_user_input`, `wait_for_user`, etc.) all carry the same
-semantic meaning ("agent awaiting user input"). `notify.sh` preserves
-the raw event name in the `raw_event` field of the envelope so UI
-mapping happens in the consumer, not at the wire.
+| Agent | Hooks registered | Meaning |
+| --- | --- | --- |
+| Claude Code | `Notification`, `Stop` | awaiting input / permission prompt, turn finished |
+| Codex CLI | `PermissionRequest`, `Stop` | approval prompt, turn finished |
+| GitHub Copilot CLI | `notification`, `agentStop` | awaiting input / permission prompt, turn finished |
+
+Only the user-facing events are hooked on every agent; telemetry events are
+intentionally left out so they don't bury the signal.
+
+The matcher `Notification:idle_prompt` (Claude) and `PermissionRequest`
+(Codex) carry different raw names but the same user-facing shape: the agent
+needs Stevie. `notify.sh` preserves the raw event name in the `raw_event` field
+of the envelope so UI mapping happens in the consumer, not at the wire.
 
 ## Envelope shape
 

--- a/plugins/ainb-hooks/codex/hooks.json
+++ b/plugins/ainb-hooks/codex/hooks.json
@@ -1,7 +1,7 @@
 {
-  "//": "ainb-hooks managed block, merged into ~/.codex/hooks.json by `ainb-notifyd install --codex`. Do not edit by hand. Only the events that need the human are registered (Notification = awaiting-input/permission, Stop = turn finished). Telemetry (SessionStart / UserPromptSubmit / PostToolUse / PreCompact) is intentionally NOT hooked — it would bury the signal. The daemon also drops any non-user-facing event defensively.",
+  "//": "ainb-hooks managed block, merged into ~/.codex/hooks.json by `ainb-notifyd install --codex`. Do not edit by hand. Only the events that need the human are registered (PermissionRequest = approval prompt, Stop = turn finished). Telemetry (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PreCompact / PostCompact / SubagentStart / SubagentStop) is intentionally NOT hooked because it would bury the signal. The daemon also drops any non-user-facing event defensively.",
   "hooks": {
-    "Notification": [
+    "PermissionRequest": [
       {
         "matcher": "",
         "hooks": [

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# ainb-hooks: universal notification hook for Claude Code + Codex CLI.
+# ainb-hooks: universal notification hook for Claude Code, Codex CLI, and Copilot CLI.
 #
-# Reads a hook event payload (Claude pipes JSON on stdin; Codex passes JSON
-# as argv[1]), builds a normalized envelope, and delivers it to ainb-notifyd
+# Reads a hook event payload (Claude/Copilot pipe JSON on stdin; Codex passes
+# JSON as argv[1]), builds a normalized envelope, and delivers it to ainb-notifyd
 # via a Unix socket at $HOME/.agents-in-a-box/notify.sock. On any delivery
 # failure the payload is appended to a fallback JSONL file that notifyd
 # replays on its next startup. The script always exits 0 so a delivery
@@ -66,7 +66,8 @@ fi
 
 # Codex emits `type` values like `agent-turn-complete`, `request_user_input`.
 # We preserve the raw_event verbatim per spec (no canonical mapping in MVP)
-# but include a matcher slot for Claude's `Notification:idle_prompt` style.
+# but include a matcher slot for Claude's `Notification:idle_prompt` and
+# Codex's `PermissionRequest` style.
 if [ -n "${AINB_MATCHER}" ]; then
   AINB_RAW_EVENT="${AINB_RAW_EVENT}:${AINB_MATCHER}"
 fi
@@ -165,6 +166,9 @@ ainb_socket_alive() {
 ainb_lazy_spawn() {
   # Best-effort lazy spawn of ainb notifyd. Silent on success and failure;
   # the fallback file is the safety net.
+  if [ "${AINB_NOTIFY_DISABLE_LAZY_SPAWN:-}" = "1" ]; then
+    return 1
+  fi
   if ainb_socket_alive; then
     return 0
   fi


### PR DESCRIPTION
## Summary
- align ainb-hooks Codex manifest to supported PermissionRequest and Stop hooks
- document hook parity across Claude, Codex, and Copilot plugins
- update notifyd install docs/tests for Codex hook parity
- fix review gaps for Copilot notification classification, Inbox filtering, and per-session markers

## Tests
- cargo fmt --check (passed; repo rustfmt config emits existing stable-channel warnings)
- cargo test --no-run (from ainb-tui; passed with existing warnings)
- cargo test -p ainb-plugin-notifyd (75 unit + 2 e2e passed; existing dead-code warnings)
- cargo test -p ainb agent_filter_cycles_in_order (passed with existing warnings)
- cargo test -p ainb agent_hook_name_maps_supported_hook_agents (passed with existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded inbox filtering and notifications to support GitHub Copilot alongside Claude and Codex.
  * Added broader lifecycle event coverage, including permission requests and session stop events.

* **Bug Fixes**
  * Improved event mapping so user-facing alerts now appear more consistently across supported agents.
  * Updated fallback and delivery behavior when the notification service is unavailable.

* **Documentation**
  * Refreshed plugin and inbox docs to reflect the expanded multi-agent support and updated installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->