### PR TITLE
feat(onboarding): per-harness auth screen (Claude/Codex/Gemini/Copilot) with system-wide auth, doc links + verified key injection

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -6539,22 +6539,27 @@ impl EventHandler {
                     }
                     // Choose a method for the agent. Stays on the step (no advance).
                     Some(AuthPane::MethodPicker { agent, cursor }) => match cursor {
-                        // Login / OAuth
+                        // Login / system-wide
                         0 => {
                             match agent {
                                 AuthAgent::Claude => {
+                                    // System-wide: config gates injection, so the
+                                    // key (if any) simply stops being injected.
                                     set_claude_provider(ClaudeAuthProvider::SystemAuth);
                                 }
-                                AuthAgent::Codex => {
-                                    // No config flag for Codex — a stored key would
-                                    // force API-key mode, so drop it to honour Login.
-                                    let had = credentials::has_openai_api_key();
-                                    let _ = credentials::delete_openai_api_key();
+                                other => {
+                                    // No config flag for these — a stored key would
+                                    // force API-key mode, so drop it to honour the
+                                    // sign-in choice (else it'd still be injected).
+                                    let key = other.credential_key();
+                                    let had = credentials::has_credential(key);
+                                    let _ = credentials::delete_credential(key);
                                     if had {
-                                        state.add_info_notification(
-                                            "Removed stored OpenAI key; Codex will use `codex login`"
-                                                .to_string(),
-                                        );
+                                        state.add_info_notification(format!(
+                                            "Removed stored {}; {} will use sign-in",
+                                            other.key_label(),
+                                            other.label()
+                                        ));
                                     }
                                 }
                             }
@@ -6564,7 +6569,7 @@ impl EventHandler {
                             }
                             state.add_info_notification(format!(
                                 "{}: {}",
-                                agent.label(),
+                                agent.login_label(),
                                 agent.login_hint()
                             ));
                         }
@@ -6592,10 +6597,8 @@ impl EventHandler {
                                 "Enter an API key first (or Esc to cancel)".to_string(),
                             );
                         } else {
-                            let stored = match agent {
-                                AuthAgent::Claude => credentials::store_anthropic_api_key(&key),
-                                AuthAgent::Codex => credentials::store_openai_api_key(&key),
-                            };
+                            let stored =
+                                credentials::store_credential(agent.credential_key(), &key);
                             match stored {
                                 Ok(()) => {
                                     if agent == AuthAgent::Claude {
@@ -6606,8 +6609,9 @@ impl EventHandler {
                                         o.refresh_auth_statuses();
                                     }
                                     state.add_success_notification(format!(
-                                        "{} saved to keychain",
-                                        agent.key_label()
+                                        "{} saved to keychain; injected as {}",
+                                        agent.key_label(),
+                                        agent.env_var()
                                     ));
                                 }
                                 Err(e) => {

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -457,12 +457,12 @@ pub enum AppEvent {
     OnboardingCursorEnd,          // Move cursor to end of input
     OnboardingCheckDeps,          // Run dependency check
     OnboardingSkipAuth,           // Skip authentication step
-    OnboardingAuthUp,             // Auth step: move option cursor up
-    OnboardingAuthDown,           // Auth step: move option cursor down
-    OnboardingAuthSelect,         // Auth step: choose focused option / save key
+    OnboardingAuthUp,             // Auth step: move cursor up (agent list / method picker)
+    OnboardingAuthDown,           // Auth step: move cursor down (agent list / method picker)
+    OnboardingAuthSelect,         // Auth step: drill in / choose method / save key
     OnboardingAuthKeyChar(char),  // Auth step: type into the API-key field
     OnboardingAuthKeyBackspace,   // Auth step: backspace the API-key field
-    OnboardingAuthKeyCancel,      // Auth step: leave API-key entry (Esc)
+    OnboardingAuthCancel,         // Auth step: leave a sub-pane (Esc) back one level
     OnboardingEditorUp,           // Move editor selection up
     OnboardingEditorDown,         // Move editor selection down
     OnboardingFinish,             // Complete onboarding
@@ -2321,31 +2321,40 @@ impl EventHandler {
                     }
                 }
                 OnboardingStep::Authentication => {
-                    let typing_key = state
-                        .onboarding_state
-                        .as_ref()
-                        .map(|o| o.auth_api_key_input.is_some())
-                        .unwrap_or(false);
-                    if typing_key {
-                        match key_event.code {
+                    use crate::components::onboarding::AuthPane;
+                    let pane = state.onboarding_state.as_ref().map(|o| o.auth_pane.clone());
+                    match pane {
+                        // Typing an API key.
+                        Some(AuthPane::KeyEntry { .. }) => match key_event.code {
                             KeyCode::Enter => Some(AppEvent::OnboardingAuthSelect),
-                            KeyCode::Esc => Some(AppEvent::OnboardingAuthKeyCancel),
+                            KeyCode::Esc => Some(AppEvent::OnboardingAuthCancel),
                             KeyCode::Backspace => Some(AppEvent::OnboardingAuthKeyBackspace),
                             KeyCode::Char(c) => Some(AppEvent::OnboardingAuthKeyChar(c)),
                             _ => None,
-                        }
-                    } else {
-                        match key_event.code {
+                        },
+                        // Choosing a method for one agent.
+                        Some(AuthPane::MethodPicker { .. }) => match key_event.code {
                             KeyCode::Up => Some(AppEvent::OnboardingAuthUp),
                             KeyCode::Down => Some(AppEvent::OnboardingAuthDown),
                             KeyCode::Enter | KeyCode::Right => Some(AppEvent::OnboardingAuthSelect),
+                            KeyCode::Esc | KeyCode::Left => Some(AppEvent::OnboardingAuthCancel),
+                            _ => None,
+                        },
+                        // Per-agent list (default). Enter drills in; Right/n advance.
+                        _ => match key_event.code {
+                            KeyCode::Up => Some(AppEvent::OnboardingAuthUp),
+                            KeyCode::Down => Some(AppEvent::OnboardingAuthDown),
+                            KeyCode::Enter => Some(AppEvent::OnboardingAuthSelect),
+                            KeyCode::Right | KeyCode::Char('n') | KeyCode::Char('N') => {
+                                Some(AppEvent::OnboardingNext)
+                            }
                             KeyCode::Esc => Some(AppEvent::OnboardingToMenu),
                             KeyCode::Left | KeyCode::Backspace => Some(AppEvent::OnboardingBack),
                             KeyCode::Char('s') | KeyCode::Char('S') => {
                                 Some(AppEvent::OnboardingSkipAuth)
                             }
                             _ => None,
-                        }
+                        },
                     }
                 }
                 OnboardingStep::OtelSetup => match key_event.code {
@@ -6355,6 +6364,12 @@ impl EventHandler {
                         if onboarding_state.current_step == OnboardingStep::EditorSelection {
                             onboarding_state.init_editors_if_needed();
                         }
+                        // Detect current per-agent auth when entering the step.
+                        if onboarding_state.current_step == OnboardingStep::Authentication {
+                            onboarding_state.auth_pane =
+                                crate::components::onboarding::AuthPane::AgentList;
+                            onboarding_state.refresh_auth_statuses();
+                        }
                     }
                 }
                 // Auto-trigger dependency check if entering DependencyCheck step
@@ -6368,9 +6383,16 @@ impl EventHandler {
                 }
             }
             AppEvent::OnboardingBack => {
+                use crate::components::onboarding::OnboardingStep;
                 tracing::debug!("Onboarding back step");
                 if let Some(ref mut onboarding_state) = state.onboarding_state {
                     onboarding_state.go_back();
+                    // Refresh per-agent auth when stepping back into the step.
+                    if onboarding_state.current_step == OnboardingStep::Authentication {
+                        onboarding_state.auth_pane =
+                            crate::components::onboarding::AuthPane::AgentList;
+                        onboarding_state.refresh_auth_statuses();
+                    }
                 }
             }
             AppEvent::OnboardingToMenu => {
@@ -6420,61 +6442,77 @@ impl EventHandler {
                 state.pending_async_action = Some(AsyncAction::OnboardingCheckDeps);
             }
             AppEvent::OnboardingSkipAuth => {
-                tracing::debug!("Skipping authentication");
+                // "Configure later" — advance without changing anything. The
+                // per-agent statuses already reflect the real current auth.
+                tracing::debug!("Skipping authentication configuration");
                 if let Some(ref mut onboarding_state) = state.onboarding_state {
-                    onboarding_state.auth_completed = true;
-                    onboarding_state.auth_method = Some("skipped".to_string());
                     onboarding_state.advance();
                 }
             }
             AppEvent::OnboardingAuthUp => {
+                use crate::components::onboarding::AuthPane;
                 if let Some(o) = state.onboarding_state.as_mut() {
-                    o.move_auth_cursor(-1);
+                    match &mut o.auth_pane {
+                        AuthPane::MethodPicker { cursor, .. } => {
+                            *cursor = cursor.saturating_sub(1);
+                        }
+                        AuthPane::AgentList => o.move_auth_agent_cursor(-1),
+                        AuthPane::KeyEntry { .. } => {}
+                    }
                 }
             }
             AppEvent::OnboardingAuthDown => {
+                use crate::components::onboarding::AuthPane;
                 if let Some(o) = state.onboarding_state.as_mut() {
-                    o.move_auth_cursor(1);
+                    match &mut o.auth_pane {
+                        AuthPane::MethodPicker { cursor, .. } => {
+                            if *cursor < 2 {
+                                *cursor += 1;
+                            }
+                        }
+                        AuthPane::AgentList => o.move_auth_agent_cursor(1),
+                        AuthPane::KeyEntry { .. } => {}
+                    }
                 }
             }
             AppEvent::OnboardingAuthKeyChar(ch) => {
+                use crate::components::onboarding::AuthPane;
                 if let Some(o) = state.onboarding_state.as_mut() {
-                    if let Some(buf) = o.auth_api_key_input.as_mut() {
+                    if let AuthPane::KeyEntry { buf, .. } = &mut o.auth_pane {
                         buf.push(ch);
                     }
                 }
             }
             AppEvent::OnboardingAuthKeyBackspace => {
+                use crate::components::onboarding::AuthPane;
                 if let Some(o) = state.onboarding_state.as_mut() {
-                    if let Some(buf) = o.auth_api_key_input.as_mut() {
+                    if let AuthPane::KeyEntry { buf, .. } = &mut o.auth_pane {
                         buf.pop();
                     }
                 }
             }
-            AppEvent::OnboardingAuthKeyCancel => {
+            AppEvent::OnboardingAuthCancel => {
+                // Esc backs out one level: key entry → its method picker,
+                // method picker → the agent list.
+                use crate::components::onboarding::AuthPane;
                 if let Some(o) = state.onboarding_state.as_mut() {
-                    o.auth_api_key_input = None;
+                    o.auth_pane = match &o.auth_pane {
+                        AuthPane::KeyEntry { agent, .. } => {
+                            AuthPane::MethodPicker { agent: *agent, cursor: 1 }
+                        }
+                        _ => AuthPane::AgentList,
+                    };
                 }
             }
             AppEvent::OnboardingAuthSelect => {
+                use crate::components::onboarding::{AuthAgent, AuthMethodKind, AuthPane};
                 use crate::config::{AppConfig, ClaudeAuthProvider};
-                // Decide from an immutable read, then mutate/notify without a
-                // held borrow. Rows: 0=Claude OAuth, 1=Claude API key,
-                // 2=Codex OAuth, 3=Skip. While typing a key, Enter = save.
-                let (typing_key, key_buf, idx) = state
-                    .onboarding_state
-                    .as_ref()
-                    .map(|o| {
-                        (
-                            o.auth_api_key_input.is_some(),
-                            o.auth_api_key_input.clone().unwrap_or_default(),
-                            o.auth_selected_index,
-                        )
-                    })
-                    .unwrap_or((false, String::new(), 0));
+
+                // Read the active pane, then mutate/notify without a held borrow.
+                let pane = state.onboarding_state.as_ref().map(|o| o.auth_pane.clone());
 
                 // Persist the Claude auth provider so build_env_setup() honours it.
-                let set_provider = |p: ClaudeAuthProvider| match AppConfig::load() {
+                let set_claude_provider = |p: ClaudeAuthProvider| match AppConfig::load() {
                     Ok(mut c) => {
                         c.authentication.claude_provider = p;
                         if let Err(e) = c.save() {
@@ -6484,73 +6522,105 @@ impl EventHandler {
                     Err(e) => tracing::error!("Failed to load config for auth provider: {}", e),
                 };
 
-                if typing_key {
-                    let key = key_buf.trim().to_string();
-                    if key.is_empty() || key == "sk-ant-" {
-                        state.add_warning_notification(
-                            "Enter an API key first (or Esc to cancel)".to_string(),
-                        );
-                    } else {
-                        match credentials::store_anthropic_api_key(&key) {
-                            Ok(()) => {
-                                set_provider(ClaudeAuthProvider::ApiKey);
-                                if let Some(o) = state.onboarding_state.as_mut() {
-                                    o.auth_api_key_input = None;
-                                    o.auth_completed = true;
-                                    o.auth_method = Some("claude-api-key".to_string());
-                                    o.advance();
-                                }
-                                state.add_success_notification(
-                                    "API key saved to keychain; sessions will use ANTHROPIC_API_KEY"
-                                        .to_string(),
-                                );
-                            }
-                            Err(e) => {
-                                state.add_error_notification(format!(
-                                    "Failed to save API key: {}",
-                                    e
-                                ));
+                match pane {
+                    // Drill into the focused agent's method picker, defaulting the
+                    // cursor to that agent's current method.
+                    Some(AuthPane::AgentList) => {
+                        if let Some(o) = state.onboarding_state.as_mut() {
+                            if let Some(st) = o.auth_statuses.get(o.auth_agent_cursor) {
+                                let agent = st.agent;
+                                let cursor = match st.method {
+                                    AuthMethodKind::Login => 0,
+                                    AuthMethodKind::ApiKey => 1,
+                                };
+                                o.auth_pane = AuthPane::MethodPicker { agent, cursor };
                             }
                         }
                     }
-                } else {
-                    match idx {
+                    // Choose a method for the agent. Stays on the step (no advance).
+                    Some(AuthPane::MethodPicker { agent, cursor }) => match cursor {
+                        // Login / OAuth
                         0 => {
-                            set_provider(ClaudeAuthProvider::SystemAuth);
-                            if let Some(o) = state.onboarding_state.as_mut() {
-                                o.auth_completed = true;
-                                o.auth_method = Some("claude-oauth".to_string());
-                                o.advance();
+                            match agent {
+                                AuthAgent::Claude => {
+                                    set_claude_provider(ClaudeAuthProvider::SystemAuth);
+                                }
+                                AuthAgent::Codex => {
+                                    // No config flag for Codex — a stored key would
+                                    // force API-key mode, so drop it to honour Login.
+                                    let had = credentials::has_openai_api_key();
+                                    let _ = credentials::delete_openai_api_key();
+                                    if had {
+                                        state.add_info_notification(
+                                            "Removed stored OpenAI key; Codex will use `codex login`"
+                                                .to_string(),
+                                        );
+                                    }
+                                }
                             }
-                            state.add_info_notification(
-                                "Claude: subscription/OAuth - run /login inside Claude on first launch"
-                                    .to_string(),
-                            );
+                            if let Some(o) = state.onboarding_state.as_mut() {
+                                o.auth_pane = AuthPane::AgentList;
+                                o.refresh_auth_statuses();
+                            }
+                            state.add_info_notification(format!(
+                                "{}: {}",
+                                agent.label(),
+                                agent.login_hint()
+                            ));
                         }
+                        // API key → inline entry seeded with the expected prefix.
                         1 => {
                             if let Some(o) = state.onboarding_state.as_mut() {
-                                o.auth_api_key_input = Some("sk-ant-".to_string());
+                                o.auth_pane = AuthPane::KeyEntry {
+                                    agent,
+                                    buf: agent.key_seed().to_string(),
+                                };
                             }
                         }
-                        2 => {
-                            if let Some(o) = state.onboarding_state.as_mut() {
-                                o.auth_completed = true;
-                                o.auth_method = Some("codex-oauth".to_string());
-                                o.advance();
-                            }
-                            state.add_info_notification(
-                                "Codex: run `codex login` (or /login in Codex) before first use"
-                                    .to_string(),
-                            );
-                        }
+                        // Back
                         _ => {
                             if let Some(o) = state.onboarding_state.as_mut() {
-                                o.auth_completed = true;
-                                o.auth_method = Some("skipped".to_string());
-                                o.advance();
+                                o.auth_pane = AuthPane::AgentList;
+                            }
+                        }
+                    },
+                    // Save the typed API key for the agent, then return to the list.
+                    Some(AuthPane::KeyEntry { agent, buf }) => {
+                        let key = buf.trim().to_string();
+                        if key.is_empty() || key == agent.key_seed() {
+                            state.add_warning_notification(
+                                "Enter an API key first (or Esc to cancel)".to_string(),
+                            );
+                        } else {
+                            let stored = match agent {
+                                AuthAgent::Claude => credentials::store_anthropic_api_key(&key),
+                                AuthAgent::Codex => credentials::store_openai_api_key(&key),
+                            };
+                            match stored {
+                                Ok(()) => {
+                                    if agent == AuthAgent::Claude {
+                                        set_claude_provider(ClaudeAuthProvider::ApiKey);
+                                    }
+                                    if let Some(o) = state.onboarding_state.as_mut() {
+                                        o.auth_pane = AuthPane::AgentList;
+                                        o.refresh_auth_statuses();
+                                    }
+                                    state.add_success_notification(format!(
+                                        "{} saved to keychain",
+                                        agent.key_label()
+                                    ));
+                                }
+                                Err(e) => {
+                                    state.add_error_notification(format!(
+                                        "Failed to save {}: {}",
+                                        agent.key_label(),
+                                        e
+                                    ));
+                                }
                             }
                         }
                     }
+                    None => {}
                 }
             }
             AppEvent::OnboardingEditorUp => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3947,6 +3947,10 @@ impl AppState {
             }
         }
 
+        // Detect current per-agent auth up front so the Authentication step
+        // always opens showing real current values (config + keychain).
+        state.refresh_auth_statuses();
+
         self.onboarding_state = Some(state);
         self.current_screen = screen_ids::ONBOARDING.to_string();
     }

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -543,78 +543,111 @@ impl OnboardingComponent {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let content = if state.auth_completed {
-            vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "✅ Authentication configured!",
-                    Style::default().fg(SELECTION_GREEN),
-                )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    format!(
-                        "Method: {}",
-                        state.auth_method.as_deref().unwrap_or("Unknown")
-                    ),
-                    Style::default().fg(MUTED_GRAY),
-                )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    "Press Enter to continue",
-                    Style::default().fg(MUTED_GRAY),
-                )),
-            ]
-        } else {
-            let mut lines: Vec<Line> = vec![Line::from("")];
-            if let Some(ref key) = state.auth_api_key_input {
-                // Inline Claude API-key entry.
-                lines.push(Line::from(Span::styled(
-                    "Enter your Anthropic API key",
-                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
-                )));
-                lines.push(Line::from(Span::styled(
-                    "Stored in the system keychain; switches Claude to API-key mode.",
-                    Style::default().fg(MUTED_GRAY),
-                )));
-                lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    format!("  {}_", key),
-                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-                )));
-                lines.push(Line::from(""));
-                lines.push(Line::from(vec![
-                    Span::styled("Enter ", Style::default().fg(GOLD)),
-                    Span::styled("save   ", Style::default().fg(MUTED_GRAY)),
-                    Span::styled("Esc ", Style::default().fg(GOLD)),
-                    Span::styled("cancel", Style::default().fg(MUTED_GRAY)),
-                ]));
-            } else {
-                lines.push(Line::from(Span::styled(
-                    "Configure auth before first use",
-                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
-                )));
-                lines.push(Line::from(""));
-                for (i, (agent, method)) in
-                    crate::components::onboarding::state::AUTH_OPTIONS.iter().enumerate()
-                {
-                    let selected = i == state.auth_selected_index;
+        use crate::components::onboarding::state::{AuthMethodKind, AuthPane};
+
+        let content: Vec<Line> = match &state.auth_pane {
+            // ── Inline API-key entry for the chosen agent ────────────────────
+            AuthPane::KeyEntry { agent, buf } => {
+                vec![
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        format!("Enter your {}", agent.key_label()),
+                        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(Span::styled(
+                        "Stored in the system keychain; switches this agent to API-key mode.",
+                        Style::default().fg(MUTED_GRAY),
+                    )),
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        format!("  {}_", buf),
+                        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(""),
+                    Line::from(vec![
+                        Span::styled("Enter ", Style::default().fg(GOLD)),
+                        Span::styled("save   ", Style::default().fg(MUTED_GRAY)),
+                        Span::styled("Esc ", Style::default().fg(GOLD)),
+                        Span::styled("back", Style::default().fg(MUTED_GRAY)),
+                    ]),
+                ]
+            }
+            // ── Method picker for the chosen agent ───────────────────────────
+            AuthPane::MethodPicker { agent, cursor } => {
+                let mut lines: Vec<Line> = vec![
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        format!("{} — choose auth method", agent.label()),
+                        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(""),
+                ];
+                let rows = [
+                    AuthMethodKind::Login.label(),
+                    AuthMethodKind::ApiKey.label(),
+                    "Back",
+                ];
+                for (i, label) in rows.iter().enumerate() {
+                    let selected = i == *cursor;
                     let marker = if selected { "\u{25b6} " } else { "  " };
-                    let agent_style = if selected {
+                    let style = if selected {
                         Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
                     } else {
                         Style::default().fg(GOLD)
                     };
                     lines.push(Line::from(vec![
                         Span::styled(marker, Style::default().fg(SELECTION_GREEN)),
-                        Span::styled(format!("{:<8}", agent), agent_style),
-                        Span::styled(*method, Style::default().fg(MUTED_GRAY)),
+                        Span::styled(*label, style),
                     ]));
                 }
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
-                    "OAuth happens inside the tool - just run /login in Claude or Codex.",
+                    format!("Login: {}", agent.login_hint()),
                     Style::default().fg(MUTED_GRAY),
                 )));
+                lines.push(Line::from(""));
+                lines.push(Line::from(vec![
+                    Span::styled("\u{2191}\u{2193} ", Style::default().fg(GOLD)),
+                    Span::styled("select   ", Style::default().fg(MUTED_GRAY)),
+                    Span::styled("Enter ", Style::default().fg(GOLD)),
+                    Span::styled("choose   ", Style::default().fg(MUTED_GRAY)),
+                    Span::styled("Esc ", Style::default().fg(GOLD)),
+                    Span::styled("back", Style::default().fg(MUTED_GRAY)),
+                ]));
+                lines
+            }
+            // ── Per-agent list (default) ─────────────────────────────────────
+            AuthPane::AgentList => {
+                let mut lines: Vec<Line> = vec![
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        "Configure agent authentication (change anytime)",
+                        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(""),
+                ];
+                for (i, st) in state.auth_statuses.iter().enumerate() {
+                    let selected = i == state.auth_agent_cursor;
+                    let marker = if selected { "\u{25b6} " } else { "  " };
+                    let agent_style = if selected {
+                        Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(GOLD)
+                    };
+                    let mut spans = vec![
+                        Span::styled(marker, Style::default().fg(SELECTION_GREEN)),
+                        Span::styled(format!("{:<8}", st.agent.label()), agent_style),
+                        Span::styled(st.method.label(), Style::default().fg(SOFT_WHITE)),
+                    ];
+                    if let Some(ref masked) = st.key_masked {
+                        spans.push(Span::styled(
+                            format!("  {}", masked),
+                            Style::default().fg(MUTED_GRAY),
+                        ));
+                    }
+                    lines.push(Line::from(spans));
+                }
+                lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "Gemini uses GEMINI_API_KEY; Copilot uses `copilot login`.",
                     Style::default().fg(MUTED_GRAY),
@@ -624,12 +657,14 @@ impl OnboardingComponent {
                     Span::styled("\u{2191}\u{2193} ", Style::default().fg(GOLD)),
                     Span::styled("select   ", Style::default().fg(MUTED_GRAY)),
                     Span::styled("Enter ", Style::default().fg(GOLD)),
-                    Span::styled("choose   ", Style::default().fg(MUTED_GRAY)),
-                    Span::styled("S ", Style::default().fg(GOLD)),
+                    Span::styled("change   ", Style::default().fg(MUTED_GRAY)),
+                    Span::styled("\u{2192} ", Style::default().fg(GOLD)),
+                    Span::styled("next   ", Style::default().fg(MUTED_GRAY)),
+                    Span::styled("s ", Style::default().fg(GOLD)),
                     Span::styled("skip", Style::default().fg(MUTED_GRAY)),
                 ]));
+                lines
             }
-            lines
         };
 
         let text = Paragraph::new(content).alignment(Alignment::Center);
@@ -969,15 +1004,11 @@ impl OnboardingComponent {
             ),
         ]));
 
-        // Auth
-        let auth_status = if state.auth_completed {
-            format!(
-                "configured ({})",
-                state.auth_method.as_deref().unwrap_or("unknown")
-            )
-        } else {
-            "skipped".to_string()
-        };
+        // Auth — per-agent summary (e.g. "Claude login • Codex api key")
+        let auth_status = state
+            .auth_method
+            .clone()
+            .unwrap_or_else(|| "not configured".to_string());
         summary_items.push(Line::from(vec![
             Span::styled(
                 if state.auth_completed {

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -555,7 +555,10 @@ impl OnboardingComponent {
                         Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
                     )),
                     Line::from(Span::styled(
-                        "Stored in the system keychain; switches this agent to API-key mode.",
+                        format!(
+                            "Stored in the system keychain; injected as {} when a session starts.",
+                            agent.env_var()
+                        ),
                         Style::default().fg(MUTED_GRAY),
                     )),
                     Line::from(""),
@@ -582,11 +585,7 @@ impl OnboardingComponent {
                     )),
                     Line::from(""),
                 ];
-                let rows = [
-                    AuthMethodKind::Login.label(),
-                    AuthMethodKind::ApiKey.label(),
-                    "Back",
-                ];
+                let rows = [agent.login_label(), "API key", "Back"];
                 for (i, label) in rows.iter().enumerate() {
                     let selected = i == *cursor;
                     let marker = if selected { "\u{25b6} " } else { "  " };
@@ -601,9 +600,21 @@ impl OnboardingComponent {
                     ]));
                 }
                 lines.push(Line::from(""));
+                // What each method actually does + the vendor auth guide.
                 lines.push(Line::from(Span::styled(
-                    format!("Login: {}", agent.login_hint()),
+                    format!("{}: {}", agent.login_label(), agent.login_hint()),
                     Style::default().fg(MUTED_GRAY),
+                )));
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "API key: stored in your keychain, injected as {} when a session starts.",
+                        agent.env_var()
+                    ),
+                    Style::default().fg(MUTED_GRAY),
+                )));
+                lines.push(Line::from(Span::styled(
+                    format!("Guide: {}", agent.doc_url()),
+                    Style::default().fg(CORNFLOWER_BLUE),
                 )));
                 lines.push(Line::from(""));
                 lines.push(Line::from(vec![
@@ -634,10 +645,16 @@ impl OnboardingComponent {
                     } else {
                         Style::default().fg(GOLD)
                     };
+                    // Login rows show the harness-specific label ("System-wide
+                    // auth", "Sign in with GitHub", …); key rows just say "API key".
+                    let method_label = match st.method {
+                        AuthMethodKind::Login => st.agent.login_label(),
+                        AuthMethodKind::ApiKey => "API key",
+                    };
                     let mut spans = vec![
                         Span::styled(marker, Style::default().fg(SELECTION_GREEN)),
-                        Span::styled(format!("{:<8}", st.agent.label()), agent_style),
-                        Span::styled(st.method.label(), Style::default().fg(SOFT_WHITE)),
+                        Span::styled(format!("{:<9}", st.agent.label()), agent_style),
+                        Span::styled(method_label, Style::default().fg(SOFT_WHITE)),
                     ];
                     if let Some(ref masked) = st.key_masked {
                         spans.push(Span::styled(
@@ -649,7 +666,8 @@ impl OnboardingComponent {
                 }
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
-                    "Gemini uses GEMINI_API_KEY; Copilot uses `copilot login`.",
+                    "System-wide auth = you set it up outside ainb. API key = ainb stores it \
+                     in your keychain and injects it when a session starts.",
                     Style::default().fg(MUTED_GRAY),
                 )));
                 lines.push(Line::from(""));
@@ -667,7 +685,9 @@ impl OnboardingComponent {
             }
         };
 
-        let text = Paragraph::new(content).alignment(Alignment::Center);
+        let text = Paragraph::new(content)
+            .alignment(Alignment::Center)
+            .wrap(ratatui::widgets::Wrap { trim: true });
         frame.render_widget(text, inner);
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/mod.rs
@@ -5,4 +5,7 @@ pub mod component;
 pub mod state;
 
 pub use component::OnboardingComponent;
-pub use state::{OnboardingFocus, OnboardingState, OnboardingStep, ValidatedPath};
+pub use state::{
+    AgentAuthStatus, AuthAgent, AuthMethodKind, AuthPane, OnboardingFocus, OnboardingState,
+    OnboardingStep, ValidatedPath,
+};

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -283,41 +283,101 @@ pub struct OnboardingState {
     pub auth_statuses: Vec<AgentAuthStatus>,
 }
 
-/// Agents whose auth is configurable on the onboarding Authentication step.
-/// Each can run in `Login` (native OAuth/subscription) or `ApiKey` mode.
+/// Harnesses whose auth is configurable on the onboarding Authentication step.
+/// Each runs in one of two modes: `Login` (native/system-wide sign-in, ainb
+/// injects nothing) or `ApiKey` (a key ainb stores in the keychain and injects
+/// as the harness's env var when a session starts).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthAgent {
     Claude,
     Codex,
+    Gemini,
+    Copilot,
 }
 
 impl AuthAgent {
-    /// The configurable agents, in row order.
+    /// The configurable harnesses, in row order.
     pub fn all() -> &'static [AuthAgent] {
-        &[Self::Claude, Self::Codex]
+        &[Self::Claude, Self::Codex, Self::Gemini, Self::Copilot]
     }
 
     pub fn label(&self) -> &'static str {
         match self {
             Self::Claude => "Claude",
             Self::Codex => "Codex",
+            Self::Gemini => "Gemini",
+            Self::Copilot => "Copilot",
         }
     }
 
-    /// What the user runs inside the tool to complete native OAuth/subscription
-    /// login — shown after choosing the Login method.
+    /// Label for the non-key method in the picker. Claude's is "system-wide"
+    /// because you configure it entirely outside ainb; the others are a native
+    /// sign-in inside the tool.
+    pub fn login_label(&self) -> &'static str {
+        match self {
+            Self::Claude => "System-wide auth",
+            Self::Codex => "Sign in with ChatGPT",
+            Self::Gemini => "Sign in with Google",
+            Self::Copilot => "Sign in with GitHub",
+        }
+    }
+
+    /// One-line explanation of what the login/system-wide method actually does.
     pub fn login_hint(&self) -> &'static str {
         match self {
-            Self::Claude => "run `claude` then /login (subscription / OAuth)",
-            Self::Codex => "run `codex login` (OAuth)",
+            Self::Claude => {
+                "Use whatever you set up for Claude at the system level — `claude` /login, a \
+                 Pro/Max subscription, or a cloud provider. ainb injects no key."
+            }
+            Self::Codex => "Run `codex login` and sign in with your ChatGPT account (OAuth).",
+            Self::Gemini => {
+                "Run `gemini` and sign in with Google, or use application-default credentials."
+            }
+            Self::Copilot => {
+                "Run `copilot login` (GitHub device flow), or reuse your `gh` CLI login."
+            }
         }
     }
 
-    /// Expected key prefix, used to seed the inline API-key entry buffer.
+    /// Official vendor auth-guide URL (terminals linkify plain URLs).
+    pub fn doc_url(&self) -> &'static str {
+        match self {
+            Self::Claude => crate::docs::AUTH_CLAUDE,
+            Self::Codex => crate::docs::AUTH_CODEX,
+            Self::Gemini => crate::docs::AUTH_GEMINI,
+            Self::Copilot => crate::docs::AUTH_COPILOT,
+        }
+    }
+
+    /// Keychain slot this harness's API key is stored under.
+    pub fn credential_key(&self) -> crate::credentials::CredentialKey {
+        use crate::credentials::CredentialKey;
+        match self {
+            Self::Claude => CredentialKey::AnthropicApiKey,
+            Self::Codex => CredentialKey::OpenAiApiKey,
+            Self::Gemini => CredentialKey::GeminiApiKey,
+            Self::Copilot => CredentialKey::GithubPat,
+        }
+    }
+
+    /// Env var the stored key is injected as when a session starts.
+    pub fn env_var(&self) -> &'static str {
+        match self {
+            Self::Claude => "ANTHROPIC_API_KEY",
+            Self::Codex => "OPENAI_API_KEY",
+            Self::Gemini => "GEMINI_API_KEY",
+            Self::Copilot => "GITHUB_TOKEN",
+        }
+    }
+
+    /// Prefix used to seed the inline API-key entry buffer (empty when the
+    /// harness's tokens have no single stable prefix, e.g. GitHub PATs).
     pub fn key_seed(&self) -> &'static str {
         match self {
             Self::Claude => "sk-ant-",
             Self::Codex => "sk-",
+            Self::Gemini => "AIza",
+            Self::Copilot => "",
         }
     }
 
@@ -325,24 +385,28 @@ impl AuthAgent {
         match self {
             Self::Claude => "Anthropic API key",
             Self::Codex => "OpenAI API key",
+            Self::Gemini => "Gemini API key",
+            Self::Copilot => "GitHub token (PAT)",
         }
     }
 }
 
-/// Auth method an agent is currently using (detected) or being switched to.
+/// Auth method a harness is currently using (detected) or being switched to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthMethodKind {
-    /// Native OAuth / subscription login, handled inside the tool.
+    /// Native / system-wide sign-in; ainb injects nothing.
     Login,
-    /// API key stored in the system keychain.
+    /// API key stored in the system keychain, injected on session start.
     ApiKey,
 }
 
 impl AuthMethodKind {
+    /// Generic label. The agent list uses this for the API-key row; the method
+    /// picker prefers `AuthAgent::login_label()` for the login row.
     pub fn label(&self) -> &'static str {
         match self {
-            Self::Login => "Login (subscription / OAuth)",
-            Self::ApiKey => "API key (pay-per-use)",
+            Self::Login => "Sign-in / system-wide",
+            Self::ApiKey => "API key",
         }
     }
 }
@@ -438,42 +502,32 @@ impl OnboardingState {
         use crate::config::{AppConfig, ClaudeAuthProvider};
         use crate::credentials;
 
-        // Claude: driven by config `claude_provider` (+ keychain for the mask).
-        let claude_method = match AppConfig::load() {
-            Ok(c) => match c.authentication.claude_provider {
-                ClaudeAuthProvider::ApiKey => AuthMethodKind::ApiKey,
-                _ => AuthMethodKind::Login,
-            },
-            Err(_) => AuthMethodKind::Login,
-        };
-        let claude_key = if claude_method == AuthMethodKind::ApiKey
-            && credentials::has_anthropic_api_key()
-        {
-            Some(credentials::get_anthropic_api_key_masked())
-        } else {
-            None
-        };
+        // Claude's mode is gated by config: a stored Anthropic key with
+        // system-wide auth selected must NOT read as API-key mode (the key
+        // isn't injected in that case). Every other harness is "key present?".
+        let claude_api = matches!(
+            AppConfig::load().map(|c| c.authentication.claude_provider),
+            Ok(ClaudeAuthProvider::ApiKey)
+        );
 
-        // Codex: no config flag — a stored OpenAI key means API-key mode,
-        // otherwise the user logs in via `codex login`.
-        let (codex_method, codex_key) = if credentials::has_openai_api_key() {
-            (AuthMethodKind::ApiKey, Some(credentials::get_openai_api_key_masked()))
-        } else {
-            (AuthMethodKind::Login, None)
-        };
+        self.auth_statuses = AuthAgent::all()
+            .iter()
+            .map(|&agent| {
+                let key = agent.credential_key();
+                let is_api = if agent == AuthAgent::Claude {
+                    claude_api
+                } else {
+                    credentials::has_credential(key)
+                };
+                let (method, key_masked) = if is_api {
+                    (AuthMethodKind::ApiKey, Some(credentials::get_credential_masked(key)))
+                } else {
+                    (AuthMethodKind::Login, None)
+                };
+                AgentAuthStatus { agent, method, key_masked }
+            })
+            .collect();
 
-        self.auth_statuses = vec![
-            AgentAuthStatus {
-                agent: AuthAgent::Claude,
-                method: claude_method,
-                key_masked: claude_key,
-            },
-            AgentAuthStatus {
-                agent: AuthAgent::Codex,
-                method: codex_method,
-                key_masked: codex_key,
-            },
-        ];
         // Auth is always in *some* state now — reflect that for the Summary step.
         self.auth_completed = true;
         self.auth_method = Some(self.auth_summary());
@@ -813,6 +867,24 @@ mod tests {
         assert_eq!(s.auth_agent_at_cursor(), Some(AuthAgent::Codex));
         s.move_auth_agent_cursor(100); // clamp at the last agent
         assert_eq!(s.auth_agent_cursor, s.auth_statuses.len() - 1);
+    }
+
+    #[test]
+    fn auth_agents_cover_four_harnesses_with_correct_env_vars() {
+        // The env var each harness's stored key is injected as — must match what
+        // session_manager::build_env_setup_for_provider actually exports.
+        let expected = [
+            (AuthAgent::Claude, "ANTHROPIC_API_KEY"),
+            (AuthAgent::Codex, "OPENAI_API_KEY"),
+            (AuthAgent::Gemini, "GEMINI_API_KEY"),
+            (AuthAgent::Copilot, "GITHUB_TOKEN"),
+        ];
+        assert_eq!(AuthAgent::all().len(), 4);
+        for (agent, env) in expected {
+            assert_eq!(agent.env_var(), env, "{} env var drift", agent.label());
+            assert!(agent.doc_url().starts_with("https://"), "{} missing doc url", agent.label());
+            assert!(!agent.login_label().is_empty());
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -273,24 +273,103 @@ pub struct OnboardingState {
     pub dep_cursor: usize,
     /// Per-dep install state, keyed by dep id (idle deps absent).
     pub install_states: std::collections::HashMap<String, DepInstall>,
-    /// Authentication step: cursor over the selectable auth option rows.
-    pub auth_selected_index: usize,
-    /// Authentication step: `Some(buffer)` while typing a Claude API key
-    /// inline (the "Claude - API key" row was chosen); `None` in normal
-    /// list-navigation mode.
-    pub auth_api_key_input: Option<String>,
+    /// Authentication step: cursor over the agent rows in the `AgentList` pane.
+    pub auth_agent_cursor: usize,
+    /// Authentication step: active sub-view (agent list / method picker / key entry).
+    pub auth_pane: AuthPane,
+    /// Authentication step: detected current auth per agent, cached so render
+    /// never touches the keychain. Refreshed on entering the step and after any
+    /// change via `refresh_auth_statuses`.
+    pub auth_statuses: Vec<AgentAuthStatus>,
 }
 
-/// Selectable rows on the onboarding Authentication step. `(agent, method)`.
-/// Index order is load-bearing - the `OnboardingAuthSelect` handler matches on
-/// it. Real auth still happens in each tool (`/login`); only the API-key row
-/// persists anything (keychain + `claude_provider = ApiKey`).
-pub const AUTH_OPTIONS: [(&str, &str); 4] = [
-    ("Claude", "Login - subscription / OAuth"),
-    ("Claude", "API key - pay-per-use"),
-    ("Codex", "Login - OAuth"),
-    ("Skip", "Configure later"),
-];
+/// Agents whose auth is configurable on the onboarding Authentication step.
+/// Each can run in `Login` (native OAuth/subscription) or `ApiKey` mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthAgent {
+    Claude,
+    Codex,
+}
+
+impl AuthAgent {
+    /// The configurable agents, in row order.
+    pub fn all() -> &'static [AuthAgent] {
+        &[Self::Claude, Self::Codex]
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+        }
+    }
+
+    /// What the user runs inside the tool to complete native OAuth/subscription
+    /// login — shown after choosing the Login method.
+    pub fn login_hint(&self) -> &'static str {
+        match self {
+            Self::Claude => "run `claude` then /login (subscription / OAuth)",
+            Self::Codex => "run `codex login` (OAuth)",
+        }
+    }
+
+    /// Expected key prefix, used to seed the inline API-key entry buffer.
+    pub fn key_seed(&self) -> &'static str {
+        match self {
+            Self::Claude => "sk-ant-",
+            Self::Codex => "sk-",
+        }
+    }
+
+    pub fn key_label(&self) -> &'static str {
+        match self {
+            Self::Claude => "Anthropic API key",
+            Self::Codex => "OpenAI API key",
+        }
+    }
+}
+
+/// Auth method an agent is currently using (detected) or being switched to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMethodKind {
+    /// Native OAuth / subscription login, handled inside the tool.
+    Login,
+    /// API key stored in the system keychain.
+    ApiKey,
+}
+
+impl AuthMethodKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Login => "Login (subscription / OAuth)",
+            Self::ApiKey => "API key (pay-per-use)",
+        }
+    }
+}
+
+/// Detected current auth for a single agent. Cached in `OnboardingState` and
+/// refreshed on entering the step / after a change — never read from the
+/// keychain during render (which runs every frame).
+#[derive(Debug, Clone)]
+pub struct AgentAuthStatus {
+    pub agent: AuthAgent,
+    pub method: AuthMethodKind,
+    /// Masked key (e.g. "sk-ant-xxxx••••") when `method == ApiKey` and a key is
+    /// actually stored; `None` otherwise.
+    pub key_masked: Option<String>,
+}
+
+/// Which sub-view of the Authentication step is active. Drives both the render
+/// and the key dispatch so the flat option list becomes a per-agent drill-down.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthPane {
+    /// Browsing the per-agent list (default).
+    AgentList,
+    /// Choosing a method for `agent`. `cursor`: 0 = Login, 1 = API key, 2 = Back.
+    MethodPicker { agent: AuthAgent, cursor: usize },
+    /// Typing an API key for `agent` into `buf`.
+    KeyEntry { agent: AuthAgent, buf: String },
+}
 
 /// Background-install state for a single dependency on the deps screen.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -330,20 +409,92 @@ impl OnboardingState {
             otel_field: 0,
             dep_cursor: 0,
             install_states: std::collections::HashMap::new(),
-            auth_selected_index: 0,
-            auth_api_key_input: None,
+            auth_agent_cursor: 0,
+            auth_pane: AuthPane::AgentList,
+            auth_statuses: Vec::new(),
         }
     }
 
-    /// Move the auth-option cursor by `delta`, clamped to `AUTH_OPTIONS`.
-    /// No-op while an API key is being typed.
-    pub fn move_auth_cursor(&mut self, delta: isize) {
-        if self.auth_api_key_input.is_some() {
+    /// Move the agent-list cursor by `delta`, clamped to `auth_statuses`.
+    pub fn move_auth_agent_cursor(&mut self, delta: isize) {
+        if self.auth_statuses.is_empty() {
+            self.auth_agent_cursor = 0;
             return;
         }
-        let max = (AUTH_OPTIONS.len() - 1) as isize;
-        self.auth_selected_index =
-            (self.auth_selected_index as isize + delta).clamp(0, max) as usize;
+        let max = (self.auth_statuses.len() - 1) as isize;
+        self.auth_agent_cursor =
+            (self.auth_agent_cursor as isize + delta).clamp(0, max) as usize;
+    }
+
+    /// The agent under the list cursor, if any.
+    pub fn auth_agent_at_cursor(&self) -> Option<AuthAgent> {
+        self.auth_statuses.get(self.auth_agent_cursor).map(|s| s.agent)
+    }
+
+    /// Re-detect each agent's current auth from config + keychain and cache it.
+    /// Call on entering the Authentication step and after every change; never
+    /// from render. Also refreshes the summary string shown on the Summary step.
+    pub fn refresh_auth_statuses(&mut self) {
+        use crate::config::{AppConfig, ClaudeAuthProvider};
+        use crate::credentials;
+
+        // Claude: driven by config `claude_provider` (+ keychain for the mask).
+        let claude_method = match AppConfig::load() {
+            Ok(c) => match c.authentication.claude_provider {
+                ClaudeAuthProvider::ApiKey => AuthMethodKind::ApiKey,
+                _ => AuthMethodKind::Login,
+            },
+            Err(_) => AuthMethodKind::Login,
+        };
+        let claude_key = if claude_method == AuthMethodKind::ApiKey
+            && credentials::has_anthropic_api_key()
+        {
+            Some(credentials::get_anthropic_api_key_masked())
+        } else {
+            None
+        };
+
+        // Codex: no config flag — a stored OpenAI key means API-key mode,
+        // otherwise the user logs in via `codex login`.
+        let (codex_method, codex_key) = if credentials::has_openai_api_key() {
+            (AuthMethodKind::ApiKey, Some(credentials::get_openai_api_key_masked()))
+        } else {
+            (AuthMethodKind::Login, None)
+        };
+
+        self.auth_statuses = vec![
+            AgentAuthStatus {
+                agent: AuthAgent::Claude,
+                method: claude_method,
+                key_masked: claude_key,
+            },
+            AgentAuthStatus {
+                agent: AuthAgent::Codex,
+                method: codex_method,
+                key_masked: codex_key,
+            },
+        ];
+        // Auth is always in *some* state now — reflect that for the Summary step.
+        self.auth_completed = true;
+        self.auth_method = Some(self.auth_summary());
+    }
+
+    /// One-line summary of current per-agent auth for the Summary step.
+    pub fn auth_summary(&self) -> String {
+        if self.auth_statuses.is_empty() {
+            return "not configured".to_string();
+        }
+        self.auth_statuses
+            .iter()
+            .map(|s| {
+                let m = match s.method {
+                    AuthMethodKind::Login => "login",
+                    AuthMethodKind::ApiKey => "api key",
+                };
+                format!("{} {}", s.agent.label(), m)
+            })
+            .collect::<Vec<_>>()
+            .join(" • ")
     }
 
     /// Deps flattened in topic order — the cursor indexes into this. Empty until
@@ -638,20 +789,48 @@ mod tests {
     }
 
     #[test]
-    fn auth_cursor_navigates_and_clamps() {
+    fn auth_agent_cursor_navigates_and_clamps() {
         let mut s = OnboardingState::new();
-        assert_eq!(s.auth_selected_index, 0);
-        s.move_auth_cursor(-1); // clamp at 0
-        assert_eq!(s.auth_selected_index, 0);
-        s.move_auth_cursor(1);
-        assert_eq!(s.auth_selected_index, 1);
-        s.move_auth_cursor(100); // clamp at the last option
-        assert_eq!(s.auth_selected_index, AUTH_OPTIONS.len() - 1);
-        // While typing an API key the cursor is frozen.
-        s.auth_api_key_input = Some("sk-ant-".to_string());
-        let before = s.auth_selected_index;
-        s.move_auth_cursor(-1);
-        assert_eq!(s.auth_selected_index, before);
+        // Seed two agents (avoids touching the real keychain in this unit test).
+        s.auth_statuses = vec![
+            AgentAuthStatus {
+                agent: AuthAgent::Claude,
+                method: AuthMethodKind::Login,
+                key_masked: None,
+            },
+            AgentAuthStatus {
+                agent: AuthAgent::Codex,
+                method: AuthMethodKind::Login,
+                key_masked: None,
+            },
+        ];
+        assert_eq!(s.auth_agent_cursor, 0);
+        s.move_auth_agent_cursor(-1); // clamp at 0
+        assert_eq!(s.auth_agent_cursor, 0);
+        assert_eq!(s.auth_agent_at_cursor(), Some(AuthAgent::Claude));
+        s.move_auth_agent_cursor(1);
+        assert_eq!(s.auth_agent_cursor, 1);
+        assert_eq!(s.auth_agent_at_cursor(), Some(AuthAgent::Codex));
+        s.move_auth_agent_cursor(100); // clamp at the last agent
+        assert_eq!(s.auth_agent_cursor, s.auth_statuses.len() - 1);
+    }
+
+    #[test]
+    fn auth_summary_lists_each_agent() {
+        let mut s = OnboardingState::new();
+        s.auth_statuses = vec![
+            AgentAuthStatus {
+                agent: AuthAgent::Claude,
+                method: AuthMethodKind::ApiKey,
+                key_masked: Some("sk-ant-xxxx••••".to_string()),
+            },
+            AgentAuthStatus {
+                agent: AuthAgent::Codex,
+                method: AuthMethodKind::Login,
+                key_masked: None,
+            },
+        ];
+        assert_eq!(s.auth_summary(), "Claude api key • Codex login");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/setup_menu.rs
+++ b/ainb-tui/crates/ainb-core/src/components/setup_menu.rs
@@ -61,7 +61,7 @@ impl SetupMenuItem {
             Self::RerunWizard => "Start the full setup wizard from scratch",
             Self::CheckDependencies => "Verify all required tools are installed",
             Self::ConfigureGitPaths => "Update your project directories",
-            Self::AuthenticationSettings => "Configure Claude authentication",
+            Self::AuthenticationSettings => "Configure auth for Claude, Codex, Gemini, Copilot",
             Self::EditorPreference => "Choose your preferred code editor",
             Self::FactoryReset => "Remove all configuration and start fresh",
         }

--- a/ainb-tui/crates/ainb-core/src/credentials.rs
+++ b/ainb-tui/crates/ainb-core/src/credentials.rs
@@ -131,6 +131,12 @@ fn store_api_key(key: CredentialKey, api_key: &str) -> Result<()> {
     store_credential(key, api_key)
 }
 
+/// Get masked display of any credential by key (for UI). Public wrapper over
+/// the internal helper so callers can render a key without a per-key function.
+pub fn get_credential_masked(key: CredentialKey) -> String {
+    get_api_key_masked(key)
+}
+
 /// Get masked display of an API key (for UI)
 fn get_api_key_masked(key: CredentialKey) -> String {
     match get_credential(key) {

--- a/ainb-tui/crates/ainb-core/src/docker/session_lifecycle.rs
+++ b/ainb-tui/crates/ainb-core/src/docker/session_lifecycle.rs
@@ -756,29 +756,41 @@ impl SessionLifecycleManager {
             mode_str, request.session_id
         );
 
-        // Set ANTHROPIC_API_KEY if configured in the system keychain
-        // This allows pay-as-you-go API usage instead of Pro/Max subscription
-        match credentials::get_anthropic_api_key() {
-            Ok(Some(api_key)) => {
-                config.environment_vars.insert("ANTHROPIC_API_KEY".to_string(), api_key);
-                info!(
-                    "Set ANTHROPIC_API_KEY from keychain for session {}",
-                    request.session_id
-                );
+        // Set ANTHROPIC_API_KEY only when the user chose API-key auth. With
+        // system-wide auth, injecting a stored key would override the
+        // subscription/OAuth login (Claude prefers ANTHROPIC_API_KEY when set),
+        // which is exactly what "system-wide auth" is meant to avoid.
+        let claude_api_key_mode = matches!(
+            crate::config::AppConfig::load().map(|c| c.authentication.claude_provider),
+            Ok(crate::config::ClaudeAuthProvider::ApiKey)
+        );
+        if claude_api_key_mode {
+            match credentials::get_anthropic_api_key() {
+                Ok(Some(api_key)) => {
+                    config.environment_vars.insert("ANTHROPIC_API_KEY".to_string(), api_key);
+                    info!(
+                        "Set ANTHROPIC_API_KEY from keychain for session {}",
+                        request.session_id
+                    );
+                }
+                Ok(None) => {
+                    warn!(
+                        "API-key auth selected but no ANTHROPIC_API_KEY in keychain for session {}",
+                        request.session_id
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to retrieve ANTHROPIC_API_KEY from keychain: {} - using claude auth for session {}",
+                        e, request.session_id
+                    );
+                }
             }
-            Ok(None) => {
-                // No API key configured - will use claude auth (Pro/Max plan)
-                info!(
-                    "No ANTHROPIC_API_KEY configured, using claude auth for session {}",
-                    request.session_id
-                );
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to retrieve ANTHROPIC_API_KEY from keychain: {} - using claude auth for session {}",
-                    e, request.session_id
-                );
-            }
+        } else {
+            info!(
+                "System-wide Claude auth — not injecting ANTHROPIC_API_KEY for session {}",
+                request.session_id
+            );
         }
 
         // Set boss prompt if in boss mode

--- a/ainb-tui/crates/ainb-core/src/docs.rs
+++ b/ainb-tui/crates/ainb-core/src/docs.rs
@@ -21,6 +21,18 @@ pub const REFLECT: &str = "https://stevengonsalvez.github.io/agents-in-a-box/kno
 /// ainb-toolkit (skills + agents).
 pub const TOOLKIT: &str = "https://stevengonsalvez.github.io/agents-in-a-box/toolkit/overview/";
 
+// Official vendor auth guides, surfaced on the onboarding Authentication step.
+/// Claude Code authentication guide.
+pub const AUTH_CLAUDE: &str = "https://code.claude.com/docs/en/authentication";
+/// OpenAI Codex CLI authentication guide.
+pub const AUTH_CODEX: &str = "https://developers.openai.com/codex/auth";
+/// Google Gemini CLI authentication guide.
+pub const AUTH_GEMINI: &str =
+    "https://google-gemini.github.io/gemini-cli/docs/get-started/authentication.html";
+/// GitHub Copilot CLI authentication guide.
+pub const AUTH_COPILOT: &str =
+    "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli";
+
 /// Docsite page for a setup-catalog dep id, if one exists. Used by the deps
 /// screen to show "what you get" on the focused row.
 pub fn docs_url_for(dep_id: &str) -> Option<&'static str> {

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1506,7 +1506,17 @@ impl InteractiveSessionManager {
                     String::new()
                 }
             }
-            SessionAgentType::Copilot => String::new(),
+            SessionAgentType::Copilot => {
+                // Copilot authenticates via `gh`/device flow by default; if the
+                // user stored a PAT in onboarding, inject it as GITHUB_TOKEN.
+                if let Ok(Some(pat)) = credentials::get_credential(credentials::CredentialKey::GithubPat)
+                {
+                    info!("Injecting GITHUB_TOKEN for Copilot CLI");
+                    format!("export GITHUB_TOKEN='{}' && ", pat)
+                } else {
+                    String::new()
+                }
+            }
             _ => String::new(),
         };
 


### PR DESCRIPTION
Reworks the Authentication onboarding step. Replaces the auto-advancing, single-method dead-end (`✅ configured! Method: claude-oauth`) with an editable per-harness screen, and makes stored keys actually reach spawned sessions.

## Screen

```
┌ Authentication ──────────────────────────────────────────────┐
│ Configure agent authentication (change anytime)               │
│                                                               │
│ ▶ Claude    System-wide auth                                  │
│   Codex     API key            sk-xxxx••••                    │
│   Gemini    Sign in with Google                               │
│   Copilot   API key            github_pat_xx••••              │
│                                                               │
│ System-wide auth = you set it up outside ainb. API key =      │
│ ainb stores it in your keychain and injects it on session.    │
│ ↑↓ select  Enter change  → next  s skip                       │
└───────────────────────────────────────────────────────────────┘
       Enter ▶ per-harness picker: Login/system-wide · API key · Back
                 + login hint + "injected as $ENV" + vendor doc URL
```

## What changed
- **All four harnesses** (Claude, Codex, Gemini, Copilot), each showing current method + masked key, detected from config + keychain on entry — never in render.
- **No auto-advance / no dead-end**: choosing a method persists and returns to the list; advance only via `→`/`n`/`s`. Re-opening shows current values.
- **Claude = System-wide auth** (configure `claude`/subscription/cloud provider outside ainb; ainb injects nothing) or **API key**. The other 5 Claude providers are deferred → #378.
- **Help + clickable guides**: each picker shows what the method does, the env var the key injects as, and the official vendor auth URL (`code.claude.com` / `developers.openai.com/codex` / `google-gemini.github.io` / `docs.github.com`). Terminals linkify plain URLs.
- **Keys actually reach sessions** (the correctness ask):
  - Host/tmux (`build_env_setup_for_provider`): Claude `ANTHROPIC_API_KEY` (gated on API-key mode), Codex `OPENAI_API_KEY`, Gemini `GEMINI_API_KEY`, **Copilot `GITHUB_TOKEN`** (newly wired from a stored PAT).
  - Docker (`session_lifecycle.rs`): `ANTHROPIC_API_KEY` now **only** injected in API-key mode — system-wide auth no longer overrides the subscription login (per Claude precedence docs).
  - Choosing sign-in for Codex/Gemini/Copilot clears any stored key so it stops being injected.

## Verification
- `cargo build -p ainb` ✓
- `cargo test -p ainb --lib onboarding` → 25 pass ✓ (incl. env-var contract test + summary/cursor tests)

## Follow-ups
- #378 — Claude cloud providers (Bedrock/Vertex/Azure/GLM/Gateway).
- Docker path injects per-harness keys only for Claude today; Codex/Gemini/Copilot keychain keys in Docker sessions are a noted gap (host path covers all four).
- ⚠️ Not yet driven live in a TUI — logic + unit tests only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The onboarding Authentication step is now a per-agent flow (choose agent → pick sign-in method → enter and validate an API key with guidance).
  * Authentication UI and the onboarding summary are updated to reflect per-agent status, including masked key previews when available.
* **Bug Fixes**
  * Improved cancel/back navigation within the Authentication step.
  * Authentication statuses now refresh immediately when onboarding starts.
  * Credential/environment injection now follows the selected auth mode and supports Copilot PATs.
* **Documentation**
  * Added vendor auth guide links and expanded Authentication menu text.
* **Tests**
  * Updated onboarding cursor and formatting coverage for the new per-agent flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->