### PR TITLE
feat(new-session): remote repo pre-flight on Configure — block Launch for missing/empty repos

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -570,6 +570,9 @@ pub enum AppEvent {
     /// Enter on the Branch row's Source segment → seed the base-branch
     /// popup from cached refs + kick the background fetch refresh.
     ConfigureOpenBranchPicker,
+    /// `[i]` on an empty-remote verdict → commit a README to the clone
+    /// cache and push it, unblocking Launch.
+    ConfigureInitRemoteRepo,
 }
 
 /// Translate a `RepoSource` variant into the `(SourceType, source_string)`
@@ -2164,6 +2167,7 @@ impl EventHandler {
                 ConfigureOutcome::Launch(spec) => Some(AppEvent::ConfigureLaunch(spec)),
                 ConfigureOutcome::OpenPresetManager => Some(AppEvent::ConfigureOpenPresetManager),
                 ConfigureOutcome::OpenBranchPicker => Some(AppEvent::ConfigureOpenBranchPicker),
+                ConfigureOutcome::InitializeRemote => Some(AppEvent::ConfigureInitRemoteRepo),
             };
         }
 
@@ -3418,6 +3422,11 @@ impl EventHandler {
                 // Git stays in the app layer — components/ never touch git2
                 // (finding #9).
                 state.open_branch_picker();
+            }
+            AppEvent::ConfigureInitRemoteRepo => {
+                // README + initial commit + push, off-thread. The component
+                // already shows the Initializing spinner.
+                state.initialize_remote_repo();
             }
             AppEvent::ShowNotification(message) => {
                 tracing::info!("Event: ShowNotification - {}", message);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7602,7 +7602,10 @@ impl AppState {
             Ok(Ok(paths)) => Ok(paths),
             Ok(Err(msg)) => {
                 tracing::error!(error = %msg, "prepare_remote_worktree failed");
-                self.add_error_notification(format!("Could not prepare worktree off main: {msg}"));
+                // Don't hardcode a base name in the message — the base is the
+                // remote's default (main/master/develop) or a picked branch;
+                // "off main" misled the empty-repo diagnosis (Stevie 2026-07-04).
+                self.add_error_notification(format!("Could not prepare worktree: {msg}"));
                 self.cancel_new_session();
                 Err(())
             }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2804,6 +2804,10 @@ impl SessionFilter {
     }
 }
 
+/// Payload of the Configure remote-repo pre-flight: generation guard + the
+/// `ls-remote` branch listing (or the error string to show on the form).
+type RepoCheckPayload = (u64, Result<Vec<crate::git::RemoteBranch>, String>);
+
 #[derive(Debug)]
 pub struct AppState {
     pub workspaces: Vec<Workspace>,
@@ -3080,6 +3084,14 @@ pub struct AppState {
     >,
     /// Current branch-refresh generation (bumped on every picker open).
     pub branch_refresh_seq: u64,
+
+    /// Background remote-repo pre-flight for the Configure screen (ls-remote
+    /// at open: does the repo exist, does it have branches). Applied by
+    /// `check_repo_check_complete` on the next tick; the `u64` is a
+    /// generation guard so a stale check can't stamp a newer Configure form.
+    pub repo_check_receiver: Option<mpsc::UnboundedReceiver<RepoCheckPayload>>,
+    /// Current repo-check generation (bumped on every Configure open).
+    pub repo_check_seq: u64,
 
     // Periodic session snapshot tracking
     pub last_snapshot_time: Option<Instant>,
@@ -3544,6 +3556,9 @@ impl Default for AppState {
             // Configure base-branch picker background refresh
             branch_refresh_receiver: None,
             branch_refresh_seq: 0,
+            // Configure remote-repo pre-flight (ls-remote at open)
+            repo_check_receiver: None,
+            repo_check_seq: 0,
 
             // Periodic session snapshot tracking
             last_snapshot_time: None,
@@ -7675,7 +7690,92 @@ impl AppState {
             ns.step = NewSessionStep::Configure;
         }
         tracing::debug!(?source, "advance_pick_repo_to_configure → Configure");
+
+        // Remote pre-flight: one background ls-remote validates the repo
+        // exists, is reachable, and has at least one branch — BEFORE Launch.
+        // Without it a typo'd repo dies after Launch with "Clone failed" and
+        // an empty repo dies even later at `prepare_remote_worktree` with a
+        // cryptic origin/HEAD error (Stevie 2026-07-04: mysocialmedia).
+        // `ConfigureState::from_pick_repo` already set `repo_check = Checking`
+        // for these sources; `check_repo_check_complete` applies the verdict.
+        if matches!(
+            source,
+            crate::git::repo_source::RepoSource::HttpsUrl(_)
+                | crate::git::repo_source::RepoSource::SshUrl(_)
+                | crate::git::repo_source::RepoSource::GithubShorthand { .. }
+        ) {
+            self.repo_check_seq += 1;
+            let seq = self.repo_check_seq;
+            let (tx, rx) = mpsc::unbounded_channel();
+            self.repo_check_receiver = Some(rx);
+            tokio::spawn(async move {
+                let join = tokio::task::spawn_blocking(move || {
+                    crate::git::RemoteRepoManager::new()
+                        .map_err(|e| e.to_string())?
+                        .list_remote_branches(&source)
+                        .map_err(|e| e.to_string())
+                })
+                .await;
+                let payload = match join {
+                    Ok(r) => r,
+                    Err(join_err) => Err(format!("repo check task panicked: {join_err}")),
+                };
+                let _ = tx.send((seq, payload));
+            });
+        }
         self.ui_needs_refresh = true;
+    }
+
+    /// Poll the background remote-repo pre-flight. Applies the verdict to the
+    /// Configure screen: `Failed` blocks Launch with an inline message; a
+    /// success also stamps the real default-branch name onto the Branch row
+    /// (was a hardcoded "main" placeholder — wrong for master-default repos)
+    /// and backfills the "⚠ exists" guard for not-yet-cached remotes.
+    /// Returns true when state changed this tick.
+    pub fn check_repo_check_complete(&mut self) -> bool {
+        use crate::components::new_session::configure::RepoCheck;
+
+        let Some(ref mut receiver) = self.repo_check_receiver else {
+            return false;
+        };
+        let (seq, result) = match receiver.try_recv() {
+            Ok(payload) => payload,
+            Err(mpsc::error::TryRecvError::Empty) => return false,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                self.repo_check_receiver = None;
+                return false;
+            }
+        };
+        self.repo_check_receiver = None;
+        if seq != self.repo_check_seq {
+            // A newer Configure form superseded this check.
+            return false;
+        }
+        let Some(cfg) = self.new_session_state.as_mut().and_then(|ns| ns.configure_state.as_mut())
+        else {
+            return false;
+        };
+
+        if let Ok(branches) = &result {
+            if let Some(default) = branches.iter().find(|b| b.is_default) {
+                // Only when the user hasn't already picked a base — a pick
+                // owns the Branch-row display.
+                if cfg.base_selection.is_none() {
+                    cfg.branch_source.clone_from(&default.name);
+                }
+            }
+            // Feed the base-off "⚠ exists" guard for not-yet-cached remotes
+            // (a cached remote was already seeded from its clone's refs —
+            // that list includes local heads, so don't clobber it).
+            if cfg.repo_branch_names.is_empty() {
+                cfg.repo_branch_names = branches.iter().map(|b| b.name.clone()).collect();
+            }
+        }
+        cfg.repo_check = RepoCheck::from_branches(result.map(|branches| branches.len()));
+        if let RepoCheck::Failed(msg) = &cfg.repo_check {
+            tracing::warn!(error = %msg, "configure repo pre-flight failed");
+        }
+        true
     }
 
     /// Pre-check GitHub authentication via `gh auth status`. Updates the
@@ -11275,6 +11375,10 @@ impl App {
         }
         // Check for a completed base-branch refresh (Configure picker)
         if self.state.check_branch_refresh_complete() {
+            self.state.ui_needs_refresh = true;
+        }
+        // Check for a completed remote-repo pre-flight (Configure screen)
+        if self.state.check_repo_check_complete() {
             self.state.ui_needs_refresh = true;
         }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7711,12 +7711,10 @@ impl AppState {
         // cryptic origin/HEAD error (Stevie 2026-07-04: mysocialmedia).
         // `ConfigureState::from_pick_repo` already set `repo_check = Checking`
         // for these sources; `check_repo_check_complete` applies the verdict.
-        if matches!(
-            source,
-            crate::git::repo_source::RepoSource::HttpsUrl(_)
-                | crate::git::repo_source::RepoSource::SshUrl(_)
-                | crate::git::repo_source::RepoSource::GithubShorthand { .. }
-        ) {
+        // Same `is_remote()` predicate as `from_pick_repo`'s Checking
+        // decision — the two must agree or the form waits on a verdict that
+        // never comes.
+        if source.is_remote() {
             self.repo_check_seq += 1;
             let seq = self.repo_check_seq;
             let (tx, rx) = mpsc::unbounded_channel();
@@ -7768,6 +7766,15 @@ impl AppState {
         else {
             return false;
         };
+        // Apply-side state gate, on top of the seq guard: the verdict only
+        // lands on a form that is actually waiting for one. The seq guard
+        // alone has a hole — it's bumped only when a REMOTE Configure form
+        // opens, so a stale check could otherwise stamp a later local-path or
+        // restart form (repo_check = NotApplicable) whose open never bumped
+        // the seq.
+        if cfg.repo_check != RepoCheck::Checking {
+            return false;
+        }
 
         if let Ok(branches) = &result {
             if let Some(default) = branches.iter().find(|b| b.is_default) {
@@ -7784,9 +7791,30 @@ impl AppState {
                 cfg.repo_branch_names = branches.iter().map(|b| b.name.clone()).collect();
             }
         }
-        cfg.repo_check = RepoCheck::from_branches(result.map(|branches| branches.len()));
+        let mut offline_warn: Option<String> = None;
+        cfg.repo_check = match RepoCheck::from_branches(result.map(|branches| branches.len())) {
+            RepoCheck::Failed(msg)
+                if crate::git::RemoteRepoManager::new()
+                    .ok()
+                    .and_then(|m| m.cached_source_path(&cfg.repo_source))
+                    .is_some() =>
+            {
+                // Warm clone cache → the launch path works offline by design
+                // (its fetch failures are warn-only). A failed validation
+                // must not brick that flow; warn and let Launch proceed.
+                offline_warn = Some(msg);
+                RepoCheck::Ok
+            }
+            verdict => verdict,
+        };
         if let RepoCheck::Failed(msg) = &cfg.repo_check {
             tracing::warn!(error = %msg, "configure repo pre-flight failed");
+        }
+        if let Some(msg) = offline_warn {
+            tracing::warn!(error = %msg, "repo pre-flight failed but clone cache is warm — allowing launch");
+            self.add_warning_notification(format!(
+                "Could not validate remote — using cached clone ({msg})"
+            ));
         }
         true
     }
@@ -7850,6 +7878,14 @@ impl AppState {
         if let Some(cfg) =
             self.new_session_state.as_mut().and_then(|ns| ns.configure_state.as_mut())
         {
+            // Apply-side state gate (mirrors check_repo_check_complete): only
+            // a form that is actually Initializing takes the verdict. Without
+            // it, [i] on repo A → Esc → open repo B lets A's init result
+            // force B's verdict to Ok while B is still Checking — reopening
+            // the fail-after-Launch hole this feature closes.
+            if cfg.repo_check != RepoCheck::Initializing {
+                return false;
+            }
             match result {
                 Ok(branch) => {
                     if cfg.base_selection.is_none() {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3093,6 +3093,13 @@ pub struct AppState {
     /// Current repo-check generation (bumped on every Configure open).
     pub repo_check_seq: u64,
 
+    /// Background empty-remote initialization (`[i]` on Configure: README +
+    /// initial commit + push). `Ok(branch)` carries the branch the commit
+    /// landed on. Applied by `check_repo_init_complete` on the next tick.
+    pub repo_init_receiver: Option<mpsc::UnboundedReceiver<(u64, Result<String, String>)>>,
+    /// Current repo-init generation.
+    pub repo_init_seq: u64,
+
     // Periodic session snapshot tracking
     pub last_snapshot_time: Option<Instant>,
 
@@ -3559,6 +3566,9 @@ impl Default for AppState {
             // Configure remote-repo pre-flight (ls-remote at open)
             repo_check_receiver: None,
             repo_check_seq: 0,
+            // Configure empty-remote initialization ([i] → README + push)
+            repo_init_receiver: None,
+            repo_init_seq: 0,
 
             // Periodic session snapshot tracking
             last_snapshot_time: None,
@@ -7781,6 +7791,98 @@ impl AppState {
         true
     }
 
+    /// `[i]` on an `EmptyRemote` verdict: initialize the empty remote in
+    /// place — clone (an empty clone succeeds), commit a README, push — so
+    /// the user never has to leave ainb to make a fresh repo launchable.
+    /// The component already flipped `repo_check` to `Initializing`; the
+    /// verdict lands via `check_repo_init_complete`.
+    pub fn initialize_remote_repo(&mut self) {
+        let Some(source) = self
+            .new_session_state
+            .as_ref()
+            .and_then(|ns| ns.configure_state.as_ref())
+            .map(|cfg| cfg.repo_source.clone())
+        else {
+            return;
+        };
+        self.repo_init_seq += 1;
+        let seq = self.repo_init_seq;
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.repo_init_receiver = Some(rx);
+        tokio::spawn(async move {
+            let join = tokio::task::spawn_blocking(move || {
+                let manager = crate::git::RemoteRepoManager::new().map_err(|e| e.to_string())?;
+                let parsed = source.parse_components().map_err(|e| e.to_string())?;
+                manager.initialize_empty_remote(&source, &parsed).map_err(|e| e.to_string())
+            })
+            .await;
+            let payload = match join {
+                Ok(r) => r,
+                Err(join_err) => Err(format!("repo init task panicked: {join_err}")),
+            };
+            let _ = tx.send((seq, payload));
+        });
+    }
+
+    /// Poll the background empty-remote initialization. Success flips the
+    /// Configure verdict to Ok, stamps the pushed branch onto the Branch row,
+    /// and toasts; failure returns to `EmptyRemote` (so `[i]` can retry) with
+    /// the exact git error in a toast. Returns true when state changed.
+    pub fn check_repo_init_complete(&mut self) -> bool {
+        use crate::components::new_session::configure::RepoCheck;
+
+        let Some(ref mut receiver) = self.repo_init_receiver else {
+            return false;
+        };
+        let (seq, result) = match receiver.try_recv() {
+            Ok(payload) => payload,
+            Err(mpsc::error::TryRecvError::Empty) => return false,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                self.repo_init_receiver = None;
+                return false;
+            }
+        };
+        self.repo_init_receiver = None;
+        if seq != self.repo_init_seq {
+            return false;
+        }
+        let mut toast: Option<Result<String, String>> = None;
+        if let Some(cfg) =
+            self.new_session_state.as_mut().and_then(|ns| ns.configure_state.as_mut())
+        {
+            match result {
+                Ok(branch) => {
+                    if cfg.base_selection.is_none() {
+                        cfg.branch_source.clone_from(&branch);
+                    }
+                    if cfg.repo_branch_names.is_empty() {
+                        cfg.repo_branch_names = vec![branch.clone()];
+                    }
+                    cfg.repo_check = RepoCheck::Ok;
+                    toast = Some(Ok(branch));
+                }
+                Err(msg) => {
+                    // Back to the actionable verdict — `[i]` retries.
+                    cfg.repo_check = RepoCheck::EmptyRemote;
+                    toast = Some(Err(msg));
+                }
+            }
+        }
+        match toast {
+            Some(Ok(branch)) => {
+                self.add_info_notification(format!(
+                    "Initialized repository — pushed README to origin/{branch}"
+                ));
+            }
+            Some(Err(msg)) => {
+                tracing::error!(error = %msg, "empty-remote initialization failed");
+                self.add_error_notification(format!("Could not initialize repository: {msg}"));
+            }
+            None => {}
+        }
+        true
+    }
+
     /// Pre-check GitHub authentication via `gh auth status`. Updates the
     /// `git_auth_status` field on PickRepoState. If authenticated and a
     /// `pending_clone_source` is waiting, automatically advances to Configure.
@@ -11382,6 +11484,10 @@ impl App {
         }
         // Check for a completed remote-repo pre-flight (Configure screen)
         if self.state.check_repo_check_complete() {
+            self.state.ui_needs_refresh = true;
+        }
+        // Check for a completed empty-remote initialization ([i] on Configure)
+        if self.state.check_repo_init_complete() {
             self.state.ui_needs_refresh = true;
         }
 

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -425,12 +425,14 @@ impl ConfigureState {
         let focused_row = ConfigureRow::Preset;
 
         // Clonable remotes start in `Checking`; the app layer kicks the
-        // background ls-remote and flips this to Ok / Failed.
-        let repo_check = match &repo_source {
-            RepoSource::HttpsUrl(_)
-            | RepoSource::SshUrl(_)
-            | RepoSource::GithubShorthand { .. } => RepoCheck::Checking,
-            _ => RepoCheck::NotApplicable,
+        // background ls-remote and flips this to Ok / Failed. Same
+        // `is_remote()` predicate as the kick site — if they disagreed, a
+        // form could open in Checking with no check ever spawned (Launch
+        // bricked behind a permanent spinner).
+        let repo_check = if repo_source.is_remote() {
+            RepoCheck::Checking
+        } else {
+            RepoCheck::NotApplicable
         };
 
         Self {

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -83,6 +83,46 @@ impl CustomOverrides {
     }
 }
 
+/// Result of the remote-repo pre-flight (`git ls-remote` at Configure open).
+///
+/// Catches "repo doesn't exist" and "repo is empty" HERE, on the form, instead
+/// of after Launch as a clone/worktree failure toast (Stevie 2026-07-04:
+/// empty mysocialmedia died at `prepare_remote_worktree` with a cryptic
+/// origin/HEAD error; a typo'd repo died with "Clone failed").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepoCheck {
+    /// Local path / SSH session — nothing to validate.
+    NotApplicable,
+    /// ls-remote in flight. Launch is held until it lands (sub-second).
+    Checking,
+    /// Remote exists and has at least one branch.
+    Ok,
+    /// Remote is unreachable, missing, or has zero branches. Blocks Launch;
+    /// the message renders on the form.
+    Failed(String),
+}
+
+impl RepoCheck {
+    /// Fold a `list_remote_branches` result into a check verdict. Pure so the
+    /// empty-repo rule is unit-testable without a network.
+    #[must_use]
+    pub fn from_branches(result: Result<usize, String>) -> Self {
+        match result {
+            Ok(0) => Self::Failed(
+                "repository is empty (no branches) — push an initial commit first".to_string(),
+            ),
+            Ok(_) => Self::Ok,
+            Err(msg) => Self::Failed(msg),
+        }
+    }
+
+    /// True when Launch must be refused (check failed or still in flight).
+    #[must_use]
+    pub const fn blocks_launch(&self) -> bool {
+        matches!(self, Self::Checking | Self::Failed(_))
+    }
+}
+
 /// Which segment of the Branch row (`source → worktree`) is targeted when
 /// the row is focused. ←/→ toggles; Enter acts on the targeted segment —
 /// Source opens the base-branch picker popup, Worktree opens the inline
@@ -302,6 +342,10 @@ pub struct ConfigureState {
     pub rtk_enabled: bool,
     /// Whether the `rtk` binary was found on PATH when this screen opened.
     pub rtk_available: bool,
+    /// Remote-repo pre-flight verdict. `Checking` for clonable remotes until
+    /// the background ls-remote lands; `Failed` blocks Launch with an inline
+    /// message; `NotApplicable` for local paths / SSH sessions.
+    pub repo_check: RepoCheck,
 }
 
 impl ConfigureState {
@@ -372,6 +416,15 @@ impl ConfigureState {
         // Initial focus: the Preset row — matches a fresh-form expectation.
         let focused_row = ConfigureRow::Preset;
 
+        // Clonable remotes start in `Checking`; the app layer kicks the
+        // background ls-remote and flips this to Ok / Failed.
+        let repo_check = match &repo_source {
+            RepoSource::HttpsUrl(_)
+            | RepoSource::SshUrl(_)
+            | RepoSource::GithubShorthand { .. } => RepoCheck::Checking,
+            _ => RepoCheck::NotApplicable,
+        };
+
         Self {
             repo_source,
             repo_label,
@@ -397,6 +450,7 @@ impl ConfigureState {
             headroom_available: crate::headroom::is_installed(),
             rtk_enabled: false,
             rtk_available: crate::rtk::is_installed(),
+            repo_check,
         }
     }
 
@@ -766,7 +820,11 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
     // and the help bar), keyed to the focused row. Headroom card for now — the
     // pattern extends to other rows when they need it.
     let filler_chunk = chunks[rows.len()];
-    if state.focused_row == ConfigureRow::HeadroomProxy && state.headroom_available {
+    // The remote pre-flight verdict outranks the focus-contextual guides —
+    // a blocked Launch must always be explained on screen.
+    if state.repo_check.blocks_launch() {
+        render_repo_check(f, &state.repo_check, filler_chunk);
+    } else if state.focused_row == ConfigureRow::HeadroomProxy && state.headroom_available {
         render_headroom_guide(f, filler_chunk);
     } else if state.focused_row == ConfigureRow::Rtk && state.rtk_available {
         render_rtk_guide(f, filler_chunk);
@@ -1168,6 +1226,29 @@ fn render_rtk_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bo
         Style::default().fg(MUTED_GRAY),
     ));
     f.render_widget(Paragraph::new(line), area);
+}
+
+/// Remote pre-flight status card, shown in the filler space while the check
+/// is in flight or has failed. A failure blocks Launch, so it must be loud.
+fn render_repo_check(f: &mut Frame, check: &RepoCheck, area: Rect) {
+    let lines = match check {
+        RepoCheck::Checking => vec![Line::from(Span::styled(
+            "  \u{23f3} validating remote repository\u{2026}",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ))],
+        RepoCheck::Failed(msg) => vec![
+            Line::from(Span::styled(
+                format!("  \u{2716} {msg}"),
+                Style::default().fg(ALERT_RED).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                "  Launch is disabled \u{2014} Esc to pick another repository",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )),
+        ],
+        RepoCheck::NotApplicable | RepoCheck::Ok => return,
+    };
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
 
 /// Contextual RTK guide card, shown while the RTK row is focused.
@@ -1986,6 +2067,14 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
         state.focused_row = ConfigureRow::Branch;
         return ConfigureOutcome::Stay;
     }
+    // Remote pre-flight gate: a missing / empty / unreachable remote can never
+    // launch — the clone or worktree step is guaranteed to fail. Refuse here
+    // and let the inline message (rendered in the filler space) explain.
+    // `Checking` also blocks: ls-remote lands sub-second, and launching before
+    // the verdict would just re-open the old fail-after-Launch hole.
+    if state.repo_check.blocks_launch() {
+        return ConfigureOutcome::Stay;
+    }
     // Defense-in-depth: a greyed-out agent (e.g. Gemini) is never selectable in
     // the UI, but a hand-authored preset could still carry one. Refuse to launch
     // a disabled provider and refocus the Agent row, mirroring the collision
@@ -2440,7 +2529,67 @@ mod tests {
             headroom_available: true,
             rtk_enabled: false,
             rtk_available: true,
+            repo_check: RepoCheck::NotApplicable,
         }
+    }
+
+    #[test]
+    fn repo_check_from_branches_folds_verdicts() {
+        // Zero branches = empty repo → explicit, actionable failure.
+        assert!(matches!(
+            RepoCheck::from_branches(Ok(0)),
+            RepoCheck::Failed(msg) if msg.contains("empty")
+        ));
+        assert_eq!(RepoCheck::from_branches(Ok(3)), RepoCheck::Ok);
+        // ls-remote error (not found / auth / network) carries through verbatim.
+        assert!(matches!(
+            RepoCheck::from_branches(Err("Repository not found: x".into())),
+            RepoCheck::Failed(msg) if msg == "Repository not found: x"
+        ));
+    }
+
+    #[test]
+    fn launch_blocked_while_repo_check_pending_or_failed() {
+        let mut s = mk_state();
+        s.repo_check = RepoCheck::Checking;
+        assert!(matches!(launch_outcome(&mut s), ConfigureOutcome::Stay));
+        s.repo_check = RepoCheck::Failed("Repository not found".into());
+        assert!(matches!(launch_outcome(&mut s), ConfigureOutcome::Stay));
+        // Verdict lands → same keypress launches.
+        s.repo_check = RepoCheck::Ok;
+        assert!(matches!(
+            launch_outcome(&mut s),
+            ConfigureOutcome::Launch(_)
+        ));
+    }
+
+    #[test]
+    fn remote_source_starts_in_checking_local_not_applicable() {
+        use crate::config::session_defaults::SessionDefaults;
+        let defaults = SessionDefaults::default();
+        let remote = ConfigureState::from_pick_repo(
+            RepoSource::GithubShorthand {
+                owner: "o".into(),
+                repo: "r".into(),
+            },
+            "r".into(),
+            &defaults,
+            None,
+            "agents/",
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(remote.repo_check, RepoCheck::Checking);
+        let local = ConfigureState::from_pick_repo(
+            RepoSource::LocalPath(PathBuf::from("/tmp/repo")),
+            "repo".into(),
+            &defaults,
+            None,
+            "agents/",
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(local.repo_check, RepoCheck::NotApplicable);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -97,8 +97,15 @@ pub enum RepoCheck {
     Checking,
     /// Remote exists and has at least one branch.
     Ok,
-    /// Remote is unreachable, missing, or has zero branches. Blocks Launch;
-    /// the message renders on the form.
+    /// Remote exists but has zero branches (fresh GitHub repo, no initial
+    /// commit). Blocks Launch, but offers `[i]` to initialize in place —
+    /// README + initial commit + push — so the user never has to leave ainb
+    /// (Stevie 2026-07-04: full-IDE-in-terminal experience).
+    EmptyRemote,
+    /// `[i]` accepted — README/commit/push in flight. Blocks Launch.
+    Initializing,
+    /// Remote is unreachable or missing. Blocks Launch; the message renders
+    /// on the form.
     Failed(String),
 }
 
@@ -108,9 +115,7 @@ impl RepoCheck {
     #[must_use]
     pub fn from_branches(result: Result<usize, String>) -> Self {
         match result {
-            Ok(0) => Self::Failed(
-                "repository is empty (no branches) — push an initial commit first".to_string(),
-            ),
+            Ok(0) => Self::EmptyRemote,
             Ok(_) => Self::Ok,
             Err(msg) => Self::Failed(msg),
         }
@@ -119,7 +124,10 @@ impl RepoCheck {
     /// True when Launch must be refused (check failed or still in flight).
     #[must_use]
     pub const fn blocks_launch(&self) -> bool {
-        matches!(self, Self::Checking | Self::Failed(_))
+        matches!(
+            self,
+            Self::Checking | Self::EmptyRemote | Self::Initializing | Self::Failed(_)
+        )
     }
 }
 
@@ -693,6 +701,10 @@ pub enum ConfigureOutcome {
     /// branches (git stays out of components/ — finding #9), seed
     /// `branch_picker`, and kick the background refresh.
     OpenBranchPicker,
+    /// `[i]` on an `EmptyRemote` verdict — the app layer must commit a README
+    /// to the clone cache and push it, then flip `repo_check` to Ok (git
+    /// stays out of components/).
+    InitializeRemote,
 }
 
 /// Launch payload built by the Configure component and threaded all the way
@@ -1234,6 +1246,28 @@ fn render_repo_check(f: &mut Frame, check: &RepoCheck, area: Rect) {
     let lines = match check {
         RepoCheck::Checking => vec![Line::from(Span::styled(
             "  \u{23f3} validating remote repository\u{2026}",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ))],
+        RepoCheck::EmptyRemote => vec![
+            Line::from(Span::styled(
+                "  \u{2716} repository is empty (no branches)",
+                Style::default().fg(ALERT_RED).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(vec![
+                Span::styled("  press ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("i", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    " to initialize it \u{2014} ainb commits a README and pushes it for you",
+                    Style::default().fg(SELECTION_GREEN),
+                ),
+            ]),
+            Line::from(Span::styled(
+                "  or Esc to pick another repository",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )),
+        ],
+        RepoCheck::Initializing => vec![Line::from(Span::styled(
+            "  \u{23f3} initializing repository \u{2014} committing README, pushing\u{2026}",
             Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
         ))],
         RepoCheck::Failed(msg) => vec![
@@ -2047,8 +2081,16 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
             if state.focused_row == ConfigureRow::Prompt {
                 state.prompt.insert_char(c);
+                return ConfigureOutcome::Stay;
             }
-            // No bare-char shortcuts elsewhere — Tab + arrows is the entire
+            // `[i]` initializes an empty remote (README + commit + push) so
+            // the user never leaves ainb. Only offered while the pre-flight
+            // verdict is EmptyRemote; the Prompt row keeps plain chars.
+            if matches!(c, 'i' | 'I') && state.repo_check == RepoCheck::EmptyRemote {
+                state.repo_check = RepoCheck::Initializing;
+                return ConfigureOutcome::InitializeRemote;
+            }
+            // No other bare-char shortcuts — Tab + arrows is the entire
             // navigation surface for non-Prompt rows.
             ConfigureOutcome::Stay
         }
@@ -2535,11 +2577,9 @@ mod tests {
 
     #[test]
     fn repo_check_from_branches_folds_verdicts() {
-        // Zero branches = empty repo → explicit, actionable failure.
-        assert!(matches!(
-            RepoCheck::from_branches(Ok(0)),
-            RepoCheck::Failed(msg) if msg.contains("empty")
-        ));
+        // Zero branches = empty repo → the actionable EmptyRemote verdict
+        // (offers `[i]` to initialize in place).
+        assert_eq!(RepoCheck::from_branches(Ok(0)), RepoCheck::EmptyRemote);
         assert_eq!(RepoCheck::from_branches(Ok(3)), RepoCheck::Ok);
         // ls-remote error (not found / auth / network) carries through verbatim.
         assert!(matches!(
@@ -2551,16 +2591,44 @@ mod tests {
     #[test]
     fn launch_blocked_while_repo_check_pending_or_failed() {
         let mut s = mk_state();
-        s.repo_check = RepoCheck::Checking;
-        assert!(matches!(launch_outcome(&mut s), ConfigureOutcome::Stay));
-        s.repo_check = RepoCheck::Failed("Repository not found".into());
-        assert!(matches!(launch_outcome(&mut s), ConfigureOutcome::Stay));
+        for blocked in [
+            RepoCheck::Checking,
+            RepoCheck::EmptyRemote,
+            RepoCheck::Initializing,
+            RepoCheck::Failed("Repository not found".into()),
+        ] {
+            s.repo_check = blocked;
+            assert!(matches!(launch_outcome(&mut s), ConfigureOutcome::Stay));
+        }
         // Verdict lands → same keypress launches.
         s.repo_check = RepoCheck::Ok;
         assert!(matches!(
             launch_outcome(&mut s),
             ConfigureOutcome::Launch(_)
         ));
+    }
+
+    #[test]
+    fn i_key_initializes_empty_remote_only() {
+        let key = KeyEvent::from(KeyCode::Char('i'));
+        // EmptyRemote → [i] fires the init and shows the spinner.
+        let mut s = mk_state();
+        s.repo_check = RepoCheck::EmptyRemote;
+        assert_eq!(handle_key(&mut s, key), ConfigureOutcome::InitializeRemote);
+        assert_eq!(s.repo_check, RepoCheck::Initializing);
+        // Second press while initializing: no double-fire.
+        assert_eq!(handle_key(&mut s, key), ConfigureOutcome::Stay);
+        // Healthy repo: 'i' is inert.
+        let mut s = mk_state();
+        s.repo_check = RepoCheck::Ok;
+        assert_eq!(handle_key(&mut s, key), ConfigureOutcome::Stay);
+        // Prompt row keeps plain chars even on an EmptyRemote verdict.
+        let mut s = mk_state();
+        s.repo_check = RepoCheck::EmptyRemote;
+        s.focused_row = ConfigureRow::Prompt;
+        assert_eq!(handle_key(&mut s, key), ConfigureOutcome::Stay);
+        assert_eq!(s.repo_check, RepoCheck::EmptyRemote);
+        assert_eq!(s.prompt.to_non_empty_string().as_deref(), Some("i"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -1015,7 +1015,25 @@ impl RemoteRepoManager {
         source: &RepoSource,
         parsed: &ParsedRepo,
     ) -> Result<String, RemoteRepoError> {
-        let cache_path = self.clone_repo(source, parsed)?;
+        // Re-verify emptiness at action time — the EmptyRemote verdict that
+        // offered [i] may be stale (a collaborator pushed meanwhile). Pushing
+        // a README onto a repo that now has history is never what's wanted.
+        let branches = self.list_remote_branches(source)?;
+        if !branches.is_empty() {
+            return Err(RemoteRepoError::InvalidRepo(
+                "repository is no longer empty — press Esc and re-open it".to_string(),
+            ));
+        }
+
+        let mut cache_path = self.clone_repo(source, parsed)?;
+        // A warm cache can carry commits the remote no longer has (repo
+        // deleted and recreated empty under the same name). Pushing that
+        // would silently upload the dead repo's entire history — the remote
+        // is verifiably empty, so wipe and re-clone fresh instead.
+        if local_head_exists(&cache_path) {
+            std::fs::remove_dir_all(&cache_path)?;
+            cache_path = self.clone_repo(source, parsed)?;
+        }
         push_initial_commit(&cache_path, &parsed.repo_name)
     }
 
@@ -1113,6 +1131,15 @@ fn delete_orphaned_branch(cache_path: &Path, branch_name: &str) -> Result<bool, 
     }
 }
 
+/// Does the clone at `path` have any commit on HEAD?
+fn local_head_exists(path: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", "HEAD"])
+        .current_dir(path)
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
 /// Create the initial commit (a README) in a clone of an EMPTY remote and
 /// push it to `origin`. Returns the branch name pushed (the clone's HEAD
 /// symref — git/GitHub advertise the default branch name even for empty
@@ -1138,11 +1165,7 @@ fn push_initial_commit(cache_path: &Path, repo_name: &str) -> Result<String, Rem
 
     // A previous attempt may have committed but failed at push — don't stack
     // a second README commit on top.
-    let has_commit = Command::new("git")
-        .args(["rev-parse", "--verify", "--quiet", "HEAD"])
-        .current_dir(cache_path)
-        .output()
-        .is_ok_and(|o| o.status.success());
+    let has_commit = local_head_exists(cache_path);
 
     if !has_commit {
         let readme = cache_path.join("README.md");
@@ -1188,7 +1211,9 @@ fn push_initial_commit(cache_path: &Path, repo_name: &str) -> Result<String, Rem
         .output()?;
     if !push.status.success() {
         let stderr = String::from_utf8_lossy(&push.stderr);
-        return Err(classify_git_error(&stderr, &branch));
+        // Second arg names the repository in NotFound messages — the branch
+        // here would render "Repository not found: main".
+        return Err(classify_git_error(&stderr, repo_name));
     }
 
     info!("Pushed initial commit to origin/{branch}");

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -1006,6 +1006,19 @@ impl RemoteRepoManager {
         Ok(repos)
     }
 
+    /// Initialize an EMPTY remote repository in place: clone it (an empty
+    /// clone succeeds), commit a README, and push. Returns the branch name
+    /// the initial commit landed on. Lets the Configure screen unblock a
+    /// fresh GitHub repo without the user ever leaving ainb.
+    pub fn initialize_empty_remote(
+        &self,
+        source: &RepoSource,
+        parsed: &ParsedRepo,
+    ) -> Result<String, RemoteRepoError> {
+        let cache_path = self.clone_repo(source, parsed)?;
+        push_initial_commit(&cache_path, &parsed.repo_name)
+    }
+
     /// Remove a cached repository
     pub fn remove_cached_repo(&self, parsed: &ParsedRepo) -> Result<(), RemoteRepoError> {
         let cache_path = self.get_cache_path(parsed);
@@ -1098,6 +1111,88 @@ fn delete_orphaned_branch(cache_path: &Path, branch_name: &str) -> Result<bool, 
         );
         Ok(false)
     }
+}
+
+/// Create the initial commit (a README) in a clone of an EMPTY remote and
+/// push it to `origin`. Returns the branch name pushed (the clone's HEAD
+/// symref — git/GitHub advertise the default branch name even for empty
+/// repos, so this respects a `master`/custom default).
+///
+/// Split from `initialize_empty_remote` so it's testable against a local
+/// bare remote without network. Idempotent-ish: if the cache already holds
+/// a local commit (a previous init attempt that failed at push), it skips
+/// the README/commit step and just pushes.
+fn push_initial_commit(cache_path: &Path, repo_name: &str) -> Result<String, RemoteRepoError> {
+    let branch = {
+        let out = Command::new("git")
+            .args(["symbolic-ref", "--short", "HEAD"])
+            .current_dir(cache_path)
+            .output()?;
+        let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if out.status.success() && !name.is_empty() {
+            name
+        } else {
+            "main".to_string()
+        }
+    };
+
+    // A previous attempt may have committed but failed at push — don't stack
+    // a second README commit on top.
+    let has_commit = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", "HEAD"])
+        .current_dir(cache_path)
+        .output()
+        .is_ok_and(|o| o.status.success());
+
+    if !has_commit {
+        let readme = cache_path.join("README.md");
+        if !readme.exists() {
+            std::fs::write(&readme, format!("# {repo_name}\n"))?;
+        }
+        let add = Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(cache_path)
+            .output()?;
+        if !add.status.success() {
+            return Err(RemoteRepoError::InvalidRepo(
+                String::from_utf8_lossy(&add.stderr).trim().to_string(),
+            ));
+        }
+        // Uses the user's own git identity — a missing identity surfaces
+        // git's exact "tell me who you are" error. Signing is forced off:
+        // a gpg pin-entry prompt would hang this non-interactive path.
+        let commit = Command::new("git")
+            .args([
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "Initial commit",
+            ])
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .current_dir(cache_path)
+            .output()?;
+        if !commit.status.success() {
+            return Err(RemoteRepoError::InvalidRepo(
+                String::from_utf8_lossy(&commit.stderr).trim().to_string(),
+            ));
+        }
+        info!("Created initial README commit in {}", cache_path.display());
+    }
+
+    let push = Command::new("git")
+        .args(["push", "-u", "origin", &branch])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "echo")
+        .current_dir(cache_path)
+        .output()?;
+    if !push.status.success() {
+        let stderr = String::from_utf8_lossy(&push.stderr);
+        return Err(classify_git_error(&stderr, &branch));
+    }
+
+    info!("Pushed initial commit to origin/{branch}");
+    Ok(branch)
 }
 
 /// Classify git errors into appropriate RemoteRepoError variants
@@ -1199,6 +1294,58 @@ mod tests {
 
         let repos = manager.list_cached_repos().unwrap();
         assert!(repos.is_empty());
+    }
+
+    fn run_git(args: &[&str], cwd: &Path) {
+        let out = Command::new("git").args(args).current_dir(cwd).output().unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[test]
+    fn push_initial_commit_initializes_empty_remote_on_its_default_branch() {
+        let tmp = TempDir::new().unwrap();
+        let bare = tmp.path().join("bare.git");
+        // Non-"main" default proves the branch name comes from the remote's
+        // advertised HEAD, not a hardcoded fallback.
+        run_git(
+            &["init", "--bare", "-b", "trunk", bare.to_str().unwrap()],
+            tmp.path(),
+        );
+        let clone = tmp.path().join("clone");
+        run_git(
+            &["clone", bare.to_str().unwrap(), clone.to_str().unwrap()],
+            tmp.path(),
+        );
+        run_git(&["config", "user.name", "Test"], &clone);
+        run_git(&["config", "user.email", "test@example.com"], &clone);
+
+        let branch = push_initial_commit(&clone, "myrepo").unwrap();
+        assert_eq!(branch, "trunk");
+
+        // The bare remote now has the branch with the README commit.
+        let out = Command::new("git")
+            .args(["ls-remote", "--heads", bare.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("refs/heads/trunk"),
+            "initial commit did not land on the bare remote"
+        );
+        assert!(clone.join("README.md").exists());
+
+        // Re-running (e.g. after a failed push retry) must not stack a second
+        // commit — just re-push.
+        assert_eq!(push_initial_commit(&clone, "myrepo").unwrap(), "trunk");
+        let count = Command::new("git")
+            .args(["rev-list", "--count", "HEAD"])
+            .current_dir(&clone)
+            .output()
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&count.stdout).trim(), "1");
     }
 
     #[test]


### PR DESCRIPTION
## Problem (Stevie 2026-07-04, from logs)

Launching a session for `stevengonsalvez/mysocialmedia` (a freshly created, **empty** GitHub repo) failed after Launch with:

```
Could not prepare worktree off main: Invalid repository: could not resolve
default branch (origin/HEAD) in cache .../mysocialmedia
```

And a typo'd / nonexistent repo sails through the Configure screen and only dies after Launch with `Clone failed for <repo>`.

### Investigation answers
- **`main` is NOT hardcoded.** `resolve_default_branch` tries `origin/HEAD` symref → remote-advertised HEAD (`ls-remote --symref`) → probes `origin/main`/`origin/master`. A `master`-default repo works fine.
- **Empty repo fails because zero branches exist** — nothing to cut a worktree from. Verified live: `git ls-remote --heads` on mysocialmedia returns zero refs.
- The "off main" in the toast was a hardcoded string, not the resolver (fixed here too).

## Fix

```
┌──────────┐  open   ┌───────────┐ ls-remote ┌──────────────────┐
│ PickRepo │────────▶│ Configure │──────────▶│ verdict on form  │
└──────────┘         └───────────┘  (async)  └───┬──────────┬───┘
                          │ Launch          Failed│     Empty│
                          ▼                       ▼          ▼
                    blocked while           ✖ message   [i] → README
                    Checking/Failed/                    commit + push
                    Empty/Initializing                  → verdict Ok
```

One background `ls-remote` when Configure opens for a clonable remote (https / ssh / `owner/repo`):

- **repo missing / unreachable / auth-failed** → classified error renders on the form (`✖ Repository not found: …`); Launch refused
- **repo empty (0 branches)** → `✖ repository is empty (no branches)` + **press `i` to initialize it — ainb commits a README and pushes it for you**. No leaving the terminal: clone (empty clone succeeds) → README on the remote's advertised default branch → `push -u origin <branch>` → verdict flips to Ok, Launch unblocks. Failure returns to the actionable verdict so `[i]` retries; git's exact error toasts.
- **success** → Branch row shows the repo's **real** default branch (was a hardcoded `main` placeholder — wrong for `master`-default repos), and the ⚠-exists guard is backfilled for not-yet-cached remotes
- worktree-failure toast no longer hardcodes "off main"

Init safety: respects the remote's default branch name (HEAD symref survives an empty clone), never stacks a second commit on a failed-push retry, forces `commit.gpgsign=false` (a pin-entry prompt would hang the non-interactive path), uses the user's own git identity (missing identity surfaces git's exact error).

## Tests
- `RepoCheck::from_branches` verdict folding (empty / ok / error)
- Launch blocked for `Checking`/`EmptyRemote`/`Initializing`/`Failed`, allowed on `Ok`
- `[i]` fires init only on `EmptyRemote`, no double-fire, Prompt row keeps plain chars
- `push_initial_commit` integration test against a local bare remote with non-main default branch (`trunk`): commit lands, retry idempotent
- configure suite 51 passed; lib suite 1611 passed, 11 failed (same 11 fail on main — Docker/network sandbox tests)

## Not verified live
TUI end-to-end against real GitHub — needs a machine with the interactive TUI. Unit + bare-remote integration + live `ls-remote` probe covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initializing an empty remote repository from the new-session flow.
  * Introduced a remote repository status check that shows progress, success, failure, and empty-remote states.
  * Added a shortcut to initialize an empty remote directly from the setup screen.

* **Bug Fixes**
  * Prevents launching when remote repository validation is still in progress or has failed.
  * Improves handling for repositories whose default branch is not the usual one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->