### PR TITLE
fix(onboarding): git directories persist correctly (save-on-leave + remember on re-open)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -6416,6 +6416,13 @@ impl EventHandler {
             AppEvent::OnboardingNext => {
                 use crate::components::onboarding::OnboardingStep;
                 tracing::debug!("Onboarding next step");
+                // Save git directories as soon as the user leaves the step,
+                // not only on wizard finish.
+                if state.onboarding_state.as_ref().map(|o| o.current_step)
+                    == Some(OnboardingStep::GitDirectories)
+                {
+                    state.persist_onboarding_git_dirs();
+                }
                 let mut trigger_dep_check = false;
                 if let Some(ref mut onboarding_state) = state.onboarding_state {
                     if onboarding_state.is_final_step() {
@@ -6454,6 +6461,12 @@ impl EventHandler {
             AppEvent::OnboardingBack => {
                 use crate::components::onboarding::OnboardingStep;
                 tracing::debug!("Onboarding back step");
+                // Persist git dirs when stepping back out of the step too.
+                if state.onboarding_state.as_ref().map(|o| o.current_step)
+                    == Some(OnboardingStep::GitDirectories)
+                {
+                    state.persist_onboarding_git_dirs();
+                }
                 if let Some(ref mut onboarding_state) = state.onboarding_state {
                     onboarding_state.go_back();
                     // Refresh per-agent auth when stepping back into the step.
@@ -6465,7 +6478,14 @@ impl EventHandler {
                 }
             }
             AppEvent::OnboardingToMenu => {
+                use crate::components::onboarding::OnboardingStep;
                 tracing::debug!("Leaving onboarding wizard for the Setup menu");
+                // Persist git dirs before dropping the wizard state.
+                if state.onboarding_state.as_ref().map(|o| o.current_step)
+                    == Some(OnboardingStep::GitDirectories)
+                {
+                    state.persist_onboarding_git_dirs();
+                }
                 state.onboarding_to_menu();
             }
             AppEvent::OnboardingInputChar(ch) => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3970,6 +3970,19 @@ impl AppState {
             OnboardingState::new()
         };
 
+        // Seed git directories from the last saved paths so re-opening onboarding
+        // shows what the user set previously, not a fresh default scan. Prefer the
+        // onboarding record; fall back to the app-config scan paths.
+        let saved = crate::config::OnboardingConfig::load()
+            .map(|c| c.git_directories)
+            .unwrap_or_default();
+        let saved = if saved.is_empty() {
+            self.app_config.workspace_defaults.workspace_scan_paths.clone()
+        } else {
+            saved
+        };
+        state.set_git_directories(&saved);
+
         // If a specific start step is provided, jump to it
         if let Some(step) = start_step {
             state.current_step = step;

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -4000,6 +4000,37 @@ impl AppState {
         self.current_screen = screen_ids::ONBOARDING.to_string();
     }
 
+    /// Persist the onboarding git directories immediately — called when leaving
+    /// the Git Directories step in any direction (Next / Back / to menu) so the
+    /// user's edit is saved without having to finish the whole wizard.
+    ///
+    /// Only writes when at least one path is VALID, so invalid/empty input never
+    /// clobbers previously-saved config.
+    pub fn persist_onboarding_git_dirs(&mut self) {
+        use crate::config::OnboardingConfig;
+
+        let Some(state) = self.onboarding_state.as_ref() else {
+            return;
+        };
+        let valid = state.get_valid_directories();
+        if valid.is_empty() {
+            return;
+        }
+
+        // Onboarding record — load first so we preserve completed/version/etc.
+        let mut cfg = OnboardingConfig::load().unwrap_or_default();
+        cfg.git_directories = valid.clone();
+        if let Err(e) = cfg.save() {
+            warn!("Failed to persist onboarding git directories: {}", e);
+        }
+
+        // App-config scan paths (what session creation actually reads).
+        self.app_config.workspace_defaults.workspace_scan_paths = valid;
+        if let Err(e) = self.app_config.save() {
+            warn!("Failed to persist workspace scan paths: {}", e);
+        }
+    }
+
     /// Complete the onboarding process
     pub fn complete_onboarding(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::config::OnboardingConfig;

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -690,6 +690,22 @@ impl OnboardingState {
         }
     }
 
+    /// Seed the git-directories input from previously-saved paths so re-opening
+    /// onboarding shows the user's last choice instead of a fresh default scan.
+    /// No-op on an empty list (keeps the default). Validates after seeding.
+    pub fn set_git_directories(&mut self, paths: &[PathBuf]) {
+        if paths.is_empty() {
+            return;
+        }
+        self.git_directories_input = paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.cursor_position = self.git_directories_input.len();
+        self.validate_git_directories();
+    }
+
     /// Validate the current git directories input
     pub fn validate_git_directories(&mut self) {
         let paths: Vec<&str> = self
@@ -929,6 +945,21 @@ mod tests {
         state.otel_backspace();
         assert_eq!(state.otel_instance_id, "");
         assert!(!state.otel_creds_complete());
+    }
+
+    #[test]
+    fn set_git_directories_seeds_and_preserves_default_when_empty() {
+        let mut state = OnboardingState::new();
+        let default = state.git_directories_input.clone();
+
+        // Empty list is a no-op — keeps the default scan.
+        state.set_git_directories(&[]);
+        assert_eq!(state.git_directories_input, default);
+
+        // Saved paths replace the input, joined by ", ".
+        state.set_git_directories(&[PathBuf::from("/a/b"), PathBuf::from("/c/d")]);
+        assert_eq!(state.git_directories_input, "/a/b, /c/d");
+        assert_eq!(state.cursor_position, state.git_directories_input.len());
     }
 
     #[test]


### PR DESCRIPTION
Two halves of the same bug: the Git Directories step only **wrote** config on wizard finish, and only **read** the default scan on open. Result: a custom path was write-only-at-the-end and never shown again.

## Save-on-leave (this is the reported issue)
Git directories were persisted only in `complete_onboarding()`. Setting a path and navigating away — **Next, Back, or Esc-to-menu** — without finishing the wizard lost the edit.

Now `persist_onboarding_git_dirs()` runs the moment you leave the step in any direction, writing both `OnboardingConfig.git_directories` and `workspace_defaults.workspace_scan_paths` (what session creation reads). It **only saves when ≥1 path is valid**, so invalid/empty input never clobbers saved config — exactly the "save on change + navigate, prevent invalid" behaviour requested.

Note: the Next key is already gated on ≥1 valid path, so it only advances (and saves) with valid input; Back/menu save the valid subset if any, else leave config untouched.

## Remember-on-re-open (original PR)
`start_onboarding` now seeds the input from saved paths (OnboardingConfig → workspace_scan_paths → default scan), so re-opening shows what you set, not the default.

## Verification
- `cargo build -p ainb` ✓
- `cargo test -p ainb --lib onboarding` → 24 pass ✓