### PR TITLE
fix(statusline): detect project-local RTK hook for the RTK pill

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/init.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/init.rs
@@ -595,7 +595,7 @@ pub fn run_statusline_step<R: std::io::BufRead, W: std::io::Write>(
                 writeln!(
                     out,
                     "  {}",
-                    crate::cli::statusline::render_powerline(&example_cache())
+                    crate::cli::statusline::render_powerline(&example_cache(), None)
                 )
                 .ok();
                 writeln!(out).ok();

--- a/ainb-tui/crates/ainb-core/src/cli/statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/statusline.rs
@@ -177,7 +177,7 @@ pub fn read_cache(path: &std::path::Path) -> Option<LiveCache> {
 /// Render the powerline-styled status string. Hand-rolled ANSI escapes
 /// keep this dependency-free. The format is intentionally plain (no
 /// nerd-font glyphs) so it works in any terminal.
-pub fn render_powerline(cache: &LiveCache) -> String {
+pub fn render_powerline(cache: &LiveCache, session_dir: Option<&std::path::Path>) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     if let Some(model) = &cache.model {
@@ -216,7 +216,7 @@ pub fn render_powerline(cache: &LiveCache) -> String {
         parts.push(hr);
     }
 
-    if let Some(rtk) = rtk_segment() {
+    if let Some(rtk) = rtk_segment(session_dir) {
         parts.push(rtk);
     }
 
@@ -255,21 +255,90 @@ fn headroom_segment() -> Option<String> {
 
 /// RTK (Rust Token Killer) statusline pill. Like the `HR` segment, it
 /// reflects the ACTUAL wiring state rather than the stored per-session
-/// toggle: the pill shows only when the Claude Code PreToolUse hook is
-/// really wired. This statusline command is only ever invoked by Claude
-/// Code, so no agent-type gate is needed.
+/// toggle: the pill shows only when the RTK `PreToolUse` hook is really
+/// wired for this session. This statusline command is only ever invoked by
+/// Claude Code, so no agent-type gate is needed.
 ///
-/// `rtk::is_wired()` spawns `rtk init --show`, so it is gated behind the
-/// cheap `is_installed()` PATH check — no subprocess on machines without
-/// rtk. ponytail: `is_wired()` checks the GLOBAL `~/.claude/settings.json`
-/// hook; a session wired only via a project-local hook won't light up.
-/// If that case matters, read the effective project settings instead.
-fn rtk_segment() -> Option<String> {
-    rtk_pill(crate::rtk::is_installed() && crate::rtk::is_wired())
+/// `session_dir` is the session's directory from the Claude Code payload
+/// (`workspace.project_dir`); see [`rtk_hook_wired_for_session`].
+fn rtk_segment(session_dir: Option<&std::path::Path>) -> Option<String> {
+    rtk_pill(rtk_hook_wired_for_session(session_dir))
+}
+
+/// True when an RTK `PreToolUse` hook is wired for THIS session.
+///
+/// ainb wires it project-locally into `<worktree>/.claude/settings.json`
+/// (see `wire_rtk_project_hook`); `rtk init -g` wires it globally into
+/// `~/.claude/settings.json`. Check both.
+///
+/// The session dir comes from the Claude Code payload rather than the
+/// process cwd — the statusline docs explicitly say the command's working
+/// directory is not guaranteed, so we resolve `<session_dir>/.claude/
+/// settings.json` from `workspace.project_dir`, falling back to the process
+/// cwd only when the payload omits it.
+///
+/// Cheap file reads only — deliberately NOT `rtk::is_wired()`, which spawns
+/// `rtk init --show` on every render AND only sees the global hook, so it
+/// missed the common project-wired session entirely.
+fn rtk_hook_wired_for_session(session_dir: Option<&std::path::Path>) -> bool {
+    let project_settings = match session_dir {
+        Some(dir) => dir.join(".claude").join("settings.json"),
+        None => std::path::PathBuf::from(".claude/settings.json"),
+    };
+    if rtk_hook_in_settings(&project_settings) {
+        return true;
+    }
+    if let Some(home) = dirs::home_dir() {
+        if rtk_hook_in_settings(&home.join(".claude").join("settings.json")) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Extract the session directory from a Claude Code statusline payload.
+/// Prefers `workspace.project_dir` (where Claude Code — and thus the
+/// session's RTK hook — was launched), then `workspace.current_dir`, then
+/// the top-level `cwd`.
+fn payload_session_dir(value: &serde_json::Value) -> Option<std::path::PathBuf> {
+    value
+        .pointer("/workspace/project_dir")
+        .or_else(|| value.pointer("/workspace/current_dir"))
+        .or_else(|| value.pointer("/cwd"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)
+}
+
+/// Whether the `settings.json` at `path` carries an RTK `PreToolUse` hook.
+/// Matches the command substring `rtk hook claude` — the same match
+/// `wire_rtk_project_hook` uses for its idempotency check. Any read/parse
+/// failure (missing file, bad JSON) is treated as "not wired".
+fn rtk_hook_in_settings(path: &std::path::Path) -> bool {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    value
+        .pointer("/hooks/PreToolUse")
+        .and_then(|v| v.as_array())
+        .is_some_and(|matchers| {
+            matchers.iter().any(|matcher| {
+                matcher.get("hooks").and_then(|h| h.as_array()).is_some_and(|hooks| {
+                    hooks.iter().any(|h| {
+                        h.get("command")
+                            .and_then(|c| c.as_str())
+                            .is_some_and(|c| c.contains("rtk hook claude"))
+                    })
+                })
+            })
+        })
 }
 
 /// Pure formatter for the RTK pill — split from `rtk_segment` so it is
-/// unit-testable without the `rtk` binary present.
+/// unit-testable without touching the filesystem.
 fn rtk_pill(wired: bool) -> Option<String> {
     wired.then(|| ansi_fg(GREEN, "RTK"))
 }
@@ -374,7 +443,13 @@ pub fn run_with(
     if cache_only {
         Ok(None)
     } else {
-        Ok(Some(render_powerline(&cache)))
+        // Resolve the session dir from the payload for project-local RTK hook
+        // detection (statusline cwd is not guaranteed; see rtk_segment).
+        let session_dir = serde_json::from_slice::<serde_json::Value>(buf)
+            .ok()
+            .as_ref()
+            .and_then(payload_session_dir);
+        Ok(Some(render_powerline(&cache, session_dir.as_deref())))
     }
 }
 
@@ -568,7 +643,7 @@ mod tests {
             context_pct: Some(45),
             model: Some("Opus".to_string()),
         };
-        let line = render_powerline(&cache);
+        let line = render_powerline(&cache, None);
         assert!(line.contains("Opus"));
         assert!(line.contains("ctx"));
         assert!(line.contains("45"));
@@ -590,7 +665,7 @@ mod tests {
             model: None,
         };
         // Just don't panic; result may be empty string.
-        let _ = render_powerline(&cache);
+        let _ = render_powerline(&cache, None);
     }
 
     #[test]
@@ -631,6 +706,75 @@ mod tests {
         // so no `rtk` binary required (mirrors the HR pill's label assertion).
         assert!(rtk_pill(true).as_deref().unwrap_or("").contains("RTK"));
         assert!(rtk_pill(false).is_none());
+    }
+
+    #[test]
+    fn rtk_hook_in_settings_detects_project_local_hook() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+
+        // Missing file → not wired.
+        assert!(!rtk_hook_in_settings(&path));
+
+        // Malformed JSON → not wired (never panics).
+        std::fs::write(&path, "{ not json").unwrap();
+        assert!(!rtk_hook_in_settings(&path));
+
+        // PreToolUse hook with an unrelated command → not wired.
+        std::fs::write(
+            &path,
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"command":"echo hi","type":"command"}]}]}}"#,
+        )
+        .unwrap();
+        assert!(!rtk_hook_in_settings(&path));
+
+        // The exact shape ainb's wire_rtk_project_hook writes → wired.
+        std::fs::write(
+            &path,
+            r#"{"hooks":{"PreToolUse":[{"matcher":"","hooks":[{"command":"/opt/homebrew/bin/rtk hook claude","type":"command"}]}]}}"#,
+        )
+        .unwrap();
+        assert!(rtk_hook_in_settings(&path));
+    }
+
+    #[test]
+    fn payload_session_dir_prefers_project_dir() {
+        let v: serde_json::Value = serde_json::from_str(
+            r#"{"cwd":"/c","workspace":{"current_dir":"/cur","project_dir":"/proj"}}"#,
+        )
+        .unwrap();
+        assert_eq!(payload_session_dir(&v), Some(std::path::PathBuf::from("/proj")));
+
+        // Falls back to current_dir, then cwd.
+        let v2: serde_json::Value =
+            serde_json::from_str(r#"{"cwd":"/c","workspace":{"current_dir":"/cur"}}"#).unwrap();
+        assert_eq!(payload_session_dir(&v2), Some(std::path::PathBuf::from("/cur")));
+        let v3: serde_json::Value = serde_json::from_str(r#"{"cwd":"/c"}"#).unwrap();
+        assert_eq!(payload_session_dir(&v3), Some(std::path::PathBuf::from("/c")));
+
+        // Absent / empty → None (callers fall back to process cwd).
+        let v4: serde_json::Value = serde_json::from_str(r#"{"workspace":{}}"#).unwrap();
+        assert_eq!(payload_session_dir(&v4), None);
+    }
+
+    #[test]
+    fn rtk_wired_resolves_hook_under_session_dir() {
+        // Mirrors the real flow: hook lives in <session_dir>/.claude/settings.json
+        // (where ainb's wire_rtk_project_hook writes it), and we resolve it from
+        // the payload-provided session dir, not the process cwd.
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+
+        // NB: the negative case (no hook) is covered hermetically by
+        // rtk_hook_in_settings_detects_project_local_hook — we don't assert it
+        // here because rtk_hook_wired_for_session also reads the real global
+        // ~/.claude/settings.json, which may legitimately carry an rtk hook.
+        std::fs::write(
+            dir.path().join(".claude").join("settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"","hooks":[{"command":"/opt/homebrew/bin/rtk hook claude","type":"command"}]}]}}"#,
+        )
+        .unwrap();
+        assert!(rtk_hook_wired_for_session(Some(dir.path())));
     }
 
     /// `--cache-only`: cache is written, stdout payload is `None`


### PR DESCRIPTION
## Problem

The RTK pill (added in v1.10.0) never appeared, even on sessions with RTK on. Root cause: it gated on `rtk::is_wired()`, which runs `rtk init --show` and only inspects the **global** `~/.claude/settings.json` hook. But ainb wires RTK **project-locally** via `wire_rtk_project_hook` into `<worktree>/.claude/settings.json`. Verified on a live session: hook present at `<worktree>/.claude/settings.json` (`/opt/homebrew/bin/rtk hook claude`), global has none → pill stayed hidden — the exact case the pill was built for.

## Fix

Detect the hook by reading the `settings.json` that actually applies to the session:
- project-local `./.claude/settings.json` (Claude Code runs the statusline command in the project dir), then
- global `~/.claude/settings.json` (for `rtk init -g`).

Match the `rtk hook claude` command substring — the same match `wire_rtk_project_hook` uses for idempotency.

Bonus: cheap file reads, **no subprocess** — removes the per-render `rtk init --show` spawn flagged in the v1.10.0 review.

## Test

New `rtk_hook_in_settings_detects_project_local_hook`: missing file / malformed JSON / unrelated hook → not wired; the exact shape ainb writes → wired. 29/29 statusline tests pass.

## Follow-up
Needs a 1.10.1 release; the box also has to upgrade off 1.9.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the RTK status indicator so it reflects whether RTK is actually wired in the current Claude settings.
  * The indicator now checks local and user configuration files directly, reducing false positives from command-based detection.
  * Detection failures are now handled safely by treating RTK as not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->