### PR TITLE
fix(otel): remember creds on re-open + inject OTLP endpoint into sessions

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3986,6 +3986,16 @@ impl AppState {
         };
         state.set_git_directories(&saved);
 
+        // Re-populate the OTEL form from previously-saved Grafana creds so
+        // re-opening onboarding shows what was configured, not blank fields
+        // (same remember-on-reopen contract as git directories).
+        if let Some(creds) = crate::otel::read_grafana_creds() {
+            state.otel_otlp_endpoint = creds.otlp_endpoint;
+            state.otel_instance_id = creds.instance_id;
+            state.otel_api_token = creds.api_token;
+            state.otel_skip = false;
+        }
+
         // If a specific start step is provided, jump to it
         if let Some(step) = start_step {
             state.current_step = step;

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1521,7 +1521,13 @@ impl InteractiveSessionManager {
             _ => String::new(),
         };
 
-        format!("{headroom_prefix}{base}")
+        // Point the agent's OTLP exporter at the local Alloy collector. The
+        // spawned pane runs `sh -c` (non-interactive — never sources the
+        // shell rc that would otherwise export these), so inject directly.
+        // Empty when OTEL isn't configured.
+        let otel_prefix = crate::otel::session_otlp_exports();
+
+        format!("{headroom_prefix}{otel_prefix}{base}")
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/otel/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/otel/mod.rs
@@ -127,14 +127,22 @@ pub fn read_grafana_creds() -> Option<GrafanaCloudCreds> {
     creds.is_complete().then_some(creds)
 }
 
-/// Shell `export … && ` prefix that points an agent's OTLP exporter at the
-/// local Alloy collector, for injection into a spawned session's command.
-/// Empty when OTEL isn't configured. Only the non-secret `OTEL_*` vars are
-/// injected (the `GRAFANA_*` creds are Alloy's, not the agent's). Combined
-/// with `CLAUDE_CODE_ENABLE_TELEMETRY` (Claude reads that from
-/// settings.json), this makes telemetry flow from a non-interactive
-/// `sh -c` pane that never sourced the shell rc.
+/// Shell `export … && ` prefix that gives a spawned agent the FULL OTEL
+/// config, for injection into a non-interactive `sh -c` pane that never
+/// sourced the shell rc. Empty unless OTEL is configured (creds present).
+///
+/// Emits the same generic `SETTINGS_ENV` block that `~/.claude/settings.json`
+/// carries (exporter/protocol/enable/log flags) PLUS the machine-specific
+/// endpoint + host resource attr — so telemetry actually flows for ANY
+/// OTel-capable agent, not just Claude (which alone reads settings.json). The
+/// secret `GRAFANA_*` creds are NOT injected — those belong to Alloy, and the
+/// agent only needs to reach the local collector.
+///
+/// All values are static config or quote-free (endpoint URL, `host.name=<h>`),
+/// so plain single-quoting is shell-safe.
 pub fn session_otlp_exports() -> String {
+    // Configured ⇔ the creds file exists with a token. Cheap gate; no need to
+    // parse for the endpoint (it's the fixed `LOCAL_OTLP_ENDPOINT` const).
     let Ok(path) = env_file_path() else {
         return String::new();
     };
@@ -142,12 +150,19 @@ pub fn session_otlp_exports() -> String {
         return String::new();
     };
     let map = parse_env_exports(&text);
+    if map.get("GRAFANA_API_TOKEN").map(String::is_empty).unwrap_or(true) {
+        return String::new();
+    }
+
     let mut prefix = String::new();
-    for key in ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES"] {
-        if let Some(val) = map.get(key).filter(|v| !v.is_empty()) {
-            // Values are URLs / host attrs — no embedded single quotes.
-            prefix.push_str(&format!("export {key}='{val}' && "));
-        }
+    for (k, v) in SETTINGS_ENV {
+        prefix.push_str(&format!("export {k}='{v}' && "));
+    }
+    prefix.push_str(&format!(
+        "export OTEL_EXPORTER_OTLP_ENDPOINT='{LOCAL_OTLP_ENDPOINT}' && "
+    ));
+    if let Some(attrs) = map.get("OTEL_RESOURCE_ATTRIBUTES").filter(|v| !v.is_empty()) {
+        prefix.push_str(&format!("export OTEL_RESOURCE_ATTRIBUTES='{attrs}' && "));
     }
     prefix
 }
@@ -670,17 +685,25 @@ mod tests {
             "http://localhost:4318"
         );
 
-        // Session exports carry the OTEL_* vars (never the GRAFANA_* creds).
+        // Session exports carry the FULL generic config + endpoint + host attr,
+        // and never the GRAFANA_* creds — built like session_otlp_exports.
+        assert!(!map.get("GRAFANA_API_TOKEN").unwrap().is_empty());
         let exports = {
-            // Exercise the same extraction session_otlp_exports uses.
             let mut p = String::new();
-            for key in ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES"] {
-                if let Some(v) = map.get(key).filter(|v| !v.is_empty()) {
-                    p.push_str(&format!("export {key}='{v}' && "));
-                }
+            for (k, v) in SETTINGS_ENV {
+                p.push_str(&format!("export {k}='{v}' && "));
+            }
+            p.push_str(&format!(
+                "export OTEL_EXPORTER_OTLP_ENDPOINT='{LOCAL_OTLP_ENDPOINT}' && "
+            ));
+            if let Some(a) = map.get("OTEL_RESOURCE_ATTRIBUTES").filter(|v| !v.is_empty()) {
+                p.push_str(&format!("export OTEL_RESOURCE_ATTRIBUTES='{a}' && "));
             }
             p
         };
+        // Generic enable/exporter config so non-Claude agents export too.
+        assert!(exports.contains("export CLAUDE_CODE_ENABLE_TELEMETRY='1'"));
+        assert!(exports.contains("export OTEL_METRICS_EXPORTER='otlp'"));
         assert!(exports.contains("export OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:4318'"));
         assert!(exports.contains("host.name=my-host"));
         assert!(

--- a/ainb-tui/crates/ainb-core/src/otel/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/otel/mod.rs
@@ -93,6 +93,65 @@ impl GrafanaCloudCreds {
     }
 }
 
+/// Parse `export KEY='VALUE'` lines out of a sourced env file into a map.
+/// Values are single-quoted by `write_env_file`; strip one matching pair of
+/// surrounding single quotes. Lines without `export`/`=` are ignored.
+fn parse_env_exports(text: &str) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    for line in text.lines() {
+        let Some(rest) = line.trim().strip_prefix("export ") else {
+            continue;
+        };
+        let Some((k, v)) = rest.split_once('=') else {
+            continue;
+        };
+        let v = v.trim();
+        let v = v.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')).unwrap_or(v);
+        out.insert(k.trim().to_string(), v.to_string());
+    }
+    out
+}
+
+/// Read previously-saved Grafana Cloud creds back from `grafana-cloud.env`,
+/// so the onboarding OTEL form re-populates on re-open (mirrors the
+/// git-directories remember-on-reopen behaviour). `None` when the file is
+/// absent or missing any of the three values.
+pub fn read_grafana_creds() -> Option<GrafanaCloudCreds> {
+    let text = std::fs::read_to_string(env_file_path().ok()?).ok()?;
+    let map = parse_env_exports(&text);
+    let creds = GrafanaCloudCreds {
+        otlp_endpoint: map.get("GRAFANA_OTLP_ENDPOINT").cloned().unwrap_or_default(),
+        instance_id: map.get("GRAFANA_INSTANCE_ID").cloned().unwrap_or_default(),
+        api_token: map.get("GRAFANA_API_TOKEN").cloned().unwrap_or_default(),
+    };
+    creds.is_complete().then_some(creds)
+}
+
+/// Shell `export … && ` prefix that points an agent's OTLP exporter at the
+/// local Alloy collector, for injection into a spawned session's command.
+/// Empty when OTEL isn't configured. Only the non-secret `OTEL_*` vars are
+/// injected (the `GRAFANA_*` creds are Alloy's, not the agent's). Combined
+/// with `CLAUDE_CODE_ENABLE_TELEMETRY` (Claude reads that from
+/// settings.json), this makes telemetry flow from a non-interactive
+/// `sh -c` pane that never sourced the shell rc.
+pub fn session_otlp_exports() -> String {
+    let Ok(path) = env_file_path() else {
+        return String::new();
+    };
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return String::new();
+    };
+    let map = parse_env_exports(&text);
+    let mut prefix = String::new();
+    for key in ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES"] {
+        if let Some(val) = map.get(key).filter(|v| !v.is_empty()) {
+            // Values are URLs / host attrs — no embedded single quotes.
+            prefix.push_str(&format!("export {key}='{val}' && "));
+        }
+    }
+    prefix
+}
+
 // ── Paths ───────────────────────────────────────────────────────────────────
 
 /// `~/.agents-in-a-box`.
@@ -586,6 +645,48 @@ mod tests {
             api_token: "line1\nexport EVIL=1".into(),
         };
         assert!(write_env_file_to(&path, &creds, "h").is_err());
+    }
+
+    /// The three Grafana values written by `write_env_file` parse back out
+    /// intact (remember-on-reopen), and the OTLP endpoint / resource attrs
+    /// become session export lines.
+    #[test]
+    fn creds_round_trip_and_session_exports() {
+        let text = ASSET_ENV_TEMPLATE
+            .replace("__GRAFANA_OTLP_ENDPOINT__", "https://otlp.grafana.net/otlp")
+            .replace("__GRAFANA_INSTANCE_ID__", "99999")
+            .replace("__GRAFANA_API_TOKEN__", "glc_secret")
+            .replace("__HOST_NAME__", "my-host");
+        let map = parse_env_exports(&text);
+        assert_eq!(
+            map.get("GRAFANA_OTLP_ENDPOINT").unwrap(),
+            "https://otlp.grafana.net/otlp"
+        );
+        assert_eq!(map.get("GRAFANA_INSTANCE_ID").unwrap(), "99999");
+        assert_eq!(map.get("GRAFANA_API_TOKEN").unwrap(), "glc_secret");
+        // Endpoint the agent actually posts to = the local Alloy collector.
+        assert_eq!(
+            map.get("OTEL_EXPORTER_OTLP_ENDPOINT").unwrap(),
+            "http://localhost:4318"
+        );
+
+        // Session exports carry the OTEL_* vars (never the GRAFANA_* creds).
+        let exports = {
+            // Exercise the same extraction session_otlp_exports uses.
+            let mut p = String::new();
+            for key in ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES"] {
+                if let Some(v) = map.get(key).filter(|v| !v.is_empty()) {
+                    p.push_str(&format!("export {key}='{v}' && "));
+                }
+            }
+            p
+        };
+        assert!(exports.contains("export OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:4318'"));
+        assert!(exports.contains("host.name=my-host"));
+        assert!(
+            !exports.contains("GRAFANA_API_TOKEN"),
+            "creds must not leak into the agent env"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two OTEL gaps from testing the onboarding.

## 1. OTLP form forgot its values on re-open
The Grafana endpoint/instance/token fields opened **blank** every time, even after configuring — the only step that did not remember. Added `otel::read_grafana_creds()` (parses `grafana-cloud.env` back out) and seed the three fields + un-skip in `start_onboarding`, mirroring the git-directories remember-on-reopen fix. Re-open now shows what you set.

## 2. Sessions did not get the OTEL env
Agent panes spawn via non-interactive `sh -c exec claude …`, which **never sources your shell rc** — so the `OTEL_*` exports from `grafana-cloud.env` only reached a session if ainb-tui itself had inherited them. `build_env_setup_for_provider` now prepends `otel::session_otlp_exports()` for **every** agent: `OTEL_EXPORTER_OTLP_ENDPOINT` (→ local Alloy `:4318`) + `OTEL_RESOURCE_ATTRIBUTES`. Only the non-secret `OTEL_*` vars are injected — the `GRAFANA_*` creds stay with Alloy, never leaking into the agent env.

```
Claude Code (settings.json: telemetry on)  +  injected OTEL_EXPORTER_OTLP_ENDPOINT
        └─ OTLP ─▶ localhost:4318  Alloy ──(GRAFANA_* creds)──▶ Grafana Cloud
```

Now telemetry flows whether or not the pane inherited the shell env.

## Editor step (you also asked)
Not a bug — `↑↓` (or `j/k`) already change the highlighted editor (`▶`+gold); `Enter`/`→` advance the wizard. #383 added the `↑↓ select` hint, so it is now discoverable. No code change.

## Verification
- `cargo test -p ainb --lib otel::` → 15 pass (new `creds_round_trip_and_session_exports`: values parse back intact, session exports carry `OTEL_*` and **never** `GRAFANA_API_TOKEN`).
- build ✓, stable fmt ✓.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On reopening onboarding, previously saved monitoring credentials now repopulate the form automatically.
  * Agent session setup now includes monitoring-related environment exports when available, enabling smoother OTLP routing.
  * Exported monitoring settings are now reused to generate session configuration snippets.

* **Bug Fixes**
  * Preserved onboarding state more consistently when returning to the setup flow.
  * Empty or unavailable monitoring values are now safely ignored in session exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->