### PR TITLE
fix(new-session): Esc from Configure no longer fabricates a phantom recent

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3395,23 +3395,36 @@ impl EventHandler {
                 if !repo_label.is_empty() {
                     let path = SessionDefaults::default_path();
                     let mut defaults = SessionDefaults::load_from(&path);
-                    let entry = defaults.per_repo.entry(repo_label.clone()).or_default();
-                    entry.last_prompt = if prompt_text.is_empty() {
-                        None
-                    } else {
-                        Some(prompt_text)
-                    };
-                    if let Err(err) = defaults.save_to(&path) {
-                        tracing::warn!(error = %err, "ConfigureBack: persist failed");
-                    }
-                    // Refresh PickRepo's in-memory snapshot so a later Enter
-                    // on PickRepo doesn't clobber the prompt we just wrote.
-                    // The picker carries its own `defaults` copy from open
-                    // time; mutations elsewhere are invisible to it.
-                    if let Some(pick) =
-                        state.new_session_state.as_mut().and_then(|ns| ns.pick_repo_state.as_mut())
-                    {
-                        pick.defaults = defaults;
+                    // Only touch per_repo when there is something to preserve:
+                    // a typed prompt, or an entry that already exists (whose
+                    // stale prompt may need clearing). Esc-ing straight out of
+                    // a never-launched repo must NOT fabricate a ⌚ recent —
+                    // that's how typo'd owner/repo entries ended up pinned to
+                    // the top of the picker (Stevie 2026-07-05: sdfads/ssdaf).
+                    let worth_persisting =
+                        !prompt_text.is_empty() || defaults.per_repo.contains_key(&repo_label);
+                    if worth_persisting {
+                        let entry = defaults.per_repo.entry(repo_label.clone()).or_default();
+                        entry.last_prompt = if prompt_text.is_empty() {
+                            None
+                        } else {
+                            Some(prompt_text)
+                        };
+                        if let Err(err) = defaults.save_to(&path) {
+                            tracing::warn!(error = %err, "ConfigureBack: persist failed");
+                        }
+                        // Refresh PickRepo's in-memory snapshot so a later
+                        // Enter on PickRepo doesn't clobber the prompt we just
+                        // wrote. The picker carries its own `defaults` copy
+                        // from open time; mutations elsewhere are invisible
+                        // to it.
+                        if let Some(pick) = state
+                            .new_session_state
+                            .as_mut()
+                            .and_then(|ns| ns.pick_repo_state.as_mut())
+                        {
+                            pick.defaults = defaults;
+                        }
                     }
                 }
                 if let Some(ns) = state.new_session_state.as_mut() {


### PR DESCRIPTION
## Problem

Typing an invalid `owner/repo` in the picker and Esc-ing back out of the Configure screen left a permanent ⌚ recent entry at the top of the picker (Stevie 2026-07-05: `sdfads`, `ssdaf`).

Recents live in `~/.agents-in-a-box/session-defaults.yaml` → `per_repo`. Two paths wrote them:

1. `ConfigureLaunch` → `record_launch` — fires before session creation, but since #388 invalid repos can't reach Launch (pre-flight blocks), so this path no longer records garbage.
2. `ConfigureBack` (Esc) — `.entry(label).or_default()` fabricated an entry even with an empty prompt and no prior history. **This PR fixes that leak**: only persist when there's a typed prompt to keep or the entry already exists.

## Not covered (follow-ups)
- No in-picker delete key for individual recents (`^R` only resets the highlight); manual cleanup = edit `session-defaults.yaml`
- A prompt typed against a garbage repo still records it (deliberate — the prompt is worth preserving)

Tests: lib suite 1611 passed, same 11 pre-existing sandbox failures as main.