### PR TITLE
feat(onboarding): per-step hint band explaining what each step does

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -43,19 +43,41 @@ impl OnboardingComponent {
         let container = Block::default().style(Style::default().bg(DARK_BG));
         frame.render_widget(container, area);
 
-        // Main layout: header, content, footer
+        // Main layout: header, hint band, content, footer
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(5), // Header with progress
-                Constraint::Min(15),   // Main content
+                Constraint::Length(3), // Per-step hint ("what this does")
+                Constraint::Min(12),   // Main content
                 Constraint::Length(3), // Navigation footer
             ])
             .split(area);
 
         self.render_header(frame, layout[0], state);
-        self.render_step_content(frame, layout[1], state);
-        self.render_navigation(frame, layout[2], state);
+        self.render_hint(frame, layout[1], state);
+        self.render_step_content(frame, layout[2], state);
+        self.render_navigation(frame, layout[3], state);
+    }
+
+    /// Render the per-step hint band — a one-liner explaining what the current
+    /// step actually does (fed by `OnboardingStep::hint()`).
+    fn render_hint(&self, frame: &mut Frame, area: Rect, state: &OnboardingState) {
+        let block = Block::default()
+            .borders(Borders::BOTTOM)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(SUBDUED_BORDER))
+            .style(Style::default().bg(DARK_BG));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let hint = Paragraph::new(Line::from(vec![
+            Span::styled("💡 ", Style::default().fg(GOLD)),
+            Span::styled(state.current_step.hint(), Style::default().fg(MUTED_GRAY)),
+        ]))
+        .wrap(ratatui::widgets::Wrap { trim: true })
+        .alignment(Alignment::Center);
+        frame.render_widget(hint, inner);
     }
 
     /// Render the header with step progress
@@ -1370,7 +1392,8 @@ mod tests {
         let comp = OnboardingComponent::new();
         let mut state = OnboardingState::new();
         state.current_step = OnboardingStep::OtelSetup;
-        let mut terminal = Terminal::new(TestBackend::new(width, 30)).unwrap();
+        // Height accounts for the header + per-step hint band + footer chrome.
+        let mut terminal = Terminal::new(TestBackend::new(width, 34)).unwrap();
         terminal.draw(|f| comp.render(f, f.size(), &state)).unwrap();
         terminal.backend().buffer().content().iter().map(|c| c.symbol()).collect()
     }
@@ -1428,7 +1451,8 @@ mod tests {
 
     fn deps_step_text(state: &OnboardingState, width: u16) -> String {
         let comp = OnboardingComponent::new();
-        let mut terminal = Terminal::new(TestBackend::new(width, 30)).unwrap();
+        // Height accounts for the header + per-step hint band + footer chrome.
+        let mut terminal = Terminal::new(TestBackend::new(width, 34)).unwrap();
         terminal.draw(|f| comp.render(f, f.size(), state)).unwrap();
         terminal.backend().buffer().content().iter().map(|c| c.symbol()).collect()
     }

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -86,6 +86,41 @@ impl OnboardingStep {
         }
     }
 
+    /// A one-line "what this step actually does" hint, shown in the hint band
+    /// above every step's content.
+    pub fn hint(&self) -> &'static str {
+        match self {
+            Self::Welcome => {
+                "First-time setup — dependencies, project folders, agent auth, telemetry, \
+                 and editor. Change any of it later from the Setup menu."
+            }
+            Self::DependencyCheck => {
+                "Checks the CLI tools ainb needs (claude, tmux, git, …). Press i to install a \
+                 missing one; required tools must pass before you can continue."
+            }
+            Self::GitDirectories => {
+                "Parent folders that hold your git repos. ainb scans these recursively — every \
+                 repo it finds becomes a session you can start. Comma-separate multiple."
+            }
+            Self::Authentication => {
+                "How each agent signs in: subscription/OAuth via its native login, or an API key \
+                 stored in your system keychain. Set per agent, changeable anytime."
+            }
+            Self::OtelSetup => {
+                "Optional: ship ainb usage metrics to your Grafana Cloud over OpenTelemetry. \
+                 Fill all three fields or skip — you can run `ainb otel setup` later."
+            }
+            Self::EditorSelection => {
+                "The editor ainb opens files and worktrees in. Detected from your PATH — pick \
+                 one, or skip to fall back to $EDITOR."
+            }
+            Self::Summary => {
+                "Review your choices and finish. Writes them to ~/.agents-in-a-box/config; \
+                 re-run this wizard anytime from the Setup menu."
+            }
+        }
+    }
+
     /// Can we go to the next step?
     pub fn can_advance(&self, state: &OnboardingState) -> bool {
         match self {


### PR DESCRIPTION
Adds a "what this actually does" hint to **every** onboarding step, so it is clear what each screen means and what happens when you act on it.

```
┌ 🛠️ AINB Setup Wizard ────────────────────────────────┐
│ ○ … ◉ Git Directories … ○ …                          │  header + progress
├──────────────────────────────────────────────────────┤
│ 💡 Parent folders that hold your git repos. ainb      │  ← new hint band
│    scans these recursively — every repo it finds       │
│    becomes a session you can start. Comma-separate.    │
├──────────────────────────────────────────────────────┤
│ (step content …)                                       │
└──────────────────────────────────────────────────────┘
```

## What

- New `OnboardingStep::hint()` — one concise "what happens" line per step (Welcome, Dependencies, Git Directories, Authentication, Telemetry, Editor, Summary).
- New `render_hint()` band inserted between the header and the step content (💡 gold icon + muted text, wraps to width), so it shows on all steps with a single edit.

## Notes

- The band adds ~3 rows of chrome; the two onboarding render-test helpers grow their buffer height to match. Tests: `cargo test -p ainb --lib onboarding` → 23 pass ✓, `cargo build` ✓.
- Independent of #375 (auth) and #376 (git dirs); all three touch onboarding but different functions/regions.