### PR TITLE
feat(hangar): auto-standup default OFF + Settings toggle

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_master_journey.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_master_journey.rs
@@ -65,6 +65,10 @@ fn main() {
         let ws = WorkspaceId::from_str(ainb_hangar_daemon::seed::WS_ID).expect("ws id");
         let now: i64 = 1_700_000_000_000;
 
+        // Auto-standup defaults OFF (opt-in), so the CH6 demo turns it on explicitly.
+        DaemonConfigRepo::set(pool, ainb_hangar_daemon::standup::KEY_ENABLED, "true")
+            .await
+            .expect("enable autostandup");
         DaemonConfigRepo::set(pool, ainb_hangar_daemon::standup::KEY_STAGNANT_MIN, "1")
             .await
             .expect("lower autostandup.stagnant_min");

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_master_journey_live.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_master_journey_live.rs
@@ -77,6 +77,10 @@ fn main() {
         let ws = WorkspaceId::from_str(ainb_hangar_daemon::seed::WS_ID).expect("ws id");
         let now: i64 = 1_700_000_000_000;
 
+        // Auto-standup defaults OFF (opt-in), so the CH6 demo turns it on explicitly.
+        DaemonConfigRepo::set(pool, ainb_hangar_daemon::standup::KEY_ENABLED, "true")
+            .await
+            .expect("enable autostandup");
         DaemonConfigRepo::set(pool, ainb_hangar_daemon::standup::KEY_STAGNANT_MIN, "1")
             .await
             .expect("lower autostandup.stagnant_min");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -219,11 +219,11 @@ pub mod seed;
 /// [`ainb_hangar_store::repo::skill::SkillRepo::upsert_by_name`] — idempotent
 /// and all-or-nothing.
 pub mod skills_sync;
-/// Auto-standup watcher (D13, Stevie's LOCKED override; spec P9 §4.8).
+/// Auto-standup watcher (D13; spec P9 §4.8).
 ///
 /// [`standup::StandupWatcher`] is a daemon-global periodic scan that WRITES
 /// `/standup` into a stagnant, idle-at-prompt session via the one verified send
-/// path — behind every guardrail: a global toggle (default ON), a per-session
+/// path — behind every guardrail: a global toggle (default OFF, opt-in), a per-session
 /// opt-out, a 60-minute per-session cooldown, and a max-one-concurrent cap. The
 /// pure [`standup::decide_standup`] gate is the exhaustively-tested heart; a busy
 /// / mid-turn session is NEVER written to (hook status, never a pane heuristic).
@@ -466,7 +466,7 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
 
     // Spec P9 (D13): spawn the auto-standup watcher — a daemon-global periodic
     // scan that WRITES `/standup` into a stagnant, idle-at-prompt session behind
-    // every guardrail (global toggle default ON, per-session opt-out, 60-min
+    // every guardrail (global toggle default OFF/opt-in, per-session opt-out, 60-min
     // cooldown, max-one concurrent). It writes via the one verified send path
     // (INV-2) and raises a `waiting` "standup ready" attention row when a fired
     // standup's turn completes. Non-fatal like the scheduler: a discovery / send /

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -707,6 +707,8 @@ async fn handle(
         methods::PROFILE_UPSERT => handle_profile_upsert(pool, req).await,
         methods::HANGAR_NOTIFY_RULES_LIST => handle_notify_rules_list(pool, req).await,
         methods::HANGAR_NOTIFY_RULE_SET => handle_notify_rule_set(pool, req).await,
+        methods::HANGAR_DAEMON_CONFIG_GET => handle_daemon_config_get(pool, req).await,
+        methods::HANGAR_DAEMON_CONFIG_SET => handle_daemon_config_set(pool, req).await,
         other => Err(RpcError {
             code: METHOD_NOT_FOUND,
             message: format!("unknown method: {other}"),
@@ -3828,6 +3830,52 @@ async fn handle_notify_rule_set(
     })
 }
 
+/// Dispatch `hangar/daemon_config_get` (D13): read one `daemon_config` value by
+/// key. A read — an unknown key returns `value = None` (the caller applies its
+/// coded default) rather than erroring. A blank key is a client error. Split out
+/// of [`handle`] to keep that dispatcher within the line cap.
+async fn handle_daemon_config_get(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let params: ainb_hangar_proto::snapshots::DaemonConfigGetParams =
+        parse_params(req, "{ key }")?;
+    let key = params.key.trim();
+    if key.is_empty() {
+        return Err(invalid_params("daemon_config key must not be empty"));
+    }
+    let value = DaemonConfigRepo::get(pool, key).await.map_err(|e| store_err(&e))?;
+    to_value(&ainb_hangar_proto::snapshots::DaemonConfigGetResult {
+        key: key.to_string(),
+        value,
+    })
+}
+
+/// Dispatch `hangar/daemon_config_set` (D13): write one `daemon_config` value by
+/// key. Mutating + idempotent (re-writing the same value is a no-op replace). A
+/// blank key is a client error. Split out of [`handle`] to keep that dispatcher
+/// within the line cap.
+async fn handle_daemon_config_set(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let params: ainb_hangar_proto::snapshots::DaemonConfigSetParams =
+        parse_params(req, "{ key, value }")?;
+    let key = params.key.trim();
+    if key.is_empty() {
+        return Err(invalid_params("daemon_config key must not be empty"));
+    }
+    DaemonConfigRepo::set(pool, key, &params.value).await.map_err(|e| store_err(&e))?;
+    to_value(&ainb_hangar_proto::snapshots::DaemonConfigSetResult {
+        key: key.to_string(),
+        value: params.value,
+    })
+}
+
 /// Dispatch `atc/unregister` (spec P9, D12): disable a registered ATC instance's
 /// heartbeat cron. The daemon-native counterpart to `ainb fleet atc teardown`'s
 /// timer removal — flips `enabled = 0` and clears `next_tick_at` (via
@@ -5625,5 +5673,82 @@ mod tests {
         )
         .await;
         assert_eq!(resp.error.unwrap().code, INVALID_PARAMS);
+    }
+
+    /// daemon_config get/set round-trip (D13): an unknown key reads `None`, a set
+    /// persists, and a follow-up get returns the written value — the wire path the
+    /// Settings auto-standup toggle rides.
+    #[tokio::test]
+    async fn daemon_config_get_set_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        // Fresh store: `autostandup.enabled` has no row → value is null.
+        let got = dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_GET,
+                serde_json::json!({"key": "autostandup.enabled"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(got.error.is_none(), "{got:?}");
+        assert_eq!(got.result.unwrap()["value"], serde_json::Value::Null);
+
+        // Write it on.
+        let set = dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "autostandup.enabled", "value": "true"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(set.error.is_none(), "{set:?}");
+        assert_eq!(set.result.unwrap()["value"], serde_json::json!("true"));
+
+        // The follow-up get returns the persisted value.
+        let got2 = dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_GET,
+                serde_json::json!({"key": "autostandup.enabled"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert_eq!(got2.result.unwrap()["value"], serde_json::json!("true"));
+    }
+
+    /// A blank daemon_config key is rejected as INVALID_PARAMS on both get and set.
+    #[tokio::test]
+    async fn daemon_config_rejects_blank_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let get = dispatch(
+            store.pool(),
+            &req(methods::HANGAR_DAEMON_CONFIG_GET, serde_json::json!({"key": "  "})),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert_eq!(get.error.unwrap().code, INVALID_PARAMS);
+        let set = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "", "value": "x"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert_eq!(set.error.unwrap().code, INVALID_PARAMS);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
@@ -1,4 +1,4 @@
-//! Auto-standup (D13, Stevie's LOCKED override) — the daemon watcher that WRITES
+//! Auto-standup (D13) — the daemon watcher that WRITES
 //! `/standup` into a stagnant, idle-at-prompt session (architecture §4.8, spec P9).
 //!
 //! The feature is a write-mode override: it types a real `/standup` into another
@@ -56,7 +56,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::events::EventSink;
 
-/// `daemon_config` key: the global auto-standup toggle (default ON per Stevie).
+/// `daemon_config` key: the global auto-standup toggle (default OFF — opt-in via
+/// the Settings screen or an explicit `daemon_config` write).
 pub const KEY_ENABLED: &str = "autostandup.enabled";
 /// `daemon_config` key: minutes a session must be stagnant before firing.
 pub const KEY_STAGNANT_MIN: &str = "autostandup.stagnant_min";
@@ -65,8 +66,13 @@ pub const KEY_COOLDOWN_MIN: &str = "autostandup.cooldown_min";
 /// `daemon_config` key: max simultaneous in-flight standups.
 pub const KEY_MAX_CONCURRENT: &str = "autostandup.max_concurrent";
 
-/// Coded default: auto-standup is ON (Stevie's override).
-pub const DEFAULT_ENABLED: bool = true;
+/// Coded default: auto-standup is OFF (opt-in).
+///
+/// The write-mode override (it types a real `/standup` into another agent's
+/// session) stays quiet on a fresh daemon, or one with no config row, until the
+/// operator enables it — via the Settings screen toggle or an explicit
+/// `autostandup.enabled` write.
+pub const DEFAULT_ENABLED: bool = false;
 /// Coded default: 15 minutes stagnant.
 pub const DEFAULT_STAGNANT_MIN: i64 = 15;
 /// Coded default: 60-minute per-session cooldown.
@@ -92,10 +98,10 @@ const STANDUP_COMMAND: &str = "/standup";
 /// The resolved global auto-standup configuration.
 ///
 /// Loaded from `daemon_config` with coded defaults, so a fresh daemon (or one
-/// with no config rows) runs with auto-standup ON at the D13 thresholds.
+/// with no config rows) runs with auto-standup OFF (opt-in) at the D13 thresholds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StandupConfig {
-    /// The global toggle (default ON).
+    /// The global toggle (default OFF — opt-in).
     pub enabled: bool,
     /// Minutes a session must be stagnant before a standup fires.
     pub stagnant_minutes: i64,
@@ -606,8 +612,17 @@ mod tests {
     const NOW: i64 = 1_767_225_600_000; // 2026-01-01T00:00:00Z
     const MIN_MS: i64 = 60_000;
 
+    /// An ENABLED config for the guardrail tests. The coded default is OFF
+    /// (opt-in), so the gate tests that exercise the downstream guards
+    /// (stagnation / cooldown / opt-out / concurrency) turn the feature on
+    /// explicitly — otherwise every one would short-circuit on `GloballyDisabled`
+    /// and never reach the guard under test. The default value itself is asserted
+    /// separately by `config_load_honours_stored_enable_and_defaults_off`.
     fn cfg() -> StandupConfig {
-        StandupConfig::default()
+        StandupConfig {
+            enabled: true,
+            ..StandupConfig::default()
+        }
     }
 
     fn idle_input() -> SessionGateInput {
@@ -808,12 +823,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn config_load_honours_stored_disable_and_defaults_on() {
+    async fn config_load_honours_stored_enable_and_defaults_off() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
-        // Fresh store: auto-standup defaults ON per Stevie.
+        // Fresh store: auto-standup defaults OFF (the write-mode override is opt-in).
+        assert!(!StandupConfig::load(store.pool()).await.unwrap().enabled);
+        // An explicit enable is honoured.
+        DaemonConfigRepo::set(store.pool(), KEY_ENABLED, "true").await.unwrap();
         assert!(StandupConfig::load(store.pool()).await.unwrap().enabled);
-        // Explicit disable is honoured.
+        // …and an explicit disable turns it back off.
         DaemonConfigRepo::set(store.pool(), KEY_ENABLED, "false").await.unwrap();
         assert!(!StandupConfig::load(store.pool()).await.unwrap().enabled);
     }

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -839,6 +839,24 @@ pub const HANGAR_NOTIFY_RULES_LIST: &str = "hangar/notify_rules_list";
 /// `kind` is rejected with `INVALID_PARAMS`.
 pub const HANGAR_NOTIFY_RULE_SET: &str = "hangar/notify_rule_set";
 
+/// `hangar/daemon_config_get` — read one `daemon_config` value by key (D13).
+///
+/// Params: [`crate::snapshots::DaemonConfigGetParams`] (`{ key }`). Result:
+/// [`crate::snapshots::DaemonConfigGetResult`] (`{ key, value }`), where `value`
+/// is `None` when the key has no stored row (the caller applies the coded
+/// default). A read — an unknown key is `value = None`, never an error. The
+/// Settings Daemon-section auto-standup toggle reads `autostandup.enabled` through
+/// this.
+pub const HANGAR_DAEMON_CONFIG_GET: &str = "hangar/daemon_config_get";
+
+/// `hangar/daemon_config_set` — write one `daemon_config` value by key (D13).
+///
+/// Params: [`crate::snapshots::DaemonConfigSetParams`] (`{ key, value }`). Result:
+/// [`crate::snapshots::DaemonConfigSetResult`] (`{ key, value }`, the stored value
+/// echoed). Mutating + idempotent (re-writing the same value is a no-op replace).
+/// The Settings auto-standup toggle persists `autostandup.enabled` through this.
+pub const HANGAR_DAEMON_CONFIG_SET: &str = "hangar/daemon_config_set";
+
 /// `auth/hello` — authenticate a freshly-opened socket connection.
 ///
 /// Params: [`crate::auth::HelloParams`] (`{ token: String }` — the plaintext
@@ -954,6 +972,10 @@ pub const ALL_METHODS: &[&str] = &[
     // the wire catalogue is append-only.
     HANGAR_NOTIFY_RULES_LIST,
     HANGAR_NOTIFY_RULE_SET,
+    // Daemon-config get/set (D13) is APPENDED at the catalogue tail — the wire
+    // catalogue is append-only.
+    HANGAR_DAEMON_CONFIG_GET,
+    HANGAR_DAEMON_CONFIG_SET,
 ];
 
 #[cfg(test)]
@@ -1145,6 +1167,8 @@ mod tests {
             HANGAR_BOARD_CARD_SET_AUTO_RUN,
             HANGAR_NOTIFY_RULES_LIST,
             HANGAR_NOTIFY_RULE_SET,
+            HANGAR_DAEMON_CONFIG_GET,
+            HANGAR_DAEMON_CONFIG_SET,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1815,6 +1815,46 @@ pub struct NotifyRuleSetResult {
     pub channels: ChannelSet,
 }
 
+/// Params for [`crate::methods::HANGAR_DAEMON_CONFIG_GET`] (D13): the
+/// `daemon_config` key to read (e.g. `autostandup.enabled`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfigGetParams {
+    /// The `daemon_config` key to read.
+    pub key: String,
+}
+
+/// Result of [`crate::methods::HANGAR_DAEMON_CONFIG_GET`] (D13): the key and its
+/// stored value, or `None` when the key has no row (the caller applies its coded
+/// default).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfigGetResult {
+    /// The key that was read (echoed).
+    pub key: String,
+    /// The stored value, or `None` when no row exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// Params for [`crate::methods::HANGAR_DAEMON_CONFIG_SET`] (D13): the
+/// `daemon_config` key + the value to persist.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfigSetParams {
+    /// The `daemon_config` key to write.
+    pub key: String,
+    /// The value to persist under `key`.
+    pub value: String,
+}
+
+/// Result of [`crate::methods::HANGAR_DAEMON_CONFIG_SET`] (D13): the key + stored
+/// value echoed back so the caller can fold it in without a re-read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfigSetResult {
+    /// The key that was written (echoed).
+    pub key: String,
+    /// The stored value after the write.
+    pub value: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -208,6 +208,10 @@ const NOTIFY_RULES_REQ_ID: i64 = 47;
 /// JSON-RPC id for a `hangar/notify_rule_set` upsert raised by a toggled routing
 /// cell (tcp T5). Its reply re-fetches the grid so the pane reflects the write.
 const NOTIFY_RULE_SET_REQ_ID: i64 = 48;
+/// `hangar/daemon_config_get` for the Settings auto-standup toggle (D13).
+const DAEMON_CONFIG_GET_REQ_ID: i64 = 49;
+/// `hangar/daemon_config_set` write from the auto-standup toggle (D13).
+const DAEMON_CONFIG_SET_REQ_ID: i64 = 50;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -802,6 +806,13 @@ impl HangarPlugin {
                     Some(crate::screen::app_screens::NotifyAction::Refresh { scope });
                 self.conn.on_event();
             }
+            // D13: the Settings auto-standup toggle's live value.
+            RpcId::Number(DAEMON_CONFIG_GET_REQ_ID) => self.apply_autostandup(resp),
+            RpcId::Number(DAEMON_CONFIG_SET_REQ_ID) => {
+                // Re-read after the write so the pane reflects the persisted value.
+                self.fetch_pending = true;
+                self.conn.on_event();
+            }
             RpcId::Number(INBOX_LIST_REQ_ID) => self.apply_inbox(resp),
             // The attention/subscribe ack carries the open-attention snapshot that
             // seeds the control-center board.
@@ -898,6 +909,22 @@ impl HangarPlugin {
                 ) {
                     self.screens.set_notify_rules(r.rules);
                 }
+            }
+        }
+        self.conn.on_event();
+    }
+
+    /// Populate the Settings auto-standup toggle from a `hangar/daemon_config_get`
+    /// result (D13): the daemon's persisted `autostandup.enabled` value.
+    fn apply_autostandup(&mut self, resp: &RpcResponse) {
+        if let Some(result) = &resp.result {
+            if let Ok(r) = serde_json::from_value::<
+                ainb_hangar_proto::snapshots::DaemonConfigGetResult,
+            >(result.clone())
+            {
+                // Absent row / unparseable value => the coded default OFF.
+                let on = r.value.as_deref() == Some("true");
+                self.screens.set_autostandup_enabled(on);
             }
         }
         self.conn.on_event();
@@ -1606,6 +1633,12 @@ impl HangarPlugin {
                 MEMBERS_REQ_ID,
                 daemon_methods::HANGAR_MEMBERS_LIST,
                 scoped.clone(),
+            ),
+            // D13: the Settings auto-standup toggle's live value.
+            (
+                DAEMON_CONFIG_GET_REQ_ID,
+                daemon_methods::HANGAR_DAEMON_CONFIG_GET,
+                serde_json::json!({ "key": "autostandup.enabled" }),
             ),
             (
                 INBOX_LIST_REQ_ID,
@@ -3714,6 +3747,26 @@ impl Plugin for HangarPlugin {
         // or a rule set from a toggled cell) and fire it over the daemon socket.
         if let Some(action) = self.screens.take_pending_notify_action() {
             self.apply_notify_action(host, action).await;
+        }
+        // D13: drain a deferred auto-standup toggle write and fire it over the
+        // daemon socket; the reply re-fetches so the pane reflects the persisted
+        // value.
+        if let Some(on) = self.screens.take_pending_autostandup_set() {
+            if let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) {
+                let body = encode_request(
+                    DAEMON_CONFIG_SET_REQ_ID,
+                    daemon_methods::HANGAR_DAEMON_CONFIG_SET,
+                    serde_json::json!({
+                        "key": "autostandup.enabled",
+                        "value": if on { "true" } else { "false" },
+                    }),
+                );
+                if let Ok(body) = body {
+                    if let Err(e) = host.unix_socket_send(stream_id, body).await {
+                        let _ = host.log_info(format!("hangar: autostandup set failed: {e}")).await;
+                    }
+                }
+            }
         }
         // P6.5: drain any deferred skill RPC (sync / detail / attach / detach)
         // raised by the skill-manager screen and fire it over the daemon socket.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -922,8 +922,16 @@ impl HangarPlugin {
                 ainb_hangar_proto::snapshots::DaemonConfigGetResult,
             >(result.clone())
             {
-                // Absent row / unparseable value => the coded default OFF.
-                let on = r.value.as_deref() == Some("true");
+                // Absent row / unrecognized value => the coded default OFF.
+                // Mirror the daemon's tolerant `parse_bool` (1/true/yes/on,
+                // case-insensitive) so the toggle can never disagree with what
+                // the daemon actually does.
+                let on = r.value.as_deref().is_some_and(|v| {
+                    matches!(
+                        v.trim().to_ascii_lowercase().as_str(),
+                        "1" | "true" | "yes" | "on"
+                    )
+                });
                 self.screens.set_autostandup_enabled(on);
             }
         }
@@ -3752,6 +3760,7 @@ impl Plugin for HangarPlugin {
         // daemon socket; the reply re-fetches so the pane reflects the persisted
         // value.
         if let Some(on) = self.screens.take_pending_autostandup_set() {
+            let mut sent = false;
             if let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) {
                 let body = encode_request(
                     DAEMON_CONFIG_SET_REQ_ID,
@@ -3762,10 +3771,22 @@ impl Plugin for HangarPlugin {
                     }),
                 );
                 if let Ok(body) = body {
-                    if let Err(e) = host.unix_socket_send(stream_id, body).await {
-                        let _ = host.log_info(format!("hangar: autostandup set failed: {e}")).await;
+                    match host.unix_socket_send(stream_id, body).await {
+                        Ok(()) => sent = true,
+                        Err(e) => {
+                            let _ =
+                                host.log_info(format!("hangar: autostandup set failed: {e}")).await;
+                        }
                     }
                 }
+            }
+            // On a successful send the SET reply re-fetches (via `fetch_pending`).
+            // If the write never left the plugin (disconnected / encode / send
+            // error), re-fetch here so the pane reconciles to the persisted value
+            // instead of showing the optimistic flip forever.
+            if !sent {
+                self.fetch_pending = true;
+                self.conn.on_event();
             }
         }
         // P6.5: drain any deferred skill RPC (sync / detail / attach / detach)

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -531,6 +531,14 @@ pub struct ScreenStates {
     /// A deferred notify-rule RPC raised by the Notifications grid (tcp T5),
     /// drained by the `render` pass. `None` when idle.
     pub pending_notify_action: Option<NotifyAction>,
+    /// Cached live `autostandup.enabled` value from `hangar/daemon_config_get`
+    /// (D13). Seeds the Settings Daemon-section toggle regardless of arrival order,
+    /// and survives a `set_health` rebuild. Defaults OFF (the coded server default).
+    pub autostandup_enabled: bool,
+    /// A deferred `autostandup.enabled` write raised by the Daemon-section toggle
+    /// (`a`, D13): the NEW value awaiting the `render` pass to fire
+    /// `hangar/daemon_config_set` over the daemon socket. `None` when idle.
+    pub pending_autostandup_set: Option<bool>,
     /// Set when the logs screen's level filter changed (P8.6), asking the glue
     /// to re-read the structured-log file under the new `--level` floor. Drained
     /// by the `render` pass. `false` when idle.
@@ -798,6 +806,9 @@ impl ScreenStates {
         state.set_members(self.member_rows.clone());
         // Carry any cached notification grid too (tcp T5), same rebuild survival.
         state.set_notify_rules(self.notify_rule_rows.clone());
+        // Carry the cached auto-standup toggle (D13) so a `set_health` rebuild keeps
+        // the live value rather than snapping the row back to OFF.
+        state.set_autostandup_enabled(self.autostandup_enabled);
         self.settings = Some(state);
     }
 
@@ -842,6 +853,23 @@ impl ScreenStates {
     /// Take the pending notify-rule RPC raised by the Notifications grid, if any.
     pub const fn take_pending_notify_action(&mut self) -> Option<NotifyAction> {
         self.pending_notify_action.take()
+    }
+
+    /// Refresh the Settings Daemon-section auto-standup toggle from a
+    /// `hangar/daemon_config_get` result (D13). Caches the value so a later
+    /// `set_health` rebuild keeps it, and overlays the live settings state when it
+    /// already exists (mirrors [`Self::set_notify_rules`]).
+    pub const fn set_autostandup_enabled(&mut self, on: bool) {
+        self.autostandup_enabled = on;
+        if let Some(s) = self.settings.as_mut() {
+            s.set_autostandup_enabled(on);
+        }
+    }
+
+    /// Take the pending `autostandup.enabled` write raised by the Daemon-section
+    /// toggle (`a`, D13), if any.
+    pub const fn take_pending_autostandup_set(&mut self) -> Option<bool> {
+        self.pending_autostandup_set.take()
     }
 
     /// The Notifications grid's current edit scope (global/workspace,
@@ -1238,6 +1266,11 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
                         states.pending_notify_action = Some(NotifyAction::Refresh {
                             scope: notify_scope,
                         });
+                    }
+                    // `a` on the Daemon section flipped the auto-standup toggle (D13):
+                    // defer the `hangar/daemon_config_set` write for the render pass.
+                    Some(SettingsIntent::ToggleAutostandup(on)) => {
+                        states.pending_autostandup_set = Some(on);
                     }
                     // KeychainWrite / New / Rename land in their own beads.
                     _ => {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -228,6 +228,11 @@ pub struct SettingsState {
     connection: ConnectionStatus,
     /// The key-entry modal's in-flight value, present while the modal is open.
     key_entry: Option<KeyMaterial>,
+    /// The live `autostandup.enabled` daemon-config toggle (D13). Read from the
+    /// daemon's `daemon_config` via `hangar/daemon_config_get` and flipped with `a`
+    /// on the Daemon section (writing back via `hangar/daemon_config_set`). Defaults
+    /// OFF until the daemon snapshot lands — matching the coded server default.
+    autostandup_enabled: bool,
 }
 
 impl SettingsState {
@@ -259,6 +264,7 @@ impl SettingsState {
             list_selected: 0,
             connection,
             key_entry: None,
+            autostandup_enabled: false,
         }
     }
 
@@ -337,6 +343,20 @@ impl SettingsState {
     pub const fn key_entry_open(&self) -> bool {
         self.key_entry.is_some()
     }
+
+    /// The live `autostandup.enabled` toggle value (D13). Read from the daemon and
+    /// flipped with `a` on the Daemon section.
+    #[must_use]
+    pub const fn autostandup_enabled(&self) -> bool {
+        self.autostandup_enabled
+    }
+
+    /// Overwrite the `autostandup.enabled` toggle from a `hangar/daemon_config_get`
+    /// snapshot (or a post-write re-read). Keeps the live pane in sync with the
+    /// daemon's stored value.
+    pub const fn set_autostandup_enabled(&mut self, on: bool) {
+        self.autostandup_enabled = on;
+    }
 }
 
 /// An input the settings reducer folds into [`SettingsState`].
@@ -384,6 +404,11 @@ pub enum SettingsIntent {
         /// The new push-channel set after the toggle.
         channels: ChannelSet,
     },
+    /// Toggle the global `autostandup.enabled` daemon-config value (`a` on the
+    /// Daemon section, D13). Carries the NEW value; the glue maps it to a
+    /// `hangar/daemon_config_set` write (key `autostandup.enabled`), whose reply
+    /// re-reads the value so the pane reflects the persisted state.
+    ToggleAutostandup(bool),
     /// Re-fetch the Notifications grid for the current scope (`g` flipped the
     /// grid's global/workspace scope, agents-in-a-box-cqh). The glue maps it to a
     /// `hangar/notify_rules_list` scoped to the state's [`SettingsState::notify_scope`]
@@ -427,6 +452,9 @@ fn reduce_key(state: &SettingsState, c: char) -> SettingsReduction {
         'J' => move_list(state, 1),
         'K' => move_list(state, -1),
         'n' if state.section == SettingsSection::Keys => open_key_entry(state),
+        // `a` on the Daemon section flips the global auto-standup toggle (D13):
+        // optimistic local flip + a `ToggleAutostandup` intent the glue persists.
+        'a' if state.section == SettingsSection::Daemon => toggle_autostandup(state),
         // Workspace pane controls (P5.5): s set-active, d toggle-default,
         // n new, r rename. All scoped to the Workspaces section.
         's' if state.section == SettingsSection::Workspaces => {
@@ -460,6 +488,20 @@ fn workspace_intent(
             intent: Some(make(w.id.clone())),
         },
     )
+}
+
+/// Flip the global `autostandup.enabled` toggle (`a` on the Daemon section, D13):
+/// update the pane optimistically so the row flips immediately, and emit a
+/// [`SettingsIntent::ToggleAutostandup`] carrying the NEW value for the glue to
+/// persist (`hangar/daemon_config_set`). The post-write re-read reconciles.
+fn toggle_autostandup(state: &SettingsState) -> SettingsReduction {
+    let mut next = state.clone();
+    let new_value = !next.autostandup_enabled;
+    next.autostandup_enabled = new_value;
+    SettingsReduction {
+        state: next,
+        intent: Some(SettingsIntent::ToggleAutostandup(new_value)),
+    }
 }
 
 /// Handle a key on the Notifications grid (tcp T5): `j`/`k` leave to the adjacent
@@ -694,6 +736,62 @@ fn render_member_rows(
     row
 }
 
+/// Paint the Daemon section body: the socket-path + connection-status line, then
+/// the global auto-standup toggle (D13). ON paints in `SELECTION_GREEN` with a
+/// `▶` indicator + filled dot; OFF is muted with a hollow dot. `[a] toggle` names
+/// the key right by the control (house rule). Returns the next free row. Split out
+/// of [`render_settings`] to keep that function within the line cap.
+fn render_daemon_body(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    mut row: u16,
+    bottom: u16,
+    state: &SettingsState,
+) -> u16 {
+    use ainb_plugin_sdk::{Cell, Color, Coord};
+    const GREEN: Color = Color::rgb(100, 200, 100);
+    const RED: Color = Color::rgb(220, 100, 100);
+    const TEXT: Color = Color::rgb(220, 220, 230);
+    const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
+
+    let put = |buf: &mut WireBuffer, row: u16, s: &str, color: Color| {
+        for (ch, cx) in s.chars().zip(4..area_w) {
+            let mut cell = Cell::new(ch.to_string());
+            cell.fg = Some(color);
+            buf.push(Coord::new(cx, row), cell);
+        }
+    };
+
+    if row < bottom {
+        let (status, color) = match state.connection {
+            ConnectionStatus::Connected => ("● connected", GREEN),
+            ConnectionStatus::Disconnected => ("○ disconnected", RED),
+        };
+        put(
+            buf,
+            row,
+            &format!("{} · {status}", state.health.socket_path),
+            color,
+        );
+        row += 1;
+    }
+    if row < bottom {
+        let (mark, dot, label, tog_color) = if state.autostandup_enabled {
+            ("▶ ", "●", "on", SELECTION_GREEN)
+        } else {
+            ("  ", "○", "off", TEXT)
+        };
+        put(
+            buf,
+            row,
+            &format!("{mark}Auto-standup: {dot} {label}  ·  [a] toggle"),
+            tog_color,
+        );
+        row += 1;
+    }
+    row
+}
+
 /// A compact display label for an attention-kind wire token (the grid's row
 /// header). An unknown token renders verbatim so a future kind is never blank.
 fn notify_kind_label(wire_kind: &str) -> &str {
@@ -832,8 +930,6 @@ pub fn render_settings(
 ) {
     use ainb_plugin_sdk::{Cell, Color, Coord};
     const TITLE: Color = Color::rgb(255, 215, 0);
-    const GREEN: Color = Color::rgb(100, 200, 100);
-    const RED: Color = Color::rgb(220, 100, 100);
     const TEXT: Color = Color::rgb(220, 220, 230);
     // Active-workspace indicator colour (TUI palette SELECTION_GREEN).
     const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
@@ -870,18 +966,7 @@ pub fn render_settings(
         }
         match section {
             SettingsSection::Daemon => {
-                let (status, color) = match state.connection {
-                    ConnectionStatus::Connected => ("● connected", GREEN),
-                    ConnectionStatus::Disconnected => ("○ disconnected", RED),
-                };
-                put(
-                    buf,
-                    4,
-                    row,
-                    &format!("{} · {status}", state.health.socket_path),
-                    color,
-                );
-                row += 1;
+                row = render_daemon_body(buf, area_w, row, bottom, state);
             }
             SettingsSection::Providers => {
                 for p in &state.providers {

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
@@ -84,6 +84,7 @@ fn tui_renders_members_with_roles() {
     insta::assert_snapshot!(map, @r###"
       Daemon
         /tmp/hangar.sock · ● connected
+          Auto-standup: ○ off  ·  [a] toggle
       Providers
       LLM Keys
       Workspaces

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -101,6 +101,42 @@ fn state() -> SettingsState {
     SettingsState::new(health(), providers(), keys(), workspaces())
 }
 
+/// `a` on the Daemon section flips the auto-standup toggle (D13): the local value
+/// inverts AND a `ToggleAutostandup` intent carries the NEW value for the glue to
+/// persist. A second `a` flips it back.
+#[test]
+fn a_on_daemon_section_toggles_autostandup_and_emits_intent() {
+    let s = state(); // lands on the Daemon section, toggle defaults OFF
+    assert!(!s.autostandup_enabled());
+    let out = reduce_settings(&s, SettingsEvent::Key('a'));
+    assert!(out.state.autostandup_enabled(), "optimistic flip to ON");
+    assert_eq!(out.intent, Some(SettingsIntent::ToggleAutostandup(true)));
+    // Toggling again flips back to OFF and emits the matching intent.
+    let out2 = reduce_settings(&out.state, SettingsEvent::Key('a'));
+    assert!(!out2.state.autostandup_enabled());
+    assert_eq!(out2.intent, Some(SettingsIntent::ToggleAutostandup(false)));
+}
+
+/// The auto-standup toggle is Daemon-section-scoped: `a` on another section never
+/// flips it (no accidental daemon-config write from the Keys/Workspaces panes).
+#[test]
+fn a_off_the_daemon_section_does_not_toggle_autostandup() {
+    let mut s = state();
+    s = reduce_settings(&s, SettingsEvent::Key('j')).state; // Providers
+    let out = reduce_settings(&s, SettingsEvent::Key('a'));
+    assert!(!out.state.autostandup_enabled());
+    assert_eq!(out.intent, None);
+}
+
+/// A `hangar/daemon_config_get` snapshot sets the live toggle value the pane shows.
+#[test]
+fn set_autostandup_enabled_reflects_live_value() {
+    let mut s = state();
+    assert!(!s.autostandup_enabled());
+    s.set_autostandup_enabled(true);
+    assert!(s.autostandup_enabled());
+}
+
 /// j/k cycle through the six settings sections.
 #[test]
 fn j_k_navigates_settings_sections() {

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_workspace_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_workspace_render_snapshot.rs
@@ -87,6 +87,7 @@ fn tui_renders_active_indicator() {
     insta::assert_snapshot!(map, @"
       Daemon
         /tmp/hangar.sock · ● connected
+          Auto-standup: ○ off  ·  [a] toggle
       Providers
       LLM Keys
     ▶ Workspaces
@@ -96,7 +97,6 @@ fn tui_renders_active_indicator() {
       Notifications
         scope: global · [g] toggle
                       phone   web     os      atc
-        J/K kind · h/l channel · space toggle
     ");
 
     // NON-VACUOUS COLOUR CHECK: the active workspace row's `▶` indicator is

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
@@ -4,6 +4,7 @@ expression: map
 ---
   Daemon
     /tmp/hangar.sock · ● connected
+      Auto-standup: ○ off  ·  [a] toggle
   Providers
   LLM Keys
   Workspaces


### PR DESCRIPTION
## Why
Auto-standup (the daemon watcher that types a real `/standup` into another idle-at-prompt, stagnant session) shipped **ON by default**, so users' sessions got written to without opting in.

## Changes
- **Default OFF (opt-in)** — flip `DEFAULT_ENABLED` to `false`; the gate decision function and every guardrail are unchanged. Doc comments and the seed-journey demos updated to set the flag explicitly.
- **Settings toggle** — new `hangar/daemon_config` get+set RPC (proto contract + daemon handlers backed by `DaemonConfigRepo`) carry `autostandup.enabled`; the Settings screen renders an Auto-standup row in the Daemon section that reads the live value on open and persists the flip.

## Reach it
`[,]Settings` → **Daemon** → press **`a`** to toggle. ON = `▶ Auto-standup: ● on` (green); OFF = `Auto-standup: ○ off` (muted).

## Tests
- `ainb-hangar-daemon` lib green (245); new `config_load_honours_stored_enable_and_defaults_off`, `daemon_config_get_set_round_trips`, `daemon_config_rejects_blank_key`.
- `ainb-hangar-proto` (43) + `ainb-plugin-hangar` suites green; 3 new settings reducer tests + shifted render snapshots.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R