### PR TITLE
fix(tui): paste in every text field, OTEL/editor onboarding UX, + source remove with confirm

### DIFF
--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -320,6 +320,71 @@ pub fn import_selected(
     Ok((installed, failed))
 }
 
+/// Uninstall every installed unit of a source (immediate file teardown +
+/// manifest/lockfile cleanup via the standard `skill remove` path), then
+/// optionally drop the source itself.
+///
+/// `keep_source = true` leaves the `SourceEntry` + `LockedSource` in place
+/// so the repo stays browsable/importable (it drops back to "preview"
+/// state — no installed units, but the dependency is remembered).
+/// `keep_source = false` removes the source records too.
+///
+/// Returns the number of units uninstalled.
+pub fn remove_source_units(
+    home: &Path,
+    name: &str,
+    keep_source: bool,
+    out: &mut dyn io::Write,
+) -> Result<usize> {
+    let manifest_path = manifest_path_in(home);
+    let lockfile_path = lockfile_path_in(home);
+
+    let manifest = Manifest::load_from(&manifest_path)?;
+    let source = manifest
+        .source(name)
+        .ok_or_else(|| ainb_skill_core::CoreError::SourceNotFound(name.to_string()))?;
+    // Units of this source: their URI is `<source-uri>@<ref>/<path>`.
+    let prefix = format!("{}@", source.uri);
+    let unit_uris: Vec<String> = manifest
+        .units
+        .iter()
+        .filter(|u| u.uri.starts_with(&prefix))
+        .map(|u| u.uri.clone())
+        .collect();
+
+    // Uninstall each unit — `skill remove` tears down deployed files and
+    // clears the manifest + lockfile records (per-file, never wipes config).
+    let mut removed = 0usize;
+    for uri in &unit_uris {
+        let args = crate::RemoveSkillArgs {
+            uri: uri.clone(),
+            targets: None,
+            yes: true,
+            dry_run: false,
+        };
+        match crate::skill::dispatch(home, crate::SkillCommand::Remove(args), out) {
+            Ok(()) => removed += 1,
+            Err(e) => writeln!(out, "# failed to remove {uri}: {e:#}")?,
+        }
+    }
+
+    if !keep_source {
+        let mut manifest = Manifest::load_from(&manifest_path)?;
+        let _ = manifest.remove_source(name);
+        manifest.save_to(&manifest_path)?;
+        let mut lockfile = Lockfile::load_from(&lockfile_path)?;
+        lockfile.sources.retain(|s| s.name != name);
+        lockfile.save_to(&lockfile_path)?;
+        writeln!(out, "removed source {name} + {removed} unit(s)")?;
+    } else {
+        writeln!(
+            out,
+            "removed {removed} unit(s); kept source {name} (re-import via [p])"
+        )?;
+    }
+    Ok(removed)
+}
+
 fn list(manifest_path: &Path, out: &mut dyn io::Write) -> Result<()> {
     let manifest = Manifest::load_from(manifest_path)?;
     if manifest.sources.is_empty() {

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -277,12 +277,21 @@ fn remove_source_units_keep_vs_drop() {
     let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
     assert!(manifest.units.is_empty(), "units removed");
     assert_eq!(manifest.sources.len(), 1, "source kept for re-import");
-    assert!(!claude_root.join("skills/commit/SKILL.md").exists(), "files torn down");
+    assert!(
+        !claude_root.join("skills/commit/SKILL.md").exists(),
+        "files torn down"
+    );
 
     // Re-import, then drop the source entirely.
     let preview = preview_source(home.path(), &uri).expect("re-preview");
-    import_selected(home.path(), &preview, &unit_paths(&preview), "claude", &mut out)
-        .expect("re-import");
+    import_selected(
+        home.path(),
+        &preview,
+        &unit_paths(&preview),
+        "claude",
+        &mut out,
+    )
+    .expect("re-import");
     ainb_cli::source::remove_source_units(home.path(), &name, false, &mut out).expect("drop");
     let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
     assert!(manifest.sources.is_empty(), "source dropped");

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -251,3 +251,42 @@ fn fully_failed_import_rolls_back_the_source() {
     let lockfile = Lockfile::load_from(&lockfile_path_in(home.path())).unwrap();
     assert!(lockfile.sources.is_empty(), "lockfile source rolled back");
 }
+
+/// remove_source_units: keep_source leaves the source registered (back to
+/// preview) with its units gone; without keep_source the source is dropped
+/// entirely. Files are torn down either way.
+#[test]
+fn remove_source_units_keep_vs_drop() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+    let (_repo, uri) = fixture_repo();
+    let claude_root = home.path().join("tools/claude");
+    unsafe { std::env::set_var("AINB_TOOL_HOME_CLAUDE", &claude_root) };
+
+    // Import both units.
+    let preview = preview_source(home.path(), &uri).expect("preview");
+    let paths = unit_paths(&preview);
+    let mut out = Vec::new();
+    import_selected(home.path(), &preview, &paths, "claude", &mut out).expect("import");
+    let name = preview.name.clone();
+
+    // Keep-source removal: units + files gone, source remains.
+    let removed =
+        ainb_cli::source::remove_source_units(home.path(), &name, true, &mut out).expect("remove");
+    assert_eq!(removed, 2);
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert!(manifest.units.is_empty(), "units removed");
+    assert_eq!(manifest.sources.len(), 1, "source kept for re-import");
+    assert!(!claude_root.join("skills/commit/SKILL.md").exists(), "files torn down");
+
+    // Re-import, then drop the source entirely.
+    let preview = preview_source(home.path(), &uri).expect("re-preview");
+    import_selected(home.path(), &preview, &unit_paths(&preview), "claude", &mut out)
+        .expect("re-import");
+    ainb_cli::source::remove_source_units(home.path(), &name, false, &mut out).expect("drop");
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert!(manifest.sources.is_empty(), "source dropped");
+    assert!(manifest.units.is_empty());
+
+    unsafe { std::env::remove_var("AINB_TOOL_HOME_CLAUDE") };
+}

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -5418,15 +5418,16 @@ impl EventHandler {
                 state.skill_manager_state.source_remove_confirm = None;
             }
             AppEvent::SkillManagerSourceRemoveConfirm => {
+                use crate::components::skill_manager_screen::SourceRemoveChoice;
                 let Some(confirm) = state.skill_manager_state.source_remove_confirm.clone() else {
                     return;
                 };
-                // 0 = remove skills + source, 1 = keep source, 2 = cancel.
-                if confirm.cursor == 2 {
+                let choice = confirm.choice();
+                if choice == SourceRemoveChoice::Cancel {
                     state.skill_manager_state.source_remove_confirm = None;
                     return;
                 }
-                let keep_source = confirm.cursor == 1;
+                let keep_source = choice.keeps_source();
                 let ainb_home = ainb_skill_core::default_ainb_home();
                 let mut buf: Vec<u8> = Vec::new();
                 let result = ainb_cli::source::remove_source_units(

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -366,47 +366,47 @@ pub enum AppEvent {
     // units of a fetched source + target tools, then import.
     SkillManagerPreviewUp,
     SkillManagerPreviewDown,
-    SkillManagerPreviewToggle,      // Space — toggle the cursor unit
-    SkillManagerPreviewAll,         // a — select every unit
-    SkillManagerPreviewNone,        // n — clear the selection
-    SkillManagerPreviewTool(usize), // 1/2/3 toggle claude/codex/copilot; 3=all-on (key 4)
-    SkillManagerPreviewConfirm,     // Enter — import selection to chosen tools
-    SkillManagerPreviewClose,       // Esc — discard, nothing persisted
-    SkillManagerPreviewSource,      // p on a source row — reopen the picker for it
-    SkillManagerSourceRemoveOpen,     // r on a source row — open the remove dialog
+    SkillManagerPreviewToggle,           // Space — toggle the cursor unit
+    SkillManagerPreviewAll,              // a — select every unit
+    SkillManagerPreviewNone,             // n — clear the selection
+    SkillManagerPreviewTool(usize),      // 1/2/3 toggle claude/codex/copilot; 3=all-on (key 4)
+    SkillManagerPreviewConfirm,          // Enter — import selection to chosen tools
+    SkillManagerPreviewClose,            // Esc — discard, nothing persisted
+    SkillManagerPreviewSource,           // p on a source row — reopen the picker for it
+    SkillManagerSourceRemoveOpen,        // r on a source row — open the remove dialog
     SkillManagerSourceRemoveMove(isize), // move the remove-dialog cursor
-    SkillManagerSourceRemoveConfirm,  // Enter — execute the chosen removal
-    SkillManagerSourceRemoveCancel,   // Esc — dismiss, remove nothing
-    GoToRecovery,                   // Navigate to session recovery view
-    GoToInbox,                      // Navigate to ainb-hooks notification inbox
-    GoToDaemons,                    // Navigate to the daemon runtime-health view
-    GoToFleetPanel,                 // Navigate to the fleet control panel (current_state)
-    FleetPanelMoveUp,               // Fleet panel: move row selection up
-    FleetPanelMoveDown,             // Fleet panel: move row selection down
-    FleetPanelOptionNext,           // Fleet panel: move ASK option cursor forward (Tab)
-    FleetPanelOptionPrev,           // Fleet panel: move ASK option cursor back (Shift+Tab)
-    FleetPanelAnswer,               // Fleet panel: answer selected ASK with the option (Enter/a)
-    FleetPanelBroadcast,            // Fleet panel: broadcast a ping to the selected session (B)
+    SkillManagerSourceRemoveConfirm,     // Enter — execute the chosen removal
+    SkillManagerSourceRemoveCancel,      // Esc — dismiss, remove nothing
+    GoToRecovery,                        // Navigate to session recovery view
+    GoToInbox,                           // Navigate to ainb-hooks notification inbox
+    GoToDaemons,                         // Navigate to the daemon runtime-health view
+    GoToFleetPanel,                      // Navigate to the fleet control panel (current_state)
+    FleetPanelMoveUp,                    // Fleet panel: move row selection up
+    FleetPanelMoveDown,                  // Fleet panel: move row selection down
+    FleetPanelOptionNext,                // Fleet panel: move ASK option cursor forward (Tab)
+    FleetPanelOptionPrev,                // Fleet panel: move ASK option cursor back (Shift+Tab)
+    FleetPanelAnswer, // Fleet panel: answer selected ASK with the option (Enter/a)
+    FleetPanelBroadcast, // Fleet panel: broadcast a ping to the selected session (B)
     FleetPanelApprove, // Fleet panel: approve the selected APPROVE permission request (y)
-    FleetPanelDeny,    // Fleet panel: deny the selected APPROVE permission request (n)
+    FleetPanelDeny,   // Fleet panel: deny the selected APPROVE permission request (n)
     FleetPanelRefresh, // Fleet panel: force-refresh from current_state (r)
     FleetPanelNewAtcOpen, // Fleet panel: open the new-ATC name prompt (n)
     FleetPanelNewAtcType(char), // Fleet panel: type a char into the name prompt
     FleetPanelNewAtcBackspace, // Fleet panel: delete last char of the name prompt
     FleetPanelNewAtcCancel, // Fleet panel: cancel the name prompt (Esc)
     FleetPanelNewAtcSubmit, // Fleet panel: create the ATC (Enter)
-    PanelBack,         // Close a panel screen: pop previous_screen (home if none)
-    GoToHangar,        // Navigate to the Hangar control plane (plugin screen)
-    InboxMoveUp,       // Inbox: move selection up one row
-    InboxMoveDown,     // Inbox: move selection down one row
-    InboxPageUp,       // Inbox: jump 10 rows up
-    InboxPageDown,     // Inbox: jump 10 rows down
+    PanelBack,        // Close a panel screen: pop previous_screen (home if none)
+    GoToHangar,       // Navigate to the Hangar control plane (plugin screen)
+    InboxMoveUp,      // Inbox: move selection up one row
+    InboxMoveDown,    // Inbox: move selection down one row
+    InboxPageUp,      // Inbox: jump 10 rows up
+    InboxPageDown,    // Inbox: jump 10 rows down
     InboxOpenSelected, // Inbox: mark selected row read (Enter)
     InboxDismissSelected, // Inbox: dismiss selected row (d)
     InboxDismissVisible, // Inbox: dismiss every visible row (Shift+C)
     InboxToggleArchived, // Inbox: toggle dismissed filter (a)
-    InboxCycleAgent,   // Inbox: cycle agent filter (p)
-    InboxRefresh,      // Inbox: force-refresh from store (r)
+    InboxCycleAgent,  // Inbox: cycle agent filter (p)
+    InboxRefresh,     // Inbox: force-refresh from store (r)
     // AINB 2.0: Agent selection events
     // AINB 2.0: Config screen events
     ConfigBack,            // Return to home screen (Esc)
@@ -8427,7 +8427,10 @@ mod text_input_guard_tests {
         );
         assert!(consumed, "OTEL form must be a paste-accepting context");
         let o = state.onboarding_state.as_ref().unwrap();
-        assert_eq!(o.otel_otlp_endpoint, "https://otlp-gateway.grafana.net/otlp");
+        assert_eq!(
+            o.otel_otlp_endpoint,
+            "https://otlp-gateway.grafana.net/otlp"
+        );
         // Still on the OTEL step: the stripped \n must not advance.
         assert_eq!(
             o.current_step,

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1114,6 +1114,29 @@ impl EventHandler {
         None
     }
 
+    /// Generic paste fallback: when any free-form text input has focus
+    /// (per `is_text_input_context`) and no dedicated paste route matched,
+    /// feed the pasted text through the normal key path one character at a
+    /// time. Every field's existing `Char` arm does the insertion, so all
+    /// current AND future text inputs accept paste without a per-field
+    /// route — the fix for "this form doesn't allow pasting".
+    ///
+    /// Control characters are skipped: a `\n` would submit the form and a
+    /// `\t` would jump fields mid-paste. Returns true when the paste was
+    /// consumed.
+    pub fn paste_into_text_input(text: &str, state: &mut AppState) -> bool {
+        if !Self::is_text_input_context(state) {
+            return false;
+        }
+        for c in text.chars().filter(|c| !c.is_control()) {
+            let key = KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE);
+            if let Some(ev) = Self::handle_key_event(key, state) {
+                Self::process_event(ev, state);
+            }
+        }
+        true
+    }
+
     /// True when the user is currently focused on any free-form text input.
     ///
     /// Single-character global shortcuts (`H`, `W`, future ones) must NOT
@@ -1209,7 +1232,24 @@ impl EventHandler {
                 || state.config_screen_state.api_key_input_mode
                 || state.config_popup_state.is_text_entry());
 
+        // Onboarding wizard text-entry steps: git-directories path input,
+        // the OTEL credential form, and the auth API-key entry pane. These
+        // must accept bracketed paste (endpoints/tokens/paths are exactly
+        // the values users paste).
+        let onboarding_text_active = state.current_screen == screen_ids::ONBOARDING
+            && state.onboarding_state.as_ref().is_some_and(|o| {
+                use crate::components::onboarding::{AuthPane, OnboardingStep};
+                match o.current_step {
+                    OnboardingStep::GitDirectories | OnboardingStep::OtelSetup => true,
+                    OnboardingStep::Authentication => {
+                        matches!(o.auth_pane, AuthPane::KeyEntry { .. })
+                    }
+                    _ => false,
+                }
+            });
+
         new_session_text_active
+            || onboarding_text_active
             || matches!(
                 state.current_screen.as_str(),
                 screen_ids::SEARCH_WORKSPACE
@@ -8266,6 +8306,41 @@ mod text_input_guard_tests {
         let evt = EventHandler::handle_paste_event("owner/repo".to_string(), &state)
             .expect("paste on PickRepo must dispatch a filter paste");
         assert!(matches!(evt, AppEvent::PickRepoPaste(ref t) if t == "owner/repo"));
+    }
+
+    /// A bracketed paste into the onboarding OTEL form must land in the
+    /// focused field via the generic fallback — the bug where the Grafana
+    /// endpoint/token fields silently dropped Cmd+V. Control characters
+    /// are stripped so a trailing newline can't submit the form.
+    #[test]
+    fn paste_lands_in_onboarding_otel_field() {
+        let mut state = AppState::default();
+        state.start_onboarding(false, None);
+        if let Some(o) = state.onboarding_state.as_mut() {
+            o.current_step = crate::components::onboarding::OnboardingStep::OtelSetup;
+        }
+
+        let consumed = EventHandler::paste_into_text_input(
+            "https://otlp-gateway.grafana.net/otlp\n",
+            &mut state,
+        );
+        assert!(consumed, "OTEL form must be a paste-accepting context");
+        let o = state.onboarding_state.as_ref().unwrap();
+        assert_eq!(o.otel_otlp_endpoint, "https://otlp-gateway.grafana.net/otlp");
+        // Still on the OTEL step: the stripped \n must not advance.
+        assert_eq!(
+            o.current_step,
+            crate::components::onboarding::OnboardingStep::OtelSetup
+        );
+    }
+
+    /// Paste with no text input focused is refused (not typed into a
+    /// navigation screen as shortcut keystrokes).
+    #[test]
+    fn paste_outside_text_input_is_refused() {
+        let mut state = AppState::default();
+        state.current_screen = screen_ids::SESSION_LIST.to_string();
+        assert!(!EventHandler::paste_into_text_input("abc", &mut state));
     }
 
     /// Esc inside a text input while help is visible must close help,

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -373,6 +373,10 @@ pub enum AppEvent {
     SkillManagerPreviewConfirm,     // Enter — import selection to chosen tools
     SkillManagerPreviewClose,       // Esc — discard, nothing persisted
     SkillManagerPreviewSource,      // p on a source row — reopen the picker for it
+    SkillManagerSourceRemoveOpen,     // r on a source row — open the remove dialog
+    SkillManagerSourceRemoveMove(isize), // move the remove-dialog cursor
+    SkillManagerSourceRemoveConfirm,  // Enter — execute the chosen removal
+    SkillManagerSourceRemoveCancel,   // Esc — dismiss, remove nothing
     GoToRecovery,                   // Navigate to session recovery view
     GoToInbox,                      // Navigate to ainb-hooks notification inbox
     GoToDaemons,                    // Navigate to the daemon runtime-health view
@@ -745,6 +749,7 @@ impl EventHandler {
             || s.library.is_some()
             || s.browse.is_some()
             || s.preview.is_some()
+            || s.source_remove_confirm.is_some()
     }
 
     /// Recompute the SkillManager top-row rects (Sources panel + Units
@@ -1656,6 +1661,24 @@ impl EventHandler {
                 };
             }
 
+            // Source-removal confirm dialog: arrows pick an option, Enter
+            // confirms, Esc cancels. Intercepts before every other key.
+            if state.skill_manager_state.source_remove_confirm.is_some() {
+                return match key_event.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        Some(AppEvent::SkillManagerSourceRemoveMove(-1))
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        Some(AppEvent::SkillManagerSourceRemoveMove(1))
+                    }
+                    KeyCode::Enter => Some(AppEvent::SkillManagerSourceRemoveConfirm),
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        Some(AppEvent::SkillManagerSourceRemoveCancel)
+                    }
+                    _ => None,
+                };
+            }
+
             // Source-preview picker: multi-select units + target tools.
             // Intercepts before browse/library/banner — it's the active
             // modal whenever open.
@@ -1788,6 +1811,11 @@ impl EventHandler {
                 // `[p]` on a source row — reopen the import picker for it
                 // (preview its units, select, install more).
                 KeyCode::Char('p') if sources_focused => Some(AppEvent::SkillManagerPreviewSource),
+                // `[r]` on a source row — remove dialog (skills+source, or
+                // skills-only / keep source). Distinct from unit `[r]`.
+                KeyCode::Char('r') if sources_focused => {
+                    Some(AppEvent::SkillManagerSourceRemoveOpen)
+                }
                 // Units panel `[s]` — dual-purpose:
                 //   * if the selected unit is part of a conflict pair,
                 //     flip the shadowed_by edge (legacy behaviour);
@@ -5354,6 +5382,79 @@ impl EventHandler {
                         return;
                     }
                     Self::open_source_preview(state, &format!("{}@{}", row.uri, row.r#ref));
+                }
+            }
+            AppEvent::SkillManagerSourceRemoveOpen => {
+                use crate::components::skill_manager_screen::SourceRemoveConfirm;
+                let Some(row) = state
+                    .skill_manager_state
+                    .sources
+                    .get(state.skill_manager_state.source_selected)
+                    .cloned()
+                else {
+                    state.add_warning_notification("remove: no source selected".to_string());
+                    return;
+                };
+                let prefix = format!("{}@", row.uri);
+                let unit_count = state
+                    .skill_manager_state
+                    .units
+                    .iter()
+                    .filter(|u| u.declared_uri.starts_with(&prefix))
+                    .count();
+                state.skill_manager_state.source_remove_confirm = Some(SourceRemoveConfirm {
+                    source_name: row.name,
+                    source_uri: row.uri,
+                    unit_count,
+                    cursor: 0,
+                });
+            }
+            AppEvent::SkillManagerSourceRemoveMove(delta) => {
+                if let Some(c) = state.skill_manager_state.source_remove_confirm.as_mut() {
+                    c.move_cursor(delta);
+                }
+            }
+            AppEvent::SkillManagerSourceRemoveCancel => {
+                state.skill_manager_state.source_remove_confirm = None;
+            }
+            AppEvent::SkillManagerSourceRemoveConfirm => {
+                let Some(confirm) = state.skill_manager_state.source_remove_confirm.clone() else {
+                    return;
+                };
+                // 0 = remove skills + source, 1 = keep source, 2 = cancel.
+                if confirm.cursor == 2 {
+                    state.skill_manager_state.source_remove_confirm = None;
+                    return;
+                }
+                let keep_source = confirm.cursor == 1;
+                let ainb_home = ainb_skill_core::default_ainb_home();
+                let mut buf: Vec<u8> = Vec::new();
+                let result = ainb_cli::source::remove_source_units(
+                    &ainb_home,
+                    &confirm.source_name,
+                    keep_source,
+                    &mut buf,
+                );
+                state.skill_manager_state.source_remove_confirm = None;
+                state.skill_manager_state.reload_from_disk(&ainb_home);
+                match result {
+                    Ok(removed) if keep_source => {
+                        state.add_success_notification(format!(
+                            "removed {removed} skill(s); kept {} (re-import with [p])",
+                            confirm.source_name
+                        ));
+                    }
+                    Ok(removed) => {
+                        state.add_success_notification(format!(
+                            "removed {} + {removed} skill(s)",
+                            confirm.source_name
+                        ));
+                    }
+                    Err(e) => {
+                        state.add_error_notification(format!("remove failed: {e:#}"));
+                        tracing::warn!(output = %String::from_utf8_lossy(&buf),
+                            "SkillManager: source remove failed");
+                    }
                 }
             }
             AppEvent::SkillManagerPreviewConfirm => {

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -773,7 +773,11 @@ impl OnboardingComponent {
         // Field renderer with focus + token masking.
         let field =
             |frame: &mut Frame, area: Rect, idx: usize, label: &str, value: &str, mask: bool| {
-                let focused = state.otel_field == idx && !state.otel_skip;
+                // Focus is pure navigation state — do NOT gate it on
+                // `otel_skip` (true until the first keystroke): the screen
+                // used to open with no visible focus anywhere, so nothing
+                // said "type here, Tab to move".
+                let focused = state.otel_field == idx;
                 let shown = if mask {
                     "•".repeat(value.chars().count())
                 } else {
@@ -960,25 +964,36 @@ impl OnboardingComponent {
             frame.render_widget(list, content_layout[1]);
         }
 
-        // Instructions
+        // Instructions — gold keys so "pick first, then Enter" is obvious
+        // (Enter advances the wizard; ↑↓ is how you actually choose).
         let selected_editor = state.get_selected_editor();
-        let instructions = if selected_editor.is_some() {
-            format!(
-                "Selected: {} • Press Enter to continue, or skip to use defaults",
-                state
-                    .available_editors
-                    .get(state.selected_editor_index)
-                    .map(|e| e.name.as_str())
-                    .unwrap_or("None")
-            )
+        let line = if selected_editor.is_some() {
+            let name = state
+                .available_editors
+                .get(state.selected_editor_index)
+                .map(|e| e.name.as_str())
+                .unwrap_or("None");
+            Line::from(vec![
+                Span::styled("\u{2191}\u{2193}", Style::default().fg(GOLD)),
+                Span::styled(" select \u{b7} ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("Enter", Style::default().fg(GOLD)),
+                Span::styled(
+                    format!(" use {name} & continue"),
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ])
         } else {
-            "No available editor selected • Press Enter to use fallback (code → $EDITOR)"
-                .to_string()
+            Line::from(vec![
+                Span::styled("\u{2191}\u{2193}", Style::default().fg(GOLD)),
+                Span::styled(" select \u{b7} ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("Enter", Style::default().fg(GOLD)),
+                Span::styled(
+                    " continue with fallback (code \u{2192} $EDITOR)",
+                    Style::default().fg(MUTED_GRAY),
+                ),
+            ])
         };
-
-        let instr_widget =
-            Paragraph::new(Span::styled(instructions, Style::default().fg(MUTED_GRAY)))
-                .alignment(Alignment::Center);
+        let instr_widget = Paragraph::new(line).alignment(Alignment::Center);
         frame.render_widget(instr_widget, content_layout[2]);
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -183,6 +183,10 @@ pub struct SkillsScreenData {
     /// background — renders a "fetching…" banner and blocks a second
     /// concurrent fetch. Cleared when the fetch completes either way.
     pub preview_loading: Option<String>,
+    /// Source-removal confirm dialog: `Some` after `[r]` on a source row.
+    /// Offers "remove skills + source", "remove skills, keep source", and
+    /// cancel — nothing is removed until a choice is confirmed.
+    pub source_remove_confirm: Option<SourceRemoveConfirm>,
     /// Width (terminal columns) of the left Sources panel. Resizable by
     /// dragging the Sources/Units divider or via `[`/`]`. Persisted to
     /// `ui_preferences.skill_manager_sources_width` on resize-finish and
@@ -231,6 +235,7 @@ impl Default for SkillsScreenData {
             browse: None,
             preview: None,
             preview_loading: None,
+            source_remove_confirm: None,
             sources_width: DEFAULT_SOURCES_WIDTH,
             focused_pane: FocusedSkillPane::default(),
             source_selected: 0,
@@ -476,6 +481,27 @@ impl SourcePreviewViewState {
         } else {
             Some(picked.join(","))
         }
+    }
+}
+
+/// Confirm dialog shown by `[r]` on a source row. `cursor`: 0 = remove
+/// skills + source, 1 = remove skills / keep source (back to preview),
+/// 2 = cancel.
+#[derive(Debug, Clone)]
+pub struct SourceRemoveConfirm {
+    pub source_name: String,
+    pub source_uri: String,
+    /// Installed units belonging to this source (for the count shown).
+    pub unit_count: usize,
+    pub cursor: usize,
+}
+
+impl SourceRemoveConfirm {
+    pub const OPTIONS: usize = 3;
+
+    pub fn move_cursor(&mut self, delta: isize) {
+        let max = (Self::OPTIONS - 1) as isize;
+        self.cursor = (self.cursor as isize + delta).clamp(0, max) as usize;
     }
 }
 
@@ -729,6 +755,11 @@ pub fn render(frame: &mut Frame, area: Rect, data: &SkillsScreenData) {
     // modal after an add-source fetch or `[p]` on a source row).
     if let Some(preview) = &data.preview {
         render_source_preview(frame, area, preview);
+    }
+
+    // Source-removal confirm — drawn above everything (active modal).
+    if let Some(confirm) = &data.source_remove_confirm {
+        render_source_remove_confirm(frame, area, confirm);
     }
 
     // Background fetch in flight — small centered banner so the user
@@ -1013,6 +1044,63 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
         Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
     ]);
     frame.render_widget(Paragraph::new(hints), rows[2]);
+}
+
+/// Confirm dialog for `[r]` on a source: remove skills + source, remove
+/// skills but keep the source (back to preview), or cancel.
+fn render_source_remove_confirm(frame: &mut Frame, area: Rect, c: &SourceRemoveConfirm) {
+    let width = (c.source_uri.len() as u16 + 20).clamp(52, area.width.saturating_sub(4));
+    let rect = centered_rect(area, width, 11);
+    frame.render_widget(Clear, rect);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(ERROR_RED))
+        .title(Span::styled(
+            " Remove source ",
+            Style::default().fg(ERROR_RED).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    let rows = [
+        format!("Remove skills + source  ({} unit(s), drops the dependency)", c.unit_count),
+        "Remove skills, keep source  (back to preview — re-import via [p])".to_string(),
+        "Cancel".to_string(),
+    ];
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled(
+            format!("{}  ({})", c.source_name, c.source_uri),
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+    for (i, label) in rows.iter().enumerate() {
+        let on = i == c.cursor;
+        let marker = if on { "\u{25b6} " } else { "  " };
+        let style = if on {
+            Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(SOFT_WHITE)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(marker, Style::default().fg(SELECTION_GREEN)),
+            Span::styled(label.clone(), style),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("\u{2191}\u{2193}", Style::default().fg(GOLD)),
+        Span::styled(" move \u{b7} ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Enter", Style::default().fg(GOLD)),
+        Span::styled(" confirm \u{b7} ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Esc", Style::default().fg(GOLD)),
+        Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
+    ]));
+    frame.render_widget(
+        Paragraph::new(lines).wrap(ratatui::widgets::Wrap { trim: true }),
+        inner,
+    );
 }
 
 fn render_browse_view(frame: &mut Frame, area: Rect, browse: &BrowseViewState) {

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -484,24 +484,53 @@ impl SourcePreviewViewState {
     }
 }
 
-/// Confirm dialog shown by `[r]` on a source row. `cursor`: 0 = remove
-/// skills + source, 1 = remove skills / keep source (back to preview),
-/// 2 = cancel.
+/// The choice a `[r]` source-remove dialog is currently on. Ordered — the
+/// render draws the options in `ALL` order and the cursor indexes into it,
+/// so the picker labels and the handler both go through this one type
+/// rather than agreeing on bare 0/1/2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceRemoveChoice {
+    /// Uninstall every unit AND drop the source (loses the dependency).
+    RemoveSkillsAndSource,
+    /// Uninstall units but keep the source registered (back to preview).
+    RemoveSkillsKeepSource,
+    Cancel,
+}
+
+impl SourceRemoveChoice {
+    /// Draw / index order.
+    pub const ALL: [SourceRemoveChoice; 3] = [
+        Self::RemoveSkillsAndSource,
+        Self::RemoveSkillsKeepSource,
+        Self::Cancel,
+    ];
+
+    /// Whether choosing this keeps the source records (units still removed).
+    pub fn keeps_source(self) -> bool {
+        matches!(self, Self::RemoveSkillsKeepSource)
+    }
+}
+
+/// Confirm dialog shown by `[r]` on a source row.
 #[derive(Debug, Clone)]
 pub struct SourceRemoveConfirm {
     pub source_name: String,
     pub source_uri: String,
     /// Installed units belonging to this source (for the count shown).
     pub unit_count: usize,
+    /// Index into [`SourceRemoveChoice::ALL`].
     pub cursor: usize,
 }
 
 impl SourceRemoveConfirm {
-    pub const OPTIONS: usize = 3;
-
     pub fn move_cursor(&mut self, delta: isize) {
-        let max = (Self::OPTIONS - 1) as isize;
+        let max = (SourceRemoveChoice::ALL.len() - 1) as isize;
         self.cursor = (self.cursor as isize + delta).clamp(0, max) as usize;
+    }
+
+    /// The currently-highlighted choice.
+    pub fn choice(&self) -> SourceRemoveChoice {
+        SourceRemoveChoice::ALL[self.cursor.min(SourceRemoveChoice::ALL.len() - 1)]
     }
 }
 
@@ -1063,14 +1092,21 @@ fn render_source_remove_confirm(frame: &mut Frame, area: Rect, c: &SourceRemoveC
     let inner = block.inner(rect);
     frame.render_widget(block, rect);
 
-    let rows = [
-        format!(
-            "Remove skills + source  ({} unit(s), drops the dependency)",
-            c.unit_count
-        ),
-        "Remove skills, keep source  (back to preview — re-import via [p])".to_string(),
-        "Cancel".to_string(),
-    ];
+    // One label per SourceRemoveChoice, in ALL order — the cursor and the
+    // handler both index this same list, so they can't drift.
+    let rows: Vec<String> = SourceRemoveChoice::ALL
+        .iter()
+        .map(|choice| match choice {
+            SourceRemoveChoice::RemoveSkillsAndSource => format!(
+                "Remove skills + source  ({} unit(s), drops the dependency)",
+                c.unit_count
+            ),
+            SourceRemoveChoice::RemoveSkillsKeepSource => {
+                "Remove skills, keep source  (back to preview — re-import via [p])".to_string()
+            }
+            SourceRemoveChoice::Cancel => "Cancel".to_string(),
+        })
+        .collect();
     let mut lines: Vec<Line> = vec![
         Line::from(Span::styled(
             format!("{}  ({})", c.source_name, c.source_uri),

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -1064,7 +1064,10 @@ fn render_source_remove_confirm(frame: &mut Frame, area: Rect, c: &SourceRemoveC
     frame.render_widget(block, rect);
 
     let rows = [
-        format!("Remove skills + source  ({} unit(s), drops the dependency)", c.unit_count),
+        format!(
+            "Remove skills + source  ({} unit(s), drops the dependency)",
+            c.unit_count
+        ),
         "Remove skills, keep source  (back to preview — re-import via [p])".to_string(),
         "Cancel".to_string(),
     ];

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -956,9 +956,15 @@ async fn run_tui_loop(
                             );
                         }
                     } else if let Some(app_event) =
-                        EventHandler::handle_paste_event(text, &app.state)
+                        EventHandler::handle_paste_event(text.clone(), &app.state)
                     {
                         EventHandler::process_event(app_event, &mut app.state);
+                    } else {
+                        // Any other focused text input (onboarding fields,
+                        // skill-manager prompts, renames, searches, …):
+                        // feed the paste through the normal key path so
+                        // every field accepts it without a dedicated route.
+                        EventHandler::paste_into_text_input(&text, &mut app.state);
                     }
                 }
             }


### PR DESCRIPTION
Four issues from testing the onboarding + Skill Manager.

## 1. Paste dead in form fields (OTEL, and others)
Bracketed paste only had routes for the config popup + repo picker; every other field (OTEL creds, git dirs, auth API key, skill-manager prompts, renames, searches) dropped Cmd+V. Added a **generic fallback**: when any focused free-form input (`is_text_input_context`, now including the onboarding text steps) has no dedicated route, the pasted text is fed through the normal key path one char at a time — each fields existing `Char` arm inserts it. Control chars stripped (no accidental submit/tab-jump). Future fields get paste for free.

## 2. OTEL form had no visible focus / editor step unclear
- OTEL field-focus styling was gated on `!otel_skip` (true until first keystroke) → the form opened with **nothing highlighted**, no cursor, no "type here". Focus now renders from nav state alone — the active field shows a gold border + cursor immediately.
- Editor step hint is now the standard gold-key form: `↑↓ select · Enter use <name> & continue`.

## 3. Skill Manager couldnt remove a source
`[r]` acted on the selected *unit*, so pressing it on a **source** row did nothing (the "remove notice pops, nothing happens" bug). Added `[r]` on the Sources panel → a **confirm dialog** with three choices:
1. **Remove skills + source** — uninstall all units, drop the dependency
2. **Remove skills, keep source** — uninstall units but keep the source registered, so it drops back to **preview** and can be re-imported via `[p]`
3. Cancel

Backend `remove_source_units` tears down each unit via the standard skill-remove path (files + manifest + lockfile), optionally dropping the source records.

## Where is this stored? (you asked)
`~/.agents-in-a-box/manifest.yaml` — sources + declared units (the Units table renders this). `~/.agents-in-a-box/lock.yaml` — resolved SHAs + per-tool deployed-file records.

## Verification
- Live tmux frame-truth: OTEL fields now show focus; source-remove confirm dialog renders (3 options, unit count); "keep source" leaves the source listed with units gone; the picker re-import works.
- Tests: build ✓, all 20 ainb-cli suites ✓ (new `remove_source_units_keep_vs_drop`), 40 skill-manager + paste tests ✓, stable fmt ✓.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a source-removal confirmation flow in the skill manager, with options to remove skills and either keep the source for re-import or drop it entirely.
  * Enabled smoother paste behavior by routing pasted text into the currently active text field, including onboarding screens.

* **Bug Fixes**
  * Kept OpenTelemetry credential-field focus visible while skipping OTEL steps.
  * Improved onboarding/editor guidance messaging and key handling so navigation/removal controls respond correctly during the dialog.

* **Tests**
  * Added coverage for keep-vs-drop source removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->