### PR TITLE
feat(setup): cross-harness plugin onboarding (Claude + Codex + Copilot)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -639,14 +639,17 @@ pub fn catalog() -> Vec<Topic> {
         Topic {
             id: "hooks",
             label: "Hooks & notifications",
-            description: "Inbox screen + session-state badges (Claude Code + Codex)",
+            description: "Inbox screen + session-state badges (Claude Code + Codex + Copilot)",
             deps: vec![dep(
                 "ainb-hooks",
                 "ainb-hooks (notifyd)",
                 "lifecycle events powering the Inbox + badges",
                 Recommended,
                 Custom("notifyd-installed"),
-                Ainb(&["notifyd", "install", "--claude", "--codex"]),
+                // `--all` covers Claude + Codex + Copilot. The notifyd installer
+                // bakes plugins/ainb-hooks/{codex,copilot}/hooks.json for the
+                // non-Claude agents; dropping a target silently loses their Inbox.
+                Ainb(&["notifyd", "install", "--all"]),
                 &[],
                 &[],
             )],
@@ -654,7 +657,7 @@ pub fn catalog() -> Vec<Topic> {
         Topic {
             id: "suggested-plugins",
             label: "Suggested plugins",
-            description: "Claude: claude plugin install <name>@agents-in-a-box · Codex: ainb skill install <uri> --targets codex",
+            description: "Claude: claude plugin install <name>@agents-in-a-box · Codex/Copilot: ainb skill install <uri> --targets codex,copilot",
             deps: vec![
                 dep(
                     "ainb-fleet",
@@ -759,6 +762,30 @@ mod tests {
         let topics = catalog();
         let gemini = topics.iter().flat_map(|t| &t.deps).find(|d| d.id == "gemini").unwrap();
         assert_eq!(gemini.install.hint(), "npm install -g @google/gemini-cli");
+    }
+
+    #[test]
+    fn suggested_plugins_offer_codex_and_copilot() {
+        // F2 guard: the skill-plugin topic must surface the cross-harness
+        // install path for BOTH Codex and Copilot, not Claude-only.
+        let topics = catalog();
+        let sp = topics.iter().find(|t| t.id == "suggested-plugins").unwrap();
+        assert!(sp.description.contains("codex"), "must mention codex: {}", sp.description);
+        assert!(sp.description.contains("copilot"), "must mention copilot: {}", sp.description);
+    }
+
+    #[test]
+    fn hooks_install_covers_every_agent() {
+        // F1 guard: onboarding must install ainb-hooks for Claude + Codex +
+        // Copilot. `--all` is the only target spec that covers Copilot; a
+        // `--claude --codex` regression would silently drop Copilot's Inbox.
+        let topics = catalog();
+        let hooks = topics.iter().flat_map(|t| &t.deps).find(|d| d.id == "ainb-hooks").unwrap();
+        let hint = hooks.install.hint();
+        assert!(
+            hint.contains("--all") || hint.contains("--copilot"),
+            "hooks install must reach Copilot, got: {hint}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -657,7 +657,7 @@ pub fn catalog() -> Vec<Topic> {
         Topic {
             id: "suggested-plugins",
             label: "Suggested plugins",
-            description: "Claude: claude plugin install <name>@agents-in-a-box · Codex/Copilot: ainb skill install <uri> --targets codex,copilot",
+            description: "Claude: claude plugin install <name>@agents-in-a-box · Codex/Copilot: skill plugins (ainb-fleet, illustration) via ainb skill install <uri> --targets codex,copilot; caveman-stats is Claude-only",
             deps: vec![
                 dep(
                     "ainb-fleet",
@@ -770,21 +770,31 @@ mod tests {
         // install path for BOTH Codex and Copilot, not Claude-only.
         let topics = catalog();
         let sp = topics.iter().find(|t| t.id == "suggested-plugins").unwrap();
-        assert!(sp.description.contains("codex"), "must mention codex: {}", sp.description);
-        assert!(sp.description.contains("copilot"), "must mention copilot: {}", sp.description);
+        assert!(
+            sp.description.contains("codex"),
+            "must mention codex: {}",
+            sp.description
+        );
+        assert!(
+            sp.description.contains("copilot"),
+            "must mention copilot: {}",
+            sp.description
+        );
     }
 
     #[test]
     fn hooks_install_covers_every_agent() {
-        // F1 guard: onboarding must install ainb-hooks for Claude + Codex +
-        // Copilot. `--all` is the only target spec that covers Copilot; a
-        // `--claude --codex` regression would silently drop Copilot's Inbox.
+        // F1 guard: onboarding must install ainb-hooks for ALL agents in one
+        // shot. `--all` is the only spec that covers every agent; `--claude
+        // --codex` (the prior regression) or any single-agent subset would
+        // silently drop an Inbox, so assert `--all` exactly rather than a weak
+        // "mentions copilot" that a Claude-dropping subset could also satisfy.
         let topics = catalog();
         let hooks = topics.iter().flat_map(|t| &t.deps).find(|d| d.id == "ainb-hooks").unwrap();
         let hint = hooks.install.hint();
         assert!(
-            hint.contains("--all") || hint.contains("--copilot"),
-            "hooks install must reach Copilot, got: {hint}"
+            hint.contains("--all"),
+            "hooks install must use --all, got: {hint}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/setup/detect.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/detect.rs
@@ -224,13 +224,25 @@ fn detect_custom(name: &str, env: &dyn Env) -> DepState {
                 DepState::Missing
             }
         }
-        // notifyd hook installed for any agent (Claude / Codex / Copilot).
+        // notifyd hook installed for every agent the user actually has. A hook
+        // present for one agent must NOT mask a missing one: an upgrader who
+        // has a Codex/Copilot home but no ainb hook there is reported Missing
+        // so the wizard re-runs `notifyd install --all` and wires the gap (the
+        // F1 cross-harness intent). Agents with no home dir aren't in use and
+        // don't count against the check.
         "notifyd-installed" => {
-            if home_path_exists(".claude/plugins/ainb-hooks")
-                || home_file_contains(".claude/settings.json", "ainb-hooks")
-                || home_path_exists(".codex/hooks.json")
-                || home_path_exists(".copilot/hooks/ainb.json")
-            {
+            let claude_hook = home_path_exists(".claude/plugins/ainb-hooks")
+                || home_file_contains(".claude/settings.json", "ainb-hooks");
+            let codex_hook = home_file_contains(".codex/hooks.json", "AINB_AGENT=codex");
+            let copilot_hook = home_path_exists(".copilot/hooks/ainb.json");
+            if notifyd_hooks_satisfied(
+                home_path_exists(".claude"),
+                claude_hook,
+                home_path_exists(".codex"),
+                codex_hook,
+                home_path_exists(".copilot"),
+                copilot_hook,
+            ) {
                 DepState::Ok(None)
             } else {
                 DepState::Missing
@@ -290,6 +302,29 @@ fn home_file_contains(rel: &str, needle: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Decide whether the notifyd hooks are satisfied, given per-agent (home dir
+/// present, ainb hook present) facts. Pure so the tricky AND/OR/guard logic is
+/// unit-testable without touching `$HOME`.
+///
+/// Rule: every agent the user actually has (home dir present) must carry its
+/// ainb hook; agents with no home dir aren't in use and don't count. At least
+/// one hook must be present, so a machine where nothing is installed reports
+/// Missing rather than vacuously Ok.
+fn notifyd_hooks_satisfied(
+    claude_present: bool,
+    claude_hook: bool,
+    codex_present: bool,
+    codex_hook: bool,
+    copilot_present: bool,
+    copilot_hook: bool,
+) -> bool {
+    let claude_ok = !claude_present || claude_hook;
+    let codex_ok = !codex_present || codex_hook;
+    let copilot_ok = !copilot_present || copilot_hook;
+    let any_hook = claude_hook || codex_hook || copilot_hook;
+    any_hook && claude_ok && codex_ok && copilot_ok
+}
+
 /// Detect a single dependency's state against the host (public for the CLI
 /// install loop, which needs to re-probe one dep after provisioning it).
 pub fn detect_dep(dep: &crate::setup::catalog::Dep, env: &dyn Env) -> DepState {
@@ -333,6 +368,33 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+
+    #[test]
+    fn notifyd_satisfied_requires_every_present_agent() {
+        // (claude_present, claude_hook, codex_present, codex_hook, copilot_present, copilot_hook)
+        // Upgrader with a Copilot home but no Copilot hook → re-wire (Missing).
+        assert!(!notifyd_hooks_satisfied(
+            true, true, true, true, true, false
+        ));
+        // Same for a Codex gap.
+        assert!(!notifyd_hooks_satisfied(
+            true, true, true, false, false, false
+        ));
+        // Claude-only user (no codex/copilot homes) with the Claude hook → Ok.
+        assert!(notifyd_hooks_satisfied(
+            true, true, false, false, false, false
+        ));
+        // All three present and hooked → Ok.
+        assert!(notifyd_hooks_satisfied(true, true, true, true, true, true));
+        // Nothing installed anywhere → Missing (not vacuously Ok).
+        assert!(!notifyd_hooks_satisfied(
+            false, false, false, false, false, false
+        ));
+        // Claude present but un-hooked → Missing.
+        assert!(!notifyd_hooks_satisfied(
+            true, false, false, false, false, false
+        ));
+    }
 
     struct MockEnv {
         present: Vec<&'static str>,

--- a/ainb-tui/crates/ainb-core/src/setup/installer.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/installer.rs
@@ -93,11 +93,13 @@ fn probe_bin(detect: &Detect) -> Option<&'static str> {
 }
 
 /// The runnable install command for a dep, or `None` if it's manual/bundled/
-/// multi-step (emitted as a comment instead). `ainb-hooks` is rewritten to the
-/// chosen agent's notifyd target.
-fn install_cmd(id: &str, install: &Install, agent: Agent) -> Option<String> {
+/// multi-step (emitted as a comment instead). `ainb-hooks` installs hooks for
+/// every agent (`--all`), not just the script's target: the notifyd inbox is
+/// shared, so whichever agent the user later runs should reach it. Wiring only
+/// the script's own agent silently leaves the others' Inbox dark.
+fn install_cmd(id: &str, install: &Install, _agent: Agent) -> Option<String> {
     if id == "ainb-hooks" {
-        return Some(format!("ainb notifyd install --{}", agent.slug()));
+        return Some("ainb notifyd install --all".to_string());
     }
     match install {
         Install::Brew(_)

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -286,6 +286,12 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
     // also clears any prior "don't ask again" — the user is opting in.
     record.plugin_version = Some(embedded_plugin_version());
     record.prompt_dismissed = false;
+    // Per-agent install failures are isolated: one agent's filesystem error
+    // (e.g. an unwritable `~/.copilot`) must NOT abort the others or prevent
+    // the Claude plugin registration that runs after this returns. We collect
+    // failures, persist whatever succeeded, and surface warnings — never let a
+    // single `--all` target take the whole step down.
+    let mut failures: Vec<(Agent, anyhow::Error)> = Vec::new();
     for agent in agents {
         match agent {
             Agent::Claude => {
@@ -297,22 +303,31 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
                 record.claude_plugin_dir = None;
                 push_unique(&mut record.agents, Agent::Claude);
             }
-            Agent::Codex => {
-                let hooks_json = install_codex(home, &hook_script)?;
-                record.codex_hooks_json = Some(hooks_json);
-                push_unique(&mut record.agents, Agent::Codex);
-            }
-            Agent::Copilot => {
-                let hooks_json = install_copilot(home, &hook_script)?;
-                record.copilot_hooks_json = Some(hooks_json);
-                push_unique(&mut record.agents, Agent::Copilot);
-            }
+            Agent::Codex => match install_codex(home, &hook_script) {
+                Ok(hooks_json) => {
+                    record.codex_hooks_json = Some(hooks_json);
+                    push_unique(&mut record.agents, Agent::Codex);
+                }
+                Err(e) => failures.push((Agent::Codex, e)),
+            },
+            Agent::Copilot => match install_copilot(home, &hook_script) {
+                Ok(hooks_json) => {
+                    record.copilot_hooks_json = Some(hooks_json);
+                    push_unique(&mut record.agents, Agent::Copilot);
+                }
+                Err(e) => failures.push((Agent::Copilot, e)),
+            },
             // Unknown agents are owned by a newer build; skip without
             // disturbing an existing record entry.
             Agent::Unknown => {}
         }
     }
     record.save(paths)?;
+    for (agent, e) in &failures {
+        eprintln!(
+            "warning: notifyd hook install for {agent:?} failed (other agents unaffected): {e:#}"
+        );
+    }
     Ok(record)
 }
 

--- a/docs/toolkit/plugins/overview.md
+++ b/docs/toolkit/plugins/overview.md
@@ -24,7 +24,7 @@ claude plugin install ainb-fleet@agents-in-a-box
 | [reflect](./reflect.md) | Agent self-improvement + retrieval — captures learnings and auto-injects relevant prior ones at session start. **(extracted → [ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory))** | `ainb reflect bootstrap` |
 | [ainb-fleet](./ainb-fleet.md) | LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration (broadcast, sequence, needs, daemon). | `claude plugin install ainb-fleet@agents-in-a-box` |
 | [ainb-hooks](./ainb-hooks.md) | Emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../../tui/inbox-notifications.md) daemon — host code, not a plugin). | `ainb-notifyd install --claude --codex --copilot` |
-| `caveman-stats` | Lifecycle hooks for caveman mode: statusline token-savings suffix and compaction survival. | `claude plugin install caveman-stats@agents-in-a-box` |
+| `caveman-stats` | Lifecycle hooks for caveman mode: statusline token-savings suffix and compaction survival. **Claude-only** — the hook *events* exist in all three harnesses (see matrix), but the code reads Claude session JSONL (`CLAUDE_CONFIG_DIR`) and writes the Claude statusline suffix, and no Codex/Copilot statusline consumes it. | `claude plugin install caveman-stats@agents-in-a-box` |
 | `illustration` | Mascot-driven illustration skill bundle; no lifecycle hooks. | `claude plugin install illustration@agents-in-a-box` |
 
 ## Hook parity target

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -1449,6 +1449,7 @@ Usage: ainb claudecode statusline [OPTIONS]
 Options:
       --cache-only       Side-channel mode: write the cache only and emit nothing on stdout.
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --install          Wire the statusline into ~/.claude/settings.json (idempotent) instead of running the hook.
   -h, --help             Print help
 ```
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,143 @@
+# Harness plugins
+
+This folder holds **harness plugins** — extensions that plug into the *coding
+agent itself* (Claude Code, Codex CLI, GitHub Copilot CLI). They add skills,
+lifecycle hooks, and notification wiring to whichever agent harness you run.
+
+They are installable through the `agents-in-a-box` plugin marketplace
+(`.claude-plugin/marketplace.json` at the repo root) or provisioned by the
+`ainb` setup wizard.
+
+> Think of the broader ecosystem's harness plugins — Codexplored, Hermes, and
+> friends. Same genre: they ride *inside* the agent. The ones here are ours.
+
+## What these are NOT
+
+These are **not** ainb-tui plugins.
+
+```
+┌──────────────────────────────┐        ┌──────────────────────────────┐
+│  HARNESS plugins (this dir)   │        │  TUI plugins (ainb-tui/)      │
+│  extend the coding AGENT      │   vs   │  extend the ainb TUI itself   │
+│  Claude / Codex / Copilot     │        │  ratatui screens + commands   │
+│  skills · hooks · notifs      │        │  JSON-RPC subprocess, ABI v2  │
+│  installed via marketplace    │        │  compiled / bundled in `ainb` │
+└──────────────────────────────┘        └──────────────────────────────┘
+```
+
+TUI plugins live in `ainb-tui/crates/ainb-plugin-*` (burndown, notifyd,
+session-reader, …) and are loaded by the TUI's plugin runtime, not by any
+agent harness. See `ainb-tui/CLAUDE.md` for that system.
+
+### ⚠️ `hangar-tui/` is the exception in this folder
+
+`plugins/hangar-tui/` is a **TUI plugin**, not a harness plugin. It is a Rust
+crate (`Cargo.toml` + `manifest.toml`, ABI v2, JSON-RPC over a Unix socket)
+and a member of the `ainb-tui` Cargo workspace
+(`ainb-tui/Cargo.toml` → `"../plugins/hangar-tui"`). It is **compiled into the
+`ainb` binary** — there is nothing to "install" from the marketplace. It sits
+here only because that's where its source path was placed; ignore it when
+reasoning about harness plugins.
+
+## The harness plugins
+
+| Plugin           | Kind   | What it does                                                          | Marketplace install                          |
+|------------------|--------|----------------------------------------------------------------------|----------------------------------------------|
+| `ainb-fleet`     | skills | Teaches agents the `ainb fleet …` multi-session orchestration verbs   | `ainb-fleet@agents-in-a-box`                 |
+| `ainb-hooks`     | hooks  | Emits Stop / Notification / PermissionRequest events to the ainb inbox| `ainb-hooks@agents-in-a-box`                 |
+| `caveman-stats`  | hooks  | Caveman token-savings statusline + compaction-survival re-inject      | `caveman-stats@agents-in-a-box`              |
+| `illustration`   | skills | Popa-mascot brand-illustration workflow (sketchnote generation)       | `illustration@agents-in-a-box`               |
+
+Two more harness plugins ship in this marketplace but are **sourced
+externally** (not files in this folder):
+
+| Plugin     | Source                                              | What it does                                          |
+|------------|-----------------------------------------------------|-------------------------------------------------------|
+| `reflect`  | `github:stevengonsalvez/ainb-reflect-memory` (pinned) | Long-term memory: SessionStart recall + capture hooks |
+| `caveman`  | external `caveman` marketplace                      | Ultra-compressed token-saving response mode           |
+
+## Install
+
+### 1. Add the marketplace (once)
+
+```bash
+claude plugin marketplace add stevengonsalvez/agents-in-a-box
+```
+
+### 2. Install a plugin (Claude Code)
+
+```bash
+claude plugin install ainb-fleet@agents-in-a-box
+claude plugin install ainb-hooks@agents-in-a-box
+claude plugin install caveman-stats@agents-in-a-box
+claude plugin install illustration@agents-in-a-box
+```
+
+`reflect` carries its own marketplace, so add that source first:
+
+```bash
+claude plugin marketplace add stevengonsalvez/ainb-reflect-memory
+claude plugin install reflect@ainb-reflect-memory
+```
+
+### 3. Or let the wizard do it
+
+```bash
+ainb init          # interactive setup, offers every plugin above
+ainb init --script # print the install script instead of running it
+```
+
+The catalog the wizard drives lives in
+`ainb-tui/crates/ainb-core/src/setup/catalog.rs` (single source of truth for
+TUI onboarding **and** the `ainb init` CLI).
+
+## Cross-harness support
+
+Codex CLI and Copilot CLI now expose the same lifecycle hook events as Claude
+Code (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`,
+and — on recent builds — compaction). So cross-harness support is no longer an
+event problem; it's a wiring problem, and the wiring exists. The marketplace
+(`claude plugin install`) is still Claude-only, but Codex and Copilot reach the
+same functionality through these mechanisms:
+
+- **Skill plugins** (`ainb-fleet`, `illustration`) are portable Markdown.
+  Install each skill unit into the Codex/Copilot skill homes:
+
+  ```bash
+  ainb skill install gh:stevengonsalvez/agents-in-a-box@main/plugins/ainb-fleet/skills/<unit> \
+    --targets codex,copilot
+  ```
+
+- **Hook plugins** (`ainb-hooks`) need per-harness hook wiring. One command
+  writes all three formats (and `ainb init` now calls it with `--all`):
+
+  ```bash
+  ainb notifyd install --all          # = --claude --codex --copilot
+  ```
+
+  (`ainb-hooks` ships `codex/hooks.json` and `copilot/hooks.json` next to the
+  Claude manifest, plus a universal `notify.sh`.)
+
+### Support matrix
+
+| Plugin          | Claude Code | Codex CLI            | Copilot CLI          | Notes                                                                 |
+|-----------------|-------------|----------------------|----------------------|----------------------------------------------------------------------|
+| `ainb-fleet`    | ✅          | ➜ via `skill install`| ➜ via `skill install`| skills are harness-portable Markdown                                 |
+| `ainb-hooks`    | ✅          | ✅                   | ✅                   | ships all three hook formats; `ainb notifyd install --all`           |
+| `caveman-stats` | ✅          | ❌                   | ❌                   | **Claude-first.** The hook *events* exist everywhere, but the code is Claude-coupled (reads Claude JSONL via `CLAUDE_CONFIG_DIR`, writes the Claude statusline file) and no Codex/Copilot statusline consumes the token-savings suffix — porting would be dead code |
+| `illustration`  | ✅          | ➜ via `skill install`| ➜ via `skill install`| skills are harness-portable Markdown                                 |
+| `reflect`       | ✅          | ✅ Codex adapter     | ✅ Copilot adapter   | full parity; `plugin/adapters/{codex,copilot}` write native hook configs. Copilot ignores `userPromptSubmitted` output → per-prompt recall is manual `/recall` (SessionStart auto-recall works) |
+| `caveman`       | ✅          | ➜ via `skill install`| ➜ via `skill install`| external marketplace                                                 |
+
+Legend: ✅ first-class · ➜ supported via a sync/adapter step · ❌ not available / not worthwhile.
+
+## Authoring a new harness plugin
+
+1. Create `plugins/<name>/.claude-plugin/plugin.json` (name, version, hooks
+   and/or a `skills/` dir).
+2. Register it in the root `.claude-plugin/marketplace.json`.
+3. If it's a **hook** plugin and should reach Codex/Copilot, add
+   `codex/hooks.json` and `copilot/hooks.json` (see `ainb-hooks/` for the
+   reference layout).
+4. Add it to the setup catalog
+   (`ainb-tui/crates/ainb-core/src/setup/catalog.rs`) so `ainb init` offers it.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -13,7 +13,9 @@ They are installable through the `agents-in-a-box` plugin marketplace
 
 ## What these are NOT
 
-These are **not** ainb-tui plugins.
+These are **not** ainb-tui plugins. For the canonical "two systems, same word"
+explainer, see [`docs/plugins/README.md`](../docs/plugins/README.md); the short
+version:
 
 ```
 ┌──────────────────────────────┐        ┌──────────────────────────────┐
@@ -21,11 +23,11 @@ These are **not** ainb-tui plugins.
 │  extend the coding AGENT      │   vs   │  extend the ainb TUI itself   │
 │  Claude / Codex / Copilot     │        │  ratatui screens + commands   │
 │  skills · hooks · notifs      │        │  JSON-RPC subprocess, ABI v2  │
-│  installed via marketplace    │        │  compiled / bundled in `ainb` │
+│  installed via marketplace    │        │  spawned over stdio JSON-RPC  │
 └──────────────────────────────┘        └──────────────────────────────┘
 ```
 
-TUI plugins live in `ainb-tui/crates/ainb-plugin-*` (burndown, notifyd,
+TUI plugins live in `ainb-tui/crates/ainb-plugin-*` (burndown,
 session-reader, …) and are loaded by the TUI's plugin runtime, not by any
 agent harness. See `ainb-tui/CLAUDE.md` for that system.
 
@@ -34,10 +36,11 @@ agent harness. See `ainb-tui/CLAUDE.md` for that system.
 `plugins/hangar-tui/` is a **TUI plugin**, not a harness plugin. It is a Rust
 crate (`Cargo.toml` + `manifest.toml`, ABI v2, JSON-RPC over a Unix socket)
 and a member of the `ainb-tui` Cargo workspace
-(`ainb-tui/Cargo.toml` → `"../plugins/hangar-tui"`). It is **compiled into the
-`ainb` binary** — there is nothing to "install" from the marketplace. It sits
-here only because that's where its source path was placed; ignore it when
-reasoning about harness plugins.
+(`ainb-tui/Cargo.toml` → `"../plugins/hangar-tui"`). It builds as its own
+executable (`[[bin]] ainb-plugin-hangar`) that the host **spawns as a JSON-RPC
+subprocess** — it is *not* linked into the `ainb` binary, and there is nothing
+to "install" from the marketplace. It sits here only because that's where its
+source path was placed; ignore it when reasoning about harness plugins.
 
 ## The harness plugins
 
@@ -115,8 +118,10 @@ same functionality through these mechanisms:
   ainb notifyd install --all          # = --claude --codex --copilot
   ```
 
-  (`ainb-hooks` ships `codex/hooks.json` and `copilot/hooks.json` next to the
-  Claude manifest, plus a universal `notify.sh`.)
+  (`ainb notifyd …` and the standalone `ainb-notifyd …` binary are the same
+  entrypoint — the docsite's [plugin overview](../docs/toolkit/plugins/overview.md)
+  uses the `ainb-notifyd` form. `ainb-hooks` ships `codex/hooks.json` and
+  `copilot/hooks.json` next to the Claude manifest, plus a universal `notify.sh`.)
 
 ### Support matrix
 
@@ -124,12 +129,12 @@ same functionality through these mechanisms:
 |-----------------|-------------|----------------------|----------------------|----------------------------------------------------------------------|
 | `ainb-fleet`    | ✅          | ➜ via `skill install`| ➜ via `skill install`| skills are harness-portable Markdown                                 |
 | `ainb-hooks`    | ✅          | ✅                   | ✅                   | ships all three hook formats; `ainb notifyd install --all`           |
-| `caveman-stats` | ✅          | ❌                   | ❌                   | **Claude-first.** The hook *events* exist everywhere, but the code is Claude-coupled (reads Claude JSONL via `CLAUDE_CONFIG_DIR`, writes the Claude statusline file) and no Codex/Copilot statusline consumes the token-savings suffix — porting would be dead code |
+| `caveman-stats` | ✅          | ❌                   | ❌                   | **Claude-only** (matches the docsite plugin overview). The hook *events* exist everywhere, but the code is Claude-coupled (reads Claude JSONL via `CLAUDE_CONFIG_DIR`, writes the Claude statusline file) and no Codex/Copilot statusline consumes the token-savings suffix — porting would be dead code |
 | `illustration`  | ✅          | ➜ via `skill install`| ➜ via `skill install`| skills are harness-portable Markdown                                 |
-| `reflect`       | ✅          | ✅ Codex adapter     | ✅ Copilot adapter   | full parity; `plugin/adapters/{codex,copilot}` write native hook configs. Copilot ignores `userPromptSubmitted` output → per-prompt recall is manual `/recall` (SessionStart auto-recall works) |
+| `reflect`       | ✅          | ✅ Codex adapter     | ◑ Copilot adapter    | Codex + Copilot adapters ship (`plugin/adapters/{codex,copilot}` write native hook configs). One Copilot gap: it ignores `userPromptSubmitted` output, so per-prompt recall there is manual `/recall` — SessionStart auto-recall still fires |
 | `caveman`       | ✅          | ➜ via `skill install`| ➜ via `skill install`| external marketplace                                                 |
 
-Legend: ✅ first-class · ➜ supported via a sync/adapter step · ❌ not available / not worthwhile.
+Legend: ✅ first-class · ◑ works with one documented gap · ➜ supported via a sync/adapter step · ❌ not available / not worthwhile.
 
 ## Authoring a new harness plugin
 


### PR DESCRIPTION
## What

Make the harness-plugin onboarding actually reach every agent, not just Claude+Codex, plus a self-contained `plugins/README.md` and corrected docs.

### F1 — hooks onboarding installs for all agents
- catalog hooks topic runs `ainb notifyd install --all` (was `--claude --codex`, silently dropping Copilot's Inbox).
- **install resilience**: one agent's filesystem failure (e.g. unwritable `~/.copilot`) no longer aborts Claude/Codex wiring or record-save — failures are isolated + warned.
- **detection**: `notifyd-installed` now requires every agent the user *has* (home dir present) to carry its ainb hook, so upgraders get re-wired instead of being masked by OR-semantics. Pure `notifyd_hooks_satisfied` + unit test.
- **script-gen**: `ainb init --script` emits `--all` too (shared inbox), not a single `--<agent>`.

### F2 — skill plugins surfaced for Codex/Copilot
- suggested-plugins description documents `ainb skill install <uri> --targets codex,copilot` (scoped to the skill plugins; caveman-stats stays Claude-only). Real auto-provisioner tracked in `agents-in-a-box-b3d`.

### F3 — reflect Copilot adapter
- Already shipped in `ainb-reflect-memory`; fixed stale adapter tests there (66 green) — stevengonsalvez/ainb-reflect-memory#12.

### F4/F5 — docs
- caveman-stats documented **Claude-only** (Claude-coupled code + no codex/copilot statusline consumer; the hook *events* exist everywhere).
- new `plugins/README.md` (harness plugins vs the ainb-tui plugin system; hangar-tui is a spawned subprocess, not compiled-in); docsite builds clean.

## Validation
- Codex: live hook → isolated `notifications.db` (`codex|Stop`) — **PASS**.
- Copilot: install verified; live fire blocked because Copilot fires no agentStop hook in this env — tracked in `agents-in-a-box-ce3` (Copilot-side, not an ainb defect).
- All setup lib tests + both onboarding tripwires green post-rebase.

## Follow-ups (beads)
- `agents-in-a-box-ce3` — Copilot not firing hooks (P1).
- `agents-in-a-box-b3d` — F2 real auto-provisioner (P2).

Reviewed via workflow code-review (xhigh); all 12 findings addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook installation now applies across all supported agents instead of only one selected agent.
  * Partial agent install failures no longer stop the remaining setup from completing.

* **Bug Fixes**
  * Improved detection for installed notification hooks so it correctly checks each available agent and avoids false positives.

* **Documentation**
  * Expanded plugin documentation with clearer install guidance, support coverage, and plugin classification.
  * Clarified plugin descriptions and install behavior for multiple agent environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->