### PR TITLE
feat(skill): library management + installed-aware picker + two-way sync (skill manager epic)

### DIFF
--- a/ainb-tui/crates/ainb-cli/src/lib.rs
+++ b/ainb-tui/crates/ainb-cli/src/lib.rs
@@ -138,6 +138,45 @@ pub enum LibraryCmd {
         #[arg(long)]
         tool: Option<String>,
     },
+    /// Copy a unit from any configured source into the user's library.
+    /// Resolves the unit like `install` does, deploys it under the
+    /// tool's skills dir (skipped if already deployed there), and
+    /// registers it as an owned unit — same as `add`/`new`.
+    Copy {
+        /// Full unit URI to copy in (e.g. `gh:org/repo@main/skills/foo`).
+        uri: String,
+
+        /// Tool whose home to deploy under. Defaults to `claude`.
+        #[arg(long)]
+        tool: Option<String>,
+    },
+    /// Mark a manifest source as a "library source", enabling
+    /// `push`/`pull` git-native two-way sync against it.
+    MarkSource {
+        /// Source name, as declared in the manifest.
+        name: String,
+    },
+    /// Unmark a source as a library source.
+    UnmarkSource {
+        /// Source name, as declared in the manifest.
+        name: String,
+    },
+    /// Publish local library edits to a library source's git remote:
+    /// sync tool-home content into the source's fetched checkout, then
+    /// commit + push. Only valid for a source already marked via
+    /// `mark-source`.
+    Push {
+        /// Library source name.
+        source: String,
+    },
+    /// Pull a library source's git remote into local library edits:
+    /// `git pull --rebase` the source's fetched checkout, then sync its
+    /// content back down into the tool home. Only valid for a source
+    /// already marked via `mark-source`.
+    Pull {
+        /// Library source name.
+        source: String,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/ainb-tui/crates/ainb-cli/src/library.rs
+++ b/ainb-tui/crates/ainb-cli/src/library.rs
@@ -20,12 +20,22 @@ use ainb_skill_core::library::{Library, OwnedUnit, library_path_in};
 use ainb_skill_core::lockfile::Lockfile;
 use ainb_skill_core::manifest::{Manifest, SourceEntry};
 use ainb_skill_core::paths::{lockfile_path_in, manifest_path_in};
+use ainb_skill_core::resolve_pair;
 use ainb_skill_core::uri::Uri;
 
 use crate::LibraryCmd;
 
 /// Default tool when none is supplied on the command line.
 const DEFAULT_TOOL: &str = "claude";
+
+/// Every tool name [`tool_dotdir`] has an explicit mapping for — used to
+/// invert a stored library path's dotdir (e.g. `.codex`) back to its
+/// tool name (e.g. `codex`) in [`split_tool_relative_path`]. Kept as a
+/// literal list rather than reverse-matching `tool_dotdir`'s arms at
+/// runtime.
+const KNOWN_TOOLS: &[&str] = &[
+    "claude", "codex", "copilot", "gemini", "cursor", "amazonq", "cline", "roo",
+];
 
 pub fn dispatch(home: &Path, cmd: LibraryCmd, out: &mut dyn io::Write) -> Result<()> {
     match cmd {
@@ -232,11 +242,20 @@ fn require_manifest_source(home: &Path, name: &str) -> Result<()> {
 }
 
 /// `ainb skill library push <source>` — publish local library edits to
-/// a library source's git remote. Runs the same bidirectional content
-/// sync `ainb skill sync` uses (scoped to this source, to-repo only),
-/// then commits + pushes anything that sync's per-file lockfile-driven
-/// diffing didn't already cover (e.g. a `library copy`/`new` skill that
-/// was never `install`ed through the lockfile).
+/// a library source's git remote.
+///
+/// Two passes cover the two ways content can enter the library:
+///  1. The same bidirectional content sync `ainb skill sync` uses
+///     (scoped to this source, to-repo only) — covers units that went
+///     through `install` and are tracked in the lockfile.
+///  2. [`stage_owned_units`] — copies every *owned* unit
+///     (`library add`/`new`/`copy`) that resolves to this source's
+///     `target_layout` directly into the checkout. Those units are
+///     registered in `library.yaml`, not the lockfile, so pass 1 never
+///     sees them; without this pass `push` would report success while
+///     silently publishing nothing for them.
+///
+/// Whatever either pass staged is then committed + pushed in one shot.
 fn push(home: &Path, source_name: &str, out: &mut dyn io::Write) -> Result<()> {
     let source = require_library_source(home, source_name)?;
 
@@ -252,7 +271,157 @@ fn push(home: &Path, source_name: &str, out: &mut dyn io::Write) -> Result<()> {
     crate::skill::bidirectional_content_sync(home, &manifest, &lockfile, &sync_args, out)?;
 
     let checkout = crate::skill::ensure_repo_clone(home, &source)?;
-    git_add_commit_push(&checkout, "ainb: sync library edits", out)
+    let staged = stage_owned_units(home, &source, &checkout, out)?;
+    if staged > 0 {
+        writeln!(out, "# staged {staged} owned-library unit(s) for publish")?;
+    }
+    git_add_commit_push(&checkout, "ainb: sync library edits", &source, out)
+}
+
+/// Copy every deployed *owned* library unit (`library add`/`new`/`copy`)
+/// into `checkout` at its repo-side convention path, so `push` actually
+/// publishes locally-authored skills that were never routed through the
+/// lockfile-driven content sync (finding: push silently dropped these).
+///
+/// For each owned unit whose deployed directory exists on this machine,
+/// the repo-side target directory is resolved via
+/// [`resolve_owned_unit_repo_dir`] — the same `target_layout` mapping
+/// [`ainb_skill_core::apply_to_repo`] uses for lockfile-driven units, so
+/// the convention (`skills/<name>`, a flat layout, …) always matches
+/// wherever this source already keeps its skills. When no mapping
+/// covers the unit, it is **not** silently skipped: a warning naming
+/// the unit is printed so the omission is visible.
+///
+/// Returns the count of units actually staged.
+fn stage_owned_units(
+    home: &Path,
+    source: &SourceEntry,
+    checkout: &Path,
+    out: &mut dyn io::Write,
+) -> Result<usize> {
+    let lib = Library::load_from(&library_path_in(home))?;
+    let mut staged = 0usize;
+    for unit in &lib.owned {
+        let (tool, unit_tool_rel) = split_tool_relative_path(&unit.path);
+        let unit_dir = read_root_for(&tool).join(&unit_tool_rel);
+        if !unit_dir.is_dir() {
+            // Not deployed on this machine (registered elsewhere, or
+            // moved) — nothing to publish, not an error.
+            continue;
+        }
+
+        match resolve_owned_unit_repo_dir(source, &unit_tool_rel, &unit_dir) {
+            Some(repo_dir) => {
+                crate::promote::copy_dir_recursive(&unit_dir, &checkout.join(&repo_dir))
+                    .with_context(|| {
+                        format!(
+                            "staging owned skill `{}` -> `{}`",
+                            unit.name,
+                            repo_dir.display()
+                        )
+                    })?;
+                staged += 1;
+            }
+            None => {
+                writeln!(
+                    out,
+                    "# warning: cannot determine a publish path for owned skill `{}` — \
+                     `{}` has no target_layout mapping covering it; NOT pushed",
+                    unit.name, source.name
+                )?;
+            }
+        }
+    }
+    Ok(staged)
+}
+
+/// Resolve the repo-relative directory a locally-authored library unit
+/// should publish to inside a source's checkout, by trying
+/// [`resolve_pair`] — the same `target_layout` resolution
+/// [`ainb_skill_core::apply_to_repo`] uses for lockfile-driven units —
+/// against each file under `unit_dir` until one resolves.
+///
+/// `unit_tool_rel` is the unit's directory relative to the tool root
+/// (dotdir already stripped, e.g. `skills/my-skill`). Returns `None`
+/// when nothing under `unit_dir` matches any mapping the source
+/// declares (e.g. a `target_layout` that simply doesn't cover this
+/// unit's kind) — callers must not silently drop that case; see
+/// [`stage_owned_units`].
+fn resolve_owned_unit_repo_dir(
+    source: &SourceEntry,
+    unit_tool_rel: &Path,
+    unit_dir: &Path,
+) -> Option<PathBuf> {
+    for rel_in_unit in unit_files_relative(unit_dir) {
+        let file_tool_rel = unit_tool_rel.join(&rel_in_unit);
+        let Some((_, repo_rel)) = resolve_pair(source, &file_tool_rel) else {
+            continue;
+        };
+        // `resolve_pair` re-roots the tail (the part of the path after
+        // the layout's static prefix) unchanged, so the mapped file's
+        // path ends with exactly `rel_in_unit`'s components — strip
+        // them back off to recover the unit's mapped directory. Same
+        // trick as `remap_unit_install_path` in skill.rs, repo side.
+        let n = rel_in_unit.components().count();
+        let comps: Vec<_> = repo_rel.components().collect();
+        if comps.len() < n {
+            continue;
+        }
+        return Some(comps[..comps.len() - n].iter().collect());
+    }
+    None
+}
+
+/// Every regular file under `dir`, as paths relative to `dir`. Symlinks
+/// are skipped — `copy_dir_recursive` (which actually stages the unit)
+/// applies the same policy, so a path this walker resolves a publish
+/// location from can never be a symlink the copier then refuses.
+fn unit_files_relative(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect_files_relative(dir, Path::new(""), &mut out);
+    out
+}
+
+fn collect_files_relative(base: &Path, rel: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(base.join(rel)) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let child_rel = rel.join(entry.file_name());
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_files_relative(base, &child_rel, out);
+        } else if file_type.is_file() {
+            out.push(child_rel);
+        }
+    }
+}
+
+/// Reverse of [`tool_dotdir`]: split a stored library path
+/// (`.claude/skills/foo`) into `(tool, tool-root-relative-rest)`
+/// (`("claude", "skills/foo")`). A path that doesn't start with a
+/// recognisable dotdir segment (unexpected, but not fatal) defaults to
+/// [`DEFAULT_TOOL`] with the path taken as-is, rather than failing the
+/// whole push over one malformed entry.
+fn split_tool_relative_path(path: &str) -> (String, PathBuf) {
+    let p = Path::new(path);
+    let mut comps = p.components();
+    let first = comps.next();
+    let rest = comps.as_path().to_path_buf();
+    match first.and_then(|c| c.as_os_str().to_str()) {
+        Some(dotdir) if dotdir.starts_with('.') && dotdir.len() > 1 => {
+            let tool = KNOWN_TOOLS
+                .iter()
+                .copied()
+                .find(|&t| tool_dotdir(t) == dotdir)
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| dotdir.trim_start_matches('.').to_string());
+            (tool, rest)
+        }
+        _ => (DEFAULT_TOOL.to_string(), p.to_path_buf()),
+    }
 }
 
 /// `ainb skill library pull <source>` — rebase-pull a library source's
@@ -297,13 +466,25 @@ fn require_library_source(home: &Path, name: &str) -> Result<SourceEntry> {
         .ok_or_else(|| anyhow!("no source named `{name}` in the manifest"))
 }
 
+/// A `git -C <checkout>` command pre-hardened against interactive
+/// credential prompts: `GIT_TERMINAL_PROMPT=0` + `GIT_ASKPASS=/bin/true`
+/// so an auth-required / unreachable remote fails fast with a plain
+/// error instead of blocking forever on a terminal prompt — mirrors
+/// `ainb_skill_core::sync`'s `git_capture` hardening (commit f34d851).
+fn git_hardened(checkout: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
+        .arg(checkout)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "/bin/true");
+    cmd
+}
+
 /// `git -C <checkout> pull --rebase`. Surfaces stderr verbatim on
 /// failure (conflicts left as standard git conflict markers — no
 /// custom merge UI).
 fn git_pull_rebase(checkout: &Path) -> Result<()> {
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(checkout)
+    let out = git_hardened(checkout)
         .args(["pull", "--rebase"])
         .output()
         .context("running `git pull --rebase`")?;
@@ -316,15 +497,29 @@ fn git_pull_rebase(checkout: &Path) -> Result<()> {
     Ok(())
 }
 
-/// `git add -A && git commit -m <message> && git push` in `checkout`.
-/// A "nothing to commit" commit outcome is treated as success (no-op —
-/// the content sync pass already published everything). Reuses
+/// `git add -A && git commit -m <message> && git push -- origin
+/// HEAD:<source.ref>` in `checkout`. A "nothing to commit" commit
+/// outcome is treated as success (no-op — the content sync pass +
+/// owned-unit staging already published everything). Reuses
 /// `promote`'s committer-identity fallback so a hermetic CI run with no
 /// global git identity still produces a clean commit.
-fn git_add_commit_push(checkout: &Path, message: &str, out: &mut dyn io::Write) -> Result<()> {
-    let add = std::process::Command::new("git")
-        .arg("-C")
-        .arg(checkout)
+///
+/// Pushes via an explicit `HEAD:<ref>` refspec rather than a bare `git
+/// push`: `ensure_repo_clone` never checks out `source.ref` (it just
+/// clones/pulls the remote's default branch), so pushing "whatever
+/// branch happens to be checked out" would silently land on the wrong
+/// remote branch for any source whose ref isn't the default. `HEAD:<ref>`
+/// pushes the checkout's current commit to `source.ref` regardless of
+/// what the local branch is named — mirrors `apply_to_repo`'s explicit
+/// `origin <source.ref>` push target, adapted to not depend on the
+/// local branch name matching.
+fn git_add_commit_push(
+    checkout: &Path,
+    message: &str,
+    source: &SourceEntry,
+    out: &mut dyn io::Write,
+) -> Result<()> {
+    let add = git_hardened(checkout)
         .args(["add", "-A"])
         .output()
         .context("running `git add -A`")?;
@@ -337,10 +532,8 @@ fn git_add_commit_push(checkout: &Path, message: &str, out: &mut dyn io::Write) 
 
     crate::promote::ensure_committer_identity(checkout)?;
 
-    let commit = std::process::Command::new("git")
+    let commit = git_hardened(checkout)
         .env("LC_ALL", "C")
-        .arg("-C")
-        .arg(checkout)
         .args(["-c", "commit.gpgsign=false", "commit", "-m", message])
         .output()
         .context("running `git commit`")?;
@@ -354,10 +547,15 @@ fn git_add_commit_push(checkout: &Path, message: &str, out: &mut dyn io::Write) 
         bail!("git commit failed: {} {}", stdout.trim(), stderr.trim());
     }
 
-    let push = std::process::Command::new("git")
-        .arg("-C")
-        .arg(checkout)
-        .args(["push"])
+    // Refuse an argv-smuggled refspec (e.g. a ref starting with `-`
+    // masquerading as a push flag) — mirrors the same guard in
+    // `ainb_skill_core::sync::apply_to_repo`.
+    if source.r#ref.starts_with('-') {
+        bail!("refusing argv-smuggled ref: `{}`", source.r#ref);
+    }
+    let refspec = format!("HEAD:{}", source.r#ref);
+    let push = git_hardened(checkout)
+        .args(["push", "--", "origin", &refspec])
         .output()
         .context("running `git push`")?;
     if !push.status.success() {
@@ -366,7 +564,12 @@ fn git_add_commit_push(checkout: &Path, message: &str, out: &mut dyn io::Write) 
             String::from_utf8_lossy(&push.stderr).trim()
         );
     }
-    writeln!(out, "pushed library edits for `{}`", checkout.display())?;
+    writeln!(
+        out,
+        "pushed library edits for `{}` to `{}`",
+        checkout.display(),
+        source.r#ref
+    )?;
     Ok(())
 }
 
@@ -471,4 +674,57 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
     let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
     (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Finding 2 (git commands hang on private/unreachable remotes):
+    /// every git `Command` built through [`git_hardened`] must disable
+    /// interactive credential prompts, or an auth-required remote
+    /// blocks `push`/`pull` forever on a terminal prompt.
+    #[test]
+    fn git_hardened_disables_interactive_prompts() {
+        let cmd = git_hardened(Path::new("/tmp/some-checkout"));
+        let env_value = |key: &str| -> Option<String> {
+            cmd.get_envs()
+                .find(|(k, _)| k.to_str() == Some(key))
+                .and_then(|(_, v)| v)
+                .and_then(|v| v.to_str())
+                .map(str::to_string)
+        };
+        assert_eq!(
+            env_value("GIT_TERMINAL_PROMPT").as_deref(),
+            Some("0"),
+            "must disable the terminal credential prompt"
+        );
+        assert_eq!(
+            env_value("GIT_ASKPASS").as_deref(),
+            Some("/bin/true"),
+            "must short-circuit GUI/askpass credential helpers"
+        );
+    }
+
+    #[test]
+    fn split_tool_relative_path_recognises_known_dotdirs() {
+        assert_eq!(
+            split_tool_relative_path(".claude/skills/my-skill"),
+            ("claude".to_string(), PathBuf::from("skills/my-skill"))
+        );
+        assert_eq!(
+            split_tool_relative_path(".codex/skills/other"),
+            ("codex".to_string(), PathBuf::from("skills/other"))
+        );
+    }
+
+    #[test]
+    fn split_tool_relative_path_defaults_claude_for_unrecognisable_input() {
+        // No leading dotdir at all — falls back to the default tool
+        // rather than failing the whole push over one malformed entry.
+        assert_eq!(
+            split_tool_relative_path("skills/my-skill"),
+            ("claude".to_string(), PathBuf::from("skills/my-skill"))
+        );
+    }
 }

--- a/ainb-tui/crates/ainb-cli/src/library.rs
+++ b/ainb-tui/crates/ainb-cli/src/library.rs
@@ -17,6 +17,10 @@ use anyhow::{Context, Result, anyhow, bail};
 use ainb_adapters_tool::read_root_for;
 use ainb_skill_core::UnitKind;
 use ainb_skill_core::library::{Library, OwnedUnit, library_path_in};
+use ainb_skill_core::lockfile::Lockfile;
+use ainb_skill_core::manifest::{Manifest, SourceEntry};
+use ainb_skill_core::paths::{lockfile_path_in, manifest_path_in};
+use ainb_skill_core::uri::Uri;
 
 use crate::LibraryCmd;
 
@@ -28,6 +32,11 @@ pub fn dispatch(home: &Path, cmd: LibraryCmd, out: &mut dyn io::Write) -> Result
         LibraryCmd::List { json } => list(home, json, out),
         LibraryCmd::Add { path, tool } => add(home, &path, tool.as_deref(), out),
         LibraryCmd::New { name, tool } => new(home, &name, tool.as_deref(), out),
+        LibraryCmd::Copy { uri, tool } => copy(home, &uri, tool.as_deref(), out),
+        LibraryCmd::MarkSource { name } => mark_source(home, &name, out),
+        LibraryCmd::UnmarkSource { name } => unmark_source(home, &name, out),
+        LibraryCmd::Push { source } => push(home, &source, out),
+        LibraryCmd::Pull { source } => pull(home, &source, out),
     }
 }
 
@@ -146,6 +155,219 @@ fn new(home: &Path, name: &str, tool: Option<&str>, out: &mut dyn io::Write) -> 
 
     let rel = tool_home_relative_path(tool, "skills", name);
     register_owned(home, name, UnitKind::Skill, &rel, out)
+}
+
+/// `ainb skill library copy <uri> [--tool t]` — copy a unit from ANY
+/// configured source into the user's library. Resolves the source unit
+/// dir the same way `install` does, deploys it under the tool's skills
+/// dir (idempotent — skipped when already deployed there), then
+/// registers it as an owned unit.
+fn copy(home: &Path, uri_str: &str, tool: Option<&str>, out: &mut dyn io::Write) -> Result<()> {
+    let tool = tool.unwrap_or(DEFAULT_TOOL);
+    let uri = Uri::parse(uri_str).with_context(|| format!("parsing `{uri_str}`"))?;
+
+    let resolution = crate::skill::resolve_unit_dir(home, &uri)?;
+    let src_dir = resolution.unit_dir();
+    let name = src_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow!("cannot derive a unit name from `{}`", src_dir.display()))?
+        .to_string();
+
+    let dest = read_root_for(tool).join("skills").join(&name);
+    if dest.exists() {
+        writeln!(
+            out,
+            "# `{name}` already deployed at `{}` — skipping copy, registering only",
+            dest.display()
+        )?;
+    } else {
+        crate::promote::copy_dir_recursive(&src_dir, &dest)
+            .with_context(|| format!("copying `{}` -> `{}`", src_dir.display(), dest.display()))?;
+    }
+
+    let rel = tool_home_relative_path(tool, "skills", &name);
+    register_owned(home, &name, resolution.kind, &rel, out)
+}
+
+/// `ainb skill library mark-source <name>` — opt a manifest source into
+/// git-native two-way library sync (`push`/`pull`).
+fn mark_source(home: &Path, name: &str, out: &mut dyn io::Write) -> Result<()> {
+    require_manifest_source(home, name)?;
+    let lib_path = library_path_in(home);
+    let mut lib = Library::load_from(&lib_path)?;
+    let inserted = lib.mark_source(name);
+    lib.save_to(&lib_path)?;
+    if inserted {
+        writeln!(out, "marked `{name}` as a library source")?;
+    } else {
+        writeln!(out, "`{name}` is already a library source")?;
+    }
+    Ok(())
+}
+
+/// `ainb skill library unmark-source <name>` — the inverse of `mark-source`.
+fn unmark_source(home: &Path, name: &str, out: &mut dyn io::Write) -> Result<()> {
+    require_manifest_source(home, name)?;
+    let lib_path = library_path_in(home);
+    let mut lib = Library::load_from(&lib_path)?;
+    let removed = lib.unmark_source(name);
+    lib.save_to(&lib_path)?;
+    if removed {
+        writeln!(out, "unmarked `{name}` as a library source")?;
+    } else {
+        writeln!(out, "`{name}` was not a library source")?;
+    }
+    Ok(())
+}
+
+/// Bail unless `name` is a source declared in the manifest — guards
+/// `mark-source`/`unmark-source` against typos.
+fn require_manifest_source(home: &Path, name: &str) -> Result<()> {
+    let manifest = Manifest::load_from(&manifest_path_in(home))?;
+    if !manifest.sources.iter().any(|s| s.name == name) {
+        bail!("no source named `{name}` in the manifest — run `ainb source add` first");
+    }
+    Ok(())
+}
+
+/// `ainb skill library push <source>` — publish local library edits to
+/// a library source's git remote. Runs the same bidirectional content
+/// sync `ainb skill sync` uses (scoped to this source, to-repo only),
+/// then commits + pushes anything that sync's per-file lockfile-driven
+/// diffing didn't already cover (e.g. a `library copy`/`new` skill that
+/// was never `install`ed through the lockfile).
+fn push(home: &Path, source_name: &str, out: &mut dyn io::Write) -> Result<()> {
+    let source = require_library_source(home, source_name)?;
+
+    let manifest = Manifest::load_from(&manifest_path_in(home))?;
+    let lockfile = Lockfile::load_from(&lockfile_path_in(home))?;
+    let sync_args = crate::SyncArgs {
+        source_or_unit: Some(source_name.to_string()),
+        yes: true,
+        dry_run: false,
+        to_home: false,
+        to_repo: true,
+    };
+    crate::skill::bidirectional_content_sync(home, &manifest, &lockfile, &sync_args, out)?;
+
+    let checkout = crate::skill::ensure_repo_clone(home, &source)?;
+    git_add_commit_push(&checkout, "ainb: sync library edits", out)
+}
+
+/// `ainb skill library pull <source>` — rebase-pull a library source's
+/// git remote, then sync its (possibly updated) content back down into
+/// the tool home.
+fn pull(home: &Path, source_name: &str, out: &mut dyn io::Write) -> Result<()> {
+    let source = require_library_source(home, source_name)?;
+    let checkout = crate::skill::ensure_repo_clone(home, &source)?;
+    git_pull_rebase(&checkout)?;
+
+    let manifest = Manifest::load_from(&manifest_path_in(home))?;
+    let lockfile = Lockfile::load_from(&lockfile_path_in(home))?;
+    let sync_args = crate::SyncArgs {
+        source_or_unit: Some(source_name.to_string()),
+        yes: true,
+        dry_run: false,
+        to_home: true,
+        to_repo: false,
+    };
+    crate::skill::bidirectional_content_sync(home, &manifest, &lockfile, &sync_args, out)?;
+    writeln!(out, "pulled `{source_name}` and synced to home")?;
+    Ok(())
+}
+
+/// Bail unless `name` is both declared in the manifest AND marked as a
+/// library source; on success returns the owned `SourceEntry` (cloned
+/// out of the manifest borrow) so the caller can resolve its checkout.
+fn require_library_source(home: &Path, name: &str) -> Result<SourceEntry> {
+    let lib = Library::load_from(&library_path_in(home))?;
+    if !lib.is_library_source(name) {
+        bail!(
+            "`{name}` is not a library source — run \
+             `ainb skill library mark-source {name}` first"
+        );
+    }
+    let manifest = Manifest::load_from(&manifest_path_in(home))?;
+    manifest
+        .sources
+        .iter()
+        .find(|s| s.name == name)
+        .cloned()
+        .ok_or_else(|| anyhow!("no source named `{name}` in the manifest"))
+}
+
+/// `git -C <checkout> pull --rebase`. Surfaces stderr verbatim on
+/// failure (conflicts left as standard git conflict markers — no
+/// custom merge UI).
+fn git_pull_rebase(checkout: &Path) -> Result<()> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["pull", "--rebase"])
+        .output()
+        .context("running `git pull --rebase`")?;
+    if !out.status.success() {
+        bail!(
+            "git pull --rebase failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// `git add -A && git commit -m <message> && git push` in `checkout`.
+/// A "nothing to commit" commit outcome is treated as success (no-op —
+/// the content sync pass already published everything). Reuses
+/// `promote`'s committer-identity fallback so a hermetic CI run with no
+/// global git identity still produces a clean commit.
+fn git_add_commit_push(checkout: &Path, message: &str, out: &mut dyn io::Write) -> Result<()> {
+    let add = std::process::Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["add", "-A"])
+        .output()
+        .context("running `git add -A`")?;
+    if !add.status.success() {
+        bail!(
+            "git add -A failed: {}",
+            String::from_utf8_lossy(&add.stderr).trim()
+        );
+    }
+
+    crate::promote::ensure_committer_identity(checkout)?;
+
+    let commit = std::process::Command::new("git")
+        .env("LC_ALL", "C")
+        .arg("-C")
+        .arg(checkout)
+        .args(["-c", "commit.gpgsign=false", "commit", "-m", message])
+        .output()
+        .context("running `git commit`")?;
+    if !commit.status.success() {
+        let stderr = String::from_utf8_lossy(&commit.stderr);
+        let stdout = String::from_utf8_lossy(&commit.stdout);
+        if stdout.contains("nothing to commit") || stderr.contains("nothing to commit") {
+            writeln!(out, "# nothing to commit — library edits already in sync")?;
+            return Ok(());
+        }
+        bail!("git commit failed: {} {}", stdout.trim(), stderr.trim());
+    }
+
+    let push = std::process::Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["push"])
+        .output()
+        .context("running `git push`")?;
+    if !push.status.success() {
+        bail!(
+            "git push failed: {}",
+            String::from_utf8_lossy(&push.stderr).trim()
+        );
+    }
+    writeln!(out, "pushed library edits for `{}`", checkout.display())?;
+    Ok(())
 }
 
 /// Shared registration tail: load `library.yaml`, register (dedup by

--- a/ainb-tui/crates/ainb-cli/src/promote.rs
+++ b/ainb-tui/crates/ainb-cli/src/promote.rs
@@ -590,7 +590,7 @@ fn git_add_and_commit(cache: &Path, unit_name: &str, message: &str) -> Result<()
 /// so the caller learns about read-only repos / permission errors
 /// instead of seeing them silently become "Author identity unknown"
 /// later in `git commit`.
-fn ensure_committer_identity(cache: &Path) -> Result<()> {
+pub(crate) fn ensure_committer_identity(cache: &Path) -> Result<()> {
     fn has_global(key: &str) -> bool {
         ProcCommand::new("git")
             .args(["config", "--get", key])
@@ -697,7 +697,7 @@ fn require_success(out: &Output, what: &str) -> Result<()> {
 /// as their target. This is deliberate: a symlink redirect would be
 /// a surprising escape from the nominal source root, and skill dirs
 /// are expected to be regular file trees only.
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     let meta = fs::symlink_metadata(src)
         .with_context(|| format!("reading metadata for `{}`", src.display()))?;
     if !meta.is_dir() {

--- a/ainb-tui/crates/ainb-cli/src/skill.rs
+++ b/ainb-tui/crates/ainb-cli/src/skill.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use ainb_adapters_source::pick_adapter;
+use ainb_adapters_source::{ResolvedUnit, pick_adapter};
 use ainb_adapters_tool::{
     AcceptDecision, ToolAdapter, adapter_by_name, all_adapters, install_root_for,
     plan::{InstallPlan, PlanOp},
@@ -87,29 +87,60 @@ pub fn dispatch(home: &Path, action: SkillCommand, out: &mut dyn io::Write) -> R
     }
 }
 
-fn install(home: &Path, args: InstallArgs, out: &mut dyn io::Write) -> Result<()> {
-    let uri = Uri::parse(&args.uri).with_context(|| format!("parsing `{}`", args.uri))?;
+/// Result of [`resolve_unit_dir`] — everything `install()` (and any other
+/// caller that needs a unit's on-disk location) derives from a unit URI:
+/// the fully resolved unit, its parsed kind, the source's current pinned
+/// SHA, and the lockfile — already updated + saved with a fresh fetch
+/// record when the source had none yet, so callers can keep mutating it
+/// (e.g. `install()` appends the `LockedUnit` and saves again).
+pub(crate) struct UnitDirResolution {
+    pub resolved: ResolvedUnit,
+    pub kind: UnitKind,
+    pub source: SourceEntry,
+    pub source_sha: Option<String>,
+    pub lockfile: Lockfile,
+}
+
+impl UnitDirResolution {
+    /// Absolute on-disk directory of the resolved unit (source root +
+    /// the descriptor's repo-relative path) — the directory `library
+    /// copy` and `install` both read files from.
+    pub fn unit_dir(&self) -> PathBuf {
+        self.resolved.source_root.join(&self.resolved.descriptor.path)
+    }
+}
+
+/// Resolve a unit URI down to its on-disk location: find the matching
+/// enabled source in the manifest, ensure it's fetched (fetching + a
+/// lockfile upsert on demand when it never was, or its cache dir is
+/// gone), then pick a source adapter and resolve the unit within the
+/// fetched checkout.
+///
+/// This is the shared front half of `install()` — factored out so other
+/// callers (e.g. `ainb skill library copy`) can resolve a unit's files
+/// without reimplementing the fetch/adapter dance.
+pub(crate) fn resolve_unit_dir(home: &Path, uri: &Uri) -> Result<UnitDirResolution> {
     if !uri.is_unit() {
         bail!(
             "`{}` is not a unit URI — expected `<source>@<ref>/<path>`",
-            args.uri
+            uri.display()
         );
     }
 
     // Look up the source matching this URI in the user manifest.
     let manifest = Manifest::load_from(&manifest_path_in(home))?;
     let source_uri = format!("{}:{}", uri.source_type, uri.locator);
-    let source =
-        manifest
-            .sources
-            .iter()
-            .find(|s| s.uri == source_uri && s.enabled)
-            .ok_or_else(|| {
-                anyhow!(
-                    "no enabled source matches `{source_uri}` — run \
+    let source = manifest
+        .sources
+        .iter()
+        .find(|s| s.uri == source_uri && s.enabled)
+        .ok_or_else(|| {
+            anyhow!(
+                "no enabled source matches `{source_uri}` — run \
                  `ainb source add {source_uri}` first"
-                )
-            })?;
+            )
+        })?
+        .clone();
 
     // Find the fetched checkout via lockfile. If the source has never been
     // fetched (or its cache dir is gone — e.g. the manifest was authored by
@@ -172,6 +203,32 @@ fn install(home: &Path, args: InstallArgs, out: &mut dyn io::Write) -> Result<()
         .parse()
         .with_context(|| format!("unit kind `{}`", resolved.descriptor.kind))?;
 
+    Ok(UnitDirResolution {
+        resolved,
+        kind,
+        source,
+        source_sha,
+        lockfile,
+    })
+}
+
+fn install(home: &Path, args: InstallArgs, out: &mut dyn io::Write) -> Result<()> {
+    let uri = Uri::parse(&args.uri).with_context(|| format!("parsing `{}`", args.uri))?;
+    if !uri.is_unit() {
+        bail!(
+            "`{}` is not a unit URI — expected `<source>@<ref>/<path>`",
+            args.uri
+        );
+    }
+
+    let UnitDirResolution {
+        resolved,
+        kind,
+        source,
+        source_sha,
+        mut lockfile,
+    } = resolve_unit_dir(home, &uri)?;
+
     // Pick target tools.
     let targets = parse_targets(args.targets.as_deref())?;
 
@@ -191,7 +248,7 @@ fn install(home: &Path, args: InstallArgs, out: &mut dyn io::Write) -> Result<()
                 // paths; we rewrite them here using `resolve_pair`. See
                 // bead v12.C.4.
                 let plan = remap_plan_via_target_layout(
-                    source,
+                    &source,
                     tool.name(),
                     &install_root_for(tool.name()),
                     plan,
@@ -770,7 +827,7 @@ fn sync(home: &Path, args: SyncArgs, out: &mut dyn io::Write) -> Result<()> {
 /// On `--dry-run`, prints the plan and returns without executing.
 /// `args.source_or_unit`, when set, scopes the iteration to one
 /// source (by source name) or one unit (by lockfile `declared_uri`).
-fn bidirectional_content_sync(
+pub(crate) fn bidirectional_content_sync(
     home: &Path,
     manifest: &Manifest,
     lockfile: &Lockfile,
@@ -1075,7 +1132,7 @@ impl ContentFetcher for GitClonedFetcher {
 /// `<ainb-home>/promote-cache/<sanitised-remote>/` and return the
 /// checkout path. Sanitised remote key mirrors `promote.rs` so the
 /// two flows share the same cache directory.
-fn ensure_repo_clone(home: &Path, source: &SourceEntry) -> Result<PathBuf> {
+pub(crate) fn ensure_repo_clone(home: &Path, source: &SourceEntry) -> Result<PathBuf> {
     let remote = git_remote_url(source)?;
     let key = sanitise_cache_key(&remote);
     let cache = home.join("promote-cache").join(&key);

--- a/ainb-tui/crates/ainb-cli/tests/skill_library_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/skill_library_tests.rs
@@ -9,8 +9,12 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use ainb_cli::{Command as CliCommand, LibraryCmd, SkillCommand, dispatch};
+use ainb_cli::{
+    AddArgs, Command as CliCommand, InstallArgs, LibraryCmd, SkillCommand, SourceCommand, dispatch,
+};
 use ainb_skill_core::library::{Library, library_path_in};
+use ainb_skill_core::manifest::{Manifest, SourceEntry, TargetMapping};
+use ainb_skill_core::paths::manifest_path_in;
 
 /// Serialises `AINB_TOOL_HOME_CLAUDE` mutation across these tests so a
 /// parallel run doesn't trample another test's tool home.
@@ -43,23 +47,77 @@ impl Sandbox {
     }
 }
 
-/// Run a `skill library` subcommand against the sandbox with the claude
-/// tool home isolated to `sandbox.claude_home`. Returns the captured
-/// stdout. Holds `ENV_LOCK` for the duration so the env override is
-/// race-free.
-fn run_library(sandbox: &Sandbox, cmd: LibraryCmd) -> (anyhow::Result<()>, String) {
+/// Run any `skill` subcommand against the sandbox with the claude tool
+/// home isolated to `sandbox.claude_home`. Returns the captured stdout.
+/// Holds `ENV_LOCK` for the duration so the env override is race-free.
+fn run_skill(sandbox: &Sandbox, action: SkillCommand) -> (anyhow::Result<()>, String) {
     let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("AINB_TOOL_HOME_CLAUDE", &sandbox.claude_home);
     let mut buf: Vec<u8> = Vec::new();
-    let res = dispatch(
-        &sandbox.home,
-        CliCommand::Skill {
-            action: SkillCommand::Library { cmd },
-        },
-        &mut buf,
-    );
+    let res = dispatch(&sandbox.home, CliCommand::Skill { action }, &mut buf);
     std::env::remove_var("AINB_TOOL_HOME_CLAUDE");
     (res, String::from_utf8(buf).expect("utf8 stdout"))
+}
+
+/// Run a `skill library` subcommand — thin wrapper over [`run_skill`].
+fn run_library(sandbox: &Sandbox, cmd: LibraryCmd) -> (anyhow::Result<()>, String) {
+    run_skill(sandbox, SkillCommand::Library { cmd })
+}
+
+/// `ainb source add` against the sandbox — no tool-home isolation
+/// needed (source add never touches a tool home).
+fn add_source(sandbox: &Sandbox, action: SourceCommand) -> anyhow::Result<()> {
+    let mut buf = Vec::new();
+    dispatch(&sandbox.home, CliCommand::Source { action }, &mut buf)
+}
+
+/// Seed a `local:` source fixture with one skill and register it in the
+/// sandbox's manifest via `source add`. Returns the fixture dir (kept
+/// alive for the caller) and the full unit URI.
+fn add_local_skill_source(
+    sandbox: &Sandbox,
+    source_name: &str,
+    skill_name: &str,
+) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join(format!("skills/{skill_name}/SKILL.md"));
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(
+        &p,
+        format!("---\nname: {skill_name}\nkind: skill\n---\nHand-authored {skill_name}.\n"),
+    )
+    .unwrap();
+    let local_uri = format!("local:{}", dir.path().display());
+
+    add_source(
+        sandbox,
+        SourceCommand::Add(AddArgs {
+            uri: local_uri.clone(),
+            name: Some(source_name.to_string()),
+            kind: None,
+        }),
+    )
+    .expect("add local source");
+
+    let unit_uri = format!("{local_uri}@main/skills/{skill_name}");
+    (dir, unit_uri)
+}
+
+/// Manually append a bare `SourceEntry` to the manifest — used by tests
+/// that only need `mark-source`/`unmark-source`'s manifest-membership
+/// check, not a real fetchable source.
+fn seed_manifest_source(home: &Path, name: &str) {
+    let mut manifest = Manifest::load_from(&manifest_path_in(home)).unwrap();
+    manifest.sources.push(SourceEntry {
+        name: name.to_string(),
+        kind: None,
+        uri: format!("local:/nonexistent/{name}"),
+        r#ref: "main".to_string(),
+        enabled: true,
+        read_only: false,
+        target_layout: Vec::new(),
+    });
+    manifest.save_to(&manifest_path_in(home)).unwrap();
 }
 
 /// Seed an on-disk skill folder under the claude tool home so
@@ -215,5 +273,311 @@ fn library_add_rejects_outside_tool_home() {
     assert!(
         lib.get("rogue").is_none(),
         "rejected path is not registered"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// `library copy` — resolves ANY configured source's unit and deploys +
+// registers it, reusing `install`'s fetch/adapter machinery.
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn library_copy_deploys_from_any_source_and_registers() {
+    let sb = Sandbox::new();
+    let (_src, unit_uri) = add_local_skill_source(&sb, "ext", "borrowed");
+
+    let (res, out) = run_library(
+        &sb,
+        LibraryCmd::Copy {
+            uri: unit_uri.clone(),
+            tool: None,
+        },
+    );
+    res.expect("library copy ok");
+    assert!(out.contains("borrowed"), "out names the skill: {out}");
+
+    let deployed = sb.claude_home.join("skills").join("borrowed").join("SKILL.md");
+    assert!(
+        deployed.is_file(),
+        "copy deploys under tool home: {deployed:?}"
+    );
+
+    let lib = sb.library();
+    let owned = lib.get("borrowed").expect("registered after copy");
+    assert_eq!(owned.path, ".claude/skills/borrowed");
+}
+
+#[test]
+fn library_copy_is_idempotent_when_already_deployed() {
+    let sb = Sandbox::new();
+    let (_src, unit_uri) = add_local_skill_source(&sb, "ext2", "already-there");
+
+    // Pre-place the destination with different bytes — copy must not
+    // clobber an existing deployment, only register it.
+    let dest = sb.claude_home.join("skills").join("already-there");
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(dest.join("SKILL.md"), "hand-edited, not the source copy\n").unwrap();
+
+    let (res, out) = run_library(
+        &sb,
+        LibraryCmd::Copy {
+            uri: unit_uri.clone(),
+            tool: None,
+        },
+    );
+    res.expect("library copy ok");
+    assert!(out.contains("skipping copy"), "out: {out}");
+    assert_eq!(
+        fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+        "hand-edited, not the source copy\n",
+        "already-deployed content must be preserved"
+    );
+
+    let lib = sb.library();
+    assert!(lib.get("already-there").is_some(), "still registered");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// `library mark-source` / `unmark-source` — opt a manifest source into
+// git-native two-way library sync.
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn mark_source_then_unmark_round_trips() {
+    let sb = Sandbox::new();
+    seed_manifest_source(&sb.home, "my-source");
+
+    let (res, out) = run_library(
+        &sb,
+        LibraryCmd::MarkSource {
+            name: "my-source".into(),
+        },
+    );
+    res.expect("mark-source ok");
+    assert!(out.contains("marked"), "out: {out}");
+    assert!(sb.library().is_library_source("my-source"));
+
+    // Reload-through-dispatch: a second mark is a no-op, not an error.
+    let (res, out) = run_library(
+        &sb,
+        LibraryCmd::MarkSource {
+            name: "my-source".into(),
+        },
+    );
+    res.expect("repeat mark-source ok");
+    assert!(out.contains("already"), "out: {out}");
+
+    let (res, out) = run_library(
+        &sb,
+        LibraryCmd::UnmarkSource {
+            name: "my-source".into(),
+        },
+    );
+    res.expect("unmark-source ok");
+    assert!(out.contains("unmarked"), "out: {out}");
+    assert!(!sb.library().is_library_source("my-source"));
+}
+
+#[test]
+fn mark_source_rejects_unknown_source() {
+    let sb = Sandbox::new();
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::MarkSource {
+            name: "ghost".into(),
+        },
+    );
+    assert!(res.is_err(), "unknown source name must bail");
+    let msg = format!("{}", res.unwrap_err());
+    assert!(
+        msg.contains("no source named"),
+        "error names the reason: {msg}"
+    );
+    assert!(!sb.library().is_library_source("ghost"));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// `library push` / `pull` — git-native two-way sync, gated on
+// `mark-source`.
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn push_bails_when_source_not_marked_library() {
+    let sb = Sandbox::new();
+    seed_manifest_source(&sb.home, "unmarked");
+
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::Push {
+            source: "unmarked".into(),
+        },
+    );
+    assert!(res.is_err(), "push must refuse a non-library source");
+    let msg = format!("{}", res.unwrap_err());
+    assert!(msg.contains("not a library source"), "error: {msg}");
+}
+
+#[test]
+fn pull_bails_when_source_not_marked_library() {
+    let sb = Sandbox::new();
+    seed_manifest_source(&sb.home, "unmarked2");
+
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::Pull {
+            source: "unmarked2".into(),
+        },
+    );
+    assert!(res.is_err(), "pull must refuse a non-library source");
+    let msg = format!("{}", res.unwrap_err());
+    assert!(msg.contains("not a library source"), "error: {msg}");
+}
+
+/// Run `git <args>` in `cwd`, panicking with the captured output on any
+/// invocation failure the caller doesn't explicitly check.
+fn git(args: &[&str], cwd: &Path) -> std::process::Output {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "ainb-test")
+        .env("GIT_AUTHOR_EMAIL", "ainb-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "ainb-test")
+        .env("GIT_COMMITTER_EMAIL", "ainb-test@example.invalid")
+        .output()
+        .expect("git")
+}
+
+fn init_bare_repo(dir: &Path) {
+    fs::create_dir_all(dir).unwrap();
+    let out = git(&["init", "--bare", "-b", "main"], dir);
+    assert!(out.status.success(), "git init --bare: {out:?}");
+}
+
+fn init_working_clone(remote: &str, dir: &Path) {
+    let out = std::process::Command::new("git")
+        .args(["clone", remote])
+        .arg(dir)
+        .output()
+        .expect("git clone");
+    assert!(out.status.success(), "git clone: {out:?}");
+    git(&["config", "user.email", "ainb-test@example.invalid"], dir);
+    git(&["config", "user.name", "ainb-test"], dir);
+}
+
+fn seed_skill_and_push(working_clone: &Path, body: &[u8]) {
+    let p = working_clone.join("skills/commit/SKILL.md");
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, body).unwrap();
+    assert!(git(&["add", "skills/commit/SKILL.md"], working_clone).status.success());
+    assert!(git(&["commit", "-m", "seed commit skill"], working_clone).status.success());
+    assert!(git(&["push", "origin", "main"], working_clone).status.success());
+}
+
+/// End-to-end: install a unit from a real (local `file://` bare) git
+/// source, mark that source as a library source, edit the deployed
+/// file, `push` — the edit must land in the source's fetched checkout
+/// (same `promote-cache` clone `ainb skill sync` uses) with a commit
+/// covering it. Exercises the reused `bidirectional_content_sync`
+/// machinery end-to-end, not just the bail path.
+#[test]
+fn push_publishes_deployed_edit_to_checkout_and_commits() {
+    let sb = Sandbox::new();
+    let bare_repo = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+
+    init_bare_repo(bare_repo.path());
+    let bare_url = format!("file://{}", bare_repo.path().display());
+    init_working_clone(&bare_url, working.path());
+    seed_skill_and_push(working.path(), b"---\nname: commit\n---\ninitial body\n");
+
+    let source_uri = format!("git:{bare_url}");
+    add_source(
+        &sb,
+        SourceCommand::Add(AddArgs {
+            uri: source_uri.clone(),
+            name: Some("upstream".into()),
+            kind: None,
+        }),
+    )
+    .expect("add git source");
+
+    // Declare `target_layout` so the content-sync planner can map the
+    // skill's path — mirrors `skill_sync_roundtrip_tests.rs` (the CLI's
+    // `source add` doesn't populate this for non-marketplace sources).
+    let mut manifest = Manifest::load_from(&manifest_path_in(&sb.home)).unwrap();
+    manifest
+        .sources
+        .iter_mut()
+        .find(|s| s.name == "upstream")
+        .unwrap()
+        .target_layout = vec![TargetMapping {
+        glob: "skills/*/SKILL.md".into(),
+        home: PathBuf::from("skills"),
+        repo: PathBuf::from("skills"),
+    }];
+    manifest.save_to(&manifest_path_in(&sb.home)).unwrap();
+
+    let unit_uri = format!("{source_uri}@main/skills/commit");
+    let (res, _out) = run_skill(
+        &sb,
+        SkillCommand::Install(InstallArgs {
+            uri: unit_uri.clone(),
+            targets: Some("claude".into()),
+            dry_run: false,
+            yes: true,
+        }),
+    );
+    res.expect("install ok");
+
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::MarkSource {
+            name: "upstream".into(),
+        },
+    );
+    res.expect("mark-source ok");
+
+    let home_file = sb.claude_home.join("skills/commit/SKILL.md");
+    assert!(
+        home_file.is_file(),
+        "install must place file: {home_file:?}"
+    );
+    let edited = b"---\nname: commit\n---\nlibrary-edited\n";
+    fs::write(&home_file, edited).unwrap();
+
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::Push {
+            source: "upstream".into(),
+        },
+    );
+    res.expect("push ok");
+
+    // The edit reached the cache checkout (`<AINB_HOME>/promote-cache/<key>/`
+    // — the same clone `ainb skill sync` maintains for this source).
+    let cache_root = sb.home.join("promote-cache");
+    assert!(cache_root.exists(), "promote-cache dir must exist");
+    let clones: Vec<_> = fs::read_dir(&cache_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(clones.len(), 1, "expected one cache clone, got: {clones:?}");
+    let clone_dir = clones[0].path();
+    let cache_file = clone_dir.join("skills/commit/SKILL.md");
+    assert_eq!(
+        fs::read(&cache_file).unwrap(),
+        edited,
+        "cache repo bytes must match the library edit"
+    );
+
+    // A commit covering the edit exists in the checkout's log — made by
+    // the reused content-sync machinery's `apply_to_repo` (subject
+    // `sync: commit`), or by `push`'s own catch-all commit otherwise.
+    let log = git(&["log", "--oneline"], &clone_dir);
+    let log_text = String::from_utf8_lossy(&log.stdout);
+    assert!(
+        log_text.contains("sync:") || log_text.contains("ainb: sync library edits"),
+        "expected a sync commit in the checkout log: {log_text}"
     );
 }

--- a/ainb-tui/crates/ainb-cli/tests/skill_library_tests.rs
+++ b/ainb-tui/crates/ainb-cli/tests/skill_library_tests.rs
@@ -581,3 +581,224 @@ fn push_publishes_deployed_edit_to_checkout_and_commits() {
         "expected a sync commit in the checkout log: {log_text}"
     );
 }
+
+/// Finding 1 regression: a `library new` skill is registered in
+/// `library.yaml` and deployed under the tool home, but is NEVER
+/// installed through the lockfile — `bidirectional_content_sync` only
+/// walks `lockfile.units`, so before the fix `push` reported success
+/// while publishing nothing for it. Assert it actually lands in the
+/// checkout, gets committed, and reaches the bare remote.
+#[test]
+fn push_stages_owned_library_units_never_installed_through_lockfile() {
+    let sb = Sandbox::new();
+    let bare_repo = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+
+    init_bare_repo(bare_repo.path());
+    let bare_url = format!("file://{}", bare_repo.path().display());
+    init_working_clone(&bare_url, working.path());
+    seed_skill_and_push(working.path(), b"---\nname: commit\n---\ninitial body\n");
+
+    let source_uri = format!("git:{bare_url}");
+    add_source(
+        &sb,
+        SourceCommand::Add(AddArgs {
+            uri: source_uri.clone(),
+            name: Some("upstream".into()),
+            kind: None,
+        }),
+    )
+    .expect("add git source");
+
+    let mut manifest = Manifest::load_from(&manifest_path_in(&sb.home)).unwrap();
+    manifest
+        .sources
+        .iter_mut()
+        .find(|s| s.name == "upstream")
+        .unwrap()
+        .target_layout = vec![TargetMapping {
+        glob: "skills/*/SKILL.md".into(),
+        home: PathBuf::from("skills"),
+        repo: PathBuf::from("skills"),
+    }];
+    manifest.save_to(&manifest_path_in(&sb.home)).unwrap();
+
+    // `library new` — owned unit, no lockfile entry at all.
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::New {
+            name: "home-grown".into(),
+            tool: None,
+        },
+    );
+    res.expect("library new ok");
+    let owned_content = "---\nname: home-grown\nkind: skill\n---\nauthored locally.\n";
+    fs::write(
+        sb.claude_home.join("skills/home-grown/SKILL.md"),
+        owned_content,
+    )
+    .unwrap();
+
+    run_library(
+        &sb,
+        LibraryCmd::MarkSource {
+            name: "upstream".into(),
+        },
+    )
+    .0
+    .expect("mark-source ok");
+
+    let (res, out) = run_library(
+        &sb,
+        LibraryCmd::Push {
+            source: "upstream".into(),
+        },
+    );
+    res.expect("push ok");
+    assert!(
+        out.contains("staged 1 owned-library unit"),
+        "push reports the staged unit: {out}"
+    );
+
+    let cache_root = sb.home.join("promote-cache");
+    let clones: Vec<_> = fs::read_dir(&cache_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(clones.len(), 1, "expected one cache clone, got: {clones:?}");
+    let clone_dir = clones[0].path();
+    let cache_file = clone_dir.join("skills/home-grown/SKILL.md");
+    assert!(
+        cache_file.is_file(),
+        "owned unit staged into checkout at {cache_file:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&cache_file).unwrap(),
+        owned_content,
+        "staged bytes match the owned unit's on-disk content"
+    );
+
+    let log = git(&["log", "--oneline"], &clone_dir);
+    let log_text = String::from_utf8_lossy(&log.stdout);
+    assert!(
+        log_text.contains("ainb: sync library edits"),
+        "expected push's catch-all commit in the checkout log: {log_text}"
+    );
+
+    // Reached the bare remote, not just the local cache checkout.
+    let verify = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new("git")
+        .args(["clone", &bare_url])
+        .arg(verify.path())
+        .output()
+        .expect("git clone verify");
+    assert!(out.status.success(), "clone verify: {out:?}");
+    assert!(
+        verify.path().join("skills/home-grown/SKILL.md").is_file(),
+        "owned unit pushed all the way to the bare remote"
+    );
+}
+
+/// Finding 3 regression: `ensure_repo_clone` never checks out
+/// `source.ref` (it clones the remote's default branch), and a bare
+/// `git push` would push whatever branch happens to be checked out —
+/// silently landing on the wrong remote branch for a source whose ref
+/// isn't the default. Set up a source pinned to a non-default branch
+/// and assert the push lands there, not on the bare repo's `main`.
+#[test]
+fn push_targets_the_sources_configured_ref_not_the_default_branch() {
+    let sb = Sandbox::new();
+    let bare_repo = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+
+    init_bare_repo(bare_repo.path());
+    let bare_url = format!("file://{}", bare_repo.path().display());
+    init_working_clone(&bare_url, working.path());
+    seed_skill_and_push(working.path(), b"---\nname: commit\n---\ninitial body\n");
+
+    // A second branch, diverging from `main` at the same commit — the
+    // source will be pinned to this one instead of the bare repo's
+    // default (which `ensure_repo_clone`'s plain `git clone` checks out).
+    assert!(git(&["checkout", "-b", "release"], working.path()).status.success());
+    assert!(git(&["push", "origin", "release"], working.path()).status.success());
+
+    let source_uri = format!("git:{bare_url}");
+    add_source(
+        &sb,
+        SourceCommand::Add(AddArgs {
+            uri: source_uri.clone(),
+            name: Some("upstream".into()),
+            kind: None,
+        }),
+    )
+    .expect("add git source");
+
+    let mut manifest = Manifest::load_from(&manifest_path_in(&sb.home)).unwrap();
+    {
+        let entry = manifest.sources.iter_mut().find(|s| s.name == "upstream").unwrap();
+        entry.r#ref = "release".to_string();
+        entry.target_layout = vec![TargetMapping {
+            glob: "skills/*/SKILL.md".into(),
+            home: PathBuf::from("skills"),
+            repo: PathBuf::from("skills"),
+        }];
+    }
+    manifest.save_to(&manifest_path_in(&sb.home)).unwrap();
+
+    let (res, _out) = run_library(
+        &sb,
+        LibraryCmd::New {
+            name: "release-only".into(),
+            tool: None,
+        },
+    );
+    res.expect("library new ok");
+    fs::write(
+        sb.claude_home.join("skills/release-only/SKILL.md"),
+        "---\nname: release-only\nkind: skill\n---\nrelease-branch content.\n",
+    )
+    .unwrap();
+
+    run_library(
+        &sb,
+        LibraryCmd::MarkSource {
+            name: "upstream".into(),
+        },
+    )
+    .0
+    .expect("mark-source ok");
+    run_library(
+        &sb,
+        LibraryCmd::Push {
+            source: "upstream".into(),
+        },
+    )
+    .0
+    .expect("push ok");
+
+    // Fresh clones verify the *remote* branch tips, not the local cache.
+    let verify_main = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new("git")
+        .args(["clone", "--branch", "main", &bare_url])
+        .arg(verify_main.path())
+        .output()
+        .expect("clone main");
+    assert!(out.status.success(), "clone main: {out:?}");
+    assert!(
+        !verify_main.path().join("skills/release-only/SKILL.md").exists(),
+        "push must not touch `main` when the source ref is `release`"
+    );
+
+    let verify_release = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new("git")
+        .args(["clone", "--branch", "release", &bare_url])
+        .arg(verify_release.path())
+        .output()
+        .expect("clone release");
+    assert!(out.status.success(), "clone release: {out:?}");
+    assert!(
+        verify_release.path().join("skills/release-only/SKILL.md").is_file(),
+        "push must land on the source's configured ref (`release`)"
+    );
+}

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -255,6 +255,12 @@ pub enum AppEvent {
     /// conflict pair — otherwise [`Self::SkillManagerConflictFlip`]
     /// fires instead.
     SkillManagerSync,
+    /// Sync assess popup: apply the previewed plan (Enter).
+    SkillManagerSyncConfirm,
+    /// Sync assess popup: dismiss without applying (Esc).
+    SkillManagerSyncCancel,
+    /// Sync assess popup: scroll the plan/diff (isize rows).
+    SkillManagerSyncScroll(isize),
     /// Units panel: move selection up one row (k / Up arrow). Wraps
     /// to last row when at top. Recomputes detail pane on move.
     SkillManagerSelectPrev,
@@ -375,6 +381,8 @@ pub enum AppEvent {
     SkillManagerPreviewSource,           // p on a source row — reopen the picker for it
     SkillManagerApplySourceFilterKey,    // f on a source row — filter the Units table to it
     SkillManagerOpenUnitInEditor,        // o on a unit — open its deployed dir in $EDITOR
+    SkillManagerToggleLibrarySource,     // L on a source row — mark/unmark it as my library
+    SkillManagerCopyToLibrary,           // y on a unit — copy it into my library
     SkillManagerSourceRemoveOpen,        // r on a source row — open the remove dialog
     SkillManagerSourceRemoveMove(isize), // move the remove-dialog cursor
     SkillManagerSourceRemoveConfirm,     // Enter — execute the chosen removal
@@ -1663,6 +1671,19 @@ impl EventHandler {
                 };
             }
 
+            // Sync assess-then-apply dialog: shows the dry-run plan as a
+            // git-style diff. Enter applies, Esc cancels, arrows scroll.
+            // Intercepts before every other key while open.
+            if state.skill_manager_state.sync_confirm.is_some() {
+                return match key_event.code {
+                    KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::SkillManagerSyncScroll(-1)),
+                    KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::SkillManagerSyncScroll(1)),
+                    KeyCode::Enter => Some(AppEvent::SkillManagerSyncConfirm),
+                    KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::SkillManagerSyncCancel),
+                    _ => None,
+                };
+            }
+
             // Source-removal confirm dialog: arrows pick an option, Enter
             // confirms, Esc cancels. Intercepts before every other key.
             if state.skill_manager_state.source_remove_confirm.is_some() {
@@ -1828,6 +1849,16 @@ impl EventHandler {
                 KeyCode::Char('r') if sources_focused => {
                     Some(AppEvent::SkillManagerSourceRemoveOpen)
                 }
+                // `[s]` on a source row — sync the whole source (all its
+                // units, both directions). Same assess popup as unit sync.
+                KeyCode::Char('s') if sources_focused => Some(AppEvent::SkillManagerSync),
+                // `[L]` on a source row — toggle "my library" mark. Capital
+                // L so lowercase `l` stays the Library overlay.
+                KeyCode::Char('L') if sources_focused => {
+                    Some(AppEvent::SkillManagerToggleLibrarySource)
+                }
+                // `[y]` on a unit — copy it into my library (yank).
+                KeyCode::Char('y') if !sources_focused => Some(AppEvent::SkillManagerCopyToLibrary),
                 // Units panel `[s]` — dual-purpose:
                 //   * if the selected unit is part of a conflict pair,
                 //     flip the shadowed_by edge (legacy behaviour);
@@ -4824,29 +4855,148 @@ impl EventHandler {
                 }
             }
             AppEvent::SkillManagerSync => {
-                // Phase D (v12.D.5): run `ainb skill sync` for the
-                // selected unit. The actual sync runs out-of-band via
-                // the CLI surface; here we only fire-and-forget the
-                // intent + reload the screen state so a successful
-                // sync surfaces fresh deployed paths / usage on next
-                // paint. Tests assert routing-only behaviour against
-                // the dispatch table; integration tests for the CLI
-                // path live in `ainb-cli/tests/skill_sync_*`.
-                //
-                // Surface a `sync: <unit>` info notification so the user
-                // sees that `[s]` routed to Sync (not ConflictFlip) and
-                // so the live tmux tripwire (v12.1.T3) can observe the
-                // routing decision in the captured pane.
-                tracing::info!("Units panel: sync selected unit");
-                let unit_name = state
+                // `[s]` — assess-then-apply sync. Run a dry-run first to
+                // compute the plan (bidirectional content diff + manifest
+                // reconciliation), then show it as a git-style diff popup;
+                // the user applies with Enter (see SkillManagerSyncConfirm).
+                // Scope: the focused source (all its units) or the selected
+                // unit. `source_or_unit` accepts a source name OR a unit URI.
+                let sources_focused = state.skill_manager_state.focused_pane
+                    == crate::components::skill_manager_screen::FocusedSkillPane::Sources;
+                let (target, label) = if sources_focused {
+                    match state
+                        .skill_manager_state
+                        .sources
+                        .get(state.skill_manager_state.source_selected)
+                    {
+                        Some(s) => (s.name.clone(), format!("source {}", s.name)),
+                        None => {
+                            state.add_warning_notification("sync: no source selected".to_string());
+                            return;
+                        }
+                    }
+                } else {
+                    match state.skill_manager_state.units.get(state.skill_manager_state.selected) {
+                        Some(u) => (u.declared_uri.clone(), format!("unit {}", u.name)),
+                        None => {
+                            state.add_warning_notification("sync: no unit selected".to_string());
+                            return;
+                        }
+                    }
+                };
+                tracing::info!(%target, "SkillManager: sync assess (dry-run)");
+                let ainb_home = ainb_skill_core::default_ainb_home();
+                let cmd = ainb_cli::SkillCommand::Sync(ainb_cli::SyncArgs {
+                    source_or_unit: Some(target.clone()),
+                    yes: false,
+                    dry_run: true,
+                    to_home: false,
+                    to_repo: false,
+                });
+                let (ok, msg) = run_skill_cli(&ainb_home, cmd);
+                if !ok {
+                    state.add_error_notification(format!("sync assess failed: {msg}"));
+                    return;
+                }
+                if msg.contains("already in sync") {
+                    state.add_info_notification(format!("{label}: already in sync"));
+                    return;
+                }
+                let plan: Vec<String> = msg.lines().map(|l| l.to_string()).collect();
+                state.skill_manager_state.sync_confirm =
+                    Some(crate::components::skill_manager_screen::SyncConfirmState {
+                        target,
+                        label,
+                        plan,
+                        scroll: 0,
+                    });
+            }
+            AppEvent::SkillManagerSyncScroll(delta) => {
+                if let Some(sc) = state.skill_manager_state.sync_confirm.as_mut() {
+                    sc.scroll_by(delta);
+                }
+            }
+            AppEvent::SkillManagerSyncCancel => {
+                state.skill_manager_state.sync_confirm = None;
+            }
+            AppEvent::SkillManagerSyncConfirm => {
+                // Apply the previewed plan: re-run the identical scope with
+                // `--yes`. Then reload so fresh deployed paths / usage paint.
+                let Some(sc) = state.skill_manager_state.sync_confirm.take() else {
+                    return;
+                };
+                let ainb_home = ainb_skill_core::default_ainb_home();
+                let cmd = ainb_cli::SkillCommand::Sync(ainb_cli::SyncArgs {
+                    source_or_unit: Some(sc.target.clone()),
+                    yes: true,
+                    dry_run: false,
+                    to_home: false,
+                    to_repo: false,
+                });
+                let (ok, msg) = run_skill_cli(&ainb_home, cmd);
+                state.skill_manager_state.reload_from_disk(&ainb_home);
+                if ok {
+                    state.add_success_notification(format!("synced {}", sc.label));
+                } else {
+                    state.add_error_notification(format!("sync failed: {msg}"));
+                }
+            }
+            AppEvent::SkillManagerToggleLibrarySource => {
+                // `[L]` — mark/unmark the focused source as my library.
+                // Toggle by the row's current `is_library` flag.
+                let ainb_home = ainb_skill_core::default_ainb_home();
+                let src = state
+                    .skill_manager_state
+                    .sources
+                    .get(state.skill_manager_state.source_selected)
+                    .map(|s| (s.name.clone(), s.is_library));
+                let Some((name, was_library)) = src else {
+                    state.add_warning_notification("library: no source selected".to_string());
+                    return;
+                };
+                let cmd = if was_library {
+                    ainb_cli::SkillCommand::Library {
+                        cmd: ainb_cli::LibraryCmd::UnmarkSource { name: name.clone() },
+                    }
+                } else {
+                    ainb_cli::SkillCommand::Library {
+                        cmd: ainb_cli::LibraryCmd::MarkSource { name: name.clone() },
+                    }
+                };
+                let (ok, msg) = run_skill_cli(&ainb_home, cmd);
+                state.skill_manager_state.reload_from_disk(&ainb_home);
+                if ok {
+                    let verb = if was_library { "unmarked" } else { "marked" };
+                    state.add_success_notification(format!("{verb} library: {name}"));
+                } else {
+                    state.add_error_notification(format!("library toggle failed: {msg}"));
+                }
+            }
+            AppEvent::SkillManagerCopyToLibrary => {
+                // `[y]` — copy the selected unit into my library (deploy to
+                // the claude tool home + register in library.yaml).
+                let ainb_home = ainb_skill_core::default_ainb_home();
+                let uri = state
                     .skill_manager_state
                     .units
                     .get(state.skill_manager_state.selected)
-                    .map(|u| u.name.clone());
-                let ainb_home = ainb_skill_core::default_ainb_home();
+                    .map(|u| u.declared_uri.clone());
+                let Some(uri) = uri else {
+                    state.add_warning_notification("copy: no unit selected".to_string());
+                    return;
+                };
+                let cmd = ainb_cli::SkillCommand::Library {
+                    cmd: ainb_cli::LibraryCmd::Copy {
+                        uri: uri.clone(),
+                        tool: None,
+                    },
+                };
+                let (ok, msg) = run_skill_cli(&ainb_home, cmd);
                 state.skill_manager_state.reload_from_disk(&ainb_home);
-                if let Some(name) = unit_name {
-                    state.add_info_notification(format!("sync: {name}"));
+                if ok {
+                    state.add_success_notification(format!("copied to library: {msg}"));
+                } else {
+                    state.add_error_notification(format!("copy failed: {msg}"));
                 }
             }
             AppEvent::SkillManagerConflictFlip => {
@@ -7951,6 +8101,7 @@ mod panel_back_tests {
             uri: "gh:o/toolkit".to_string(),
             r#ref: "main".to_string(),
             enabled: true,
+            is_library: false,
         }];
         state.skill_manager_state.units = vec![UnitRow {
             idx: 0,

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -373,6 +373,8 @@ pub enum AppEvent {
     SkillManagerPreviewConfirm,          // Enter — import selection to chosen tools
     SkillManagerPreviewClose,            // Esc — discard, nothing persisted
     SkillManagerPreviewSource,           // p on a source row — reopen the picker for it
+    SkillManagerApplySourceFilterKey,    // f on a source row — filter the Units table to it
+    SkillManagerOpenUnitInEditor,        // o on a unit — open its deployed dir in $EDITOR
     SkillManagerSourceRemoveOpen,        // r on a source row — open the remove dialog
     SkillManagerSourceRemoveMove(isize), // move the remove-dialog cursor
     SkillManagerSourceRemoveConfirm,     // Enter — execute the chosen removal
@@ -1807,10 +1809,20 @@ impl EventHandler {
                 KeyCode::Down | KeyCode::Char('j') if sources_focused => {
                     Some(AppEvent::SkillManagerSourceSelectNext)
                 }
-                KeyCode::Enter if sources_focused => Some(AppEvent::SkillManagerApplySourceFilter),
-                // `[p]` on a source row — reopen the import picker for it
-                // (preview its units, select, install more).
+                // `Enter` on a source row opens the installed-aware import
+                // picker (its skills, pre-checked if already installed) —
+                // the primary action. `[f]` keeps the older filter-to-source
+                // behaviour for when you just want to scope the Units table.
+                KeyCode::Enter if sources_focused => Some(AppEvent::SkillManagerPreviewSource),
+                KeyCode::Char('f') if sources_focused => {
+                    Some(AppEvent::SkillManagerApplySourceFilterKey)
+                }
+                // `[p]` still opens the picker too (muscle-memory alias).
                 KeyCode::Char('p') if sources_focused => Some(AppEvent::SkillManagerPreviewSource),
+                // `[o]` on a unit — open its deployed skill dir in $EDITOR.
+                KeyCode::Char('o') if !sources_focused => {
+                    Some(AppEvent::SkillManagerOpenUnitInEditor)
+                }
                 // `[r]` on a source row — remove dialog (skills+source, or
                 // skills-only / keep source). Distinct from unit `[r]`.
                 KeyCode::Char('r') if sources_focused => {
@@ -5127,7 +5139,8 @@ impl EventHandler {
                     crate::components::skill_manager_screen::SelectionMove::Next,
                 );
             }
-            AppEvent::SkillManagerApplySourceFilter => {
+            AppEvent::SkillManagerApplySourceFilter
+            | AppEvent::SkillManagerApplySourceFilterKey => {
                 state.skill_manager_state.apply_selected_source_filter();
                 // Refresh the detail pane against the newly-selected unit.
                 let ainb_home = ainb_skill_core::default_ainb_home();
@@ -5135,6 +5148,34 @@ impl EventHandler {
                     &mut state.skill_manager_state,
                     &ainb_home,
                 );
+            }
+            AppEvent::SkillManagerOpenUnitInEditor => {
+                // `[o]` — open the selected unit's deployed skill dir in the
+                // user's editor. Reuses the generic OpenInEditor async action
+                // (resolve_editor → $EDITOR fallback chain). Open the parent
+                // dir when the deployed path is a file (e.g. SKILL.md) so the
+                // whole skill folder lands in the editor.
+                let deployed = state
+                    .skill_manager_state
+                    .detail
+                    .as_ref()
+                    .and_then(|d| d.deployed.first().cloned());
+                match deployed {
+                    Some(path) => {
+                        let p = std::path::PathBuf::from(&path);
+                        let target = if p.is_file() {
+                            p.parent().map(|d| d.to_path_buf()).unwrap_or(p)
+                        } else {
+                            p
+                        };
+                        state.pending_async_action = Some(AsyncAction::OpenInEditor(target));
+                    }
+                    None => {
+                        state.add_warning_notification(
+                            "open: no deployed path for selected unit".to_string(),
+                        );
+                    }
+                }
             }
             AppEvent::SkillManagerClearSourceFilter => {
                 state.skill_manager_state.clear_source_filter();

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4876,7 +4876,14 @@ impl EventHandler {
                         }
                     }
                 } else {
-                    match state.skill_manager_state.units.get(state.skill_manager_state.selected) {
+                    // Act on the unit the user SEES highlighted, not a stale
+                    // absolute `selected` that drifted out of the filter.
+                    let Some(idx) = state.skill_manager_state.highlighted_unit_index() else {
+                        state.add_warning_notification("sync: no unit selected".to_string());
+                        return;
+                    };
+                    state.skill_manager_state.selected = idx;
+                    match state.skill_manager_state.units.get(idx) {
                         Some(u) => (u.declared_uri.clone(), format!("unit {}", u.name)),
                         None => {
                             state.add_warning_notification("sync: no unit selected".to_string());
@@ -4893,7 +4900,10 @@ impl EventHandler {
                     to_home: false,
                     to_repo: false,
                 });
-                let (ok, msg) = run_skill_cli(&ainb_home, cmd);
+                // Full output — the popup renders the WHOLE multi-line plan
+                // as a diff, and the "already in sync" marker is a `#` comment
+                // line that last_meaningful_line would strip.
+                let (ok, msg) = run_skill_cli_full(&ainb_home, cmd);
                 if !ok {
                     state.add_error_notification(format!("sync assess failed: {msg}"));
                     return;
@@ -4902,7 +4912,11 @@ impl EventHandler {
                     state.add_info_notification(format!("{label}: already in sync"));
                     return;
                 }
-                let plan: Vec<String> = msg.lines().map(|l| l.to_string()).collect();
+                let plan: Vec<String> = msg
+                    .lines()
+                    .map(|l| l.trim_end().to_string())
+                    .filter(|l| !l.is_empty())
+                    .collect();
                 state.skill_manager_state.sync_confirm =
                     Some(crate::components::skill_manager_screen::SyncConfirmState {
                         target,
@@ -4976,11 +4990,14 @@ impl EventHandler {
                 // `[y]` — copy the selected unit into my library (deploy to
                 // the claude tool home + register in library.yaml).
                 let ainb_home = ainb_skill_core::default_ainb_home();
-                let uri = state
-                    .skill_manager_state
-                    .units
-                    .get(state.skill_manager_state.selected)
-                    .map(|u| u.declared_uri.clone());
+                // Copy the unit the user SEES highlighted, not a stale
+                // absolute `selected` that drifted out of the filter.
+                let Some(idx) = state.skill_manager_state.highlighted_unit_index() else {
+                    state.add_warning_notification("copy: no unit selected".to_string());
+                    return;
+                };
+                state.skill_manager_state.selected = idx;
+                let uri = state.skill_manager_state.units.get(idx).map(|u| u.declared_uri.clone());
                 let Some(uri) = uri else {
                     state.add_warning_notification("copy: no unit selected".to_string());
                     return;
@@ -5305,6 +5322,18 @@ impl EventHandler {
                 // (resolve_editor → $EDITOR fallback chain). Open the parent
                 // dir when the deployed path is a file (e.g. SKILL.md) so the
                 // whole skill folder lands in the editor.
+                //
+                // Resolve the unit the user SEES highlighted and refresh the
+                // detail pane against it first — `detail` is keyed off
+                // `selected`, which can drift out of the active filter.
+                if let Some(idx) = state.skill_manager_state.highlighted_unit_index() {
+                    state.skill_manager_state.selected = idx;
+                    let ainb_home = ainb_skill_core::default_ainb_home();
+                    crate::components::skill_manager_screen::recompute_detail(
+                        &mut state.skill_manager_state,
+                        &ainb_home,
+                    );
+                }
                 let deployed = state
                     .skill_manager_state
                     .detail
@@ -7524,6 +7553,20 @@ fn run_skill_cli(ainb_home: &std::path::Path, cmd: ainb_cli::SkillCommand) -> (b
     let mut buf: Vec<u8> = Vec::new();
     match ainb_cli::skill::dispatch(ainb_home, cmd, &mut buf) {
         Ok(()) => (true, last_meaningful_line(&buf)),
+        Err(e) => (false, format!("{e}")),
+    }
+}
+
+/// Like [`run_skill_cli`] but returns the FULL captured output, not just
+/// the last non-comment line. The assess-sync popup needs the whole
+/// multi-line plan (`# sync plan`, `+ uri`, content-sync rows, …) to
+/// render it as a diff — `last_meaningful_line` would collapse it to one
+/// meaningless row (and strip the `# already in sync` marker the caller
+/// keys on).
+fn run_skill_cli_full(ainb_home: &std::path::Path, cmd: ainb_cli::SkillCommand) -> (bool, String) {
+    let mut buf: Vec<u8> = Vec::new();
+    match ainb_cli::skill::dispatch(ainb_home, cmd, &mut buf) {
+        Ok(()) => (true, String::from_utf8_lossy(&buf).into_owned()),
         Err(e) => (false, format!("{e}")),
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9438,9 +9438,20 @@ impl AppState {
                         Ok(Ok(preview)) => {
                             info!(uri = %uri, units = preview.units.len(),
                                   "SkillManager: source preview open");
+                            // Pre-check + badge units already installed: the
+                            // manifest-declared URIs of the units we already
+                            // track. `declared_uri` is the same
+                            // `<source>@<ref>/<path>` shape the picker rebuilds.
+                            let installed_uris: std::collections::HashSet<String> = self
+                                .skill_manager_state
+                                .units
+                                .iter()
+                                .map(|u| u.declared_uri.clone())
+                                .collect();
                             self.skill_manager_state.preview = Some(
                                 crate::components::skill_manager_screen::SourcePreviewViewState::new(
                                     preview,
+                                    &installed_uris,
                                 ),
                             );
                         }

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -2447,6 +2447,23 @@ impl SkillsScreenData {
             .collect()
     }
 
+    /// The `units` index the user actually SEES highlighted under the
+    /// current filter. Render highlights `visible[position(selected) | 0]`,
+    /// so keystroke actions (`[s]` sync, `[y]` copy, `[o]` open) must map
+    /// `selected` through the same logic — a stale absolute `selected` that
+    /// drifted out of the filtered set would act on an off-screen unit
+    /// (the bug `[r]` remove already guards against). Returns `None` when
+    /// nothing is visible. Callers should also assign the result back to
+    /// `selected` so the detail pane + subsequent keys agree.
+    pub fn highlighted_unit_index(&self) -> Option<usize> {
+        let visible = self.visible_indices();
+        if visible.is_empty() {
+            return None;
+        }
+        let pos = visible.iter().position(|&i| i == self.selected).unwrap_or(0);
+        Some(visible[pos])
+    }
+
     /// Toggle keyboard focus between the Sources and Units panels
     /// (`Tab` / `Shift-Tab`). Symmetric, so Shift-Tab routes here too.
     pub fn toggle_focus(&mut self) {

--- a/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/skill_manager_screen.rs
@@ -51,6 +51,10 @@ pub struct SourceRow {
     /// must fetch this ref, not default to `main`.
     pub r#ref: String,
     pub enabled: bool,
+    /// True when this source is marked as (one of) the user's own
+    /// libraries in `library.yaml` — drives the `★lib` badge and lets
+    /// `[L]` toggle + `[s]` two-way-sync it back to its remote.
+    pub is_library: bool,
 }
 
 /// One unit row in the right table.
@@ -187,6 +191,10 @@ pub struct SkillsScreenData {
     /// Offers "remove skills + source", "remove skills, keep source", and
     /// cancel — nothing is removed until a choice is confirmed.
     pub source_remove_confirm: Option<SourceRemoveConfirm>,
+    /// Sync assess-then-apply dialog: `Some` after `[s]` computes a
+    /// dry-run plan. Renders the planned mutations as a git-style diff;
+    /// `Enter` applies, `Esc` cancels. Nothing is written until applied.
+    pub sync_confirm: Option<SyncConfirmState>,
     /// Width (terminal columns) of the left Sources panel. Resizable by
     /// dragging the Sources/Units divider or via `[`/`]`. Persisted to
     /// `ui_preferences.skill_manager_sources_width` on resize-finish and
@@ -236,6 +244,7 @@ impl Default for SkillsScreenData {
             preview: None,
             preview_loading: None,
             source_remove_confirm: None,
+            sync_confirm: None,
             sources_width: DEFAULT_SOURCES_WIDTH,
             focused_pane: FocusedSkillPane::default(),
             source_selected: 0,
@@ -405,8 +414,14 @@ pub const PREVIEW_TOOLS: [&str; 3] = ["claude", "codex", "copilot"];
 #[derive(Debug, Clone)]
 pub struct SourcePreviewViewState {
     pub preview: ainb_cli::source::SourcePreview,
-    /// One checkbox per `preview.units` entry. Opt-in: all false on open.
+    /// One checkbox per `preview.units` entry. Pre-checked for units
+    /// already installed (see [`installed`]) so the picker opens showing
+    /// current state; the user toggles the rest to install more.
     pub checked: Vec<bool>,
+    /// One flag per `preview.units` entry: is this unit already installed
+    /// (its full URI is declared in the manifest)? Drives the "installed"
+    /// badge and the pre-check above.
+    pub installed: Vec<bool>,
     pub cursor: usize,
     /// claude / codex / copilot (see [`PREVIEW_TOOLS`]). Claude on by
     /// default — the primary tool this manager fronts.
@@ -414,13 +429,27 @@ pub struct SourcePreviewViewState {
 }
 
 impl SourcePreviewViewState {
-    pub fn new(preview: ainb_cli::source::SourcePreview) -> Self {
-        let n = preview.units.len();
+    /// Build the picker. `installed_uris` is the set of full unit URIs
+    /// (`<source>@<ref>/<path>`) already declared in the manifest, used
+    /// to pre-check + badge units the user already has.
+    pub fn new(
+        preview: ainb_cli::source::SourcePreview,
+        installed_uris: &std::collections::HashSet<String>,
+    ) -> Self {
+        let installed: Vec<bool> = preview
+            .units
+            .iter()
+            .map(|u| {
+                let full = format!("{}@{}/{}", preview.stored_uri, preview.r#ref, u.path);
+                installed_uris.contains(&full)
+            })
+            .collect();
         Self {
-            preview,
-            checked: vec![false; n],
+            checked: installed.clone(),
+            installed,
             cursor: 0,
             tools: [true, false, false],
+            preview,
         }
     }
 
@@ -531,6 +560,29 @@ impl SourceRemoveConfirm {
     /// The currently-highlighted choice.
     pub fn choice(&self) -> SourceRemoveChoice {
         SourceRemoveChoice::ALL[self.cursor.min(SourceRemoveChoice::ALL.len() - 1)]
+    }
+}
+
+/// Assess-then-apply dialog for `[s]` sync. Holds the dry-run plan text
+/// (rendered as a git-style diff) and the scope that produced it so the
+/// apply step re-runs the identical scope with `--yes`.
+#[derive(Debug, Clone, Default)]
+pub struct SyncConfirmState {
+    /// What the sync is scoped to — a source name or a unit URI. Passed
+    /// back verbatim as `SyncArgs.source_or_unit` on apply.
+    pub target: String,
+    /// Human label for the dialog title (e.g. `unit foo` / `source bar`).
+    pub label: String,
+    /// The dry-run plan, one line per emitted output row.
+    pub plan: Vec<String>,
+    /// Vertical scroll offset into [`Self::plan`].
+    pub scroll: usize,
+}
+
+impl SyncConfirmState {
+    pub fn scroll_by(&mut self, delta: isize) {
+        let max = self.plan.len().saturating_sub(1) as isize;
+        self.scroll = (self.scroll as isize + delta).clamp(0, max.max(0)) as usize;
     }
 }
 
@@ -791,6 +843,11 @@ pub fn render(frame: &mut Frame, area: Rect, data: &SkillsScreenData) {
         render_source_remove_confirm(frame, area, confirm);
     }
 
+    // Sync assess-then-apply — the plan rendered as a git-style diff.
+    if let Some(sc) = &data.sync_confirm {
+        render_sync_confirm(frame, area, sc);
+    }
+
     // Background fetch in flight — small centered banner so the user
     // sees progress instead of a frozen screen.
     if let Some(uri) = &data.preview_loading {
@@ -950,6 +1007,7 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
             Constraint::Min(4),    // unit list | detail
             Constraint::Length(1), // tool checkboxes
             Constraint::Length(1), // key hints
+            Constraint::Length(1), // CLI-equivalent tip
         ])
         .split(inner);
 
@@ -974,7 +1032,7 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
         } else {
             Style::default().fg(MUTED_GRAY)
         };
-        list_lines.push(Line::from(vec![
+        let mut spans = vec![
             Span::styled(marker, Style::default().fg(SELECTION_GREEN)),
             Span::styled(
                 box_glyph,
@@ -985,7 +1043,14 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
                 Style::default().fg(CORNFLOWER_BLUE),
             ),
             Span::styled(unit.name.clone(), name_style),
-        ]));
+        ];
+        if view.installed.get(i).copied().unwrap_or(false) {
+            spans.push(Span::styled(
+                "  \u{2713} installed",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::DIM),
+            ));
+        }
+        list_lines.push(Line::from(spans));
     }
     frame.render_widget(Paragraph::new(list_lines), cols[0]);
 
@@ -1073,6 +1138,24 @@ fn render_source_preview(frame: &mut Frame, area: Rect, view: &SourcePreviewView
         Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
     ]);
     frame.render_widget(Paragraph::new(hints), rows[2]);
+
+    // ── CLI-equivalent tip: the same import as a shell command, so the
+    // TUI stays discoverable from (and teaches) the CLI surface.
+    let targets = view.targets_csv().unwrap_or_else(|| "claude".to_string());
+    let cli_tip = Line::from(vec![
+        Span::styled(
+            " CLI  ",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::DIM),
+        ),
+        Span::styled(
+            format!(
+                "ainb skill install {}@{}/<unit> --targets {targets}",
+                p.stored_uri, p.r#ref
+            ),
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::DIM),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(cli_tip), rows[3]);
 }
 
 /// Confirm dialog for `[r]` on a source: remove skills + source, remove
@@ -1140,6 +1223,68 @@ fn render_source_remove_confirm(frame: &mut Frame, area: Rect, c: &SourceRemoveC
         Paragraph::new(lines).wrap(ratatui::widgets::Wrap { trim: true }),
         inner,
     );
+}
+
+/// Assess-then-apply sync popup. Renders the dry-run plan as a
+/// git-style coloured diff (`+` additions green, `-` removals red, `#`
+/// section headers gold), scrollable, with apply/cancel hints.
+fn render_sync_confirm(frame: &mut Frame, area: Rect, sc: &SyncConfirmState) {
+    let width = area.width.saturating_sub(6).clamp(60, 120);
+    let height = area.height.saturating_sub(4).clamp(12, 40);
+    let rect = centered_rect(area, width, height);
+    frame.render_widget(Clear, rect);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(GOLD))
+        .title(Span::styled(
+            format!(" Sync {} — review plan ", sc.label),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(1)])
+        .split(inner);
+
+    // Colour each plan line like a unified diff.
+    let body_h = rows[0].height as usize;
+    let start = sc.scroll.min(sc.plan.len().saturating_sub(1));
+    let end = (start + body_h).min(sc.plan.len());
+    let lines: Vec<Line> = sc.plan[start..end]
+        .iter()
+        .map(|l| {
+            let t = l.trim_start();
+            let style = if t.starts_with('+') {
+                Style::default().fg(SELECTION_GREEN)
+            } else if t.starts_with('-') || t.starts_with('~') {
+                Style::default().fg(ERROR_RED)
+            } else if t.starts_with('#') {
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(SOFT_WHITE)
+            };
+            Line::from(Span::styled(l.clone(), style))
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+
+    let hints = Line::from(vec![
+        Span::styled(
+            format!(" [{}/{}] ", end, sc.plan.len().max(1)),
+            Style::default().fg(MUTED_GRAY),
+        ),
+        Span::styled("\u{2191}\u{2193}", Style::default().fg(GOLD)),
+        Span::styled(" scroll \u{b7} ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Enter", Style::default().fg(GOLD)),
+        Span::styled(" apply \u{b7} ", Style::default().fg(MUTED_GRAY)),
+        Span::styled("Esc", Style::default().fg(GOLD)),
+        Span::styled(" cancel", Style::default().fg(MUTED_GRAY)),
+    ]);
+    frame.render_widget(Paragraph::new(hints), rows[1]);
 }
 
 fn render_browse_view(frame: &mut Frame, area: Rect, browse: &BrowseViewState) {
@@ -1467,7 +1612,7 @@ fn render_sources_panel(frame: &mut Frame, area: Rect, data: &SkillsScreenData) 
                 Style::default().fg(name_color).add_modifier(name_mods),
             );
             let uri = Span::styled(format!("({})", source.uri), Style::default().fg(MUTED_GRAY));
-            lines.push(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(
                     marker,
                     Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
@@ -1475,7 +1620,14 @@ fn render_sources_panel(frame: &mut Frame, area: Rect, data: &SkillsScreenData) 
                 Span::styled(glyph, glyph_style),
                 name,
                 uri,
-            ]));
+            ];
+            if source.is_library {
+                spans.push(Span::styled(
+                    "  ★lib",
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ));
+            }
+            lines.push(Line::from(spans));
         }
     }
     let para = Paragraph::new(lines).block(block);
@@ -1680,6 +1832,12 @@ fn render_help_bar(frame: &mut Frame, area: Rect) {
         Span::styled("emove  ", Style::default().fg(MUTED_GRAY)),
         key_span("s"),
         Span::styled("ync  ", Style::default().fg(MUTED_GRAY)),
+        key_span("o"),
+        Span::styled("pen  ", Style::default().fg(MUTED_GRAY)),
+        key_span("y"),
+        Span::styled(" copy→lib  ", Style::default().fg(MUTED_GRAY)),
+        key_span("L"),
+        Span::styled(" mark-lib  ", Style::default().fg(MUTED_GRAY)),
         key_span("b"),
         Span::styled("rowse  ", Style::default().fg(MUTED_GRAY)),
         key_span("l"),
@@ -2053,7 +2211,7 @@ pub fn apply_discovery_import(
         return Err(std::io::Error::other(format!("manifest save failed: {e}")));
     }
 
-    refresh_view_model_from_manifest(data, &manifest);
+    refresh_view_model_from_manifest(data, &manifest, ainb_home);
     data.banner = DiscoveryBannerState::Hidden;
     Ok(())
 }
@@ -2144,7 +2302,7 @@ pub fn apply_conflict_flip(data: &mut SkillsScreenData, ainb_home: &Path) -> std
         .save_to(&manifest_path)
         .map_err(|e| std::io::Error::other(format!("manifest save failed: {e}")))?;
 
-    refresh_view_model_from_manifest(data, &manifest);
+    refresh_view_model_from_manifest(data, &manifest, ainb_home);
     Ok(())
 }
 
@@ -2234,7 +2392,7 @@ impl SkillsScreenData {
         let manifest = Manifest::load_from(&manifest_path_in(home)).unwrap_or_default();
         let lockfile = Lockfile::load_from(&lockfile_path_in(home)).unwrap_or_default();
         let mut data = SkillsScreenData::default();
-        refresh_view_model_from_manifest(&mut data, &manifest);
+        refresh_view_model_from_manifest(&mut data, &manifest, home);
         data.detail = compute_detail_for_selected(&data, &lockfile);
         data
     }
@@ -2247,7 +2405,7 @@ impl SkillsScreenData {
     pub fn reload_from_disk(&mut self, home: &Path) {
         let manifest = Manifest::load_from(&manifest_path_in(home)).unwrap_or_default();
         let lockfile = Lockfile::load_from(&lockfile_path_in(home)).unwrap_or_default();
-        refresh_view_model_from_manifest(self, &manifest);
+        refresh_view_model_from_manifest(self, &manifest, home);
         self.detail = compute_detail_for_selected(self, &lockfile);
         // Any disk-changing action invalidates a pending remove confirm.
         self.pending_remove_confirm = None;
@@ -2484,7 +2642,13 @@ fn manifest_uri_for_row(row: &UnitRow) -> String {
 /// after `[Enter]` so the user immediately sees imported entries
 /// without waiting for a separate refresh trigger. Best-effort;
 /// keeps existing `selected` / `detail` state unchanged.
-fn refresh_view_model_from_manifest(data: &mut SkillsScreenData, manifest: &Manifest) {
+fn refresh_view_model_from_manifest(data: &mut SkillsScreenData, manifest: &Manifest, home: &Path) {
+    // Which sources the user has marked as their own library
+    // (`library.yaml`). Missing / malformed file → nothing marked.
+    let lib = ainb_skill_core::library::Library::load_from(
+        &ainb_skill_core::library::library_path_in(home),
+    )
+    .unwrap_or_default();
     data.sources = manifest
         .sources
         .iter()
@@ -2493,6 +2657,7 @@ fn refresh_view_model_from_manifest(data: &mut SkillsScreenData, manifest: &Mani
             uri: s.uri.clone(),
             r#ref: s.r#ref.clone(),
             enabled: s.enabled,
+            is_library: lib.is_library_source(&s.name),
         })
         .collect();
     data.units = manifest
@@ -2573,17 +2738,20 @@ mod tests {
     };
 
     fn mk_preview(unit_names: &[&str]) -> SourcePreviewViewState {
-        SourcePreviewViewState::new(ainb_cli::source::SourcePreview {
-            name: "test-src".to_string(),
-            stored_uri: "gh:o/r".to_string(),
-            r#ref: "main".to_string(),
-            kind: "raw".to_string(),
-            fetched_path: PathBuf::from("/tmp/x"),
-            resolved_sha: "abc".to_string(),
-            fetched_at: "now".to_string(),
-            units: unit_names.iter().map(|n| ainb_adapters_source_unit(n)).collect(),
-            already_added: false,
-        })
+        SourcePreviewViewState::new(
+            ainb_cli::source::SourcePreview {
+                name: "test-src".to_string(),
+                stored_uri: "gh:o/r".to_string(),
+                r#ref: "main".to_string(),
+                kind: "raw".to_string(),
+                fetched_path: PathBuf::from("/tmp/x"),
+                resolved_sha: "abc".to_string(),
+                fetched_at: "now".to_string(),
+                units: unit_names.iter().map(|n| ainb_adapters_source_unit(n)).collect(),
+                already_added: false,
+            },
+            &std::collections::HashSet::new(),
+        )
     }
 
     fn ainb_adapters_source_unit(name: &str) -> ainb_cli::source::UnitDescriptor {
@@ -3038,6 +3206,7 @@ mod tests {
             uri: uri.to_string(),
             r#ref: "main".to_string(),
             enabled: true,
+            is_library: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-skill-core/src/library.rs
+++ b/ainb-tui/crates/ainb-skill-core/src/library.rs
@@ -71,6 +71,13 @@ pub struct Library {
 
     #[serde(default)]
     pub owned: Vec<OwnedUnit>,
+
+    /// Manifest source names that have opted into git-native two-way
+    /// library sync (`ainb skill library push/pull`). A source must be
+    /// marked here before `push`/`pull` will touch it — see
+    /// [`Library::mark_source`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub library_sources: Vec<String>,
 }
 
 impl Default for Library {
@@ -78,6 +85,7 @@ impl Default for Library {
         Self {
             schema_version: LIBRARY_SCHEMA_VERSION,
             owned: Vec::new(),
+            library_sources: Vec::new(),
         }
     }
 }
@@ -139,6 +147,30 @@ impl Library {
     pub fn get(&self, name: &str) -> Option<&OwnedUnit> {
         self.owned.iter().find(|u| u.name == name)
     }
+
+    /// Mark `name` (a manifest source name) as a library source, enabling
+    /// `ainb skill library push/pull`. Dedup-ed by name. Returns `true`
+    /// when the name was newly added, `false` when it was already marked.
+    pub fn mark_source(&mut self, name: &str) -> bool {
+        if self.library_sources.iter().any(|s| s == name) {
+            return false;
+        }
+        self.library_sources.push(name.to_string());
+        true
+    }
+
+    /// Unmark `name` as a library source. Returns `true` when an entry
+    /// was actually removed, `false` when it was not marked.
+    pub fn unmark_source(&mut self, name: &str) -> bool {
+        let before = self.library_sources.len();
+        self.library_sources.retain(|s| s != name);
+        self.library_sources.len() != before
+    }
+
+    /// Whether `name` is currently marked as a library source.
+    pub fn is_library_source(&self, name: &str) -> bool {
+        self.library_sources.iter().any(|s| s == name)
+    }
 }
 
 /// `library.yaml` path for an explicit ainb home directory — sibling to
@@ -182,5 +214,43 @@ mod tests {
             promoted_uri: None,
         }));
         assert_eq!(lib.get("x").map(|u| u.name.as_str()), Some("x"));
+    }
+
+    #[test]
+    fn mark_source_dedups_and_reports_insert_vs_noop() {
+        let mut lib = Library::default();
+        assert!(!lib.is_library_source("my-source"));
+        assert!(lib.mark_source("my-source"), "first mark is a fresh insert");
+        assert!(lib.is_library_source("my-source"));
+        assert!(!lib.mark_source("my-source"), "repeat mark is a no-op");
+        assert_eq!(lib.library_sources, vec!["my-source".to_string()]);
+    }
+
+    #[test]
+    fn unmark_source_removes_and_reports() {
+        let mut lib = Library::default();
+        lib.mark_source("my-source");
+        assert!(lib.unmark_source("my-source"), "removes an existing mark");
+        assert!(!lib.is_library_source("my-source"));
+        assert!(
+            !lib.unmark_source("my-source"),
+            "unmarking again is a no-op"
+        );
+    }
+
+    #[test]
+    fn library_sources_round_trip_through_save_and_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = library_path_in(dir.path());
+
+        let mut lib = Library::default();
+        lib.mark_source("alpha");
+        lib.mark_source("beta");
+        lib.save_to(&path).expect("save");
+
+        let reloaded = Library::load_from(&path).expect("load");
+        assert!(reloaded.is_library_source("alpha"));
+        assert!(reloaded.is_library_source("beta"));
+        assert!(!reloaded.is_library_source("gamma"));
     }
 }


### PR DESCRIPTION
Stacked on #387 (install-root fix). Review/merge #387 first; this PR's base retargets to `main` once #387 lands.

## What this delivers

The Skill Manager library epic — point ainb at your own skills repo, sync it two ways, and drive the whole thing from the TUI (not just the CLI).

### Foundation (skill-core)
- `library.yaml` gains `library_sources` + `mark_source`/`unmark_source`/`is_library_source`.

### CLI — `ainb skill library`
- `copy <uri> [--tool]` — copy a unit from any source into your library (resolves unit dir via the shared `resolve_unit_dir` factored out of `install()`, deploys under the tool home, registers). Idempotent.
- `mark-source` / `unmark-source <name>` — flag a manifest source as your library.
- `push` / `pull <source>` — **git-native** two-way sync for a library-marked source. `push` = existing bidirectional content sync → `git add/commit/push`; `pull` = `git pull --rebase` → sync to home. Conflicts surface git's own 3-way merge output; no bespoke merge UI.

### TUI (skill manager screen)
- **Enter on a source** opens the import picker (was filter); picker **pre-checks + badges already-installed units** so you see current state and toggle the rest. `[f]` = filter-to-source.
- **`[s]` assess-then-apply sync**: dry-run computes the plan, rendered as a scrollable **git-style diff popup**; Enter applies. Works per-source or per-unit.
- **`[L]`** toggles a source's "my library" mark → **★lib badge** in the Sources panel (multiple allowed).
- **`[y]`** copies the selected unit into your library.
- **`[o]`** opens a unit's deployed skill dir in `$EDITOR`.
- **CLI-equivalent tip** in the picker + `[o]/[y]/[L]` in the help bar — the TUI teaches its CLI counterparts.

## Decisions (confirmed with the maintainer)
- **Flat install layout, no prefix** — Claude & Codex both scan exactly one level (`skills/<name>/SKILL.md`), so nesting breaks discovery; dir name = skill name, kept intact. Source identity already lives in the manifest, so no ainb-managed subfolder.
- **Git-native library sync** over a mirror+diff/interpolation engine — library is single-owner, single-tool, edited in place; git gives real merge + history for ~a wrapper's worth of code.
- **`library.yaml` flag** (not a manifest `SourceEntry` bool) — no struct-literal churn.
- **Assess-then-apply popup** reusing the existing TUI git-diff renderer.

## Verification
- `cargo check --workspace` — clean; `cargo fmt --check` + `cargo clippy` clean.
- `ainb-cli` + `ainb-skill-core` full test suites green (incl. 7 new library-CLI tests + a real bare-repo `push` roundtrip, 3 new skill-core tests).
- `ainb` skill-manager unit tests (41) green.

## Commits
1. `feat(skill): track which sources are your own library` (skill-core)
2. `feat(skill-cli): library copy, mark-source, and git-native two-way sync`
3. `feat(skill-tui): open a unit's deployed skill in $EDITOR with [o]`
4. `feat(skill-tui): installed-aware picker, assess-then-apply sync, library actions`

Commits 3–4 (TUI) bundle cohesive same-screen features that share `events.rs`/`skill_manager_screen.rs` — split by file would produce non-compiling intermediates.