### PR TITLE
fix(hangar): escape the two stuck-key traps (create overlay + panel quit)

### DIFF
--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -266,6 +266,19 @@ pub struct HangarPlugin {
     /// The host-shell start + re-dial can't run inline in `handle_key` (it would
     /// deadlock the reader loop), so it is deferred and drained in `render`.
     start_daemon_pending: bool,
+    /// Set when the user pressed the quit key (`q` → [`Intent::Quit`]) on a
+    /// hangar screen. The plugin can't quit the host itself; it publishes a
+    /// `ui.close_request` so the host pops this panel back to wherever it was
+    /// opened. Like `start_daemon_pending`, the publish awaits a host cap and so
+    /// can't run inline in `handle_key` (reader-loop deadlock) — it is drained in
+    /// `render`. Without this the router computed `Intent::Quit` and dropped it,
+    /// so `q` was dead on every hangar screen (only `Ctrl+C` escaped).
+    close_request_pending: bool,
+    /// The host's screen-id string for the surface the plugin is currently
+    /// focused on, captured from each `plugin/handle_key`. `ui.close_request`
+    /// must name the screen to pop, and the SDK `RenderParams` doesn't carry it —
+    /// so we stash it here from the key event that armed `close_request_pending`.
+    current_screen_id: String,
     /// The message from the last failed `[s]` start attempt (e38.36), surfaced in
     /// the offline empty-state so a start failure is visible rather than silent.
     /// `None` once a start succeeds or while none has been attempted.
@@ -381,6 +394,8 @@ impl Default for HangarPlugin {
             opener: crate::shell::default_opener(),
             daemon_starter: crate::shell::default_daemon_starter(),
             start_daemon_pending: false,
+            close_request_pending: false,
+            current_screen_id: String::new(),
             daemon_start_error: None,
             daemon_start_redial_until: None,
             daemon_start_last_redial: None,
@@ -2691,6 +2706,12 @@ impl HangarPlugin {
         // Routing-layer keys: tab switches, `?` help, Esc-close-modal, `q` quit.
         if let Some(ev) = routing_event(key, &app) {
             let reduction = crate::screen::reduce(&app, ev);
+            // `q` reduces to `Intent::Quit`. The plugin can't quit the host, so
+            // arm a `ui.close_request` (drained in `render`) instead of dropping
+            // the intent — otherwise `q` is dead on every hangar screen.
+            if matches!(reduction.intent, Some(crate::screen::Intent::Quit)) {
+                self.close_request_pending = true;
+            }
             self.app = Some(reduction.state);
             return;
         }
@@ -3610,6 +3631,9 @@ impl Plugin for HangarPlugin {
         if matches!(params.key.kind, ainb_plugin_sdk::KeyKind::Release) {
             return Ok(());
         }
+        // Remember the focused screen-id so a `q`-armed `ui.close_request` (drained
+        // in `render`, which lacks the screen-id) can name the surface to pop.
+        self.current_screen_id.clone_from(&params.screen_id);
         self.on_key(&params.key);
         // A Workspace-pane action (s/d/Refresh) may have been raised. We must NOT
         // perform the host-cap call here: `plugin/handle_key` runs INLINE on the
@@ -3814,6 +3838,17 @@ impl Plugin for HangarPlugin {
         // + re-dial handshake (awaiting host caps) can't deadlock the reader loop.
         if std::mem::take(&mut self.start_daemon_pending) {
             self.start_daemon_and_redial(host).await;
+        }
+        // Drain a deferred quit (`q` → `Intent::Quit`, armed in `handle_key`). The
+        // plugin can't quit the host; it asks the host to pop this panel back to
+        // wherever it was opened. Best-effort: if the publish is lost the user
+        // just presses `q` again.
+        if std::mem::take(&mut self.close_request_pending) {
+            let req = ainb_plugin_sdk::topics::UiCloseRequest {
+                screen_id: self.current_screen_id.clone(),
+            };
+            let payload = serde_json::to_vec(&req).unwrap_or_default();
+            let _ = host.snapshot_publish(ainb_plugin_sdk::topics::UI_CLOSE_REQUEST, payload).await;
         }
         // Keep re-dialing after a `[s]` start until the daemon binds or the
         // window expires (`wants_redraw` keeps frames coming meanwhile).
@@ -4222,6 +4257,21 @@ mod tests {
         assert!(
             p.start_daemon_pending,
             "[s] while offline must arm the daemon-start"
+        );
+    }
+
+    /// USER-VISIBLE PROOF (key dispatch): `q` arms a `ui.close_request` so the
+    /// host pops the hangar panel back. Regression guard — the router computed
+    /// `Intent::Quit` but the routing branch dropped it, so `q` was dead on every
+    /// hangar screen (e.g. Daemon-health) and only `Ctrl+C` escaped.
+    #[test]
+    fn q_key_arms_close_request() {
+        let mut p = HangarPlugin::new();
+        assert!(!p.close_request_pending);
+        p.on_key(&char_press('q'));
+        assert!(
+            p.close_request_pending,
+            "`q` must arm a ui.close_request instead of being swallowed"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -1593,8 +1593,8 @@ fn card_title_key(
 /// dropdown over the injected roster (scratch always first); ↑↓ move the
 /// highlight, Enter picks it and advances to the agent chips. Repo is REQUIRED —
 /// Enter with the dropdown closed re-opens it (the pointer at scratch) rather
-/// than advancing repo-less. Esc closes an open dropdown, else steps back to the
-/// title input.
+/// than advancing repo-less. Esc closes an open dropdown, else cancels the whole
+/// overlay (single-press abort from any stage).
 fn card_repo_key(
     state: &BoardsState,
     column_id: &str,
@@ -1615,14 +1615,9 @@ fn card_repo_key(
         )
     };
     match (dropdown, key) {
-        // Field closed: `@` opens the dropdown; Esc steps back to the title.
-        (None, BoardsKey::Esc) => set_overlay(
-            state,
-            BoardsOverlay::CardTitle {
-                column_id: column_id.to_string(),
-                title,
-            },
-        ),
+        // Field closed: `@` opens the dropdown; Esc cancels the whole overlay
+        // (single-press abort from any stage — no invisible per-stage back-step).
+        (None, BoardsKey::Esc) => close_overlay(state),
         (None, BoardsKey::Char('@')) => reopen(state, String::new(), Some(0)),
         // Enter with the field closed: in an EDIT, KEEP the card's current repo
         // (prefill) and advance to the agent stage — the user changes the repo only
@@ -1709,8 +1704,7 @@ fn edit_focused_card(state: &BoardsState) -> BoardsReduction {
 
 /// Stage 3 of card create: pick the provider agent chip (spec F1/F4). ↑↓ move
 /// over claude / codex / copilot; Enter advances to the profile pick. Copilot is
-/// selectable (F8 — the dispatch gate fires at run). Esc steps back to the repo
-/// pick.
+/// selectable (F8 — the dispatch gate fires at run). Esc cancels the whole overlay.
 fn card_agent_key(
     state: &BoardsState,
     column_id: &str,
@@ -1731,15 +1725,7 @@ fn card_agent_key(
         )
     };
     match key {
-        BoardsKey::Esc => set_overlay(
-            state,
-            BoardsOverlay::CardRepo {
-                column_id: column_id.to_string(),
-                title,
-                query: String::new(),
-                dropdown: None,
-            },
-        ),
+        BoardsKey::Esc => close_overlay(state),
         BoardsKey::Up => reopen(state, cursor.saturating_sub(1)),
         BoardsKey::Down => reopen(state, (cursor + 1).min(AgentChip::ALL.len() - 1)),
         // The BRANCHED commit point (F6): an EDIT commits here — the agent stage is
@@ -1778,8 +1764,8 @@ fn card_agent_key(
 
 /// Stage 4 of card create: pick the assignee profile. Up/Down move the cursor
 /// over the injected roster; Enter commits the create carrying the title + repo +
-/// agent + profile (with a `None` profile when the roster is empty); Esc steps
-/// back to the agent chips.
+/// agent + profile (with a `None` profile when the roster is empty); Esc cancels
+/// the whole overlay.
 fn card_profile_key(
     state: &BoardsState,
     column_id: &str,
@@ -1803,15 +1789,7 @@ fn card_profile_key(
         )
     };
     match key {
-        BoardsKey::Esc => set_overlay(
-            state,
-            BoardsOverlay::CardAgent {
-                column_id: column_id.to_string(),
-                title,
-                repo_ref,
-                cursor: agent.index(),
-            },
-        ),
+        BoardsKey::Esc => close_overlay(state),
         BoardsKey::Up => reopen(state, cursor.saturating_sub(1)),
         BoardsKey::Down => reopen(state, (cursor + 1).min(n.saturating_sub(1))),
         BoardsKey::Enter => {
@@ -3393,6 +3371,51 @@ mod tests {
         let out = reduce_boards(&s, BoardsEvent::Key(BoardsKey::Esc));
         assert_eq!(out.intent, None);
         assert!(out.state.overlay().is_none(), "Esc closes the overlay");
+    }
+
+    /// Esc is a single-press abort from EVERY create-wizard stage (repo / agent /
+    /// profile), not an invisible per-stage back-step. Regression guard: a user who
+    /// typed a title + Enter landed in the repo stage and pressed Esc/`q` expecting
+    /// to bail; the old back-step left the overlay open (swallowing `q` as text) and
+    /// the board frozen.
+    #[test]
+    fn esc_cancels_from_every_wizard_stage() {
+        let mut state = BoardsState::from_snapshot(&one_board());
+        state.set_profiles(vec!["codex-agent".into()]);
+        // Stage 2 (repo, closed field): Esc closes the whole overlay.
+        let repo = typed_card(&state, "test");
+        let repo = reduce_boards(&repo, BoardsEvent::Key(BoardsKey::Enter)).state;
+        assert!(matches!(
+            repo.overlay(),
+            Some(BoardsOverlay::CardRepo { .. })
+        ));
+        let out = reduce_boards(&repo, BoardsEvent::Key(BoardsKey::Esc));
+        assert_eq!(out.intent, None);
+        assert!(out.state.overlay().is_none(), "Esc cancels at repo stage");
+
+        // Stage 3 (agent): drive repo → scratch → agent, then Esc closes.
+        let agent = reduce_boards(&repo, BoardsEvent::Key(BoardsKey::Char('@'))).state;
+        let agent = reduce_boards(&agent, BoardsEvent::Key(BoardsKey::Enter)).state; // scratch → agent
+        assert!(matches!(
+            agent.overlay(),
+            Some(BoardsOverlay::CardAgent { .. })
+        ));
+        let out = reduce_boards(&agent, BoardsEvent::Key(BoardsKey::Esc));
+        assert_eq!(out.intent, None);
+        assert!(out.state.overlay().is_none(), "Esc cancels at agent stage");
+
+        // Stage 4 (profile): Enter at agent → profile, then Esc closes.
+        let profile = reduce_boards(&agent, BoardsEvent::Key(BoardsKey::Enter)).state;
+        assert!(matches!(
+            profile.overlay(),
+            Some(BoardsOverlay::CardProfile { .. })
+        ));
+        let out = reduce_boards(&profile, BoardsEvent::Key(BoardsKey::Esc));
+        assert_eq!(out.intent, None);
+        assert!(
+            out.state.overlay().is_none(),
+            "Esc cancels at profile stage"
+        );
     }
 
     /// A refresh preserves the injected profile roster + an in-flight overlay so a


### PR DESCRIPTION
## Problem
Two ways to get trapped in the Hangar TUI, both forcing a full app quit:

1. **Create-card overlay** — the create wizard (title → repo → agent → profile) stepped `Esc` back one hidden stage at a time. Typing a title + Enter landed in the repo stage; pressing `Esc`/`q` to bail appeared to do nothing (Esc unwound one invisible stage; the open overlay captured `q` as text). Board looked frozen.
2. **Daemon-health (and every) screen** — `q` was dead; only `Ctrl+C` escaped. The screen router computed `Intent::Quit` but the routing branch discarded the intent, and the plugin had no host-close mechanism at all, so the footer's `q:quit` was a lie.

## Fix
- `Esc` now cancels the whole create-card overlay in a single press from any stage (dropdown-open `Esc` still closes the dropdown first).
- `q` now arms a deferred `ui.close_request` (drained in `render`, mirroring the offline `[s]` daemon-start seam) so the host pops the panel back — the same escape mechanism the burndown and learnings plugins already use.

## Tests
- New guard `esc_cancels_from_every_wizard_stage` (repo/agent/profile).
- New guard `q_key_arms_close_request`.
- Full `ainb-plugin-hangar` lib suite green (286 tests).

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing `q` in the Hangar panel now closes the panel and returns to the screen that opened it.
  * Pressing `Esc` during any later stage of the Boards card creation wizard now cancels the entire overlay consistently.
  * Fixed an issue where navigating backward through wizard stages could leave the interface unresponsive or interpret subsequent key presses incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->