### PR TITLE
feat(sessions): toggle to hide the bottom keymap legend (⇧M)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -896,6 +896,14 @@ impl EventHandler {
 
                 // Check if we're in the main view (not in overlays)
                 if state.current_screen == screen_ids::SESSION_LIST && !state.help_visible {
+                    // Click on the bottom keymap legend (or its collapsed hint
+                    // row) toggles it — the mouse twin of ⇧M.
+                    if let Some(area) = state.menu_bar_area {
+                        if Self::point_in_rect(x, y, area) {
+                            return Some(AppEvent::ToggleSessionMenuBar);
+                        }
+                    }
+
                     if state.sessions_pane_state.is_on_toggle(x, y) {
                         state.sessions_pane_state.toggle_collapsed();
                         Self::persist_sessions_pane_preferences(state);
@@ -7373,6 +7381,24 @@ mod panel_back_tests {
 
         EventHandler::process_event(AppEvent::PanelBack, &mut state);
         assert_eq!(state.current_screen, ids::SESSION_LIST);
+    }
+
+    /// A click anywhere on the published menu-bar rect toggles the legend
+    /// (the mouse twin of ⇧M); a click above it does not.
+    #[test]
+    fn click_on_menu_bar_toggles_the_legend() {
+        use ratatui::layout::Rect;
+        let mut state = AppState::default();
+        state.current_screen = ids::SESSION_LIST.to_string();
+        state.menu_bar_area = Some(Rect::new(0, 20, 100, 6));
+
+        let inside =
+            EventHandler::handle_mouse_event(AppEvent::MouseClick { x: 10, y: 22 }, &mut state);
+        assert!(matches!(inside, Some(AppEvent::ToggleSessionMenuBar)));
+
+        let outside =
+            EventHandler::handle_mouse_event(AppEvent::MouseClick { x: 10, y: 5 }, &mut state);
+        assert!(!matches!(outside, Some(AppEvent::ToggleSessionMenuBar)));
     }
 
     /// `[r]` in the Skill Manager must arm a confirm on the first press

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -195,6 +195,7 @@ pub enum AppEvent {
     ScrollPreviewUp,      // Scroll tmux preview up
     ScrollPreviewDown,    // Scroll tmux preview down
     ToggleExpandAll,      // Toggle expand/collapse all workspaces
+    ToggleSessionMenuBar, // Hide/show the Sessions bottom keymap legend (⇧M)
     // Other tmux rename events
     OtherTmuxStartRename, // Start rename mode for selected "Other tmux" session
     OtherTmuxRenameChar(char), // Character input for rename
@@ -1920,6 +1921,8 @@ impl EventHandler {
             // Sidebar collapse/expand was mouse-only (the [-]/[+] glyph);
             // 'B' is its keyboard twin. Hinted next to the glyph itself.
             KeyCode::Char('B') => Some(AppEvent::ToggleSessionsSidebar),
+            // Hide/show the bottom keymap legend to reclaim vertical space.
+            KeyCode::Char('M') => Some(AppEvent::ToggleSessionMenuBar),
             // Panel screens mirror their home-menu letters here so every
             // panel opens from the session list too (i stats, w witr,
             // k skills, m memory, t abtop — same set
@@ -3057,6 +3060,7 @@ impl EventHandler {
             AppEvent::DaemonsOverlayRestartNotifyd => state.spawn_notifyd_restart(),
             AppEvent::ToggleClaudeChat => state.toggle_claude_chat(),
             AppEvent::ToggleExpandAll => state.toggle_expand_all_workspaces(),
+            AppEvent::ToggleSessionMenuBar => state.toggle_session_menu_bar(),
             AppEvent::ToggleSessionsSidebar => {
                 // Same path the [-]/[+] mouse glyph takes: flip + persist the
                 // preference so the choice survives restarts.

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -6365,6 +6365,20 @@ impl AppState {
         self.expand_all_workspaces = !self.expand_all_workspaces;
     }
 
+    /// Hide/show the Sessions bottom keymap legend (⇧M) and persist the choice.
+    pub fn toggle_session_menu_bar(&mut self) {
+        let show = !self.app_config.ui_preferences.show_session_menu_bar;
+        self.app_config.ui_preferences.show_session_menu_bar = show;
+        if let Err(e) = self.app_config.save() {
+            warn!("Failed to persist show_session_menu_bar: {}", e);
+        }
+        self.add_info_notification(if show {
+            "Keymap legend shown".to_string()
+        } else {
+            "Keymap legend hidden — ⇧M to show".to_string()
+        });
+    }
+
     /// Cycle the session-status filter (Shift+F): All → ActiveOnly → StoppedOnly → All.
     /// Resets the session selection so it doesn't point to a now-hidden row.
     pub fn cycle_session_filter(&mut self) {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2857,6 +2857,9 @@ pub struct AppState {
     // mouse-coordinate translation into 1-based pane-local SGR sequences.
     // None whenever the embed is not rendering.
     pub embed_pane_area: Option<Rect>,
+    // Bottom keymap-legend rect (or its collapsed hint row), published each
+    // frame on the Sessions screen so a mouse click on it toggles visibility.
+    pub menu_bar_area: Option<Rect>,
     // Mouse/layout state for the Sessions split pane.
     pub sessions_pane_state: SessionsPaneState,
     // Track if current directory is a git repository
@@ -3437,6 +3440,7 @@ impl Default for AppState {
             embed: None,
             embed_session: None,
             embed_pane_area: None,
+            menu_bar_area: None,
             sessions_pane_state,
             is_current_dir_git_repo: false,
             last_logs_session_id: None,

--- a/ainb-tui/crates/ainb-core/src/components/help.rs
+++ b/ainb-tui/crates/ainb-core/src/components/help.rs
@@ -81,6 +81,7 @@ impl HelpComponent {
             row("Tab", "Switch focus (list <-> preview)"),
             row("Shift+E", "Expand / collapse all workspaces"),
             row("Shift+B", "Collapse / expand the sidebar"),
+            row("Shift+M", "Hide / show the bottom keymap legend"),
             ListItem::new(""),
             head("General:"),
             row("? / Shift+H", "Toggle this help"),

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -121,13 +121,20 @@ impl LayoutComponent {
             return;
         }
 
+        // The bottom keymap legend can be hidden (⇧M) to give the session list
+        // more room; hidden it collapses to a single hint row.
+        let menu_bar_h = if state.app_config.ui_preferences.show_session_menu_bar {
+            6 // full legend: 4 lines + borders
+        } else {
+            1 // collapsed hint row
+        };
         let main_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Top status bar
-                Constraint::Min(0),    // Main content area
-                Constraint::Length(3), // Session info (single line + borders)
-                Constraint::Length(6), // Bottom menu bar (4 lines + borders)
+                Constraint::Length(3),          // Top status bar
+                Constraint::Min(0),             // Main content area
+                Constraint::Length(3),          // Session info (single line + borders)
+                Constraint::Length(menu_bar_h), // Bottom menu bar / collapsed hint
             ])
             .split(frame.area());
 
@@ -290,6 +297,12 @@ impl LayoutComponent {
     /// `menu_bar_keys_not_truncated_at_80_cols` test exercises the stacked
     /// path unchanged.
     fn render_menu_bar(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        // Hidden legend → a single muted hint row (still discoverable: shows the
+        // ⇧M un-hide key plus help/home).
+        if !state.app_config.ui_preferences.show_session_menu_bar {
+            self.render_menu_bar_collapsed(frame, area);
+            return;
+        }
         // Below this width the two-column split can't hold the widest
         // session-action line (~41 cols) plus the panels column without
         // clipping, so fall back to the stacked legend.
@@ -299,6 +312,26 @@ impl LayoutComponent {
         } else {
             self.render_menu_bar_stacked(frame, area, state);
         }
+    }
+
+    /// One-line stand-in shown when the keymap legend is hidden.
+    fn render_menu_bar_collapsed(&self, frame: &mut Frame, area: Rect) {
+        let key = |k: &'static str, color: Color| {
+            Span::styled(k, Style::default().fg(color).add_modifier(Modifier::BOLD))
+        };
+        let desc = |d: &'static str| Span::styled(d, Style::default().fg(MUTED_GRAY));
+        let line = Line::from(vec![
+            key("⇧M", GOLD),
+            desc(" keymap  "),
+            key("?/H", CORNFLOWER_BLUE),
+            desc(" help  "),
+            key("q", CORNFLOWER_BLUE),
+            desc(" home"),
+        ]);
+        frame.render_widget(
+            Paragraph::new(line).alignment(Alignment::Center).style(Style::default().bg(PANEL_BG)),
+            area,
+        );
     }
 
     fn render_menu_bar_stacked(&self, frame: &mut Frame, area: Rect, state: &AppState) {

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -331,7 +331,9 @@ impl LayoutComponent {
             desc(" home"),
         ]);
         frame.render_widget(
-            Paragraph::new(line).alignment(Alignment::Center).style(Style::default().bg(PANEL_BG)),
+            Paragraph::new(line)
+                .alignment(Alignment::Center)
+                .style(Style::default().bg(PANEL_BG)),
             area,
         );
     }

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -198,7 +198,9 @@ impl LayoutComponent {
         // Render bottom logs area (traditional logs viewer)
         self.logs_viewer.render(frame, main_layout[2], state);
 
-        // Render bottom menu bar
+        // Render bottom menu bar. Publish its rect so a mouse click on the
+        // legend (or its collapsed hint row) can toggle visibility.
+        state.menu_bar_area = Some(main_layout[3]);
         self.render_menu_bar(frame, main_layout[3], state);
 
         // Render help overlay if visible

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -681,6 +681,12 @@ pub struct UiPreferences {
     #[serde(default = "default_true")]
     pub show_git_status: bool,
 
+    /// Whether to show the Sessions-screen bottom keymap legend ("Session
+    /// actions" / "Panels & views"). When false it collapses to a single hint
+    /// row, reclaiming vertical space for the session list. Toggle with ⇧M.
+    #[serde(default = "default_true")]
+    pub show_session_menu_bar: bool,
+
     /// Preferred editor command (e.g., "code", "cursor", "nvim")
     /// If None, falls back to: code -> $EDITOR -> error
     #[serde(default)]
@@ -753,6 +759,7 @@ impl Default for UiPreferences {
             theme: default_theme(),
             show_container_status: true,
             show_git_status: true,
+            show_session_menu_bar: true,
             preferred_editor: None,
             home_sidebar_width: None,
             sessions_sidebar_width: None,
@@ -988,6 +995,8 @@ impl AppConfig {
             // New config: respect explicit settings
             self.ui_preferences.show_container_status = other.ui_preferences.show_container_status;
             self.ui_preferences.show_git_status = other.ui_preferences.show_git_status;
+            self.ui_preferences.show_session_menu_bar =
+                other.ui_preferences.show_session_menu_bar;
         }
         // Old configs keep the default (true) values
         if other.ui_preferences.preferred_editor.is_some() {
@@ -1678,6 +1687,7 @@ mod old_config_tests {
                 theme: "".to_string(), // Empty theme indicates old config
                 show_container_status: false,
                 show_git_status: false,
+                show_session_menu_bar: false,
                 preferred_editor: None,
                 home_sidebar_width: None,
                 sessions_sidebar_width: None,
@@ -1723,6 +1733,7 @@ mod old_config_tests {
                 theme: "light".to_string(), // Non-empty theme indicates new config
                 show_container_status: false,
                 show_git_status: false,
+                show_session_menu_bar: false,
                 preferred_editor: None,
                 home_sidebar_width: Some(38),
                 sessions_sidebar_width: Some(46),

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -995,8 +995,7 @@ impl AppConfig {
             // New config: respect explicit settings
             self.ui_preferences.show_container_status = other.ui_preferences.show_container_status;
             self.ui_preferences.show_git_status = other.ui_preferences.show_git_status;
-            self.ui_preferences.show_session_menu_bar =
-                other.ui_preferences.show_session_menu_bar;
+            self.ui_preferences.show_session_menu_bar = other.ui_preferences.show_session_menu_bar;
         }
         // Old configs keep the default (true) values
         if other.ui_preferences.preferred_editor.is_some() {


### PR DESCRIPTION
Hide the Sessions-screen bottom keymap legend ("Session actions" / "Panels & views", 6 rows) to reclaim vertical space — via keyboard **or mouse**.

## Behaviour

- **⇧M** or **click the legend** → hides it; it collapses to a single hint row (`⇧M keymap · ?/H help · q home`), reclaiming 5 rows for the session list + logs.
- **⇧M** or **click the hint row** → shows it again.

```
shown  ┌ Session actions ──────── Panels & views ┐  6 rows   ← click to hide
       │ n new  a attach …     b inbox  i stats … │
       └──────────────────────────────────────────┘
hidden        ⇧M keymap   ?/H help   q home         1 row     ← click to show
```

The choice **persists** in `ui_preferences.show_session_menu_bar` (default true).

## Implementation
- New `ui_preferences.show_session_menu_bar` bool (default true), merged like the other UI bool prefs.
- Layout allocates `Length(6)` shown / `Length(1)` hidden; `render_menu_bar` draws a collapsed hint row when hidden.
- `⇧M` → `ToggleSessionMenuBar` → flips + saves config + toast; documented in help (`Shift+M`).
- **Mouse**: the menu-bar rect is published each frame (`state.menu_bar_area`); a left-click on it in the session-list handler emits `ToggleSessionMenuBar` — mirrors the sidebar `[-]/[+]` click pattern.

## Verification
- tmux frame-truth (keyboard): full legend → ⇧M → 1-row hint + "hidden" toast + content grows → ⇧M → legend back. 3 frames read + confirmed.
- `cargo test -p ainb --lib` → `menu_bar_` 6 pass, `click_on_menu_bar_toggles_the_legend` pass ✓ (mouse hit-test covered by unit test; vhs cannot script clicks).
- `cargo build -p ainb` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Shift+M** shortcut to hide or show the bottom keymap legend.
  * The bottom menu bar is now interactive: clicking the legend area toggles visibility.
  * When hidden, the menu bar collapses into a compact hint row with the Shift+M toggle.
* **Bug Fixes**
  * Legend visibility is now persisted and restored reliably across app sessions.
  * Legacy configurations keep the default visible behavior while new saved preferences are respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->