### PR TITLE
feat(fleet): synchronous permission approve/deny round-trip

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -52,6 +52,8 @@ pub enum AppEvent {
     DaemonsOverlayOpen,
     DaemonsOverlayClose,
     DaemonsOverlayRefresh,
+    /// Restart the notifyd daemon (single resume/repair) from the overlay.
+    DaemonsOverlayRestartNotifyd,
     RefreshWorkspaces,  // Manual refresh of workspace data
     CycleSessionFilter, // Cycle Interactive session filter (Shift+F): All → ActiveOnly → StoppedOnly
     ToggleClaudeChat,   // Toggle Claude chat visibility
@@ -1258,13 +1260,15 @@ impl EventHandler {
             };
         }
 
-        // Daemons overlay captures all keys while open (read-only: only r and esc/q).
+        // Daemons overlay captures all keys while open: r refresh, R restart
+        // notifyd (single resume/repair), esc/q/d close.
         if state.daemons_overlay.is_some() {
             return match key_event.code {
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('d') => {
                     Some(AppEvent::DaemonsOverlayClose)
                 }
                 KeyCode::Char('r') => Some(AppEvent::DaemonsOverlayRefresh),
+                KeyCode::Char('R') => Some(AppEvent::DaemonsOverlayRestartNotifyd),
                 _ => None,
             };
         }
@@ -3024,6 +3028,7 @@ impl EventHandler {
             AppEvent::DaemonsOverlayOpen => state.toggle_daemons_overlay(),
             AppEvent::DaemonsOverlayClose => state.close_daemons_overlay(),
             AppEvent::DaemonsOverlayRefresh => state.spawn_daemons_fetch(),
+            AppEvent::DaemonsOverlayRestartNotifyd => state.spawn_notifyd_restart(),
             AppEvent::ToggleClaudeChat => state.toggle_claude_chat(),
             AppEvent::ToggleExpandAll => state.toggle_expand_all_workspaces(),
             AppEvent::ToggleSessionsSidebar => {
@@ -5257,9 +5262,10 @@ impl EventHandler {
                 // permission decision to the notifyd approve broker, which
                 // unblocks the parked PermissionRequest hook (it flows back to
                 // Claude as `permissionDecision: allow`). NOT a tmux send.
-                state
-                    .fleet_panel_state
-                    .guarded_decide(ainb_plugin_notifyd::broker::DecisionKind::Approve, "approved");
+                state.fleet_panel_state.guarded_decide(
+                    ainb_plugin_notifyd::broker::DecisionKind::Approve,
+                    "approved",
+                );
             }
             AppEvent::FleetPanelDeny => {
                 // Deny the selected APPROVE row (broker relays `deny` back to the
@@ -7493,6 +7499,34 @@ mod panel_back_tests {
 
         let event = EventHandler::handle_key_event(KeyEvent::from(KeyCode::Char('q')), &mut state);
         assert!(matches!(event, Some(AppEvent::PanelBack)), "got {event:?}");
+    }
+
+    /// While the Daemons `d` overlay is open, `R` maps to the notifyd restart
+    /// (single resume/repair) event, and `r` still maps to refresh — the two
+    /// case-paired verbs live on the same surface.
+    #[test]
+    fn daemons_overlay_restart_key_routing() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        // Opening the overlay fires the first lazy fetch (tokio::spawn), so the
+        // test needs a live reactor.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let mut state = AppState::default();
+        state.toggle_daemons_overlay();
+        assert!(state.daemons_overlay.is_some(), "overlay must be open");
+
+        let route =
+            |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('R')),
+            Some(AppEvent::DaemonsOverlayRestartNotifyd)
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('r')),
+            Some(AppEvent::DaemonsOverlayRefresh)
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -369,6 +369,8 @@ pub enum AppEvent {
     FleetPanelOptionPrev, // Fleet panel: move ASK option cursor back (Shift+Tab)
     FleetPanelAnswer,     // Fleet panel: answer selected ASK with the option (Enter/a)
     FleetPanelBroadcast,  // Fleet panel: broadcast a ping to the selected session (B)
+    FleetPanelApprove,    // Fleet panel: approve the selected APPROVE permission request (y)
+    FleetPanelDeny,       // Fleet panel: deny the selected APPROVE permission request (n)
     FleetPanelRefresh,    // Fleet panel: force-refresh from current_state (r)
     PanelBack,            // Close a panel screen: pop previous_screen (home if none)
     GoToHangar,           // Navigate to the Hangar control plane (plugin screen)
@@ -2730,6 +2732,8 @@ impl EventHandler {
             KeyCode::BackTab => Some(AppEvent::FleetPanelOptionPrev),
             KeyCode::Enter | KeyCode::Char('a') => Some(AppEvent::FleetPanelAnswer),
             KeyCode::Char('B') => Some(AppEvent::FleetPanelBroadcast),
+            KeyCode::Char('y') => Some(AppEvent::FleetPanelApprove),
+            KeyCode::Char('n') => Some(AppEvent::FleetPanelDeny),
             KeyCode::Char('r') => Some(AppEvent::FleetPanelRefresh),
             _ => None,
         }
@@ -5247,6 +5251,22 @@ impl EventHandler {
                         .fleet_panel_state
                         .set_feedback("no session selected to broadcast to".to_string());
                 }
+            }
+            AppEvent::FleetPanelApprove => {
+                // Approve the selected APPROVE row: deliver a first-class
+                // permission decision to the notifyd approve broker, which
+                // unblocks the parked PermissionRequest hook (it flows back to
+                // Claude as `permissionDecision: allow`). NOT a tmux send.
+                state
+                    .fleet_panel_state
+                    .guarded_decide(ainb_plugin_notifyd::broker::DecisionKind::Approve, "approved");
+            }
+            AppEvent::FleetPanelDeny => {
+                // Deny the selected APPROVE row (broker relays `deny` back to the
+                // blocked hook). Same guard as approve/send.
+                state
+                    .fleet_panel_state
+                    .guarded_decide(ainb_plugin_notifyd::broker::DecisionKind::Deny, "denied");
             }
             AppEvent::GoToHangar => {
                 tracing::info!("Navigating to Hangar");

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1014,6 +1014,11 @@ pub struct DaemonsOverlayState {
     pub last_refreshed: Option<std::time::Instant>,
     /// Receiver for the in-flight fetch (None = no fetch pending).
     pub fetch_rx: Option<mpsc::UnboundedReceiver<DaemonsFetchResult>>,
+    /// Receiver for an in-flight `notifyd` restart (None = no restart pending).
+    /// Carries the one-line outcome to show under the notifyd section.
+    pub notifyd_restart_rx: Option<mpsc::UnboundedReceiver<String>>,
+    /// Last restart outcome line (transient, shown until the next refresh).
+    pub notifyd_restart_status: Option<String>,
 }
 
 /// Blocking portion of the daemons fetch: MCP alive probe + SessionStore read
@@ -4838,6 +4843,8 @@ impl AppState {
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
+            notifyd_restart_rx: None,
+            notifyd_restart_status: None,
         });
         self.spawn_daemons_fetch();
     }
@@ -4879,6 +4886,46 @@ impl AppState {
         });
     }
 
+    /// Restart the notifyd daemon from the Daemons overlay — the single
+    /// resume/repair lever. Runs [`ainb_plugin_notifyd::procs::restart`] off the
+    /// UI thread (it SIGTERMs the old owner, reaps stragglers, respawns, and
+    /// polls the approve socket, up to a few seconds). Once the socket rebinds,
+    /// every still-blocked permission waiter re-dials and resumes on its own —
+    /// so this one action both repairs a dead socket and resumes pending
+    /// prompts. One-outstanding guard mirrors the fetch path.
+    pub fn spawn_notifyd_restart(&mut self) {
+        let Some(o) = self.daemons_overlay.as_mut() else {
+            return;
+        };
+        if o.notifyd_restart_rx.is_some() {
+            return;
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        o.notifyd_restart_rx = Some(rx);
+        o.notifyd_restart_status = Some("restarting notifyd…".to_string());
+        tokio::spawn(async move {
+            let line = tokio::task::spawn_blocking(|| {
+                match ainb_plugin_notifyd::procs::restart(std::time::Duration::from_secs(3)) {
+                    Ok(out) => {
+                        let spawned = out
+                            .spawned
+                            .map(|p| format!("pid {p}"))
+                            .unwrap_or_else(|| "spawn failed".to_string());
+                        if out.socket_bound {
+                            format!("restarted notifyd ({spawned}) — approve socket live, pending prompts resume")
+                        } else {
+                            format!("restarted notifyd ({spawned}) — socket not yet rebound; hooks keep re-dialling")
+                        }
+                    }
+                    Err(e) => format!("restart failed: {e:#}"),
+                }
+            })
+            .await
+            .unwrap_or_else(|e| format!("restart task panicked: {e}"));
+            let _ = tx.send(line);
+        });
+    }
+
     /// Drain a completed daemons fetch. Called from the 250ms app tick.
     pub fn check_daemons_overlay(&mut self) {
         let Some(o) = self.daemons_overlay.as_mut() else {
@@ -4893,6 +4940,15 @@ impl AppState {
                 o.headroom_consumers = result.headroom_consumers;
                 o.notifyd = result.notifyd;
                 o.last_refreshed = Some(std::time::Instant::now());
+            }
+        }
+        // A finished restart updates the status line and triggers a fresh scan
+        // so the new pid shows up in the notifyd section.
+        if let Some(rx) = o.notifyd_restart_rx.as_mut() {
+            if let Ok(line) = rx.try_recv() {
+                o.notifyd_restart_rx = None;
+                o.notifyd_restart_status = Some(line);
+                self.spawn_daemons_fetch();
             }
         }
     }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -999,6 +999,10 @@ pub struct DaemonsFetchResult {
     pub headroom_consumers: Vec<String>,
     /// Every running `notifyd` process, classified live / stale / orphan.
     pub notifyd: Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
+    /// approve.sock liveness: serving? + the probe's health reason (carries the
+    /// pending-waiter count). Sockets are tracked here too, not just daemons.
+    pub approve_running: bool,
+    pub approve_reason: String,
 }
 
 /// Live, lazily-refreshed snapshot for the Daemons overlay. Present only while
@@ -1010,6 +1014,9 @@ pub struct DaemonsOverlayState {
     pub headroom_consumers: Vec<String>,
     /// Every running `notifyd` process, classified live / stale / orphan.
     pub notifyd: Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
+    /// approve.sock liveness + health reason (see [`DaemonsFetchResult`]).
+    pub approve_running: bool,
+    pub approve_reason: String,
     pub loading: bool,
     pub last_refreshed: Option<std::time::Instant>,
     /// Receiver for the in-flight fetch (None = no fetch pending).
@@ -1028,6 +1035,7 @@ pub(crate) fn daemons_sync_probe() -> (
     bool,
     Vec<String>,
     Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
+    (bool, String),
 ) {
     let mcp_alive = crate::mcp_pool::client::daemon_alive();
     let headroom_consumers = crate::interactive::SessionStore::load()
@@ -1037,7 +1045,22 @@ pub(crate) fn daemons_sync_probe() -> (
         .map(|m| m.tmux_session_name.clone())
         .collect::<Vec<_>>();
     let notifyd = ainb_plugin_notifyd::scan_daemons();
-    (mcp_alive, headroom_consumers, notifyd)
+    // approve.sock — same probe the `ainb fleet daemons` health view uses, so
+    // the two surfaces can't drift. Reason carries the pending-waiter count.
+    let approve = match ainb_plugin_notifyd::Paths::from_home() {
+        Ok(paths) => {
+            let s = crate::fleet::daemons::probe::probe_approve_broker(
+                &paths.base,
+                crate::fleet::daemons::heartbeat::now_ms(),
+            );
+            (
+                s.state == crate::fleet::daemons::DaemonState::Running,
+                s.reason,
+            )
+        }
+        Err(e) => (false, format!("home unresolved: {e}")),
+    };
+    (mcp_alive, headroom_consumers, notifyd, approve)
 }
 
 // ============================================================================
@@ -4840,6 +4863,8 @@ impl AppState {
             },
             headroom_consumers: Vec::new(),
             notifyd: Vec::new(),
+            approve_running: false,
+            approve_reason: "probing…".to_string(),
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
@@ -4869,11 +4894,13 @@ impl AppState {
         tokio::spawn(async move {
             // Blocking I/O (control socket + file read + `ps` scan) on the
             // blocking pool.
-            let (mcp_alive, headroom_consumers, notifyd) = tokio::task::spawn_blocking(
-                daemons_sync_probe,
-            )
-            .await
-            .unwrap_or((false, Vec::new(), Vec::new()));
+            let (mcp_alive, headroom_consumers, notifyd, approve) =
+                tokio::task::spawn_blocking(daemons_sync_probe).await.unwrap_or((
+                    false,
+                    Vec::new(),
+                    Vec::new(),
+                    (false, "probe failed".to_string()),
+                ));
             // Async HTTP probe of the Headroom /health + /stats endpoints.
             let headroom = crate::headroom::status().await;
             let result = DaemonsFetchResult {
@@ -4881,6 +4908,8 @@ impl AppState {
                 headroom,
                 headroom_consumers,
                 notifyd,
+                approve_running: approve.0,
+                approve_reason: approve.1,
             };
             let _ = tx.send(result);
         });
@@ -4939,6 +4968,8 @@ impl AppState {
                 o.headroom = result.headroom;
                 o.headroom_consumers = result.headroom_consumers;
                 o.notifyd = result.notifyd;
+                o.approve_running = result.approve_running;
+                o.approve_reason = result.approve_reason;
                 o.last_refreshed = Some(std::time::Instant::now());
             }
         }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/approve.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/approve.rs
@@ -15,6 +15,12 @@ use anyhow::{Context, Result};
 use crate::cli::OutputFormat;
 use ainb_plugin_notifyd::broker::{DecisionKind, client_decide, client_list};
 
+/// Replace control characters (terminal-escape injection vector — these
+/// strings are registered by whoever dialled the socket) with spaces.
+fn sanitize(s: &str) -> String {
+    s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
+}
+
 pub async fn execute(
     matches: &clap::ArgMatches,
     format: OutputFormat,
@@ -22,9 +28,11 @@ pub async fn execute(
 ) -> Result<()> {
     let session_id = matches.get_one::<String>("session-id").cloned();
     let reason = matches.get_one::<String>("reason").cloned().unwrap_or_default();
-    let verb = match kind {
-        DecisionKind::Approve => "approved",
-        _ => "denied",
+    // Keep the JSON `decision` vocabulary identical to the broker wire enum
+    // (`approve`/`deny`) so scripts see one vocabulary end to end.
+    let (verb, wire) = match kind {
+        DecisionKind::Approve => ("approved", "approve"),
+        _ => ("denied", "deny"),
     };
 
     // Broker clients are blocking unix I/O — keep them off the async reactor.
@@ -47,12 +55,14 @@ pub async fn execute(
                     "{}",
                     serde_json::json!({
                         "session_id": session_id,
-                        "decision": verb,
+                        "decision": wire,
                         "matched": matched,
                     })
                 );
             } else if matched {
-                println!("{verb} → {session_id}: delivered");
+                // "matched" not "delivered": the broker handed the decision to a
+                // parked waiter, but the hook-side write isn't acknowledged.
+                println!("{verb} → {session_id}: matched the waiting hook");
             } else {
                 println!("{verb} → {session_id}: no waiter (already resolved or timed out)");
             }
@@ -78,17 +88,17 @@ pub async fn execute(
             } else if pending.is_empty() {
                 println!("no sessions waiting on a permission decision");
             } else {
-                println!(
-                    "{:<38} {:<18} {:<8} {}",
-                    "SESSION", "TOOL", "WAITING", "CONTEXT"
-                );
+                println!("{:<38} {:<18} {:<8} CONTEXT", "SESSION", "TOOL", "WAITING");
                 for p in pending {
+                    // AWAIT fields come from whatever dialled the socket — strip
+                    // control chars so a hostile registration can't inject
+                    // terminal escapes into the operator's shell.
                     println!(
                         "{:<38} {:<18} {:<8} {}",
-                        p.session_id,
-                        p.tool,
+                        sanitize(&p.session_id),
+                        sanitize(&p.tool),
                         format!("{}s", p.waiting_ms / 1000),
-                        p.context,
+                        sanitize(&p.context),
                     );
                 }
             }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/approve.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/approve.rs
@@ -1,0 +1,98 @@
+// ABOUTME: `ainb fleet approve|deny [session-id]` — CLI lever for the
+// synchronous permission round-trip.
+//
+// The blocked `PermissionRequest` hook is parked on the notifyd approve
+// socket in `client_await`; this verb delivers the human's decision via
+// `client_decide`, which flows back to Claude as its `hookSpecificOutput`
+// permission decision — the same broker path the TUI fleet-panel lever
+// uses, so the two surfaces can never diverge.
+//
+// With no session-id, both verbs list the sessions currently waiting on a
+// decision (discovery for scripting: `ainb fleet approve --format json`).
+
+use anyhow::{Context, Result};
+
+use crate::cli::OutputFormat;
+use ainb_plugin_notifyd::broker::{DecisionKind, client_decide, client_list};
+
+pub async fn execute(
+    matches: &clap::ArgMatches,
+    format: OutputFormat,
+    kind: DecisionKind,
+) -> Result<()> {
+    let session_id = matches.get_one::<String>("session-id").cloned();
+    let reason = matches.get_one::<String>("reason").cloned().unwrap_or_default();
+    let verb = match kind {
+        DecisionKind::Approve => "approved",
+        _ => "denied",
+    };
+
+    // Broker clients are blocking unix I/O — keep them off the async reactor.
+    let sock = ainb_plugin_notifyd::paths::Paths::from_home()?.approve_socket;
+    match session_id {
+        Some(session_id) => {
+            let matched = tokio::task::spawn_blocking({
+                let (sock, session_id) = (sock.clone(), session_id.clone());
+                move || client_decide(&sock, &session_id, kind, &reason)
+            })
+            .await?
+            .with_context(|| {
+                format!(
+                    "approve broker unreachable at {} — repair with `ainb notifyd restart`",
+                    sock.display()
+                )
+            })?;
+            if matches!(format, OutputFormat::Json) {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "session_id": session_id,
+                        "decision": verb,
+                        "matched": matched,
+                    })
+                );
+            } else if matched {
+                println!("{verb} → {session_id}: delivered");
+            } else {
+                println!("{verb} → {session_id}: no waiter (already resolved or timed out)");
+            }
+            // A miss is an actionable failure for scripts: exit non-zero.
+            if !matched {
+                std::process::exit(1);
+            }
+        }
+        None => {
+            let pending = tokio::task::spawn_blocking({
+                let sock = sock.clone();
+                move || client_list(&sock)
+            })
+            .await?
+            .with_context(|| {
+                format!(
+                    "approve broker unreachable at {} — repair with `ainb notifyd restart`",
+                    sock.display()
+                )
+            })?;
+            if matches!(format, OutputFormat::Json) {
+                println!("{}", serde_json::to_string_pretty(&pending)?);
+            } else if pending.is_empty() {
+                println!("no sessions waiting on a permission decision");
+            } else {
+                println!(
+                    "{:<38} {:<18} {:<8} {}",
+                    "SESSION", "TOOL", "WAITING", "CONTEXT"
+                );
+                for p in pending {
+                    println!(
+                        "{:<38} {:<18} {:<8} {}",
+                        p.session_id,
+                        p.tool,
+                        format!("{}s", p.waiting_ms / 1000),
+                        p.context,
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -731,9 +731,11 @@ fn permission_emit_json(decision: &ainb_plugin_notifyd::broker::Decision) -> Str
 /// from the hook payload (e.g. the Bash command), compacted to one line. Empty
 /// when the payload has none.
 fn extract_permission_context(payload: &str) -> String {
+    // `input` tolerated as an alias, mirroring `approve_context` in the
+    // notifyd transition fold — the two surfaces must read the same payloads.
     serde_json::from_str::<serde_json::Value>(payload)
         .ok()
-        .and_then(|v| v.get("tool_input").cloned())
+        .and_then(|v| v.get("tool_input").or_else(|| v.get("input")).cloned())
         .map(|ti| ti.to_string())
         .unwrap_or_default()
 }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1103,6 +1103,10 @@ fn resolve_matcher(
     let v = payload?;
     let key = match base_event {
         "PreToolUse" => "tool_name",
+        // The managed hook registers PermissionRequest with matcher "", so the
+        // tool shown in `ainb fleet approve` / the TUI detail must come from
+        // the payload — without this arm the TOOL column is empty on real fires.
+        "PermissionRequest" => "tool_name",
         "Notification" => "notification_type",
         "StopFailure" => "error_type",
         _ => return None,

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1693,7 +1693,10 @@ mod tests {
             reason: "human approved".into(),
         });
         let v: serde_json::Value = serde_json::from_str(&allow).unwrap();
-        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PermissionRequest");
+        assert_eq!(
+            v["hookSpecificOutput"]["hookEventName"],
+            "PermissionRequest"
+        );
         assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "allow");
         assert_eq!(
             v["hookSpecificOutput"]["permissionDecisionReason"],
@@ -1706,7 +1709,10 @@ mod tests {
         });
         let v: serde_json::Value = serde_json::from_str(&deny).unwrap();
         assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
-        assert_eq!(v["hookSpecificOutput"]["permissionDecisionReason"], "timed out");
+        assert_eq!(
+            v["hookSpecificOutput"]["permissionDecisionReason"],
+            "timed out"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -641,15 +641,26 @@ async fn hook(matches: &clap::ArgMatches) -> Result<()> {
     Ok(())
 }
 
+/// What the lifecycle hook emits on stdout. Two distinct JSON shapes flow to the
+/// same stdout: a `Stop`-block decision (`{"decision":"block",...}`) and the
+/// `PermissionRequest` `hookSpecificOutput` decision. The permission line is
+/// pre-serialized (built by [`permission_emit_json`]) and emitted verbatim.
+enum HookEmit {
+    /// A Stop-drain block decision, serialized on emit.
+    Stop(plumbing::StopDecision),
+    /// A pre-serialized `hookSpecificOutput` permission-decision JSON line.
+    Permission(String),
+}
+
 /// Convert a [`hook_inner`]/[`hook_core`] result into the hook's exit behaviour:
 /// `(exit_ok, emitted_stdout)`. This is the H-A1 swallow contract in one place —
 /// it NEVER yields a non-zero exit. A block decision serializes to the stdout
-/// JSON; a `None` decision emits nothing; an Err is logged and swallowed (no
-/// stdout). `exit_ok` is always `true` (the tuple keeps the intent explicit +
-/// unit-testable).
-fn swallow_hook_result(result: Result<Option<plumbing::StopDecision>>) -> (bool, Option<String>) {
+/// JSON; a permission decision is emitted verbatim; a `None` decision emits
+/// nothing; an Err is logged and swallowed (no stdout). `exit_ok` is always
+/// `true` (the tuple keeps the intent explicit + unit-testable).
+fn swallow_hook_result(result: Result<Option<HookEmit>>) -> (bool, Option<String>) {
     match result {
-        Ok(Some(decision)) => match serde_json::to_string(&decision) {
+        Ok(Some(HookEmit::Stop(decision))) => match serde_json::to_string(&decision) {
             Ok(s) => (true, Some(s)),
             Err(e) => {
                 // Serialization of a StopDecision cannot realistically fail, but
@@ -659,6 +670,8 @@ fn swallow_hook_result(result: Result<Option<plumbing::StopDecision>>) -> (bool,
                 (true, None)
             }
         },
+        // Already a complete JSON line — emit as-is.
+        Ok(Some(HookEmit::Permission(json))) => (true, Some(json)),
         Ok(None) => (true, None),
         Err(e) => {
             // Log-and-swallow: a drain/serialize/IO failure must NOT wedge Stop
@@ -669,12 +682,42 @@ fn swallow_hook_result(result: Result<Option<plumbing::StopDecision>>) -> (bool,
     }
 }
 
+/// Build the Claude `PermissionRequest` hook output from a broker decision.
+/// `approve` → `allow`; anything else (deny / timeout / superseded / dead
+/// socket) → `deny`. Never auto-approves on a fallback.
+fn permission_emit_json(decision: &ainb_plugin_notifyd::broker::Decision) -> String {
+    use ainb_plugin_notifyd::broker::DecisionKind;
+    let verdict = match decision.decision {
+        DecisionKind::Approve => "allow",
+        DecisionKind::Deny => "deny",
+    };
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "permissionDecision": verdict,
+            "permissionDecisionReason": decision.reason,
+        }
+    })
+    .to_string()
+}
+
+/// Best-effort short context for the permission prompt: the `tool_input` JSON
+/// from the hook payload (e.g. the Bash command), compacted to one line. Empty
+/// when the payload has none.
+fn extract_permission_context(payload: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(payload)
+        .ok()
+        .and_then(|v| v.get("tool_input").cloned())
+        .map(|ti| ti.to_string())
+        .unwrap_or_default()
+}
+
 /// The fallible body of [`hook`]: resolves the process env (`AINB_HOME`,
 /// `AINB_PARENT_SESSION`) + stdin payload, then delegates the I/O-on-an-explicit-
 /// home work to [`hook_core`] (which is env-free so it unit-tests against a
 /// tempdir without mutating process-global env — the crate forbids `unsafe`, so
-/// tests can't call `set_var`). Returns the optional Stop-block decision to emit.
-fn hook_inner(matches: &clap::ArgMatches) -> Result<Option<plumbing::StopDecision>> {
+/// tests can't call `set_var`). Returns the optional stdout emit ([`HookEmit`]).
+fn hook_inner(matches: &clap::ArgMatches) -> Result<Option<HookEmit>> {
     let event = matches.get_one::<String>("event").cloned().unwrap_or_default();
     let session_id = matches.get_one::<String>("session-id").cloned().unwrap_or_default();
     let cwd = matches.get_one::<String>("cwd").cloned().unwrap_or_default();
@@ -726,7 +769,7 @@ fn hook_core(
     now_ms: i64,
     payload: &str,
     matcher: Option<&str>,
-) -> Result<Option<plumbing::StopDecision>> {
+) -> Result<Option<HookEmit>> {
     let base_event = event.split(':').next().unwrap_or(event);
     let inbox_dir = plumbing::paths::inbox_dir_in(home);
 
@@ -837,8 +880,30 @@ fn hook_core(
         if !inbox.is_empty() {
             let (_completions, decision) =
                 inbox.drain_with_budget(plumbing::DEFAULT_BLOCK_BUDGET)?;
-            return Ok(decision);
+            return Ok(decision.map(HookEmit::Stop));
         }
+    }
+
+    // 4. PermissionRequest: SYNCHRONOUS approve/deny round-trip. The waiting
+    //    Claude hook BLOCKS here on the approve broker socket until a human
+    //    answers from the fleet UI (or `ainb fleet ... approve/deny`), then
+    //    relays the verdict straight back as a `hookSpecificOutput` permission
+    //    decision. Fleet members only — an unrelated host session must NOT wedge
+    //    on our socket. `client_await` re-dials to its deadline, so a notifyd
+    //    restart mid-wait is survived; a dead socket / no answer deny-falls-back
+    //    (never auto-approves).
+    if base_event == "PermissionRequest" && !session_id.is_empty() && is_fleet_member {
+        let sock = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
+        let tool = matcher.unwrap_or_default();
+        let context = extract_permission_context(payload);
+        let decision = ainb_plugin_notifyd::broker::client_await(
+            &sock,
+            session_id,
+            tool,
+            &context,
+            ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
+        );
+        return Ok(Some(HookEmit::Permission(permission_emit_json(&decision))));
     }
 
     Ok(None)
@@ -1310,7 +1375,10 @@ mod tests {
             None,
         )
         .unwrap();
-        let d = decision.expect("Stop-hook must block on the child completion");
+        let HookEmit::Stop(d) = decision.expect("Stop-hook must block on the child completion")
+        else {
+            panic!("Stop hook must emit a Stop decision, not a permission decision");
+        };
         assert_eq!(d.decision, "block");
         assert!(
             d.reason.contains("child-1"),
@@ -1611,5 +1679,42 @@ mod tests {
         let (exit_ok, emitted) = swallow_hook_result(result);
         assert!(exit_ok, "a forced drain error must still yield exit 0");
         assert!(emitted.is_none(), "an error must emit no decision JSON");
+    }
+
+    // The broker round-trip (live approve + dead-socket deny fallback) is proven
+    // in `ainb-plugin-notifyd::broker::tests`; here we only pin the thin glue that
+    // maps a broker `Decision` onto the exact Claude `PermissionRequest` output.
+    #[test]
+    fn permission_emit_maps_approve_and_deny() {
+        use ainb_plugin_notifyd::broker::{Decision, DecisionKind};
+
+        let allow = permission_emit_json(&Decision {
+            decision: DecisionKind::Approve,
+            reason: "human approved".into(),
+        });
+        let v: serde_json::Value = serde_json::from_str(&allow).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PermissionRequest");
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            v["hookSpecificOutput"]["permissionDecisionReason"],
+            "human approved"
+        );
+
+        let deny = permission_emit_json(&Decision {
+            decision: DecisionKind::Deny,
+            reason: "timed out".into(),
+        });
+        let v: serde_json::Value = serde_json::from_str(&deny).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert_eq!(v["hookSpecificOutput"]["permissionDecisionReason"], "timed out");
+    }
+
+    #[test]
+    fn extract_permission_context_pulls_tool_input() {
+        let payload = r#"{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"}}"#;
+        let ctx = extract_permission_context(payload);
+        assert!(ctx.contains("rm -rf /tmp/x"), "context was: {ctx}");
+        assert!(extract_permission_context("not json").is_empty());
+        assert!(extract_permission_context("{}").is_empty());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{Result, bail};
 
 use crate::cli::OutputFormat;
 
+pub mod approve;
 pub mod atc;
 pub mod bridge;
 pub mod broadcast;
@@ -22,6 +23,17 @@ pub mod standup;
 
 pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
     match matches.subcommand() {
+        Some(("approve", sub)) => {
+            approve::execute(
+                sub,
+                format,
+                ainb_plugin_notifyd::broker::DecisionKind::Approve,
+            )
+            .await
+        }
+        Some(("deny", sub)) => {
+            approve::execute(sub, format, ainb_plugin_notifyd::broker::DecisionKind::Deny).await
+        }
         Some(("standup", sub)) => standup::execute(sub, format).await,
         Some(("broadcast", sub)) => broadcast::execute(sub, format).await,
         Some(("sequence", sub)) => sequence::execute(sub, format).await,

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2094,6 +2094,29 @@ impl CliCommand for FleetCommand {
             "Unified runtime health of every long-running daemon \
              (phone bridge / notifyd / ATC / fleet daemon)",
         );
+        // approve/deny share one arg shape: with a session-id they deliver the
+        // decision to the waiting PermissionRequest hook via the approve
+        // broker; without one they list the sessions currently blocked.
+        let decision_args = |c: Command| {
+            c.arg(
+                clap::Arg::new("session-id")
+                    .help("Session blocked on a permission decision (omit to list waiters)"),
+            )
+            .arg(
+                clap::Arg::new("reason")
+                    .long("reason")
+                    .default_value("")
+                    .help("Optional reason relayed to the agent with the decision"),
+            )
+        };
+        let approve = decision_args(
+            Command::new("approve")
+                .about("Approve a session's pending permission request (no arg: list waiters)"),
+        );
+        let deny = decision_args(
+            Command::new("deny")
+                .about("Deny a session's pending permission request (no arg: list waiters)"),
+        );
         let atc = build_atc_command();
         let bridge = Command::new("bridge")
             .about(
@@ -2116,6 +2139,8 @@ impl CliCommand for FleetCommand {
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
+                .subcommand(approve)
+                .subcommand(deny)
                 .subcommand(standup)
                 .subcommand(broadcast)
                 .subcommand(sequence)
@@ -2131,7 +2156,10 @@ impl CliCommand for FleetCommand {
                      ainb fleet standup               Live status of all sessions\n  \
                      ainb fleet needs                 Sessions blocked on input / errors\n  \
                      ainb fleet broadcast \"git pull\" --all     Send a prompt to every session\n  \
-                     ainb fleet sequence \"step 1\" \"step 2\"     Ordered prompts with ack between steps",
+                     ainb fleet sequence \"step 1\" \"step 2\"     Ordered prompts with ack between steps\n  \
+                     ainb fleet approve               List sessions waiting on a permission decision\n  \
+                     ainb fleet approve <session-id>  Approve that session's pending permission request\n  \
+                     ainb fleet deny <session-id> --reason \"not now\"   Deny it, with a reason",
                 ),
         )
     }

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2573,11 +2573,12 @@ mod tests {
     }
 
     #[test]
-    fn fleet_exposes_ten_subcommands_including_daemons() {
+    fn fleet_exposes_twelve_subcommands_including_approve_deny() {
         // The `fleet` namespace surface. Adding/removing a fleet subcommand MUST
         // update this count + list — it is the registry guard the daemons-
         // observability feature wired through. `daemon` (the watcher) and
-        // `daemons` (the health view) are deliberately distinct.
+        // `daemons` (the health view) are deliberately distinct; `approve` /
+        // `deny` are the permission round-trip levers.
         let r = CommandRegistry::built_ins();
         let app = r.build_clap(root());
         let fleet = app
@@ -2589,12 +2590,14 @@ mod tests {
         assert_eq!(
             names,
             [
+                "approve",
                 "atc",
                 "bridge",
                 "broadcast",
                 "cost",
                 "daemon",
                 "daemons",
+                "deny",
                 "enrich-cache",
                 "needs",
                 "sequence",
@@ -2604,8 +2607,8 @@ mod tests {
         );
         assert_eq!(
             names.len(),
-            10,
-            "expected 10 fleet subcommands, got {names:?}"
+            12,
+            "expected 12 fleet subcommands, got {names:?}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1320,12 +1320,10 @@ impl CliCommand for NotifydCommand {
                     Command::new("reap")
                         .about("Kill orphan / wedged notifyd processes, sparing the live owner"),
                 )
-                .subcommand(
-                    Command::new("restart").about(
-                        "Stop, reap, and respawn the daemon — the single resume/repair \
+                .subcommand(Command::new("restart").about(
+                    "Stop, reap, and respawn the daemon — the single resume/repair \
                          command for a dead or wedged approve socket",
-                    ),
-                )
+                ))
                 .subcommand(agent_flags(
                     Command::new("install").about("Install the ainb-hooks hook"),
                 ))
@@ -1382,7 +1380,9 @@ impl CliCommand for NotifydCommand {
             },
             Install(Vec<ainb_plugin_notifyd::Agent>),
             Uninstall(Vec<ainb_plugin_notifyd::Agent>),
-            Status,
+            Status {
+                json: bool,
+            },
             List {
                 dismissed: bool,
                 agent: Option<String>,
@@ -1412,7 +1412,9 @@ impl CliCommand for NotifydCommand {
             },
             Some(("install", m)) => Verb::Install(agents(m)),
             Some(("uninstall", m)) => Verb::Uninstall(agents(m)),
-            Some(("status", _)) => Verb::Status,
+            Some(("status", _)) => Verb::Status {
+                json: matches!(ctx.format, crate::cli::OutputFormat::Json),
+            },
             Some(("list", m)) => Verb::List {
                 dismissed: m.get_flag("dismissed"),
                 agent: m.get_one::<String>("agent").cloned(),
@@ -1435,7 +1437,7 @@ impl CliCommand for NotifydCommand {
                 Verb::Restart { json } => cli::cmd_restart(json),
                 Verb::Install(a) => cli::cmd_install(&a),
                 Verb::Uninstall(a) => cli::cmd_uninstall(&a),
-                Verb::Status => cli::cmd_status(),
+                Verb::Status { json } => cli::cmd_status(json),
                 Verb::List {
                     dismissed,
                     agent,

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -115,7 +115,7 @@ impl CommandRegistry {
         r.register(FleetCommand);
         r.register(HeadroomCommand);
         r.register(McpCommand);
-        r.register(NotifydCommand); // hidden — ainb-hooks daemon alias
+        r.register(NotifydCommand); // ainb-hooks daemon: status/restart/install
         r.register(HangarCommand); // Hangar control plane (issue / task / beads / daemon)
         r.register(RtkCommand); // RTK token-killer: install/uninstall/status
         r
@@ -1263,18 +1263,16 @@ impl CliCommand for TmuxCommand {
     }
 }
 
-/// `ainb notifyd {run,stop,install,uninstall,status}` — the ainb-hooks
-/// notification daemon, exposed as a hidden subcommand of the main
-/// binary.
+/// `ainb notifyd {run,stop,reap,restart,install,uninstall,status,list}`
+/// — the ainb-hooks notification daemon.
 ///
-/// The standalone `ainb-notifyd` binary remains the documented
-/// entrypoint, but `notify.sh`'s lazy-spawn fires `ainb notifyd` (the
-/// host binary is the one guaranteed to be on `PATH` after a normal
-/// install). This subcommand makes that path real: it delegates to the
-/// same `ainb_plugin_notifyd` functions the standalone binary uses, so
-/// both entrypoints share one implementation. Hidden from `--help`
-/// because end users should reach for `ainb-notifyd` or the TUI Inbox;
-/// this exists for the hook script's auto-start.
+/// `notify.sh`'s lazy-spawn fires `ainb notifyd` (the host binary is the
+/// one guaranteed to be on `PATH` after a normal install), and it
+/// delegates to the same `ainb_plugin_notifyd` functions the standalone
+/// `ainb-notifyd` binary uses, so both entrypoints share one
+/// implementation. Visible in `--help` because `restart` is the
+/// user-facing single resume/repair command for a dead approve socket —
+/// the very command `ainb fleet approve`'s dead-socket error points at.
 pub struct NotifydCommand;
 impl CliCommand for NotifydCommand {
     fn name(&self) -> &'static str {
@@ -1310,10 +1308,9 @@ impl CliCommand for NotifydCommand {
         app.subcommand(
             Command::new(self.name())
                 .about(
-                    "ainb-hooks notification daemon (alias of the ainb-notifyd \
-                     binary; used by notify.sh lazy-spawn).",
+                    "ainb-hooks notification daemon: status, restart (the approve-socket \
+                     resume/repair command), install/uninstall hooks",
                 )
-                .hide(true)
                 .subcommand(Command::new("run").about("Run the daemon in the foreground (default)"))
                 .subcommand(Command::new("stop").about("Stop a running daemon via its PID file"))
                 .subcommand(
@@ -2525,7 +2522,7 @@ mod tests {
         let r = CommandRegistry::built_ins();
         let names = r.names();
         // main's 30 (built-ins + doctor + reflect + claudecode + codex + tmux +
-        // otel + abtop + witr + learnings + plugin stub + fleet + mcp + hidden
+        // otel + abtop + witr + learnings + plugin stub + fleet + mcp +
         // notifyd + hangar) + headroom + rtk + the web dashboard = 33.
         // The TUI is NOT in the registry — main.rs handles `tui` /
         // no-subcommand inline.

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1320,6 +1320,12 @@ impl CliCommand for NotifydCommand {
                     Command::new("reap")
                         .about("Kill orphan / wedged notifyd processes, sparing the live owner"),
                 )
+                .subcommand(
+                    Command::new("restart").about(
+                        "Stop, reap, and respawn the daemon — the single resume/repair \
+                         command for a dead or wedged approve socket",
+                    ),
+                )
                 .subcommand(agent_flags(
                     Command::new("install").about("Install the ainb-hooks hook"),
                 ))
@@ -1371,6 +1377,9 @@ impl CliCommand for NotifydCommand {
             Reap {
                 json: bool,
             },
+            Restart {
+                json: bool,
+            },
             Install(Vec<ainb_plugin_notifyd::Agent>),
             Uninstall(Vec<ainb_plugin_notifyd::Agent>),
             Status,
@@ -1398,6 +1407,9 @@ impl CliCommand for NotifydCommand {
             Some(("reap", _)) => Verb::Reap {
                 json: matches!(ctx.format, crate::cli::OutputFormat::Json),
             },
+            Some(("restart", _)) => Verb::Restart {
+                json: matches!(ctx.format, crate::cli::OutputFormat::Json),
+            },
             Some(("install", m)) => Verb::Install(agents(m)),
             Some(("uninstall", m)) => Verb::Uninstall(agents(m)),
             Some(("status", _)) => Verb::Status,
@@ -1420,6 +1432,7 @@ impl CliCommand for NotifydCommand {
                 Verb::Run => cli::cmd_run().await,
                 Verb::Stop => cli::cmd_stop(),
                 Verb::Reap { json } => cli::cmd_reap(json),
+                Verb::Restart { json } => cli::cmd_restart(json),
                 Verb::Install(a) => cli::cmd_install(&a),
                 Verb::Uninstall(a) => cli::cmd_uninstall(&a),
                 Verb::Status => cli::cmd_status(),

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_title_header_and_all_four_rows() {
+    fn renders_title_header_and_all_daemon_rows() {
         // Seed the shared snapshot so render reads a deterministic cache and never
         // touches the host's real ~/.agents-in-a-box state (H-D2: render does no
         // collect of its own).
@@ -316,6 +316,12 @@ mod tests {
                 Some("Telegram (@bot)"),
             ),
             status(DaemonKind::Notifyd, DaemonState::Stopped, false, None),
+            status(
+                DaemonKind::ApproveBroker,
+                DaemonState::Running,
+                true,
+                Some("approve socket"),
+            ),
             status(
                 DaemonKind::Atc,
                 DaemonState::Running,
@@ -331,6 +337,7 @@ mod tests {
         // Every daemon's display name renders as a row.
         assert!(out.contains("phone bridge"), "bridge row missing");
         assert!(out.contains("notifyd"), "notifyd row missing");
+        assert!(out.contains("approve broker"), "approve broker row missing");
         assert!(out.contains("ATC"), "ATC row missing");
         assert!(out.contains("fleet daemon"), "fleet daemon row missing");
         // State glyphs + a connected channel render.
@@ -365,11 +372,11 @@ mod tests {
     #[test]
     fn collect_into_publishes_into_the_shared_snapshot() {
         // The background collector's publish step populates the snapshot from a
-        // real collect() (always 4 daemons) without any render involved.
+        // real collect() (every daemon) without any render involved.
         let shared = Mutex::new(Snapshot::default());
         collect_into(&shared);
         let guard = shared.lock().unwrap();
-        assert_eq!(guard.rows.len(), 4, "collect publishes all four daemons");
+        assert_eq!(guard.rows.len(), 5, "collect publishes every daemon");
         assert!(
             guard.collected_at_ms > 0,
             "publish stamps the collect clock"

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -186,6 +186,7 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
 fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
     let lines = build_notifyd_lines(
         &state.notifyd,
+        (state.approve_running, &state.approve_reason),
         state.notifyd_restart_status.as_deref(),
         area.height as usize,
     );
@@ -199,6 +200,7 @@ fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayS
 /// the last visible row becomes a "… +N more" pointer instead.
 fn build_notifyd_lines(
     notifyd: &[ainb_plugin_notifyd::ClassifiedDaemon],
+    approve: (bool, &str),
     restart_status: Option<&str>,
     capacity: usize,
 ) -> Vec<Line<'static>> {
@@ -229,6 +231,27 @@ fn build_notifyd_lines(
     ));
     lines.push(Line::from(header));
 
+    // approve.sock — the permission broker socket notifyd serves. Sockets are
+    // first-class on this screen, not just processes: a dead socket here is
+    // exactly what `R` repairs.
+    let (approve_running, approve_reason) = approve;
+    let (glyph, color) = if approve_running {
+        ("●", SELECTION_GREEN)
+    } else {
+        ("○", CLAY)
+    };
+    lines.push(Line::from(vec![
+        Span::styled(format!("    {glyph} "), Style::default().fg(color)),
+        Span::styled(
+            "approve.sock",
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  {approve_reason}"),
+            Style::default().fg(MUTED_GRAY),
+        ),
+    ]));
+
     // Transient restart outcome, shown until the next refresh clears it.
     if let Some(status) = restart_status {
         lines.push(Line::from(Span::styled(
@@ -245,9 +268,10 @@ fn build_notifyd_lines(
         return lines;
     }
 
-    // Header (+ optional status) consumed the top rows; if the rest don't fit,
-    // reserve one row for the overflow pointer and fill with daemon rows.
-    let head_rows = 1 + restart_status.is_some() as usize;
+    // Header + approve.sock line (+ optional status) consumed the top rows; if
+    // the rest don't fit, reserve one row for the overflow pointer and fill
+    // with daemon rows.
+    let head_rows = 2 + restart_status.is_some() as usize;
     let body_cap = capacity.saturating_sub(head_rows);
     let (shown, overflow) = if notifyd.len() <= body_cap {
         (notifyd.len(), 0)
@@ -343,6 +367,8 @@ mod tests {
             },
             headroom_consumers: vec!["agents/worktree-abc".to_string()],
             notifyd: Vec::new(),
+            approve_running: true,
+            approve_reason: "serving — no pending requests".to_string(),
             loading: false,
             last_refreshed: Some(std::time::Instant::now()),
             fetch_rx: None,
@@ -405,6 +431,8 @@ mod tests {
             },
             headroom_consumers: Vec::new(),
             notifyd: Vec::new(),
+            approve_running: false,
+            approve_reason: "probing…".to_string(),
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
@@ -488,20 +516,43 @@ mod tests {
                 binary_drift: false,
             })
             .collect();
-        // capacity 4 → header + 2 rows + "… +5 more"
-        let lines = build_notifyd_lines(&many, None, 4);
+        // capacity 4 → header + approve.sock + 1 row + "… +6 more"
+        let lines = build_notifyd_lines(&many, (true, "serving"), None, 4);
         assert!(lines.len() <= 4, "exceeded capacity: {}", lines.len());
         let last: String = lines.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();
         assert!(last.contains("more"), "no overflow pointer in: {last}");
 
         // Ample capacity → all 7 rows, no overflow line.
-        let full = build_notifyd_lines(&many, None, 30);
-        assert_eq!(full.len(), 8); // header + 7
+        let full = build_notifyd_lines(&many, (true, "serving"), None, 30);
+        assert_eq!(full.len(), 9); // header + approve.sock + 7
         let full_last: String =
             full.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();
         assert!(
             !full_last.contains("more"),
             "unexpected overflow: {full_last}"
+        );
+    }
+
+    /// The approve socket is a first-class row on this screen — sockets are
+    /// tracked alongside daemons, with the probe's pending-count reason.
+    #[test]
+    fn daemons_overlay_renders_approve_socket_row() {
+        let state = make_state(true, 8787, Some(1), Some(0));
+        let backend = TestBackend::new(120, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.size();
+            render(f, area, &state);
+        })
+        .unwrap();
+        let text = buffer_text(&term);
+        assert!(
+            text.contains("approve.sock"),
+            "missing approve.sock row in:\n{text}"
+        );
+        assert!(
+            text.contains("serving — no pending requests"),
+            "missing approve reason in:\n{text}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -184,7 +184,11 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
 /// This is the only daemon surface that enumerates *every* process rather
 /// than a single pid — orphans are invisible to a pid-file-only view.
 fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
-    let lines = build_notifyd_lines(&state.notifyd, area.height as usize);
+    let lines = build_notifyd_lines(
+        &state.notifyd,
+        state.notifyd_restart_status.as_deref(),
+        area.height as usize,
+    );
     frame.render_widget(Paragraph::new(lines), area);
 }
 
@@ -195,13 +199,14 @@ fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayS
 /// the last visible row becomes a "… +N more" pointer instead.
 fn build_notifyd_lines(
     notifyd: &[ainb_plugin_notifyd::ClassifiedDaemon],
+    restart_status: Option<&str>,
     capacity: usize,
 ) -> Vec<Line<'static>> {
     let orphan_count = notifyd.iter().filter(|d| !d.class.is_healthy()).count();
 
     let mut lines: Vec<Line<'static>> = Vec::new();
 
-    // Header: "notifyd processes (N)  · M to clean up".
+    // Header: "notifyd processes (N)  · M to clean up  · R restart".
     let mut header = vec![Span::styled(
         format!("  notifyd processes ({})", notifyd.len()),
         Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
@@ -212,7 +217,25 @@ fn build_notifyd_lines(
             Style::default().fg(CLAY),
         ));
     }
+    // Restart affordance sits next to the notifyd control it acts on.
+    header.push(Span::styled("   · ", Style::default().fg(MUTED_GRAY)));
+    header.push(Span::styled(
+        "R",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
+    header.push(Span::styled(
+        " restart (resume/repair)",
+        Style::default().fg(MUTED_GRAY),
+    ));
     lines.push(Line::from(header));
+
+    // Transient restart outcome, shown until the next refresh clears it.
+    if let Some(status) = restart_status {
+        lines.push(Line::from(Span::styled(
+            format!("    {status}"),
+            Style::default().fg(GOLD).add_modifier(Modifier::ITALIC),
+        )));
+    }
 
     if notifyd.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -222,9 +245,10 @@ fn build_notifyd_lines(
         return lines;
     }
 
-    // Header consumed one row; if the rest don't fit, reserve one row for the
-    // overflow pointer and fill the remainder with daemon rows.
-    let body_cap = capacity.saturating_sub(1);
+    // Header (+ optional status) consumed the top rows; if the rest don't fit,
+    // reserve one row for the overflow pointer and fill with daemon rows.
+    let head_rows = 1 + restart_status.is_some() as usize;
+    let body_cap = capacity.saturating_sub(head_rows);
     let (shown, overflow) = if notifyd.len() <= body_cap {
         (notifyd.len(), 0)
     } else {
@@ -282,6 +306,8 @@ fn render_help_bar(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
     let spans = vec![
         Span::styled("r", Style::default().fg(GOLD)),
         Span::styled(" refresh  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("R", Style::default().fg(GOLD)),
+        Span::styled(" restart notifyd  ", Style::default().fg(MUTED_GRAY)),
         Span::styled("esc", Style::default().fg(GOLD)),
         Span::styled(" close", Style::default().fg(MUTED_GRAY)),
         Span::styled(
@@ -320,6 +346,8 @@ mod tests {
             loading: false,
             last_refreshed: Some(std::time::Instant::now()),
             fetch_rx: None,
+            notifyd_restart_rx: None,
+            notifyd_restart_status: None,
         }
     }
 
@@ -380,6 +408,8 @@ mod tests {
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
+            notifyd_restart_rx: None,
+            notifyd_restart_status: None,
         };
         let backend = TestBackend::new(120, 30);
         let mut term = Terminal::new(backend).unwrap();
@@ -459,13 +489,13 @@ mod tests {
             })
             .collect();
         // capacity 4 → header + 2 rows + "… +5 more"
-        let lines = build_notifyd_lines(&many, 4);
+        let lines = build_notifyd_lines(&many, None, 4);
         assert!(lines.len() <= 4, "exceeded capacity: {}", lines.len());
         let last: String = lines.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();
         assert!(last.contains("more"), "no overflow pointer in: {last}");
 
         // Ample capacity → all 7 rows, no overflow line.
-        let full = build_notifyd_lines(&many, 30);
+        let full = build_notifyd_lines(&many, None, 30);
         assert_eq!(full.len(), 8); // header + 7
         let full_last: String =
             full.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();

--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -23,6 +23,7 @@
 //   - Tab / Shift+Tab    move the ASK option cursor (when the row is an ASK)
 //   - Enter / a          answer the selected ASK with the highlighted option
 //   - B                  broadcast a ping prompt to the selected session
+//   - y / n              approve / deny the selected APPROVE permission request
 //   - r                  force-refresh from the store
 //   - q / Esc            back to the previous screen
 //
@@ -319,6 +320,47 @@ impl FleetPanelState {
             text,
             kind_label,
             is_answer,
+        );
+        true
+    }
+
+    /// Guarded approve/deny for the selected APPROVE row: refuses while another
+    /// action is in flight (shares the send guard) and only fires when the
+    /// selected row is actually a waiting permission request (`APPROVE`).
+    /// Returns `true` if a decision was dispatched.
+    ///
+    /// Unlike [`guarded_dispatch`], this delivers a first-class permission
+    /// decision to the notifyd approve broker (`dispatch_decide`), which unblocks
+    /// the parked `PermissionRequest` hook — it does NOT route text via tmux.
+    pub fn guarded_decide(
+        &mut self,
+        kind: ainb_plugin_notifyd::broker::DecisionKind,
+        kind_label: &'static str,
+    ) -> bool {
+        if self.is_sending() {
+            self.set_feedback("action already in flight — wait for it to finish".to_string());
+            return false;
+        }
+        let Some(row) = self.selected_row() else {
+            return false;
+        };
+        if row.kind != "APPROVE" {
+            self.set_feedback("no permission request selected".to_string());
+            return false;
+        }
+        let session_id = row.session_id.clone();
+        if session_id.is_empty() {
+            self.set_feedback("cannot decide: row has no session id".to_string());
+            return false;
+        }
+        self.set_feedback(format!("{kind_label} → {session_id}: delivering…"));
+        crate::fleet::control::dispatch_decide(
+            Arc::clone(&self.feedback),
+            Arc::clone(&self.in_flight),
+            session_id,
+            kind,
+            String::new(),
+            kind_label,
         );
         true
     }
@@ -624,6 +666,13 @@ fn render_detail(frame: &mut Frame, area: Rect, state: &FleetPanelState) {
             )));
             lines.push(label("tool:", tool.to_string()));
             lines.push(label("input:", input));
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("y", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(" approve   ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("n", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(" deny", Style::default().fg(MUTED_GRAY)),
+            ]));
         }
         "ERR" => {
             let et = row
@@ -987,6 +1036,29 @@ mod tests {
         let (target, answer) = state.pending_answer().expect("ask row has an answer");
         assert_eq!(target.session_id, "s");
         assert_eq!(answer, "no");
+    }
+
+    #[test]
+    fn guarded_decide_refuses_non_approve_row() {
+        use ainb_plugin_notifyd::broker::DecisionKind;
+        let mut state = state_with(vec![row(
+            "s",
+            "/p",
+            "ASK",
+            Some(r#"{"question":"q?","options":[{"label":"a"}]}"#),
+            "hook",
+        )]);
+        // Selected row is ASK, not APPROVE → decide refused, no dispatch.
+        assert!(!state.guarded_decide(DecisionKind::Approve, "approved"));
+        assert!(!state.is_sending(), "no worker claimed for non-APPROVE row");
+    }
+
+    #[test]
+    fn guarded_decide_refuses_empty_session_id() {
+        use ainb_plugin_notifyd::broker::DecisionKind;
+        let mut state = state_with(vec![row("", "/p", "APPROVE", None, "hook")]);
+        assert!(!state.guarded_decide(DecisionKind::Deny, "denied"));
+        assert!(!state.is_sending(), "empty session id must not claim a worker");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -373,10 +373,12 @@ fn parse_ask(context_json: Option<&str>) -> Option<AskUserQuestionData> {
 fn kind_badge(kind: &str) -> (&'static str, Color) {
     match kind {
         "ASK" => ("ASK ", GOLD),
+        "APPROVE" => ("APRV", GOLD),
         "ERR" => ("ERR ", ALERT_RED),
         "WAIT" => ("WAIT", WAIT_AMBER),
         "IDLE" => ("IDLE", MUTED_GRAY),
         "RUNNING" => ("RUN ", SELECTION_GREEN),
+        "STARTING" => ("STRT", CORNFLOWER_BLUE),
         "DONE" => ("DONE", CORNFLOWER_BLUE),
         _ => ("????", MUTED_GRAY),
     }
@@ -405,6 +407,8 @@ fn short_context(row: &StateRow) -> String {
         "ASK" => parse_ask(row.context.as_deref())
             .map(|a| truncate_chars(&a.question, 40))
             .unwrap_or_default(),
+        "APPROVE" => "needs approval".to_string(),
+        "STARTING" => "starting".to_string(),
         "ERR" => row
             .context
             .as_deref()
@@ -480,7 +484,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &FleetPanelState) {
     let needs = state
         .rows
         .iter()
-        .filter(|r| matches!(r.kind.as_str(), "ASK" | "ERR" | "WAIT" | "IDLE"))
+        .filter(|r| matches!(r.kind.as_str(), "ASK" | "ERR" | "WAIT" | "IDLE" | "APPROVE"))
         .count();
     let title = Line::from(vec![
         Span::styled(
@@ -600,6 +604,27 @@ fn render_detail(frame: &mut Frame, area: Rect, state: &FleetPanelState) {
 
     match row.kind.as_str() {
         "ASK" => render_ask_detail(&mut lines, row, state.option_cursor),
+        "APPROVE" => {
+            let v = row
+                .context
+                .as_deref()
+                .and_then(|c| serde_json::from_str::<serde_json::Value>(c).ok());
+            let tool = v
+                .as_ref()
+                .and_then(|v| v.get("tool").and_then(|t| t.as_str()))
+                .unwrap_or("(unknown)");
+            let input = v
+                .as_ref()
+                .and_then(|v| v.get("tool_input"))
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "null".to_string());
+            lines.push(Line::from(Span::styled(
+                "needs approval:",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            )));
+            lines.push(label("tool:", tool.to_string()));
+            lines.push(label("input:", input));
+        }
         "ERR" => {
             let et = row
                 .context
@@ -658,6 +683,10 @@ fn render_detail(frame: &mut Frame, area: Rect, state: &FleetPanelState) {
         "RUNNING" => lines.push(Line::from(Span::styled(
             "actively working — no action needed",
             Style::default().fg(SELECTION_GREEN),
+        ))),
+        "STARTING" => lines.push(Line::from(Span::styled(
+            "starting — session is booting",
+            Style::default().fg(CORNFLOWER_BLUE),
         ))),
         "DONE" => lines.push(Line::from(Span::styled(
             "finished — completion delivered via the inbox",
@@ -851,6 +880,34 @@ mod tests {
         );
         assert!(out.contains("staging"), "ASK option 'staging' missing");
         assert!(out.contains("prod"), "ASK option 'prod' missing");
+    }
+
+    #[test]
+    fn renders_approve_and_starting_badges() {
+        let mut state = state_with(vec![
+            row(
+                "sess-approve",
+                "/work/deploy",
+                "APPROVE",
+                Some(r#"{"tool":"Bash","tool_input":{"command":"rm -rf /tmp/x"}}"#),
+                "hook",
+            ),
+            row("sess-starting", "/work/boot", "STARTING", None, "hook"),
+        ]);
+        let out = render_to_string(&mut state, 130, 24);
+        assert!(out.contains("APRV"), "APPROVE badge missing: {out}");
+        assert!(out.contains("STRT"), "STARTING badge missing: {out}");
+        // APPROVE needs attention; the counter reflects it.
+        assert!(
+            out.contains("1 need attention"),
+            "needs counter wrong: {out}"
+        );
+        // The selected (first) row is APPROVE → detail shows the tool.
+        assert!(
+            out.contains("needs approval"),
+            "APPROVE detail missing: {out}"
+        );
+        assert!(out.contains("Bash"), "APPROVE tool missing: {out}");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -135,6 +135,72 @@ impl Drop for InFlightGuard {
     }
 }
 
+/// Dispatch an approve/deny decision for a waiting `PermissionRequest` hook,
+/// off the UI thread. Unlike [`dispatch_send`] (which routes text to a live
+/// agent via tmux/broker), this delivers a first-class permission decision to
+/// the notifyd approve broker: the blocked hook is parked on the approve
+/// socket in `client_await`, and `client_decide` hands it the human's answer,
+/// which flows back to Claude as its `hookSpecificOutput` permission decision.
+///
+/// Shares the same `in_flight` guard as sends so rapid key-repeat can't spawn
+/// unbounded workers or double-decide. The worker is a plain thread — the
+/// broker client is blocking `std::os::unix` I/O, no tokio runtime needed.
+///
+/// `kind_label` is the short verb for the feedback line ("approved" / "denied").
+/// The socket is resolved at dispatch time via [`Paths::from_home`], the same
+/// layout the daemon and hook use, so no home has to be threaded through the
+/// panel.
+pub fn dispatch_decide(
+    feedback: Arc<Mutex<ActionFeedback>>,
+    in_flight: Arc<AtomicBool>,
+    session_id: String,
+    kind: ainb_plugin_notifyd::broker::DecisionKind,
+    reason: String,
+    kind_label: &'static str,
+) {
+    // Atomically claim the single in-flight slot (shared with sends).
+    if in_flight
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        publish(
+            &feedback,
+            "action already in flight — wait for it to finish".to_string(),
+        );
+        return;
+    }
+
+    let spawn_err_feedback = Arc::clone(&feedback);
+    let spawn_err_flag = Arc::clone(&in_flight);
+    let target_label = session_id.clone();
+    let spawn_result =
+        std::thread::Builder::new().name("ainb-fleet-decide".into()).spawn(move || {
+            let _guard = InFlightGuard(in_flight);
+            let sock = match ainb_plugin_notifyd::paths::Paths::from_home() {
+                Ok(paths) => paths.approve_socket,
+                Err(e) => {
+                    publish(&feedback, format!("{kind_label} failed: {e}"));
+                    return;
+                }
+            };
+            let outcome =
+                match ainb_plugin_notifyd::broker::client_decide(&sock, &session_id, kind, &reason) {
+                    Ok(true) => "delivered".to_string(),
+                    Ok(false) => "no waiter (already resolved or timed out)".to_string(),
+                    Err(e) => format!("broker unreachable: {e}"),
+                };
+            publish(&feedback, format!("{kind_label} → {target_label}: {outcome}"));
+        });
+    if let Err(e) = spawn_result {
+        tracing::warn!(error = %e, "fleet panel: decide worker thread spawn failed");
+        spawn_err_flag.store(false, Ordering::Release);
+        publish(
+            &spawn_err_feedback,
+            format!("{kind_label} failed: thread spawn error: {e}"),
+        );
+    }
+}
+
 /// Resolve a `current_state` row to a live `Session` and send `text` to it,
 /// returning a human-readable outcome string.
 ///

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -183,10 +183,13 @@ pub fn dispatch_decide(
                     return;
                 }
             };
+            // `matched` means a waiter WAS parked and the broker handed it the
+            // decision — the final write to the hook's socket is not itself
+            // acknowledged, so don't claim "delivered".
             let outcome =
                 match ainb_plugin_notifyd::broker::client_decide(&sock, &session_id, kind, &reason)
                 {
-                    Ok(true) => "delivered".to_string(),
+                    Ok(true) => "matched the waiting hook".to_string(),
                     Ok(false) => "no waiter (already resolved or timed out)".to_string(),
                     Err(e) => format!("broker unreachable: {e}"),
                 };

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -538,21 +538,14 @@ pub fn collect_in(ainb_home: &Path, notifyd_base: &Path, now_ms: i64) -> Vec<Dae
 }
 
 /// Aggregate every daemon from the real on-disk layout. Resolves the ainb
-/// home (honouring `$AINB_HOME`) for bridge/fleet/ATC, and notifyd's own base
-/// (`~/.agents-in-a-box`, which it does NOT key off `$AINB_HOME`).
+/// home (honouring `$AINB_HOME`) for bridge/fleet/ATC; notifyd's base comes
+/// from `Paths::from_home()`, which honours the same `$AINB_HOME` override,
+/// so the probe reads exactly the files the daemon writes.
 pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
     let ainb_home = crate::fleet::plumbing::paths::ainb_home()?;
-    // notifyd resolves its base via `dirs::home_dir()/.agents-in-a-box` and does
-    // NOT honour `$AINB_HOME`; mirror that exactly so the probe reads the same
-    // files the daemon writes. When `$AINB_HOME` is set (tests / unusual setups)
-    // we still point notifyd at the ainb home so an isolated run is coherent.
-    let notifyd_base = if std::env::var("AINB_HOME").map(|h| !h.is_empty()).unwrap_or(false) {
-        ainb_home.clone()
-    } else {
-        dirs::home_dir()
-            .map(|h| h.join(".agents-in-a-box"))
-            .unwrap_or_else(|| ainb_home.clone())
-    };
+    let notifyd_base = ainb_plugin_notifyd::Paths::from_home()
+        .map(|p| p.base)
+        .unwrap_or_else(|_| ainb_home.clone());
     Ok(collect_in(
         &ainb_home,
         &notifyd_base,

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -830,7 +830,11 @@ mod tests {
         let s = probe_approve_broker(base.path(), super::super::heartbeat::now_ms());
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(!s.connected);
-        assert!(s.reason.contains("stale approve.sock"), "reason: {}", s.reason);
+        assert!(
+            s.reason.contains("stale approve.sock"),
+            "reason: {}",
+            s.reason
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -41,6 +41,10 @@ pub enum DaemonKind {
     Bridge,
     /// Unix-socket notification daemon (`ainb-notifyd`).
     Notifyd,
+    /// Synchronous permission approve/deny broker (`approve.sock`, served on
+    /// notifyd's runtime). A distinct socket, tracked as its own row so every
+    /// socket ainb serves is visible in the Daemons view.
+    ApproveBroker,
     /// Air Traffic Control fleet brain.
     Atc,
     /// Auto-continue API-error watcher (`ainb fleet daemon`).
@@ -54,6 +58,7 @@ impl DaemonKind {
         match self {
             Self::Bridge => "bridge",
             Self::Notifyd => "notifyd",
+            Self::ApproveBroker => "approve-broker",
             Self::Atc => "atc",
             Self::FleetDaemon => "fleet-daemon",
         }
@@ -65,6 +70,7 @@ impl DaemonKind {
         match self {
             Self::Bridge => "phone bridge",
             Self::Notifyd => "notifyd",
+            Self::ApproveBroker => "approve broker",
             Self::Atc => "ATC",
             Self::FleetDaemon => "fleet daemon",
         }
@@ -310,6 +316,53 @@ pub fn probe_notifyd(base: &Path, now_ms: i64) -> DaemonStatus {
     .with_now(now_ms)
 }
 
+/// Probe the permission approve/deny broker from its socket. The broker is
+/// served on notifyd's runtime, so its liveness is `approve.sock` accepting a
+/// connection — not a separate pid. A listening socket means the synchronous
+/// round-trip is available; the pending-request count (cheap `client_list` over
+/// the same socket) goes in the reason so the operator can see waiting hooks.
+#[must_use]
+pub fn probe_approve_broker(base: &Path, now_ms: i64) -> DaemonStatus {
+    let kind = DaemonKind::ApproveBroker;
+    let socket_path = base.join("approve.sock");
+
+    // L1: a bound listener, not merely a socket file on disk. A crashed notifyd
+    // can leave a stale `approve.sock`; a non-blocking connect proves a server.
+    if !socket_is_listening(&socket_path) {
+        let reason = if socket_path.exists() {
+            "stale approve.sock — broker not accepting (notifyd down?)".to_string()
+        } else {
+            "no approve.sock — broker not running".to_string()
+        };
+        return DaemonStatus::stopped(kind, reason);
+    }
+
+    // Socket is serving. Fold in the pending-waiter count when the list RPC
+    // answers; a transient RPC error must not flip the row to Stopped (the
+    // listener is provably up), so degrade to a countless "serving" reason.
+    let reason = match ainb_plugin_notifyd::broker::client_list(&socket_path) {
+        Ok(pending) => match pending.len() {
+            0 => "serving — no pending requests".to_string(),
+            1 => "serving — 1 pending request".to_string(),
+            n => format!("serving — {n} pending requests"),
+        },
+        Err(_) => "serving (pending count unavailable)".to_string(),
+    };
+    DaemonStatus {
+        kind,
+        state: DaemonState::Running,
+        pid: None, // rides notifyd's process; no pid of its own
+        uptime_ms: None,
+        connected: true,
+        channel: Some("approve socket".to_string()),
+        last_activity_at: None,
+        error_count: 0,
+        last_error: None,
+        reason,
+    }
+    .with_now(now_ms)
+}
+
 /// Probe ATC from its existing per-instance `heartbeat-state.json` files. ATC is
 /// timer-driven (no foreground daemon), so "running" here means: at least one
 /// provisioned instance with `heartbeat_enabled` whose last heartbeat is within
@@ -469,7 +522,7 @@ fn db_mtime_ms(path: &Path) -> Option<i64> {
     i64::try_from(dur.as_millis()).ok()
 }
 
-/// Aggregate all four daemons under an explicit ainb home + notifyd base. The
+/// Aggregate every daemon under an explicit ainb home + notifyd base. The
 /// test seam — every path is injected so a test isolates to a tempdir.
 ///
 /// `now_ms` is the single clock the staleness checks measure against.
@@ -478,12 +531,13 @@ pub fn collect_in(ainb_home: &Path, notifyd_base: &Path, now_ms: i64) -> Vec<Dae
     vec![
         probe_heartbeat_daemon(ainb_home, DaemonKind::Bridge, now_ms),
         probe_notifyd(notifyd_base, now_ms),
+        probe_approve_broker(notifyd_base, now_ms),
         probe_atc(ainb_home, now_ms),
         probe_heartbeat_daemon(ainb_home, DaemonKind::FleetDaemon, now_ms),
     ]
 }
 
-/// Aggregate all four daemons from the real on-disk layout. Resolves the ainb
+/// Aggregate every daemon from the real on-disk layout. Resolves the ainb
 /// home (honouring `$AINB_HOME`) for bridge/fleet/ATC, and notifyd's own base
 /// (`~/.agents-in-a-box`, which it does NOT key off `$AINB_HOME`).
 pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
@@ -759,6 +813,59 @@ mod tests {
     }
 
     #[test]
+    fn probe_approve_broker_no_socket_is_stopped() {
+        let base = TempDir::new().unwrap();
+        let s = probe_approve_broker(base.path(), super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(!s.connected);
+        assert!(s.reason.contains("no approve.sock"), "reason: {}", s.reason);
+    }
+
+    #[test]
+    fn probe_approve_broker_stale_socket_file_is_stopped() {
+        // A crashed notifyd left an `approve.sock` FILE with no listener. `exists()`
+        // alone would falsely report it up; connect() refuses, so → Stopped.
+        let base = TempDir::new().unwrap();
+        std::fs::write(base.path().join("approve.sock"), b"").unwrap();
+        let s = probe_approve_broker(base.path(), super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Stopped);
+        assert!(!s.connected);
+        assert!(s.reason.contains("stale approve.sock"), "reason: {}", s.reason);
+    }
+
+    #[test]
+    fn probe_approve_broker_bound_listener_is_running_connected() {
+        use std::io::{BufRead, BufReader, Write};
+        let base = TempDir::new().unwrap();
+        let listener =
+            std::os::unix::net::UnixListener::bind(base.path().join("approve.sock")).unwrap();
+        // Minimal broker stand-in: answer each `list` RPC with an empty pending
+        // array so `client_list` returns fast (else it waits out the RPC timeout).
+        // Detached — it blocks on accept and dies at process exit; the probe makes
+        // only a couple of connects, so joining would hang on the next accept.
+        std::thread::spawn(move || {
+            for conn in listener.incoming().flatten() {
+                let mut reader = BufReader::new(conn.try_clone().unwrap());
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) > 0 {
+                    let mut w = conn;
+                    let _ = w.write_all(b"{\"pending\":[]}\n");
+                    let _ = w.flush();
+                }
+            }
+        });
+        let s = probe_approve_broker(base.path(), super::super::heartbeat::now_ms());
+        assert_eq!(s.state, DaemonState::Running);
+        assert!(s.connected, "a bound listener must report connected");
+        assert_eq!(s.channel.as_deref(), Some("approve socket"));
+        assert!(
+            s.reason.contains("no pending requests"),
+            "empty pending list should read as no pending: {}",
+            s.reason
+        );
+    }
+
+    #[test]
     fn probe_notifyd_live_pid_without_socket_is_running_not_connected() {
         let base = TempDir::new().unwrap();
         std::fs::write(
@@ -904,7 +1011,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_in_returns_all_four_in_stable_order() {
+    fn collect_in_returns_all_daemons_in_stable_order() {
         let home = TempDir::new().unwrap();
         let notifyd = TempDir::new().unwrap();
         let rows = collect_in(
@@ -912,11 +1019,12 @@ mod tests {
             notifyd.path(),
             super::super::heartbeat::now_ms(),
         );
-        assert_eq!(rows.len(), 4);
+        assert_eq!(rows.len(), 5);
         assert_eq!(rows[0].kind, DaemonKind::Bridge);
         assert_eq!(rows[1].kind, DaemonKind::Notifyd);
-        assert_eq!(rows[2].kind, DaemonKind::Atc);
-        assert_eq!(rows[3].kind, DaemonKind::FleetDaemon);
+        assert_eq!(rows[2].kind, DaemonKind::ApproveBroker);
+        assert_eq!(rows[3].kind, DaemonKind::Atc);
+        assert_eq!(rows[4].kind, DaemonKind::FleetDaemon);
         // Empty homes → everything stopped, never a false running.
         assert!(rows.iter().all(|r| r.state == DaemonState::Stopped));
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/plumbing/hooks.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/plumbing/hooks.rs
@@ -41,8 +41,28 @@ pub const ATC_EVENTS: &[(&str, &str)] = &[
     ("Notification", ""),
     ("SessionEnd", ""),
     ("PreToolUse", "AskUserQuestion"),
+    ("PermissionRequest", ""),
     ("StopFailure", ""),
 ];
+
+/// Default per-hook timeout (seconds) Claude allows before it kills the hook.
+/// Fast lifecycle events resolve in well under a second.
+const DEFAULT_HOOK_TIMEOUT: u64 = 10;
+
+/// `PermissionRequest` is the SYNCHRONOUS approve/deny gate: the hook blocks on
+/// the approve broker until a human decides. Its Claude-side timeout must exceed
+/// the broker's own AWAIT timeout (600s) so the broker's deny-fallback answers
+/// the hook cleanly before Claude ever hard-kills it.
+const PERMISSION_HOOK_TIMEOUT: u64 = 660;
+
+/// The Claude `timeout` (seconds) to register for `event`.
+#[must_use]
+fn timeout_for(event: &str) -> u64 {
+    match event {
+        "PermissionRequest" => PERMISSION_HOOK_TIMEOUT,
+        _ => DEFAULT_HOOK_TIMEOUT,
+    }
+}
 
 /// Single-quote a string for POSIX shell command interpolation.
 ///
@@ -75,7 +95,7 @@ pub fn managed_entry(event: &str, matcher: &str, hook_script: &str) -> Value {
         ATC_MANAGED_KEY: true,
         "matcher": matcher,
         "hooks": [
-            { "type": "command", "command": command, "timeout": 10 }
+            { "type": "command", "command": command, "timeout": timeout_for(event) }
         ]
     })
 }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_daemons_opens_and_renders.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_daemons_opens_and_renders.rs
@@ -212,13 +212,18 @@ fn daemons_opens_and_renders_four_rows() {
     }
     let post = post_cap.unwrap();
 
-    // The four daemon rows are present.
+    // The daemon rows are present — including the approve broker, which is a
+    // socket (rides notifyd's process) yet still gets a first-class row.
     assert!(post.contains("phone bridge"), "bridge row missing:\n{post}");
     assert!(post.contains("notifyd"), "notifyd row missing:\n{post}");
     assert!(post.contains("ATC"), "ATC row missing:\n{post}");
     assert!(
         post.contains("fleet daemon"),
         "fleet daemon row missing:\n{post}"
+    );
+    assert!(
+        post.contains("approve broker"),
+        "approve broker row missing:\n{post}"
     );
 
     // The seeded live bridge heartbeat flips the bridge to running + connected,
@@ -230,6 +235,30 @@ fn daemons_opens_and_renders_four_rows() {
     assert!(
         post.contains("Telegram (@tripwire_bot)"),
         "bridge channel label missing — heartbeat not surfaced:\n{post}"
+    );
+
+    // Back home, then the `d` overlay: sockets are tracked there too — the
+    // approve.sock line must render with the notifyd section (goal invariant:
+    // every daemon AND socket shows in the d overlay).
+    send_key(&session, "Escape");
+    let overlay = poll_capture_resending(
+        &session,
+        "d",
+        Instant::now() + Duration::from_secs(30),
+        |c| c.contains("notifyd processes") && c.contains("approve.sock"),
+    );
+    if overlay.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!(
+            "d overlay never rendered the approve.sock line; \
+             last capture:\n---\n{last}\n---"
+        );
+    }
+    let overlay = overlay.unwrap();
+    assert!(
+        overlay.contains("restart (resume/repair)"),
+        "overlay must advertise the R repair lever next to the socket row:\n{overlay}"
     );
 
     kill_session(&session);

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
@@ -244,7 +244,7 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
         panic!("approve feedback never rendered; last capture:\n---\n{last}\n---");
     };
     assert!(
-        feedback_cap.contains("delivered"),
+        feedback_cap.contains("matched the waiting hook"),
         "approve must report a matched waiter, not a miss:\n{feedback_cap}"
     );
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
@@ -1,0 +1,259 @@
+//! Tripwire: the synchronous permission round-trip, end to end through the
+//! real TUI binary.
+//!
+//! Proves, against a live `ainb tui` in tmux with an isolated HOME:
+//!
+//! 1. a `PermissionRequest`-derived state renders as the gold `APRV` badge and
+//!    a `SessionStart`-derived state as the blue `STRT` badge in the Fleet
+//!    panel (`f`);
+//! 2. pressing `y` on the APPROVE row delivers a first-class approve to a REAL
+//!    broker waiter parked on the isolated `approve.sock` — the same
+//!    `client_await` call a blocked Claude `PermissionRequest` hook makes —
+//!    and the waiter unblocks with `DecisionKind::Approve`.
+//!
+//! The broker end is the real `ainb_plugin_notifyd::broker::serve` accept
+//! loop, not a stand-in, so the bytes on the socket are exactly what
+//! production speaks. HOME lives under `/tmp` (not `TMPDIR`) because
+//! `approve.sock` must stay inside AF_UNIX's ~104-char path limit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ainb_plugin_notifyd::broker::{self, BrokerState, DecisionKind};
+use ainb_plugin_notifyd::{Paths, StateRow, Store};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Seed onboarding + dismissed notify prompt + the two fleet states:
+/// APPROVE (newest → selected row 0) and STARTING.
+fn seed_isolated_home(home: &Path) {
+    let base = home.join(".agents-in-a-box");
+    let cfg = base.join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-06-30T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+    let install_record = r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#;
+    fs::write(base.join("install.json"), install_record).expect("seed install.json");
+
+    let paths = Paths::under(&base);
+    let store = Store::open(&paths.db).expect("open notifications.db");
+    let approve = StateRow {
+        session_id: "fleet-approve-1".to_string(),
+        cwd: home.join("approving-project").display().to_string(),
+        kind: "APPROVE".to_string(),
+        context: Some(r#"{"tool":"Bash","input":"rm -rf build/"}"#.to_string()),
+        parent: Some("atc-main".to_string()),
+        last_event_ts: 400,
+        source: "hook".to_string(),
+    };
+    let starting = StateRow {
+        session_id: "fleet-start-1".to_string(),
+        cwd: home.join("booting-project").display().to_string(),
+        kind: "STARTING".to_string(),
+        context: None,
+        parent: Some("atc-main".to_string()),
+        last_event_ts: 300,
+        source: "hook".to_string(),
+    };
+    store.upsert_current_state(&approve).expect("seed APPROVE current_state");
+    store.upsert_current_state(&starting).expect("seed STARTING current_state");
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+
+fn send_key(session: &str, key: &str) {
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+    assert!(status.success(), "tmux send-keys {key:?} failed");
+}
+
+fn poll_capture_resending<F>(
+    session: &str,
+    key: &str,
+    deadline: Instant,
+    mut ok: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        send_key(session, key);
+        thread::sleep(Duration::from_millis(500));
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+    }
+    None
+}
+
+fn kill_session(session: &str) {
+    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
+}
+
+#[test]
+fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    // Short-path HOME: AF_UNIX socket paths cap at ~104 chars.
+    let home = PathBuf::from(format!("/tmp/ainb-aprv-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&home);
+    fs::create_dir_all(&home).expect("create short-path home");
+    seed_isolated_home(&home);
+
+    // Real broker on the isolated approve.sock, riding a test-owned runtime.
+    let paths = Paths::under(home.join(".agents-in-a-box"));
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let broker_state = BrokerState::new();
+    {
+        let sock = paths.approve_socket.clone();
+        let state = broker_state.clone();
+        rt.spawn(async move {
+            let listener = tokio::net::UnixListener::bind(&sock).expect("bind approve.sock");
+            broker::serve(listener, state).await;
+        });
+    }
+
+    // Park a REAL waiter — the same blocking call a Claude PermissionRequest
+    // hook makes. It blocks until the TUI's `y` decides it (or 60s deny-falls-back,
+    // which the assertion below would catch as a wrong decision).
+    let waiter = {
+        let sock = paths.approve_socket.clone();
+        thread::spawn(move || {
+            broker::client_await(
+                &sock,
+                "fleet-approve-1",
+                "Bash",
+                "rm -rf build/",
+                Duration::from_secs(60),
+            )
+        })
+    };
+
+    let session = format!("tripwire-fleet-aprv-{}", std::process::id());
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "180", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    let peers_db = home.join("peers.db");
+    let jobs_dir = home.join("jobs");
+    let cmd = format!(
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        home = home.display(),
+        peers = peers_db.display(),
+        jobs = jobs_dir.display(),
+        bin = ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("send launch cmd");
+
+    let pre = poll_capture(&session, Instant::now() + Duration::from_secs(90), |c| {
+        c.contains("Fleet") && c.contains("[f]")
+    });
+    if pre.is_none() {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        let _ = fs::remove_dir_all(&home);
+        panic!("HomeScreen never rendered Fleet shortcut; last capture:\n---\n{last}\n---");
+    }
+
+    // 1. Frame truth: both new badges render, APPROVE row selected (newest ts).
+    let opened = poll_capture_resending(
+        &session,
+        "f",
+        Instant::now() + Duration::from_secs(30),
+        |c| {
+            c.contains("APRV")
+                && c.contains("STRT")
+                && c.contains("needs approval")
+                && c.contains("starting")
+                && c.contains("approving-project")
+                && c.contains("booting-project")
+        },
+    );
+    let Some(open_cap) = opened else {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        let _ = fs::remove_dir_all(&home);
+        panic!("Fleet panel did not render APRV+STRT badges; last capture:\n---\n{last}\n---");
+    };
+    assert!(
+        open_cap.contains("y") && open_cap.contains("approve"),
+        "help bar must advertise the y approve lever:\n{open_cap}"
+    );
+
+    // 2. y on the selected APPROVE row → broker → parked waiter unblocks.
+    send_key(&session, "y");
+    let feedback = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
+        c.contains("approved → fleet-approve-1")
+    });
+    let Some(feedback_cap) = feedback else {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        let _ = fs::remove_dir_all(&home);
+        panic!("approve feedback never rendered; last capture:\n---\n{last}\n---");
+    };
+    assert!(
+        feedback_cap.contains("delivered"),
+        "approve must report a matched waiter, not a miss:\n{feedback_cap}"
+    );
+
+    let decision = waiter.join().expect("waiter thread");
+    kill_session(&session);
+    let _ = fs::remove_dir_all(&home);
+    assert_eq!(
+        decision.decision,
+        DecisionKind::Approve,
+        "the parked PermissionRequest waiter must receive the human's approve"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/bin/ainb-notifyd.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/bin/ainb-notifyd.rs
@@ -32,6 +32,9 @@ enum Cmd {
     Stop,
     /// Kill orphan / wedged notifyd processes, sparing the live owner.
     Reap,
+    /// Stop, reap, and respawn the daemon — the single resume/repair
+    /// command for a dead or wedged approve socket.
+    Restart,
     /// Install the ainb-hooks plugin for one or more agents.
     Install(AgentArgs),
     /// Uninstall the ainb-hooks plugin for one or more agents.
@@ -71,6 +74,7 @@ async fn main() -> ExitCode {
         Cmd::Run => cli::cmd_run().await,
         Cmd::Stop => cli::cmd_stop(),
         Cmd::Reap => cli::cmd_reap(false),
+        Cmd::Restart => cli::cmd_restart(false),
         Cmd::Install(a) => {
             cli::cmd_install(&cli::agents_from_flags(a.claude, a.codex, a.copilot, a.all))
         }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/bin/ainb-notifyd.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/bin/ainb-notifyd.rs
@@ -11,7 +11,7 @@
 use std::process::ExitCode;
 
 use anyhow::Result;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use ainb_plugin_notifyd::cli;
 
@@ -20,8 +20,18 @@ use ainb_plugin_notifyd::cli;
 #[derive(Debug, Parser)]
 #[command(name = "ainb-notifyd", version)]
 struct Cli {
+    /// Output format for machine-readable verbs (status/reap/restart).
+    #[arg(long, global = true, value_enum, default_value_t = Format::Text)]
+    format: Format,
     #[command(subcommand)]
     cmd: Option<Cmd>,
+}
+
+/// Output rendering for the daemon-control verbs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Format {
+    Text,
+    Json,
 }
 
 #[derive(Debug, Subcommand)]
@@ -70,18 +80,19 @@ async fn main() -> ExitCode {
         .try_init();
 
     let cli = Cli::parse();
+    let json = cli.format == Format::Json;
     let result: Result<()> = match cli.cmd.unwrap_or(Cmd::Run) {
         Cmd::Run => cli::cmd_run().await,
         Cmd::Stop => cli::cmd_stop(),
-        Cmd::Reap => cli::cmd_reap(false),
-        Cmd::Restart => cli::cmd_restart(false),
+        Cmd::Reap => cli::cmd_reap(json),
+        Cmd::Restart => cli::cmd_restart(json),
         Cmd::Install(a) => {
             cli::cmd_install(&cli::agents_from_flags(a.claude, a.codex, a.copilot, a.all))
         }
         Cmd::Uninstall(a) => {
             cli::cmd_uninstall(&cli::agents_from_flags(a.claude, a.codex, a.copilot, a.all))
         }
-        Cmd::Status => cli::cmd_status(),
+        Cmd::Status => cli::cmd_status(json),
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -446,28 +446,19 @@ pub fn client_decide(
             "reason": reason,
         }),
     )?;
-    Ok(resp
-        .get("matched")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false))
+    Ok(resp.get("matched").and_then(serde_json::Value::as_bool).unwrap_or(false))
 }
 
 /// List sessions currently blocked on a human decision (Daemons overlay / CLI
 /// status).
 pub fn client_list(sock: &Path) -> std::io::Result<Vec<PendingInfo>> {
     let resp = client_round_trip(sock, &serde_json::json!({ "op": "list" }))?;
-    let pending = resp
-        .get("pending")
-        .cloned()
-        .unwrap_or(serde_json::Value::Null);
+    let pending = resp.get("pending").cloned().unwrap_or(serde_json::Value::Null);
     Ok(serde_json::from_value(pending).unwrap_or_default())
 }
 
 /// Shared one-shot request/response for decide + list.
-fn client_round_trip(
-    sock: &Path,
-    req: &serde_json::Value,
-) -> std::io::Result<serde_json::Value> {
+fn client_round_trip(sock: &Path, req: &serde_json::Value) -> std::io::Result<serde_json::Value> {
     let mut stream = StdUnixStream::connect(sock)?;
     stream.set_read_timeout(Some(CLIENT_RPC_TIMEOUT))?;
     let mut line = serde_json::to_string(req).unwrap_or_default();
@@ -488,7 +479,9 @@ mod tests {
 
     /// Bind a broker on a short-path socket (AF_UNIX has a ~104-char
     /// limit, so tempdirs under long worktree paths overflow — use /tmp).
-    async fn spawn_broker(timeout: Duration) -> (std::path::PathBuf, BrokerState, tokio::task::JoinHandle<()>) {
+    async fn spawn_broker(
+        timeout: Duration,
+    ) -> (std::path::PathBuf, BrokerState, tokio::task::JoinHandle<()>) {
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let sock = std::env::temp_dir().join(format!(
             "ainb-broker-test-{}-{}.sock",
@@ -708,11 +701,12 @@ mod tests {
         assert_eq!(pending[0].tool, "Bash");
 
         let s = sock.clone();
-        let matched =
-            tokio::task::spawn_blocking(move || client_decide(&s, "cli-A", DecisionKind::Approve, "ok"))
-                .await
-                .unwrap()
-                .unwrap();
+        let matched = tokio::task::spawn_blocking(move || {
+            client_decide(&s, "cli-A", DecisionKind::Approve, "ok")
+        })
+        .await
+        .unwrap()
+        .unwrap();
         assert!(matched, "decide should match the waiting session");
 
         let decision = waiter.await.unwrap();
@@ -728,10 +722,8 @@ mod tests {
         // Fault tolerance: no broker listening at all → the waiter never hangs
         // forever and never auto-approves; it re-dials until the deadline and
         // falls back to deny. The waiting hook is never lost.
-        let sock = std::env::temp_dir().join(format!(
-            "ainb-broker-dead-{}.sock",
-            std::process::id()
-        ));
+        let sock =
+            std::env::temp_dir().join(format!("ainb-broker-dead-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&sock);
         let sock_w = sock.clone();
         let decision = tokio::task::spawn_blocking(move || {
@@ -757,8 +749,8 @@ mod tests {
     /// safe (dropping a Runtime inside async panics).
     #[test]
     fn waiter_resumes_after_socket_restart() {
-        let sock = std::env::temp_dir()
-            .join(format!("ainb-broker-restart-{}.sock", std::process::id()));
+        let sock =
+            std::env::temp_dir().join(format!("ainb-broker-restart-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&sock);
 
         // Poll client_list on this thread until `session_id` is registered on
@@ -790,7 +782,13 @@ mod tests {
         let rt1 = spawn_broker_rt(sock.clone());
         let sock_w = sock.clone();
         let waiter = std::thread::spawn(move || {
-            client_await(&sock_w, "resume-A", "Bash", "rm -rf /tmp/x", Duration::from_secs(20))
+            client_await(
+                &sock_w,
+                "resume-A",
+                "Bash",
+                "rm -rf /tmp/x",
+                Duration::from_secs(20),
+            )
         });
         wait_registered("resume-A");
 
@@ -809,7 +807,10 @@ mod tests {
 
         // Human approves against the fresh daemon; the resumed waiter answers.
         let matched = client_decide(&sock, "resume-A", DecisionKind::Approve, "ok").unwrap();
-        assert!(matched, "fresh broker should match the re-registered waiter");
+        assert!(
+            matched,
+            "fresh broker should match the re-registered waiter"
+        );
 
         let decision = waiter.join().unwrap();
         assert_eq!(

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -174,21 +174,17 @@ impl BrokerState {
             .collect()
     }
 
-    /// Resolve a pending AWAIT. Returns `true` if a waiter was blocked on
-    /// this `session_id` and has now been handed the decision.
+    /// Resolve a pending AWAIT. Returns `true` only if a waiter was blocked on
+    /// this `session_id` AND actually received the decision — a send onto a
+    /// dropped receiver (the AWAIT raced into its timeout/supersede path)
+    /// reports `false`, so the TUI/CLI never claims a match that nobody heard.
     pub fn decide(&self, session_id: &str, decision: Decision) -> bool {
         let taken = {
             let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
             map.remove(session_id)
         };
         match taken {
-            Some(p) => {
-                // Ok(_) is impossible to observe here beyond the send; if the
-                // waiter's receiver was already dropped the decision is simply
-                // discarded, which is fine (the waiter is gone).
-                let _ = p.tx.send(decision);
-                true
-            }
+            Some(p) => p.tx.send(decision).is_ok(),
             None => false,
         }
     }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -29,10 +29,13 @@
 //! blocks on at most one permission request per session at a time.
 
 use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::os::unix::net::UnixStream as StdUnixStream;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -343,6 +346,141 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+// ---------------------------------------------------------------------------
+// Blocking clients.
+//
+// The server above is async — it rides notifyd's tokio runtime. Its clients
+// are not: the `PermissionRequest` hook is a short-lived synchronous process,
+// and the CLI decide/list verbs are one-shot. So the client side is plain
+// blocking `std::os::unix::net` — dial in, write one line, read one line.
+// No runtime, no async colouring bleeding into the sync hook path.
+
+/// How long a re-dialing waiter keeps trying before giving up and letting the
+/// caller fall back to deny. Sits *above* the broker's own AWAIT ceiling
+/// ([`DEFAULT_AWAIT_TIMEOUT`], 600s) so a live broker's decision always wins
+/// the race, and *below* the Claude `PermissionRequest` hook timeout (660s)
+/// so we answer before Claude hard-kills the hook. The re-dial loop only
+/// matters across a notifyd restart — the single resume path.
+pub const CLIENT_AWAIT_DEADLINE: Duration = Duration::from_secs(640);
+
+/// Pause between re-dials when the broker is unreachable mid-wait.
+const REDIAL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Read timeout for the one-shot decide/list round-trips.
+const CLIENT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Dial the approve socket, register an AWAIT for `session_id`, and block
+/// until a human decides. Re-dials and re-sends AWAIT if the connection drops
+/// mid-wait (a notifyd restart), so restarting the daemon is the single
+/// resume command: every still-alive waiter re-registers itself. Falls back
+/// to **deny** if no decision lands within `deadline`; never returns without
+/// a decision, so the waiting hook is never lost.
+#[must_use]
+pub fn client_await(
+    sock: &Path,
+    session_id: &str,
+    tool: &str,
+    context: &str,
+    deadline: Duration,
+) -> Decision {
+    let started = Instant::now();
+    let req = serde_json::json!({
+        "op": "await",
+        "session_id": session_id,
+        "tool": tool,
+        "context": context,
+    });
+    let line = serde_json::to_string(&req).unwrap_or_default();
+    loop {
+        let remaining = deadline.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Decision::timed_out();
+        }
+        match try_await_once(sock, &line, remaining) {
+            Ok(Some(decision)) => return decision,
+            // EOF or connect/read error → broker down or dropped us mid-wait.
+            // Re-dial + re-register until the deadline.
+            Ok(None) | Err(_) => std::thread::sleep(REDIAL_INTERVAL),
+        }
+    }
+}
+
+/// One AWAIT attempt: connect, send, block for a decision. `Ok(None)` means
+/// the broker closed the connection before deciding (re-dial); `Err` means
+/// connect/read failed (re-dial).
+fn try_await_once(
+    sock: &Path,
+    line: &str,
+    read_timeout: Duration,
+) -> std::io::Result<Option<Decision>> {
+    let mut stream = StdUnixStream::connect(sock)?;
+    stream.set_read_timeout(Some(read_timeout))?;
+    stream.write_all(line.as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let mut reader = std::io::BufReader::new(stream);
+    let mut resp = String::new();
+    if reader.read_line(&mut resp)? == 0 {
+        return Ok(None);
+    }
+    let decision: Decision = serde_json::from_str(resp.trim())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    Ok(Some(decision))
+}
+
+/// Deliver a decision for `session_id` to the broker (the TUI/CLI approve/deny
+/// lever). Returns whether a waiter was actually blocked on that session
+/// (`matched` false = nothing was waiting, e.g. it already timed out).
+pub fn client_decide(
+    sock: &Path,
+    session_id: &str,
+    decision: DecisionKind,
+    reason: &str,
+) -> std::io::Result<bool> {
+    let resp = client_round_trip(
+        sock,
+        &serde_json::json!({
+            "op": "decide",
+            "session_id": session_id,
+            "decision": decision,
+            "reason": reason,
+        }),
+    )?;
+    Ok(resp
+        .get("matched")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false))
+}
+
+/// List sessions currently blocked on a human decision (Daemons overlay / CLI
+/// status).
+pub fn client_list(sock: &Path) -> std::io::Result<Vec<PendingInfo>> {
+    let resp = client_round_trip(sock, &serde_json::json!({ "op": "list" }))?;
+    let pending = resp
+        .get("pending")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    Ok(serde_json::from_value(pending).unwrap_or_default())
+}
+
+/// Shared one-shot request/response for decide + list.
+fn client_round_trip(
+    sock: &Path,
+    req: &serde_json::Value,
+) -> std::io::Result<serde_json::Value> {
+    let mut stream = StdUnixStream::connect(sock)?;
+    stream.set_read_timeout(Some(CLIENT_RPC_TIMEOUT))?;
+    let mut line = serde_json::to_string(req).unwrap_or_default();
+    line.push('\n');
+    stream.write_all(line.as_bytes())?;
+    stream.flush()?;
+    let mut reader = std::io::BufReader::new(stream);
+    let mut resp = String::new();
+    reader.read_line(&mut resp)?;
+    serde_json::from_str(resp.trim())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,5 +650,70 @@ mod tests {
 
         handle.abort();
         let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_clients_round_trip_with_server() {
+        // Proves the sync client (hook/CLI side) and the async server agree on
+        // the wire: client_await blocks, client_list sees it, client_decide
+        // approves, client_await returns approve.
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+
+        let sock_w = sock.clone();
+        let waiter = tokio::task::spawn_blocking(move || {
+            client_await(
+                &sock_w,
+                "cli-A",
+                "Bash",
+                "rm -rf /tmp/x",
+                Duration::from_secs(10),
+            )
+        });
+
+        // Wait for the AWAIT to register.
+        let mut pending = Vec::new();
+        for _ in 0..100 {
+            pending = client_list(&sock).unwrap_or_default();
+            if !pending.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(pending.len(), 1, "list should report one pending await");
+        assert_eq!(pending[0].session_id, "cli-A");
+        assert_eq!(pending[0].tool, "Bash");
+
+        let matched = client_decide(&sock, "cli-A", DecisionKind::Approve, "ok").unwrap();
+        assert!(matched, "decide should match the waiting session");
+
+        let decision = waiter.await.unwrap();
+        assert_eq!(decision.decision, DecisionKind::Approve);
+        assert_eq!(decision.reason, "ok");
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn client_await_denies_when_socket_dead() {
+        // Fault tolerance: no broker listening at all → the waiter never hangs
+        // forever and never auto-approves; it re-dials until the deadline and
+        // falls back to deny. The waiting hook is never lost.
+        let sock = std::env::temp_dir().join(format!(
+            "ainb-broker-dead-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&sock);
+        let sock_w = sock.clone();
+        let decision = tokio::task::spawn_blocking(move || {
+            client_await(&sock_w, "orphan", "Bash", "x", Duration::from_secs(1))
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            decision.decision,
+            DecisionKind::Deny,
+            "dead socket must fall back to deny, never approve"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -503,6 +503,23 @@ mod tests {
         (sock, state, handle)
     }
 
+    /// Poll `client_list` until an await for `session_id` is registered,
+    /// or panic after ~4s. Runs the blocking client call off-thread so it
+    /// never starves the server task that must answer it.
+    async fn wait_for_pending(sock: &Path, session_id: &str) {
+        for _ in 0..200 {
+            let s = sock.to_path_buf();
+            let pending = tokio::task::spawn_blocking(move || client_list(&s).unwrap_or_default())
+                .await
+                .unwrap();
+            if pending.iter().any(|p| p.session_id == session_id) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("await for {session_id} never registered");
+    }
+
     /// Send one request line, read one response line.
     async fn round_trip(sock: &Path, request: &str) -> String {
         let mut stream = UnixStream::connect(sock).await.unwrap();
@@ -727,5 +744,82 @@ mod tests {
             DecisionKind::Deny,
             "dead socket must fall back to deny, never approve"
         );
+    }
+
+    /// The single-resume guarantee, proven end-to-end: a permission waiter
+    /// parked on the broker survives a full daemon restart. We kill broker
+    /// one outright (drop its runtime → every connection closes, exactly like
+    /// the process exiting), rebind a *fresh* broker on the same socket path
+    /// with new state that has no memory of the waiter, and the waiter's own
+    /// re-dial ladder re-registers itself — then a human approve round-trips
+    /// back to it. Restarting notifyd is all it takes to resume a pending
+    /// prompt; no waiting hook is lost. Sync test so dropping the runtimes is
+    /// safe (dropping a Runtime inside async panics).
+    #[test]
+    fn waiter_resumes_after_socket_restart() {
+        let sock = std::env::temp_dir()
+            .join(format!("ainb-broker-restart-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+
+        // Poll client_list on this thread until `session_id` is registered on
+        // whatever broker currently owns the socket, or panic after ~6s.
+        let wait_registered = |session_id: &str| {
+            for _ in 0..300 {
+                if client_list(&sock)
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|p| p.session_id == session_id)
+                {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            panic!("await for {session_id} never registered");
+        };
+
+        let spawn_broker_rt = |sock: std::path::PathBuf| {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.spawn(async move {
+                let listener = UnixListener::bind(&sock).unwrap();
+                serve(listener, BrokerState::with_timeout(Duration::from_secs(30))).await;
+            });
+            rt
+        };
+
+        // Broker one comes up; a hook parks on AWAIT and registers.
+        let rt1 = spawn_broker_rt(sock.clone());
+        let sock_w = sock.clone();
+        let waiter = std::thread::spawn(move || {
+            client_await(&sock_w, "resume-A", "Bash", "rm -rf /tmp/x", Duration::from_secs(20))
+        });
+        wait_registered("resume-A");
+
+        // Daemon dies: dropping the runtime aborts the accept loop AND every
+        // detached connection task, closing the waiter's socket — the true
+        // "process exited" signal, not a soft abort. Unlink the stale path.
+        rt1.shutdown_background();
+        let _ = std::fs::remove_file(&sock);
+
+        // Restart: a fresh daemon binds the same path with brand-new state.
+        let rt2 = spawn_broker_rt(sock.clone());
+
+        // The waiter's re-dial ladder must find the new broker and re-register
+        // there, all on its own — this is the resume with no lost hook.
+        wait_registered("resume-A");
+
+        // Human approves against the fresh daemon; the resumed waiter answers.
+        let matched = client_decide(&sock, "resume-A", DecisionKind::Approve, "ok").unwrap();
+        assert!(matched, "fresh broker should match the re-registered waiter");
+
+        let decision = waiter.join().unwrap();
+        assert_eq!(
+            decision.decision,
+            DecisionKind::Approve,
+            "waiter must round-trip approve after the restart"
+        );
+        assert_eq!(decision.reason, "ok");
+
+        rt2.shutdown_background();
+        let _ = std::fs::remove_file(&sock);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -1,0 +1,516 @@
+//! The approve/deny broker — a synchronous permission round-trip.
+//!
+//! Unlike the notify socket ([`crate::paths::Paths::socket`]), which is
+//! one-way fire-and-forget, the broker listens on a *request/response*
+//! socket ([`crate::paths::Paths::approve_socket`]). It exists to close
+//! the one gap where AgentPeek's design beats ours: a human synchronously
+//! approving or denying a live Claude `PermissionRequest` hook.
+//!
+//! Three line-JSON operations, one per connection:
+//!
+//! - **AWAIT** — a waiting hook (the `ainb fleet atc hook`
+//!   `PermissionRequest` branch) dials in, registers itself keyed by
+//!   `session_id`, and BLOCKS on the connection until a human decides or
+//!   the broker times out. The response is the decision.
+//! - **DECIDE** — the fleet TUI / CLI dials in, names a `session_id` and
+//!   an `approve`/`deny`, the broker hands the decision to the blocked
+//!   AWAIT, and both connections resolve.
+//! - **LIST** — dump the pending session ids (what is currently waiting
+//!   for a human), for the Daemons overlay / CLI status.
+//!
+//! ## Durability model
+//!
+//! Pending approvals live ONLY in memory. Waiters re-dial and re-send
+//! AWAIT on disconnect, so restarting notifyd is the single resume
+//! command: every still-alive waiter re-registers itself. There is no
+//! durable pending file. If a waiter's AWAIT times out (no human in the
+//! window) the fallback is **deny** — never auto-approve. The
+//! correlation key across every surface is `session_id`, because Claude
+//! blocks on at most one permission request per session at a time.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::oneshot;
+use tracing::{debug, error, warn};
+
+/// Default AWAIT ceiling. Deliberately longer than the hook's own
+/// timeout (the `PermissionRequest` hook is registered with a ~300s
+/// budget) so that, in the normal case, Claude's hook timeout fires
+/// first and the broker's own timeout is only a backstop against a
+/// leaked pending entry. On expiry the fallback is deny.
+pub const DEFAULT_AWAIT_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// A human's answer to a permission request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DecisionKind {
+    /// Allow the tool call to proceed.
+    Approve,
+    /// Block the tool call.
+    Deny,
+}
+
+/// The resolved decision handed back to a blocked AWAIT.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Decision {
+    /// Approve or deny.
+    pub decision: DecisionKind,
+    /// Human-readable reason (empty when none was given). For the
+    /// timeout/superseded fallbacks this explains why it defaulted to
+    /// deny.
+    #[serde(default)]
+    pub reason: String,
+}
+
+impl Decision {
+    /// The safe fallback when no human answered in time.
+    fn timed_out() -> Self {
+        Self {
+            decision: DecisionKind::Deny,
+            reason: "no human decision before timeout (fallback: deny)".into(),
+        }
+    }
+
+    /// The fallback when a newer AWAIT for the same session superseded
+    /// this one (e.g. the waiter re-dialled after a notifyd restart).
+    fn superseded() -> Self {
+        Self {
+            decision: DecisionKind::Deny,
+            reason: "superseded by a newer request for this session".into(),
+        }
+    }
+}
+
+/// One entry in the pending map: a registered AWAIT waiting for a human.
+struct Pending {
+    /// Monotone id disambiguating two AWAITs racing on the same
+    /// `session_id` — only the entry whose id we still hold gets removed
+    /// on our own timeout, so a superseding AWAIT is never clobbered.
+    id: u64,
+    /// Tool the permission request is for (e.g. `Bash`), for display.
+    tool: String,
+    /// Short human context (e.g. the command), for display.
+    context: String,
+    /// When this AWAIT registered, ms since epoch — drives `waiting_ms`.
+    since_ms: u64,
+    /// Channel to deliver the human's decision to the blocked AWAIT.
+    tx: oneshot::Sender<Decision>,
+}
+
+/// One pending approval as reported by LIST.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingInfo {
+    /// The session blocked on a human decision.
+    pub session_id: String,
+    /// Tool the permission request is for.
+    pub tool: String,
+    /// Short human context.
+    pub context: String,
+    /// How long it has been waiting, in milliseconds.
+    pub waiting_ms: u64,
+}
+
+/// Shared broker state: the pending map plus the AWAIT timeout. Cloneable
+/// (the inner map is behind an `Arc`) so the accept loop can hand a
+/// handle to each connection task.
+#[derive(Clone)]
+pub struct BrokerState {
+    pending: Arc<Mutex<HashMap<String, Pending>>>,
+    next_id: Arc<AtomicU64>,
+    await_timeout: Duration,
+}
+
+impl BrokerState {
+    /// Fresh state with the default AWAIT timeout.
+    pub fn new() -> Self {
+        Self::with_timeout(DEFAULT_AWAIT_TIMEOUT)
+    }
+
+    /// Fresh state with a custom AWAIT timeout (tests use a tiny value).
+    pub fn with_timeout(await_timeout: Duration) -> Self {
+        Self {
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(AtomicU64::new(1)),
+            await_timeout,
+        }
+    }
+
+    /// Snapshot of every session currently waiting for a human.
+    pub fn list(&self) -> Vec<PendingInfo> {
+        let now = now_ms();
+        let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+        map.iter()
+            .map(|(session_id, p)| PendingInfo {
+                session_id: session_id.clone(),
+                tool: p.tool.clone(),
+                context: p.context.clone(),
+                waiting_ms: now.saturating_sub(p.since_ms),
+            })
+            .collect()
+    }
+
+    /// Resolve a pending AWAIT. Returns `true` if a waiter was blocked on
+    /// this `session_id` and has now been handed the decision.
+    pub fn decide(&self, session_id: &str, decision: Decision) -> bool {
+        let taken = {
+            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            map.remove(session_id)
+        };
+        match taken {
+            Some(p) => {
+                // Ok(_) is impossible to observe here beyond the send; if the
+                // waiter's receiver was already dropped the decision is simply
+                // discarded, which is fine (the waiter is gone).
+                let _ = p.tx.send(decision);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Register an AWAIT and block until a human decides, the entry is
+    /// superseded, or the timeout fires (fallback: deny). Never returns
+    /// without a decision — the waiting hook is never left empty-handed.
+    async fn await_decision(&self, session_id: String, tool: String, context: String) -> Decision {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            map.insert(
+                session_id.clone(),
+                Pending {
+                    id,
+                    tool,
+                    context,
+                    since_ms: now_ms(),
+                    tx,
+                },
+            );
+        }
+
+        match tokio::time::timeout(self.await_timeout, rx).await {
+            // A human decided.
+            Ok(Ok(decision)) => decision,
+            // Sender dropped without sending → a newer AWAIT replaced us.
+            Ok(Err(_)) => Decision::superseded(),
+            // Timed out. Remove ourselves — but only if the entry is still
+            // ours (a superseding AWAIT owns a different id and must survive).
+            Err(_) => {
+                let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+                if map.get(&session_id).is_some_and(|p| p.id == id) {
+                    map.remove(&session_id);
+                }
+                Decision::timed_out()
+            }
+        }
+    }
+}
+
+impl Default for BrokerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A single line-JSON request on the approve socket.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "lowercase")]
+enum Request {
+    /// A waiting hook registers and blocks for a decision.
+    Await {
+        session_id: String,
+        #[serde(default)]
+        tool: String,
+        #[serde(default)]
+        context: String,
+    },
+    /// A human (TUI/CLI) delivers a decision for a session.
+    Decide {
+        session_id: String,
+        decision: DecisionKind,
+        #[serde(default)]
+        reason: String,
+    },
+    /// Dump the pending session ids.
+    List,
+}
+
+/// Response to a DECIDE.
+#[derive(Debug, Serialize)]
+struct DecideAck {
+    ok: bool,
+    /// True when a waiter was actually blocked on that session.
+    matched: bool,
+}
+
+/// Response to a LIST.
+#[derive(Debug, Serialize)]
+struct ListResponse {
+    pending: Vec<PendingInfo>,
+}
+
+/// Accept loop for the approve socket. Runs until the listener errors
+/// unrecoverably or the task is aborted (on daemon shutdown). Each
+/// connection is handled on its own task so a blocked AWAIT never stalls
+/// a concurrent DECIDE/LIST.
+pub async fn serve(listener: UnixListener, state: BrokerState) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _peer)) => {
+                let state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_connection(stream, state).await {
+                        debug!(error = ?e, "approve broker connection ended with error");
+                    }
+                });
+            }
+            Err(e) => {
+                error!(error = ?e, "approve broker accept failed; continuing");
+            }
+        }
+    }
+}
+
+/// Handle one connection: read a single request line, dispatch, respond.
+async fn handle_connection(stream: UnixStream, state: BrokerState) -> Result<()> {
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await.context("reading request")?;
+    if n == 0 {
+        return Ok(()); // client hung up without sending
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    let request: Request = match serde_json::from_str(trimmed) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, line = %trimmed, "rejecting malformed broker request");
+            let body = serde_json::json!({ "ok": false, "error": e.to_string() });
+            write_line(reader.get_mut(), &body).await?;
+            return Ok(());
+        }
+    };
+
+    match request {
+        Request::Await {
+            session_id,
+            tool,
+            context,
+        } => {
+            let decision = state.await_decision(session_id, tool, context).await;
+            write_line(reader.get_mut(), &decision).await?;
+        }
+        Request::Decide {
+            session_id,
+            decision,
+            reason,
+        } => {
+            let matched = state.decide(&session_id, Decision { decision, reason });
+            write_line(reader.get_mut(), &DecideAck { ok: true, matched }).await?;
+        }
+        Request::List => {
+            let pending = state.list();
+            write_line(reader.get_mut(), &ListResponse { pending }).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Write one line-JSON response and flush.
+async fn write_line<T: Serialize>(stream: &mut UnixStream, body: &T) -> Result<()> {
+    let mut buf = serde_json::to_vec(body).context("serializing response")?;
+    buf.push(b'\n');
+    stream.write_all(&buf).await.context("writing response")?;
+    stream.flush().await.context("flushing response")?;
+    Ok(())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Bind a broker on a short-path socket (AF_UNIX has a ~104-char
+    /// limit, so tempdirs under long worktree paths overflow — use /tmp).
+    async fn spawn_broker(timeout: Duration) -> (std::path::PathBuf, BrokerState, tokio::task::JoinHandle<()>) {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let sock = std::env::temp_dir().join(format!(
+            "ainb-broker-test-{}-{}.sock",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+        let state = BrokerState::with_timeout(timeout);
+        let state2 = state.clone();
+        let handle = tokio::spawn(async move { serve(listener, state2).await });
+        (sock, state, handle)
+    }
+
+    /// Send one request line, read one response line.
+    async fn round_trip(sock: &Path, request: &str) -> String {
+        let mut stream = UnixStream::connect(sock).await.unwrap();
+        stream.write_all(request.as_bytes()).await.unwrap();
+        stream.write_all(b"\n").await.unwrap();
+        stream.flush().await.unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        line
+    }
+
+    #[tokio::test]
+    async fn await_then_decide_approve_round_trips() {
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+
+        // A waiter blocks on AWAIT.
+        let sock_w = sock.clone();
+        let waiter = tokio::spawn(async move {
+            round_trip(
+                &sock_w,
+                r#"{"op":"await","session_id":"s1","tool":"Bash","context":"rm -rf /tmp/x"}"#,
+            )
+            .await
+        });
+
+        // Give the AWAIT a beat to register, then a human approves.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let ack = round_trip(
+            &sock,
+            r#"{"op":"decide","session_id":"s1","decision":"approve","reason":"ok"}"#,
+        )
+        .await;
+        assert!(ack.contains("\"matched\":true"), "decide matched: {ack}");
+
+        let decision = waiter.await.unwrap();
+        let parsed: Decision = serde_json::from_str(decision.trim()).unwrap();
+        assert_eq!(parsed.decision, DecisionKind::Approve);
+        assert_eq!(parsed.reason, "ok");
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn await_times_out_to_deny() {
+        // Tiny timeout: the waiter gets a deny fallback with no human.
+        let (sock, _state, handle) = spawn_broker(Duration::from_millis(80)).await;
+        let decision = round_trip(&sock, r#"{"op":"await","session_id":"s2"}"#).await;
+        let parsed: Decision = serde_json::from_str(decision.trim()).unwrap();
+        assert_eq!(
+            parsed.decision,
+            DecisionKind::Deny,
+            "timeout must fall back to deny, never approve"
+        );
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn list_reports_pending_await() {
+        let (sock, state, handle) = spawn_broker(Duration::from_secs(30)).await;
+        let sock_w = sock.clone();
+        let waiter = tokio::spawn(async move {
+            round_trip(
+                &sock_w,
+                r#"{"op":"await","session_id":"s3","tool":"Write","context":"foo.rs"}"#,
+            )
+            .await
+        });
+        // Wait for registration.
+        for _ in 0..50 {
+            if !state.list().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let listing = round_trip(&sock, r#"{"op":"list"}"#).await;
+        assert!(listing.contains("\"session_id\":\"s3\""), "list: {listing}");
+        assert!(listing.contains("\"tool\":\"Write\""), "list: {listing}");
+
+        // Clean up the waiter with a decision.
+        round_trip(
+            &sock,
+            r#"{"op":"decide","session_id":"s3","decision":"deny"}"#,
+        )
+        .await;
+        let _ = waiter.await;
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn decide_with_no_waiter_reports_unmatched() {
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+        let ack = round_trip(
+            &sock,
+            r#"{"op":"decide","session_id":"ghost","decision":"approve"}"#,
+        )
+        .await;
+        assert!(ack.contains("\"matched\":false"), "no waiter: {ack}");
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn re_await_supersedes_and_new_await_wins() {
+        // Models a waiter re-dialling (e.g. after a notifyd restart): a second
+        // AWAIT on the same session replaces the first. The stale AWAIT resolves
+        // to a superseded-deny; the fresh one receives the real decision.
+        let (sock, state, handle) = spawn_broker(Duration::from_secs(30)).await;
+
+        let sock1 = sock.clone();
+        let stale = tokio::spawn(async move {
+            round_trip(&sock1, r#"{"op":"await","session_id":"s4","tool":"Bash"}"#).await
+        });
+        // Ensure the stale AWAIT registered first.
+        for _ in 0..50 {
+            if !state.list().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let sock2 = sock.clone();
+        let fresh = tokio::spawn(async move {
+            round_trip(&sock2, r#"{"op":"await","session_id":"s4","tool":"Bash"}"#).await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // The stale waiter should already be resolved (superseded → deny).
+        let stale_decision: Decision = serde_json::from_str(stale.await.unwrap().trim()).unwrap();
+        assert_eq!(stale_decision.decision, DecisionKind::Deny);
+        assert!(stale_decision.reason.contains("superseded"));
+
+        // Decide now hits the fresh waiter.
+        round_trip(
+            &sock,
+            r#"{"op":"decide","session_id":"s4","decision":"approve"}"#,
+        )
+        .await;
+        let fresh_decision: Decision = serde_json::from_str(fresh.await.unwrap().trim()).unwrap();
+        assert_eq!(fresh_decision.decision, DecisionKind::Approve);
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -27,6 +27,17 @@
 //! window) the fallback is **deny** — never auto-approve. The
 //! correlation key across every surface is `session_id`, because Claude
 //! blocks on at most one permission request per session at a time.
+//!
+//! ## Trust boundary
+//!
+//! The socket is chmod `0600`, so other users are excluded — but every
+//! process running as the SAME uid can DECIDE, including the supervised
+//! agents themselves (an agent with any pre-approved shell access could
+//! self-approve by writing one JSON line). This is the same trust
+//! boundary as the pre-existing tmux `send-keys` surface: the broker
+//! gates *remote/UI* approval, it is not a sandbox against a hostile
+//! local process. Do not treat an `allow` from this broker as proof a
+//! HUMAN clicked it if same-uid code is untrusted.
 
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
@@ -44,11 +55,14 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::oneshot;
 use tracing::{debug, error, warn};
 
-/// Default AWAIT ceiling. Deliberately longer than the hook's own
-/// timeout (the `PermissionRequest` hook is registered with a ~300s
-/// budget) so that, in the normal case, Claude's hook timeout fires
-/// first and the broker's own timeout is only a backstop against a
-/// leaked pending entry. On expiry the fallback is deny.
+/// Default AWAIT ceiling — the BOTTOM of the timeout ladder, by design:
+/// broker AWAIT (600s) < client re-dial deadline
+/// ([`CLIENT_AWAIT_DEADLINE`], 640s) < Claude's registered
+/// `PermissionRequest` hook timeout (660s, see fleet plumbing's
+/// `PERMISSION_HOOK_TIMEOUT`). The broker answers first with a deny, the
+/// client relays it well inside its own deadline, and Claude's hard-kill
+/// never fires against a still-waiting hook. On expiry the fallback is
+/// deny — never approve.
 pub const DEFAULT_AWAIT_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// A human's answer to a permission request.

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -670,10 +670,17 @@ mod tests {
             )
         });
 
-        // Wait for the AWAIT to register.
+        // Wait for the AWAIT to register. The client calls are blocking sync
+        // IO; run them via spawn_blocking so they never occupy a worker thread
+        // — otherwise a blocked `client_list` starves the server task that must
+        // answer it, each call hits CLIENT_RPC_TIMEOUT, and the poll loop stalls
+        // for minutes under whole-suite CPU pressure.
         let mut pending = Vec::new();
         for _ in 0..100 {
-            pending = client_list(&sock).unwrap_or_default();
+            let s = sock.clone();
+            pending = tokio::task::spawn_blocking(move || client_list(&s).unwrap_or_default())
+                .await
+                .unwrap();
             if !pending.is_empty() {
                 break;
             }
@@ -683,7 +690,12 @@ mod tests {
         assert_eq!(pending[0].session_id, "cli-A");
         assert_eq!(pending[0].tool, "Bash");
 
-        let matched = client_decide(&sock, "cli-A", DecisionKind::Approve, "ok").unwrap();
+        let s = sock.clone();
+        let matched =
+            tokio::task::spawn_blocking(move || client_decide(&s, "cli-A", DecisionKind::Approve, "ok"))
+                .await
+                .unwrap()
+                .unwrap();
         assert!(matched, "decide should match the waiting session");
 
         let decision = waiter.await.unwrap();

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
@@ -101,6 +101,40 @@ pub fn cmd_reap(json: bool) -> Result<()> {
     Ok(())
 }
 
+/// `restart` — the single resume/repair command. Stop the current owner,
+/// reap stragglers, spawn a fresh daemon, and wait for the approve socket
+/// to rebind. Because [`crate::broker::client_await`] re-dials until its
+/// own deadline, every still-blocked permission waiter re-registers the
+/// moment the socket is back — so this one command both repairs a dead
+/// socket and resumes pending prompts, without losing a waiting hook.
+pub fn cmd_restart(json: bool) -> Result<()> {
+    let outcome = crate::procs::restart(std::time::Duration::from_secs(3))?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+        return Ok(());
+    }
+    match outcome.stopped {
+        Some(p) => println!("stopped previous daemon (pid {p})"),
+        None => println!("no previous daemon was running"),
+    }
+    if !outcome.reaped.is_empty() {
+        println!("reaped {} straggler(s)", outcome.reaped.len());
+    }
+    match outcome.spawned {
+        Some(p) => println!("spawned fresh daemon (pid {p})"),
+        None => println!("failed to spawn daemon"),
+    }
+    if outcome.socket_bound {
+        println!("approve socket is live — pending permission prompts will resume");
+    } else {
+        println!(
+            "approve socket did not rebind in time; still-waiting hooks keep re-dialling \
+             until it does or they time out"
+        );
+    }
+    Ok(())
+}
+
 /// `install` — wire the ainb-hooks hook into the chosen agents and
 /// print the resolved on-disk paths.
 pub fn cmd_install(agents: &[Agent]) -> Result<()> {

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
@@ -173,9 +173,21 @@ pub fn cmd_uninstall(agents: &[Agent]) -> Result<()> {
 
 /// `status` — per-agent install/hook/socket state + the most recent
 /// event + daemon PID liveness.
-pub fn cmd_status() -> Result<()> {
+pub fn cmd_status(json: bool) -> Result<()> {
     let paths = Paths::from_home()?;
     let rows = status(&paths)?;
+    let pid = crate::pid::read(&paths.pid)?;
+    let running = pid.is_some_and(crate::pid::is_running);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "agents": rows,
+                "daemon": { "pid": pid, "running": running },
+            }))?
+        );
+        return Ok(());
+    }
     println!(
         "{:<8} {:<10} {:<10} {:<10} {}",
         "agent", "installed", "hook_ok", "socket_ok", "last_event"
@@ -195,14 +207,10 @@ pub fn cmd_status() -> Result<()> {
         );
     }
     // Daemon PID liveness, for at-a-glance debugging.
-    if let Some(pid) = crate::pid::read(&paths.pid)? {
-        if crate::pid::is_running(pid) {
-            println!("\ndaemon: pid {pid} (running)");
-        } else {
-            println!("\ndaemon: stale pid {pid} (not running)");
-        }
-    } else {
-        println!("\ndaemon: not running");
+    match pid {
+        Some(pid) if running => println!("\ndaemon: pid {pid} (running)"),
+        Some(pid) => println!("\ndaemon: stale pid {pid} (not running)"),
+        None => println!("\ndaemon: not running"),
     }
     Ok(())
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/cli.rs
@@ -189,8 +189,8 @@ pub fn cmd_status(json: bool) -> Result<()> {
         return Ok(());
     }
     println!(
-        "{:<8} {:<10} {:<10} {:<10} {}",
-        "agent", "installed", "hook_ok", "socket_ok", "last_event"
+        "{:<8} {:<10} {:<10} {:<10} last_event",
+        "agent", "installed", "hook_ok", "socket_ok"
     );
     for r in rows {
         println!(
@@ -250,10 +250,7 @@ pub fn cmd_list(
     } else if rows.is_empty() {
         println!("no notifications");
     } else {
-        println!(
-            "{:<14} {:<8} {:<22} {}",
-            "ts(ms)", "agent", "project", "event"
-        );
+        println!("{:<14} {:<8} {:<22} event", "ts(ms)", "agent", "project");
         for r in &rows {
             println!(
                 "{:<14} {:<8} {:<22} {}",

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -677,7 +677,7 @@ fn strip_codex_managed_entries(hooks_json: &Path) -> Result<()> {
 }
 
 /// One row in `ainb-notifyd status` output.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct StatusRow {
     /// Agent name (`claude` / `codex`).
     pub agent: String,

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -76,12 +76,6 @@ const CODEX_HOOKS_TEMPLATE: &str = include_str!("../../../../plugins/ainb-hooks/
 const COPILOT_HOOKS_TEMPLATE: &str =
     include_str!("../../../../plugins/ainb-hooks/copilot/hooks.json");
 
-/// Sentinels used to delimit our managed block inside the user's
-/// `~/.codex/hooks.json`. Stable strings — never change without a
-/// migration path because uninstall greps for them.
-const CODEX_BEGIN_MARKER: &str = "// >>> ainb-hooks managed block (do not edit) >>>";
-const CODEX_END_MARKER: &str = "// <<< ainb-hooks managed block <<<";
-
 /// The host CLI agent being installed for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -161,7 +155,7 @@ impl InstallRecord {
         }
         let text =
             std::fs::read_to_string(&p).with_context(|| format!("reading {}", p.display()))?;
-        Ok(serde_json::from_str(&text).with_context(|| format!("parsing {}", p.display()))?)
+        serde_json::from_str(&text).with_context(|| format!("parsing {}", p.display()))
     }
 
     /// Persist to disk under the standard path.

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -23,6 +23,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::too_many_lines)]
 
+pub mod broker;
 pub mod cli;
 pub mod envelope;
 pub mod fallback;
@@ -37,6 +38,7 @@ pub mod transition;
 
 mod listener;
 
+pub use broker::{BrokerState, Decision, DecisionKind, PendingInfo};
 pub use envelope::{Envelope, EnvelopeError};
 pub use fallback::FallbackFile;
 pub use install::{

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/listener.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/listener.rs
@@ -364,10 +364,40 @@ pub async fn run_daemon(config: RunConfig) -> Result<()> {
         }))
     };
 
+    use std::os::unix::fs::PermissionsExt;
+
+    // APPROVE BROKER (permission round-trip): the synchronous approve/deny
+    // socket. A waiting Claude `PermissionRequest` hook dials `approve.sock`
+    // and BLOCKS until a human decides from the fleet TUI/CLI (or the broker
+    // times out → deny). Pending approvals live only in the broker's memory —
+    // on disconnect the waiter re-dials and re-registers, so a single notifyd
+    // restart is the whole resume story. Bound + chmod like the main socket,
+    // and aborted on shutdown when the handle drops. The `BrokerState` handle
+    // is cloned into the connection handler so `List`/`Decide` from other
+    // callers reach the same pending map.
+    if config.paths.approve_socket.exists() {
+        std::fs::remove_file(&config.paths.approve_socket).ok();
+    }
+    let approve_listener = UnixListener::bind(&config.paths.approve_socket).with_context(|| {
+        format!(
+            "binding approve socket {}",
+            config.paths.approve_socket.display()
+        )
+    })?;
+    if let Ok(meta) = std::fs::metadata(&config.paths.approve_socket) {
+        let mut perms = meta.permissions();
+        perms.set_mode(0o600);
+        let _ = std::fs::set_permissions(&config.paths.approve_socket, perms);
+    }
+    let _approve_task = AbortOnDrop(tokio::spawn(crate::broker::serve(
+        approve_listener,
+        crate::broker::BrokerState::new(),
+    )));
+    info!(socket = %config.paths.approve_socket.display(), "approve broker listening");
+
     let listener = UnixListener::bind(&config.paths.socket)
         .with_context(|| format!("binding unix socket {}", config.paths.socket.display()))?;
     // chmod 0600 — only the owner can write.
-    use std::os::unix::fs::PermissionsExt;
     if let Ok(meta) = std::fs::metadata(&config.paths.socket) {
         let mut perms = meta.permissions();
         perms.set_mode(0o600);
@@ -418,9 +448,11 @@ pub async fn run_daemon(config: RunConfig) -> Result<()> {
         }
     }
 
-    // Cleanup before drop — remove the socket so future hook fires
-    // know the daemon is down.
+    // Cleanup before drop — remove the sockets so future hook fires
+    // know the daemon is down. The approve broker task is aborted when
+    // `_approve_task` drops; remove its socket too.
     let _ = std::fs::remove_file(&config.paths.socket);
+    let _ = std::fs::remove_file(&config.paths.approve_socket);
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/paths.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/paths.rs
@@ -17,6 +17,13 @@ pub struct Paths {
     /// The Unix domain socket used by the hook script to deliver
     /// envelopes.
     pub socket: PathBuf,
+    /// The Unix domain socket the approve/deny broker listens on. Unlike
+    /// [`Paths::socket`] (one-way fire-and-forget), this is a
+    /// request/response socket: a waiting Claude `PermissionRequest` hook
+    /// dials it and BLOCKS (`AWAIT`) until a human issues an approve/deny
+    /// (`DECIDE`) from the fleet TUI or CLI, or the broker times out
+    /// (fallback: deny). The `LIST` op enumerates pending approvals.
+    pub approve_socket: PathBuf,
     /// The PID file written by the daemon at startup.
     pub pid: PathBuf,
     /// The fallback JSONL file that the hook script writes to when
@@ -54,6 +61,7 @@ impl Paths {
         Self {
             db: base.join("notifications.db"),
             socket: base.join("notify.sock"),
+            approve_socket: base.join("approve.sock"),
             pid: base.join("notify.pid"),
             fallback: base.join("notify.fallback.jsonl"),
             events_jsonl: base.join("events.jsonl"),
@@ -81,6 +89,8 @@ mod tests {
         assert_eq!(p.base, dir.path());
         assert!(p.db.starts_with(dir.path()));
         assert!(p.socket.starts_with(dir.path()));
+        assert!(p.approve_socket.starts_with(dir.path()));
+        assert!(p.approve_socket.ends_with("approve.sock"));
         assert!(p.pid.starts_with(dir.path()));
         assert!(p.fallback.starts_with(dir.path()));
         assert!(p.events_jsonl.starts_with(dir.path()));

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/paths.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/paths.rs
@@ -45,10 +45,17 @@ pub struct Paths {
 }
 
 impl Paths {
-    /// Resolve paths under the user's home directory
-    /// (`~/.agents-in-a-box/`). Fails if the home directory cannot be
-    /// determined.
+    /// Resolve paths under the ainb base directory: `$AINB_HOME` when set
+    /// (the same override the fleet plumbing honours — the hook, the daemon,
+    /// and the TUI/CLI deciders MUST all resolve the approve socket to the
+    /// same base or a waiting hook parks on a socket nothing serves),
+    /// otherwise `~/.agents-in-a-box/`. Fails if neither can be determined.
     pub fn from_home() -> anyhow::Result<Self> {
+        if let Ok(h) = std::env::var("AINB_HOME") {
+            if !h.is_empty() {
+                return Ok(Self::under(PathBuf::from(h)));
+            }
+        }
         let home =
             dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?;
         Ok(Self::under(home.join(".agents-in-a-box")))

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
@@ -284,6 +284,125 @@ pub fn reap() -> ReapReport {
     report
 }
 
+/// Outcome of a [`restart`] — the single resume/repair command for a dead
+/// or wedged approve socket. Serialisable so the CLI can render it as
+/// `--format json`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RestartOutcome {
+    /// The prior owner pid that was signalled to stop, if one was live.
+    pub stopped: Option<u32>,
+    /// Wedged / orphan pids reaped before the fresh spawn.
+    pub reaped: Vec<u32>,
+    /// Pid of the freshly detach-spawned daemon.
+    pub spawned: Option<u32>,
+    /// Whether the approve socket came back up within the bind timeout.
+    /// `true` means still-blocked `client_await` waiters can re-dial and
+    /// resume; `false` means the caller should investigate (the waiters
+    /// keep re-dialling until their own deadline regardless).
+    pub socket_bound: bool,
+}
+
+/// argv for respawning *this* daemon binary. The shared `notifyd` CLI is
+/// reached two ways: the standalone `ainb-notifyd` binary (daemon verbs at
+/// the top level → `run`) and the host `ainb notifyd run` subcommand. Pick
+/// by the current exe's basename so a restart re-execs the right entrypoint
+/// regardless of which one called it.
+fn daemon_respawn_argv() -> (std::path::PathBuf, Vec<&'static str>) {
+    let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("ainb"));
+    let name = exe.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    (exe.clone(), respawn_args_for(name))
+}
+
+/// Pure argv picker: the standalone `ainb-notifyd` binary exposes daemon
+/// verbs at the top level (`run`); the host `ainb` binary nests them under
+/// `notifyd`.
+fn respawn_args_for(exe_name: &str) -> Vec<&'static str> {
+    if exe_name.starts_with("ainb-notifyd") {
+        vec!["run"]
+    } else {
+        vec!["notifyd", "run"]
+    }
+}
+
+/// Detach-spawn a fresh daemon: null stdio + its own process group so a
+/// closing tmux pane or terminal SIGHUP can't take it down — the Rust
+/// equivalent of the hook script's `nohup ainb notifyd </dev/null
+/// >/dev/null 2>&1 &`. Returns the child pid.
+fn spawn_detached() -> anyhow::Result<u32> {
+    use anyhow::Context;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let (exe, args) = daemon_respawn_argv();
+    let child = Command::new(&exe)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()
+        .with_context(|| format!("spawning {} {}", exe.display(), args.join(" ")))?;
+    Ok(child.id())
+}
+
+/// Poll the approve socket until something is accepting on it, up to
+/// `timeout`. Returns whether it came up.
+fn wait_for_socket_bound(path: &std::path::Path, timeout: std::time::Duration) -> bool {
+    let started = std::time::Instant::now();
+    loop {
+        if socket_accepting(path) {
+            return true;
+        }
+        if started.elapsed() >= timeout {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+/// The single resume/repair command (goal req: "one command to resume/repair;
+/// must not lose the waiting hook"). Stops any current owner, reaps wedged /
+/// orphan stragglers, then detach-spawns a fresh daemon and waits for the
+/// approve socket to bind. Because [`crate::broker::client_await`] re-dials
+/// on every `REDIAL_INTERVAL` until its own deadline, a still-blocked
+/// permission waiter re-registers itself the moment the socket is back — so
+/// restarting the daemon is all it takes to resume pending prompts, and no
+/// waiting hook is ever lost. `stop`-first (not just reap) because
+/// [`crate::run_daemon`] refuses to start while a live owner holds the pid.
+pub fn restart(bind_timeout: std::time::Duration) -> anyhow::Result<RestartOutcome> {
+    use nix::sys::signal::Signal;
+
+    let paths = Paths::from_home()?;
+    let mut outcome = RestartOutcome::default();
+
+    // 1. Stop the recorded owner and wait for it to actually exit — spawning
+    //    while it still holds the pid would make the new daemon bail.
+    if let Ok(Some(pid)) = crate::pid::read(&paths.pid) {
+        if crate::pid::is_running(pid) {
+            let _ = signal_pid(pid, Signal::SIGTERM);
+            outcome.stopped = Some(pid);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            while crate::pid::is_running(pid) && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            if crate::pid::is_running(pid) {
+                let _ = signal_pid(pid, Signal::SIGKILL);
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    }
+
+    // 2. Reap any wedged / orphan stragglers so the fresh daemon is the only
+    //    notifyd-family process left.
+    outcome.reaped = reap().killed;
+
+    // 3. Detach-spawn a fresh daemon and wait for the approve socket to bind.
+    outcome.spawned = Some(spawn_detached()?);
+    outcome.socket_bound = wait_for_socket_bound(&paths.approve_socket, bind_timeout);
+
+    Ok(outcome)
+}
+
 /// One-shot scan: enumerate notifyd processes and classify them against
 /// the on-disk owner pid, the live socket, and this process's own binary.
 /// Used by the TUI's Daemons overlay.
@@ -324,6 +443,41 @@ mod tests {
             class,
             binary_drift: false,
         }
+    }
+
+    #[test]
+    fn respawn_argv_standalone_uses_top_level_run() {
+        assert_eq!(respawn_args_for("ainb-notifyd"), vec!["run"]);
+        assert_eq!(respawn_args_for("ainb-notifyd-x86"), vec!["run"]);
+    }
+
+    #[test]
+    fn respawn_argv_host_binary_nests_under_notifyd() {
+        assert_eq!(respawn_args_for("ainb"), vec!["notifyd", "run"]);
+        assert_eq!(respawn_args_for(""), vec!["notifyd", "run"]);
+    }
+
+    #[test]
+    fn wait_for_socket_bound_true_when_listener_up() {
+        let dir = std::env::temp_dir().join(format!("ainb-sockbound-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("live.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        assert!(wait_for_socket_bound(
+            &sock,
+            std::time::Duration::from_millis(200)
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn wait_for_socket_bound_false_when_absent() {
+        let sock = std::env::temp_dir().join(format!("ainb-nosock-{}.sock", std::process::id()));
+        std::fs::remove_file(&sock).ok();
+        assert!(!wait_for_socket_bound(
+            &sock,
+            std::time::Duration::from_millis(120)
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/transition.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/transition.rs
@@ -30,12 +30,15 @@
 //!
 //! | event_type · matcher                  | kind   | effect                                   |
 //! |---------------------------------------|--------|------------------------------------------|
+//! | `SessionStart`                        | `STARTING` | session booting, before the first user turn |
 //! | `PreToolUse` · `AskUserQuestion`      | `ASK`  | unanswered interview is the latest signal |
+//! | `PermissionRequest`                   | `APPROVE` | tool call awaiting the user's approval    |
 //! | `Notification` · `permission_prompt`  | `WAIT` | waiting on the user (permission)          |
 //! | `Notification` · `idle_prompt`        | `WAIT` | waiting on the user (idle input prompt)   |
 //! | `StopFailure`                         | `ERR`  | API error after retries exhausted         |
 //! | `Stop`                                | `IDLE` once `age >= idle_threshold`, else `RUNNING` (turn-ended-but-fresh) |
-//! | `UserPromptSubmit` / `SessionStart`   | `RUNNING` | a new user turn → clears ASK/WAIT/IDLE/ERR |
+//! | `UserPromptSubmit`                    | `RUNNING` | a new user turn → clears ASK/WAIT/IDLE/ERR/APPROVE |
+//! | `PostToolUse` / `SubagentStart`       | `RUNNING` | active work resumed → clears ASK/WAIT/APPROVE |
 //! | `SessionEnd`                          | `DONE` | terminal                                  |
 //!
 //! So the materialized kind is "the latest non-lifecycle signal (ASK/WAIT/ERR),
@@ -61,7 +64,7 @@
 //!
 //! Readers treat `RUNNING` (with or without a `stopped_ts` marker) as
 //! not-a-need, so the marker is invisible to the reader contract — the kind set
-//! stays exactly `ASK|ERR|WAIT|IDLE|RUNNING|DONE`. Once promoted to `IDLE` the
+//! stays exactly `ASK|ERR|WAIT|IDLE|RUNNING|DONE|STARTING|APPROVE`. Once promoted to `IDLE` the
 //! row's context is the classifier-shaped `{"idle_minutes": N}`; a later user
 //! turn clears it back to plain `RUNNING` (no marker) via the normal fold.
 
@@ -98,6 +101,8 @@ mod kind {
     pub const IDLE: &str = "IDLE";
     pub const RUNNING: &str = "RUNNING";
     pub const DONE: &str = "DONE";
+    pub const STARTING: &str = "STARTING";
+    pub const APPROVE: &str = "APPROVE";
 }
 
 /// The provenance stamped on every row this loop writes.
@@ -141,6 +146,14 @@ struct WaitContext {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ErrContext {
     error_type: String,
+}
+
+/// APPROVE context — the tool + its input from a `PermissionRequest` payload,
+/// so a reader can show the user what they're being asked to approve.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ApproveContext {
+    tool: String,
+    tool_input: Value,
 }
 
 /// Fold one pass of the event log into `current_state`.
@@ -281,14 +294,17 @@ struct Accum {
 /// The kind + its context decided by the latest meaningful event.
 #[derive(Debug, Clone)]
 enum Decision {
-    Ask(String),  // serialized AskUserQuestionData
-    Err(String),  // serialized ErrContext
-    Wait(String), // serialized WaitContext
+    Ask(String),     // serialized AskUserQuestionData
+    Err(String),     // serialized ErrContext
+    Wait(String),    // serialized WaitContext
+    Approve(String), // serialized ApproveContext (tool + tool_input)
     /// A `Stop` fired at this ts — resolved to IDLE-on-age or RUNNING when the
     /// row is built (age is recomputed against `now` at materialize time).
     Stopped(i64),
-    /// A new user turn (UserPromptSubmit / SessionStart) → RUNNING.
+    /// A new user turn (UserPromptSubmit) → RUNNING.
     Running,
+    /// SessionStart — session booting, distinct from an active user turn.
+    Starting,
     /// SessionEnd → terminal DONE.
     Done(Option<String>), // optional reason
 }
@@ -312,12 +328,16 @@ impl Accum {
                 ev.matcher.as_deref(),
                 &ev.payload,
             ))),
+            "PermissionRequest" => Some(Decision::Approve(approve_context(&ev.payload))),
             "StopFailure" => Some(Decision::Err(err_context(
                 ev.matcher.as_deref(),
                 &ev.payload,
             ))),
             "Stop" => Some(Decision::Stopped(ev.ts)),
-            "UserPromptSubmit" | "SessionStart" => Some(Decision::Running),
+            "UserPromptSubmit" => Some(Decision::Running),
+            "SessionStart" => Some(Decision::Starting),
+            // Active work resumed after an ASK/WAIT/APPROVE — clear back to RUNNING.
+            "PostToolUse" | "SubagentStart" => Some(Decision::Running),
             "SessionEnd" => Some(Decision::Done(reason_from_payload(&ev.payload))),
             // Unknown / telemetry event — does not change the decided kind.
             _ => None,
@@ -343,11 +363,13 @@ impl Accum {
             Decision::Ask(ctx) => (kind::ASK, Some(ctx)),
             Decision::Err(ctx) => (kind::ERR, Some(ctx)),
             Decision::Wait(ctx) => (kind::WAIT, Some(ctx)),
+            Decision::Approve(ctx) => (kind::APPROVE, Some(ctx)),
             Decision::Done(reason) => {
                 let ctx = reason.map(|r| serde_json::json!({ "reason": r }).to_string());
                 (kind::DONE, ctx)
             }
             Decision::Running => (kind::RUNNING, None),
+            Decision::Starting => (kind::STARTING, None),
             Decision::Stopped(stop_ts) => {
                 // Claude Code 2.1.19 `Stop` carries no stop_reason: the firing
                 // IS turn-end. A freshly-stopped session is RUNNING/quiet until
@@ -466,6 +488,24 @@ fn err_context(matcher: Option<&str>, payload: &str) -> String {
         })
         .unwrap_or_else(|| "unknown".to_string());
     serde_json::to_string(&ErrContext { error_type }).unwrap_or_default()
+}
+
+/// Build the APPROVE context (serialized `ApproveContext`) from a
+/// `PermissionRequest` payload. Claude's PermissionRequest stdin carries
+/// `tool_name` (string) + `tool_input` (object); tolerate `tool`/`input`
+/// aliases like `parse_ask` does. A best-effort placeholder is produced when
+/// the payload is malformed so APPROVE still surfaces rather than being
+/// dropped.
+fn approve_context(payload: &str) -> String {
+    let v: Value = serde_json::from_str(payload).unwrap_or(Value::Null);
+    let tool = v
+        .get("tool_name")
+        .or_else(|| v.get("tool"))
+        .and_then(Value::as_str)
+        .unwrap_or("(unknown)")
+        .to_string();
+    let tool_input = v.get("tool_input").or_else(|| v.get("input")).cloned().unwrap_or(Value::Null);
+    serde_json::to_string(&ApproveContext { tool, tool_input }).unwrap_or_default()
 }
 
 /// The session's `parent` — carried at the top level of the canonical event
@@ -620,6 +660,87 @@ mod tests {
         let ictx: WaitContext = serde_json::from_str(idle.context.as_deref().unwrap()).unwrap();
         assert_eq!(ictx.reason, "idle_prompt");
         assert_eq!(ictx.tool, None);
+    }
+
+    #[test]
+    fn approve_from_permissionrequest_carries_tool_and_input() {
+        let (_d, store) = store();
+        push(
+            &store,
+            NOW,
+            "s",
+            "/p",
+            "PermissionRequest",
+            None,
+            r#"{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"}}"#,
+        );
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+
+        let row = state(&store, "s", "/p");
+        assert_eq!(row.kind, "APPROVE");
+        let ctx: ApproveContext = serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.tool, "Bash");
+        assert_eq!(ctx.tool_input["command"], "rm -rf /tmp/x");
+    }
+
+    #[test]
+    fn approve_from_malformed_permissionrequest_still_surfaces() {
+        // Malformed payload — APPROVE still surfaces with placeholder context
+        // rather than being dropped (same defensive pattern as ask_context).
+        let (_d, store) = store();
+        push(
+            &store,
+            NOW,
+            "s",
+            "/p",
+            "PermissionRequest",
+            None,
+            "not json",
+        );
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+
+        let row = state(&store, "s", "/p");
+        assert_eq!(row.kind, "APPROVE");
+        let ctx: ApproveContext = serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.tool, "(unknown)");
+        assert_eq!(ctx.tool_input, Value::Null);
+    }
+
+    #[test]
+    fn starting_from_sessionstart() {
+        let (_d, store) = store();
+        push(&store, NOW, "s", "/p", "SessionStart", None, "{}");
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        assert_eq!(state(&store, "s", "/p").kind, "STARTING");
+    }
+
+    #[test]
+    fn running_after_user_prompt_then_posttooluse() {
+        let (_d, store) = store();
+        push(&store, NOW, "s", "/p", "UserPromptSubmit", None, "{}");
+        push(&store, NOW + 1000, "s", "/p", "PostToolUse", None, "{}");
+        materialize_at(&store, NOW + 1000, IDLE_MIN).unwrap();
+        assert_eq!(state(&store, "s", "/p").kind, "RUNNING");
+    }
+
+    #[test]
+    fn posttooluse_clears_established_approve_back_to_running() {
+        let (_d, store) = store();
+        push(
+            &store,
+            NOW,
+            "s",
+            "/p",
+            "PermissionRequest",
+            None,
+            r#"{"tool_name":"Bash","tool_input":{}}"#,
+        );
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        assert_eq!(state(&store, "s", "/p").kind, "APPROVE");
+
+        push(&store, NOW + 1000, "s", "/p", "PostToolUse", None, "{}");
+        materialize_at(&store, NOW + 1000, IDLE_MIN).unwrap();
+        assert_eq!(state(&store, "s", "/p").kind, "RUNNING");
     }
 
     #[test]

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -94,6 +94,7 @@ Options:
       --dangerously-skip-permissions   Skip permission prompts (dangerous!)
       --name <NAME>                    Custom session name
   -i, --interactive                    Run in interactive mode (spawn tmux and attach)
+      --parent <PARENT>                Parent session id — links this session to an orchestrator (e.g. ATC) so its completions route to the parent's durable inbox (event-driven plumbing). Exported into the session as `AINB_PARENT_SESSION`
   -h, --help                           Print help
 
 EXAMPLES:
@@ -1119,7 +1120,7 @@ Arguments:
 
 Options:
       --format <format>            Output format [default: text] [possible values: text, json, csv, markdown]
-      --monthly-usd <MONTHLY_USD>
+      --monthly-usd <MONTHLY_USD>  
       --provider <PROVIDER>        [default: all] [possible values: all, claude, codex, cursor]
       --reset-day <RESET_DAY>      [default: 1]
   -h, --help                       Print help
@@ -1670,6 +1671,25 @@ EXAMPLES:
   ainb abtop --theme dracula       Forward flags to `abtop --once`
 ```
 
+## `ainb web`
+
+Serve an SSE-live web dashboard (live terminal + web-push) for the fleet
+
+```console
+$ ainb web --help
+Serve an SSE-live web dashboard (live terminal + web-push) for the fleet
+
+Usage: ainb web [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --listen <ADDR>    Address to bind (default loopback; non-loopback needs --token) [default: 127.0.0.1:8420]
+      --token <SECRET>   Bearer token required on every /api/* route (enables non-loopback bind)
+      --insecure-bind    Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface — the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
+      --read-only        Viewer-only: disable the live terminal write surface (the WS terminal is refused with 403)
+  -h, --help             Print help
+```
+
 ## `ainb witr`
 
 Trace a running process's causality chain (via the witr plugin)
@@ -1782,7 +1802,7 @@ Update an installed plugin to the latest matching version (NOT YET IMPLEMENTED)
 Usage: ainb plugin update [OPTIONS] <plugin>
 
 Arguments:
-  <plugin>
+  <plugin>  
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -1801,7 +1821,7 @@ Remove an installed plugin (NOT YET IMPLEMENTED)
 Usage: ainb plugin remove [OPTIONS] <plugin>
 
 Arguments:
-  <plugin>
+  <plugin>  
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -1835,7 +1855,7 @@ Search registered marketplaces by plugin name (NOT YET IMPLEMENTED)
 Usage: ainb plugin search [OPTIONS] <query>
 
 Arguments:
-  <query>
+  <query>  
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -1874,7 +1894,7 @@ Register a marketplace by URL or local path (NOT YET IMPLEMENTED)
 Usage: ainb plugin marketplace add [OPTIONS] <url>
 
 Arguments:
-  <url>
+  <url>  
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -1892,7 +1912,7 @@ Unregister a marketplace by name (NOT YET IMPLEMENTED)
 Usage: ainb plugin marketplace remove [OPTIONS] <name>
 
 Arguments:
-  <name>
+  <name>  
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -1974,20 +1994,26 @@ Options:
 
 ## `ainb fleet`
 
-Fleet orchestration: standup / broadcast / sequence / needs / daemon
+Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / daemons / atc / bridge
 
 ```console
 $ ainb fleet --help
-Fleet orchestration: standup / broadcast / sequence / needs / daemon
+Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / daemons / atc / bridge
 
 Usage: ainb fleet [OPTIONS] <COMMAND>
 
 Commands:
+  approve       Approve a session's pending permission request (no arg: list waiters)
+  deny          Deny a session's pending permission request (no arg: list waiters)
   standup       Live fleet status: every claude session across ainb + peers + bg jobs
   broadcast     Send one prompt to selected sessions (peers-first, tmux fallback)
   sequence      Ordered prompts with ack between steps
   needs         Center control panel — sessions blocked on input / errors / idle / waiting
+  cost          Per-session / model / day / group spend rollups + budget caps
   daemon        Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
+  daemons       Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
+  atc           Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
+  bridge        Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
   enrich-cache  Content-addressed enrich cache (the producer's write path)
   help          Print this message or the help of the given subcommand(s)
 
@@ -2000,6 +2026,47 @@ EXAMPLES:
   ainb fleet needs                 Sessions blocked on input / errors
   ainb fleet broadcast "git pull" --all     Send a prompt to every session
   ainb fleet sequence "step 1" "step 2"     Ordered prompts with ack between steps
+  ainb fleet approve               List sessions waiting on a permission decision
+  ainb fleet approve <session-id>  Approve that session's pending permission request
+  ainb fleet deny <session-id> --reason "not now"   Deny it, with a reason
+```
+
+### `ainb fleet approve`
+
+Approve a session's pending permission request (no arg: list waiters)
+
+```console
+$ ainb fleet approve --help
+Approve a session's pending permission request (no arg: list waiters)
+
+Usage: ainb fleet approve [OPTIONS] [session-id]
+
+Arguments:
+  [session-id]  Session blocked on a permission decision (omit to list waiters)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --reason <reason>  Optional reason relayed to the agent with the decision [default: ""]
+  -h, --help             Print help
+```
+
+### `ainb fleet deny`
+
+Deny a session's pending permission request (no arg: list waiters)
+
+```console
+$ ainb fleet deny --help
+Deny a session's pending permission request (no arg: list waiters)
+
+Usage: ainb fleet deny [OPTIONS] [session-id]
+
+Arguments:
+  [session-id]  Session blocked on a permission decision (omit to list waiters)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --reason <reason>  Optional reason relayed to the agent with the decision [default: ""]
+  -h, --help             Print help
 ```
 
 ### `ainb fleet standup`
@@ -2030,7 +2097,7 @@ Send one prompt to selected sessions (peers-first, tmux fallback)
 Usage: ainb fleet broadcast [OPTIONS] <prompt>
 
 Arguments:
-  <prompt>
+  <prompt>  
 
 Options:
       --all              Fan out to every running session
@@ -2051,10 +2118,10 @@ Ordered prompts with ack between steps
 Usage: ainb fleet sequence [OPTIONS] <steps>...
 
 Arguments:
-  <steps>...
+  <steps>...  
 
 Options:
-      --all
+      --all                
       --format <format>    Output format [default: text] [possible values: text, json, csv, markdown]
       --timeout <timeout>  Per-step timeout (seconds) [default: 300]
   -h, --help               Print help
@@ -2077,6 +2144,22 @@ Options:
   -h, --help                 Print help
 ```
 
+### `ainb fleet cost`
+
+Per-session / model / day / group spend rollups + budget caps
+
+```console
+$ ainb fleet cost --help
+Per-session / model / day / group spend rollups + budget caps
+
+Usage: ainb fleet cost [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --period <period>  Reporting window passed to the burndown plugin [default: month] [possible values: today, week, 30days, month, all]
+  -h, --help             Print help
+```
+
 ### `ainb fleet daemon`
 
 Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
@@ -2089,7 +2172,223 @@ Usage: ainb fleet daemon [OPTIONS]
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
-  -v, --verbose
+  -v, --verbose          
+  -h, --help             Print help
+```
+
+### `ainb fleet daemons`
+
+Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
+
+```console
+$ ainb fleet daemons --help
+Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
+
+Usage: ainb fleet daemons [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb fleet atc`
+
+Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
+
+```console
+$ ainb fleet atc --help
+Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
+
+Usage: ainb fleet atc [OPTIONS] <COMMAND>
+
+Commands:
+  setup     Provision an ATC instance: CLAUDE.md policy + meta + heartbeat timer + session
+  teardown  Remove an ATC instance's heartbeat timer + session
+  status    Report one ATC instance (meta + timer + session liveness)
+  list      List all provisioned ATC instances
+  inbox     Inspect / drain / commit a parent's durable completion inbox
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet atc setup`
+
+Provision an ATC instance: CLAUDE.md policy + meta + heartbeat timer + session
+
+```console
+$ ainb fleet atc setup --help
+Provision an ATC instance: CLAUDE.md policy + meta + heartbeat timer + session
+
+Usage: ainb fleet atc setup [OPTIONS] <name>
+
+Arguments:
+  <name>  Instance name (also the session name)
+
+Options:
+      --format <format>          Output format [default: text] [possible values: text, json, csv, markdown]
+      --interval <interval>      Heartbeat cadence in minutes (default 15)
+      --idle-pause <idle-pause>  Minutes of fleet quiet before the heartbeat downgrades to an idle ping (default 60)
+      --no-heartbeat             Provision without installing the OS heartbeat timer
+      --no-spawn                 Provision files + timer but do not spawn the ainb session
+      --no-hooks                 Skip installing the event-driven lifecycle hooks into ~/.claude/settings.json (poll-mode only)
+  -h, --help                     Print help
+```
+
+#### `ainb fleet atc teardown`
+
+Remove an ATC instance's heartbeat timer + session
+
+```console
+$ ainb fleet atc teardown --help
+Remove an ATC instance's heartbeat timer + session
+
+Usage: ainb fleet atc teardown [OPTIONS] <name>
+
+Arguments:
+  <name>  
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --purge            Also delete the instance dir (state.json + task-log.md)
+  -h, --help             Print help
+```
+
+#### `ainb fleet atc status`
+
+Report one ATC instance (meta + timer + session liveness)
+
+```console
+$ ainb fleet atc status --help
+Report one ATC instance (meta + timer + session liveness)
+
+Usage: ainb fleet atc status [OPTIONS] <name>
+
+Arguments:
+  <name>  
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet atc list`
+
+List all provisioned ATC instances
+
+```console
+$ ainb fleet atc list --help
+List all provisioned ATC instances
+
+Usage: ainb fleet atc list [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet atc inbox`
+
+Inspect / drain / commit a parent's durable completion inbox
+
+```console
+$ ainb fleet atc inbox --help
+Inspect / drain / commit a parent's durable completion inbox
+
+Usage: ainb fleet atc inbox [OPTIONS] <COMMAND>
+
+Commands:
+  peek    Show undrained completions without consuming them
+  drain   Drain completions exactly-once and print the Stop-drain decision
+  commit  Commit a child completion to a parent's inbox (testing/integration)
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb fleet bridge`
+
+Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
+
+```console
+$ ainb fleet bridge --help
+Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
+
+Usage: ainb fleet bridge [OPTIONS] [COMMAND]
+
+Commands:
+  run        Run the bridge daemon in the foreground (default; reads config.toml)
+  install    Install as a launchd/systemd service (tokens read from config, never argv)
+  uninstall  Remove the bridge service
+  status     Report bridge service install status
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet bridge run`
+
+Run the bridge daemon in the foreground (default; reads config.toml)
+
+```console
+$ ainb fleet bridge run --help
+Run the bridge daemon in the foreground (default; reads config.toml)
+
+Usage: ainb fleet bridge run [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet bridge install`
+
+Install as a launchd/systemd service (tokens read from config, never argv)
+
+```console
+$ ainb fleet bridge install --help
+Install as a launchd/systemd service (tokens read from config, never argv)
+
+Usage: ainb fleet bridge install [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet bridge uninstall`
+
+Remove the bridge service
+
+```console
+$ ainb fleet bridge uninstall --help
+Remove the bridge service
+
+Usage: ainb fleet bridge uninstall [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet bridge status`
+
+Report bridge service install status
+
+```console
+$ ainb fleet bridge status --help
+Report bridge service install status
+
+Usage: ainb fleet bridge status [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
   -h, --help             Print help
 ```
 
@@ -2125,8 +2424,8 @@ Usage: ainb fleet enrich-cache put [OPTIONS] --key <key> --suggestion <suggestio
 
 Options:
       --format <format>          Output format [default: text] [possible values: text, json, csv, markdown]
-      --key <key>
-      --suggestion <suggestion>
+      --key <key>                
+      --suggestion <suggestion>  
   -h, --help                     Print help
 ```
 
@@ -2142,7 +2441,7 @@ Usage: ainb fleet enrich-cache get [OPTIONS] --key <key>
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
-      --key <key>
+      --key <key>        
   -h, --help             Print help
 ```
 
@@ -2249,7 +2548,7 @@ Usage: ainb mcp daemon [OPTIONS]
 Options:
       --format <format>
           Output format
-
+          
           [default: text]
           [possible values: text, json, csv, markdown]
 
@@ -2345,6 +2644,164 @@ Options:
   -h, --help             Print help
 ```
 
+## `ainb notifyd`
+
+ainb-hooks notification daemon: status, restart (the approve-socket resume/repair command), install/uninstall hooks
+
+```console
+$ ainb notifyd --help
+ainb-hooks notification daemon: status, restart (the approve-socket resume/repair command), install/uninstall hooks
+
+Usage: ainb notifyd [OPTIONS] [COMMAND]
+
+Commands:
+  run        Run the daemon in the foreground (default)
+  stop       Stop a running daemon via its PID file
+  reap       Kill orphan / wedged notifyd processes, sparing the live owner
+  restart    Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
+  install    Install the ainb-hooks hook
+  uninstall  Uninstall the ainb-hooks hook
+  status     Report install + daemon status
+  list       List persisted notifications (most recent first)
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb notifyd run`
+
+Run the daemon in the foreground (default)
+
+```console
+$ ainb notifyd run --help
+Run the daemon in the foreground (default)
+
+Usage: ainb notifyd run [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb notifyd stop`
+
+Stop a running daemon via its PID file
+
+```console
+$ ainb notifyd stop --help
+Stop a running daemon via its PID file
+
+Usage: ainb notifyd stop [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb notifyd reap`
+
+Kill orphan / wedged notifyd processes, sparing the live owner
+
+```console
+$ ainb notifyd reap --help
+Kill orphan / wedged notifyd processes, sparing the live owner
+
+Usage: ainb notifyd reap [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb notifyd restart`
+
+Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
+
+```console
+$ ainb notifyd restart --help
+Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
+
+Usage: ainb notifyd restart [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb notifyd install`
+
+Install the ainb-hooks hook
+
+```console
+$ ainb notifyd install --help
+Install the ainb-hooks hook
+
+Usage: ainb notifyd install [OPTIONS]
+
+Options:
+      --claude           Target Claude Code
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --codex            Target Codex CLI
+      --copilot          Target GitHub Copilot CLI
+      --all              Target every known agent
+  -h, --help             Print help
+```
+
+### `ainb notifyd uninstall`
+
+Uninstall the ainb-hooks hook
+
+```console
+$ ainb notifyd uninstall --help
+Uninstall the ainb-hooks hook
+
+Usage: ainb notifyd uninstall [OPTIONS]
+
+Options:
+      --claude           Target Claude Code
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --codex            Target Codex CLI
+      --copilot          Target GitHub Copilot CLI
+      --all              Target every known agent
+  -h, --help             Print help
+```
+
+### `ainb notifyd status`
+
+Report install + daemon status
+
+```console
+$ ainb notifyd status --help
+Report install + daemon status
+
+Usage: ainb notifyd status [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb notifyd list`
+
+List persisted notifications (most recent first)
+
+```console
+$ ainb notifyd list --help
+List persisted notifications (most recent first)
+
+Usage: ainb notifyd list [OPTIONS]
+
+Options:
+      --dismissed          Include dismissed notifications
+      --format <format>    Output format [default: text] [possible values: text, json, csv, markdown]
+      --agent <agent>      Filter by agent (claude|codex|copilot)
+      --project <project>  Filter by project (basename of cwd)
+      --limit <limit>      Max rows to show [default: 50]
+  -h, --help               Print help
+```
+
 ## `ainb hangar`
 
 Hangar managed-agents control plane (issue / task / beads / daemon)
@@ -2413,7 +2870,7 @@ Usage: ainb hangar issue create [OPTIONS] --title <TITLE>
 Options:
       --format <format>
           Output format
-
+          
           [default: text]
           [possible values: text, json, csv, markdown]
 
@@ -2425,12 +2882,12 @@ Options:
 
       --state <STATE>
           Initial lifecycle state
-
+          
           [default: open]
 
       --assign <ASSIGN>
           Assign the issue to an agent (`agent.id`) and enqueue a task for it.
-
+          
           When set, the issue's assignee is the agent and a `queued` task is enqueued for the agent's runtime, so the daemon's claim loop picks it up, materialises the agent's attached skills (P6.4), and dispatches the provider. The created task id is printed alongside the issue id.
 
   -h, --help

--- a/docs/tui/daemons.mdx
+++ b/docs/tui/daemons.mdx
@@ -1,36 +1,62 @@
 ---
 title: "Daemons overlay"
-description: "Press d in the ainb TUI to open the read-only Daemons overlay — every ainb-managed background daemon in one place: the shared MCP pool, the Headroom compression proxy with its live saved-token count, and the in-loop watchdog watching it."
+description: "Press d in the ainb TUI to open the Daemons overlay — every ainb-managed background daemon and socket in one place: the shared MCP pool, the Headroom compression proxy, the notifyd notification daemon with its approve socket, plus the R restart lever that repairs a dead approve socket."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-ainb runs a few background daemons on your behalf — the shared MCP server pool and the Headroom compression proxy. Rather than make you hunt for them with `ps`, every ainb-managed daemon shows up in one place: press **`d`** from anywhere in the TUI to open the read-only **Daemons** overlay.
+ainb runs a few background daemons on your behalf — the shared MCP server pool, the Headroom compression proxy, and the `notifyd` notification daemon that also serves the permission approve socket. Rather than make you hunt for them with `ps`, every ainb-managed daemon and socket shows up in one place: press **`d`** from anywhere in the TUI to open the **Daemons** overlay.
 
 ![ainb TUI Daemons overlay showing the shared MCP pool row as down and the Headroom proxy on port 8787 as up with a saved-tokens count and a watched marker, plus the consuming-sessions line; r refreshes and esc closes](../assets/screenshots/daemons-overlay.gif)
 
-*The overlay lists each daemon with a live status dot, and for the Headroom proxy: its port (`:8787`), the tokens it has saved so far (the same figure as the [Savings tab](token-optimization.md) and `ainb usage savings`), and which sessions are routed through it. `r` refreshes; `Esc` closes.*
+*The overlay lists each daemon with a live status dot, and for the Headroom proxy: its port (`:8787`), the tokens it has saved so far (the same figure as the [Savings tab](token-optimization.md) and `ainb usage savings`), and which sessions are routed through it. `r` refreshes; `R` restarts notifyd; `Esc` closes.*
 
 ## What's on it
 
 - **MCP pool** — the shared `ainb mcp daemon` that spawns each MCP server once behind a unix socket. See [Shared MCP pool](mcp-pool.md).
 - **Headroom proxy** — the ainb-managed compression proxy. Its row carries the live saved-token count and a **`watched`** marker when the in-loop watchdog is keeping it alive for a routed session.
+- **notifyd processes** — every running `ainb-notifyd` process, one line each, with its pid and health class. Orphaned or wedged strays are counted with a `· N to clean up (run \`ainb notifyd reap\`)` hint. notifyd owns the [Inbox](inbox-notifications.md) socket **and** the **approve socket** (`~/.agents-in-a-box/approve.sock`) that the synchronous permission round-trip blocks on.
 
 <Aside type="note">
-The watchdog isn't a separate process — it's an in-loop tick (~10 s) that re-ensures the proxy if a routed session is live but the proxy has died. Because it belongs to the Headroom proxy, it's surfaced as the `watched` attribute on that row rather than as its own daemon. Every ainb-managed daemon lives on this screen.
+The Headroom watchdog isn't a separate process — it's an in-loop tick (~10 s) that re-ensures the proxy if a routed session is live but the proxy has died. Because it belongs to the Headroom proxy, it's surfaced as the `watched` attribute on that row rather than as its own daemon. Every ainb-managed daemon and socket lives on this screen — that's the invariant.
 </Aside>
 
-## Read-only by design
+## The restart lever (`R`)
 
-The overlay is for **observing**, not controlling — it never stops anything from under a running session. Stop a daemon deliberately from the CLI instead:
+The overlay is mostly for observing, but notifyd gets one deliberate control: **`R` restarts notifyd** — stop the owner, reap strays, respawn, and wait for the approve socket to bind. This is the **single resume/repair command** for a dead or wedged approve socket, and it is safe to run while permission prompts are mid-wait: a blocked `PermissionRequest` hook re-dials the socket every 500 ms until its deadline, so every still-waiting prompt re-registers itself the moment the fresh daemon binds. One restart repairs the socket *and* resumes the pending prompts — no hook is lost.
+
+The outcome (`stopped · reaped · spawned pid · socket bound`) is shown as a transient status line under the notifyd header, and the daemon list re-scans automatically so the new pid appears.
+
+The same command exists on the CLI:
+
+```bash
+ainb notifyd restart                  # stop + reap + respawn + wait for approve.sock
+ainb notifyd restart --format json    # machine-readable outcome
+```
+
+## The full health view
+
+The overlay is the quick glance; `ainb fleet daemons` is the full table — every daemon with state, pid, uptime, last activity, and a health reason. The **approve broker** appears as its own row there: it rides notifyd's process (no pid of its own), so its liveness is the socket accepting a connection, and its health reason carries the live pending-waiter count (`serving — 2 pending requests`) so you can see blocked hooks at a glance.
+
+```bash
+ainb fleet daemons                    # unified daemon health table
+ainb fleet daemons --format json      # typed rows for scripting
+```
+
+## Stopping things deliberately
+
+The overlay never stops anything from under a running session. Stop a daemon deliberately from the CLI instead:
 
 ```bash
 ainb mcp stop          # stop the shared MCP pool daemon
 ainb headroom stop     # stop the ainb-managed Headroom proxy
+ainb notifyd stop      # stop the notification daemon (SIGTERM via pid file)
+ainb notifyd reap      # kill orphan/wedged notifyd strays, sparing the live owner
 ```
 
 ## See also
 
+- [Inbox & notifications](inbox-notifications.md) — the daemon behind the notifyd rows, and the permission approve/deny round-trip.
 - [Token optimisation — Headroom & RTK](token-optimization.md) — the proxy this overlay watches.
 - [Shared MCP pool](mcp-pool.md) — the other daemon on this screen.
 - [Keyboard shortcuts](keyboard-shortcuts.md).

--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -43,8 +43,8 @@ The agents register the same intent, but not the same raw hook names. The mappin
 |------------|--------|-------|-------------|
 | `Notification` | `[?]` amber | awaiting input — asked a question, needs permission, or the prompt sat idle (~60s) | the agent resumes generating · you attach · a newer `Stop` supersedes it — **no TTL** |
 | `Stop` | `[✓]` green | turn finished — over to you | **5-minute TTL** · the agent resumes · you attach · a newer event |
-| *(none — Claude has no permission hook)* | `[!]` red | "blocked on approval" | **never shows today** — Claude folds permission into `Notification`, so a permission-block reads as `[?]` |
-| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry — deliberately not hooked | — |
+| `PermissionRequest` | `[!]` red | blocked on tool approval | the agent resumes · attach. Fires only on sessions with the **fleet plumbing** hook set installed (fleet-managed sessions register `PermissionRequest` there); the plain notifyd install folds permission into `Notification`, which reads as `[?]`. On fleet sessions this hook also *blocks* for a live approve/deny — see [Permission approve/deny round-trip](#permission-approvedeny-round-trip) |
+| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry — not hooked by the notifyd install (fleet plumbing registers `SessionStart`/`UserPromptSubmit` to drive the fleet panel's `STARTING`/`RUNNING` states) | — |
 
 ### Codex
 
@@ -68,6 +68,37 @@ While a session is **actively generating**, the marker is suppressed (the busy s
 
 Markers are matched to sessions by **working directory + agent**: each hook event carries the `cwd` it fired in, joined to the ainb session whose `workspace_path` matches (trailing-slash tolerant). Only events within a rolling **6-hour window** count — so opening ainb immediately surfaces sessions that were already waiting before you launched it (the `[✓]` TTL keeps long-finished turns from piling up, so only genuinely-pending `[?]` / `[!]` survive).
 
+## Permission approve/deny round-trip
+
+Fleet-managed Claude sessions get a **synchronous, first-class permission gate**: when Claude fires a `PermissionRequest` hook, the hook process *blocks* on notifyd's approve socket until a human approves or denies it — from the fleet panel, the CLI, or not at all (timeout ⇒ deny). The answer flows straight back to Claude as the hook's `hookSpecificOutput` permission decision, so approving in the TUI is exactly as authoritative as pressing `y` in the Claude session itself.
+
+```
+┌────────┐ PermissionRequest ┌───────────┐  AWAIT   ┌────────────────┐
+│ Claude │──────────────────▶│ hook proc │─────────▶│ approve.sock   │
+│ session│                   │ (blocks)  │          │ (notifyd)      │
+└────────┘                   └───────────┘          └────────────────┘
+     ▲                             │                        ▲
+     │  hookSpecificOutput         │ decision               │ DECIDE
+     │  allow / deny               ▼                        │
+     └─────────────────────────────┘             ┌──────────┴───────┐
+                                                 │ fleet panel y/n  │
+                                                 │ ainb fleet       │
+                                                 │   approve/deny   │
+                                                 └──────────────────┘
+```
+
+- **Fleet panel (TUI)** — press `f` on the home screen. A session blocked on approval shows the gold **`APRV`** badge (a freshly booting one shows blue **`STRT`**); select the row and press **`y`** to approve or **`n`** to deny.
+- **CLI** — `ainb fleet approve` with no argument lists the sessions currently waiting (with tool, context, and wait time; `--format json` for scripting). `ainb fleet approve <session-id>` / `ainb fleet deny <session-id> [--reason "…"]` delivers the decision; a no-waiter miss exits non-zero.
+
+### Fault tolerance — no hook is ever lost
+
+The waiting side is built to survive every failure mode without silently green-lighting a tool call:
+
+- **Timeout ladder** — the broker holds an AWAIT for up to 600 s; the waiting hook re-dials until 640 s; Claude's own hook timeout is registered at 660 s. Each layer answers before the one above kills it, and an unanswered wait falls back to **deny** — never auto-approve.
+- **Dead or restarted socket** — the blocked hook re-dials `approve.sock` every 500 ms until its deadline. If notifyd dies mid-wait, the prompt isn't lost: the moment a fresh daemon binds the socket, every still-waiting hook re-registers itself.
+- **Single resume/repair command** — `ainb notifyd restart` (CLI) or **`R`** in the [Daemons overlay](daemons.md) stops the owner, reaps strays, respawns, and waits for `approve.sock` to bind. Because of the re-dial loop, that one command repairs the socket *and* resumes every pending prompt.
+- **Observability** — the approve broker is a first-class row in `ainb fleet daemons`, with the live pending-waiter count in its health reason (`serving — 2 pending requests`), and notifyd's processes are listed in the `d` overlay.
+
 ## Host resources it touches
 
 Because this is host code, there is **no manifest and no capability declaration** — the capability gate that governs subprocess plugins does not apply. It reaches the filesystem, the socket, and the OS notifier directly. For reference, the host-side resources it touches are:
@@ -77,6 +108,7 @@ Because this is host code, there is **no manifest and no capability declaration*
 | `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist captured envelopes; back the Inbox list and the unread badge. |
 | `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from the `ainb-hooks` script. |
 | `~/.agents-in-a-box/notify.pid`, `notify.fallback.jsonl` | Single-instance guard; recover events queued while the daemon was down. |
+| `~/.agents-in-a-box/approve.sock` (Unix socket, `0600`) | The **approve broker** — blocked `PermissionRequest` hooks park here awaiting a human approve/deny from the fleet panel or CLI. Rides notifyd's process; visible as its own row in `ainb fleet daemons`. |
 | `claude` CLI (subprocess), `~/.codex/hooks.json` (read+write), `~/.copilot/hooks/ainb.json`, `~/.agents-in-a-box/hooks/notify.sh` | The `install` / `uninstall` verbs wire the hook into the host agents — Claude via `claude plugin install/uninstall`, Codex via a managed `hooks.json` block, Copilot via a standalone drop-in. |
 | `osascript` / `notify-send` (subprocess) | Emit the native OS notification for user-facing events. |
 
@@ -92,13 +124,15 @@ Because this is host code, there is **no manifest and no capability declaration*
   - The Sessions screen renders a live **status marker** (`[!]` / `[?]` / `[✓]`) on the row of any session with a pending hook event, matched by `cwd` ↔ `workspace_path`. This is the primary surface — notifications are tied to the session that produced them, not a separate destination. See [Per-session status markers](#per-session-status-markers).
 - **Inbox screen** — press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex → copilot), `r` force refresh, `q`/`Esc` back.
 - **cwd-based correlation (jump-to-tmux)** — every envelope carries the agent's `cwd` at hook-fire time, and every ainb `Session` carries a `workspace_path`. When the user presses `Enter` on an Inbox row, notifyd resolves the row's `cwd` to the first ainb workspace whose path matches (exact or `workspace_path/`-prefix to cover worktree subdirs), picks a session in that workspace, and queues an `AttachToOtherTmux` action with that session's `tmux_session_name`. There is no shared session-id namespace between the host agents' `session_id` strings and ainb's `Session.id` `Uuid`; the cwd is the bridge.
-- **Daemon + installer CLI** — the documented entrypoint is the standalone `ainb-notifyd` binary. The same verbs are also available as a **hidden `ainb notifyd …` subcommand** on the main `ainb` binary (it delegates to the identical `ainb_plugin_notifyd` functions). The hidden alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd` — the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
+- **Daemon + installer CLI** — the verbs live both on the standalone `ainb-notifyd` binary and as the **`ainb notifyd …` subcommand** on the main `ainb` binary (both delegate to the identical `ainb_plugin_notifyd` functions, so they can never diverge). The alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd` — the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
   - `ainb-notifyd run` (or `ainb notifyd run` / bare `ainb notifyd`) — run the daemon in the foreground. The hook script lazy-spawns `ainb notifyd` when the socket is missing; if `ainb` is on `PATH` the daemon auto-starts and the event is delivered live (no fallback file).
   - `ainb-notifyd install --claude --codex --copilot` (or `--all`) — install the `ainb-hooks` hook for the chosen agents.
   - `ainb-notifyd uninstall --claude --codex --copilot` (or `--all`) — reverse the install; preserves user-authored Codex hooks and other Copilot hook files.
-  - `ainb-notifyd status` — report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness.
+  - `ainb-notifyd status` — report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness. `--format json` emits `{agents, daemon: {pid, running}}` for scripting.
   - `ainb-notifyd stop` — send `SIGTERM` to a running daemon via its PID file.
-  - Every verb accepts `--format text|json|csv|markdown` (default `text`) for scripting — e.g. `ainb notifyd status --format json`.
+  - `ainb-notifyd restart` — stop the owner, reap strays, respawn, and wait for the approve socket to bind: the **single resume/repair command** for a dead or wedged approve socket (see the [round-trip section](#permission-approvedeny-round-trip) for why waiting prompts survive it).
+  - `ainb-notifyd reap` — kill orphaned/wedged notifyd strays, sparing the live owner.
+  - Every verb accepts `--format` (default `text`) for scripting — e.g. `ainb notifyd status --format json`. The host form takes `text|json|csv|markdown`; the standalone `ainb-notifyd` binary takes `text|json`.
 - **Snapshot topics** — none. `notifyd` does not publish or subscribe on the event bus; the Inbox reads SQLite directly. There is no slash command.
 
 ## Source

--- a/docs/tui/keyboard-shortcuts.md
+++ b/docs/tui/keyboard-shortcuts.md
@@ -16,6 +16,8 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 | `w` | Witr (process causality) |
 | `t` | abtop (top-for-agents monitor) |
 | `b` | Inbox (notifications) |
+| `f` | Fleet control panel (statuses, answer ASK, approve/deny) |
+| `d` | Daemons overlay |
 | `c` | Catalog |
 | `C` | Config |
 | `v` | Changelog |
@@ -50,6 +52,26 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 | `f` | Refresh workspaces |
 | `Space` | Toggle multi-select |
 | `Shift`+`D` | Delete all selected sessions |
+
+## Fleet control panel (`f`)
+
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` or `k`/`j` | Move row selection |
+| `Tab` / `Shift+Tab` | Move the ASK option cursor (on an ASK row) |
+| `Enter` / `a` | Answer the selected ASK with the highlighted option |
+| `y` / `n` | Approve / deny the selected APPROVE permission request |
+| `B` | Broadcast a ping prompt to the selected session |
+| `r` | Force refresh |
+| `q` / `Esc` | Back |
+
+## Daemons overlay (`d`)
+
+| Key | Action |
+|-----|--------|
+| `r` | Refresh |
+| `R` | Restart notifyd — the single resume/repair command for a dead approve socket |
+| `Esc` / `q` / `d` | Close |
 
 ## Recovery screen
 


### PR DESCRIPTION
## Summary

AgentPeek-parity rich fleet status + a **synchronous, first-class permission round-trip** for notifyd/ATC:

- **STARTING + APPROVE fold states** (SessionStart / PermissionRequest) in notifyd's transition engine, rendered as `STRT`/`APRV` badges in the Fleet panel (`f`).
- **Synchronous round-trip**: the Claude `PermissionRequest` hook blocks on notifyd's `approve.sock` (Claude-side timeout 660s > client re-dial deadline 640s > broker AWAIT 600s); the human's answer returns as the hook's `hookSpecificOutput` permission decision. Unanswered ⇒ deny, never auto-approve.
- **TUI levers**: `y`/`n` approve/deny on the APPROVE row; `R` in the Daemons overlay restarts notifyd.
- **Fault tolerance**: blocked waiters re-dial every 500ms, so `ainb notifyd restart` is the single resume/repair command — it repairs a dead socket AND resumes every pending prompt (proven live + by `waiter_resumes_after_socket_restart`).
- **Observability**: approve broker row (live pending count) in `ainb fleet daemons` + the `h` screen; `approve.sock` line in the `d` overlay.
- **CLI parity**: `ainb fleet approve|deny [session] [--reason]` (no arg lists waiters), `ainb notifyd status/restart/reap` — all `--format text/json`; `ainb notifyd` now visible in `--help`.
- **Docs**: round-trip + fault-tolerance sections, daemons overlay page, keyboard shortcuts, regenerated CLI reference.

## Validation (frame-truth, /tmux-verify)

- `tripwire_fleet_approve_roundtrip` — real TUI in tmux + real `broker::serve` + real `client_await` waiter: badges render, `y` → waiter receives Approve. 3/3 green.
- `tripwire_daemons_opens_and_renders` extended for approve broker/socket rows. 3/3 green.
- Live restart-mid-wait proof: waiter parked → `ainb notifyd restart` → waiter re-registered → approve → hook exits 0 with `permissionDecision: allow`.
- Explainer with journey GIFs: https://golden-pocket-2xyf.here.now/