### PR TITLE
feat(hangar): auto-bootstrap fresh home + create-agent (RPC/CLI/TUI)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -3078,12 +3078,33 @@ async fn run_daemon_run() -> Result<()> {
 /// `$AINB_HANGAR_HOME` this process resolved, so it shares one home; its stdout/
 /// stderr go to the daemon's own rolling log, not this terminal.
 fn run_daemon_start() -> Result<()> {
+    start_daemon_if_stopped(true)
+}
+
+/// Best-effort autostart of the Hangar daemon before the TUI connects.
+///
+/// Idempotent (a live pid is a no-op) and non-fatal: a spawn failure is logged
+/// and swallowed so the TUI still launches (it shows the offline panel until the
+/// daemon comes up). Quiet — no stdout, since the TUI owns the terminal. Mirrors
+/// `mcp_pool`'s `ensure_daemon` warn-and-continue.
+pub fn ensure_hangar_daemon() {
+    if let Err(e) = start_daemon_if_stopped(false) {
+        tracing::warn!(error = %e, "hangar daemon autostart failed (TUI continues)");
+    }
+}
+
+/// Spawn the daemon as a detached background child unless it is already running,
+/// recording its EXACT pid. When `announce` is true the outcome is printed
+/// (the `hangar daemon start` CLI verb); the TUI autostart passes `false`.
+fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     let pid_path = daemon_pid_path()?;
 
     // Already running? Bail out cleanly rather than spawning a duplicate.
     if let Some(pid) = read_daemon_pid(&pid_path) {
         if pid_is_running(pid) {
-            println!("hangar daemon: already running (pid {pid})");
+            if announce {
+                println!("hangar daemon: already running (pid {pid})");
+            }
             return Ok(());
         }
         // Stale pid file from a crashed daemon: drop it before re-spawning.
@@ -3130,7 +3151,9 @@ fn run_daemon_start() -> Result<()> {
     std::fs::write(&pid_path, format!("{pid}\n"))
         .with_context(|| format!("write pid file {}", pid_path.display()))?;
 
-    println!("hangar daemon: started (pid {pid})");
+    if announce {
+        println!("hangar daemon: started (pid {pid})");
+    }
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -49,16 +49,12 @@ use ainb_hangar_store::service::retry::{RetryDecision, RetryService};
 
 use crate::cli::OutputFormat;
 
-/// Default workspace bootstrapped when the Hangar database has no workspace yet.
+/// The default workspace slug + owner details now live in
+/// [`ainb_hangar_store::bootstrap`] — the single shared, idempotent lay-down the
+/// CLI, the daemon boot seed, and `agent_create` all delegate to. The wrappers
+/// [`ensure_default_workspace`] / [`find_default_workspace`] / [`default_owner_id`]
+/// keep the existing CLI callers untouched.
 ///
-/// The CLI is usable standalone (no daemon / TUI onboarding required), so
-/// `issue create` lazily lays down a single workspace + owner the first time it
-/// runs. Mirrors the single-workspace-at-v1 reality (migration 0001 docs).
-const DEFAULT_WORKSPACE_SLUG: &str = "default";
-/// Human name of the bootstrapped default workspace.
-const DEFAULT_WORKSPACE_NAME: &str = "Default Workspace";
-/// Email of the bootstrapped owner user.
-const DEFAULT_OWNER_EMAIL: &str = "stevie@local";
 /// Member id used as the default issue creator (`member:stevie`).
 const DEFAULT_CREATOR_ID: &str = "stevie";
 /// Lifecycle state a freshly-created issue lands in.
@@ -3178,12 +3174,9 @@ async fn resolve_agent_runtime(
 
 /// Return the default workspace id, or `None` if no workspace exists yet.
 async fn find_default_workspace(store: &Store) -> Result<Option<String>> {
-    let id: Option<String> =
-        sqlx::query_scalar("SELECT id FROM workspace ORDER BY created_at LIMIT 1")
-            .fetch_optional(store.pool())
-            .await
-            .context("query default workspace")?;
-    Ok(id)
+    ainb_hangar_store::bootstrap::find_default_workspace(store.pool())
+        .await
+        .context("query default workspace")
 }
 
 /// Return the default workspace id, lazily bootstrapping a workspace + owner
@@ -3194,41 +3187,9 @@ async fn find_default_workspace(store: &Store) -> Result<Option<String>> {
 /// (FK-less by design, per the actor module), so the member row is informational
 /// but kept consistent. Idempotent: a second call returns the existing id.
 async fn ensure_default_workspace(store: &Store) -> Result<String> {
-    if let Some(id) = find_default_workspace(store).await? {
-        return Ok(id);
-    }
-    let pool = store.pool();
-    let idgen = SystemIdGen;
-    let now = ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock);
-    let workspace_id = idgen.new_ulid();
-    let user_id = idgen.new_ulid();
-
-    // The workspace's `issue_prefix` is left NULL ("no explicit prefix"): the
-    // HGR default issue id (63l.3) lives at the display layer
-    // (`issue_display_id`), not the stored column, so a fresh issue's TITLE stays
-    // verbatim while its display id still reads HGR-1, HGR-2, ….
-    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
-        .bind(&workspace_id)
-        .bind(DEFAULT_WORKSPACE_SLUG)
-        .bind(DEFAULT_WORKSPACE_NAME)
-        .bind(now)
-        .execute(pool)
+    ainb_hangar_store::bootstrap::ensure_default_workspace(store.pool())
         .await
-        .context("bootstrap default workspace")?;
-    sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
-        .bind(&user_id)
-        .bind(DEFAULT_OWNER_EMAIL)
-        .bind(now)
-        .execute(pool)
-        .await
-        .context("bootstrap default owner user")?;
-    sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES (?, ?, 'owner')")
-        .bind(&workspace_id)
-        .bind(&user_id)
-        .execute(pool)
-        .await
-        .context("bootstrap default member")?;
-    Ok(workspace_id)
+        .context("bootstrap default workspace")
 }
 
 /// Read a workspace's configured `issue_prefix` by id (e38.21).
@@ -3253,11 +3214,9 @@ async fn workspace_issue_prefix(
 /// Return the default owner user id (the first user, oldest first), or `None`
 /// if no user exists yet.
 async fn default_owner_id(store: &Store) -> Result<Option<String>> {
-    let id: Option<String> = sqlx::query_scalar("SELECT id FROM user ORDER BY created_at LIMIT 1")
-        .fetch_optional(store.pool())
+    ainb_hangar_store::bootstrap::default_owner_id(store.pool())
         .await
-        .context("query default owner user")?;
-    Ok(id)
+        .context("query default owner user")
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -410,8 +410,8 @@ pub enum AgentCommand {
 ///
 /// The daemon-less create-from-scratch path: fills the workspace / runtime /
 /// owner FKs behind the scenes so the caller supplies only a `name`. `provider`
-/// is optional (`claude`/`codex`/`copilot`, default `claude`) and recorded on the
-/// row; the agent binds the default runtime regardless, so its tasks still run.
+/// is optional (`claude`/`codex`/`copilot`, default `claude`) and is HONOURED at
+/// dispatch — the daemon spawns that provider's backend for the agent's tasks.
 #[derive(Args, Debug)]
 pub struct AgentCreateArgs {
     /// The new agent's name.
@@ -1704,10 +1704,15 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
         }
         None => ensure_default_workspace(store).await?,
     };
-    let agent =
-        ainb_hangar_store::bootstrap::create_agent(store.pool(), &workspace_id, name, &provider, args.instructions)
-            .await
-            .context("create agent")?;
+    let agent = ainb_hangar_store::bootstrap::create_agent(
+        store.pool(),
+        &workspace_id,
+        name,
+        &provider,
+        args.instructions,
+    )
+    .await
+    .context("create agent")?;
     println!("created agent {}", agent.name);
     Ok(())
 }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -394,6 +394,8 @@ pub struct AutopilotIdArgs {
 /// `model`/`args` is a separate concern (e38.16).
 #[derive(Subcommand, Debug)]
 pub enum AgentCommand {
+    /// Create a new agent from scratch (fills workspace/runtime/owner behind the scenes).
+    Create(AgentCreateArgs),
     /// List the workspace's agents (active by default; `--all` includes archived).
     List(AgentListArgs),
     /// Edit an agent's config knobs (model / args / MCP / thinking / env / name).
@@ -402,6 +404,29 @@ pub enum AgentCommand {
     Archive(AgentArchiveArgs),
     /// Un-archive an agent (restore it to the active picker).
     Unarchive(AgentArchiveArgs),
+}
+
+/// Arguments for `hangar agent create`.
+///
+/// The daemon-less create-from-scratch path: fills the workspace / runtime /
+/// owner FKs behind the scenes so the caller supplies only a `name`. `provider`
+/// is optional (`claude`/`codex`/`copilot`, default `claude`) and recorded on the
+/// row; the agent binds the default runtime regardless, so its tasks still run.
+#[derive(Args, Debug)]
+pub struct AgentCreateArgs {
+    /// The new agent's name.
+    #[arg(long)]
+    pub name: String,
+    /// Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Optional instructions / system prompt for the agent.
+    #[arg(long)]
+    pub instructions: Option<String>,
+    /// Workspace slug to create the agent in. Defaults to the bootstrapped
+    /// `default` workspace (created if absent).
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// Arguments for `hangar agent list`.
@@ -1649,11 +1674,42 @@ async fn run_templates_use(store: &Store, args: TemplatesUseArgs) -> Result<()> 
 async fn dispatch_agent(cmd: AgentCommand, format: OutputFormat) -> Result<()> {
     let store = Store::open_default().await.context("open hangar database")?;
     match cmd {
+        AgentCommand::Create(args) => run_agent_create(&store, args).await,
         AgentCommand::List(args) => run_agent_list(&store, args, format).await,
         AgentCommand::Edit(args) => run_agent_edit(&store, args).await,
         AgentCommand::Archive(args) => run_agent_set_archived(&store, args, true).await,
         AgentCommand::Unarchive(args) => run_agent_set_archived(&store, args, false).await,
     }
+}
+
+/// `hangar agent create`: create one agent from scratch, filling the workspace /
+/// runtime / owner FKs behind the scenes. Prints the created agent's name (never
+/// the id). An unsupported provider or empty name is a CLI error.
+async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
+    let name = args.name.trim();
+    if name.is_empty() {
+        anyhow::bail!("agent name must not be empty");
+    }
+    let provider = ainb_hangar_store::bootstrap::normalize_provider(args.provider.as_deref())
+        .map_err(|e| anyhow::anyhow!(e))?;
+    // An explicit --workspace must exist; the default is ensured (created if absent).
+    let workspace_id = match args.workspace.as_deref() {
+        Some(slug) => {
+            let id: Option<String> = sqlx::query_scalar("SELECT id FROM workspace WHERE slug = ?")
+                .bind(slug)
+                .fetch_optional(store.pool())
+                .await
+                .context("look up workspace by slug")?;
+            id.ok_or_else(|| anyhow::anyhow!("no workspace with slug {slug}"))?
+        }
+        None => ensure_default_workspace(store).await?,
+    };
+    let agent =
+        ainb_hangar_store::bootstrap::create_agent(store.pool(), &workspace_id, name, &provider, args.instructions)
+            .await
+            .context("create agent")?;
+    println!("created agent {}", agent.name);
+    Ok(())
 }
 
 /// `hangar agent list`: list the workspace's agents (active, or all with `--all`).

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -165,6 +165,12 @@ async fn tokio_main() -> Result<()> {
         Some(("tui", _)) | None => {
             entered_tui = true;
 
+            // Best-effort: bring the Hangar daemon up before the TUI connects, so
+            // a fresh home shows a runtime + a seeded agent (the boot seed runs in
+            // the daemon) instead of an offline panel. Idempotent + non-fatal — a
+            // spawn failure is logged and the TUI still launches.
+            cli::hangar::ensure_hangar_daemon();
+
             // Best-effort: drop shipped default presets into
             // ~/.agents-in-a-box/presets.toml on first run. Never overwrites
             // user-edited files (see `install_default_presets`). Also migrates

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -583,6 +583,34 @@ fn agent_list_on_empty_db_is_clean_noop() {
     assert!(out.contains("no agents"), "expected empty marker:\n{out}");
 }
 
+/// `ainb hangar agent create --name` on a fresh home lays down the default
+/// workspace/runtime/owner behind the scenes, inserts the agent, and prints its
+/// NAME (never an id). A follow-up `agent list` shows it, and an unsupported
+/// provider is a clean error.
+#[test]
+fn agent_create_on_fresh_home_inserts_and_lists() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "agent", "create", "--name", "reviewer", "--provider", "codex"],
+    );
+    assert!(ok, "agent create should exit 0 on a fresh home; out={out}");
+    assert!(out.contains("created agent reviewer"), "missing create ack (by name):\n{out}");
+
+    let (ok, out) = run(tmp.path(), &["hangar", "agent", "list"]);
+    assert!(ok, "agent list should exit 0; out={out}");
+    assert!(out.contains("reviewer"), "created agent not in list:\n{out}");
+
+    // An unsupported provider is rejected, not silently coerced.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "agent", "create", "--name", "x", "--provider", "gpt5"],
+    );
+    assert!(!ok, "an unsupported provider must fail; out={out}");
+    assert!(out.contains("unsupported provider"), "missing provider error:\n{out}");
+}
+
 /// Create an issue via the CLI and return its id (pulled from the create ack).
 fn create_issue(home: &std::path::Path, title: &str) -> String {
     let (ok, out) = run(home, &["hangar", "issue", "create", "--title", title]);

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -593,22 +593,47 @@ fn agent_create_on_fresh_home_inserts_and_lists() {
 
     let (ok, out) = run(
         tmp.path(),
-        &["hangar", "agent", "create", "--name", "reviewer", "--provider", "codex"],
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "reviewer",
+            "--provider",
+            "codex",
+        ],
     );
     assert!(ok, "agent create should exit 0 on a fresh home; out={out}");
-    assert!(out.contains("created agent reviewer"), "missing create ack (by name):\n{out}");
+    assert!(
+        out.contains("created agent reviewer"),
+        "missing create ack (by name):\n{out}"
+    );
 
     let (ok, out) = run(tmp.path(), &["hangar", "agent", "list"]);
     assert!(ok, "agent list should exit 0; out={out}");
-    assert!(out.contains("reviewer"), "created agent not in list:\n{out}");
+    assert!(
+        out.contains("reviewer"),
+        "created agent not in list:\n{out}"
+    );
 
     // An unsupported provider is rejected, not silently coerced.
     let (ok, out) = run(
         tmp.path(),
-        &["hangar", "agent", "create", "--name", "x", "--provider", "gpt5"],
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "x",
+            "--provider",
+            "gpt5",
+        ],
     );
     assert!(!ok, "an unsupported provider must fail; out={out}");
-    assert!(out.contains("unsupported provider"), "missing provider error:\n{out}");
+    assert!(
+        out.contains("unsupported provider"),
+        "missing provider error:\n{out}"
+    );
 }
 
 /// Create an issue via the CLI and return its id (pulled from the create ack).

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -427,6 +427,7 @@ fn seed_agent(home: &std::path::Path) {
                 mcp_config: None,
                 thinking: None,
                 agent_env: Vec::new(),
+                provider: None,
             },
         )
         .await
@@ -1000,6 +1001,7 @@ fn seed_assignable_agent(home: &std::path::Path) {
                 mcp_config: None,
                 thinking: None,
                 agent_env: Vec::new(),
+                provider: None,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_autopilot_fire.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_autopilot_fire.rs
@@ -193,6 +193,7 @@ async fn seed_minimal_tenancy(pool: &sqlx::SqlitePool) {
             mcp_config: None,
             thinking: None,
             agent_env: Vec::new(),
+            provider: None,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_squads_journey.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_squads_journey.rs
@@ -165,6 +165,7 @@ async fn seed_agent(
             mcp_config: None,
             thinking: None,
             agent_env: Vec::new(),
+            provider: None,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
@@ -39,14 +39,17 @@ const STARTER_AGENT_NAME: &str = "claude";
 /// boot path logs and swallows this — a seed failure must never down the daemon.
 pub async fn ensure_default_home(pool: &SqlitePool) -> Result<()> {
     let workspace_id = bootstrap::ensure_default_workspace(pool).await?;
-    // An already-registered runtime's id wins (a runtime cannot be renamed), so
-    // the seed, the claim loop, and every bound agent stay on ONE id.
-    let runtime_id = crate::runtime_register::effective_runtime_id(pool).await;
     let now = SystemClock.now_ms();
-    // Self-register the host runtime (logs the outcome, swallows a transient
-    // failure). The starter-agent create below re-ensures the runtime, so a
-    // swallowed error here still surfaces if it would strand the agent's FK.
-    crate::runtime_register::self_register(pool, &runtime_id, now).await;
+    // Self-register the host runtime (and resolve its effective id) in one atomic
+    // upsert: an already-registered runtime's id wins — a runtime cannot be
+    // renamed — so the seed, the claim loop, and every bound agent stay on ONE id.
+    // Called for the registration + the "configured id ignored" warning; the
+    // returned id is not needed here because `create_agent` below takes the id
+    // from its own atomic ensure. Registering here matters even when the starter
+    // agent is skipped (an existing roster), so the runtime still shows online.
+    // A transient failure is swallowed inside — the create re-ensures and would
+    // surface anything that actually strands the agent's FK.
+    let _effective = crate::runtime_register::effective_runtime_id(pool, now).await;
 
     // Non-clobber guard: seed a starter agent ONLY when the workspace has none.
     // A user who made/renamed/archived their own agent keeps count > 0 → skip;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
@@ -1,0 +1,140 @@
+//! Fresh-home boot seed: make an empty `~/.agents-in-a-box/hangar.db` "just work".
+//!
+//! A brand-new home has no workspace, no runtime, and no agent, so the Daemon
+//! pane shows no runtime and the Squad screen rejects a create with "no agent
+//! available to lead a squad". [`ensure_default_home`] lays down, on every boot:
+//!
+//! 1. the default workspace + owner (via the shared
+//!    [`ainb_hangar_store::bootstrap::ensure_default_workspace`]),
+//! 2. the host runtime keyed on [`ainb_hangar_store::bootstrap::default_runtime_id`]
+//!    — the SAME id the claim loop keys off, so seeded tasks actually get claimed,
+//! 3. exactly ONE starter agent (`claude`) bound to that runtime, but ONLY when
+//!    the workspace has zero agents.
+//!
+//! Every step is idempotent and non-clobbering. The starter-agent guard reads the
+//! FULL agent count (active + archived), so a user who created, renamed, or
+//! archived their own agent has count > 0 and the seed skips — a user's roster is
+//! never clobbered, and a restart never re-seeds (the starter agent persists).
+//! Collision-safe with the test tripwires that pre-seed slug `default`: the
+//! workspace ensure finds the existing row and the agent-count guard skips.
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+
+use ainb_hangar_core::clock::{HangarClock, SystemClock};
+use ainb_hangar_store::bootstrap;
+
+/// The starter agent's name — a plain, provider-named agent so the roster reads
+/// naturally and the Squad gate clears out of the box.
+const STARTER_AGENT_NAME: &str = "claude";
+
+/// Seed the default workspace + runtime + one starter agent on a fresh home.
+///
+/// Idempotent and non-clobbering (see the module docs). Returns `Ok(())` on a
+/// successful seed OR a benign no-op (everything already present).
+///
+/// # Errors
+///
+/// Propagates a [`sqlx::Error`] (as `anyhow`) if a lookup or insert fails. The
+/// boot path logs and swallows this — a seed failure must never down the daemon.
+pub async fn ensure_default_home(pool: &SqlitePool) -> Result<()> {
+    let workspace_id = bootstrap::ensure_default_workspace(pool).await?;
+    let runtime_id = bootstrap::default_runtime_id();
+    let now = SystemClock.now_ms();
+    // Self-register the host runtime (logs the outcome, swallows a transient
+    // failure). The starter-agent create below re-ensures the runtime, so a
+    // swallowed error here still surfaces if it would strand the agent's FK.
+    crate::runtime_register::self_register(pool, &runtime_id, now).await;
+
+    // Non-clobber guard: seed a starter agent ONLY when the workspace has none.
+    // A user who made/renamed/archived their own agent keeps count > 0 → skip;
+    // a restart also skips (the seeded agent persists).
+    if bootstrap::agent_count(pool, &workspace_id).await? == 0 {
+        bootstrap::create_agent(
+            pool,
+            &workspace_id,
+            STARTER_AGENT_NAME,
+            bootstrap::DEFAULT_PROVIDER,
+            None,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_hangar_store::Store;
+
+    async fn agent_count(pool: &SqlitePool) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM agent").fetch_one(pool).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn seeds_workspace_runtime_and_one_agent_on_empty_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        ensure_default_home(pool).await.unwrap();
+
+        let ws: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspace")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(ws, 1, "one default workspace");
+        let rt = ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo::get(
+            pool,
+            &bootstrap::default_runtime_id(),
+        )
+        .await
+        .unwrap()
+        .expect("the default runtime is registered");
+        assert_eq!(rt.status, "online");
+        assert_eq!(agent_count(pool).await, 1, "exactly one starter agent");
+    }
+
+    #[tokio::test]
+    async fn is_a_noop_on_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        ensure_default_home(pool).await.unwrap();
+        ensure_default_home(pool).await.unwrap();
+
+        let ws: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspace")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(ws, 1, "restart does not duplicate the workspace");
+        assert_eq!(agent_count(pool).await, 1, "restart does not re-seed the starter agent");
+        let rt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(rt, 1, "restart upserts the same runtime row");
+    }
+
+    #[tokio::test]
+    async fn does_not_clobber_a_users_own_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        // A user lays down the workspace + runtime and their own single agent.
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1).await.unwrap();
+        let mine = bootstrap::create_agent(pool, &ws, "my-reviewer", "codex", None).await.unwrap();
+
+        // A subsequent boot seed must NOT add a second (starter) agent.
+        ensure_default_home(pool).await.unwrap();
+        assert_eq!(agent_count(pool).await, 1, "the seed skips when a user agent exists");
+        let still = ainb_hangar_store::repo::agent::AgentRepo::get(pool, &mine.id)
+            .await
+            .unwrap()
+            .expect("the user's own agent survives");
+        assert_eq!(still.name, "my-reviewer");
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
@@ -109,7 +109,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ws, 1, "restart does not duplicate the workspace");
-        assert_eq!(agent_count(pool).await, 1, "restart does not re-seed the starter agent");
+        assert_eq!(
+            agent_count(pool).await,
+            1,
+            "restart does not re-seed the starter agent"
+        );
         let rt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
             .fetch_one(pool)
             .await
@@ -125,12 +129,18 @@ mod tests {
 
         // A user lays down the workspace + runtime and their own single agent.
         let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
-        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
         let mine = bootstrap::create_agent(pool, &ws, "my-reviewer", "codex", None).await.unwrap();
 
         // A subsequent boot seed must NOT add a second (starter) agent.
         ensure_default_home(pool).await.unwrap();
-        assert_eq!(agent_count(pool).await, 1, "the seed skips when a user agent exists");
+        assert_eq!(
+            agent_count(pool).await,
+            1,
+            "the seed skips when a user agent exists"
+        );
         let still = ainb_hangar_store::repo::agent::AgentRepo::get(pool, &mine.id)
             .await
             .unwrap()

--- a/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/default_home.rs
@@ -39,7 +39,9 @@ const STARTER_AGENT_NAME: &str = "claude";
 /// boot path logs and swallows this — a seed failure must never down the daemon.
 pub async fn ensure_default_home(pool: &SqlitePool) -> Result<()> {
     let workspace_id = bootstrap::ensure_default_workspace(pool).await?;
-    let runtime_id = bootstrap::default_runtime_id();
+    // An already-registered runtime's id wins (a runtime cannot be renamed), so
+    // the seed, the claim loop, and every bound agent stay on ONE id.
+    let runtime_id = crate::runtime_register::effective_runtime_id(pool).await;
     let now = SystemClock.now_ms();
     // Self-register the host runtime (logs the outcome, swallows a transient
     // failure). The starter-agent create below re-ensures the runtime, so a

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -543,6 +543,7 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     // changed `HANGAR_DAEMON_RUNTIME_ID` (which is warned about, not obeyed).
     // Resolving here keeps the registered row, the agents, and the claim loop on
     // ONE id instead of claiming for an id nothing is bound to.
-    cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool()).await);
+    let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
+    cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
     run(store.pool().clone(), cfg, stats, broker.sink()).await
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -50,6 +50,10 @@ pub mod board;
 /// cancel RPC uses to signal the claim loop to stop a live run (headless process
 /// group / interactive tmux session). See [`cancel::registry`].
 pub mod cancel;
+/// Fresh-home boot seed: lay down the default workspace + runtime + one starter
+/// agent so an empty `hangar.db` "just works" (a runtime shows in the Daemon
+/// pane and the Squad create gate is already cleared). Idempotent + non-clobbering.
+pub mod default_home;
 /// Env allowlist config + task-env builder (P5.3).
 ///
 /// Loads/saves `~/.agents-in-a-box/hangar/env.allow.toml` (foreign sections preserved,
@@ -57,10 +61,6 @@ pub mod cancel;
 /// the claim loop uses before spawning a provider: ambient env is filtered by
 /// [`ainb_hangar_core::env_policy`] then keychain keys are layered on top.
 pub mod dispatch;
-/// Fresh-home boot seed: lay down the default workspace + runtime + one starter
-/// agent so an empty `hangar.db` "just works" (a runtime shows in the Daemon
-/// pane and the Squad create gate is already cleared). Idempotent + non-clobbering.
-pub mod default_home;
 /// The durable event outbox drain (T1 / architecture §4.1–§4.2).
 ///
 /// [`event_outbox::spawn`] drains the [`events::EventBroker`]'s lossless outbox

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -57,6 +57,10 @@ pub mod cancel;
 /// the claim loop uses before spawning a provider: ambient env is filtered by
 /// [`ainb_hangar_core::env_policy`] then keychain keys are layered on top.
 pub mod dispatch;
+/// Fresh-home boot seed: lay down the default workspace + runtime + one starter
+/// agent so an empty `hangar.db` "just works" (a runtime shows in the Daemon
+/// pane and the Squad create gate is already cleared). Idempotent + non-clobbering.
+pub mod default_home;
 /// The durable event outbox drain (T1 / architecture §4.1–§4.2).
 ///
 /// [`event_outbox::spawn`] drains the [`events::EventBroker`]'s lossless outbox
@@ -322,11 +326,16 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
 
     let store: Store = Store::open_in(&dir).await?;
 
-    // e38.20: self-register this daemon's runtime so a real (non-test) boot
-    // advertises an `agent_runtime` row the claim loop, agent picker, and
-    // daemon-health pane all key off. A failure here is non-fatal (logged +
-    // swallowed inside the helper) — the daemon must still sweep + serve.
-    crate::runtime_register::self_register_from_env(store.pool()).await;
+    // Fresh-home boot seed: lay down the default workspace + runtime + one
+    // starter agent so an empty home "just works" (a runtime shows in the Daemon
+    // pane, the agent picker is non-empty, and the Squad create gate is already
+    // cleared). Idempotent + non-clobbering, and it self-registers the runtime
+    // under the SAME default id the claim loop keys off (subsuming the old
+    // e38.20 self-register). A failure is non-fatal — the daemon must still
+    // sweep + serve — so it is logged and swallowed here.
+    if let Err(e) = crate::default_home::ensure_default_home(store.pool()).await {
+        tracing::warn!(error = %e, "fresh-home boot seed failed (daemon continues)");
+    }
 
     // P8.5: the in-memory health stats collector — shared between the RPC server
     // (which snapshots the rolling throughput ring for the `hangar/daemon_health`

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -536,6 +536,13 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     if once {
         return Ok(());
     }
-    let cfg = DaemonConfig::from_env();
+    let mut cfg = DaemonConfig::from_env();
+    // The claim loop MUST key off the runtime id that is actually registered (and
+    // that the seeded/created agents are bound to). A runtime cannot be renamed —
+    // `agent.runtime_id` is an enforced FK — so an existing row's id wins over a
+    // changed `HANGAR_DAEMON_RUNTIME_ID` (which is warned about, not obeyed).
+    // Resolving here keeps the registered row, the agents, and the claim loop on
+    // ONE id instead of claiming for an id nothing is bound to.
+    cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool()).await);
     run(store.pool().clone(), cfg, stats, broker.sink()).await
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -654,6 +654,7 @@ async fn handle(
         methods::HANGAR_ISSUE_LABEL_ATTACH => handle_issue_label(pool, req, events, true).await,
         methods::HANGAR_ISSUE_LABEL_DETACH => handle_issue_label(pool, req, events, false).await,
         methods::HANGAR_COMMENT_ADD => handle_comment_add(pool, req, events).await,
+        methods::HANGAR_AGENT_CREATE => handle_agent_create(pool, req).await,
         methods::HANGAR_AGENT_UPDATE => handle_agent_update(pool, req).await,
         methods::HANGAR_AGENT_ARCHIVE => handle_agent_archive(pool, req).await,
         methods::HANGAR_MEMBERS_LIST => handle_members_list(pool, req).await,
@@ -1528,6 +1529,40 @@ async fn handle_comment_add(
 /// config; the provider EXEC consumption of `model`/`args` is a separate bead
 /// (e38.16), so no event is pushed (the agent list is not event-driven — the
 /// plugin re-pulls `agents_list` after a mutation).
+/// Dispatch `hangar/agent_create`: create one agent from scratch, filling every
+/// FK behind the scenes, and answer with the refreshed `agents_list` so the
+/// client folds the new agent into the cache that drives its "has an agent" gate.
+///
+/// The daemon ensures the default workspace + owner (so the fresh-home / TUI
+/// create path never rejects on a not-yet-materialised default workspace), binds
+/// the single default runtime (the id the claim loop keys off, so the agent's
+/// tasks actually run), and mints the id — the caller supplies only `name`
+/// (+ optional `provider` / `instructions`). An empty `name` or an unsupported
+/// `provider` is rejected with `INVALID_PARAMS`; creation is never gated on the
+/// provider (an agent bound to the default runtime always runs).
+async fn handle_agent_create(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::snapshots::AgentCreateParams =
+        parse_params(req, "{ workspace_id?, name, provider?, instructions? }")?;
+    let name = params.name.trim();
+    if name.is_empty() {
+        return Err(invalid_params("agent name must not be empty"));
+    }
+    let provider = ainb_hangar_store::bootstrap::normalize_provider(params.provider.as_deref())
+        .map_err(|e| invalid_params(&e))?;
+    let wire = params.workspace_id.as_deref().unwrap_or("").trim();
+    let ws = resolve_or_bootstrap_default(pool, wire).await?;
+    ainb_hangar_store::bootstrap::create_agent(pool, ws.as_str(), name, &provider, params.instructions)
+        .await
+        .map_err(|e| store_err(&e))?;
+    // Answer with the refreshed roster (the same shape agents_list returns) so
+    // the plugin folds the new agent into its cached list and the squad gate clears.
+    let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;
+    to_value(&ainb_hangar_proto::snapshots::AgentsListResult { actors })
+}
+
 async fn handle_agent_update(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -1761,7 +1796,9 @@ async fn handle_squad_create(
 
     let params: ainb_hangar_proto::snapshots::SquadCreateParams =
         parse_params(req, "{ workspace_id, name, leader }")?;
-    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    // Ensure-then-resolve: a squad create against a just-booted default workspace
+    // (or before the boot seed materialised it) lays it down rather than rejecting.
+    let ws = resolve_or_bootstrap_default(pool, &params.workspace_id).await?;
     if params.name.trim().is_empty() {
         return Err(invalid_params("squad name must not be empty"));
     }
@@ -3898,6 +3935,32 @@ async fn resolve_wire_or_reject(pool: &SqlitePool, wire: &str) -> Result<Workspa
     resolve_wire(pool, wire)
         .await?
         .ok_or_else(|| invalid_params(&format!("unknown workspace `{wire}`")))
+}
+
+/// Resolve `wire` to a workspace, lazily laying down the DEFAULT workspace when
+/// it is unresolved AND the caller meant the default (an empty wire, or the
+/// literal default slug) — the fresh-home / TUI create path, which must
+/// ensure-then-resolve rather than reject a not-yet-materialised default.
+///
+/// A non-empty, non-default wire that resolves to nothing is still rejected
+/// (`INVALID_PARAMS`) — a typo'd or foreign workspace must never be silently
+/// bootstrapped into existence.
+async fn resolve_or_bootstrap_default(
+    pool: &SqlitePool,
+    wire: &str,
+) -> Result<WorkspaceId, RpcError> {
+    if let Some(ws) = resolve_wire(pool, wire).await? {
+        return Ok(ws);
+    }
+    let means_default =
+        wire.is_empty() || wire == ainb_hangar_store::bootstrap::DEFAULT_WORKSPACE_SLUG;
+    if !means_default {
+        return Err(invalid_params(&format!("unknown workspace `{wire}`")));
+    }
+    ainb_hangar_store::bootstrap::ensure_default_workspace(pool)
+        .await
+        .map_err(|e| store_err(&e))?;
+    resolve_wire_or_reject(pool, ainb_hangar_store::bootstrap::DEFAULT_WORKSPACE_SLUG).await
 }
 
 /// Serialize a result payload to a JSON value, mapping a (near-impossible)

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1538,8 +1538,9 @@ async fn handle_comment_add(
 /// the single default runtime (the id the claim loop keys off, so the agent's
 /// tasks actually run), and mints the id — the caller supplies only `name`
 /// (+ optional `provider` / `instructions`). An empty `name` or an unsupported
-/// `provider` is rejected with `INVALID_PARAMS`; creation is never gated on the
-/// provider (an agent bound to the default runtime always runs).
+/// `provider` is rejected with `INVALID_PARAMS`. The recorded provider is HONOURED
+/// at dispatch (the daemon spawns that backend per task), so a `codex` agent runs
+/// codex even though it binds the single `claude`-advertised runtime.
 async fn handle_agent_create(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -1554,9 +1555,15 @@ async fn handle_agent_create(
         .map_err(|e| invalid_params(&e))?;
     let wire = params.workspace_id.as_deref().unwrap_or("").trim();
     let ws = resolve_or_bootstrap_default(pool, wire).await?;
-    ainb_hangar_store::bootstrap::create_agent(pool, ws.as_str(), name, &provider, params.instructions)
-        .await
-        .map_err(|e| store_err(&e))?;
+    ainb_hangar_store::bootstrap::create_agent(
+        pool,
+        ws.as_str(),
+        name,
+        &provider,
+        params.instructions,
+    )
+    .await
+    .map_err(|e| store_err(&e))?;
     // Answer with the refreshed roster (the same shape agents_list returns) so
     // the plugin folds the new agent into its cached list and the squad gate clears.
     let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -118,7 +118,11 @@ impl DaemonConfig {
     /// Build the config from the process environment (see the module table).
     #[must_use]
     pub fn from_env() -> Self {
-        let runtime_id = std::env::var("HANGAR_DAEMON_RUNTIME_ID").ok().filter(|s| !s.is_empty());
+        // A fresh home now claims for the stable default runtime even with no
+        // env override: the boot seed registers that runtime + a starter agent
+        // bound to it, so the claim loop (run_loop.rs, skipped when `None`) is
+        // enabled out of the box. `HANGAR_DAEMON_RUNTIME_ID` still overrides.
+        let runtime_id = Some(ainb_hangar_store::bootstrap::default_runtime_id());
         let claude_path = std::env::var_os("HANGAR_CLAUDE_PATH")
             .map_or_else(|| PathBuf::from("claude"), PathBuf::from);
         let codex_path = std::env::var_os("HANGAR_CODEX_PATH")

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -279,14 +279,12 @@ pub async fn run(
         Arc::new(SystemClock),
     );
 
-    if cfg.disable_claim || cfg.runtime_id.is_none() {
+    let Some(runtime_id) = cfg.runtime_id.clone().filter(|_| !cfg.disable_claim) else {
         tracing::info!(claim = false, "claim loop disabled; sweepers only");
         tokio::signal::ctrl_c().await?;
         tracing::info!("ainb-hangar-daemon shutting down");
         return Ok(());
-    }
-
-    let runtime_id = cfg.runtime_id.clone().expect("runtime_id present");
+    };
 
     // e38.25 crash recovery: this daemon just booted, so any task still frozen
     // `dispatched`/`running` for its runtime is an orphan from a previous

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -94,6 +94,8 @@ pub struct DaemonConfig {
     pub claude_path: PathBuf,
     /// Path to the `codex` provider binary (e38.16).
     pub codex_path: PathBuf,
+    /// Path to the `copilot` provider binary (GitHub Copilot CLI).
+    pub copilot_path: PathBuf,
     /// Interval between claim polls.
     pub poll_interval: Duration,
     /// Hard wall-clock deadline for each provider run; the subprocess is killed
@@ -127,6 +129,8 @@ impl DaemonConfig {
             .map_or_else(|| PathBuf::from("claude"), PathBuf::from);
         let codex_path = std::env::var_os("HANGAR_CODEX_PATH")
             .map_or_else(|| PathBuf::from("codex"), PathBuf::from);
+        let copilot_path = std::env::var_os("HANGAR_COPILOT_PATH")
+            .map_or_else(|| PathBuf::from("copilot"), PathBuf::from);
         let poll_interval =
             Duration::from_millis(env_u64("HANGAR_DAEMON_POLL_MS", DEFAULT_POLL_MS));
         let provider_max_runtime = env_u64_opt("HANGAR_PROVIDER_MAX_RUNTIME_MS")
@@ -156,6 +160,7 @@ impl DaemonConfig {
             runtime_id,
             claude_path,
             codex_path,
+            copilot_path,
             poll_interval,
             provider_max_runtime,
             sweeper,
@@ -299,6 +304,7 @@ pub async fn run(
     let runner = Runner::new(RunnerConfig {
         claude_path: cfg.claude_path.clone(),
         codex_path: cfg.codex_path.clone(),
+        copilot_path: cfg.copilot_path.clone(),
         max_runtime: cfg.provider_max_runtime,
         tail_lines: TAIL_LINES,
         // e38.23: confine every provider spawn in the OS-level FS sandbox by
@@ -799,6 +805,16 @@ async fn execute_claimed(
                     )
                     .await
                     .map_err(anyhow::Error::from),
+                Backend::Copilot => runner
+                    .run_copilot_in(
+                        &env,
+                        task_env,
+                        dispatch.agent_env,
+                        &dispatch.invocation,
+                        &location,
+                    )
+                    .await
+                    .map_err(anyhow::Error::from),
             }
         }
     };
@@ -887,10 +903,11 @@ async fn run_interactive(
     // which is the trust model D6 chose for interactive over headless.
     let session_name = crate::interactive::session_name_for(&task.id);
     let (program, argv) = runner.provider_command(dispatch.backend, &dispatch.invocation);
-    // Mirror the headless env composition: the codex path layers the agent's
-    // `agent_env`; the claude path layers nothing (parity with `execute_claimed`).
+    // Mirror the headless env composition: the codex / copilot paths layer the
+    // agent's `agent_env`; the claude path layers nothing (parity with
+    // `execute_claimed`).
     let extra_env = match dispatch.backend {
-        Backend::Codex => dispatch.agent_env.clone(),
+        Backend::Codex | Backend::Copilot => dispatch.agent_env.clone(),
         Backend::Claude => Vec::new(),
     };
     let child_env = crate::runner::compose_child_env(task_env, extra_env);
@@ -1931,8 +1948,9 @@ mod tests {
     /// Provider-honoring proof: `resolve_dispatch` selects the backend from the
     /// AGENT's provider, overriding the runtime's advertised default. A `codex`
     /// agent bound to the single `claude`-advertised host runtime dispatches the
-    /// codex backend; a `claude` agent dispatches claude; an agent with no
-    /// override falls back to the runtime's provider.
+    /// codex backend, a `copilot` agent dispatches the copilot backend, a `claude`
+    /// agent dispatches claude, and an agent with no override falls back to the
+    /// runtime's provider.
     #[tokio::test]
     async fn resolve_dispatch_honours_the_agent_provider_over_the_runtime() {
         use ainb_hangar_store::bootstrap;
@@ -1954,6 +1972,16 @@ mod tests {
             disp.backend,
             Backend::Codex,
             "a codex agent must dispatch the codex backend, not the runtime's claude"
+        );
+
+        // A copilot agent on that claude-advertised runtime → copilot backend
+        // (no more silent claude fallback).
+        let copilot = bootstrap::create_agent(pool, &ws, "helper", "copilot", None).await.unwrap();
+        let disp = resolve_dispatch(pool, &copilot.id).await.unwrap();
+        assert_eq!(
+            disp.backend,
+            Backend::Copilot,
+            "a copilot agent must dispatch the copilot backend, not fall back to claude"
         );
 
         // A claude agent on the same runtime → claude backend.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -1513,9 +1513,14 @@ struct ResolvedDispatch {
 /// Resolve the provider routing for a task's agent (e38.16).
 ///
 /// Reads the agent row (its migration-0015 `model`/`cli_args`/`agent_env`
-/// config) and its runtime's `provider` wire name, mapping the latter to a
-/// [`Backend`]. The agent's `model` and `cli_args` become the
-/// [`ProviderInvocation`]; its `agent_env` is carried separately.
+/// config) and picks the backend from the agent's OWN `provider` when set
+/// (migration 0041), falling back to its runtime's advertised `provider` when
+/// the agent has no override. The runtime is an execution slot the claim loop
+/// keys off by `runtime_id` (never by provider — see `claim.rs` `CLAIM_SQL`), so
+/// a `codex` agent bound to the single default (`claude`-advertised) runtime is
+/// still claimed and now dispatches the codex backend. The agent's `model` and
+/// `cli_args` become the [`ProviderInvocation`]; its `agent_env` is carried
+/// separately.
 ///
 /// # Errors
 ///
@@ -1530,8 +1535,10 @@ async fn resolve_dispatch(pool: &SqlitePool, agent_id: &str) -> anyhow::Result<R
     let runtime = AgentRuntimeRepo::get(pool, &agent.runtime_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("runtime {} not found", agent.runtime_id))?;
+    // Per-agent provider wins; an agent with no override uses the runtime default.
+    let provider = agent.provider.as_deref().unwrap_or(&runtime.provider);
     Ok(ResolvedDispatch {
-        backend: Backend::from_provider(&runtime.provider),
+        backend: Backend::from_provider(provider),
         invocation: ProviderInvocation {
             model: agent.model,
             cli_args: agent.cli_args,
@@ -1919,5 +1926,65 @@ mod tests {
     #[test]
     fn interactive_sessions_empty_drains_to_nothing() {
         assert!(InteractiveSessions::default().drain().is_empty());
+    }
+
+    /// Provider-honoring proof: `resolve_dispatch` selects the backend from the
+    /// AGENT's provider, overriding the runtime's advertised default. A `codex`
+    /// agent bound to the single `claude`-advertised host runtime dispatches the
+    /// codex backend; a `claude` agent dispatches claude; an agent with no
+    /// override falls back to the runtime's provider.
+    #[tokio::test]
+    async fn resolve_dispatch_honours_the_agent_provider_over_the_runtime() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::agent::{Agent, AgentRepo};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        // The single host runtime advertises claude.
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+
+        // A codex agent on that claude-advertised runtime → codex backend.
+        let codex = bootstrap::create_agent(pool, &ws, "coder", "codex", None).await.unwrap();
+        let disp = resolve_dispatch(pool, &codex.id).await.unwrap();
+        assert_eq!(
+            disp.backend,
+            Backend::Codex,
+            "a codex agent must dispatch the codex backend, not the runtime's claude"
+        );
+
+        // A claude agent on the same runtime → claude backend.
+        let claude = bootstrap::create_agent(pool, &ws, "writer", "claude", None).await.unwrap();
+        let disp = resolve_dispatch(pool, &claude.id).await.unwrap();
+        assert_eq!(disp.backend, Backend::Claude);
+
+        // An agent with NO provider override falls back to the runtime's provider.
+        let owner = bootstrap::default_owner_id(pool).await.unwrap().unwrap();
+        let bare = Agent {
+            id: "bare-agent".into(),
+            workspace_id: ws.clone(),
+            name: "bare".into(),
+            runtime_id: bootstrap::default_runtime_id(),
+            instructions: None,
+            visibility: "workspace".into(),
+            owner_id: owner,
+            archived: false,
+            model: None,
+            cli_args: Vec::new(),
+            mcp_config: None,
+            thinking: None,
+            agent_env: Vec::new(),
+            provider: None,
+        };
+        AgentRepo::insert(pool, &bare).await.unwrap();
+        let disp = resolve_dispatch(pool, "bare-agent").await.unwrap();
+        assert_eq!(
+            disp.backend,
+            Backend::Claude,
+            "no per-agent override falls back to the runtime's advertised provider"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -139,6 +139,15 @@ const CODEX_MODEL_FLAG: &str = "-m";
 /// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
 /// provider. Its own log keeps a copilot transcript separate from claude/codex.
 const COPILOT_LOG_FILE: &str = "copilot.jsonl";
+/// The copilot flag that permits tool use without an interactive confirmation
+/// prompt. Verified against GitHub Copilot CLI 1.0.68: `--allow-all-tools` is
+/// documented as "required for non-interactive mode", so a headless run without
+/// it stalls on a permission prompt it can never answer (stdin is null). The FS
+/// sandbox + env allowlist remain the real confinement boundary.
+const COPILOT_ALLOW_ALL_TOOLS_FLAG: &str = "--allow-all-tools";
+/// The copilot model flag (`copilot --model <model>`), verified against Copilot
+/// CLI 1.0.68 (`$ copilot --model gpt-5.4`).
+const COPILOT_MODEL_FLAG: &str = "--model";
 
 /// Static configuration for a [`Runner`].
 #[derive(Debug, Clone)]
@@ -719,22 +728,37 @@ impl Runner {
         }
     }
 
-    /// The `copilot` provider spec: copilot log file + the agent's configured
-    /// `cli_args`.
+    /// The `copilot` provider spec: copilot log file + `--allow-all-tools`
+    /// [+ `--model <model>`] [+ the agent's `cli_args`].
     ///
-    /// Deliberately NO model flag and no invented subcommand. The GitHub Copilot
-    /// CLI is launched by ainb as the bare `copilot` binary (see
-    /// `providers::copilot::CopilotProvider`), and ainb never passes `--model` to
-    /// copilot ("No model flag for these providers (today)" — `cli/run.rs`,
-    /// `interactive/session_manager.rs`), so the runner does not fabricate one.
-    /// Copilot's real permission flag is `--yolo`; it is not hard-coded here
-    /// because permission policy is not the runner's call — set it per agent via
-    /// the agent's `cli_args` config, which flows in through `invocation`.
+    /// Flags verified against GitHub Copilot CLI 1.0.68 (`copilot --help`):
+    /// `--allow-all-tools` is "required for non-interactive mode", and `--model`
+    /// is a real flag (`$ copilot --model gpt-5.4`) — so, unlike the interactive
+    /// session launcher's stale "no model flag for these providers" rule, the
+    /// agent's configured `model` IS threaded here. No subcommand is invented
+    /// (copilot has none).
+    ///
+    /// # Known gap: no `-p` prompt (headless copilot cannot run yet)
+    ///
+    /// Copilot only runs non-interactively with `-p/--prompt <text>`; bare
+    /// `copilot` starts an INTERACTIVE session. The daemon has no prompt→argv
+    /// plumbing for ANY provider — [`ExecEnv`] carries no prompt and the task
+    /// brief reaches the agent only as `CLAUDE.md` in the workdir (the same reason
+    /// [`Self::claude_spec`] passes no `-p`). So this argv routes and confines
+    /// copilot correctly, but a REAL copilot run would still open a session rather
+    /// than execute the brief. Closing that needs a prompt on `ExecEnv` +
+    /// [`ProviderSpec`], which is a separate change (it affects claude too).
     fn copilot_spec(invocation: &ProviderInvocation) -> ProviderSpec {
+        let mut argv = vec![COPILOT_ALLOW_ALL_TOOLS_FLAG.to_string()];
+        if let Some(model) = &invocation.model {
+            argv.push(COPILOT_MODEL_FLAG.to_string());
+            argv.push(model.clone());
+        }
+        argv.extend(invocation.cli_args.iter().cloned());
         ProviderSpec {
             name: "copilot",
             log_file: COPILOT_LOG_FILE,
-            argv: invocation.cli_args.clone(),
+            argv,
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -738,6 +738,32 @@ impl Runner {
     /// agent's configured `model` IS threaded here. No subcommand is invented
     /// (copilot has none).
     ///
+    /// # Permission policy: copilot is granted blanket tool autonomy, claude is not
+    ///
+    /// `--allow-all-tools` auto-approves EVERY tool call in an unattended
+    /// background subprocess, and it is the ONLY provider argv here that does so
+    /// ([`Self::claude_spec`] passes no `--dangerously-skip-permissions`). That
+    /// asymmetry is deliberate, not an oversight:
+    ///
+    /// * It is **mandatory**, not discretionary — Copilot CLI 1.0.68 documents
+    ///   `--allow-all-tools` as "required for non-interactive mode", so a copilot
+    ///   agent without it stalls on a permission prompt it can never answer (stdin
+    ///   is null) and dies. Gating it behind agent config would ship a provider
+    ///   that is broken by default — the "recorded but doesn't actually work"
+    ///   footgun this surface already rejected once. A required flag is not a
+    ///   policy knob.
+    /// * The blast radius is bounded by the FS sandbox (Seatbelt/Landlock) and the
+    ///   deny-by-default env allowlist, but NOT eliminated: within the sandbox the
+    ///   agent may still execute arbitrary commands and reach the network. This is
+    ///   the same trust posture the daemon already warns about at dispatch
+    ///   (`warnings::danger-full-access`), so copilot is not a new exposure class
+    ///   — it is the existing one made explicit in argv.
+    /// * Claude reaches the same place by a different route (its permission
+    ///   behaviour under `--print` differs), so the two are not yet symmetrical.
+    ///   When the `-p` gap below is closed, claude will need this decision too —
+    ///   resolve BOTH providers' permission policy in one pass then, rather than
+    ///   inventing a half-policy here.
+    ///
     /// # Known gap: no `-p` prompt (headless copilot cannot run yet)
     ///
     /// Copilot only runs non-interactively with `-p/--prompt <text>`; bare
@@ -747,7 +773,9 @@ impl Runner {
     /// [`Self::claude_spec`] passes no `-p`). So this argv routes and confines
     /// copilot correctly, but a REAL copilot run would still open a session rather
     /// than execute the brief. Closing that needs a prompt on `ExecEnv` +
-    /// [`ProviderSpec`], which is a separate change (it affects claude too).
+    /// [`ProviderSpec`], which is a separate change (it affects claude too —
+    /// verified: bare `claude` with a null stdin exits 1 with "Input must be
+    /// provided either through stdin or as a prompt argument when using --print").
     fn copilot_spec(invocation: &ProviderInvocation) -> ProviderSpec {
         let mut argv = vec![COPILOT_ALLOW_ALL_TOOLS_FLAG.to_string()];
         if let Some(model) = &invocation.model {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -136,6 +136,9 @@ const CODEX_LOG_FILE: &str = "codex.jsonl";
 const CODEX_EXEC_SUBCOMMAND: &str = "exec";
 /// The codex model flag (`codex exec -m <model> …`).
 const CODEX_MODEL_FLAG: &str = "-m";
+/// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
+/// provider. Its own log keeps a copilot transcript separate from claude/codex.
+const COPILOT_LOG_FILE: &str = "copilot.jsonl";
 
 /// Static configuration for a [`Runner`].
 #[derive(Debug, Clone)]
@@ -146,6 +149,10 @@ pub struct RunnerConfig {
     /// [`Runner::run_codex`] (e38.16); a daemon that never dispatches a codex
     /// task simply never spawns it.
     pub codex_path: PathBuf,
+    /// Absolute path to the `copilot` binary (or a test stand-in script). Used by
+    /// [`Runner::run_copilot`]; a daemon that never dispatches a copilot task
+    /// simply never spawns it.
+    pub copilot_path: PathBuf,
     /// Hard wall-clock deadline; the subprocess is killed past it
     /// ([`FailureReason::Timeout`]). Reference default: 2.5h.
     pub max_runtime: Duration,
@@ -273,10 +280,11 @@ struct UsageBlock {
 
 /// Which provider exec path the daemon routes a task to (e38.16).
 ///
-/// Resolved from the task's agent → runtime → `provider` wire name. An
-/// unrecognised provider falls back to [`Self::Claude`] so a misconfigured or
-/// not-yet-implemented backend still dispatches (rather than stranding the
-/// task) — the same default-to-claude convention the rest of the daemon uses.
+/// Resolved from the task's AGENT `provider` when set (migration 0041), else its
+/// runtime's advertised `provider`. Every wired provider — `claude`, `codex`,
+/// `copilot` — has its own exec path; only a genuinely unrecognised name falls
+/// back to [`Self::Claude`] so a misconfigured agent still dispatches (rather than
+/// stranding the task).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Backend {
     /// The `claude` provider — [`Runner::run_claude`]. The default exec path: a
@@ -285,18 +293,22 @@ pub enum Backend {
     Claude,
     /// The `codex` provider — [`Runner::run_codex`].
     Codex,
+    /// The `copilot` provider (GitHub Copilot CLI) — [`Runner::run_copilot`].
+    Copilot,
 }
 
 impl Backend {
-    /// Resolve a provider wire name (`"claude"`, `"codex"`, …) to a backend.
+    /// Resolve a provider wire name (`"claude"`, `"codex"`, `"copilot"`) to a
+    /// backend.
     ///
-    /// Matching is case-insensitive. Any name that is not a wired exec path maps
-    /// to [`Self::Claude`] (the safe default), mirroring
-    /// [`crate::materialise::ProviderSkillLayout::from_provider`]'s catch-all.
+    /// Matching is case-insensitive. Only a genuinely UNKNOWN name falls back to
+    /// [`Self::Claude`] (the safe default) — every wired provider routes to its own
+    /// exec path, mirroring [`crate::materialise::ProviderSkillLayout::from_provider`].
     #[must_use]
     pub fn from_provider(provider: &str) -> Self {
         match provider.to_ascii_lowercase().as_str() {
             "codex" => Self::Codex,
+            "copilot" => Self::Copilot,
             _ => Self::Claude,
         }
     }
@@ -307,6 +319,7 @@ impl Backend {
         match self {
             Self::Claude => "claude",
             Self::Codex => "codex",
+            Self::Copilot => "copilot",
         }
     }
 }
@@ -331,10 +344,11 @@ pub struct ProviderInvocation {
 ///
 /// The orchestration in [`Runner::run_provider`] is identical across providers;
 /// only these three differ. A new provider is one more `ProviderSpec` builder
-/// (see [`Runner::claude_spec`] / [`Runner::codex_spec`]) rather than a new copy
-/// of the run loop.
+/// (see [`Runner::claude_spec`] / [`Runner::codex_spec`] / [`Runner::copilot_spec`])
+/// rather than a new copy of the run loop.
 struct ProviderSpec {
-    /// The provider's wire name (`"claude"`, `"codex"`), for logs/tracing.
+    /// The provider's wire name (`"claude"`, `"codex"`, `"copilot"`), for
+    /// logs/tracing.
     name: &'static str,
     /// The provider-log file under [`ExecEnv::logs`].
     log_file: &'static str,
@@ -381,7 +395,7 @@ impl Runner {
     /// Build the (tokio) spawn command for `program`, wrapped in the OS-level FS
     /// sandbox when [`RunnerConfig::sandbox`] is on.
     ///
-    /// `program` is the provider binary (claude or codex): every provider spawns
+    /// `program` is the provider binary (claude / codex / copilot): every provider spawns
     /// through this one wrapper, so the codex exec path gets exactly the same
     /// confinement as claude (e38.16). The confinement policy is derived from the
     /// task's [`ExecEnv`]: writes are confined to the task root
@@ -575,6 +589,85 @@ impl Runner {
         .await
     }
 
+    /// Run the `copilot` provider (GitHub Copilot CLI) for one task.
+    ///
+    /// The copilot counterpart of [`Self::run_codex`]: same orchestration
+    /// ([`Self::run_provider`]), same env allowlist + sandbox confinement, its own
+    /// program path, argv, and log file.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::run_claude`].
+    pub async fn run_copilot<I>(
+        &self,
+        env: &ExecEnv,
+        source_env: I,
+        invocation: &ProviderInvocation,
+    ) -> std::io::Result<RunOutcome>
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        self.run_copilot_with_env(env, source_env, std::iter::empty(), invocation).await
+    }
+
+    /// [`Self::run_copilot`], plus per-agent `extra_env` overrides layered onto the
+    /// child env *after* the allowlist filter — the copilot counterpart of
+    /// [`Self::run_codex_with_env`].
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::run_claude`].
+    pub async fn run_copilot_with_env<I, E>(
+        &self,
+        env: &ExecEnv,
+        source_env: I,
+        extra_env: E,
+        invocation: &ProviderInvocation,
+    ) -> std::io::Result<RunOutcome>
+    where
+        I: IntoIterator<Item = (String, String)>,
+        E: IntoIterator<Item = (String, String)>,
+    {
+        self.run_copilot_in(
+            env,
+            source_env,
+            extra_env,
+            invocation,
+            &RunLocation::in_task_tree(env),
+        )
+        .await
+    }
+
+    /// [`Self::run_copilot_with_env`], but executing in an explicit [`RunLocation`]
+    /// (F5) — the copilot counterpart of [`Self::run_codex_in`].
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::run_claude`].
+    pub async fn run_copilot_in<I, E>(
+        &self,
+        env: &ExecEnv,
+        source_env: I,
+        extra_env: E,
+        invocation: &ProviderInvocation,
+        location: &RunLocation,
+    ) -> std::io::Result<RunOutcome>
+    where
+        I: IntoIterator<Item = (String, String)>,
+        E: IntoIterator<Item = (String, String)>,
+    {
+        let spec = Self::copilot_spec(invocation);
+        self.run_provider(
+            &self.cfg.copilot_path,
+            env,
+            source_env,
+            extra_env,
+            spec,
+            location,
+        )
+        .await
+    }
+
     /// The program path + argv for a provider run, WITHOUT spawning it (ccc / D6).
     ///
     /// The interactive tmux path ([`crate::interactive`]) needs the exact program
@@ -593,6 +686,10 @@ impl Runner {
             Backend::Codex => (
                 self.cfg.codex_path.clone(),
                 Self::codex_spec(invocation).argv,
+            ),
+            Backend::Copilot => (
+                self.cfg.copilot_path.clone(),
+                Self::copilot_spec(invocation).argv,
             ),
         }
     }
@@ -619,6 +716,25 @@ impl Runner {
             name: "codex",
             log_file: CODEX_LOG_FILE,
             argv,
+        }
+    }
+
+    /// The `copilot` provider spec: copilot log file + the agent's configured
+    /// `cli_args`.
+    ///
+    /// Deliberately NO model flag and no invented subcommand. The GitHub Copilot
+    /// CLI is launched by ainb as the bare `copilot` binary (see
+    /// `providers::copilot::CopilotProvider`), and ainb never passes `--model` to
+    /// copilot ("No model flag for these providers (today)" — `cli/run.rs`,
+    /// `interactive/session_manager.rs`), so the runner does not fabricate one.
+    /// Copilot's real permission flag is `--yolo`; it is not hard-coded here
+    /// because permission policy is not the runner's call — set it per agent via
+    /// the agent's `cli_args` config, which flows in through `invocation`.
+    fn copilot_spec(invocation: &ProviderInvocation) -> ProviderSpec {
+        ProviderSpec {
+            name: "copilot",
+            log_file: COPILOT_LOG_FILE,
+            argv: invocation.cli_args.clone(),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
@@ -9,27 +9,73 @@
 //! place to run.
 //!
 //! [`register_runtime`] closes that gap: at boot the daemon upserts an
-//! `agent_runtime` row keyed on its own runtime id, marking it `online`. It is
-//! **idempotent** — a restart updates the same row (`status` + `last_seen_at`)
-//! rather than conflicting — so booting twice never duplicates or errors.
+//! `agent_runtime` row for its `(workspace, daemon_id, provider)` tuple, marking
+//! it `online`. It is **idempotent** — a restart refreshes the same row
+//! (`status` + `last_seen_at`) rather than conflicting — so booting twice never
+//! duplicates or errors.
+//!
+//! # A runtime cannot be renamed
+//!
+//! `agent.runtime_id` is a NOT NULL `REFERENCES agent_runtime(id)` FK and SQLite
+//! enforces foreign keys (sqlx sets `PRAGMA foreign_keys = ON`), so a registered
+//! runtime's `id` can never change once an agent binds it. [`effective_runtime_id`]
+//! therefore resolves the daemon's claim identity from the DB up front: an
+//! already-registered runtime's id WINS over whatever `HANGAR_DAEMON_RUNTIME_ID` /
+//! the default says (with a warning), so the registered row, the agents bound to
+//! it, and the claim loop always agree. Only a brand-new home adopts the
+//! configured id.
 //!
 //! The row's `workspace_id` FK requires a `workspace` row to exist. A daemon
 //! booted against a brand-new home with no workspace yet has nothing to attach
-//! to, so registration is a no-op in that case (returns `false`); the first
-//! `ainb hangar issue create` lazily bootstraps the workspace, and the next
-//! daemon boot registers against it.
+//! to, so registration is a no-op in that case (returns `false`); the boot seed
+//! lays the workspace down first, so in practice this only guards odd orderings.
 
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 
-/// Upsert this daemon's `agent_runtime` row, keyed on `runtime_id`.
+/// Resolve the runtime id this daemon registers under AND claims for.
+///
+/// An already-registered runtime's id WINS: a runtime cannot be renamed once an
+/// agent's `runtime_id` FK references it (see the module docs), so a changed
+/// `HANGAR_DAEMON_RUNTIME_ID` is ignored — with a `warn!` naming both ids — rather
+/// than silently registering nothing and stranding every task. Only a brand-new
+/// home (no runtime row yet) adopts the configured/default id.
+///
+/// Read-only + infallible from the caller's view: a lookup fault falls back to the
+/// configured id (logged), because refusing to boot over a transient read is worse
+/// than registering the configured identity.
+pub async fn effective_runtime_id(pool: &SqlitePool) -> String {
+    let configured = ainb_hangar_store::bootstrap::default_runtime_id();
+    match ainb_hangar_store::bootstrap::existing_host_runtime_id(pool).await {
+        Ok(Some(existing)) => {
+            if existing != configured {
+                tracing::warn!(
+                    configured = %configured,
+                    existing = %existing,
+                    "HANGAR_DAEMON_RUNTIME_ID={configured} ignored; existing runtime {existing} \
+                     is in use; a runtime cannot be renamed after first boot"
+                );
+            }
+            existing
+        }
+        Ok(None) => configured,
+        Err(e) => {
+            tracing::warn!(error = %e, "runtime id resolve failed; using the configured id");
+            configured
+        }
+    }
+}
+
+/// Upsert this daemon's `agent_runtime` row for its
+/// `(workspace, daemon_id, provider)` tuple.
 ///
 /// A thin wrapper over [`ainb_hangar_store::bootstrap::ensure_runtime`], the one
 /// shared upsert every entry point uses (the CLI `agent create`, the boot seed,
 /// this self-register). Resolves the default (oldest) workspace and writes — or,
-/// on a restart, refreshes — a single `agent_runtime` row with `id = runtime_id`,
-/// marking it `online` with a fresh `last_seen_at`. Idempotent via
-/// `ON CONFLICT(id)`.
+/// on a restart, refreshes (`status` + `last_seen_at`) — the host runtime row.
+/// Idempotent, and it never changes an existing row's `id` (that would break the
+/// `agent.runtime_id` FK); pass [`effective_runtime_id`] so the id you register is
+/// the id already in use.
 ///
 /// Returns `Ok(true)` when a row was written/refreshed, `Ok(false)` when there
 /// is no workspace to attach to yet (a brand-new home before the boot seed) — a
@@ -50,9 +96,8 @@ pub async fn register_runtime(pool: &SqlitePool, runtime_id: &str, now_ms: i64) 
 /// daemon (it still sweeps + serves).
 ///
 /// Called by the boot seed ([`crate::default_home::ensure_default_home`]) with
-/// the resolved [`ainb_hangar_store::bootstrap::default_runtime_id`] — the SAME
-/// id the claim loop keys off, keeping the seed, the claim runtime, and every
-/// created agent's binding in lockstep.
+/// [`effective_runtime_id`] — the SAME id the claim loop keys off, keeping the
+/// seed, the claim runtime, and every created agent's binding in lockstep.
 pub async fn self_register(pool: &SqlitePool, runtime_id: &str, now_ms: i64) {
     match register_runtime(pool, runtime_id, now_ms).await {
         Ok(true) => tracing::info!(runtime_id = %runtime_id, "self-registered agent runtime"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
@@ -48,6 +48,11 @@ pub async fn register_runtime(pool: &SqlitePool, runtime_id: &str, now_ms: i64) 
 /// Self-register the host runtime under the given id, logging the outcome. A
 /// failure is logged and swallowed — self-registration must never down the
 /// daemon (it still sweeps + serves).
+///
+/// Called by the boot seed ([`crate::default_home::ensure_default_home`]) with
+/// the resolved [`ainb_hangar_store::bootstrap::default_runtime_id`] — the SAME
+/// id the claim loop keys off, keeping the seed, the claim runtime, and every
+/// created agent's binding in lockstep.
 pub async fn self_register(pool: &SqlitePool, runtime_id: &str, now_ms: i64) {
     match register_runtime(pool, runtime_id, now_ms).await {
         Ok(true) => tracing::info!(runtime_id = %runtime_id, "self-registered agent runtime"),
@@ -58,20 +63,6 @@ pub async fn self_register(pool: &SqlitePool, runtime_id: &str, now_ms: i64) {
             tracing::warn!(error = %e, runtime_id = %runtime_id, "runtime self-register failed");
         }
     }
-}
-
-/// Boot-time entry point: self-register this daemon's runtime under the resolved
-/// default runtime id, logging the outcome.
-///
-/// Resolves [`ainb_hangar_store::bootstrap::default_runtime_id`] — the
-/// `HANGAR_DAEMON_RUNTIME_ID` override when set, else the stable default — so a
-/// no-env boot still registers (the fresh-home "just works" path). This is the
-/// SAME id the claim loop keys off, keeping the seed, the claim runtime, and
-/// every created agent's binding in lockstep.
-pub async fn self_register_from_env(pool: &SqlitePool) {
-    let runtime_id = ainb_hangar_store::bootstrap::default_runtime_id();
-    let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
-    self_register(pool, &runtime_id, now).await;
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
@@ -41,26 +41,37 @@ use sqlx::SqlitePool;
 /// than silently registering nothing and stranding every task. Only a brand-new
 /// home (no runtime row yet) adopts the configured/default id.
 ///
-/// Read-only + infallible from the caller's view: a lookup fault falls back to the
-/// configured id (logged), because refusing to boot over a transient read is worse
-/// than registering the configured identity.
-pub async fn effective_runtime_id(pool: &SqlitePool) -> String {
+/// Registers AND resolves in ONE atomic upsert
+/// ([`ainb_hangar_store::bootstrap::ensure_runtime`], which returns the id it
+/// settled on), so there is no read-then-write window in which the resolved id
+/// could stop being the registered one.
+///
+/// Infallible from the caller's view: a fault falls back to the configured id
+/// (logged), because refusing to boot over a transient error is worse than
+/// carrying on with the configured identity.
+pub async fn effective_runtime_id(pool: &SqlitePool, now_ms: i64) -> String {
     let configured = ainb_hangar_store::bootstrap::default_runtime_id();
-    match ainb_hangar_store::bootstrap::existing_host_runtime_id(pool).await {
-        Ok(Some(existing)) => {
-            if existing != configured {
+    match ainb_hangar_store::bootstrap::ensure_runtime(pool, &configured, now_ms).await {
+        Ok(Some(settled)) => {
+            if settled != configured {
                 tracing::warn!(
                     configured = %configured,
-                    existing = %existing,
-                    "HANGAR_DAEMON_RUNTIME_ID={configured} ignored; existing runtime {existing} \
+                    existing = %settled,
+                    "HANGAR_DAEMON_RUNTIME_ID={configured} ignored; existing runtime {settled} \
                      is in use; a runtime cannot be renamed after first boot"
                 );
+            } else {
+                tracing::info!(runtime_id = %settled, "self-registered agent runtime");
             }
-            existing
+            settled
         }
-        Ok(None) => configured,
+        // No workspace to attach to yet: nothing registered, carry the configured id.
+        Ok(None) => {
+            tracing::info!(runtime_id = %configured, "runtime self-register skipped (no workspace yet)");
+            configured
+        }
         Err(e) => {
-            tracing::warn!(error = %e, "runtime id resolve failed; using the configured id");
+            tracing::warn!(error = %e, "runtime self-register/resolve failed; using the configured id");
             configured
         }
     }
@@ -77,37 +88,22 @@ pub async fn effective_runtime_id(pool: &SqlitePool) -> String {
 /// `agent.runtime_id` FK); pass [`effective_runtime_id`] so the id you register is
 /// the id already in use.
 ///
-/// Returns `Ok(true)` when a row was written/refreshed, `Ok(false)` when there
-/// is no workspace to attach to yet (a brand-new home before the boot seed) — a
-/// benign no-op the daemon logs and continues past.
+/// Returns `Ok(Some(id))` — the id the row actually settled on (the pre-existing
+/// one when a runtime is already registered) — or `Ok(None)` when there is no
+/// workspace to attach to yet (a brand-new home before the boot seed).
 ///
 /// # Errors
 ///
 /// Propagates a [`sqlx::Error`] (wrapped) if the workspace lookup or the upsert
 /// itself fails for a reason other than the absent-workspace no-op.
-pub async fn register_runtime(pool: &SqlitePool, runtime_id: &str, now_ms: i64) -> Result<bool> {
+pub async fn register_runtime(
+    pool: &SqlitePool,
+    runtime_id: &str,
+    now_ms: i64,
+) -> Result<Option<String>> {
     ainb_hangar_store::bootstrap::ensure_runtime(pool, runtime_id, now_ms)
         .await
         .context("upsert self-registered agent_runtime row")
-}
-
-/// Self-register the host runtime under the given id, logging the outcome. A
-/// failure is logged and swallowed — self-registration must never down the
-/// daemon (it still sweeps + serves).
-///
-/// Called by the boot seed ([`crate::default_home::ensure_default_home`]) with
-/// [`effective_runtime_id`] — the SAME id the claim loop keys off, keeping the
-/// seed, the claim runtime, and every created agent's binding in lockstep.
-pub async fn self_register(pool: &SqlitePool, runtime_id: &str, now_ms: i64) {
-    match register_runtime(pool, runtime_id, now_ms).await {
-        Ok(true) => tracing::info!(runtime_id = %runtime_id, "self-registered agent runtime"),
-        Ok(false) => {
-            tracing::info!(runtime_id = %runtime_id, "runtime self-register skipped (no workspace yet)");
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, runtime_id = %runtime_id, "runtime self-register failed");
-        }
-    }
 }
 
 #[cfg(test)]
@@ -135,8 +131,12 @@ mod tests {
         let pool = store.pool();
         seed_workspace(pool).await;
 
-        let wrote = register_runtime(pool, "rt-self", 1_000).await.unwrap();
-        assert!(wrote, "a workspace exists, so the runtime must register");
+        let settled = register_runtime(pool, "rt-self", 1_000).await.unwrap();
+        assert_eq!(
+            settled.as_deref(),
+            Some("rt-self"),
+            "a workspace exists, so the runtime must register under the given id"
+        );
 
         let row = ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo::get(pool, "rt-self")
             .await
@@ -157,10 +157,16 @@ mod tests {
         seed_workspace(pool).await;
 
         // First boot.
-        assert!(register_runtime(pool, "rt-self", 1_000).await.unwrap());
+        assert_eq!(
+            register_runtime(pool, "rt-self", 1_000).await.unwrap().as_deref(),
+            Some("rt-self")
+        );
         // Second boot (restart) with a later heartbeat: must NOT error on the PK
         // / unique-index conflict, and must refresh the existing row.
-        assert!(register_runtime(pool, "rt-self", 2_000).await.unwrap());
+        assert_eq!(
+            register_runtime(pool, "rt-self", 2_000).await.unwrap().as_deref(),
+            Some("rt-self")
+        );
 
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
             .fetch_one(pool)
@@ -188,8 +194,8 @@ mod tests {
 
         // No workspace seeded: registration is a benign no-op, never an error
         // (the FK would otherwise fail).
-        let wrote = register_runtime(pool, "rt-self", 1_000).await.unwrap();
-        assert!(!wrote, "no workspace ⇒ nothing to register");
+        let settled = register_runtime(pool, "rt-self", 1_000).await.unwrap();
+        assert_eq!(settled, None, "no workspace ⇒ nothing to register");
 
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
             .fetch_one(pool)

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
@@ -22,92 +22,34 @@
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
 
-/// `daemon_id` recorded for a self-registered runtime.
-///
-/// The reference schema keys uniqueness on `(workspace_id, daemon_id, provider)`;
-/// a single host daemon advertises one provider, so a stable literal keeps the
-/// upsert deterministic (a restart targets the same tuple). The runtime's own
-/// id (the PK) is what callers route to; `daemon_id` is descriptive metadata.
-const SELF_DAEMON_ID: &str = "ainb-hangar-daemon";
-
-/// Provider a self-registered runtime advertises.
-///
-/// The daemon's claim loop resolves the actual provider per-task from the
-/// agent's backend; the runtime row's `provider` column is the advertised
-/// default. `claude` mirrors the seed fixture + the v1 default backend.
-const SELF_PROVIDER: &str = "claude";
-
-/// Runtime mode for a self-registered runtime (always a local daemon today).
-const SELF_RUNTIME_MODE: &str = "local";
-
 /// Upsert this daemon's `agent_runtime` row, keyed on `runtime_id`.
 ///
-/// Resolves the default (oldest) workspace and writes — or, on a restart,
-/// refreshes — a single `agent_runtime` row with `id = runtime_id`, marking it
-/// `online` with a fresh `last_seen_at`. Idempotent: the `ON CONFLICT(id)`
-/// clause updates the existing row instead of erroring, so booting repeatedly is
-/// safe.
+/// A thin wrapper over [`ainb_hangar_store::bootstrap::ensure_runtime`], the one
+/// shared upsert every entry point uses (the CLI `agent create`, the boot seed,
+/// this self-register). Resolves the default (oldest) workspace and writes — or,
+/// on a restart, refreshes — a single `agent_runtime` row with `id = runtime_id`,
+/// marking it `online` with a fresh `last_seen_at`. Idempotent via
+/// `ON CONFLICT(id)`.
 ///
 /// Returns `Ok(true)` when a row was written/refreshed, `Ok(false)` when there
-/// is no workspace to attach to yet (a brand-new home before the first
-/// `issue create` bootstrap) — a benign no-op the daemon logs and continues past.
+/// is no workspace to attach to yet (a brand-new home before the boot seed) — a
+/// benign no-op the daemon logs and continues past.
 ///
 /// # Errors
 ///
 /// Propagates a [`sqlx::Error`] (wrapped) if the workspace lookup or the upsert
 /// itself fails for a reason other than the absent-workspace no-op.
 pub async fn register_runtime(pool: &SqlitePool, runtime_id: &str, now_ms: i64) -> Result<bool> {
-    let workspace_id: Option<String> =
-        sqlx::query_scalar("SELECT id FROM workspace ORDER BY created_at LIMIT 1")
-            .fetch_optional(pool)
-            .await
-            .context("resolve default workspace for runtime self-register")?;
-
-    let Some(workspace_id) = workspace_id else {
-        // No workspace yet: nothing to attach a runtime to. The first
-        // `issue create` lays one down; the next boot registers against it.
-        return Ok(false);
-    };
-
-    // Idempotent upsert. `ON CONFLICT(id)` refreshes a row a previous boot wrote
-    // (a restart) rather than tripping the PK / the unique
-    // (workspace_id, daemon_id, provider) index.
-    sqlx::query(
-        "INSERT INTO agent_runtime \
-         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
-         VALUES (?, ?, ?, ?, ?, ?, 'online') \
-         ON CONFLICT(id) DO UPDATE SET \
-           status = 'online', \
-           last_seen_at = excluded.last_seen_at",
-    )
-    .bind(runtime_id)
-    .bind(&workspace_id)
-    .bind(SELF_DAEMON_ID)
-    .bind(SELF_PROVIDER)
-    .bind(SELF_RUNTIME_MODE)
-    .bind(now_ms)
-    .execute(pool)
-    .await
-    .context("upsert self-registered agent_runtime row")?;
-
-    Ok(true)
+    ainb_hangar_store::bootstrap::ensure_runtime(pool, runtime_id, now_ms)
+        .await
+        .context("upsert self-registered agent_runtime row")
 }
 
-/// Boot-time entry point: self-register this daemon's runtime from the
-/// environment, logging the outcome.
-///
-/// Reads `HANGAR_DAEMON_RUNTIME_ID` (the same identity the claim loop keys off);
-/// an unset/empty value means an anonymous daemon with nothing to register, so
-/// this is a no-op. Otherwise it calls [`register_runtime`] with a fresh
-/// timestamp and logs the result. A failure is logged and swallowed — runtime
-/// self-registration must never down the daemon (it still sweeps + serves).
-pub async fn self_register_from_env(pool: &SqlitePool) {
-    let Some(runtime_id) = std::env::var("HANGAR_DAEMON_RUNTIME_ID").ok().filter(|s| !s.is_empty())
-    else {
-        return;
-    };
-    let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
-    match register_runtime(pool, &runtime_id, now).await {
+/// Self-register the host runtime under the given id, logging the outcome. A
+/// failure is logged and swallowed — self-registration must never down the
+/// daemon (it still sweeps + serves).
+pub async fn self_register(pool: &SqlitePool, runtime_id: &str, now_ms: i64) {
+    match register_runtime(pool, runtime_id, now_ms).await {
         Ok(true) => tracing::info!(runtime_id = %runtime_id, "self-registered agent runtime"),
         Ok(false) => {
             tracing::info!(runtime_id = %runtime_id, "runtime self-register skipped (no workspace yet)");
@@ -116,6 +58,20 @@ pub async fn self_register_from_env(pool: &SqlitePool) {
             tracing::warn!(error = %e, runtime_id = %runtime_id, "runtime self-register failed");
         }
     }
+}
+
+/// Boot-time entry point: self-register this daemon's runtime under the resolved
+/// default runtime id, logging the outcome.
+///
+/// Resolves [`ainb_hangar_store::bootstrap::default_runtime_id`] — the
+/// `HANGAR_DAEMON_RUNTIME_ID` override when set, else the stable default — so a
+/// no-env boot still registers (the fresh-home "just works" path). This is the
+/// SAME id the claim loop keys off, keeping the seed, the claim runtime, and
+/// every created agent's binding in lockstep.
+pub async fn self_register_from_env(pool: &SqlitePool) {
+    let runtime_id = ainb_hangar_store::bootstrap::default_runtime_id();
+    let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
+    self_register(pool, &runtime_id, now).await;
 }
 
 #[cfg(test)]
@@ -152,7 +108,7 @@ mod tests {
             .expect("the self-registered runtime row exists");
         assert_eq!(row.id, "rt-self");
         assert_eq!(row.workspace_id, "ws-1");
-        assert_eq!(row.provider, SELF_PROVIDER);
+        assert_eq!(row.provider, "claude", "the host runtime advertises claude");
         assert_eq!(row.status, "online");
         assert_eq!(row.last_seen_at, Some(1_000));
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
@@ -195,6 +195,7 @@ async fn seed_runtime_and_agent(pool: &SqlitePool, now: i64) -> Result<(), sqlx:
             mcp_config: None,
             thinking: None,
             agent_env: Vec::new(),
+            provider: None,
         },
     )
     .await?;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -67,17 +67,25 @@ exit 0"#,
 /// Build a runner whose claude/codex paths are two DISTINCT fake binaries, so a
 /// mis-route would spawn the wrong one (and the log-file assertion would catch
 /// it regardless).
-fn runner_with(claude: PathBuf, codex: PathBuf) -> Runner {
+fn runner_with(claude: PathBuf, codex: PathBuf, copilot: PathBuf) -> Runner {
     Runner::new(RunnerConfig {
         claude_path: claude,
         codex_path: codex,
-        // Not exercised by these two routes; a bogus path proves a mis-route to
-        // copilot would fail loudly rather than silently succeed.
-        copilot_path: PathBuf::from("/nonexistent/copilot"),
+        copilot_path: copilot,
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
     })
+}
+
+/// The three fake providers + a runner wired to them, so every route has a REAL
+/// distinct binary and a mis-route is proven by the wrong log file appearing.
+fn runner_with_all(dir: &Path) -> Runner {
+    runner_with(
+        fake_provider(dir, "fake-claude.sh"),
+        fake_provider(dir, "fake-codex.sh"),
+        fake_provider(dir, "fake-copilot.sh"),
+    )
 }
 
 /// Mirror the daemon's `execute_claimed` routing: backend → exec method.
@@ -99,9 +107,7 @@ async fn dispatch(runner: &Runner, backend: Backend, env: &ExecEnv) -> RunOutcom
 async fn claude_backend_takes_claude_path() {
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
-    let claude = fake_provider(tmp.path(), "fake-claude.sh");
-    let codex = fake_provider(tmp.path(), "fake-codex.sh");
-    let runner = runner_with(claude, codex);
+    let runner = runner_with_all(tmp.path());
 
     // A claude runtime's provider wire name resolves to the claude backend.
     let backend = Backend::from_provider("claude");
@@ -125,9 +131,7 @@ async fn claude_backend_takes_claude_path() {
 async fn codex_backend_takes_codex_path() {
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
-    let claude = fake_provider(tmp.path(), "fake-claude.sh");
-    let codex = fake_provider(tmp.path(), "fake-codex.sh");
-    let runner = runner_with(claude, codex);
+    let runner = runner_with_all(tmp.path());
 
     // A codex runtime's provider wire name resolves to the codex backend.
     let backend = Backend::from_provider("codex");
@@ -146,6 +150,74 @@ async fn codex_backend_takes_codex_path() {
     assert!(
         !env.logs.join("claude.jsonl").exists(),
         "codex backend must NOT fall through to run_claude (no claude.jsonl)"
+    );
+}
+
+/// A `copilot`-backend agent takes the `run_copilot` exec path: it spawns the
+/// COPILOT binary (through the same sandbox + env allowlist) and writes
+/// `copilot.jsonl` — never claude's or codex's log. This exercises the real
+/// `run_copilot_in` → `run_provider` path end-to-end against a stand-in binary;
+/// without it the `Backend::Copilot` exec arm would be dead code no test runs.
+#[tokio::test]
+async fn copilot_backend_takes_copilot_path() {
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    let runner = runner_with_all(tmp.path());
+
+    // A copilot agent's provider wire name resolves to the copilot backend.
+    let backend = Backend::from_provider("copilot");
+    assert_eq!(backend, Backend::Copilot);
+
+    let outcome = dispatch(&runner, backend, &env).await;
+    assert!(matches!(outcome, RunOutcome::Success(_)));
+
+    // Positive proof the copilot exec path ran…
+    assert!(
+        env.logs.join("copilot.jsonl").exists(),
+        "copilot backend must take run_copilot (writes copilot.jsonl)"
+    );
+    // …and negative proof it did not fall through to either other provider (the
+    // silent claude fallback this branch removed).
+    assert!(
+        !env.logs.join("claude.jsonl").exists(),
+        "copilot backend must NOT fall through to run_claude (no claude.jsonl)"
+    );
+    assert!(
+        !env.logs.join("codex.jsonl").exists(),
+        "copilot backend must NOT take the codex path (no codex.jsonl)"
+    );
+}
+
+/// The copilot argv carries the flags a REAL non-interactive copilot run needs
+/// (verified against GitHub Copilot CLI 1.0.68): `--allow-all-tools` is
+/// documented "required for non-interactive mode", and `--model` is threaded from
+/// the agent's config when set.
+#[test]
+fn copilot_command_carries_verified_non_interactive_flags() {
+    let tmp = TempDir::new().expect("tmp");
+    let runner = runner_with_all(tmp.path());
+
+    let (_program, argv) =
+        runner.provider_command(Backend::Copilot, &ProviderInvocation::default());
+    assert!(
+        argv.contains(&"--allow-all-tools".to_string()),
+        "copilot needs --allow-all-tools for non-interactive mode: {argv:?}"
+    );
+
+    // The agent's configured model is threaded (copilot DOES support --model).
+    let invocation = ProviderInvocation {
+        model: Some("gpt-5.4".to_string()),
+        cli_args: vec!["--add-dir".to_string(), "/tmp/x".to_string()],
+    };
+    let (_program, argv) = runner.provider_command(Backend::Copilot, &invocation);
+    let joined = argv.join(" ");
+    assert!(
+        joined.contains("--model gpt-5.4"),
+        "model must be threaded: {argv:?}"
+    );
+    assert!(
+        joined.contains("--add-dir /tmp/x"),
+        "cli_args must be appended: {argv:?}"
     );
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -1,15 +1,17 @@
-//! e38.16 dispatch-routing test: a `claude`-backend agent takes the
-//! `run_claude` exec path and a `codex`-backend agent takes the `run_codex`
-//! exec path.
+//! e38.16 dispatch-routing test: each backend (`claude` / `codex` / `copilot`)
+//! takes its own exec path.
 //!
 //! Pure + deterministic (no tmux, no DB, no real provider). It exercises the
 //! exact routing the daemon's claim loop uses: resolve a [`Backend`] from a
-//! provider wire name, then dispatch to the matching [`Runner`] method. The
-//! exec path actually taken is proven by **which provider log file the run
-//! wrote** — `run_claude` writes `claude.jsonl`, `run_codex` writes
-//! `codex.jsonl`. A regression that ignored the backend (always `run_claude`)
-//! would write `claude.jsonl` for the codex case and the codex assertions would
-//! fail.
+//! provider wire name, then dispatch to the matching [`Runner`] method.
+//!
+//! The exec path actually taken is proven by **which BINARY was spawned** — each
+//! fake provider appends its own name to a shared marker file. That is the
+//! assertion that bites: the provider log file (`claude.jsonl` / `codex.jsonl` /
+//! `copilot.jsonl`) is chosen by the `ProviderSpec`, NOT by the binary, so a route
+//! that kept the right spec but spawned the WRONG program would still write the
+//! expected log and pass a log-only assertion. The log-file assertions are kept as
+//! a secondary signal (they catch a wrong SPEC); the marker catches a wrong BINARY.
 //!
 //! This is the fast both-legs companion to the tmux e2e tripwire
 //! `tripwire_dispatch_routes_by_backend.rs` (which drives the genuine daemon
@@ -53,20 +55,46 @@ fn write_script(dir: &Path, name: &str, body: &str) -> PathBuf {
     path
 }
 
-/// A fake provider that just emits a system line + result and exits 0.
-fn fake_provider(dir: &Path, name: &str) -> PathBuf {
+/// A fake provider that IDENTIFIES ITSELF, then emits a system line + result and
+/// exits 0.
+///
+/// The identity marker is the point: the per-provider log file
+/// (`claude.jsonl`/`codex.jsonl`/`copilot.jsonl`) is chosen by the `ProviderSpec`,
+/// NOT by the binary, so a log-file assertion alone proves only which SPEC ran. A
+/// `run_copilot_in` that wrongly spawned `cfg.claude_path` while keeping
+/// `copilot_spec` would still write `copilot.jsonl` and pass. Each fake therefore
+/// appends its OWN name to a marker file, so a test can assert WHICH BINARY the
+/// runner actually executed.
+///
+/// The marker path is baked into the script rather than passed as an env var:
+/// the runner filters the child env deny-by-default, so an env-carried marker
+/// would be stripped before the fake could read it.
+fn fake_provider(dir: &Path, name: &str, marker: &Path) -> PathBuf {
     write_script(
         dir,
         name,
-        r#"echo '{"type":"system","session_id":"s"}'
-echo '{"type":"result","content":"ok"}'
+        &format!(
+            r#"echo '{name}' >> '{}'
+echo '{{"type":"system","session_id":"s"}}'
+echo '{{"type":"result","content":"ok"}}'
 exit 0"#,
+            marker.display()
+        ),
     )
 }
 
-/// Build a runner whose claude/codex paths are two DISTINCT fake binaries, so a
-/// mis-route would spawn the wrong one (and the log-file assertion would catch
-/// it regardless).
+/// The provider binaries the runner actually spawned, in order.
+fn spawned(marker: &Path) -> Vec<String> {
+    fs::read_to_string(marker)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Build a runner whose claude/codex/copilot paths are three DISTINCT fake
+/// binaries, so a mis-route spawns the wrong one and the identity marker catches
+/// it.
 fn runner_with(claude: PathBuf, codex: PathBuf, copilot: PathBuf) -> Runner {
     Runner::new(RunnerConfig {
         claude_path: claude,
@@ -78,14 +106,18 @@ fn runner_with(claude: PathBuf, codex: PathBuf, copilot: PathBuf) -> Runner {
     })
 }
 
-/// The three fake providers + a runner wired to them, so every route has a REAL
-/// distinct binary and a mis-route is proven by the wrong log file appearing.
-fn runner_with_all(dir: &Path) -> Runner {
-    runner_with(
-        fake_provider(dir, "fake-claude.sh"),
-        fake_provider(dir, "fake-codex.sh"),
-        fake_provider(dir, "fake-copilot.sh"),
-    )
+/// The three fake providers + a runner wired to them, plus the marker file each
+/// fake records its identity in. Every route has a REAL distinct binary, so a
+/// mis-route (right spec, wrong binary) is caught by the marker — not just by the
+/// spec-chosen log file.
+fn runner_with_all(dir: &Path) -> (Runner, PathBuf) {
+    let marker = dir.join("spawned.txt");
+    let runner = runner_with(
+        fake_provider(dir, "fake-claude.sh", &marker),
+        fake_provider(dir, "fake-codex.sh", &marker),
+        fake_provider(dir, "fake-copilot.sh", &marker),
+    );
+    (runner, marker)
 }
 
 /// Mirror the daemon's `execute_claimed` routing: backend → exec method.
@@ -107,7 +139,7 @@ async fn dispatch(runner: &Runner, backend: Backend, env: &ExecEnv) -> RunOutcom
 async fn claude_backend_takes_claude_path() {
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
-    let runner = runner_with_all(tmp.path());
+    let (runner, marker) = runner_with_all(tmp.path());
 
     // A claude runtime's provider wire name resolves to the claude backend.
     let backend = Backend::from_provider("claude");
@@ -116,6 +148,12 @@ async fn claude_backend_takes_claude_path() {
     let outcome = dispatch(&runner, backend, &env).await;
     assert!(matches!(outcome, RunOutcome::Success(_)));
 
+    // The CLAUDE BINARY ran (not merely: the claude spec's log file appeared).
+    assert_eq!(
+        spawned(&marker),
+        vec!["fake-claude.sh"],
+        "claude backend must spawn the claude binary"
+    );
     // run_claude writes claude.jsonl and never codex.jsonl.
     assert!(
         env.logs.join("claude.jsonl").exists(),
@@ -131,7 +169,7 @@ async fn claude_backend_takes_claude_path() {
 async fn codex_backend_takes_codex_path() {
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
-    let runner = runner_with_all(tmp.path());
+    let (runner, marker) = runner_with_all(tmp.path());
 
     // A codex runtime's provider wire name resolves to the codex backend.
     let backend = Backend::from_provider("codex");
@@ -139,6 +177,14 @@ async fn codex_backend_takes_codex_path() {
 
     let outcome = dispatch(&runner, backend, &env).await;
     assert!(matches!(outcome, RunOutcome::Success(_)));
+
+    // The CODEX BINARY ran — a spec-only assertion would not catch a route that
+    // kept codex_spec but spawned the claude path.
+    assert_eq!(
+        spawned(&marker),
+        vec!["fake-codex.sh"],
+        "codex backend must spawn the codex binary"
+    );
 
     // run_codex writes codex.jsonl and never claude.jsonl — the positive proof
     // the new path is taken, plus the negative proof it did NOT fall through to
@@ -162,7 +208,7 @@ async fn codex_backend_takes_codex_path() {
 async fn copilot_backend_takes_copilot_path() {
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
-    let runner = runner_with_all(tmp.path());
+    let (runner, marker) = runner_with_all(tmp.path());
 
     // A copilot agent's provider wire name resolves to the copilot backend.
     let backend = Backend::from_provider("copilot");
@@ -170,6 +216,23 @@ async fn copilot_backend_takes_copilot_path() {
 
     let outcome = dispatch(&runner, backend, &env).await;
     assert!(matches!(outcome, RunOutcome::Success(_)));
+
+    // The COPILOT BINARY ran. This is the assertion that actually bites: the log
+    // file below is chosen by copilot_spec, so a run_copilot_in that wrongly used
+    // cfg.claude_path would still write copilot.jsonl and pass without this.
+    assert_eq!(
+        spawned(&marker),
+        vec!["fake-copilot.sh"],
+        "copilot backend must spawn the COPILOT binary, not another provider's"
+    );
+    // The program the runner would exec is the configured copilot path.
+    let (program, _argv) =
+        runner.provider_command(Backend::Copilot, &ProviderInvocation::default());
+    assert_eq!(
+        program.file_name().unwrap(),
+        "fake-copilot.sh",
+        "provider_command must name the copilot binary"
+    );
 
     // Positive proof the copilot exec path ran…
     assert!(
@@ -195,7 +258,7 @@ async fn copilot_backend_takes_copilot_path() {
 #[test]
 fn copilot_command_carries_verified_non_interactive_flags() {
     let tmp = TempDir::new().expect("tmp");
-    let runner = runner_with_all(tmp.path());
+    let (runner, _marker) = runner_with_all(tmp.path());
 
     let (_program, argv) =
         runner.provider_command(Backend::Copilot, &ProviderInvocation::default());

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -67,10 +67,13 @@ exit 0"#,
 /// Build a runner whose claude/codex paths are two DISTINCT fake binaries, so a
 /// mis-route would spawn the wrong one (and the log-file assertion would catch
 /// it regardless).
-const fn runner_with(claude: PathBuf, codex: PathBuf) -> Runner {
+fn runner_with(claude: PathBuf, codex: PathBuf) -> Runner {
     Runner::new(RunnerConfig {
         claude_path: claude,
         codex_path: codex,
+        // Not exercised by these two routes; a bogus path proves a mis-route to
+        // copilot would fail loudly rather than silently succeed.
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -85,6 +88,10 @@ async fn dispatch(runner: &Runner, backend: Backend, env: &ExecEnv) -> RunOutcom
             .run_codex(env, std::iter::empty(), &ProviderInvocation::default())
             .await
             .expect("run codex"),
+        Backend::Copilot => runner
+            .run_copilot(env, std::iter::empty(), &ProviderInvocation::default())
+            .await
+            .expect("run copilot"),
     }
 }
 
@@ -143,12 +150,17 @@ async fn codex_backend_takes_codex_path() {
 }
 
 #[test]
-fn unknown_provider_defaults_to_claude() {
-    // A not-yet-wired / misconfigured provider must still dispatch (to the safe
-    // default) rather than strand the task.
+fn wired_providers_route_and_unknown_defaults_to_claude() {
+    // Every WIRED provider routes to its own exec path — copilot included; it no
+    // longer silently falls back to claude.
+    assert_eq!(Backend::from_provider("codex"), Backend::Codex);
+    assert_eq!(Backend::from_provider("copilot"), Backend::Copilot);
+    assert_eq!(Backend::from_provider("claude"), Backend::Claude);
+    // A genuinely not-wired / misconfigured provider must still dispatch (to the
+    // safe default) rather than strand the task.
     assert_eq!(Backend::from_provider("gemini"), Backend::Claude);
-    assert_eq!(Backend::from_provider("copilot"), Backend::Claude);
     assert_eq!(Backend::from_provider(""), Backend::Claude);
     // Case-insensitive on the wired names.
     assert_eq!(Backend::from_provider("CODEX"), Backend::Codex);
+    assert_eq!(Backend::from_provider("Copilot"), Backend::Copilot);
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/materialise_skills_tests.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/materialise_skills_tests.rs
@@ -25,8 +25,9 @@ use sqlx::SqlitePool;
 const AGENT_ID: &str = "ag-test-0001";
 
 /// Seed one workspace + one agent (+ its runtime/owner rows) and return the
-/// typed ids the materialiser keys off. `PRAGMA foreign_keys` is off in the
-/// store crate, but we seed the parent rows anyway for fidelity.
+/// typed ids the materialiser keys off. The parent rows are REQUIRED: foreign
+/// keys are enforced (sqlx sets `PRAGMA foreign_keys = ON`), so the agent's
+/// workspace/runtime/owner must exist before it can be inserted.
 async fn seed(pool: &SqlitePool) -> (WorkspaceId, AgentId) {
     let ws = "ws-test-0001";
     sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, 'test', 'Test', 0)")

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
@@ -183,6 +183,7 @@ async fn seed_second_agent(store: &Store) {
             mcp_config: None,
             thinking: None,
             agent_env: Vec::new(),
+            provider: None,
         },
     )
     .await
@@ -227,6 +228,7 @@ async fn seed_agent_on(store: &Store, agent_id: &str, runtime_id: &str) {
             mcp_config: None,
             thinking: None,
             agent_env: Vec::new(),
+            provider: None,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -79,6 +79,7 @@ exit 0"#,
         // e38.16: the codex path is irrelevant to a claude run; a placeholder is
         // fine since `run_claude` never spawns it.
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         // Exercise the WIRED sandbox path: the stand-in script reads `$HOME`
@@ -120,6 +121,7 @@ async fn exec_captures_exit_code() {
         // e38.16: the codex path is irrelevant to a claude run; a placeholder is
         // fine since `run_claude` never spawns it.
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -149,6 +151,7 @@ exit 0"#,
     let runner = Runner::new(RunnerConfig {
         claude_path: script,
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -171,6 +174,7 @@ async fn exec_no_result_usage_leaves_usage_none() {
     let runner = Runner::new(RunnerConfig {
         claude_path: script,
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -198,6 +202,7 @@ exit 1"#,
         // e38.16: the codex path is irrelevant to a claude run; a placeholder is
         // fine since `run_claude` never spawns it.
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -232,6 +237,7 @@ exit 75"#,
     let runner = Runner::new(RunnerConfig {
         claude_path: script,
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -266,6 +272,7 @@ exit 0"#,
         // e38.16: the codex path is irrelevant to a claude run; a placeholder is
         // fine since `run_claude` never spawns it.
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -297,6 +304,7 @@ exit 0"#,
         // e38.16: the codex path is irrelevant to a claude run; a placeholder is
         // fine since `run_claude` never spawns it.
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,
@@ -332,6 +340,7 @@ exit 0"#,
         // e38.16: the codex path is irrelevant to a claude run; a placeholder is
         // fine since `run_claude` never spawns it.
         codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_millis(100),
         tail_lines: 50,
         sandbox: true,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
@@ -58,6 +58,7 @@ fn cfg_with_codex(codex_path: PathBuf) -> RunnerConfig {
         // bogus path is fine since `run_codex` never touches it.
         claude_path: PathBuf::from("/nonexistent/claude"),
         codex_path,
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
         max_runtime: Duration::from_secs(10),
         tail_lines: 50,
         sandbox: true,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_fresh_home_squad_create.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_fresh_home_squad_create.rs
@@ -1,0 +1,284 @@
+//! The money test: an EMPTY hangar home works end-to-end.
+//!
+//! Drives the whole fresh-home story over a real framed `UnixStream`, with NO
+//! seed fixture:
+//!   1. `ensure_default_home` on an empty Store lays down the default workspace,
+//!      the host runtime, and exactly one starter agent.
+//!   2. The seeded runtime id equals the daemon's default claim runtime id — so a
+//!      seeded/created agent binds the runtime the daemon actually claims for.
+//!   3. `hangar/agent_create` (no ids supplied) inserts a SECOND agent with every
+//!      FK filled.
+//!   4. `hangar/squad_create` — which on an empty home used to fail "no agent
+//!      available to lead a squad" — now SUCCEEDS with a seeded agent as leader,
+//!      and `hangar/squads_list` shows the squad (the gate at plugin.rs:2003 is
+//!      cleared).
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+const WS_SLUG: &str = "default";
+
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(methods::AUTH_HELLO, serde_json::json!({ "token": token.trim() }))
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    /// The active AGENT actor-refs (`agent:<id>`) in `workspace`'s agents_list.
+    async fn agent_refs(&mut self, workspace: &str) -> Vec<String> {
+        let list = self
+            .call(methods::HANGAR_AGENTS_LIST, serde_json::json!({ "workspace_id": workspace }))
+            .await;
+        list["result"]["actors"]
+            .as_array()
+            .expect("actors array")
+            .iter()
+            .filter(|a| a["is_agent"] == true)
+            .map(|a| a["actor_ref"].as_str().unwrap().to_string())
+            .collect()
+    }
+}
+
+/// Bind + serve the real listener over a store seeded ONLY by `ensure_default_home`
+/// (no fixture) — the fresh-home path.
+async fn start_fresh_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    // The whole point: seed a brand-new home with the boot seed, nothing else.
+    ainb_hangar_daemon::default_home::ensure_default_home(store.pool())
+        .await
+        .expect("fresh-home seed");
+    rpc::auth::ensure_socket_token(store.pool(), dir).await.expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// Bind + serve over a BARE store — no seed at all (not even the boot seed) — to
+/// prove `agent_create` ensures-then-resolves the default workspace itself.
+async fn start_bare_server(dir: &std::path::Path) -> std::path::PathBuf {
+    let store = Store::open_in(dir).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir).await.expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    socket_path
+}
+
+/// `agent_create` with an empty name is a client error, not an empty insert.
+#[tokio::test]
+async fn agent_create_rejects_empty_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_fresh_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c.call(methods::HANGAR_AGENT_CREATE, serde_json::json!({ "name": "   " })).await;
+    assert!(!resp["error"].is_null(), "an empty name must be rejected: {resp}");
+}
+
+/// `agent_create` on a bare home (no workspace row yet) bootstraps the default
+/// workspace itself rather than rejecting — the TUI create path ensure-then-resolves.
+#[tokio::test]
+async fn agent_create_bootstraps_default_workspace_when_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = start_bare_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(methods::HANGAR_AGENT_CREATE, serde_json::json!({ "name": "solo" }))
+        .await;
+    assert!(
+        resp["error"].is_null(),
+        "agent_create must bootstrap the default workspace, not reject: {resp}"
+    );
+    let refs = c.agent_refs(WS_SLUG).await;
+    assert_eq!(refs.len(), 1, "the created agent is in the default workspace: {refs:?}");
+}
+
+#[tokio::test]
+async fn fresh_home_seeds_then_agent_create_and_squad_create_succeed() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_fresh_server(dir.path()).await;
+
+    // (1) The boot seed laid down workspace + runtime + exactly one starter agent.
+    let ws_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspace")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(ws_count, 1, "one default workspace seeded");
+    let agent_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM agent").fetch_one(store.pool()).await.unwrap();
+    assert_eq!(agent_count, 1, "exactly one starter agent seeded");
+
+    // (2) The seeded agent binds the SAME runtime the daemon claims for.
+    let default_rt = ainb_hangar_store::bootstrap::default_runtime_id();
+    let seeded_rt: String = sqlx::query_scalar("SELECT runtime_id FROM agent LIMIT 1")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        seeded_rt, default_rt,
+        "the seeded agent's runtime must equal the daemon's claim runtime id"
+    );
+    let rt_online: String =
+        sqlx::query_scalar("SELECT status FROM agent_runtime WHERE id = ?")
+            .bind(&default_rt)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(rt_online, "online", "the seeded runtime is registered online");
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    // (3) agent_create with NO ids supplied inserts a second agent.
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({ "name": "reviewer", "provider": "codex" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "agent_create must ack: {resp}");
+    let refs = c.agent_refs(WS_SLUG).await;
+    assert_eq!(refs.len(), 2, "two agents after create: {refs:?}");
+
+    // The recorded provider persisted onto the created agent's row.
+    let codex_provider: Option<String> =
+        sqlx::query_scalar("SELECT provider FROM agent WHERE name = ?")
+            .bind("reviewer")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(codex_provider.as_deref(), Some("codex"), "provider recorded on the row");
+
+    // (4) squad_create with a seeded agent leader SUCCEEDS (the gate is cleared).
+    let leader = refs.first().expect("at least one agent to lead").clone();
+    let resp = c
+        .call(
+            methods::HANGAR_SQUAD_CREATE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "name": "alpha", "leader": leader }),
+        )
+        .await;
+    assert!(
+        resp["error"].is_null(),
+        "squad_create on a fresh home must SUCCEED (the 'no agent available' gate is cleared): {resp}"
+    );
+
+    // squads_list shows the new squad.
+    let squads = c
+        .call(methods::HANGAR_SQUADS_LIST, serde_json::json!({ "workspace_id": WS_SLUG }))
+        .await;
+    let names: Vec<String> = squads["result"]["squads"]
+        .as_array()
+        .expect("squads array")
+        .iter()
+        .map(|s| s["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(names.contains(&"alpha".to_string()), "the created squad is listed: {names:?}");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_fresh_home_squad_create.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_fresh_home_squad_create.rs
@@ -99,7 +99,10 @@ impl Client {
         let token_path = ainb_hangar_proto::auth::token_file_in(dir);
         let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
         let resp = self
-            .call(methods::AUTH_HELLO, serde_json::json!({ "token": token.trim() }))
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
             .await;
         assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
     }
@@ -107,7 +110,10 @@ impl Client {
     /// The active AGENT actor-refs (`agent:<id>`) in `workspace`'s agents_list.
     async fn agent_refs(&mut self, workspace: &str) -> Vec<String> {
         let list = self
-            .call(methods::HANGAR_AGENTS_LIST, serde_json::json!({ "workspace_id": workspace }))
+            .call(
+                methods::HANGAR_AGENTS_LIST,
+                serde_json::json!({ "workspace_id": workspace }),
+            )
             .await;
         list["result"]["actors"]
             .as_array()
@@ -127,7 +133,9 @@ async fn start_fresh_server(dir: &std::path::Path) -> (std::path::PathBuf, Store
     ainb_hangar_daemon::default_home::ensure_default_home(store.pool())
         .await
         .expect("fresh-home seed");
-    rpc::auth::ensure_socket_token(store.pool(), dir).await.expect("ensure socket token");
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
     let socket_path = rpc::socket_path_in(dir);
     let listener = rpc::bind(&socket_path).expect("bind socket");
     let health = DaemonHealth {
@@ -150,7 +158,9 @@ async fn start_fresh_server(dir: &std::path::Path) -> (std::path::PathBuf, Store
 /// prove `agent_create` ensures-then-resolves the default workspace itself.
 async fn start_bare_server(dir: &std::path::Path) -> std::path::PathBuf {
     let store = Store::open_in(dir).await.unwrap();
-    rpc::auth::ensure_socket_token(store.pool(), dir).await.expect("ensure socket token");
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
     let socket_path = rpc::socket_path_in(dir);
     let listener = rpc::bind(&socket_path).expect("bind socket");
     let health = DaemonHealth {
@@ -177,8 +187,16 @@ async fn agent_create_rejects_empty_name() {
     let mut c = Client::connect(&socket_path).await;
     c.auth_from_file(dir.path()).await;
 
-    let resp = c.call(methods::HANGAR_AGENT_CREATE, serde_json::json!({ "name": "   " })).await;
-    assert!(!resp["error"].is_null(), "an empty name must be rejected: {resp}");
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({ "name": "   " }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an empty name must be rejected: {resp}"
+    );
 }
 
 /// `agent_create` on a bare home (no workspace row yet) bootstraps the default
@@ -191,14 +209,21 @@ async fn agent_create_bootstraps_default_workspace_when_absent() {
     c.auth_from_file(dir.path()).await;
 
     let resp = c
-        .call(methods::HANGAR_AGENT_CREATE, serde_json::json!({ "name": "solo" }))
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({ "name": "solo" }),
+        )
         .await;
     assert!(
         resp["error"].is_null(),
         "agent_create must bootstrap the default workspace, not reject: {resp}"
     );
     let refs = c.agent_refs(WS_SLUG).await;
-    assert_eq!(refs.len(), 1, "the created agent is in the default workspace: {refs:?}");
+    assert_eq!(
+        refs.len(),
+        1,
+        "the created agent is in the default workspace: {refs:?}"
+    );
 }
 
 #[tokio::test]
@@ -212,8 +237,10 @@ async fn fresh_home_seeds_then_agent_create_and_squad_create_succeed() {
         .await
         .unwrap();
     assert_eq!(ws_count, 1, "one default workspace seeded");
-    let agent_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM agent").fetch_one(store.pool()).await.unwrap();
+    let agent_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
     assert_eq!(agent_count, 1, "exactly one starter agent seeded");
 
     // (2) The seeded agent binds the SAME runtime the daemon claims for.
@@ -226,13 +253,15 @@ async fn fresh_home_seeds_then_agent_create_and_squad_create_succeed() {
         seeded_rt, default_rt,
         "the seeded agent's runtime must equal the daemon's claim runtime id"
     );
-    let rt_online: String =
-        sqlx::query_scalar("SELECT status FROM agent_runtime WHERE id = ?")
-            .bind(&default_rt)
-            .fetch_one(store.pool())
-            .await
-            .unwrap();
-    assert_eq!(rt_online, "online", "the seeded runtime is registered online");
+    let rt_online: String = sqlx::query_scalar("SELECT status FROM agent_runtime WHERE id = ?")
+        .bind(&default_rt)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        rt_online, "online",
+        "the seeded runtime is registered online"
+    );
 
     let mut c = Client::connect(&socket_path).await;
     c.auth_from_file(dir.path()).await;
@@ -255,7 +284,11 @@ async fn fresh_home_seeds_then_agent_create_and_squad_create_succeed() {
             .fetch_one(store.pool())
             .await
             .unwrap();
-    assert_eq!(codex_provider.as_deref(), Some("codex"), "provider recorded on the row");
+    assert_eq!(
+        codex_provider.as_deref(),
+        Some("codex"),
+        "provider recorded on the row"
+    );
 
     // (4) squad_create with a seeded agent leader SUCCEEDS (the gate is cleared).
     let leader = refs.first().expect("at least one agent to lead").clone();
@@ -272,7 +305,10 @@ async fn fresh_home_seeds_then_agent_create_and_squad_create_succeed() {
 
     // squads_list shows the new squad.
     let squads = c
-        .call(methods::HANGAR_SQUADS_LIST, serde_json::json!({ "workspace_id": WS_SLUG }))
+        .call(
+            methods::HANGAR_SQUADS_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
         .await;
     let names: Vec<String> = squads["result"]["squads"]
         .as_array()
@@ -280,5 +316,8 @@ async fn fresh_home_seeds_then_agent_create_and_squad_create_succeed() {
         .iter()
         .map(|s| s["name"].as_str().unwrap().to_string())
         .collect();
-    assert!(names.contains(&"alpha".to_string()), "the created squad is listed: {names:?}");
+    assert!(
+        names.contains(&"alpha".to_string()),
+        "the created squad is listed: {names:?}"
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -290,8 +290,10 @@ pub const HANGAR_AGENT_ARCHIVE: &str = "hangar/agent_archive";
 /// folds the new agent into the cache that drives its "has an agent" gate.
 ///
 /// Mutating: an empty `name` or an unsupported `provider` is rejected with
-/// `INVALID_PARAMS`. Creation is never gated on the provider — an agent bound to
-/// the default runtime always runs.
+/// `INVALID_PARAMS`. The recorded provider is HONOURED at dispatch: the agent
+/// binds the single default runtime (an execution slot the claim loop keys off by
+/// id, not provider), and the daemon spawns the recorded provider's backend per
+/// task — so a `codex` agent runs codex.
 pub const HANGAR_AGENT_CREATE: &str = "hangar/agent_create";
 
 /// `hangar/members_list` — snapshot the human members of a workspace (e38.11).

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -278,6 +278,22 @@ pub const HANGAR_AGENT_UPDATE: &str = "hangar/agent_update";
 /// agent id flips no row and is rejected as a not-found error.
 pub const HANGAR_AGENT_ARCHIVE: &str = "hangar/agent_archive";
 
+/// `hangar/agent_create` — create one agent from scratch (fresh-home path).
+///
+/// Params: [`crate::snapshots::AgentCreateParams`]
+/// (`{ workspace_id?, name, provider?, instructions? }`). The daemon fills every
+/// FK behind the scenes — it ensures the default workspace + owner, binds the
+/// single default runtime, and mints the id — so the caller supplies only the
+/// human `name` (+ an optional `provider` of `claude`/`codex`/`copilot`,
+/// defaulting to the runtime's advertised `claude`, and optional `instructions`).
+/// Result: the refreshed [`crate::snapshots::AgentsListResult`] so the client
+/// folds the new agent into the cache that drives its "has an agent" gate.
+///
+/// Mutating: an empty `name` or an unsupported `provider` is rejected with
+/// `INVALID_PARAMS`. Creation is never gated on the provider — an agent bound to
+/// the default runtime always runs.
+pub const HANGAR_AGENT_CREATE: &str = "hangar/agent_create";
+
 /// `hangar/members_list` — snapshot the human members of a workspace (e38.11).
 ///
 /// Params: [`crate::snapshots::WorkspaceScopedParams`] (`{ workspace_id }`).
@@ -954,6 +970,9 @@ pub const ALL_METHODS: &[&str] = &[
     // the wire catalogue is append-only.
     HANGAR_NOTIFY_RULES_LIST,
     HANGAR_NOTIFY_RULE_SET,
+    // Agent create-from-scratch (fresh-home bootstrap) is APPENDED at the
+    // catalogue tail — the wire catalogue is append-only.
+    HANGAR_AGENT_CREATE,
 ];
 
 #[cfg(test)]
@@ -1056,6 +1075,7 @@ mod tests {
             HANGAR_BOARD_CARD_MOVE,
             HANGAR_SQUAD_FANOUT,
             HANGAR_RUN_HISTORY,
+            HANGAR_AGENT_CREATE,
         ] {
             assert!(m.starts_with("hangar/"), "{m:?} not under hangar/");
         }
@@ -1145,6 +1165,7 @@ mod tests {
             HANGAR_BOARD_CARD_SET_AUTO_RUN,
             HANGAR_NOTIFY_RULES_LIST,
             HANGAR_NOTIFY_RULE_SET,
+            HANGAR_AGENT_CREATE,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2383,7 +2383,10 @@ mod tests {
         assert!(minimal.provider.is_none());
         assert!(minimal.instructions.is_none());
         // The optional fields are omitted from the serialized form when absent.
-        assert_eq!(serde_json::to_string(&minimal).unwrap(), r#"{"name":"claude"}"#);
+        assert_eq!(
+            serde_json::to_string(&minimal).unwrap(),
+            r#"{"name":"claude"}"#
+        );
     }
 
     /// The e38.11 member-management envelopes round-trip through JSON.

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1041,6 +1041,32 @@ pub struct AgentUpdateParams {
     pub agent_env: Option<Vec<(String, String)>>,
 }
 
+/// Params for [`crate::methods::HANGAR_AGENT_CREATE`]: create one agent from
+/// scratch on the fresh-home path.
+///
+/// The daemon fills every FK behind the scenes (default workspace + owner +
+/// runtime), so the caller supplies only the human `name`. `workspace_id` is
+/// optional — absent/empty means "the default workspace" (the daemon ensures it),
+/// so the TUI never has to surface an id. `provider` is optional
+/// (`claude`/`codex`/`copilot`); absent defaults to the runtime's advertised
+/// `claude`. `instructions` is the optional free-form system prompt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AgentCreateParams {
+    /// The target workspace; absent/empty = the default workspace (ensured by
+    /// the daemon). Kept optional so the TUI create prompt never surfaces an id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    /// The new agent's human name (required, non-empty).
+    pub name: String,
+    /// Optional provider (`claude`/`codex`/`copilot`); absent = the runtime's
+    /// advertised default (`claude`). Recorded on the agent row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Optional free-form system prompt / instructions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
 /// Params for [`crate::methods::HANGAR_AGENT_ARCHIVE`] (e38.15): archive or
 /// un-archive one agent, scoped to a workspace.
 ///
@@ -2334,6 +2360,30 @@ mod tests {
             serde_json::from_str::<AgentArchiveParams>(&s).unwrap(),
             params
         );
+    }
+
+    /// `AgentCreateParams` round-trips, and the optional fields are omitted when
+    /// absent so a minimal `{ "name": ... }` payload deserializes (the fresh-home
+    /// create needs neither an id nor a provider).
+    #[test]
+    fn agent_create_params_roundtrip_and_minimal() {
+        let full = AgentCreateParams {
+            workspace_id: Some("ws-1".into()),
+            name: "reviewer".into(),
+            provider: Some("codex".into()),
+            instructions: Some("be terse".into()),
+        };
+        let s = serde_json::to_string(&full).unwrap();
+        assert_eq!(serde_json::from_str::<AgentCreateParams>(&s).unwrap(), full);
+
+        // A name-only payload deserializes with every optional field defaulted.
+        let minimal: AgentCreateParams = serde_json::from_str(r#"{"name":"claude"}"#).unwrap();
+        assert_eq!(minimal.name, "claude");
+        assert!(minimal.workspace_id.is_none());
+        assert!(minimal.provider.is_none());
+        assert!(minimal.instructions.is_none());
+        // The optional fields are omitted from the serialized form when absent.
+        assert_eq!(serde_json::to_string(&minimal).unwrap(), r#"{"name":"claude"}"#);
     }
 
     /// The e38.11 member-management envelopes round-trip through JSON.

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0041_agent_provider.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0041_agent_provider.sql
@@ -1,0 +1,17 @@
+-- Hangar v1 schema, migration 0041: per-agent provider override.
+--
+-- Until now an agent had no provider of its own: the daemon resolves which
+-- provider exec path a task takes from the agent's RUNTIME (`agent_runtime.provider`),
+-- and the single self-registered host runtime advertises `claude`. The
+-- `hangar/agent_create` surface (fresh-home bootstrap) lets a user pick a
+-- provider (`claude`/`codex`/`copilot`) at create time, so the choice must be
+-- recorded ON the agent row rather than inferred from the shared runtime.
+--
+-- `provider` is nullable TEXT (no default): NULL means "no per-agent override —
+-- use the runtime's advertised provider", so every pre-existing agent keeps its
+-- current behaviour untouched. A freshly-created agent records the chosen
+-- provider verbatim. Following migration 0015's precedent, an ALTER TABLE ...
+-- ADD COLUMN with no non-constant default is an O(1) catalog change (no table
+-- rewrite) and is non-destructive.
+ALTER TABLE agent
+    ADD COLUMN provider TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -202,32 +202,46 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
 /// runtime therefore CANNOT be renamed after first boot: if a caller passes a
 /// different `runtime_id` for an existing `(workspace, daemon, provider)` tuple
 /// (e.g. a changed `HANGAR_DAEMON_RUNTIME_ID`), this refreshes the EXISTING row's
-/// `status`/`last_seen_at` and keeps its original `id`. Boot resolves the
-/// effective claim id from the existing row up front (see the daemon's
+/// `status`/`last_seen_at`, keeps its original `id`, and RETURNS that id. Boot
+/// takes the daemon's claim id from this same call (see the daemon's
 /// `effective_runtime_id`), so the registered row, the agents bound to it, and the
 /// claim loop all stay aligned — no drift, no stranding, no FK error.
 ///
-/// Returns `Ok(true)` when a row was written/refreshed, `Ok(false)` when there is
-/// no workspace to attach to yet (a benign no-op).
+/// Returns `Ok(Some(id))` — the id the row ACTUALLY settled on, which is the
+/// pre-existing id when one was already registered and `runtime_id` otherwise —
+/// or `Ok(None)` when there is no workspace to attach to yet (a benign no-op).
+///
+/// Returning the settled id makes this the single atomic resolve+register: a
+/// caller binds what demonstrably exists rather than re-reading (a read-then-write
+/// race where a concurrent daemon registered a different id between the read and
+/// the insert would otherwise FK-fail the caller's insert).
 ///
 /// # Errors
 ///
-/// Returns a [`sqlx::Error`] if the workspace lookup or the upsert fails.
+/// Returns a [`sqlx::Error`] if the workspace lookup or the upsert fails. It never
+/// FK-errors (the `id` is never rewritten); a `UNIQUE constraint failed:
+/// agent_runtime.id` can still surface if the CONFIGURED id already exists under a
+/// DIFFERENT `(workspace, daemon, provider)` tuple — a genuine misconfiguration,
+/// reported here rather than silently mis-binding an agent later.
 pub async fn ensure_runtime(
     pool: &SqlitePool,
     runtime_id: &str,
     now_ms: i64,
-) -> Result<bool, sqlx::Error> {
+) -> Result<Option<String>, sqlx::Error> {
     let Some(workspace_id) = find_default_workspace(pool).await? else {
-        return Ok(false);
+        return Ok(None);
     };
-    sqlx::query(
+    // One statement: insert-or-refresh and hand back the id that now owns the
+    // tuple. `DO UPDATE` (not `DO NOTHING`) is what makes `RETURNING` yield the
+    // existing row on the conflict path.
+    let settled: String = sqlx::query_scalar(
         "INSERT INTO agent_runtime \
          (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
          VALUES (?, ?, ?, ?, ?, ?, 'online') \
          ON CONFLICT(workspace_id, daemon_id, provider) DO UPDATE SET \
            status = 'online', \
-           last_seen_at = excluded.last_seen_at",
+           last_seen_at = excluded.last_seen_at \
+         RETURNING id",
     )
     .bind(runtime_id)
     .bind(&workspace_id)
@@ -235,69 +249,30 @@ pub async fn ensure_runtime(
     .bind(DEFAULT_PROVIDER)
     .bind(SELF_RUNTIME_MODE)
     .bind(now_ms)
-    .execute(pool)
+    .fetch_one(pool)
     .await?;
-    Ok(true)
-}
-
-/// The id of the host runtime already registered for this daemon's
-/// `(workspace, daemon_id, provider)` tuple, or `None` when none exists yet.
-///
-/// Because a runtime cannot be renamed after first boot (its `id` is an FK
-/// target), an existing row's id is the identity the claim loop, the registered
-/// row, and every bound agent must all use.
-///
-/// # Errors
-///
-/// Returns a [`sqlx::Error`] if the lookup fails.
-pub async fn existing_host_runtime_id(pool: &SqlitePool) -> Result<Option<String>, sqlx::Error> {
-    let Some(workspace_id) = find_default_workspace(pool).await? else {
-        return Ok(None);
-    };
-    sqlx::query_scalar(
-        "SELECT id FROM agent_runtime \
-         WHERE workspace_id = ? AND daemon_id = ? AND provider = ? LIMIT 1",
-    )
-    .bind(&workspace_id)
-    .bind(SELF_DAEMON_ID)
-    .bind(DEFAULT_PROVIDER)
-    .fetch_optional(pool)
-    .await
-}
-
-/// Resolve the runtime id a new agent binds to (and the daemon claims for).
-///
-/// The EXISTING host runtime's id when one is registered — a runtime cannot be
-/// renamed, so its id wins — else the configured/default id
-/// ([`default_runtime_id`]) for a brand-new home. Keeping create and claim on this
-/// one resolver is what keeps a created agent bound to the runtime the daemon
-/// actually claims for.
-///
-/// # Errors
-///
-/// Returns a [`sqlx::Error`] if the lookup fails.
-pub async fn resolve_runtime_id(pool: &SqlitePool) -> Result<String, sqlx::Error> {
-    Ok(existing_host_runtime_id(pool).await?.unwrap_or_else(default_runtime_id))
+    Ok(Some(settled))
 }
 
 /// Create one agent from scratch, filling every FK behind the scenes.
 ///
-/// Binds the default runtime (ensuring its row exists), resolves the default
-/// owner, mints a fresh id, and inserts. The caller supplies only the human
-/// `name` (+ an already-normalised `provider` and optional `instructions`).
+/// Ensures the host runtime and binds the id that upsert SETTLED on, resolves the
+/// default owner, mints a fresh id, and inserts. The caller supplies only the
+/// human `name` (+ an already-normalised `provider` and optional `instructions`).
 ///
 /// The returned [`Agent`] carries the minted id so a caller can route to it
 /// (e.g. as a squad leader). `provider` is recorded on the row and HONOURED at
 /// dispatch: the agent binds the single host runtime (an execution slot the claim
 /// loop keys off by id, not by provider), and the daemon spawns the recorded
-/// provider's backend per task — so a `codex` agent runs codex. The agent binds
-/// the EXISTING runtime id when one is registered ([`resolve_runtime_id`]), so a
-/// created agent is always on the runtime the daemon actually claims for.
+/// provider's backend per task — so a `codex` agent runs codex. Binding the id
+/// [`ensure_runtime`] returned (rather than re-reading it) means the agent is
+/// always on a runtime that demonstrably exists — no read-then-write window in
+/// which a concurrent daemon could register a different id and FK-fail this insert.
 ///
 /// # Errors
 ///
-/// Returns a [`sqlx::Error`] if the workspace has no owner user yet (the FK could
-/// not be filled) or if the runtime upsert / agent insert fails.
+/// Returns a [`sqlx::Error`] if there is no workspace / owner user yet (the FK
+/// could not be filled) or if the runtime upsert / agent insert fails.
 pub async fn create_agent(
     pool: &SqlitePool,
     workspace_id: &str,
@@ -305,14 +280,14 @@ pub async fn create_agent(
     provider: &str,
     instructions: Option<String>,
 ) -> Result<Agent, sqlx::Error> {
-    // Bind the runtime the daemon actually claims for: the existing host runtime
-    // when one is registered (a runtime cannot be renamed), else the default.
-    let runtime_id = resolve_runtime_id(pool).await?;
     let now = SystemClock.now_ms();
-    // The agent's runtime FK must exist; ensure it before the insert. A fresh
-    // home may not have registered a runtime yet (the CLI create path runs with
-    // no daemon), so this makes the create self-sufficient.
-    ensure_runtime(pool, &runtime_id, now).await?;
+    // ONE atomic upsert: ensure the runtime FK exists (a fresh home may have none
+    // — the CLI create path runs with no daemon) and take back the id it settled
+    // on, which is the pre-existing runtime's id when one is already registered
+    // (a runtime cannot be renamed) and the configured default otherwise.
+    let runtime_id = ensure_runtime(pool, &default_runtime_id(), now)
+        .await?
+        .ok_or(sqlx::Error::RowNotFound)?;
 
     let owner_id = default_owner_id(pool).await?.ok_or_else(|| sqlx::Error::RowNotFound)?;
 
@@ -432,17 +407,22 @@ mod tests {
         let store = Store::open_in(dir.path()).await.unwrap();
         let pool = store.pool();
 
-        assert!(
-            !ensure_runtime(pool, "default", 1_000).await.unwrap(),
+        assert_eq!(
+            ensure_runtime(pool, "default", 1_000).await.unwrap(),
+            None,
             "no workspace ⇒ no-op"
         );
         ensure_default_workspace(pool).await.unwrap();
-        assert!(
-            ensure_runtime(pool, "default", 1_000).await.unwrap(),
-            "workspace ⇒ upsert"
+        assert_eq!(
+            ensure_runtime(pool, "default", 1_000).await.unwrap().as_deref(),
+            Some("default"),
+            "workspace ⇒ upsert, returning the id it settled on"
         );
         // A restart upserts, never duplicates.
-        assert!(ensure_runtime(pool, "default", 2_000).await.unwrap());
+        assert_eq!(
+            ensure_runtime(pool, "default", 2_000).await.unwrap().as_deref(),
+            Some("default")
+        );
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
             .fetch_one(pool)
             .await
@@ -468,17 +448,23 @@ mod tests {
 
         // First boot registers the runtime; an agent binds it (the FK that makes a
         // rename impossible).
-        assert!(ensure_runtime(pool, "runtime-a", 1_000).await.unwrap());
+        assert_eq!(
+            ensure_runtime(pool, "runtime-a", 1_000).await.unwrap().as_deref(),
+            Some("runtime-a")
+        );
         let agent = create_agent(pool, &ws, "bound", "claude", None).await.unwrap();
         assert_eq!(
             agent.runtime_id, "runtime-a",
             "the agent binds the existing runtime"
         );
 
-        // (a) A later boot with a DIFFERENT configured id must NOT error.
-        assert!(
-            ensure_runtime(pool, "runtime-b", 2_000).await.unwrap(),
-            "a changed runtime id must refresh the existing row, never FK-error"
+        // (a) A later boot with a DIFFERENT configured id must NOT error, and must
+        //     report back the EXISTING id it settled on (never the configured one).
+        assert_eq!(
+            ensure_runtime(pool, "runtime-b", 2_000).await.unwrap().as_deref(),
+            Some("runtime-a"),
+            "a changed runtime id must refresh the existing row (never FK-error) and \
+             return the id actually in use"
         );
 
         // (b) Still exactly one runtime row.
@@ -505,10 +491,12 @@ mod tests {
                 .is_none(),
             "the configured-but-rejected id never became a row"
         );
+        // A fresh agent created AFTER the rename attempt still binds the existing
+        // runtime — create takes its id from the same atomic ensure.
+        let later = create_agent(pool, &ws, "later", "codex", None).await.unwrap();
         assert_eq!(
-            existing_host_runtime_id(pool).await.unwrap().as_deref(),
-            Some("runtime-a"),
-            "the resolver reports the existing id as the one to bind/claim"
+            later.runtime_id, "runtime-a",
+            "a later create binds the id in use, not the configured one"
         );
 
         // (d) The agent is not orphaned: its FK still resolves to a live runtime.

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -11,17 +11,18 @@
 //!
 //! # The stable-runtime invariant (correctness-critical)
 //!
-//! Every seeded / created agent binds [`resolve_runtime_id`], and the daemon's
-//! claim loop + self-register resolve the SAME id. If they diverged, an agent
-//! would bind a runtime the daemon never claims for and its tasks would never
-//! run. This module is the single source of that id, so the callers cannot drift.
+//! Every seeded / created agent binds the id [`ensure_runtime`] returns, and the
+//! daemon's claim loop + self-register resolve the SAME id through that same
+//! call. If they diverged, an agent would bind a runtime the daemon never claims
+//! for and its tasks would never run. That one atomic upsert is the single source
+//! of the id, so the callers cannot drift.
 //!
 //! A runtime **cannot be renamed** after first boot: `agent.runtime_id` is an
 //! enforced `REFERENCES agent_runtime(id)` FK (sqlx sets `PRAGMA foreign_keys = ON`),
 //! so an already-registered runtime's id always WINS over a changed
-//! `HANGAR_DAEMON_RUNTIME_ID` / [`DEFAULT_RUNTIME_ID`]. Only a brand-new home
-//! adopts the configured id ([`resolve_runtime_id`]); the daemon warns when it
-//! ignores a configured id.
+//! `HANGAR_DAEMON_RUNTIME_ID` / [`crate::bootstrap::DEFAULT_RUNTIME_ID`]. Only a brand-new
+//! home adopts the configured id (again via [`ensure_runtime`], which RETURNS the
+//! id it settled on); the daemon warns when it ignores a configured id.
 //!
 //! Every function here is idempotent and non-clobbering: it finds-or-creates and
 //! never rewrites or deletes a user's own rows, so calling it on every boot is
@@ -44,8 +45,8 @@ pub const DEFAULT_OWNER_EMAIL: &str = "stevie@local";
 /// Stable id used for the host runtime on a BRAND-NEW home.
 ///
 /// Once a runtime row exists its id wins forever (a runtime cannot be renamed —
-/// see the module docs), so this is only the first-boot default; use
-/// [`resolve_runtime_id`] to get the id actually in use.
+/// see the module docs), so this is only the first-boot default; take the id
+/// actually in use from [`ensure_runtime`]'s return value.
 pub const DEFAULT_RUNTIME_ID: &str = "default";
 
 /// The provider a freshly-seeded starter agent (and the self-registered runtime)
@@ -72,8 +73,8 @@ const SELF_RUNTIME_MODE: &str = "local";
 ///
 /// This is only the first-boot identity. Once a runtime is registered its id wins
 /// (a runtime cannot be renamed), so callers that need the id actually in use must
-/// go through [`resolve_runtime_id`] — the seam the seed, the claim loop, and
-/// `agent_create` all share.
+/// take it from [`ensure_runtime`]'s return value — the seam the seed, the claim
+/// loop, and `agent_create` all share.
 #[must_use]
 pub fn default_runtime_id() -> String {
     std::env::var("HANGAR_DAEMON_RUNTIME_ID")
@@ -219,10 +220,13 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
 /// # Errors
 ///
 /// Returns a [`sqlx::Error`] if the workspace lookup or the upsert fails. It never
-/// FK-errors (the `id` is never rewritten); a `UNIQUE constraint failed:
-/// agent_runtime.id` can still surface if the CONFIGURED id already exists under a
-/// DIFFERENT `(workspace, daemon, provider)` tuple — a genuine misconfiguration,
-/// reported here rather than silently mis-binding an agent later.
+/// FK-errors (the `id` is never rewritten). A `UNIQUE constraint failed:
+/// agent_runtime.id` can surface if the CONFIGURED id already exists under a
+/// DIFFERENT `(workspace, daemon, provider)` tuple: the `ON CONFLICT` target is the
+/// tuple, so a PK collision is not caught by it. That is unreachable in production
+/// — nothing outside tests writes a second `agent_runtime` row — and it is a
+/// genuine misconfiguration (two daemons/providers claiming one id), so erroring is
+/// the right answer.
 pub async fn ensure_runtime(
     pool: &SqlitePool,
     runtime_id: &str,

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -11,11 +11,17 @@
 //!
 //! # The stable-runtime invariant (correctness-critical)
 //!
-//! Every seeded / created agent binds [`default_runtime_id`], and the daemon's
-//! claim loop + self-register key off the SAME id. If they diverged, an agent
+//! Every seeded / created agent binds [`resolve_runtime_id`], and the daemon's
+//! claim loop + self-register resolve the SAME id. If they diverged, an agent
 //! would bind a runtime the daemon never claims for and its tasks would never
-//! run. This module is the single source of that id, so the three callers cannot
-//! drift.
+//! run. This module is the single source of that id, so the callers cannot drift.
+//!
+//! A runtime **cannot be renamed** after first boot: `agent.runtime_id` is an
+//! enforced `REFERENCES agent_runtime(id)` FK (sqlx sets `PRAGMA foreign_keys = ON`),
+//! so an already-registered runtime's id always WINS over a changed
+//! `HANGAR_DAEMON_RUNTIME_ID` / [`DEFAULT_RUNTIME_ID`]. Only a brand-new home
+//! adopts the configured id ([`resolve_runtime_id`]); the daemon warns when it
+//! ignores a configured id.
 //!
 //! Every function here is idempotent and non-clobbering: it finds-or-creates and
 //! never rewrites or deletes a user's own rows, so calling it on every boot is
@@ -35,10 +41,11 @@ pub const DEFAULT_WORKSPACE_NAME: &str = "Default Workspace";
 /// Email of the bootstrapped owner user.
 pub const DEFAULT_OWNER_EMAIL: &str = "stevie@local";
 
-/// Stable id of the single host runtime the daemon self-registers and claims for.
+/// Stable id used for the host runtime on a BRAND-NEW home.
 ///
-/// The seed, the daemon's default claim id, and every `agent_create` binding MUST
-/// resolve to this same value (see [`default_runtime_id`]).
+/// Once a runtime row exists its id wins forever (a runtime cannot be renamed —
+/// see the module docs), so this is only the first-boot default; use
+/// [`resolve_runtime_id`] to get the id actually in use.
 pub const DEFAULT_RUNTIME_ID: &str = "default";
 
 /// The provider a freshly-seeded starter agent (and the self-registered runtime)
@@ -59,11 +66,13 @@ const SELF_DAEMON_ID: &str = "ainb-hangar-daemon";
 /// Runtime mode of the self-registered runtime (a local daemon today).
 const SELF_RUNTIME_MODE: &str = "local";
 
-/// Resolve the runtime id the daemon claims for: `HANGAR_DAEMON_RUNTIME_ID` when
-/// set + non-empty (an operator override), else the stable [`DEFAULT_RUNTIME_ID`].
+/// The CONFIGURED runtime id: `HANGAR_DAEMON_RUNTIME_ID` when set + non-empty (an
+/// operator override), else the stable [`DEFAULT_RUNTIME_ID`].
 ///
-/// This is the single seam the seed, the daemon claim loop, and `agent_create`
-/// all take the runtime id through, so they cannot diverge.
+/// This is only the first-boot identity. Once a runtime is registered its id wins
+/// (a runtime cannot be renamed), so callers that need the id actually in use must
+/// go through [`resolve_runtime_id`] — the seam the seed, the claim loop, and
+/// `agent_create` all share.
 #[must_use]
 pub fn default_runtime_id() -> String {
     std::env::var("HANGAR_DAEMON_RUNTIME_ID")
@@ -185,15 +194,17 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
 ///
 /// The conflict target is the REAL uniqueness key
 /// `(workspace_id, daemon_id, provider)` (migration 0002's unique index), not the
-/// primary key `id`. This matters when `HANGAR_DAEMON_RUNTIME_ID` changes between
-/// boots: a fresh `id` with the same `(workspace, daemon, provider)` tuple would
-/// collide on the UNIQUE index (never on the PK), so an `ON CONFLICT(id)` clause
-/// would NOT catch it and the INSERT would error — swallowed on the seed path,
-/// leaving the new runtime unregistered while the claim loop keys off the new id
-/// (tasks silently stranded). Upserting on the tuple instead adopts the new id
-/// (`id = excluded.id`) so the single registered runtime always matches the id the
-/// claim loop claims for. A restart with an UNCHANGED id resolves to the same row
-/// (both the PK and the tuple point at it) and simply refreshes it.
+/// primary key `id` — and the upsert NEVER changes the `id`. `agent.runtime_id`
+/// is a NOT NULL `REFERENCES agent_runtime(id)` FK and SQLite enforces foreign
+/// keys (sqlx sets `PRAGMA foreign_keys = ON`), so changing the runtime's `id`
+/// while agents reference it would raise `FOREIGN KEY constraint failed`. A
+/// runtime therefore CANNOT be renamed after first boot: if a caller passes a
+/// different `runtime_id` for an existing `(workspace, daemon, provider)` tuple
+/// (e.g. a changed `HANGAR_DAEMON_RUNTIME_ID`), this refreshes the EXISTING row's
+/// `status`/`last_seen_at` and keeps its original `id`. Boot resolves the
+/// effective claim id from the existing row up front (see the daemon's
+/// `effective_runtime_id`), so the registered row, the agents bound to it, and the
+/// claim loop all stay aligned — no drift, no stranding, no FK error.
 ///
 /// Returns `Ok(true)` when a row was written/refreshed, `Ok(false)` when there is
 /// no workspace to attach to yet (a benign no-op).
@@ -214,7 +225,6 @@ pub async fn ensure_runtime(
          (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
          VALUES (?, ?, ?, ?, ?, ?, 'online') \
          ON CONFLICT(workspace_id, daemon_id, provider) DO UPDATE SET \
-           id = excluded.id, \
            status = 'online', \
            last_seen_at = excluded.last_seen_at",
     )
@@ -229,6 +239,46 @@ pub async fn ensure_runtime(
     Ok(true)
 }
 
+/// The id of the host runtime already registered for this daemon's
+/// `(workspace, daemon_id, provider)` tuple, or `None` when none exists yet.
+///
+/// Because a runtime cannot be renamed after first boot (its `id` is an FK
+/// target), an existing row's id is the identity the claim loop, the registered
+/// row, and every bound agent must all use.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the lookup fails.
+pub async fn existing_host_runtime_id(pool: &SqlitePool) -> Result<Option<String>, sqlx::Error> {
+    let Some(workspace_id) = find_default_workspace(pool).await? else {
+        return Ok(None);
+    };
+    sqlx::query_scalar(
+        "SELECT id FROM agent_runtime \
+         WHERE workspace_id = ? AND daemon_id = ? AND provider = ? LIMIT 1",
+    )
+    .bind(&workspace_id)
+    .bind(SELF_DAEMON_ID)
+    .bind(DEFAULT_PROVIDER)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Resolve the runtime id a new agent binds to (and the daemon claims for).
+///
+/// The EXISTING host runtime's id when one is registered — a runtime cannot be
+/// renamed, so its id wins — else the configured/default id
+/// ([`default_runtime_id`]) for a brand-new home. Keeping create and claim on this
+/// one resolver is what keeps a created agent bound to the runtime the daemon
+/// actually claims for.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the lookup fails.
+pub async fn resolve_runtime_id(pool: &SqlitePool) -> Result<String, sqlx::Error> {
+    Ok(existing_host_runtime_id(pool).await?.unwrap_or_else(default_runtime_id))
+}
+
 /// Create one agent from scratch, filling every FK behind the scenes.
 ///
 /// Binds the default runtime (ensuring its row exists), resolves the default
@@ -237,9 +287,11 @@ pub async fn ensure_runtime(
 ///
 /// The returned [`Agent`] carries the minted id so a caller can route to it
 /// (e.g. as a squad leader). `provider` is recorded on the row and HONOURED at
-/// dispatch: the agent binds the single default runtime (an execution slot the
-/// claim loop keys off by id, not by provider), and the daemon spawns the
-/// recorded provider's backend per task — so a `codex` agent runs codex.
+/// dispatch: the agent binds the single host runtime (an execution slot the claim
+/// loop keys off by id, not by provider), and the daemon spawns the recorded
+/// provider's backend per task — so a `codex` agent runs codex. The agent binds
+/// the EXISTING runtime id when one is registered ([`resolve_runtime_id`]), so a
+/// created agent is always on the runtime the daemon actually claims for.
 ///
 /// # Errors
 ///
@@ -252,7 +304,9 @@ pub async fn create_agent(
     provider: &str,
     instructions: Option<String>,
 ) -> Result<Agent, sqlx::Error> {
-    let runtime_id = default_runtime_id();
+    // Bind the runtime the daemon actually claims for: the existing host runtime
+    // when one is registered (a runtime cannot be renamed), else the default.
+    let runtime_id = resolve_runtime_id(pool).await?;
     let now = SystemClock.now_ms();
     // The agent's runtime FK must exist; ensure it before the insert. A fresh
     // home may not have registered a runtime yet (the CLI create path runs with
@@ -395,51 +449,97 @@ mod tests {
         assert_eq!(count, 1, "a restart upserts the same runtime row");
     }
 
-    /// Regression: a boot whose `HANGAR_DAEMON_RUNTIME_ID` changed keeps the same
-    /// `(workspace, daemon, provider)` tuple. The upsert must adopt the new id on
-    /// that tuple's UNIQUE index — NOT error on it (which `ON CONFLICT(id)` would,
-    /// silently stranding tasks) — leaving exactly one online row keyed on the new id.
+    /// A runtime CANNOT be renamed after first boot: `agent.runtime_id` is an
+    /// ENFORCED FK (sqlx sets `PRAGMA foreign_keys = ON`), so changing the
+    /// runtime's `id` while an agent references it raises
+    /// `FOREIGN KEY constraint failed`. A second ensure with a DIFFERENT configured
+    /// id must therefore refresh the EXISTING row: no error, no rename, no orphan.
+    ///
+    /// This test deliberately binds a real agent to the runtime — the case a
+    /// no-agent test dodges, and which made an earlier `id = excluded.id` upsert
+    /// look green while it FK-errored on every populated home.
     #[tokio::test]
-    async fn ensure_runtime_adopts_a_changed_id_without_error() {
+    async fn runtime_rename_is_refused_existing_id_wins() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
         let pool = store.pool();
-        ensure_default_workspace(pool).await.unwrap();
+        let ws = ensure_default_workspace(pool).await.unwrap();
 
-        // First boot under one runtime id.
+        // First boot registers the runtime; an agent binds it (the FK that makes a
+        // rename impossible).
         assert!(ensure_runtime(pool, "runtime-a", 1_000).await.unwrap());
-        // Next boot after the operator changed HANGAR_DAEMON_RUNTIME_ID: the tuple
-        // is unchanged, so this collides on the UNIQUE index, not the PK — and must
-        // NOT error.
-        assert!(
-            ensure_runtime(pool, "runtime-b", 2_000).await.unwrap(),
-            "a changed runtime id must upsert cleanly, not error"
+        let agent = create_agent(pool, &ws, "bound", "claude", None).await.unwrap();
+        assert_eq!(
+            agent.runtime_id, "runtime-a",
+            "the agent binds the existing runtime"
         );
 
+        // (a) A later boot with a DIFFERENT configured id must NOT error.
+        assert!(
+            ensure_runtime(pool, "runtime-b", 2_000).await.unwrap(),
+            "a changed runtime id must refresh the existing row, never FK-error"
+        );
+
+        // (b) Still exactly one runtime row.
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
             .fetch_one(pool)
             .await
             .unwrap();
-        assert_eq!(
-            count, 1,
-            "still exactly one runtime row after the id change"
-        );
-        let row = crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-b")
+        assert_eq!(count, 1, "still exactly one runtime row");
+
+        // (c) The EXISTING id wins — the rename was refused.
+        let row = crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-a")
             .await
             .unwrap()
-            .expect("the row now carries the NEW id (the one the claim loop keys off)");
-        assert_eq!(row.status, "online");
+            .expect("the original id still owns the row (a runtime cannot be renamed)");
         assert_eq!(
-            row.last_seen_at,
-            Some(2_000),
-            "the new-id row is the refreshed one"
+            row.status, "online",
+            "the existing row was refreshed online"
         );
+        assert_eq!(row.last_seen_at, Some(2_000), "…with the new heartbeat");
         assert!(
-            crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-a")
+            crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-b")
                 .await
                 .unwrap()
                 .is_none(),
-            "the old id no longer resolves — it was adopted, not duplicated"
+            "the configured-but-rejected id never became a row"
+        );
+        assert_eq!(
+            existing_host_runtime_id(pool).await.unwrap().as_deref(),
+            Some("runtime-a"),
+            "the resolver reports the existing id as the one to bind/claim"
+        );
+
+        // (d) The agent is not orphaned: its FK still resolves to a live runtime.
+        let still = crate::repo::agent::AgentRepo::get(pool, &agent.id).await.unwrap().unwrap();
+        assert_eq!(
+            still.runtime_id, "runtime-a",
+            "the bound agent is untouched"
+        );
+        assert!(
+            crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, &still.runtime_id)
+                .await
+                .unwrap()
+                .is_some(),
+            "the agent's runtime FK still resolves (never orphaned)"
+        );
+    }
+
+    /// A new agent binds the EXISTING runtime id, not a changed configured/default
+    /// one — so a created agent is always on the runtime the daemon claims for.
+    #[tokio::test]
+    async fn create_agent_binds_the_existing_runtime_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = ensure_default_workspace(pool).await.unwrap();
+        // A runtime already exists under a non-default id.
+        ensure_runtime(pool, "runtime-existing", 1_000).await.unwrap();
+
+        let agent = create_agent(pool, &ws, "late", "codex", None).await.unwrap();
+        assert_eq!(
+            agent.runtime_id, "runtime-existing",
+            "a created agent binds the existing runtime, not the default id"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -134,35 +134,66 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
     let workspace_id = idgen.new_ulid();
     let user_id = idgen.new_ulid();
 
+    // The workspace + owner + membership land in ONE transaction so a partial
+    // "workspace with no owner" can never persist. `workspace.slug` is NOT NULL
+    // UNIQUE, so two concurrent fresh-home writers (the daemon autostart + a
+    // racing `ainb hangar ...` CLI) can both pass the find-None above; the loser's
+    // workspace INSERT then trips the slug UNIQUE. That is not an error to the
+    // caller — the workspace exists — so on a unique violation we roll back and
+    // return the winner's id (which is committed + visible on a fresh connection
+    // under WAL).
+    let mut tx = pool.begin().await?;
     // `issue_prefix` is left NULL (the HGR display id lives at the render layer).
-    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
-        .bind(&workspace_id)
-        .bind(DEFAULT_WORKSPACE_SLUG)
-        .bind(DEFAULT_WORKSPACE_NAME)
-        .bind(now)
-        .execute(pool)
-        .await?;
+    let insert_ws =
+        sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
+            .bind(&workspace_id)
+            .bind(DEFAULT_WORKSPACE_SLUG)
+            .bind(DEFAULT_WORKSPACE_NAME)
+            .bind(now)
+            .execute(&mut *tx)
+            .await;
+    if let Err(e) = insert_ws {
+        let lost_the_race = e
+            .as_database_error()
+            .is_some_and(sqlx::error::DatabaseError::is_unique_violation);
+        if lost_the_race {
+            drop(tx); // roll back this loser's transaction
+            return find_default_workspace(pool).await?.ok_or(e);
+        }
+        return Err(e);
+    }
     sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
         .bind(&user_id)
         .bind(DEFAULT_OWNER_EMAIL)
         .bind(now)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
     sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES (?, ?, 'owner')")
         .bind(&workspace_id)
         .bind(&user_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(workspace_id)
 }
 
-/// Upsert the host runtime row keyed on `runtime_id`, attaching it to the
-/// default (oldest) workspace and marking it `online`.
+/// Upsert the host runtime row for this daemon, attaching it to the default
+/// (oldest) workspace and marking it `online`.
 ///
-/// Idempotent: `ON CONFLICT(id)` refreshes an existing row (a daemon restart)
-/// rather than tripping the PK or the `(workspace_id, daemon_id, provider)`
-/// unique index. Returns `Ok(true)` when a row was written/refreshed, `Ok(false)`
-/// when there is no workspace to attach to yet (a benign no-op).
+/// The conflict target is the REAL uniqueness key
+/// `(workspace_id, daemon_id, provider)` (migration 0002's unique index), not the
+/// primary key `id`. This matters when `HANGAR_DAEMON_RUNTIME_ID` changes between
+/// boots: a fresh `id` with the same `(workspace, daemon, provider)` tuple would
+/// collide on the UNIQUE index (never on the PK), so an `ON CONFLICT(id)` clause
+/// would NOT catch it and the INSERT would error — swallowed on the seed path,
+/// leaving the new runtime unregistered while the claim loop keys off the new id
+/// (tasks silently stranded). Upserting on the tuple instead adopts the new id
+/// (`id = excluded.id`) so the single registered runtime always matches the id the
+/// claim loop claims for. A restart with an UNCHANGED id resolves to the same row
+/// (both the PK and the tuple point at it) and simply refreshes it.
+///
+/// Returns `Ok(true)` when a row was written/refreshed, `Ok(false)` when there is
+/// no workspace to attach to yet (a benign no-op).
 ///
 /// # Errors
 ///
@@ -179,7 +210,8 @@ pub async fn ensure_runtime(
         "INSERT INTO agent_runtime \
          (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
          VALUES (?, ?, ?, ?, ?, ?, 'online') \
-         ON CONFLICT(id) DO UPDATE SET \
+         ON CONFLICT(workspace_id, daemon_id, provider) DO UPDATE SET \
+           id = excluded.id, \
            status = 'online', \
            last_seen_at = excluded.last_seen_at",
     )
@@ -200,8 +232,10 @@ pub async fn ensure_runtime(
 /// already-normalised `provider` and optional `instructions`).
 ///
 /// The returned [`Agent`] carries the minted id so a caller can route to it
-/// (e.g. as a squad leader). `provider` is recorded on the row; the daemon binds
-/// the default runtime regardless, so the task still runs.
+/// (e.g. as a squad leader). `provider` is recorded on the row and HONOURED at
+/// dispatch: the agent binds the single default runtime (an execution slot the
+/// claim loop keys off by id, not by provider), and the daemon spawns the
+/// recorded provider's backend per task — so a `codex` agent runs codex.
 ///
 /// # Errors
 ///
@@ -272,12 +306,47 @@ mod tests {
         let second = ensure_default_workspace(pool).await.unwrap();
         assert_eq!(first, second, "second call returns the same workspace id");
 
-        let ws_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM workspace").fetch_one(pool).await.unwrap();
+        let ws_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspace")
+            .fetch_one(pool)
+            .await
+            .unwrap();
         assert_eq!(ws_count, 1, "only one workspace row is ever created");
         let user_count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM user").fetch_one(pool).await.unwrap();
         assert_eq!(user_count, 1, "only one owner user is ever created");
+    }
+
+    /// Two concurrent fresh-home writers (the daemon autostart + a racing CLI)
+    /// can both pass the find-None; the loser's slug-UNIQUE collision must resolve
+    /// to the winner's id, never an error or a duplicate.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_ensure_default_workspace_converges_without_duplicate() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool_a = store.pool().clone();
+        let pool_b = store.pool().clone();
+
+        let (a, b) = tokio::join!(
+            tokio::spawn(async move { ensure_default_workspace(&pool_a).await }),
+            tokio::spawn(async move { ensure_default_workspace(&pool_b).await }),
+        );
+        let a = a.unwrap().expect("racer A must not error");
+        let b = b.unwrap().expect("racer B must not error (slug race resolves to the winner)");
+        assert_eq!(a, b, "both racers converge on the one workspace id");
+
+        let ws: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspace")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(ws, 1, "no duplicate workspace under concurrency");
+        let users: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM user")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            users, 1,
+            "the loser rolled back its owner insert (no orphan user)"
+        );
     }
 
     #[tokio::test]
@@ -285,9 +354,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
         let pool = store.pool();
-        assert!(default_owner_id(pool).await.unwrap().is_none(), "no user before ensure");
+        assert!(
+            default_owner_id(pool).await.unwrap().is_none(),
+            "no user before ensure"
+        );
         ensure_default_workspace(pool).await.unwrap();
-        assert!(default_owner_id(pool).await.unwrap().is_some(), "an owner exists after ensure");
+        assert!(
+            default_owner_id(pool).await.unwrap().is_some(),
+            "an owner exists after ensure"
+        );
     }
 
     #[tokio::test]
@@ -296,9 +371,15 @@ mod tests {
         let store = Store::open_in(dir.path()).await.unwrap();
         let pool = store.pool();
 
-        assert!(!ensure_runtime(pool, "default", 1_000).await.unwrap(), "no workspace ⇒ no-op");
+        assert!(
+            !ensure_runtime(pool, "default", 1_000).await.unwrap(),
+            "no workspace ⇒ no-op"
+        );
         ensure_default_workspace(pool).await.unwrap();
-        assert!(ensure_runtime(pool, "default", 1_000).await.unwrap(), "workspace ⇒ upsert");
+        assert!(
+            ensure_runtime(pool, "default", 1_000).await.unwrap(),
+            "workspace ⇒ upsert"
+        );
         // A restart upserts, never duplicates.
         assert!(ensure_runtime(pool, "default", 2_000).await.unwrap());
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
@@ -306,6 +387,54 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 1, "a restart upserts the same runtime row");
+    }
+
+    /// Regression: a boot whose `HANGAR_DAEMON_RUNTIME_ID` changed keeps the same
+    /// `(workspace, daemon, provider)` tuple. The upsert must adopt the new id on
+    /// that tuple's UNIQUE index — NOT error on it (which `ON CONFLICT(id)` would,
+    /// silently stranding tasks) — leaving exactly one online row keyed on the new id.
+    #[tokio::test]
+    async fn ensure_runtime_adopts_a_changed_id_without_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        ensure_default_workspace(pool).await.unwrap();
+
+        // First boot under one runtime id.
+        assert!(ensure_runtime(pool, "runtime-a", 1_000).await.unwrap());
+        // Next boot after the operator changed HANGAR_DAEMON_RUNTIME_ID: the tuple
+        // is unchanged, so this collides on the UNIQUE index, not the PK — and must
+        // NOT error.
+        assert!(
+            ensure_runtime(pool, "runtime-b", 2_000).await.unwrap(),
+            "a changed runtime id must upsert cleanly, not error"
+        );
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "still exactly one runtime row after the id change"
+        );
+        let row = crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-b")
+            .await
+            .unwrap()
+            .expect("the row now carries the NEW id (the one the claim loop keys off)");
+        assert_eq!(row.status, "online");
+        assert_eq!(
+            row.last_seen_at,
+            Some(2_000),
+            "the new-id row is the refreshed one"
+        );
+        assert!(
+            crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-a")
+                .await
+                .unwrap()
+                .is_none(),
+            "the old id no longer resolves — it was adopted, not duplicated"
+        );
     }
 
     #[tokio::test]
@@ -317,8 +446,16 @@ mod tests {
 
         let agent = create_agent(pool, &ws, "reviewer", "codex", None).await.unwrap();
         assert_eq!(agent.name, "reviewer");
-        assert_eq!(agent.runtime_id, default_runtime_id(), "binds the default runtime");
-        assert_eq!(agent.provider.as_deref(), Some("codex"), "records the chosen provider");
+        assert_eq!(
+            agent.runtime_id,
+            default_runtime_id(),
+            "binds the default runtime"
+        );
+        assert_eq!(
+            agent.provider.as_deref(),
+            Some("codex"),
+            "records the chosen provider"
+        );
         assert!(!agent.owner_id.is_empty(), "owner FK filled");
 
         // The agent is readable back (all FKs satisfied at insert).
@@ -332,8 +469,15 @@ mod tests {
         assert_eq!(normalize_provider(None).unwrap(), "claude");
         assert_eq!(normalize_provider(Some("")).unwrap(), "claude");
         assert_eq!(normalize_provider(Some("  ")).unwrap(), "claude");
-        assert_eq!(normalize_provider(Some("Codex")).unwrap(), "codex", "case-insensitive");
+        assert_eq!(
+            normalize_provider(Some("Codex")).unwrap(),
+            "codex",
+            "case-insensitive"
+        );
         assert_eq!(normalize_provider(Some("copilot")).unwrap(), "copilot");
-        assert!(normalize_provider(Some("gpt5")).is_err(), "unknown provider is rejected");
+        assert!(
+            normalize_provider(Some("gpt5")).is_err(),
+            "unknown provider is rejected"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -46,8 +46,9 @@ pub const DEFAULT_RUNTIME_ID: &str = "default";
 pub const DEFAULT_PROVIDER: &str = "claude";
 
 /// The providers `hangar/agent_create` accepts. The chosen value is recorded on
-/// the agent row (migration 0041); the daemon still binds the single default
-/// runtime so the task runs regardless (the runtime resolves the exec path).
+/// the agent row (migration 0041) and HONOURED at dispatch: the agent binds the
+/// single default runtime (an execution slot claimed by id, not provider) and the
+/// daemon spawns the recorded provider's backend per task.
 pub const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
 
 /// `daemon_id` recorded for the self-registered host runtime. Keyed with

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -35,20 +35,22 @@ pub const DEFAULT_WORKSPACE_NAME: &str = "Default Workspace";
 /// Email of the bootstrapped owner user.
 pub const DEFAULT_OWNER_EMAIL: &str = "stevie@local";
 
-/// Stable id of the single host runtime the daemon self-registers and claims
-/// tasks for. The seed, the daemon's default claim id, and every
-/// `agent_create` binding MUST resolve to this same value (see
-/// [`default_runtime_id`]).
+/// Stable id of the single host runtime the daemon self-registers and claims for.
+///
+/// The seed, the daemon's default claim id, and every `agent_create` binding MUST
+/// resolve to this same value (see [`default_runtime_id`]).
 pub const DEFAULT_RUNTIME_ID: &str = "default";
 
 /// The provider a freshly-seeded starter agent (and the self-registered runtime)
 /// advertises by default.
 pub const DEFAULT_PROVIDER: &str = "claude";
 
-/// The providers `hangar/agent_create` accepts. The chosen value is recorded on
-/// the agent row (migration 0041) and HONOURED at dispatch: the agent binds the
-/// single default runtime (an execution slot claimed by id, not provider) and the
-/// daemon spawns the recorded provider's backend per task.
+/// The providers `hangar/agent_create` accepts.
+///
+/// The chosen value is recorded on the agent row (migration 0041) and HONOURED at
+/// dispatch: the agent binds the single default runtime (an execution slot claimed
+/// by id, not provider) and the daemon spawns the recorded provider's backend per
+/// task.
 pub const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
 
 /// `daemon_id` recorded for the self-registered host runtime. Keyed with
@@ -227,10 +229,11 @@ pub async fn ensure_runtime(
     Ok(true)
 }
 
-/// Create one agent from scratch, filling every FK behind the scenes: bind the
-/// default runtime (ensuring its row exists), resolve the default owner, mint a
-/// fresh id, and insert. The caller supplies only the human `name` (+ an
-/// already-normalised `provider` and optional `instructions`).
+/// Create one agent from scratch, filling every FK behind the scenes.
+///
+/// Binds the default runtime (ensuring its row exists), resolves the default
+/// owner, mints a fresh id, and inserts. The caller supplies only the human
+/// `name` (+ an already-normalised `provider` and optional `instructions`).
 ///
 /// The returned [`Agent`] carries the minted id so a caller can route to it
 /// (e.g. as a squad leader). `provider` is recorded on the row and HONOURED at
@@ -278,9 +281,11 @@ pub async fn create_agent(
     Ok(agent)
 }
 
-/// Count the workspace's agents (active AND archived), the non-clobber guard the
-/// boot seed reads before laying down a starter agent: a user who created,
-/// renamed, or archived their own agent has count > 0, so the seed skips.
+/// Count the workspace's agents (active AND archived).
+///
+/// The non-clobber guard the boot seed reads before laying down a starter agent:
+/// a user who created, renamed, or archived their own agent has count > 0, so the
+/// seed skips.
 ///
 /// # Errors
 ///

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -54,10 +54,11 @@ pub const DEFAULT_PROVIDER: &str = "claude";
 
 /// The providers `hangar/agent_create` accepts.
 ///
-/// The chosen value is recorded on the agent row (migration 0041) and HONOURED at
-/// dispatch: the agent binds the single default runtime (an execution slot claimed
-/// by id, not provider) and the daemon spawns the recorded provider's backend per
-/// task.
+/// Each has a real exec path in the daemon's runner, and the chosen value is
+/// recorded on the agent row (migration 0041) and HONOURED at dispatch: the agent
+/// binds the single host runtime (an execution slot claimed by id, not provider)
+/// and the daemon spawns THIS provider's backend per task — a `codex` agent runs
+/// codex, a `copilot` agent runs copilot.
 pub const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
 
 /// `daemon_id` recorded for the self-registered host runtime. Keyed with
@@ -195,7 +196,7 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
 /// The conflict target is the REAL uniqueness key
 /// `(workspace_id, daemon_id, provider)` (migration 0002's unique index), not the
 /// primary key `id` — and the upsert NEVER changes the `id`. `agent.runtime_id`
-/// is a NOT NULL `REFERENCES agent_runtime(id)` FK and SQLite enforces foreign
+/// is a NOT NULL `REFERENCES agent_runtime(id)` FK and `SQLite` enforces foreign
 /// keys (sqlx sets `PRAGMA foreign_keys = ON`), so changing the runtime's `id`
 /// while agents reference it would raise `FOREIGN KEY constraint failed`. A
 /// runtime therefore CANNOT be renamed after first boot: if a caller passes a

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -1,0 +1,339 @@
+//! Fresh-home bootstrap: the idempotent default workspace + owner + runtime +
+//! starter agent that make an empty `hangar.db` "just work".
+//!
+//! A brand-new `~/.agents-in-a-box/hangar.db` has no workspace, no runtime, and
+//! no agent, so the TUI shows no runtime and the Squad screen rejects a create
+//! with "no agent available to lead a squad". This module owns the ONE shared,
+//! idempotent, non-destructive lay-down every entry point (the CLI's lazy
+//! `issue create`, the daemon boot seed, and the `hangar/agent_create` RPC)
+//! delegates to, so a workspace / runtime / owner is materialised in exactly one
+//! place and the same way every time.
+//!
+//! # The stable-runtime invariant (correctness-critical)
+//!
+//! Every seeded / created agent binds [`default_runtime_id`], and the daemon's
+//! claim loop + self-register key off the SAME id. If they diverged, an agent
+//! would bind a runtime the daemon never claims for and its tasks would never
+//! run. This module is the single source of that id, so the three callers cannot
+//! drift.
+//!
+//! Every function here is idempotent and non-clobbering: it finds-or-creates and
+//! never rewrites or deletes a user's own rows, so calling it on every boot is
+//! safe.
+
+use sqlx::SqlitePool;
+
+use ainb_hangar_core::clock::{HangarClock, SystemClock};
+use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+
+use crate::repo::agent::{Agent, AgentRepo};
+
+/// Slug of the workspace bootstrapped when the database has none.
+pub const DEFAULT_WORKSPACE_SLUG: &str = "default";
+/// Human name of the bootstrapped default workspace.
+pub const DEFAULT_WORKSPACE_NAME: &str = "Default Workspace";
+/// Email of the bootstrapped owner user.
+pub const DEFAULT_OWNER_EMAIL: &str = "stevie@local";
+
+/// Stable id of the single host runtime the daemon self-registers and claims
+/// tasks for. The seed, the daemon's default claim id, and every
+/// `agent_create` binding MUST resolve to this same value (see
+/// [`default_runtime_id`]).
+pub const DEFAULT_RUNTIME_ID: &str = "default";
+
+/// The provider a freshly-seeded starter agent (and the self-registered runtime)
+/// advertises by default.
+pub const DEFAULT_PROVIDER: &str = "claude";
+
+/// The providers `hangar/agent_create` accepts. The chosen value is recorded on
+/// the agent row (migration 0041); the daemon still binds the single default
+/// runtime so the task runs regardless (the runtime resolves the exec path).
+pub const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
+
+/// `daemon_id` recorded for the self-registered host runtime. Keyed with
+/// `(workspace_id, daemon_id, provider)` for the runtime's unique index.
+const SELF_DAEMON_ID: &str = "ainb-hangar-daemon";
+/// Runtime mode of the self-registered runtime (a local daemon today).
+const SELF_RUNTIME_MODE: &str = "local";
+
+/// Resolve the runtime id the daemon claims for: `HANGAR_DAEMON_RUNTIME_ID` when
+/// set + non-empty (an operator override), else the stable [`DEFAULT_RUNTIME_ID`].
+///
+/// This is the single seam the seed, the daemon claim loop, and `agent_create`
+/// all take the runtime id through, so they cannot diverge.
+#[must_use]
+pub fn default_runtime_id() -> String {
+    std::env::var("HANGAR_DAEMON_RUNTIME_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_RUNTIME_ID.to_string())
+}
+
+/// Normalise + validate a caller-supplied provider: trim, lower-case, default an
+/// absent/empty value to [`DEFAULT_PROVIDER`], and reject anything outside
+/// [`SUPPORTED_PROVIDERS`].
+///
+/// # Errors
+///
+/// Returns the offending value in an error message when the provider is not one
+/// of `claude` / `codex` / `copilot`.
+pub fn normalize_provider(provider: Option<&str>) -> Result<String, String> {
+    let raw = provider.map(str::trim).filter(|s| !s.is_empty());
+    let Some(raw) = raw else {
+        return Ok(DEFAULT_PROVIDER.to_string());
+    };
+    let lowered = raw.to_ascii_lowercase();
+    if SUPPORTED_PROVIDERS.contains(&lowered.as_str()) {
+        Ok(lowered)
+    } else {
+        Err(format!(
+            "unsupported provider `{raw}` (expected one of {})",
+            SUPPORTED_PROVIDERS.join(", ")
+        ))
+    }
+}
+
+/// The oldest workspace's id (the default), or `None` when none exists yet.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the query fails.
+pub async fn find_default_workspace(pool: &SqlitePool) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar("SELECT id FROM workspace ORDER BY created_at LIMIT 1")
+        .fetch_optional(pool)
+        .await
+}
+
+/// The default owner user id (the oldest user), or `None` when no user exists.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the query fails.
+pub async fn default_owner_id(pool: &SqlitePool) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar("SELECT id FROM user ORDER BY created_at LIMIT 1")
+        .fetch_optional(pool)
+        .await
+}
+
+/// Return the default workspace id, lazily laying down a workspace + owner user
+/// + owner member when the database has none.
+///
+/// Idempotent: a second call finds the existing workspace and returns the same
+/// id without inserting anything. Non-destructive: it never rewrites an existing
+/// workspace.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if a lookup or insert fails.
+pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx::Error> {
+    if let Some(id) = find_default_workspace(pool).await? {
+        return Ok(id);
+    }
+    let now = SystemClock.now_ms();
+    let idgen = SystemIdGen;
+    let workspace_id = idgen.new_ulid();
+    let user_id = idgen.new_ulid();
+
+    // `issue_prefix` is left NULL (the HGR display id lives at the render layer).
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
+        .bind(&workspace_id)
+        .bind(DEFAULT_WORKSPACE_SLUG)
+        .bind(DEFAULT_WORKSPACE_NAME)
+        .bind(now)
+        .execute(pool)
+        .await?;
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
+        .bind(&user_id)
+        .bind(DEFAULT_OWNER_EMAIL)
+        .bind(now)
+        .execute(pool)
+        .await?;
+    sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES (?, ?, 'owner')")
+        .bind(&workspace_id)
+        .bind(&user_id)
+        .execute(pool)
+        .await?;
+    Ok(workspace_id)
+}
+
+/// Upsert the host runtime row keyed on `runtime_id`, attaching it to the
+/// default (oldest) workspace and marking it `online`.
+///
+/// Idempotent: `ON CONFLICT(id)` refreshes an existing row (a daemon restart)
+/// rather than tripping the PK or the `(workspace_id, daemon_id, provider)`
+/// unique index. Returns `Ok(true)` when a row was written/refreshed, `Ok(false)`
+/// when there is no workspace to attach to yet (a benign no-op).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the workspace lookup or the upsert fails.
+pub async fn ensure_runtime(
+    pool: &SqlitePool,
+    runtime_id: &str,
+    now_ms: i64,
+) -> Result<bool, sqlx::Error> {
+    let Some(workspace_id) = find_default_workspace(pool).await? else {
+        return Ok(false);
+    };
+    sqlx::query(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
+         VALUES (?, ?, ?, ?, ?, ?, 'online') \
+         ON CONFLICT(id) DO UPDATE SET \
+           status = 'online', \
+           last_seen_at = excluded.last_seen_at",
+    )
+    .bind(runtime_id)
+    .bind(&workspace_id)
+    .bind(SELF_DAEMON_ID)
+    .bind(DEFAULT_PROVIDER)
+    .bind(SELF_RUNTIME_MODE)
+    .bind(now_ms)
+    .execute(pool)
+    .await?;
+    Ok(true)
+}
+
+/// Create one agent from scratch, filling every FK behind the scenes: bind the
+/// default runtime (ensuring its row exists), resolve the default owner, mint a
+/// fresh id, and insert. The caller supplies only the human `name` (+ an
+/// already-normalised `provider` and optional `instructions`).
+///
+/// The returned [`Agent`] carries the minted id so a caller can route to it
+/// (e.g. as a squad leader). `provider` is recorded on the row; the daemon binds
+/// the default runtime regardless, so the task still runs.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the workspace has no owner user yet (the FK could
+/// not be filled) or if the runtime upsert / agent insert fails.
+pub async fn create_agent(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    name: &str,
+    provider: &str,
+    instructions: Option<String>,
+) -> Result<Agent, sqlx::Error> {
+    let runtime_id = default_runtime_id();
+    let now = SystemClock.now_ms();
+    // The agent's runtime FK must exist; ensure it before the insert. A fresh
+    // home may not have registered a runtime yet (the CLI create path runs with
+    // no daemon), so this makes the create self-sufficient.
+    ensure_runtime(pool, &runtime_id, now).await?;
+
+    let owner_id = default_owner_id(pool).await?.ok_or_else(|| sqlx::Error::RowNotFound)?;
+
+    let agent = Agent {
+        id: SystemIdGen.new_ulid(),
+        workspace_id: workspace_id.to_string(),
+        name: name.to_string(),
+        runtime_id,
+        instructions,
+        visibility: "workspace".to_string(),
+        owner_id,
+        archived: false,
+        model: None,
+        cli_args: Vec::new(),
+        mcp_config: None,
+        thinking: None,
+        agent_env: Vec::new(),
+        provider: Some(provider.to_string()),
+    };
+    AgentRepo::insert(pool, &agent).await?;
+    Ok(agent)
+}
+
+/// Count the workspace's agents (active AND archived), the non-clobber guard the
+/// boot seed reads before laying down a starter agent: a user who created,
+/// renamed, or archived their own agent has count > 0, so the seed skips.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the query fails.
+pub async fn agent_count(pool: &SqlitePool, workspace_id: &str) -> Result<i64, sqlx::Error> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM agent WHERE workspace_id = ?")
+        .bind(workspace_id)
+        .fetch_one(pool)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    #[tokio::test]
+    async fn ensure_default_workspace_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        let first = ensure_default_workspace(pool).await.unwrap();
+        let second = ensure_default_workspace(pool).await.unwrap();
+        assert_eq!(first, second, "second call returns the same workspace id");
+
+        let ws_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM workspace").fetch_one(pool).await.unwrap();
+        assert_eq!(ws_count, 1, "only one workspace row is ever created");
+        let user_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM user").fetch_one(pool).await.unwrap();
+        assert_eq!(user_count, 1, "only one owner user is ever created");
+    }
+
+    #[tokio::test]
+    async fn default_owner_id_after_ensure() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        assert!(default_owner_id(pool).await.unwrap().is_none(), "no user before ensure");
+        ensure_default_workspace(pool).await.unwrap();
+        assert!(default_owner_id(pool).await.unwrap().is_some(), "an owner exists after ensure");
+    }
+
+    #[tokio::test]
+    async fn ensure_runtime_noop_without_workspace_then_upserts() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        assert!(!ensure_runtime(pool, "default", 1_000).await.unwrap(), "no workspace ⇒ no-op");
+        ensure_default_workspace(pool).await.unwrap();
+        assert!(ensure_runtime(pool, "default", 1_000).await.unwrap(), "workspace ⇒ upsert");
+        // A restart upserts, never duplicates.
+        assert!(ensure_runtime(pool, "default", 2_000).await.unwrap());
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "a restart upserts the same runtime row");
+    }
+
+    #[tokio::test]
+    async fn create_agent_fills_every_fk_and_records_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = ensure_default_workspace(pool).await.unwrap();
+
+        let agent = create_agent(pool, &ws, "reviewer", "codex", None).await.unwrap();
+        assert_eq!(agent.name, "reviewer");
+        assert_eq!(agent.runtime_id, default_runtime_id(), "binds the default runtime");
+        assert_eq!(agent.provider.as_deref(), Some("codex"), "records the chosen provider");
+        assert!(!agent.owner_id.is_empty(), "owner FK filled");
+
+        // The agent is readable back (all FKs satisfied at insert).
+        let fetched = AgentRepo::get(pool, &agent.id).await.unwrap().expect("agent persisted");
+        assert_eq!(fetched.provider.as_deref(), Some("codex"));
+        assert_eq!(agent_count(pool, &ws).await.unwrap(), 1);
+    }
+
+    #[test]
+    fn normalize_provider_defaults_and_validates() {
+        assert_eq!(normalize_provider(None).unwrap(), "claude");
+        assert_eq!(normalize_provider(Some("")).unwrap(), "claude");
+        assert_eq!(normalize_provider(Some("  ")).unwrap(), "claude");
+        assert_eq!(normalize_provider(Some("Codex")).unwrap(), "codex", "case-insensitive");
+        assert_eq!(normalize_provider(Some("copilot")).unwrap(), "copilot");
+        assert!(normalize_provider(Some("gpt5")).is_err(), "unknown provider is rejected");
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -12,6 +12,32 @@
 //! embedded at compile time by [`sqlx::migrate!`], so a migration edit that is
 //! not picked up usually means a stale build cache — run
 //! `cargo clean -p ainb-hangar-store` and rebuild.
+//!
+//! ## An applied migration file is IMMUTABLE — including its comments
+//!
+//! `sqlx` records a checksum of each migration's FULL FILE TEXT in
+//! `_sqlx_migrations`. Editing an already-applied file — even a comment — changes
+//! that checksum, and the next boot against an existing database aborts with
+//! `migration N was previously applied but has been modified`, i.e. the daemon
+//! refuses to start on every home that ever booted. Corrections to an applied
+//! migration's prose therefore CANNOT be made in-file; document the correction
+//! here (or in the owning repo module) instead. Only brand-new migrations are
+//! editable, and only until they ship.
+//!
+//! ## Foreign keys ARE enforced
+//!
+//! Several applied migration comments (0009/0010/0016/0017/0018/0027/0036) claim
+//! "`PRAGMA foreign_keys` is off in this crate". That is **false and frozen**:
+//! `sqlx` turns `PRAGMA foreign_keys = ON` on by default for every `SQLite`
+//! connection and [`Store::open_in`] never disables it, so every declared
+//! `REFERENCES` IS engine-enforced (e.g. `agent.runtime_id` cannot be orphaned,
+//! and `0010`'s `autopilot_run_id` link is a real constraint, not documentation).
+//! Those comments cannot be corrected in place (see above) — this is the
+//! authoritative statement. Where a table declares NO foreign key, that is a
+//! deliberate schema choice (a polymorphic actor-ref, or a link an FK could not
+//! tenant-scope), NOT a consequence of FKs being off; the service-layer guards
+//! those repos apply are still required, because an FK proves only that a parent
+//! row exists, never which workspace owns it.
 
 use sqlx::SqlitePool;
 

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -18,6 +18,12 @@ use sqlx::SqlitePool;
 mod store;
 pub use store::Store;
 
+/// Fresh-home bootstrap: the idempotent default workspace + owner + runtime +
+/// starter-agent lay-down every entry point (CLI, daemon boot, `agent_create`)
+/// shares, plus the stable [`bootstrap::default_runtime_id`] the seed and the
+/// daemon's claim loop both key off.
+pub mod bootstrap;
+
 /// Typed repository wrappers over the Hangar schema.
 ///
 /// One sub-module per logical table group: [`repo::agent`],

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -70,10 +70,11 @@ pub struct Agent {
     /// column), kept as an ordered key-value list for deterministic encoding.
     pub agent_env: Vec<(String, String)>,
     /// Optional per-agent provider override (`"claude"`/`"codex"`/`"copilot"`),
-    /// recorded at create time (migration 0041); `None` = use the runtime's
-    /// advertised provider. The daemon still binds the agent to the single
-    /// default runtime, so a task always runs — this column records the user's
-    /// pick rather than gating dispatch.
+    /// recorded at create time (migration 0041); `None` = fall back to the
+    /// runtime's advertised provider. Honoured at dispatch: the agent binds the
+    /// single default runtime (an execution slot claimed by id, not by provider),
+    /// and the daemon spawns THIS provider's backend per task, so a `codex` agent
+    /// runs codex.
     pub provider: Option<String>,
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -69,6 +69,12 @@ pub struct Agent {
     /// Per-agent environment variables (stored as a JSON-object `agent_env`
     /// column), kept as an ordered key-value list for deterministic encoding.
     pub agent_env: Vec<(String, String)>,
+    /// Optional per-agent provider override (`"claude"`/`"codex"`/`"copilot"`),
+    /// recorded at create time (migration 0041); `None` = use the runtime's
+    /// advertised provider. The daemon still binds the agent to the single
+    /// default runtime, so a task always runs — this column records the user's
+    /// pick rather than gating dispatch.
+    pub provider: Option<String>,
 }
 
 /// A partial-edit instruction for one agent's mutable config (e38.15).
@@ -136,8 +142,8 @@ impl AgentRepo {
         sqlx::query(
             "INSERT INTO agent \
              (id, workspace_id, name, runtime_id, instructions, visibility, owner_id, \
-              archived, model, cli_args, mcp_config, thinking, agent_env) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              archived, model, cli_args, mcp_config, thinking, agent_env, provider) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&agent.id)
         .bind(&agent.workspace_id)
@@ -152,6 +158,7 @@ impl AgentRepo {
         .bind(agent.mcp_config.clone().unwrap_or_else(|| "{}".to_string()))
         .bind(&agent.thinking)
         .bind(env_to_json(&agent.agent_env))
+        .bind(&agent.provider)
         .execute(pool)
         .await?;
         Ok(())
@@ -328,7 +335,7 @@ impl AgentRepo {
 /// The full column list every `SELECT` reads, in [`Agent::from_row`] order. A
 /// single constant keeps the read queries in lockstep with the `FromRow` impl.
 const SELECT_COLS: &str = "SELECT id, workspace_id, name, runtime_id, instructions, visibility, \
-     owner_id, archived, model, cli_args, mcp_config, thinking, agent_env FROM agent";
+     owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, provider FROM agent";
 
 /// Serialize a CLI-args list into the JSON-array text the `cli_args` column
 /// stores. An empty list yields `"[]"` (the column default).
@@ -400,6 +407,7 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Agent {
             mcp_config: mcp_config_from_raw(row.try_get::<String, _>("mcp_config")?),
             thinking: row.try_get("thinking")?,
             agent_env: env_from_json(&row.try_get::<String, _>("agent_env")?)?,
+            provider: row.try_get("provider")?,
         })
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
@@ -15,8 +15,10 @@
 //!
 //! # Workspace scoping (every by-id method)
 //!
-//! `PRAGMA foreign_keys` is off in this crate, so tenant isolation is enforced in
-//! application SQL, not by the engine. **Every by-id read and mutation filters
+//! Foreign keys ARE enforced (sqlx enables `PRAGMA foreign_keys` by default), but
+//! an FK only constrains that a parent row EXISTS — it says nothing about WHICH
+//! tenant it belongs to. So tenant isolation is enforced in application SQL, not
+//! by the engine. **Every by-id read and mutation filters
 //! `WHERE id = ? AND workspace_id = ?`**, and [`AutopilotRepo::list_runs`] joins
 //! through `autopilot` to verify the workspace — a caller holding an
 //! [`AutopilotId`] minted in workspace A can never read, toggle, or list the runs

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/board.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/board.rs
@@ -29,11 +29,13 @@
 //! creating (or renaming into) a board name that already exists in the workspace
 //! is rejected with [`BoardRepoError::DuplicateName`].
 //!
-//! `PRAGMA foreign_keys` is off in this crate (mirroring the rest of the repos),
-//! so the `(workspace_id, name)` UNIQUE index, the `(board_id, issue_id)`
-//! composite PK, and the `board_id`/`column_id` FKs are the engine-enforced
-//! invariants; the workspace-scope guard, the `ord` contiguity, and the
-//! card-reparking on column delete are enforced here in application code.
+//! The `(workspace_id, name)` UNIQUE index, the `(board_id, issue_id)` composite
+//! PK, and the declared `board_id`/`column_id` FKs are the engine-enforced
+//! invariants (foreign keys ARE on — sqlx enables `PRAGMA foreign_keys` by
+//! default). What the engine does NOT give us is tenant scoping (an FK proves a
+//! parent exists, not which workspace owns it) or ordering: the workspace-scope
+//! guard, the `ord` contiguity, and the card-reparking on column delete are
+//! enforced here in application code.
 
 use ainb_hangar_core::ids::WorkspaceId;
 use sqlx::{Row, SqlitePool};
@@ -459,10 +461,12 @@ impl BoardRepo {
     ///
     /// Workspace-scoped via the board; a `column_id` that is `Some` must belong to
     /// the board, and `issue_id` must name an issue that lives in the SAME
-    /// workspace (else [`BoardRepoError::NotFound`]). `board_card.issue_id` carries
-    /// no FK (`PRAGMA foreign_keys` is off), so this service-layer check is the
-    /// only guard against persisting a card for a nonexistent or sibling-tenant
-    /// issue — the "card = issue, workspace-scoped" invariant (D8/§4.5).
+    /// workspace (else [`BoardRepoError::NotFound`]). The schema declares NO FK on
+    /// `board_card.issue_id` (so the engine — which does enforce declared FKs —
+    /// has nothing to check here), and an FK would prove only existence, never the
+    /// tenant. This service-layer check is therefore the only guard against
+    /// persisting a card for a nonexistent or sibling-tenant issue — the
+    /// "card = issue, workspace-scoped" invariant (D8/§4.5).
     ///
     /// # Errors
     ///

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
@@ -24,7 +24,8 @@
 //! # Workspace scoping
 //!
 //! Every mutation takes a [`WorkspaceId`] and resolves BOTH endpoints inside it
-//! before writing (there is no FK — `PRAGMA foreign_keys` is off in this crate),
+//! before writing (the schema declares no FK on either issue id, and an FK would
+//! prove only existence, never the tenant — see migration 0036),
 //! so a dependency can never reference a foreign-tenant / nonexistent issue or
 //! cross a workspace boundary. The composite PK `(dependent, blocker)` is the sole
 //! engine-enforced invariant; existence, scoping, and acyclicity are enforced

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/label.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/label.rs
@@ -32,8 +32,8 @@
 //! - the label is resolved (or, on attach, created) by `(workspace_id, name)`,
 //!   so a label name always binds to the caller's tenant.
 //!
-//! `PRAGMA foreign_keys` is off in this crate, so the `(workspace_id, name)`
-//! UNIQUE index (`idx_label_workspace_name`, migration 0016) and the
+//! Tenant scoping is NOT something the engine does for us: the `(workspace_id,
+//! name)` UNIQUE index (`idx_label_workspace_name`, migration 0016) and the
 //! `(issue_id, label_id)` composite PK are the engine-enforced invariants;
 //! referential integrity of the join (and its cascade on issue/label deletion)
 //! is enforced here in application code.

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
@@ -25,10 +25,11 @@
 //! it) and only blocks when the *target* is currently an owner and is the *only*
 //! one; demoting one of two owners is allowed.
 //!
-//! `PRAGMA foreign_keys` is off in this crate (mirroring the rest of the repos),
-//! so the `(workspace_id, user_id)` composite PK and the `role` `CHECK` are the
-//! engine-enforced invariants; the role-token validation and last-owner guard
-//! are enforced here in application code.
+//! The `(workspace_id, user_id)` composite PK and the `role` `CHECK` are the
+//! engine-enforced invariants (as are the declared FKs — sqlx enables `PRAGMA
+//! foreign_keys` by default). The role-token validation and the last-owner guard
+//! are semantic rules no constraint can express, so they are enforced here in
+//! application code.
 
 use ainb_hangar_core::ids::WorkspaceId;
 use sqlx::SqlitePool;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/skill.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/skill.rs
@@ -43,9 +43,9 @@
 //!
 //! The `(workspace_id, name)` unique index (`idx_skill_workspace_name`,
 //! migration 0008) is the authoritative guard that a skill name resolves to
-//! exactly one row per tenant — `PRAGMA foreign_keys` is off in this crate, so
-//! uniqueness and cascade-on-delete are enforced in application code, not by the
-//! engine.
+//! exactly one row per tenant. The schema declares no `ON DELETE CASCADE` on
+//! `skill_file`, so the cascade-on-delete is performed explicitly in application
+//! code (see [`SkillRepo::delete`]) rather than by the engine.
 
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_core::ids::{AgentId, SkillId, WorkspaceId};
@@ -458,9 +458,10 @@ impl SkillRepo {
     /// cross-tenant call is a complete no-op — it removes neither the parent nor
     /// any child file.
     ///
-    /// `PRAGMA foreign_keys` is off in this crate (and the schema declares no
-    /// `ON DELETE CASCADE` on `skill_file`), so the cascade is performed
-    /// explicitly: child files are deleted first, then the parent, atomically.
+    /// The schema declares no `ON DELETE CASCADE` on `skill_file`, so the cascade
+    /// is performed explicitly: child files are deleted first, then the parent,
+    /// atomically. (Foreign keys ARE enforced — sqlx enables `PRAGMA
+    /// foreign_keys` — which is exactly why the children must go first.)
     /// Any `agent_skill` links are left to the caller (deleting a skill that is
     /// still attached is a service-layer decision, not a storage one).
     ///

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -29,11 +29,13 @@
 //! index is the resolve-or-reject guard: creating a second squad with a name that
 //! already exists in the workspace is rejected with [`SquadRepoError::DuplicateName`].
 //!
-//! `PRAGMA foreign_keys` is off in this crate (mirroring the rest of the repos),
-//! so the `(workspace_id, name)` UNIQUE index, the `(squad_id, member_type,
+//! The `(workspace_id, name)` UNIQUE index, the `(squad_id, member_type,
 //! member_id)` composite PK, the two `leader_type`/`member_type` CHECKs, and the
-//! `squad_id` FK are the engine-enforced invariants; the workspace-scope guard and
-//! the leader-resolution are enforced here in application code.
+//! `squad_id` FK are the engine-enforced invariants (foreign keys ARE on — sqlx
+//! enables `PRAGMA foreign_keys` by default). The actor-ref `_id` halves carry no
+//! FK by design (they are polymorphic), and an FK could not express tenant scope
+//! anyway, so the workspace-scope guard and the leader-resolution are enforced
+//! here in application code.
 
 use ainb_hangar_core::actor::ActorRef;
 use ainb_hangar_core::ids::WorkspaceId;

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -483,6 +483,7 @@ mod tests {
                 mcp_config: None,
                 thinking: None,
                 agent_env: Vec::new(),
+                provider: None,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-store/src/store.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/store.rs
@@ -66,6 +66,14 @@ impl Store {
         let opts = SqliteConnectOptions::new()
             .filename(&db_path)
             .create_if_missing(true)
+            // Foreign keys are load-bearing, so DECLARE the dependency rather than
+            // inheriting sqlx's default. `agent.runtime_id` (and every other
+            // `REFERENCES`) is only a real constraint with this on: it is what stops
+            // a runtime being renamed out from under its agents, and what several
+            // repos' "the engine enforces the parent link" reasoning rests on. An
+            // sqlx default change would otherwise silently turn every FK inert with
+            // nothing going red — see `fk_enforcement_is_on_and_rejects_orphans`.
+            .foreign_keys(true)
             .journal_mode(SqliteJournalMode::Wal)
             // WAL + `NORMAL` fsync is the standard durable-enough tuning: the
             // default `FULL` fsyncs on EVERY commit, so under the daemon's many
@@ -131,5 +139,45 @@ impl Store {
     #[must_use]
     pub const fn home_env() -> &'static str {
         HOME_ENV
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Foreign keys MUST be enforced. The whole runtime-identity design rests on
+    /// it (`agent.runtime_id` is an FK, which is why a runtime cannot be renamed),
+    /// as does several repos' "the engine enforces the parent link" reasoning.
+    ///
+    /// This is pinned in CI deliberately: it was previously only an inherited sqlx
+    /// default that no test asserted, and a comment claiming the OPPOSITE ("PRAGMA
+    /// foreign_keys is off in this crate") survived long enough to justify a real
+    /// bug. An sqlx default change — or a stray `.foreign_keys(false)` — must fail
+    /// here rather than silently turning every `REFERENCES` into a decoration.
+    #[tokio::test]
+    async fn fk_enforcement_is_on_and_rejects_orphans() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        // (a) The pragma itself is ON.
+        let fk: i64 = sqlx::query_scalar("PRAGMA foreign_keys").fetch_one(pool).await.unwrap();
+        assert_eq!(fk, 1, "PRAGMA foreign_keys must be ON");
+
+        // (b) It is actually ENFORCED: an agent naming a nonexistent runtime (and
+        //     workspace/owner) is rejected, not silently persisted as an orphan.
+        let err = sqlx::query(
+            "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+             VALUES ('a-orphan', 'ws-nope', 'orphan', 'rt-nope', 'workspace', 'u-nope')",
+        )
+        .execute(pool)
+        .await
+        .expect_err("an agent with a dangling runtime_id FK must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("FOREIGN KEY constraint failed"),
+            "expected an FK violation, got: {msg}"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
@@ -582,7 +582,7 @@ async fn full_chain_upgrade_preserves_every_seeded_entity_and_is_idempotent() {
         .fetch_one(&pool)
         .await
         .expect("read head migration version");
-    assert_eq!(head_version, 40, "head is migration 0040");
+    assert_eq!(head_version, 41, "head is migration 0041");
 
     // (b) Every seeded row survived: the population is row-for-row identical.
     let after = population_snapshot(&pool).await;

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -69,6 +69,7 @@ async fn insert_and_get_agent_roundtrip() {
         mcp_config: None,
         thinking: None,
         agent_env: Vec::new(),
+        provider: None,
     };
 
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
@@ -105,6 +106,7 @@ async fn update_config_persists_and_is_partial() {
         mcp_config: None,
         thinking: None,
         agent_env: Vec::new(),
+        provider: None,
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 
@@ -175,6 +177,7 @@ async fn update_config_is_workspace_scoped_and_empty_is_noop() {
         mcp_config: None,
         thinking: None,
         agent_env: Vec::new(),
+        provider: None,
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 
@@ -223,6 +226,7 @@ async fn archive_flips_flag_and_hides_from_active_list() {
         mcp_config: None,
         thinking: None,
         agent_env: Vec::new(),
+        provider: None,
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/skill_repo_tests.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/skill_repo_tests.rs
@@ -3,9 +3,10 @@
 //! Proves the workspace-scoped skill repository: create writes a `skill` row
 //! plus its ordered `skill_file` children, lookups are tenant-isolated, the
 //! agent junction is idempotent, `(workspace_id, name)` is unique, and deleting
-//! a skill cascades to its files in-app (FK cascade is unavailable — the crate
-//! runs with `PRAGMA foreign_keys` off, so `SkillRepo::delete` removes children
-//! explicitly inside a transaction).
+//! a skill cascades to its files in-app (the schema declares no
+//! `ON DELETE CASCADE` on `skill_file`, so `SkillRepo::delete` removes children
+//! explicitly inside a transaction — foreign keys themselves ARE enforced, which
+//! is exactly why the children must be removed first).
 
 use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_core::skill::SkillFileInput;

--- a/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
@@ -147,6 +147,7 @@ async fn seed_agent(
             mcp_config: None,
             thinking: None,
             agent_env: Vec::new(),
+            provider: None,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -208,6 +208,11 @@ const NOTIFY_RULES_REQ_ID: i64 = 47;
 /// JSON-RPC id for a `hangar/notify_rule_set` upsert raised by a toggled routing
 /// cell (tcp T5). Its reply re-fetches the grid so the pane reflects the write.
 const NOTIFY_RULE_SET_REQ_ID: i64 = 48;
+/// JSON-RPC id for a `hangar/agent_create` raised by the Squads screen `n`
+/// create-agent prompt. The reply carries the refreshed `AgentsListResult`, so
+/// it folds through [`Self::apply_agents`] into the cached actors that drive
+/// `first_agent_ref` — clearing the "no agent available to lead a squad" gate live.
+const AGENT_CREATE_REQ_ID: i64 = 49;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -786,6 +791,17 @@ impl HangarPlugin {
             RpcId::Number(BOARD_CARD_CANCEL_REQ_ID) => self.apply_board_card_cancel(resp),
             RpcId::Number(BOARD_CARD_TIMELINE_REQ_ID) => self.apply_board_card_timeline(resp),
             RpcId::Number(SQUADS_LIST_REQ_ID) => self.apply_squads(resp),
+            // The `n` create-agent reply folds the refreshed roster into the cached
+            // actors (clearing the squad gate live) and surfaces a note on the pane.
+            RpcId::Number(AGENT_CREATE_REQ_ID) => {
+                self.apply_agents(resp);
+                if let Some(e) = &resp.error {
+                    self.screens.squads.note_err(format!("agent create failed: {}", e.message));
+                } else {
+                    self.screens.squads.note_ok("agent created");
+                }
+                self.conn.on_event();
+            }
             RpcId::Number(SQUAD_FANOUT_REQ_ID) => self.apply_squad_fanout(resp),
             RpcId::Number(DAEMON_HEALTH_REQ_ID) => self.apply_daemon_health(resp),
             RpcId::Number(USAGE_ROLLUP_REQ_ID) => self.apply_usage(resp),
@@ -1999,6 +2015,15 @@ impl HangarPlugin {
         self.screens.squads.clear_note();
 
         let (id, method, params) = match action {
+            SquadAction::CreateAgent { name } => {
+                // Fire agent_create with NO ids — the daemon fills workspace/runtime/
+                // owner. The reply's refreshed roster clears the squad gate live.
+                (
+                    AGENT_CREATE_REQ_ID,
+                    daemon_methods::HANGAR_AGENT_CREATE,
+                    serde_json::json!({ "name": name }),
+                )
+            }
             SquadAction::Create { name } => {
                 let Some(agent_id) = self.first_agent_ref() else {
                     self.screens.squads.note_err("no agent available to lead a squad");

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -212,7 +212,9 @@ const NOTIFY_RULE_SET_REQ_ID: i64 = 48;
 /// create-agent prompt. The reply carries the refreshed `AgentsListResult`, so
 /// it folds through [`Self::apply_agents`] into the cached actors that drive
 /// `first_agent_ref` — clearing the "no agent available to lead a squad" gate live.
-const AGENT_CREATE_REQ_ID: i64 = 49;
+// 49/50 are taken by the daemon-config get/set pair, which landed on main while
+// this branch was in review — this id must stay clear of them.
+const AGENT_CREATE_REQ_ID: i64 = 51;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -381,6 +381,13 @@ pub enum IssueCreateAction {
 /// agents/issues — the screen intent carries only ids.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SquadAction {
+    /// Create an AGENT named `name` (`n` + Enter) — `hangar/agent_create`; the glue
+    /// fires it with no ids and folds the refreshed roster back, clearing the
+    /// "no agent available to lead a squad" gate live.
+    CreateAgent {
+        /// The new agent's name.
+        name: String,
+    },
     /// Create a squad named `name` (`c` + Enter) — `hangar/squad_create`; the glue
     /// picks the leader from the cached agents.
     Create {
@@ -709,10 +716,12 @@ impl ScreenStates {
     pub fn set_squads(&mut self, snapshot: &ainb_hangar_proto::snapshots::SquadsListResult) {
         let selected = self.squads.selected_index();
         let creating = self.squads.create_buffer().map(str::to_string);
+        let creating_agent = self.squads.agent_buffer().map(str::to_string);
         let note = self.squads.note().cloned();
         let mut next = SquadsState::from_snapshot(snapshot, &self.actors);
         next.set_selected(selected);
         next.set_create_buffer(creating);
+        next.set_agent_buffer(creating_agent);
         next.set_note(note);
         self.squads = next;
         // tcp T4 / F7: the Boards assign-squad picker draws from the same roster, so
@@ -1721,6 +1730,7 @@ fn route_squads(states: &mut ScreenStates, key: &KeyEvent) {
     let out = reduce_squads(&states.squads, ev);
     states.squads = out.state;
     states.pending_squads_action = match out.intent {
+        Some(SquadsIntent::CreateAgent { name }) => Some(SquadAction::CreateAgent { name }),
         Some(SquadsIntent::CreateSquad { name }) => Some(SquadAction::Create { name }),
         Some(SquadsIntent::AddMember { squad_id }) => Some(SquadAction::AddMember { squad_id }),
         Some(SquadsIntent::RemoveMember {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
@@ -113,6 +113,9 @@ pub struct SquadsState {
     selected: usize,
     /// The create-squad name buffer — `Some` only while the create input is open.
     create_input: Option<String>,
+    /// The create-AGENT name buffer — `Some` only while the `n` agent-create input
+    /// is open. Mutually exclusive with `create_input` (only one input at a time).
+    agent_input: Option<String>,
     /// A transient status note (last assignment / add / error), rendered above the
     /// list; its kind drives the color (green = ok, red = error).
     note: Option<Note>,
@@ -126,6 +129,7 @@ impl SquadsState {
             squads,
             selected: 0,
             create_input: None,
+            agent_input: None,
             note: None,
         }
     }
@@ -162,6 +166,18 @@ impl SquadsState {
     #[must_use]
     pub fn create_buffer(&self) -> Option<&str> {
         self.create_input.as_deref()
+    }
+
+    /// The current create-AGENT name buffer, if the `n` input is open.
+    #[must_use]
+    pub fn agent_buffer(&self) -> Option<&str> {
+        self.agent_input.as_deref()
+    }
+
+    /// Restore (or clear) the create-AGENT input buffer after a refresh, so a
+    /// snapshot arriving mid-typing does not wipe the half-typed name.
+    pub fn set_agent_buffer(&mut self, buf: Option<String>) {
+        self.agent_input = buf;
     }
 
     /// Set (or clear) the transient status note the render shows above the list.
@@ -321,6 +337,13 @@ pub enum SquadsEvent {
 /// of the actor catalogue.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SquadsIntent {
+    /// Create an AGENT named `name` (`n` + Enter) — `hangar/agent_create`; the glue
+    /// fires it with no ids (the daemon fills workspace/runtime/owner) and folds the
+    /// refreshed roster back, so the "no agent available" squad gate clears live.
+    CreateAgent {
+        /// The new agent's name (non-blank).
+        name: String,
+    },
     /// Create a squad named `name` (`c` + Enter) — `hangar/squad_create`; the glue
     /// picks the leader from the cached agents.
     CreateSquad {
@@ -363,7 +386,9 @@ pub struct SquadsReduction {
 pub fn reduce_squads(state: &SquadsState, ev: SquadsEvent) -> SquadsReduction {
     match ev {
         SquadsEvent::Key(c) => {
-            if state.create_input.is_some() {
+            if state.agent_input.is_some() {
+                reduce_agent_key(state, c)
+            } else if state.create_input.is_some() {
                 reduce_create_key(state, c)
             } else {
                 reduce_key(state, c)
@@ -404,9 +429,47 @@ fn reduce_create_key(state: &SquadsState, c: char) -> SquadsReduction {
     }
 }
 
+/// Handle a key while the create-AGENT input is open: Enter submits (when
+/// non-blank) and emits [`SquadsIntent::CreateAgent`], Backspace deletes, any
+/// other printable char appends. Mirrors [`reduce_create_key`] exactly so the
+/// Esc-cancels-in-one-press semantics are identical.
+fn reduce_agent_key(state: &SquadsState, c: char) -> SquadsReduction {
+    let mut buf = state.agent_input.clone().unwrap_or_default();
+    match c {
+        '\n' => {
+            let name = buf.trim().to_string();
+            if name.is_empty() {
+                // Blank submit is a no-op — keep the input open.
+                return unchanged(state);
+            }
+            let mut next = state.clone();
+            next.agent_input = None;
+            with_intent(next, SquadsIntent::CreateAgent { name })
+        }
+        '\u{8}' => {
+            buf.pop();
+            let mut next = state.clone();
+            next.agent_input = Some(buf);
+            no_intent(next)
+        }
+        c if !c.is_control() => {
+            buf.push(c);
+            let mut next = state.clone();
+            next.agent_input = Some(buf);
+            no_intent(next)
+        }
+        _ => unchanged(state),
+    }
+}
+
 /// Handle a normal-mode key (P7 bindings).
 fn reduce_key(state: &SquadsState, c: char) -> SquadsReduction {
     match c {
+        'n' => {
+            let mut next = state.clone();
+            next.agent_input = Some(String::new());
+            no_intent(next)
+        }
         'j' => {
             let mut next = state.clone();
             next.move_selection(1);
@@ -460,9 +523,15 @@ fn reduce_key(state: &SquadsState, c: char) -> SquadsReduction {
     }
 }
 
-/// Handle Esc: cancel an open create input; a no-op otherwise.
+/// Handle Esc: cancel whichever input (agent-create or squad-create) is open in
+/// a SINGLE press; a no-op otherwise. Esc never steps back through state — it
+/// closes the open input outright.
 fn reduce_esc(state: &SquadsState) -> SquadsReduction {
-    if state.create_input.is_some() {
+    if state.agent_input.is_some() {
+        let mut next = state.clone();
+        next.agent_input = None;
+        no_intent(next)
+    } else if state.create_input.is_some() {
         let mut next = state.clone();
         next.create_input = None;
         no_intent(next)
@@ -526,7 +595,22 @@ pub fn render_squads(
         row = row.saturating_add(1);
     }
 
-    // Create-name input takes over the body while open.
+    // Create-AGENT input takes over the body while open (the `n` prompt).
+    if let Some(buffer) = state.agent_buffer() {
+        let line = format!("New agent name: {buffer}▏");
+        put_str(
+            buf,
+            0,
+            row,
+            "Enter an agent name, Esc to cancel",
+            MUTED_GRAY,
+            area_w,
+        );
+        put_str(buf, 0, row.saturating_add(1), &line, GOLD, area_w);
+        return;
+    }
+
+    // Create-squad name input takes over the body while open.
     if let Some(buffer) = state.create_buffer() {
         let line = format!("New squad name: {buffer}▏");
         put_str(
@@ -546,7 +630,7 @@ pub fn render_squads(
             buf,
             0,
             row,
-            "No squads. Press 'c' to create a squad",
+            "No squads. Press 'n' to create an agent, 'c' to create a squad",
             MUTED_GRAY,
             area_w,
         );
@@ -591,7 +675,7 @@ const fn first_visible(selected: usize, visible_rows: usize) -> usize {
 /// beside the controls it drives (`feedback_keybinding_hints_near_control`).
 /// Dropped on a terminal too narrow to hold them (the footer carries them too).
 fn render_action_hints(buf: &mut WireBuffer, row: u16, area_w: u16) {
-    const HINTS: &str = "[c]reate [a]dd [d]el [x]assign";
+    const HINTS: &str = "[n]ew-agent [c]reate [a]dd [d]el [x]assign";
     let hint_w = u16::try_from(HINTS.chars().count()).unwrap_or(0);
     if hint_w >= area_w {
         return;
@@ -816,6 +900,42 @@ mod tests {
         let cancel = reduce_squads(&opened, SquadsEvent::Esc);
         assert!(!cancel.state.is_creating());
         assert!(cancel.intent.is_none());
+    }
+
+    /// `n` opens the create-AGENT input; typing + Enter raises a `CreateAgent`
+    /// intent; a single Esc cancels it outright (never stepping back).
+    #[test]
+    fn create_agent_flow_raises_intent_and_esc_cancels_in_one_press() {
+        let state = SquadsState::from_snapshot(&snapshot(), &actors());
+        let opened = reduce_squads(&state, SquadsEvent::Key('n')).state;
+        assert_eq!(opened.agent_buffer(), Some(""), "n opens the agent-create input");
+        assert!(!opened.is_creating(), "the squad-create input stays closed");
+
+        // Type "bot".
+        let typed = reduce_squads(&opened, SquadsEvent::Key('b')).state;
+        let typed = reduce_squads(&typed, SquadsEvent::Key('o')).state;
+        let typed = reduce_squads(&typed, SquadsEvent::Key('t')).state;
+        assert_eq!(typed.agent_buffer(), Some("bot"));
+
+        // Enter submits and closes the input.
+        let out = reduce_squads(&typed, SquadsEvent::Key('\n'));
+        assert_eq!(out.intent, Some(SquadsIntent::CreateAgent { name: "bot".into() }));
+        assert!(out.state.agent_buffer().is_none(), "input closes on submit");
+
+        // A SINGLE Esc on the open input cancels with no intent.
+        let cancel = reduce_squads(&typed, SquadsEvent::Esc);
+        assert!(cancel.state.agent_buffer().is_none(), "one Esc closes the agent input");
+        assert!(cancel.intent.is_none());
+    }
+
+    /// A blank agent-create submit is a no-op — the input stays open, no intent.
+    #[test]
+    fn blank_agent_create_submit_is_a_noop() {
+        let state = SquadsState::from_snapshot(&snapshot(), &actors());
+        let opened = reduce_squads(&state, SquadsEvent::Key('n')).state;
+        let out = reduce_squads(&opened, SquadsEvent::Key('\n'));
+        assert!(out.intent.is_none());
+        assert_eq!(out.state.agent_buffer(), Some(""), "blank submit keeps the input open");
     }
 
     /// A blank create submit is a no-op — the input stays open, no intent.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_create_input_shows_prompt_and_buffer.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_create_input_shows_prompt_and_buffer.snap
@@ -2,6 +2,6 @@
 source: crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
 expression: full
 ---
-                                                                      [c]reate [a]dd [d]el [x]assign
+                                                          [n]ew-agent [c]reate [a]dd [d]el [x]assign
 Enter a squad name, Esc to cancel
 New squad name: qa▏

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_empty_shows_help.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_empty_shows_help.snap
@@ -2,5 +2,5 @@
 source: crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
 expression: full
 ---
-                                                                      [c]reate [a]dd [d]el [x]assign
-No squads. Press 'c' to create a squad
+                                                          [n]ew-agent [c]reate [a]dd [d]el [x]assign
+No squads. Press 'n' to create an agent, 'c' to create a squad

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_loaded_lists_squads_leaders_and_members.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_loaded_lists_squads_leaders_and_members.snap
@@ -2,7 +2,7 @@
 source: crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
 expression: full
 ---
-                                                                      [c]reate [a]dd [d]el [x]assign
+                                                          [n]ew-agent [c]reate [a]dd [d]el [x]assign
 ▶ shippers  leader: ● lead-bot  (2 members)
     └ ◐ worker-bot  · agent
     └ ● alice  · human

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_narrow_width_stays_in_bounds.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/squads_screen_snapshot__render_narrow_width_stays_in_bounds.snap
@@ -2,7 +2,7 @@
 source: crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
 expression: full
 ---
-              [c]reate [a]dd [d]el [x]assign
+  [n]ew-agent [c]reate [a]dd [d]el [x]assign
 ▶ shippers  leader: ● lead-bot  (2 members)
     └ ◐ worker-bot  · agent
     └ ● alice  · human

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
@@ -86,9 +86,10 @@ fn render_empty_shows_help() {
     let full = glyph_map(&buf, 100);
     insta::assert_snapshot!(full);
     assert!(
-        full.contains("No squads. Press 'c' to create a squad"),
+        full.contains("Press 'n' to create an agent, 'c' to create a squad"),
         "empty help line missing:\n{full}"
     );
+    assert!(full.contains("[n]ew-agent"), "new-agent hint missing:\n{full}");
     assert!(full.contains("[c]reate"), "create hint missing:\n{full}");
 }
 


### PR DESCRIPTION
## Why
A fresh Hangar home (empty `~/.agents-in-a-box/hangar.db`) was unusable: zero `workspace`/`agent_runtime`/`agent` rows meant the Daemon pane showed "no runtimes registered" and creating a Squad errored "no agent available to lead a squad". TUI create paths rejected instead of bootstrapping.

## What
- **Boot seed** (`default_home.rs`): on daemon boot, idempotently lay down a default workspace + host runtime + one starter `claude` agent. Non-clobbering, restart-safe.
- **Seam A** (`bootstrap.rs`): one shared idempotent ensure-workspace/runtime/agent module consumed by CLI, boot seed, and RPC.
- **Seam B**: daemon defaults its claim runtime id to a shared `DEFAULT_RUNTIME_ID` so `agent_runtime` self-registers with no env.
- **Seam C**: create-from-scratch — `hangar/agent_create` RPC + `ainb hangar agent create` CLI + minimal in-TUI `n` prompt. Fills workspace/runtime/owner behind the scenes.
- **Seam D**: `ensure_hangar_daemon` auto-starts the daemon on TUI launch (mirrors `mcp_pool::ensure_daemon`).
- **Provider honored at dispatch**: `agent.provider` (nullable, migration 0041) read at dispatch — a codex/copilot agent runs that backend, not claude.

## Review + fixes
Opus review returned "merge after fixes (one Major)"; all applied:
- Major: `ensure_runtime` upsert targets the real `(workspace_id, daemon_id, provider)` unique index and adopts a changed id (fixes silent task-stranding).
- Race: `ensure_default_workspace` wrapped in a transaction.
- Provider honored at dispatch (no longer dead data).

## Proof
- Money test `tripwire_fresh_home_squad_create` (3 green): empty DB → seed → agent_create → squad_create succeeds.
- `resolve_dispatch_honours_the_agent_provider_over_the_runtime`: codex → Backend::Codex; null → runtime fallback.
- Store/proto/daemon/plugin suites green; migration 0041 purely additive.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent creation from the Squads screen using the **n** key (now fully RPC-backed, with refreshed agent list).
  * Added **`hangar/agent_create`** JSON-RPC support.
  * Fresh installs now seed a default workspace/runtime plus a starter agent.
  * Added per-agent provider overrides (including **Copilot**) and support for optional agent instructions.
  * The daemon now best-effort starts when launching the TUI.

* **Bug Fixes**
  * Default-workspace bootstrapping is now lazy for agent/squad creation.
  * Blank names and unsupported providers are rejected with clear errors.
  * Provider selection correctly prioritizes per-agent overrides over runtime defaults.
  * Provider field persistence updated; related integration coverage expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->