### PR TITLE
fix(skills): source-remove actually drops discovered units

### DIFF
--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -365,7 +365,15 @@ pub fn remove_source_units(
             yes: true,
             dry_run: false,
         };
-        let _ = crate::skill::dispatch(home, crate::SkillCommand::Remove(args), out);
+        if let Err(e) = crate::skill::dispatch(home, crate::SkillCommand::Remove(args), out) {
+            // A "not in the lockfile" bail is expected for discovered units —
+            // stay quiet. Surface any OTHER failure (e.g. a real file teardown
+            // error) so a lingering deployment isn't hidden behind "removed".
+            let msg = e.to_string();
+            if !msg.contains("not in the lockfile") {
+                writeln!(out, "# {uri}: {msg}")?;
+            }
+        }
     }
 
     // Authoritatively drop every one of this source's units from the

--- a/ainb-tui/crates/ainb-cli/src/source.rs
+++ b/ainb-tui/crates/ainb-cli/src/source.rs
@@ -352,9 +352,12 @@ pub fn remove_source_units(
         .map(|u| u.uri.clone())
         .collect();
 
-    // Uninstall each unit — `skill remove` tears down deployed files and
-    // clears the manifest + lockfile records (per-file, never wipes config).
-    let mut removed = 0usize;
+    // Tear down each unit's deployed tool files. `skill remove` handles
+    // units ainb actually installed; a *discovered* unit (adopted from
+    // ~/.claude, never installed by ainb) has no lockfile entry, so
+    // `skill remove` bails "not in the lockfile" WITHOUT touching the
+    // manifest — the "removed but not removed" bug. So the file teardown is
+    // best-effort and the manifest teardown below does NOT depend on it.
     for uri in &unit_uris {
         let args = crate::RemoveSkillArgs {
             uri: uri.clone(),
@@ -362,16 +365,25 @@ pub fn remove_source_units(
             yes: true,
             dry_run: false,
         };
-        match crate::skill::dispatch(home, crate::SkillCommand::Remove(args), out) {
-            Ok(()) => removed += 1,
-            Err(e) => writeln!(out, "# failed to remove {uri}: {e:#}")?,
+        let _ = crate::skill::dispatch(home, crate::SkillCommand::Remove(args), out);
+    }
+
+    // Authoritatively drop every one of this source's units from the
+    // manifest — `skill remove` already cleared the installed ones (#382),
+    // this sweeps up the discovered ones it bailed on. Count from the
+    // pre-teardown set so the total is right regardless of which path each
+    // unit took.
+    let removed = unit_uris.len();
+    {
+        let mut manifest = Manifest::load_from(&manifest_path)?;
+        manifest.units.retain(|u| !u.uri.starts_with(&prefix));
+        if !keep_source {
+            let _ = manifest.remove_source(name);
         }
+        manifest.save_to(&manifest_path)?;
     }
 
     if !keep_source {
-        let mut manifest = Manifest::load_from(&manifest_path)?;
-        let _ = manifest.remove_source(name);
-        manifest.save_to(&manifest_path)?;
         let mut lockfile = Lockfile::load_from(&lockfile_path)?;
         lockfile.sources.retain(|s| s.name != name);
         lockfile.save_to(&lockfile_path)?;

--- a/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/preview_import_tests.rs
@@ -299,3 +299,56 @@ fn remove_source_units_keep_vs_drop() {
 
     unsafe { std::env::remove_var("AINB_TOOL_HOME_CLAUDE") };
 }
+
+/// remove_source_units must drop DISCOVERED units (manifest-declared but
+/// never installed by ainb, so no lockfile entry) — `skill remove` bails
+/// on those, so the manifest teardown must not depend on it. Regression:
+/// source-remove reported success while the units stayed.
+#[test]
+fn remove_source_units_drops_discovered_units_without_lockfile() {
+    use ainb_skill_core::manifest::{SourceEntry, UnitEntry};
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = tmp_home();
+
+    // Hand-author a source + two units with NO lockfile (the discovery /
+    // adopt shape). std::fs so no install path runs.
+    std::fs::create_dir_all(manifest_path_in(home.path()).parent().unwrap()).unwrap();
+    let mut manifest = Manifest::default();
+    manifest
+        .add_source(SourceEntry {
+            name: "mkt".into(),
+            kind: Some("marketplace".into()),
+            uri: "marketplace:caveman".into(),
+            r#ref: "caveman".into(),
+            enabled: true,
+            read_only: false,
+            target_layout: Vec::new(),
+        })
+        .unwrap();
+    for path in ["skills/a", "skills/b"] {
+        manifest.units.push(UnitEntry {
+            uri: format!("marketplace:caveman@caveman/{path}"),
+            targets: Some(vec!["claude".into()]),
+            shadowed_by: None,
+        });
+    }
+    manifest.save_to(&manifest_path_in(home.path())).unwrap();
+
+    let mut out = Vec::new();
+    let removed =
+        ainb_cli::source::remove_source_units(home.path(), "mkt", false, &mut out).unwrap();
+    assert_eq!(
+        removed,
+        2,
+        "both discovered units dropped: {}",
+        String::from_utf8_lossy(&out)
+    );
+
+    let manifest = Manifest::load_from(&manifest_path_in(home.path())).unwrap();
+    assert!(
+        manifest.units.is_empty(),
+        "units gone: {:?}",
+        manifest.units
+    );
+    assert!(manifest.sources.is_empty(), "source gone");
+}


### PR DESCRIPTION
Fixes "removed (get the ✓) but not actually removed" — the units stay in the list.

## Root cause
`skill remove` **bails** on a unit that has no lockfile entry — a *discovered* unit (adopted from `~/.claude` via the discovery banner, never installed by ainb):
```
Error: `marketplace:caveman@caveman/skills/x` is not in the lockfile — nothing to remove
```
`remove_source_units` (#383) looped `skill remove` per unit to clear the manifest, so for a source of discovered units it removed **nothing** from the manifest — the source dropped but its units stayed declared and rendered.

(Unit `[r]` remove was unaffected — it has a `drop_unit_from_manifest` fallback. This was the source-remove path.)

## Fix
Per-unit `skill remove` is now **best-effort file teardown only**; the manifest teardown then unconditionally retains-out every one of the sources units (installed AND discovered). The count comes from the pre-teardown set so its correct regardless of which path each unit took.

## Verified (live tmux, frame-read)
Marketplace source of 2 **discovered** units + a local source. `[r]` on the marketplace source → "remove skills + source" → notification `✓ removed marketplace-caveman + 2 skill(s)`, and both the source AND its units are gone from the manifest + Units table; the local source is untouched. Backed by a new `remove_source_units_drops_discovered_units_without_lockfile` test (hand-authored manifest, no lockfile).

Gates: build ✓, all ainb-cli suites ✓ (8 preview/import incl. the new test + fixed keep-vs-drop), stable fmt ✓.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source cleanup so units are removed reliably even when some entries were only discovered and never installed.
  * Suppressed the expected “not in the lockfile” message during cleanup while still showing other errors.
  * Updated cleanup results to reflect all matching units removed, not just successfully torn-down ones.
  * When keeping the source is disabled, the source entry is now removed in the same cleanup pass.
* **Tests**
  * Added a regression test covering removal of discovered units without lockfile entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->