### PR TITLE
feat(raycast): multi-host clipboard image -> SSH paste

### DIFF
--- a/scripts/raycast/_cc-paste-lib.sh
+++ b/scripts/raycast/_cc-paste-lib.sh
@@ -1,0 +1,30 @@
+# shellcheck shell=bash
+# Shared host registry + persisted-selection helpers for the cc-paste Raycast commands.
+# Sourced by clipboard-image-to-ssh-path.sh (sender) and clipboard-image-set-host.sh (switcher).
+# Not a Raycast command itself (no @raycast headers) so Raycast ignores it.
+# bash 3.2 compatible (macOS /bin/bash) — no associative arrays.
+
+CC_DEFAULT_HOST="mac"
+CC_STATE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/cc-paste-host"
+
+# Host registry. key -> "ssh-target|tailscale-peer-hostname"
+# ssh-target may include user@ ; peer-hostname is matched (case-insensitive) for the online check.
+# Add a host = add a case line here (and a dropdown entry in clipboard-image-set-host.sh).
+cc_resolve() {
+  case "$1" in
+    mac)     echo "stevens-macbook-pro-5|Stevens-MacBook-Pro-5" ;;
+    hetzner) echo "claude@claude-hetzner|claude-hetzner" ;;
+    *)       echo "" ;;
+  esac
+}
+
+# Current host key: persisted choice if valid, else default.
+cc_current_key() {
+  local k=""
+  [ -f "$CC_STATE_FILE" ] && k="$(tr -d '[:space:]' < "$CC_STATE_FILE")"
+  if [ -n "$k" ] && [ -n "$(cc_resolve "$k")" ]; then
+    printf '%s' "$k"
+  else
+    printf '%s' "$CC_DEFAULT_HOST"
+  fi
+}

--- a/scripts/raycast/clipboard-image-set-host.sh
+++ b/scripts/raycast/clipboard-image-set-host.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Set SSH Host
+# @raycast.mode silent
+# @raycast.packageName Stevie Utils
+# @raycast.icon 🎯
+# @raycast.description Choose which host "Clipboard Image -> SSH Path" copies to. Persists the choice.
+#
+# Optional parameters:
+# @raycast.argument1 { "type": "dropdown", "placeholder": "Host", "data": [{ "title": "Mac (stevens-macbook-pro-5)", "value": "mac" }, { "title": "Hetzner (claude@claude-hetzner)", "value": "hetzner" }] }
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/_cc-paste-lib.sh"
+
+KEY="${1:-}"
+HOST_SPEC="$(cc_resolve "$KEY")"
+[ -n "$HOST_SPEC" ] || { echo "unknown host: $KEY" >&2; exit 1; }
+
+mkdir -p "$(dirname "$CC_STATE_FILE")"
+printf '%s' "$KEY" > "$CC_STATE_FILE"
+
+printf "SSH host set to %s (%s)\n" "$KEY" "${HOST_SPEC%%|*}"

--- a/scripts/raycast/clipboard-image-to-ssh-path.sh
+++ b/scripts/raycast/clipboard-image-to-ssh-path.sh
@@ -5,11 +5,17 @@
 # @raycast.mode silent
 # @raycast.packageName Stevie Utils
 # @raycast.icon 📋
-# @raycast.description Copy clipboard image to remote Mac /tmp over Tailscale SSH; put bare /tmp/... path on clipboard for pasting into Claude SSH session
+# @raycast.description Copy clipboard image to the current host's /tmp over Tailscale SSH; put bare /tmp/... path on clipboard. Change host with "Set SSH Host".
 
 set -euo pipefail
 
-REMOTE_HOST="stevens-macbook-pro-5"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/_cc-paste-lib.sh"
+
+HOST_KEY="$(cc_current_key)"
+HOST_SPEC="$(cc_resolve "$HOST_KEY")"
+REMOTE_HOST="${HOST_SPEC%%|*}"
+PEER_NAME="${HOST_SPEC##*|}"
+
 REMOTE_DIR="/tmp"
 FILE_PREFIX="cc-paste"
 
@@ -25,12 +31,13 @@ if ! tailscale status --json >/dev/null 2>&1; then
   fail "tailscale not running"
 fi
 
-if ! tailscale status --json | /usr/bin/python3 -c '
-import json, sys
+if ! tailscale status --json | PEER_NAME="$PEER_NAME" /usr/bin/python3 -c '
+import json, os, sys
+want = os.environ["PEER_NAME"].lower()
 j = json.load(sys.stdin)
 peer = next((p for p in j.get("Peer", {}).values()
-             if p.get("HostName") == "Stevens-MacBook-Pro-5"
-             or p.get("DNSName", "").startswith("stevens-macbook-pro-5.")), None)
+             if p.get("HostName", "").lower() == want
+             or p.get("DNSName", "").lower().startswith(want + ".")), None)
 raise SystemExit(0 if peer and peer.get("Online") else 1)
 '; then
   fail "remote host offline: ${REMOTE_HOST}"
@@ -55,4 +62,4 @@ if ! tailscale ssh "$REMOTE_HOST" "test -s $(printf '%q' "$remote_path")"; then
 fi
 
 printf "%s" "$remote_path" | pbcopy
-printf "Copied: %s\n" "$remote_path"
+printf "Copied to %s: %s\n" "$HOST_KEY" "$remote_path"


### PR DESCRIPTION
Make the Raycast clipboard-image SSH-paste script target a selectable host instead of a hardcoded Mac.

## What
- `_cc-paste-lib.sh` — shared host registry + persisted-selection helpers (bash 3.2 compatible; `case` resolver, no associative arrays).
- `clipboard-image-to-ssh-path.sh` — sender now reads the current host from the lib; fires prompt-free to whichever host is set. Per-host tailscale online check.
- `clipboard-image-set-host.sh` — new **Set SSH Host** command; dropdown picks Mac / Hetzner and persists it.

## Hosts
| key | target |
|---|---|
| mac (default) | stevens-macbook-pro-5 |
| hetzner | claude@claude-hetzner |

## Tested
- Hetzner transfer end-to-end over tailscale: online check PASS, cat-over-ssh PASS, **sha256 match**, cleanup OK.
- All 3 scripts syntax + run under `/bin/bash` 3.2 (Raycast's shell). Fixes the `unbound variable` from the earlier `declare -A` version.
- Bad host key rejected; state defaults to mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing and saving the target host used by clipboard-to-SSH path actions.
  * Clipboard image uploads now resolve the active remote host dynamically instead of using a fixed destination.

* **Bug Fixes**
  * Improved remote host matching so the correct Tailscale peer is selected more reliably.
  * Added a clearer confirmation message showing which host was used for the copy action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->