### PR TITLE
feat(skills): preview-first source import picker + fix invisible installed units

### DIFF
--- a/ainb-tui/crates/ainb-cli/src/skill.rs
+++ b/ainb-tui/crates/ainb-cli/src/skill.rs
@@ -246,21 +246,19 @@ fn install(home: &Path, args: InstallArgs, out: &mut dyn io::Write) -> Result<()
     // Record the unit in the manifest too — the manifest is the
     // declarative intent the Skill Manager's Units table renders;
     // without this entry an installed unit was lockfile-only and
-    // invisible in the TUI ("imported but nothing shows").
+    // invisible in the TUI ("imported but nothing shows"). Upsert, not
+    // insert-only: a reinstall with different --targets must refresh
+    // the declared targets or manifest and lockfile drift apart.
     {
         let manifest_path = manifest_path_in(home);
         let mut manifest = Manifest::load_from(&manifest_path)?;
-        if !manifest.units.iter().any(|u| u.uri == args.uri) {
-            manifest.units.push(ainb_skill_core::manifest::UnitEntry {
-                uri: args.uri.clone(),
-                targets: args
-                    .targets
-                    .as_deref()
-                    .map(|s| s.split(',').map(|t| t.trim().to_string()).collect()),
-                shadowed_by: None,
-            });
-            manifest.save_to(&manifest_path)?;
-        }
+        manifest.upsert_unit(
+            &args.uri,
+            args.targets
+                .as_deref()
+                .map(|s| s.split(',').map(|t| t.trim().to_string()).collect()),
+        );
+        manifest.save_to(&manifest_path)?;
     }
 
     // Replace or insert the LockedUnit.

--- a/ainb-tui/crates/ainb-cli/src/skill.rs
+++ b/ainb-tui/crates/ainb-cli/src/skill.rs
@@ -351,6 +351,22 @@ fn remove(home: &Path, args: RemoveSkillArgs, out: &mut dyn io::Write) -> Result
         }
     }
 
+    // Mirror the outcome into the manifest — install declares the unit
+    // there (that's what the Skill Manager renders), so remove must
+    // undeclare it or the next `sync` reinstalls what was just removed.
+    {
+        let manifest_path = manifest_path_in(home);
+        let mut manifest = Manifest::load_from(&manifest_path)?;
+        if retained.is_empty() {
+            manifest.units.retain(|u| u.uri != args.uri);
+        } else if let Some(entry) = manifest.units.iter_mut().find(|u| u.uri == args.uri) {
+            // Partial removal: keep the declaration, narrowed to the
+            // tools that still hold a deployment.
+            entry.targets = Some(retained.keys().cloned().collect());
+        }
+        manifest.save_to(&manifest_path)?;
+    }
+
     if retained.is_empty() {
         lockfile.units.remove(idx);
     } else {

--- a/ainb-tui/crates/ainb-cli/src/skill.rs
+++ b/ainb-tui/crates/ainb-cli/src/skill.rs
@@ -243,6 +243,26 @@ fn install(home: &Path, args: InstallArgs, out: &mut dyn io::Write) -> Result<()
         );
     }
 
+    // Record the unit in the manifest too — the manifest is the
+    // declarative intent the Skill Manager's Units table renders;
+    // without this entry an installed unit was lockfile-only and
+    // invisible in the TUI ("imported but nothing shows").
+    {
+        let manifest_path = manifest_path_in(home);
+        let mut manifest = Manifest::load_from(&manifest_path)?;
+        if !manifest.units.iter().any(|u| u.uri == args.uri) {
+            manifest.units.push(ainb_skill_core::manifest::UnitEntry {
+                uri: args.uri.clone(),
+                targets: args
+                    .targets
+                    .as_deref()
+                    .map(|s| s.split(',').map(|t| t.trim().to_string()).collect()),
+                shadowed_by: None,
+            });
+            manifest.save_to(&manifest_path)?;
+        }
+    }
+
     // Replace or insert the LockedUnit.
     lockfile.units.retain(|u| u.declared_uri != args.uri);
     lockfile.units.push(LockedUnit {

--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -200,13 +200,28 @@ pub fn preview_source(home: &Path, uri_str: &str) -> Result<SourcePreview> {
     }
     let stored_uri = format!("{}:{}", uri.source_type, uri.locator);
     let ref_ = uri.ref_.clone().unwrap_or_else(|| "main".to_string());
-    let name = derive_name_slug(&uri.source_type, &uri.locator);
-    if name.is_empty() {
+    let derived = derive_name_slug(&uri.source_type, &uri.locator);
+    if derived.is_empty() {
         bail!("could not derive a source name from `{uri_str}`");
     }
 
+    // Identity is the stored URI, not the derived name — a source added
+    // earlier under a custom --name must be recognised (or import would
+    // persist a duplicate entry for the same repo), and a slug collision
+    // with a DIFFERENT repo must fail here, before the expensive fetch,
+    // not per-unit at install time.
     let manifest = Manifest::load_from(&manifest_path_in(home)).unwrap_or_default();
-    let already_added = manifest.source(&name).is_some();
+    let existing = manifest.sources.iter().find(|s| s.uri == stored_uri);
+    let already_added = existing.is_some();
+    // Reuse the existing entry's name (fetch cache is keyed by name, so
+    // this also re-fetches into the right checkout).
+    let name = existing.map(|s| s.name.clone()).unwrap_or(derived);
+    if !already_added && manifest.source(&name).is_some() {
+        bail!(
+            "source name `{name}` is already taken by a different URI — \
+             add `{stored_uri}` via `ainb source add {stored_uri} --name <other>`"
+        );
+    }
 
     let fetched = run_fetcher(&uri, &name, &cache_dir_in(home))
         .with_context(|| format!("fetching source `{name}`"))?;

--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -264,6 +264,9 @@ pub fn import_selected(
     let lockfile_path = lockfile_path_in(home);
 
     // Persist the source on first import — same records `add` writes.
+    // Remembered so a fully-failed import can roll it back (the
+    // preview-first contract: no imported units → no trace).
+    let persisted_now = !preview.already_added;
     if !preview.already_added {
         let mut manifest = Manifest::load_from(&manifest_path)?;
         if manifest.source(&preview.name).is_none() {
@@ -313,6 +316,18 @@ pub fn import_selected(
             }
         }
     }
+    // Nothing landed and we created the source in this call → roll the
+    // records back so a failed import leaves no trace, matching cancel.
+    if installed == 0 && persisted_now {
+        let mut manifest = Manifest::load_from(&manifest_path)?;
+        let _ = manifest.remove_source(&preview.name);
+        manifest.save_to(&manifest_path)?;
+        let mut lockfile = Lockfile::load_from(&lockfile_path)?;
+        lockfile.sources.retain(|s| s.name != preview.name);
+        lockfile.save_to(&lockfile_path)?;
+        writeln!(out, "# rolled back source `{}` (no unit imported)", preview.name)?;
+    }
+
     writeln!(
         out,
         "imported {installed} unit(s), {failed} failed → {targets}"

--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -54,80 +54,68 @@ fn add(
     lockfile_path: &Path,
     out: &mut dyn io::Write,
 ) -> Result<()> {
-    let uri =
-        Uri::parse(&args.uri).with_context(|| format!("parsing source URI `{}`", args.uri))?;
-
-    if uri.path.is_some() {
-        bail!(
-            "`{}` looks like a unit URI (has a path). Use `ainb skill install` for units; \
-             pass a source URI (no `/path`) here.",
-            args.uri
-        );
+    // `add` = the shared preview front-half + persist. Duplicate NAME is
+    // rejected up front (before the fetch) to keep the historical
+    // fast-fail + `SourceAlreadyExists` contract.
+    if let Some(name) = args.name.as_deref() {
+        let manifest = Manifest::load_from(manifest_path)?;
+        if manifest.source(name).is_some() {
+            return Err(ainb_skill_core::CoreError::SourceAlreadyExists(name.to_string()).into());
+        }
     }
 
-    let stored_uri = format!("{}:{}", uri.source_type, uri.locator);
-    let ref_ = uri.ref_.clone().unwrap_or_else(|| "main".to_string());
-    let name = args
-        .name
-        .clone()
-        .unwrap_or_else(|| derive_name_slug(&uri.source_type, &uri.locator));
-
-    if name.is_empty() {
-        return Err(anyhow!(
-            "could not derive a non-empty name from `{}` — pass --name explicitly",
-            args.uri
-        ));
+    let preview = preview_source_with(home, &args.uri, args.name.as_deref(), args.kind.as_deref())?;
+    if preview.already_added {
+        return Err(ainb_skill_core::CoreError::SourceAlreadyExists(preview.name).into());
     }
-
-    // Reject duplicate before doing any expensive fetch work.
-    let mut manifest = Manifest::load_from(manifest_path)?;
-    if manifest.source(&name).is_some() {
-        return Err(ainb_skill_core::CoreError::SourceAlreadyExists(name).into());
-    }
-
-    // Fetch the source via the type-appropriate fetcher.
-    let cache_root = cache_dir_in(home);
-    let fetched = run_fetcher(&uri, &name, &cache_root)
-        .with_context(|| format!("fetching source `{name}`"))?;
-
-    // Adapter selection: explicit --type wins, otherwise auto-detect.
-    let (adapter, detected_kind) = pick_adapter_for(&fetched.path, args.kind.as_deref())?;
-    let units = adapter
-        .list_units(&fetched.path)
-        .with_context(|| format!("listing units in `{}`", fetched.path.display()))?;
-    let unit_count = units.len();
-
-    // Persist the discovered kind in the manifest.
-    manifest
-        .add_source(SourceEntry {
-            name: name.clone(),
-            kind: Some(detected_kind.clone()),
-            uri: stored_uri,
-            r#ref: ref_.clone(),
-            enabled: true,
-            read_only: false,
-            target_layout: Vec::new(),
-        })
-        .map_err(anyhow::Error::from)?;
-    manifest.save_to(manifest_path)?;
-
-    // Lockfile records where the fetched checkout lives so `search`
-    // can find it without re-running the fetcher.
-    let mut lockfile = Lockfile::load_from(lockfile_path)?;
-    lockfile.sources.push(LockedSource {
-        name: name.clone(),
-        uri: format!("{}:{}", uri.source_type, uri.locator),
-        declared_ref: ref_,
-        resolved_sha: Some(fetched.resolved_sha),
-        fetched_at: Some(fetched.fetched_at),
-        fetched_path: Some(fetched.path.to_string_lossy().to_string()),
-    });
-    lockfile.save_to(lockfile_path)?;
+    persist_source(manifest_path, lockfile_path, &preview)?;
 
     writeln!(
         out,
-        "added source {name} ({detected_kind}) → {unit_count} unit(s)"
+        "added source {} ({}) → {} unit(s)",
+        preview.name,
+        preview.kind,
+        preview.units.len()
     )?;
+    Ok(())
+}
+
+/// Write the manifest `SourceEntry` + lockfile `LockedSource` for a
+/// previewed source. The single persistence point shared by `add` and
+/// `import_selected`, so TUI-imported and CLI-added sources can never
+/// drift in record shape.
+fn persist_source(
+    manifest_path: &Path,
+    lockfile_path: &Path,
+    preview: &SourcePreview,
+) -> Result<()> {
+    let mut manifest = Manifest::load_from(manifest_path)?;
+    if manifest.source(&preview.name).is_none() {
+        manifest
+            .add_source(SourceEntry {
+                name: preview.name.clone(),
+                kind: Some(preview.kind.clone()),
+                uri: preview.stored_uri.clone(),
+                r#ref: preview.r#ref.clone(),
+                enabled: true,
+                read_only: false,
+                target_layout: Vec::new(),
+            })
+            .map_err(anyhow::Error::from)?;
+        manifest.save_to(manifest_path)?;
+    }
+    let mut lockfile = Lockfile::load_from(lockfile_path)?;
+    if !lockfile.sources.iter().any(|s| s.name == preview.name) {
+        lockfile.sources.push(LockedSource {
+            name: preview.name.clone(),
+            uri: preview.stored_uri.clone(),
+            declared_ref: preview.r#ref.clone(),
+            resolved_sha: Some(preview.resolved_sha.clone()),
+            fetched_at: Some(preview.fetched_at.clone()),
+            fetched_path: Some(preview.fetched_path.to_string_lossy().to_string()),
+        });
+        lockfile.save_to(lockfile_path)?;
+    }
     Ok(())
 }
 
@@ -194,15 +182,33 @@ pub struct SourcePreview {
 /// Fetch `uri_str` into the cache and list its units — no manifest or
 /// lockfile writes. Backs the Skill Manager's preview-first add flow.
 pub fn preview_source(home: &Path, uri_str: &str) -> Result<SourcePreview> {
+    preview_source_with(home, uri_str, None, None)
+}
+
+/// [`preview_source`] with the `add`-path overrides: an explicit source
+/// name (`--name`) and a forced adapter kind (`--type`). The one shared
+/// front-half for CLI add and TUI preview, so name derivation, ref
+/// defaulting, and validation cannot drift between the two.
+fn preview_source_with(
+    home: &Path,
+    uri_str: &str,
+    name_override: Option<&str>,
+    kind_override: Option<&str>,
+) -> Result<SourcePreview> {
     let uri = Uri::parse(uri_str).with_context(|| format!("parsing source URI `{uri_str}`"))?;
     if uri.path.is_some() {
-        bail!("`{uri_str}` looks like a unit URI (has a path) — pass a repo/source URI");
+        bail!(
+            "`{uri_str}` looks like a unit URI (has a path). Use `ainb skill install` for \
+             units; pass a repo/source URI (no `/path`) here."
+        );
     }
     let stored_uri = format!("{}:{}", uri.source_type, uri.locator);
     let ref_ = uri.ref_.clone().unwrap_or_else(|| "main".to_string());
-    let derived = derive_name_slug(&uri.source_type, &uri.locator);
+    let derived = name_override
+        .map(str::to_string)
+        .unwrap_or_else(|| derive_name_slug(&uri.source_type, &uri.locator));
     if derived.is_empty() {
-        bail!("could not derive a source name from `{uri_str}`");
+        bail!("could not derive a source name from `{uri_str}` — pass --name explicitly");
     }
 
     // Identity is the stored URI, not the derived name — a source added
@@ -225,7 +231,7 @@ pub fn preview_source(home: &Path, uri_str: &str) -> Result<SourcePreview> {
 
     let fetched = run_fetcher(&uri, &name, &cache_dir_in(home))
         .with_context(|| format!("fetching source `{name}`"))?;
-    let (adapter, kind) = pick_adapter_for(&fetched.path, None)?;
+    let (adapter, kind) = pick_adapter_for(&fetched.path, kind_override)?;
     let units = adapter
         .list_units(&fetched.path)
         .with_context(|| format!("listing units in `{}`", fetched.path.display()))?;
@@ -263,38 +269,13 @@ pub fn import_selected(
     let manifest_path = manifest_path_in(home);
     let lockfile_path = lockfile_path_in(home);
 
-    // Persist the source on first import — same records `add` writes.
-    // Remembered so a fully-failed import can roll it back (the
-    // preview-first contract: no imported units → no trace).
+    // Persist the source on first import — the same records `add` writes
+    // (shared `persist_source`). Remembered so a fully-failed import can
+    // roll it back (the preview-first contract: no imported units → no
+    // trace).
     let persisted_now = !preview.already_added;
-    if !preview.already_added {
-        let mut manifest = Manifest::load_from(&manifest_path)?;
-        if manifest.source(&preview.name).is_none() {
-            manifest
-                .add_source(SourceEntry {
-                    name: preview.name.clone(),
-                    kind: Some(preview.kind.clone()),
-                    uri: preview.stored_uri.clone(),
-                    r#ref: preview.r#ref.clone(),
-                    enabled: true,
-                    read_only: false,
-                    target_layout: Vec::new(),
-                })
-                .map_err(anyhow::Error::from)?;
-            manifest.save_to(&manifest_path)?;
-        }
-        let mut lockfile = Lockfile::load_from(&lockfile_path)?;
-        if !lockfile.sources.iter().any(|s| s.name == preview.name) {
-            lockfile.sources.push(LockedSource {
-                name: preview.name.clone(),
-                uri: preview.stored_uri.clone(),
-                declared_ref: preview.r#ref.clone(),
-                resolved_sha: Some(preview.resolved_sha.clone()),
-                fetched_at: Some(preview.fetched_at.clone()),
-                fetched_path: Some(preview.fetched_path.to_string_lossy().to_string()),
-            });
-            lockfile.save_to(&lockfile_path)?;
-        }
+    if persisted_now {
+        persist_source(&manifest_path, &lockfile_path, preview)?;
     }
 
     // Install each selected unit via the standard install path so plans,
@@ -325,7 +306,11 @@ pub fn import_selected(
         let mut lockfile = Lockfile::load_from(&lockfile_path)?;
         lockfile.sources.retain(|s| s.name != preview.name);
         lockfile.save_to(&lockfile_path)?;
-        writeln!(out, "# rolled back source `{}` (no unit imported)", preview.name)?;
+        writeln!(
+            out,
+            "# rolled back source `{}` (no unit imported)",
+            preview.name
+        )?;
     }
 
     writeln!(

--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -298,7 +298,10 @@ pub fn import_selected(
             }
         }
     }
-    writeln!(out, "imported {installed} unit(s), {failed} failed → {targets}")?;
+    writeln!(
+        out,
+        "imported {installed} unit(s), {failed} failed → {targets}"
+    )?;
     Ok((installed, failed))
 }
 

--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -167,6 +167,141 @@ fn pick_adapter_for(
     Ok((picked, name))
 }
 
+/// Re-export so TUI callers can build/inspect preview units without a
+/// direct ainb-adapters-source dependency.
+pub use ainb_adapters_source::UnitDescriptor;
+
+/// Fetched-and-parsed view of a source, produced WITHOUT touching the
+/// manifest or lockfile. The Skill Manager previews a repo with this and
+/// only persists on import — cancelling a preview leaves no trace (the
+/// cache checkout is harmless and reused on a later add).
+#[derive(Debug, Clone)]
+pub struct SourcePreview {
+    pub name: String,
+    /// Canonical stored form, e.g. `gh:owner/repo`.
+    pub stored_uri: String,
+    pub r#ref: String,
+    /// Detected adapter kind (marketplace / manifest / raw / single).
+    pub kind: String,
+    pub fetched_path: std::path::PathBuf,
+    pub resolved_sha: String,
+    pub fetched_at: String,
+    pub units: Vec<ainb_adapters_source::UnitDescriptor>,
+    /// True when the manifest already has this source (import skips add).
+    pub already_added: bool,
+}
+
+/// Fetch `uri_str` into the cache and list its units — no manifest or
+/// lockfile writes. Backs the Skill Manager's preview-first add flow.
+pub fn preview_source(home: &Path, uri_str: &str) -> Result<SourcePreview> {
+    let uri = Uri::parse(uri_str).with_context(|| format!("parsing source URI `{uri_str}`"))?;
+    if uri.path.is_some() {
+        bail!("`{uri_str}` looks like a unit URI (has a path) — pass a repo/source URI");
+    }
+    let stored_uri = format!("{}:{}", uri.source_type, uri.locator);
+    let ref_ = uri.ref_.clone().unwrap_or_else(|| "main".to_string());
+    let name = derive_name_slug(&uri.source_type, &uri.locator);
+    if name.is_empty() {
+        bail!("could not derive a source name from `{uri_str}`");
+    }
+
+    let manifest = Manifest::load_from(&manifest_path_in(home)).unwrap_or_default();
+    let already_added = manifest.source(&name).is_some();
+
+    let fetched = run_fetcher(&uri, &name, &cache_dir_in(home))
+        .with_context(|| format!("fetching source `{name}`"))?;
+    let (adapter, kind) = pick_adapter_for(&fetched.path, None)?;
+    let units = adapter
+        .list_units(&fetched.path)
+        .with_context(|| format!("listing units in `{}`", fetched.path.display()))?;
+
+    Ok(SourcePreview {
+        name,
+        stored_uri,
+        r#ref: ref_,
+        kind,
+        fetched_path: fetched.path,
+        resolved_sha: fetched.resolved_sha,
+        fetched_at: fetched.fetched_at,
+        units,
+        already_added,
+    })
+}
+
+/// Persist a previewed source (unless already present) and install the
+/// selected units to the chosen tools. `selected_paths` are unit paths
+/// relative to the source root (`UnitDescriptor.path`); `targets` is the
+/// comma-separated tool list `ainb skill install --targets` accepts.
+/// Returns (installed, failed) counts; per-unit failures are reported in
+/// `out` rather than aborting the batch.
+pub fn import_selected(
+    home: &Path,
+    preview: &SourcePreview,
+    selected_paths: &[String],
+    targets: &str,
+    out: &mut dyn io::Write,
+) -> Result<(usize, usize)> {
+    if selected_paths.is_empty() {
+        bail!("no units selected");
+    }
+
+    let manifest_path = manifest_path_in(home);
+    let lockfile_path = lockfile_path_in(home);
+
+    // Persist the source on first import — same records `add` writes.
+    if !preview.already_added {
+        let mut manifest = Manifest::load_from(&manifest_path)?;
+        if manifest.source(&preview.name).is_none() {
+            manifest
+                .add_source(SourceEntry {
+                    name: preview.name.clone(),
+                    kind: Some(preview.kind.clone()),
+                    uri: preview.stored_uri.clone(),
+                    r#ref: preview.r#ref.clone(),
+                    enabled: true,
+                    read_only: false,
+                    target_layout: Vec::new(),
+                })
+                .map_err(anyhow::Error::from)?;
+            manifest.save_to(&manifest_path)?;
+        }
+        let mut lockfile = Lockfile::load_from(&lockfile_path)?;
+        if !lockfile.sources.iter().any(|s| s.name == preview.name) {
+            lockfile.sources.push(LockedSource {
+                name: preview.name.clone(),
+                uri: preview.stored_uri.clone(),
+                declared_ref: preview.r#ref.clone(),
+                resolved_sha: Some(preview.resolved_sha.clone()),
+                fetched_at: Some(preview.fetched_at.clone()),
+                fetched_path: Some(preview.fetched_path.to_string_lossy().to_string()),
+            });
+            lockfile.save_to(&lockfile_path)?;
+        }
+    }
+
+    // Install each selected unit via the standard install path so plans,
+    // target_layout remapping, and lockfile records all apply.
+    let (mut installed, mut failed) = (0usize, 0usize);
+    for path in selected_paths {
+        let unit_uri = format!("{}@{}/{}", preview.stored_uri, preview.r#ref, path);
+        let args = crate::InstallArgs {
+            uri: unit_uri.clone(),
+            targets: Some(targets.to_string()),
+            dry_run: false,
+            yes: true,
+        };
+        match crate::skill::dispatch(home, crate::SkillCommand::Install(args), out) {
+            Ok(()) => installed += 1,
+            Err(e) => {
+                failed += 1;
+                writeln!(out, "# failed {unit_uri}: {e:#}")?;
+            }
+        }
+    }
+    writeln!(out, "imported {installed} unit(s), {failed} failed → {targets}")?;
+    Ok((installed, failed))
+}
+
 fn list(manifest_path: &Path, out: &mut dyn io::Write) -> Result<()> {
     let manifest = Manifest::load_from(manifest_path)?;
     if manifest.sources.is_empty() {

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -172,3 +172,43 @@ fn reinstall_with_different_targets_refreshes_manifest_entry() {
         std::env::remove_var("AINB_TOOL_HOME_CODEX");
     }
 }
+
+/// Source identity is the URI, not the derived name slug: a source added
+/// earlier under a custom --name is recognised (already_added, name
+/// reused — no duplicate entry), and a slug collision with a different
+/// URI fails fast at preview time.
+#[test]
+fn preview_matches_existing_source_by_uri_not_slug() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+
+    // Add the repo under a custom name via the normal add path.
+    let mut buf = Vec::new();
+    ainb_cli::dispatch(
+        home.path(),
+        ainb_cli::Command::Source {
+            action: ainb_cli::SourceCommand::Add(ainb_cli::AddArgs {
+                uri: uri.clone(),
+                name: Some("mytools".to_string()),
+                kind: None,
+            }),
+        },
+        &mut buf,
+    )
+    .expect("add source");
+
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    assert!(preview.already_added, "same URI under custom name must be recognised");
+    assert_eq!(preview.name, "mytools", "existing entry's name reused");
+
+    // Import must not create a duplicate source.
+    let claude_root = home.path().join("tools/claude");
+    unsafe { std::env::set_var("AINB_TOOL_HOME_CLAUDE", &claude_root) };
+    let paths = unit_paths(&preview);
+    let mut out = Vec::new();
+    import_selected(home.path(), &preview, &paths[..1], "claude", &mut out).expect("import");
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert_eq!(manifest.sources.len(), 1, "no duplicate source entry");
+    unsafe { std::env::remove_var("AINB_TOOL_HOME_CLAUDE") };
+}

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -13,17 +13,26 @@ use ainb_skill_core::paths::{lockfile_path_in, manifest_path_in};
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn tmp_home() -> tempfile::TempDir {
-    tempfile::Builder::new().prefix("ainb-preview-test-").tempdir().expect("tempdir")
+    tempfile::Builder::new()
+        .prefix("ainb-preview-test-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 /// Two-skill local fixture repo.
 fn fixture_repo() -> (tempfile::TempDir, String) {
     let dir = tempfile::tempdir().unwrap();
-    for (name, desc) in [("commit", "well-formed commits"), ("review", "review diffs")] {
+    for (name, desc) in [
+        ("commit", "well-formed commits"),
+        ("review", "review diffs"),
+    ] {
         let p: PathBuf = dir.path().join(format!("skills/{name}/SKILL.md"));
         std::fs::create_dir_all(p.parent().unwrap()).unwrap();
-        std::fs::write(&p, format!("---\nname: {name}\ndescription: {desc}\n---\nbody\n"))
-            .unwrap();
+        std::fs::write(
+            &p,
+            format!("---\nname: {name}\ndescription: {desc}\n---\nbody\n"),
+        )
+        .unwrap();
     }
     let uri = format!("local:{}", dir.path().display());
     (dir, uri)
@@ -48,8 +57,14 @@ fn preview_lists_units_without_persisting() {
     assert_eq!(commit.description.as_deref(), Some("well-formed commits"));
 
     // No manifest / lockfile writes on preview.
-    assert!(!manifest_path_in(home.path()).exists(), "preview must not write the manifest");
-    assert!(!lockfile_path_in(home.path()).exists(), "preview must not write the lockfile");
+    assert!(
+        !manifest_path_in(home.path()).exists(),
+        "preview must not write the manifest"
+    );
+    assert!(
+        !lockfile_path_in(home.path()).exists(),
+        "preview must not write the lockfile"
+    );
 }
 
 #[test]
@@ -71,9 +86,13 @@ fn import_persists_source_and_installs_selection() {
 
     let mut out = Vec::new();
     let (installed, failed) =
-        import_selected(home.path(), &preview, &[commit_path], "claude", &mut out)
-            .expect("import");
-    assert_eq!((installed, failed), (1, 0), "{}", String::from_utf8_lossy(&out));
+        import_selected(home.path(), &preview, &[commit_path], "claude", &mut out).expect("import");
+    assert_eq!(
+        (installed, failed),
+        (1, 0),
+        "{}",
+        String::from_utf8_lossy(&out)
+    );
 
     // Source persisted once; selected unit locked; unselected one absent.
     let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -124,13 +124,12 @@ fn import_nothing_selected_is_an_error_and_persists_nothing() {
     assert!(!manifest_path_in(home.path()).exists());
 }
 
-fn _assert_send(_: impl Send) {}
-fn _types(p: ainb_cli::source::SourcePreview, home: &Path) {
-    // Compile-time: preview is Send (safe to move across the TUI's async
-    // action boundary later) and paths derive from `home`.
-    _assert_send(p);
-    let _ = home;
-}
+// Compile-time: SourcePreview is Send — it crosses the TUI's
+// spawn_blocking boundary in AsyncAction::SkillPreviewFetch.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<ainb_cli::source::SourcePreview>();
+};
 
 #[test]
 fn reinstall_with_different_targets_refreshes_manifest_entry() {
@@ -153,8 +152,14 @@ fn reinstall_with_different_targets_refreshes_manifest_entry() {
         .expect("commit path");
 
     let mut out = Vec::new();
-    import_selected(home.path(), &preview, &[commit_path.clone()], "claude", &mut out)
-        .expect("first import");
+    import_selected(
+        home.path(),
+        &preview,
+        &[commit_path.clone()],
+        "claude",
+        &mut out,
+    )
+    .expect("first import");
     // Re-import the same unit targeting codex only.
     import_selected(home.path(), &preview, &[commit_path], "codex", &mut out)
         .expect("second import");
@@ -199,7 +204,10 @@ fn preview_matches_existing_source_by_uri_not_slug() {
     .expect("add source");
 
     let preview = preview_source(home.path(), &uri).expect("preview");
-    assert!(preview.already_added, "same URI under custom name must be recognised");
+    assert!(
+        preview.already_added,
+        "same URI under custom name must be recognised"
+    );
     assert_eq!(preview.name, "mytools", "existing entry's name reused");
 
     // Import must not create a duplicate source.

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -131,3 +131,44 @@ fn _types(p: ainb_cli::source::SourcePreview, home: &Path) {
     _assert_send(p);
     let _ = home;
 }
+
+#[test]
+fn reinstall_with_different_targets_refreshes_manifest_entry() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+
+    let claude_root = home.path().join("tools/claude");
+    let codex_root = home.path().join("tools/codex");
+    // SAFETY: ENV_LOCK serialises env mutation across this suite.
+    unsafe {
+        std::env::set_var("AINB_TOOL_HOME_CLAUDE", &claude_root);
+        std::env::set_var("AINB_TOOL_HOME_CODEX", &codex_root);
+    }
+
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    let commit_path = unit_paths(&preview)
+        .into_iter()
+        .find(|p| p.contains("commit"))
+        .expect("commit path");
+
+    let mut out = Vec::new();
+    import_selected(home.path(), &preview, &[commit_path.clone()], "claude", &mut out)
+        .expect("first import");
+    // Re-import the same unit targeting codex only.
+    import_selected(home.path(), &preview, &[commit_path], "codex", &mut out)
+        .expect("second import");
+
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert_eq!(manifest.units.len(), 1, "still one declaration");
+    assert_eq!(
+        manifest.units[0].targets.as_deref(),
+        Some(&["codex".to_string()][..]),
+        "declared targets must follow the latest install"
+    );
+
+    unsafe {
+        std::env::remove_var("AINB_TOOL_HOME_CLAUDE");
+        std::env::remove_var("AINB_TOOL_HOME_CODEX");
+    }
+}

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -212,3 +212,34 @@ fn preview_matches_existing_source_by_uri_not_slug() {
     assert_eq!(manifest.sources.len(), 1, "no duplicate source entry");
     unsafe { std::env::remove_var("AINB_TOOL_HOME_CLAUDE") };
 }
+
+/// A fully-failed import must leave no trace: the source records written
+/// at the start of import_selected are rolled back when zero units land.
+#[test]
+fn fully_failed_import_rolls_back_the_source() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    // Bogus unit path → every install fails; no tool-home env needed.
+    let mut out = Vec::new();
+    let (installed, failed) = import_selected(
+        home.path(),
+        &preview,
+        &["skills/does-not-exist".to_string()],
+        "claude",
+        &mut out,
+    )
+    .expect("import returns Ok with counts");
+    assert_eq!((installed, failed), (0, 1));
+
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert!(
+        manifest.sources.is_empty(),
+        "failed import must not leave the source behind: {:?}",
+        manifest.sources
+    );
+    let lockfile = Lockfile::load_from(&lockfile_path_in(home.path())).unwrap();
+    assert!(lockfile.sources.is_empty(), "lockfile source rolled back");
+}

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -1,0 +1,114 @@
+//! `preview_source` / `import_selected` — the Skill Manager's
+//! preview-first add flow. Preview must leave manifest + lockfile
+//! untouched; import persists the source and installs the selected
+//! units to the chosen tools.
+
+use std::path::{Path, PathBuf};
+
+use ainb_cli::source::{import_selected, preview_source};
+use ainb_skill_core::lockfile::Lockfile;
+use ainb_skill_core::manifest::Manifest;
+use ainb_skill_core::paths::{lockfile_path_in, manifest_path_in};
+
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn tmp_home() -> tempfile::TempDir {
+    tempfile::Builder::new().prefix("ainb-preview-test-").tempdir().expect("tempdir")
+}
+
+/// Two-skill local fixture repo.
+fn fixture_repo() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    for (name, desc) in [("commit", "well-formed commits"), ("review", "review diffs")] {
+        let p: PathBuf = dir.path().join(format!("skills/{name}/SKILL.md"));
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, format!("---\nname: {name}\ndescription: {desc}\n---\nbody\n"))
+            .unwrap();
+    }
+    let uri = format!("local:{}", dir.path().display());
+    (dir, uri)
+}
+
+fn unit_paths(preview: &ainb_cli::source::SourcePreview) -> Vec<String> {
+    preview.units.iter().map(|u| u.path.clone()).collect()
+}
+
+#[test]
+fn preview_lists_units_without_persisting() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    assert_eq!(preview.units.len(), 2, "both skills discovered");
+    assert!(!preview.already_added);
+    // Frontmatter description survives into the descriptor (drives the
+    // picker's insight pane).
+    let commit = preview.units.iter().find(|u| u.name == "commit").expect("commit unit");
+    assert_eq!(commit.description.as_deref(), Some("well-formed commits"));
+
+    // No manifest / lockfile writes on preview.
+    assert!(!manifest_path_in(home.path()).exists(), "preview must not write the manifest");
+    assert!(!lockfile_path_in(home.path()).exists(), "preview must not write the lockfile");
+}
+
+#[test]
+fn import_persists_source_and_installs_selection() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+
+    // Route the claude adapter into the sandbox.
+    let claude_root = home.path().join("tools/claude");
+    // SAFETY: ENV_LOCK serialises env mutation across this suite.
+    unsafe { std::env::set_var("AINB_TOOL_HOME_CLAUDE", &claude_root) };
+
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    let commit_path = unit_paths(&preview)
+        .into_iter()
+        .find(|p| p.contains("commit"))
+        .expect("commit path");
+
+    let mut out = Vec::new();
+    let (installed, failed) =
+        import_selected(home.path(), &preview, &[commit_path], "claude", &mut out)
+            .expect("import");
+    assert_eq!((installed, failed), (1, 0), "{}", String::from_utf8_lossy(&out));
+
+    // Source persisted once; selected unit locked; unselected one absent.
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert_eq!(manifest.sources.len(), 1);
+    // The installed unit must land in manifest.units too — that's what
+    // the Skill Manager's Units table renders (regression: lockfile-only
+    // installs were invisible in the TUI).
+    assert_eq!(manifest.units.len(), 1);
+    assert!(manifest.units[0].uri.contains("commit"));
+    let lockfile = Lockfile::load_from(&lockfile_path_in(home.path())).unwrap();
+    assert_eq!(lockfile.units.len(), 1);
+    assert!(lockfile.units[0].declared_uri.contains("commit"));
+    // Deployed file actually landed under the claude root.
+    assert!(claude_root.join("skills/commit/SKILL.md").exists());
+
+    unsafe { std::env::remove_var("AINB_TOOL_HOME_CLAUDE") };
+}
+
+#[test]
+fn import_nothing_selected_is_an_error_and_persists_nothing() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    let mut out = Vec::new();
+    let err = import_selected(home.path(), &preview, &[], "claude", &mut out);
+    assert!(err.is_err());
+    assert!(!manifest_path_in(home.path()).exists());
+}
+
+fn _assert_send(_: impl Send) {}
+fn _types(p: ainb_cli::source::SourcePreview, home: &Path) {
+    // Compile-time: preview is Send (safe to move across the TUI's async
+    // action boundary later) and paths derive from `home`.
+    _assert_send(p);
+    let _ = home;
+}

--- a/ainb-tui/crates/ainb-cli/tests/skill_sync_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/skill_sync_tests.rs
@@ -170,12 +170,14 @@ fn sync_removes_orphan_lockfile_unit() {
         );
         res.expect("install");
 
-        // Manifest does NOT declare the unit → orphan.
-        let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
-        assert!(
-            manifest.units.is_empty(),
-            "manifest must not list units yet"
-        );
+        // Install now declares the unit in the manifest (so the TUI can
+        // render it). Manufacture the orphan the way it happens in the
+        // wild — the manifest entry removed by hand — then sync must
+        // clear the stale lockfile record + deployed files.
+        let mut manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+        assert_eq!(manifest.units.len(), 1, "install declares the unit");
+        manifest.units.clear();
+        manifest.save_to(&manifest_path_in(home.path())).unwrap();
 
         let (out, res) = run(
             home.path(),

--- a/ainb-tui/crates/ainb-cli/tests/skill_sync_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/skill_sync_tests.rs
@@ -307,3 +307,64 @@ fn sync_skips_non_installable_local_orphan_units() {
         );
     });
 }
+
+/// install → remove → sync must be a no-op: remove undeclares the unit
+/// from the manifest (not just the lockfile), so sync doesn't classify
+/// it as "declared but missing" and reinstall what was just removed.
+#[test]
+fn remove_undeclares_unit_so_sync_does_not_reinstall() {
+    let home = tmp_home();
+    let (_src, unit_uri) = seed_source(home.path(), "src-remove");
+    let base = tempfile::tempdir().unwrap();
+
+    with_all_tool_homes_under(base.path(), || {
+        let (_o, res) = run(
+            home.path(),
+            SkillCommand::Install(InstallArgs {
+                uri: unit_uri.clone(),
+                targets: Some("claude".into()),
+                dry_run: false,
+                yes: true,
+            }),
+        );
+        res.expect("install");
+
+        let (_o, res) = run(
+            home.path(),
+            SkillCommand::Remove(ainb_cli::RemoveSkillArgs {
+                uri: unit_uri.clone(),
+                targets: None,
+                dry_run: false,
+                yes: true,
+            }),
+        );
+        res.expect("remove");
+
+        // Manifest no longer declares the unit.
+        let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+        assert!(
+            manifest.units.is_empty(),
+            "remove must undeclare the unit: {:?}",
+            manifest.units
+        );
+
+        // Sync sees aligned state — nothing reinstalled.
+        let (out, res) = run(
+            home.path(),
+            SkillCommand::Sync(SyncArgs {
+                yes: true,
+                dry_run: false,
+                ..Default::default()
+            }),
+        );
+        res.expect("sync ok");
+        assert!(
+            out.contains("already in sync"),
+            "sync must not reinstall the removed unit, got: {out}"
+        );
+        assert!(
+            !base.path().join("claude/skills/commit/SKILL.md").exists(),
+            "removed files must stay removed after sync"
+        );
+    });
+}

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -362,6 +362,17 @@ pub enum AppEvent {
     SkillManagerBrowseToggleCatalog,
     /// Esc — close the browse modal, discarding the ephemeral results.
     SkillManagerBrowseClose,
+    // Source-preview picker (preview-first add flow): multi-select the
+    // units of a fetched source + target tools, then import.
+    SkillManagerPreviewUp,
+    SkillManagerPreviewDown,
+    SkillManagerPreviewToggle,      // Space — toggle the cursor unit
+    SkillManagerPreviewAll,         // a — select every unit
+    SkillManagerPreviewNone,        // n — clear the selection
+    SkillManagerPreviewTool(usize), // 1/2/3 toggle claude/codex/copilot; 3=all-on (key 4)
+    SkillManagerPreviewConfirm,     // Enter — import selection to chosen tools
+    SkillManagerPreviewClose,       // Esc — discard, nothing persisted
+    SkillManagerPreviewSource,      // p on a source row — reopen the picker for it
     GoToRecovery,               // Navigate to session recovery view
     GoToInbox,                  // Navigate to ainb-hooks notification inbox
     GoToDaemons,                // Navigate to the daemon runtime-health view
@@ -778,6 +789,32 @@ impl EventHandler {
             && x < rect.x.saturating_add(rect.width)
             && y >= rect.y
             && y < rect.y.saturating_add(rect.height)
+    }
+
+    /// Fetch `uri` into the cache and open the source-preview picker.
+    /// Blocking (like the pre-existing add-source path — same clone cost);
+    /// nothing is persisted until the picker's import confirms.
+    fn open_source_preview(state: &mut AppState, uri: &str) {
+        let ainb_home = ainb_skill_core::default_ainb_home();
+        match ainb_cli::source::preview_source(&ainb_home, uri) {
+            Ok(preview) if preview.units.is_empty() => {
+                state.add_warning_notification(format!(
+                    "{uri}: fetched OK but no skills/agents/commands found"
+                ));
+            }
+            Ok(preview) => {
+                tracing::info!(
+                    uri = %uri, units = preview.units.len(),
+                    "SkillManager: source preview open"
+                );
+                state.skill_manager_state.preview = Some(
+                    crate::components::skill_manager_screen::SourcePreviewViewState::new(preview),
+                );
+            }
+            Err(e) => {
+                state.add_error_notification(format!("preview failed: {e:#}"));
+            }
+        }
     }
 
     /// Map a slash-command name (leading `/` already stripped by the
@@ -1589,6 +1626,26 @@ impl EventHandler {
                 };
             }
 
+            // Source-preview picker: multi-select units + target tools.
+            // Intercepts before browse/library/banner — it's the active
+            // modal whenever open.
+            if state.skill_manager_state.preview.is_some() {
+                return match key_event.code {
+                    KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::SkillManagerPreviewUp),
+                    KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::SkillManagerPreviewDown),
+                    KeyCode::Char(' ') => Some(AppEvent::SkillManagerPreviewToggle),
+                    KeyCode::Char('a') => Some(AppEvent::SkillManagerPreviewAll),
+                    KeyCode::Char('n') => Some(AppEvent::SkillManagerPreviewNone),
+                    KeyCode::Char('1') => Some(AppEvent::SkillManagerPreviewTool(0)),
+                    KeyCode::Char('2') => Some(AppEvent::SkillManagerPreviewTool(1)),
+                    KeyCode::Char('3') => Some(AppEvent::SkillManagerPreviewTool(2)),
+                    KeyCode::Char('4') => Some(AppEvent::SkillManagerPreviewTool(3)),
+                    KeyCode::Enter => Some(AppEvent::SkillManagerPreviewConfirm),
+                    KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::SkillManagerPreviewClose),
+                    _ => None,
+                };
+            }
+
             // Catalog browse overlay (`[b]`, bead ai-a20): two phases.
             //   * Query mode — every char goes into the query buffer
             //     (so `/`, `:`, spaces all reach it); Enter searches.
@@ -1698,6 +1755,11 @@ impl EventHandler {
                     Some(AppEvent::SkillManagerSourceSelectNext)
                 }
                 KeyCode::Enter if sources_focused => Some(AppEvent::SkillManagerApplySourceFilter),
+                // `[p]` on a source row — reopen the import picker for it
+                // (preview its units, select, install more).
+                KeyCode::Char('p') if sources_focused => {
+                    Some(AppEvent::SkillManagerPreviewSource)
+                }
                 // Units panel `[s]` — dual-purpose:
                 //   * if the selected unit is part of a conflict pair,
                 //     flip the shadowed_by edge (legacy behaviour);
@@ -4927,24 +4989,14 @@ impl EventHandler {
                         let uri = crate::components::skill_manager_screen::normalize_source_input(
                             &input.buffer,
                         );
-                        tracing::info!(uri = %uri, "SkillManager: add-source submit");
+                        tracing::info!(uri = %uri, "SkillManager: add-source submit (preview-first)");
                         if uri.is_empty() {
                             return;
                         }
-                        let ainb_home = ainb_skill_core::default_ainb_home();
-                        let cmd = ainb_cli::SourceCommand::Add(ainb_cli::AddArgs {
-                            uri: uri.clone(),
-                            name: None,
-                            kind: None,
-                        });
-                        let (ok, msg) = run_source_cli(&ainb_home, cmd);
-                        tracing::info!(ok, msg = %msg, "SkillManager: add-source result");
-                        state.skill_manager_state.reload_from_disk(&ainb_home);
-                        if ok {
-                            state.add_success_notification(format!("source added: {msg}"));
-                        } else {
-                            state.add_error_notification(format!("add source failed: {msg}"));
-                        }
+                        // Preview-first: fetch + list units WITHOUT persisting;
+                        // the picker that opens decides what (if anything) is
+                        // imported. Cancelling leaves no manifest trace.
+                        Self::open_source_preview(state, &uri);
                     }
                 }
             }
@@ -5219,6 +5271,99 @@ impl EventHandler {
             }
             AppEvent::SkillManagerBrowseClose => {
                 state.skill_manager_state.browse = None;
+            }
+            AppEvent::SkillManagerPreviewUp => {
+                if let Some(p) = state.skill_manager_state.preview.as_mut() {
+                    p.move_cursor(-1);
+                }
+            }
+            AppEvent::SkillManagerPreviewDown => {
+                if let Some(p) = state.skill_manager_state.preview.as_mut() {
+                    p.move_cursor(1);
+                }
+            }
+            AppEvent::SkillManagerPreviewToggle => {
+                if let Some(p) = state.skill_manager_state.preview.as_mut() {
+                    p.toggle_current();
+                }
+            }
+            AppEvent::SkillManagerPreviewAll => {
+                if let Some(p) = state.skill_manager_state.preview.as_mut() {
+                    p.set_all(true);
+                }
+            }
+            AppEvent::SkillManagerPreviewNone => {
+                if let Some(p) = state.skill_manager_state.preview.as_mut() {
+                    p.set_all(false);
+                }
+            }
+            AppEvent::SkillManagerPreviewTool(i) => {
+                if let Some(p) = state.skill_manager_state.preview.as_mut() {
+                    p.toggle_tool(i);
+                }
+            }
+            AppEvent::SkillManagerPreviewClose => {
+                // Discard — preview never persisted anything.
+                state.skill_manager_state.preview = None;
+            }
+            AppEvent::SkillManagerPreviewSource => {
+                // `[p]` on a source row — reopen the picker for that source.
+                let uri = state
+                    .skill_manager_state
+                    .sources
+                    .get(state.skill_manager_state.source_selected)
+                    .map(|s| s.uri.clone());
+                if let Some(uri) = uri {
+                    Self::open_source_preview(state, &uri);
+                }
+            }
+            AppEvent::SkillManagerPreviewConfirm => {
+                let Some(view) = state.skill_manager_state.preview.clone() else {
+                    return;
+                };
+                let paths = view.checked_paths();
+                if paths.is_empty() {
+                    state.add_warning_notification(
+                        "Nothing selected — Space to pick, a for all".to_string(),
+                    );
+                    return;
+                }
+                let Some(targets) = view.targets_csv() else {
+                    state.add_warning_notification(
+                        "No target tool — 1/2/3 toggle claude/codex/copilot".to_string(),
+                    );
+                    return;
+                };
+                let ainb_home = ainb_skill_core::default_ainb_home();
+                let mut buf: Vec<u8> = Vec::new();
+                match ainb_cli::source::import_selected(
+                    &ainb_home,
+                    &view.preview,
+                    &paths,
+                    &targets,
+                    &mut buf,
+                ) {
+                    Ok((installed, failed)) => {
+                        state.skill_manager_state.preview = None;
+                        state.skill_manager_state.reload_from_disk(&ainb_home);
+                        if failed == 0 {
+                            state.add_success_notification(format!(
+                                "imported {installed} unit(s) → {targets}"
+                            ));
+                        } else {
+                            state.add_warning_notification(format!(
+                                "imported {installed}, {failed} failed → {targets} (see logs)"
+                            ));
+                            tracing::warn!(
+                                output = %String::from_utf8_lossy(&buf),
+                                "SkillManager: import finished with failures"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        state.add_error_notification(format!("import failed: {e:#}"));
+                    }
+                }
             }
             AppEvent::GoToInbox => {
                 tracing::info!("Navigating to Inbox");

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -373,36 +373,36 @@ pub enum AppEvent {
     SkillManagerPreviewConfirm,     // Enter — import selection to chosen tools
     SkillManagerPreviewClose,       // Esc — discard, nothing persisted
     SkillManagerPreviewSource,      // p on a source row — reopen the picker for it
-    GoToRecovery,               // Navigate to session recovery view
-    GoToInbox,                  // Navigate to ainb-hooks notification inbox
-    GoToDaemons,                // Navigate to the daemon runtime-health view
-    GoToFleetPanel,             // Navigate to the fleet control panel (current_state)
-    FleetPanelMoveUp,           // Fleet panel: move row selection up
-    FleetPanelMoveDown,         // Fleet panel: move row selection down
-    FleetPanelOptionNext,       // Fleet panel: move ASK option cursor forward (Tab)
-    FleetPanelOptionPrev,       // Fleet panel: move ASK option cursor back (Shift+Tab)
-    FleetPanelAnswer,           // Fleet panel: answer selected ASK with the option (Enter/a)
-    FleetPanelBroadcast,        // Fleet panel: broadcast a ping to the selected session (B)
-    FleetPanelApprove,          // Fleet panel: approve the selected APPROVE permission request (y)
-    FleetPanelDeny,             // Fleet panel: deny the selected APPROVE permission request (n)
-    FleetPanelRefresh,          // Fleet panel: force-refresh from current_state (r)
-    FleetPanelNewAtcOpen,       // Fleet panel: open the new-ATC name prompt (n)
+    GoToRecovery,                   // Navigate to session recovery view
+    GoToInbox,                      // Navigate to ainb-hooks notification inbox
+    GoToDaemons,                    // Navigate to the daemon runtime-health view
+    GoToFleetPanel,                 // Navigate to the fleet control panel (current_state)
+    FleetPanelMoveUp,               // Fleet panel: move row selection up
+    FleetPanelMoveDown,             // Fleet panel: move row selection down
+    FleetPanelOptionNext,           // Fleet panel: move ASK option cursor forward (Tab)
+    FleetPanelOptionPrev,           // Fleet panel: move ASK option cursor back (Shift+Tab)
+    FleetPanelAnswer,               // Fleet panel: answer selected ASK with the option (Enter/a)
+    FleetPanelBroadcast,            // Fleet panel: broadcast a ping to the selected session (B)
+    FleetPanelApprove, // Fleet panel: approve the selected APPROVE permission request (y)
+    FleetPanelDeny,    // Fleet panel: deny the selected APPROVE permission request (n)
+    FleetPanelRefresh, // Fleet panel: force-refresh from current_state (r)
+    FleetPanelNewAtcOpen, // Fleet panel: open the new-ATC name prompt (n)
     FleetPanelNewAtcType(char), // Fleet panel: type a char into the name prompt
-    FleetPanelNewAtcBackspace,  // Fleet panel: delete last char of the name prompt
-    FleetPanelNewAtcCancel,     // Fleet panel: cancel the name prompt (Esc)
-    FleetPanelNewAtcSubmit,     // Fleet panel: create the ATC (Enter)
-    PanelBack,                  // Close a panel screen: pop previous_screen (home if none)
-    GoToHangar,                 // Navigate to the Hangar control plane (plugin screen)
-    InboxMoveUp,                // Inbox: move selection up one row
-    InboxMoveDown,              // Inbox: move selection down one row
-    InboxPageUp,                // Inbox: jump 10 rows up
-    InboxPageDown,              // Inbox: jump 10 rows down
-    InboxOpenSelected,          // Inbox: mark selected row read (Enter)
-    InboxDismissSelected,       // Inbox: dismiss selected row (d)
-    InboxDismissVisible,        // Inbox: dismiss every visible row (Shift+C)
-    InboxToggleArchived,        // Inbox: toggle dismissed filter (a)
-    InboxCycleAgent,            // Inbox: cycle agent filter (p)
-    InboxRefresh,               // Inbox: force-refresh from store (r)
+    FleetPanelNewAtcBackspace, // Fleet panel: delete last char of the name prompt
+    FleetPanelNewAtcCancel, // Fleet panel: cancel the name prompt (Esc)
+    FleetPanelNewAtcSubmit, // Fleet panel: create the ATC (Enter)
+    PanelBack,         // Close a panel screen: pop previous_screen (home if none)
+    GoToHangar,        // Navigate to the Hangar control plane (plugin screen)
+    InboxMoveUp,       // Inbox: move selection up one row
+    InboxMoveDown,     // Inbox: move selection down one row
+    InboxPageUp,       // Inbox: jump 10 rows up
+    InboxPageDown,     // Inbox: jump 10 rows down
+    InboxOpenSelected, // Inbox: mark selected row read (Enter)
+    InboxDismissSelected, // Inbox: dismiss selected row (d)
+    InboxDismissVisible, // Inbox: dismiss every visible row (Shift+C)
+    InboxToggleArchived, // Inbox: toggle dismissed filter (a)
+    InboxCycleAgent,   // Inbox: cycle agent filter (p)
+    InboxRefresh,      // Inbox: force-refresh from store (r)
     // AINB 2.0: Agent selection events
     // AINB 2.0: Config screen events
     ConfigBack,            // Return to home screen (Esc)
@@ -1757,9 +1757,7 @@ impl EventHandler {
                 KeyCode::Enter if sources_focused => Some(AppEvent::SkillManagerApplySourceFilter),
                 // `[p]` on a source row — reopen the import picker for it
                 // (preview its units, select, install more).
-                KeyCode::Char('p') if sources_focused => {
-                    Some(AppEvent::SkillManagerPreviewSource)
-                }
+                KeyCode::Char('p') if sources_focused => Some(AppEvent::SkillManagerPreviewSource),
                 // Units panel `[s]` — dual-purpose:
                 //   * if the selected unit is part of a conflict pair,
                 //     flip the shadowed_by edge (legacy behaviour);
@@ -6731,9 +6729,10 @@ impl EventHandler {
                 use crate::components::onboarding::AuthPane;
                 if let Some(o) = state.onboarding_state.as_mut() {
                     o.auth_pane = match &o.auth_pane {
-                        AuthPane::KeyEntry { agent, .. } => {
-                            AuthPane::MethodPicker { agent: *agent, cursor: 1 }
-                        }
+                        AuthPane::KeyEntry { agent, .. } => AuthPane::MethodPicker {
+                            agent: *agent,
+                            cursor: 1,
+                        },
                         _ => AuthPane::AgentList,
                     };
                 }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -802,8 +802,9 @@ impl EventHandler {
             return;
         }
         state.skill_manager_state.preview_loading = Some(uri.to_string());
-        state.pending_async_action =
-            Some(crate::app::state::AsyncAction::SkillPreviewFetch(uri.to_string()));
+        state.pending_async_action = Some(crate::app::state::AsyncAction::SkillPreviewFetch(
+            uri.to_string(),
+        ));
     }
 
     /// Map a slash-command name (leading `/` already stripped by the
@@ -5316,20 +5317,28 @@ impl EventHandler {
                 }
             }
             AppEvent::SkillManagerPreviewConfirm => {
-                let Some(view) = state.skill_manager_state.preview.clone() else {
-                    return;
+                // Validate on a borrow (no deep clone of a potentially
+                // 95-unit view); only take() the state once we commit.
+                let (paths, targets) = {
+                    let Some(view) = state.skill_manager_state.preview.as_ref() else {
+                        return;
+                    };
+                    let paths = view.checked_paths();
+                    if paths.is_empty() {
+                        state.add_warning_notification(
+                            "Nothing selected — Space to pick, a for all".to_string(),
+                        );
+                        return;
+                    }
+                    let Some(targets) = view.targets_csv() else {
+                        state.add_warning_notification(
+                            "No target tool — 1/2/3 toggle claude/codex/copilot".to_string(),
+                        );
+                        return;
+                    };
+                    (paths, targets)
                 };
-                let paths = view.checked_paths();
-                if paths.is_empty() {
-                    state.add_warning_notification(
-                        "Nothing selected — Space to pick, a for all".to_string(),
-                    );
-                    return;
-                }
-                let Some(targets) = view.targets_csv() else {
-                    state.add_warning_notification(
-                        "No target tool — 1/2/3 toggle claude/codex/copilot".to_string(),
-                    );
+                let Some(view) = state.skill_manager_state.preview.take() else {
                     return;
                 };
                 let ainb_home = ainb_skill_core::default_ainb_home();
@@ -5342,7 +5351,6 @@ impl EventHandler {
                     &mut buf,
                 ) {
                     Ok((installed, failed)) => {
-                        state.skill_manager_state.preview = None;
                         state.skill_manager_state.reload_from_disk(&ainb_home);
                         if failed == 0 {
                             state.add_success_notification(format!(
@@ -5360,6 +5368,8 @@ impl EventHandler {
                     }
                     Err(e) => {
                         state.add_error_notification(format!("import failed: {e:#}"));
+                        // Reopen the picker with the user's selection intact.
+                        state.skill_manager_state.preview = Some(view);
                     }
                 }
             }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -5306,14 +5306,25 @@ impl EventHandler {
                 state.skill_manager_state.preview = None;
             }
             AppEvent::SkillManagerPreviewSource => {
-                // `[p]` on a source row — reopen the picker for that source.
-                let uri = state
+                // `[p]` on a source row — reopen the picker for that source,
+                // at its DECLARED ref (bare uri would default to `main`,
+                // silently swapping the name-keyed cache checkout).
+                let row = state
                     .skill_manager_state
                     .sources
                     .get(state.skill_manager_state.source_selected)
-                    .map(|s| s.uri.clone());
-                if let Some(uri) = uri {
-                    Self::open_source_preview(state, &uri);
+                    .cloned();
+                if let Some(row) = row {
+                    if !row.enabled {
+                        // install() only matches enabled sources — a preview
+                        // would fetch fine and then fail every unit late.
+                        state.add_warning_notification(format!(
+                            "source `{}` is disabled — enable it before importing",
+                            row.name
+                        ));
+                        return;
+                    }
+                    Self::open_source_preview(state, &format!("{}@{}", row.uri, row.r#ref));
                 }
             }
             AppEvent::SkillManagerPreviewConfirm => {

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -792,30 +792,18 @@ impl EventHandler {
             && y < rect.y.saturating_add(rect.height)
     }
 
-    /// Fetch `uri` into the cache and open the source-preview picker.
-    /// Blocking (like the pre-existing add-source path — same clone cost);
-    /// nothing is persisted until the picker's import confirms.
+    /// Queue a background fetch of `uri` (git clone off the event loop) that
+    /// opens the source-preview picker on completion. The loading banner
+    /// renders meanwhile; a second request while one is in flight is
+    /// ignored. Nothing is persisted until the picker's import confirms.
     fn open_source_preview(state: &mut AppState, uri: &str) {
-        let ainb_home = ainb_skill_core::default_ainb_home();
-        match ainb_cli::source::preview_source(&ainb_home, uri) {
-            Ok(preview) if preview.units.is_empty() => {
-                state.add_warning_notification(format!(
-                    "{uri}: fetched OK but no skills/agents/commands found"
-                ));
-            }
-            Ok(preview) => {
-                tracing::info!(
-                    uri = %uri, units = preview.units.len(),
-                    "SkillManager: source preview open"
-                );
-                state.skill_manager_state.preview = Some(
-                    crate::components::skill_manager_screen::SourcePreviewViewState::new(preview),
-                );
-            }
-            Err(e) => {
-                state.add_error_notification(format!("preview failed: {e:#}"));
-            }
+        if state.skill_manager_state.preview_loading.is_some() {
+            state.add_warning_notification("a source fetch is already running".to_string());
+            return;
         }
+        state.skill_manager_state.preview_loading = Some(uri.to_string());
+        state.pending_async_action =
+            Some(crate::app::state::AsyncAction::SkillPreviewFetch(uri.to_string()));
     }
 
     /// Map a slash-command name (leading `/` already stripped by the

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -733,10 +733,10 @@ impl EventHandler {
     }
 
     /// True when a SkillManager overlay (banner / input prompt / library
-    /// / browse modal) is open OR the help overlay is visible — i.e. the
-    /// underlying Sources/Units panels are NOT the active surface. Mouse
-    /// hit-testing on the panels is suppressed in that case so a click
-    /// meant for the modal doesn't leak through.
+    /// / browse / source-preview modal) is open OR the help overlay is
+    /// visible — i.e. the underlying Sources/Units panels are NOT the
+    /// active surface. Mouse hit-testing on the panels is suppressed in
+    /// that case so a click meant for the modal doesn't leak through.
     fn skill_manager_overlay_open(state: &AppState) -> bool {
         let s = &state.skill_manager_state;
         state.help_visible
@@ -744,6 +744,7 @@ impl EventHandler {
             || s.input.is_some()
             || s.library.is_some()
             || s.browse.is_some()
+            || s.preview.is_some()
     }
 
     /// Recompute the SkillManager top-row rects (Sources panel + Units

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3399,6 +3399,9 @@ pub enum AsyncAction {
     // Onboarding actions
     OnboardingCheckDeps,          // Run dependency check during onboarding
     OnboardingInstallDep(String), // Install one dep (by id) from the deps screen
+    /// Fetch + parse a skill source (git clone) off the event loop, then
+    /// open the Skill Manager's source-preview picker with the result.
+    SkillPreviewFetch(String),
 }
 
 impl Default for AppState {
@@ -9395,6 +9398,40 @@ impl AppState {
                             }
                         }
                     }
+                }
+                AsyncAction::SkillPreviewFetch(uri) => {
+                    info!(uri = %uri, "Fetching skill source for preview");
+                    let ainb_home = ainb_skill_core::default_ainb_home();
+                    let fetch_uri = uri.clone();
+                    // Git clone + adapter scan — blocking I/O off the runtime.
+                    let result = tokio::task::spawn_blocking(move || {
+                        ainb_cli::source::preview_source(&ainb_home, &fetch_uri)
+                    })
+                    .await;
+                    self.skill_manager_state.preview_loading = None;
+                    match result {
+                        Ok(Ok(preview)) if preview.units.is_empty() => {
+                            self.add_warning_notification(format!(
+                                "{uri}: fetched OK but no skills/agents/commands found"
+                            ));
+                        }
+                        Ok(Ok(preview)) => {
+                            info!(uri = %uri, units = preview.units.len(),
+                                  "SkillManager: source preview open");
+                            self.skill_manager_state.preview = Some(
+                                crate::components::skill_manager_screen::SourcePreviewViewState::new(
+                                    preview,
+                                ),
+                            );
+                        }
+                        Ok(Err(e)) => {
+                            self.add_error_notification(format!("preview failed: {e:#}"));
+                        }
+                        Err(e) => {
+                            self.add_error_notification(format!("preview task failed: {e}"));
+                        }
+                    }
+                    self.ui_needs_refresh = true;
                 }
             }
         }

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -1047,10 +1047,7 @@ impl OnboardingComponent {
         ]));
 
         // Auth — per-agent summary (e.g. "Claude login • Codex api key")
-        let auth_status = state
-            .auth_method
-            .clone()
-            .unwrap_or_else(|| "not configured".to_string());
+        let auth_status = state.auth_method.clone().unwrap_or_else(|| "not configured".to_string());
         summary_items.push(Line::from(vec![
             Span::styled(
                 if state.auth_completed {

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -521,8 +521,7 @@ impl OnboardingState {
             return;
         }
         let max = (self.auth_statuses.len() - 1) as isize;
-        self.auth_agent_cursor =
-            (self.auth_agent_cursor as isize + delta).clamp(0, max) as usize;
+        self.auth_agent_cursor = (self.auth_agent_cursor as isize + delta).clamp(0, max) as usize;
     }
 
     /// The agent under the list cursor, if any.
@@ -555,11 +554,18 @@ impl OnboardingState {
                     credentials::has_credential(key)
                 };
                 let (method, key_masked) = if is_api {
-                    (AuthMethodKind::ApiKey, Some(credentials::get_credential_masked(key)))
+                    (
+                        AuthMethodKind::ApiKey,
+                        Some(credentials::get_credential_masked(key)),
+                    )
                 } else {
                     (AuthMethodKind::Login, None)
                 };
-                AgentAuthStatus { agent, method, key_masked }
+                AgentAuthStatus {
+                    agent,
+                    method,
+                    key_masked,
+                }
             })
             .collect();
 
@@ -732,11 +738,8 @@ impl OnboardingState {
         if paths.is_empty() {
             return;
         }
-        self.git_directories_input = paths
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
+        self.git_directories_input =
+            paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ");
         self.cursor_position = self.git_directories_input.len();
         self.validate_git_directories();
     }
@@ -933,7 +936,11 @@ mod tests {
         assert_eq!(AuthAgent::all().len(), 4);
         for (agent, env) in expected {
             assert_eq!(agent.env_var(), env, "{} env var drift", agent.label());
-            assert!(agent.doc_url().starts_with("https://"), "{} missing doc url", agent.label());
+            assert!(
+                agent.doc_url().starts_with("https://"),
+                "{} missing doc url",
+                agent.label()
+            );
             assert!(!agent.login_label().is_empty());
         }
     }

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -179,6 +179,10 @@ pub struct SkillsScreenData {
     /// on an existing source row). Multi-select units + target tools;
     /// nothing is persisted until Enter confirms the import.
     pub preview: Option<SourcePreviewViewState>,
+    /// `Some(uri)` while a preview fetch (git clone) runs in the
+    /// background — renders a "fetching…" banner and blocks a second
+    /// concurrent fetch. Cleared when the fetch completes either way.
+    pub preview_loading: Option<String>,
     /// Width (terminal columns) of the left Sources panel. Resizable by
     /// dragging the Sources/Units divider or via `[`/`]`. Persisted to
     /// `ui_preferences.skill_manager_sources_width` on resize-finish and
@@ -226,6 +230,7 @@ impl Default for SkillsScreenData {
             library: None,
             browse: None,
             preview: None,
+            preview_loading: None,
             sources_width: DEFAULT_SOURCES_WIDTH,
             focused_pane: FocusedSkillPane::default(),
             source_selected: 0,
@@ -724,6 +729,28 @@ pub fn render(frame: &mut Frame, area: Rect, data: &SkillsScreenData) {
     // modal after an add-source fetch or `[p]` on a source row).
     if let Some(preview) = &data.preview {
         render_source_preview(frame, area, preview);
+    }
+
+    // Background fetch in flight — small centered banner so the user
+    // sees progress instead of a frozen screen.
+    if let Some(uri) = &data.preview_loading {
+        let rect = centered_rect(area, (uri.len() as u16 + 20).clamp(30, area.width), 3);
+        frame.render_widget(Clear, rect);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(GOLD));
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("⏳ fetching ", Style::default().fg(SOFT_WHITE)),
+                Span::styled(uri.clone(), Style::default().fg(CORNFLOWER_BLUE)),
+                Span::styled(" …", Style::default().fg(MUTED_GRAY)),
+            ]))
+            .alignment(ratatui::layout::Alignment::Center),
+            inner,
+        );
     }
 
     // Input prompt overlay (add-source / search) — drawn on top of

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -47,6 +47,9 @@ const ERROR_RED: Color = Color::Rgb(230, 110, 110);
 pub struct SourceRow {
     pub name: String,
     pub uri: String,
+    /// Declared ref (branch/tag) from the manifest — `[p]` re-preview
+    /// must fetch this ref, not default to `main`.
+    pub r#ref: String,
     pub enabled: bool,
 }
 
@@ -2334,6 +2337,7 @@ fn refresh_view_model_from_manifest(data: &mut SkillsScreenData, manifest: &Mani
         .map(|s| SourceRow {
             name: s.name.clone(),
             uri: s.uri.clone(),
+            r#ref: s.r#ref.clone(),
             enabled: s.enabled,
         })
         .collect();
@@ -2878,6 +2882,7 @@ mod tests {
         SourceRow {
             name: name.to_string(),
             uri: uri.to_string(),
+            r#ref: "main".to_string(),
             enabled: true,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -463,7 +463,11 @@ impl SourcePreviewViewState {
             .filter(|(_, on)| **on)
             .map(|(t, _)| *t)
             .collect();
-        if picked.is_empty() { None } else { Some(picked.join(",")) }
+        if picked.is_empty() {
+            None
+        } else {
+            Some(picked.join(","))
+        }
     }
 }
 
@@ -886,7 +890,10 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
                 box_glyph,
                 Style::default().fg(if checked { SELECTION_GREEN } else { MUTED_GRAY }),
             ),
-            Span::styled(format!("{:<8}", unit.kind), Style::default().fg(CORNFLOWER_BLUE)),
+            Span::styled(
+                format!("{:<8}", unit.kind),
+                Style::default().fg(CORNFLOWER_BLUE),
+            ),
             Span::styled(unit.name.clone(), name_style),
         ]));
     }
@@ -953,7 +960,10 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
             Style::default().fg(if *on { SELECTION_GREEN } else { MUTED_GRAY }),
         ));
     }
-    tool_spans.push(Span::styled("4 ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)));
+    tool_spans.push(Span::styled(
+        "4 ",
+        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+    ));
     tool_spans.push(Span::styled("all", Style::default().fg(MUTED_GRAY)));
     frame.render_widget(Paragraph::new(Line::from(tool_spans)), rows[1]);
 
@@ -2413,10 +2423,7 @@ mod tests {
             fetched_path: PathBuf::from("/tmp/x"),
             resolved_sha: "abc".to_string(),
             fetched_at: "now".to_string(),
-            units: unit_names
-                .iter()
-                .map(|n| ainb_adapters_source_unit(n))
-                .collect(),
+            units: unit_names.iter().map(|n| ainb_adapters_source_unit(n)).collect(),
             already_added: false,
         })
     }

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -172,6 +172,10 @@ pub struct SkillsScreenData {
     /// ephemeral search results (NO SQLite — discarded on close). Sourced
     /// from a `CatalogBackend`, not the manifest (bead ai-a20).
     pub browse: Option<BrowseViewState>,
+    /// Source-preview picker: `Some` after an add-source fetch (or `[p]`
+    /// on an existing source row). Multi-select units + target tools;
+    /// nothing is persisted until Enter confirms the import.
+    pub preview: Option<SourcePreviewViewState>,
     /// Width (terminal columns) of the left Sources panel. Resizable by
     /// dragging the Sources/Units divider or via `[`/`]`. Persisted to
     /// `ui_preferences.skill_manager_sources_width` on resize-finish and
@@ -218,6 +222,7 @@ impl Default for SkillsScreenData {
             search: None,
             library: None,
             browse: None,
+            preview: None,
             sources_width: DEFAULT_SOURCES_WIDTH,
             focused_pane: FocusedSkillPane::default(),
             source_selected: 0,
@@ -374,6 +379,91 @@ impl BrowseViewState {
         self.status = Some(format!(
             "⚠ runs a shell command — Enter again to run: {cmd}"
         ));
+    }
+}
+
+/// Target tools offered as checkboxes in the source-preview picker, in
+/// key order (`1`/`2`/`3` toggle; `4` = all). Other adapters stay
+/// CLI-only (`ainb skill install --targets`).
+pub const PREVIEW_TOOLS: [&str; 3] = ["claude", "codex", "copilot"];
+
+/// Source-preview picker state: the fetched-but-not-persisted source, a
+/// checkbox per discovered unit, and the target-tool checkboxes.
+#[derive(Debug, Clone)]
+pub struct SourcePreviewViewState {
+    pub preview: ainb_cli::source::SourcePreview,
+    /// One checkbox per `preview.units` entry. Opt-in: all false on open.
+    pub checked: Vec<bool>,
+    pub cursor: usize,
+    /// claude / codex / copilot (see [`PREVIEW_TOOLS`]). Claude on by
+    /// default — the primary tool this manager fronts.
+    pub tools: [bool; 3],
+}
+
+impl SourcePreviewViewState {
+    pub fn new(preview: ainb_cli::source::SourcePreview) -> Self {
+        let n = preview.units.len();
+        Self {
+            preview,
+            checked: vec![false; n],
+            cursor: 0,
+            tools: [true, false, false],
+        }
+    }
+
+    pub fn move_cursor(&mut self, delta: isize) {
+        let len = self.preview.units.len();
+        if len == 0 {
+            return;
+        }
+        let max = (len - 1) as isize;
+        self.cursor = (self.cursor as isize + delta).clamp(0, max) as usize;
+    }
+
+    pub fn toggle_current(&mut self) {
+        if let Some(c) = self.checked.get_mut(self.cursor) {
+            *c = !*c;
+        }
+    }
+
+    pub fn set_all(&mut self, on: bool) {
+        self.checked.iter_mut().for_each(|c| *c = on);
+    }
+
+    /// Toggle tool checkbox `i` (0..3). `3` = turn all three on.
+    pub fn toggle_tool(&mut self, i: usize) {
+        if i == 3 {
+            self.tools = [true, true, true];
+        } else if let Some(t) = self.tools.get_mut(i) {
+            *t = !*t;
+        }
+    }
+
+    pub fn checked_count(&self) -> usize {
+        self.checked.iter().filter(|c| **c).count()
+    }
+
+    /// Unit paths (relative to the source root) currently checked.
+    pub fn checked_paths(&self) -> Vec<String> {
+        self.preview
+            .units
+            .iter()
+            .zip(&self.checked)
+            .filter(|(_, c)| **c)
+            .map(|(u, _)| u.path.clone())
+            .collect()
+    }
+
+    /// Comma-separated targets for `import_selected`; `None` when no
+    /// tool is checked.
+    pub fn targets_csv(&self) -> Option<String> {
+        let picked: Vec<&str> = PREVIEW_TOOLS
+            .iter()
+            .zip(&self.tools)
+            .filter(|(_, on)| **on)
+            .map(|(t, _)| *t)
+            .collect();
+        if picked.is_empty() { None } else { Some(picked.join(",")) }
     }
 }
 
@@ -623,6 +713,12 @@ pub fn render(frame: &mut Frame, area: Rect, data: &SkillsScreenData) {
         render_browse_view(frame, area, browse);
     }
 
+    // Source-preview picker — drawn above the panels + banner (active
+    // modal after an add-source fetch or `[p]` on a source row).
+    if let Some(preview) = &data.preview {
+        render_source_preview(frame, area, preview);
+    }
+
     // Input prompt overlay (add-source / search) — drawn on top of
     // everything, including the banner, since it's the active modal.
     if let Some(input) = &data.input {
@@ -728,6 +824,157 @@ fn render_library_view(frame: &mut Frame, area: Rect, library: &LibraryViewState
 /// below. In Query mode the input is the active focus (type → Enter
 /// searches); in Results mode the list is focused (arrows → Enter
 /// installs the selected hit).
+/// Source-preview picker: left = unit list with checkboxes, right =
+/// frontmatter insight for the cursor row, bottom = target-tool
+/// checkboxes + key hints.
+fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewViewState) {
+    let width = area.width.saturating_sub(4).clamp(60, 130);
+    let height = area.height.saturating_sub(2).clamp(14, 40);
+    let rect = centered_rect(area, width, height);
+    frame.render_widget(Clear, rect);
+
+    let p = &view.preview;
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(GOLD))
+        .title(Span::styled(
+            format!(
+                " Import from {} — {} unit(s), {} selected ",
+                p.stored_uri,
+                p.units.len(),
+                view.checked_count()
+            ),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(4),    // unit list | detail
+            Constraint::Length(1), // tool checkboxes
+            Constraint::Length(1), // key hints
+        ])
+        .split(inner);
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(rows[0]);
+
+    // ── Left: scrolling unit list with checkboxes.
+    let visible = cols[0].height as usize;
+    let top = view.cursor.saturating_sub(visible.saturating_sub(1));
+    let mut list_lines: Vec<Line> = Vec::new();
+    for (i, unit) in p.units.iter().enumerate().skip(top).take(visible) {
+        let on_cursor = i == view.cursor;
+        let checked = view.checked.get(i).copied().unwrap_or(false);
+        let box_glyph = if checked { "[x] " } else { "[ ] " };
+        let marker = if on_cursor { "\u{25b6} " } else { "  " };
+        let name_style = if on_cursor {
+            Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
+        } else if checked {
+            Style::default().fg(SOFT_WHITE)
+        } else {
+            Style::default().fg(MUTED_GRAY)
+        };
+        list_lines.push(Line::from(vec![
+            Span::styled(marker, Style::default().fg(SELECTION_GREEN)),
+            Span::styled(
+                box_glyph,
+                Style::default().fg(if checked { SELECTION_GREEN } else { MUTED_GRAY }),
+            ),
+            Span::styled(format!("{:<8}", unit.kind), Style::default().fg(CORNFLOWER_BLUE)),
+            Span::styled(unit.name.clone(), name_style),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(list_lines), cols[0]);
+
+    // ── Right: frontmatter insight for the cursor row.
+    let mut detail: Vec<Line> = Vec::new();
+    if let Some(unit) = p.units.get(view.cursor) {
+        detail.push(Line::from(vec![
+            Span::styled("name  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                unit.name.clone(),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        detail.push(Line::from(vec![
+            Span::styled("kind  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(unit.kind.clone(), Style::default().fg(CORNFLOWER_BLUE)),
+        ]));
+        detail.push(Line::from(vec![
+            Span::styled("path  ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(unit.path.clone(), Style::default().fg(MUTED_GRAY)),
+        ]));
+        detail.push(Line::from(""));
+        detail.push(Line::from(Span::styled(
+            unit.description.clone().unwrap_or_else(|| "(no description)".to_string()),
+            Style::default().fg(SOFT_WHITE),
+        )));
+        if !unit.tags.is_empty() {
+            detail.push(Line::from(""));
+            detail.push(Line::from(Span::styled(
+                format!("tags: {}", unit.tags.join(", ")),
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+        if !unit.requires.is_empty() {
+            detail.push(Line::from(Span::styled(
+                format!("requires: {}", unit.requires.join(", ")),
+                Style::default().fg(MUTED_GRAY),
+            )));
+        }
+    }
+    frame.render_widget(
+        Paragraph::new(detail).wrap(ratatui::widgets::Wrap { trim: true }).block(
+            Block::default()
+                .borders(Borders::LEFT)
+                .border_style(Style::default().fg(MUTED_GRAY)),
+        ),
+        cols[1],
+    );
+
+    // ── Tool checkboxes.
+    let mut tool_spans: Vec<Span> = vec![Span::styled(
+        " Install to  ",
+        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+    )];
+    for (i, (tool, on)) in PREVIEW_TOOLS.iter().zip(&view.tools).enumerate() {
+        tool_spans.push(Span::styled(
+            format!("{} ", i + 1),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+        tool_spans.push(Span::styled(
+            format!("[{}] {tool}   ", if *on { "x" } else { " " }),
+            Style::default().fg(if *on { SELECTION_GREEN } else { MUTED_GRAY }),
+        ));
+    }
+    tool_spans.push(Span::styled("4 ", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)));
+    tool_spans.push(Span::styled("all", Style::default().fg(MUTED_GRAY)));
+    frame.render_widget(Paragraph::new(Line::from(tool_spans)), rows[1]);
+
+    // ── Key hints.
+    let hints = Line::from(vec![
+        Span::styled(" \u{2191}\u{2193}", Style::default().fg(GOLD)),
+        Span::styled(" move  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Space", Style::default().fg(GOLD)),
+        Span::styled(" toggle  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("a", Style::default().fg(GOLD)),
+        Span::styled(" all  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("n", Style::default().fg(GOLD)),
+        Span::styled(" none  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Enter", Style::default().fg(GOLD)),
+        Span::styled(" import  ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Esc", Style::default().fg(GOLD)),
+        Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
+    ]);
+    frame.render_widget(Paragraph::new(hints), rows[2]);
+}
+
 fn render_browse_view(frame: &mut Frame, area: Rect, browse: &BrowseViewState) {
     let width = area.width.saturating_sub(6).clamp(50, 110);
     let list_lines = (browse.results.len() as u16).max(1);
@@ -2156,6 +2403,68 @@ mod tests {
     use ainb_cli::discovery::class_a::{
         DiscoveredMarketplaceUnit, DiscoveredUnit, DiscoveredUnitKind,
     };
+
+    fn mk_preview(unit_names: &[&str]) -> SourcePreviewViewState {
+        SourcePreviewViewState::new(ainb_cli::source::SourcePreview {
+            name: "test-src".to_string(),
+            stored_uri: "gh:o/r".to_string(),
+            r#ref: "main".to_string(),
+            kind: "raw".to_string(),
+            fetched_path: PathBuf::from("/tmp/x"),
+            resolved_sha: "abc".to_string(),
+            fetched_at: "now".to_string(),
+            units: unit_names
+                .iter()
+                .map(|n| ainb_adapters_source_unit(n))
+                .collect(),
+            already_added: false,
+        })
+    }
+
+    fn ainb_adapters_source_unit(name: &str) -> ainb_cli::source::UnitDescriptor {
+        ainb_cli::source::UnitDescriptor {
+            name: name.to_string(),
+            kind: "skill".to_string(),
+            description: Some(format!("{name} desc")),
+            path: format!("skills/{name}"),
+            tags: Vec::new(),
+            requires: Vec::new(),
+        }
+    }
+
+    /// Picker defaults: opt-in selection (nothing checked), claude the
+    /// only target; a/n + Space + tool keys drive the state; targets_csv
+    /// reflects the checkboxes and goes None when all are off.
+    #[test]
+    fn preview_picker_selection_and_targets() {
+        let mut v = mk_preview(&["one", "two", "three"]);
+        assert_eq!(v.checked_count(), 0, "opt-in default");
+        assert_eq!(v.targets_csv().as_deref(), Some("claude"));
+
+        v.toggle_current(); // check `one`
+        v.move_cursor(1);
+        v.toggle_current(); // check `two`
+        assert_eq!(v.checked_paths(), vec!["skills/one", "skills/two"]);
+
+        v.set_all(true);
+        assert_eq!(v.checked_count(), 3);
+        v.set_all(false);
+        assert_eq!(v.checked_count(), 0);
+
+        v.toggle_tool(1); // + codex
+        assert_eq!(v.targets_csv().as_deref(), Some("claude,codex"));
+        v.toggle_tool(0); // - claude
+        v.toggle_tool(1); // - codex
+        assert_eq!(v.targets_csv(), None, "no tools selected");
+        v.toggle_tool(3); // all on
+        assert_eq!(v.targets_csv().as_deref(), Some("claude,codex,copilot"));
+
+        // Cursor clamps at both ends.
+        v.move_cursor(-10);
+        assert_eq!(v.cursor, 0);
+        v.move_cursor(10);
+        assert_eq!(v.cursor, 2);
+    }
     use ainb_cli::discovery::class_c::DiscoveredOrphanUnit;
     use ainb_skill_core::UnitKind;
 

--- a/ainb-tui/crates/ainb-core/src/docs.rs
+++ b/ainb-tui/crates/ainb-core/src/docs.rs
@@ -30,8 +30,7 @@ pub const AUTH_CODEX: &str = "https://developers.openai.com/codex/auth";
 pub const AUTH_GEMINI: &str =
     "https://google-gemini.github.io/gemini-cli/docs/get-started/authentication.html";
 /// GitHub Copilot CLI authentication guide.
-pub const AUTH_COPILOT: &str =
-    "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli";
+pub const AUTH_COPILOT: &str = "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli";
 
 /// Docsite page for a setup-catalog dep id, if one exists. Used by the deps
 /// screen to show "what you get" on the focused row.

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1509,7 +1509,8 @@ impl InteractiveSessionManager {
             SessionAgentType::Copilot => {
                 // Copilot authenticates via `gh`/device flow by default; if the
                 // user stored a PAT in onboarding, inject it as GITHUB_TOKEN.
-                if let Ok(Some(pat)) = credentials::get_credential(credentials::CredentialKey::GithubPat)
+                if let Ok(Some(pat)) =
+                    credentials::get_credential(credentials::CredentialKey::GithubPat)
                 {
                     info!("Injecting GITHUB_TOKEN for Copilot CLI");
                     format!("export GITHUB_TOKEN='{}' && ", pat)

--- a/ainb-tui/crates/ainb-skill-core/src/manifest.rs
+++ b/ainb-tui/crates/ainb-skill-core/src/manifest.rs
@@ -276,6 +276,22 @@ impl Manifest {
         Ok(())
     }
 
+    /// Insert or update a unit declaration, keyed by URI. On update the
+    /// targets are replaced (the latest install's target set wins) while
+    /// `shadowed_by` is preserved. Keeps the declare-on-install invariant
+    /// in one place instead of each caller hand-rolling a push + dedup.
+    pub fn upsert_unit(&mut self, uri: &str, targets: Option<Vec<String>>) {
+        if let Some(entry) = self.units.iter_mut().find(|u| u.uri == uri) {
+            entry.targets = targets;
+        } else {
+            self.units.push(UnitEntry {
+                uri: uri.to_string(),
+                targets,
+                shadowed_by: None,
+            });
+        }
+    }
+
     /// Remove a source by name; returns it on success.
     pub fn remove_source(&mut self, name: &str) -> Result<SourceEntry> {
         let pos = self


### PR DESCRIPTION
Fixes "added gh:stevengonsalvez/ainb-toolkit and the Skill Manager shows nothing", and builds the requested preview → select → import flow.

## Root causes (two)

1. **Discovered units had no UI.** `source add` cloned the repo and found **95 units** (verified against the real repo), but the Units table renders `manifest.units` = *installed* only, and `[b]` browse only covers the curated catalog — never your added sources. The 95 sat invisible in the cache.
2. **Installed units were invisible too.** `ainb skill install` recorded units in the **lockfile only**; the Units table reads `manifest.units`. Every install (CLI or browse) rendered nothing. Install now upserts a manifest `UnitEntry` (uri + targets).

## The new flow (preview-first)

```
[i] gh:owner/repo ─▶ fetch to cache (NO manifest write)
        ▼
┌ Import from gh:stevengonsalvez/ainb-toolkit — 95 unit(s), 2 selected ┐
│ [x] skill shadcn-ui        │ name/kind/path                          │
│ [x] skill tmux-status      │ + frontmatter description               │
│ [ ] skill notebooklm       │ + tags/requires                         │
│ Install to 1 [x] claude  2 [ ] codex  3 [ ] copilot  4 all           │
│ ↑↓ move · Space toggle · a all · n none · Enter import · Esc cancel  │
└──────────────────────────────────────────────────────────────────────┘
        ▼
source persisted ONLY on import · units land in Units table + tool homes
```

- Esc = zero trace (nothing persisted). Opt-in selection (nothing pre-checked).
- `[p]` on an existing source row reopens the picker to import more later.
- Backend: `preview_source` (fetch + list, no writes) + `import_selected` (persist source on first import, install each unit via the standard install path — plans, target_layout remap, lockfile all apply).

## Verification
- `cargo test -p ainb-cli` → all 20 suites green (incl. new `preview_import_tests`; sync orphan test updated — it manufactured its orphan via the manifest bug).
- `cargo test -p ainb --lib skill_manager` → 40 pass (+ picker state test).
- **Live tmux/vhs against `gh:stevengonsalvez/ainb-toolkit`**: frames confirm 95 units listed with frontmatter insight, 2 selected, codex toggled, and after Enter the Units table shows both units with `targets: claude codex` and Detail lists deployed paths under both tool homes. Files verified on disk in both `tools/claude/skills/` and `tools/codex/skills/`.

Commits are atomic: manifest-visibility fix / CLI preview+import / TUI picker / fmt sweep (includes stable-rustfmt drift from the admin-merged onboarding PRs, so this PR turns the Rustfmt job green again).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preview step before importing sources, letting you review available units, choose which ones to install, and pick target tools.
  * Added a new source preview panel in the Skills screen with keyboard controls for selection, bulk actions, and confirmation.

* **Bug Fixes**
  * Installing a skill now also updates the manifest so the installed unit is tracked properly.
  * Source imports now continue past individual unit failures and report a clear installed/failed summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->