### PR TITLE
feat(hangar): every daemon configurable visible in the TUI + controllable from the CLI

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1154,6 +1154,43 @@ pub enum DaemonCommand {
     Restart,
     /// One-command bring-up: ensure the store + socket-auth token, then `start`.
     Setup,
+    /// View + edit the daemon's user-config knobs (`list`/`get`/`set`).
+    #[command(subcommand)]
+    Config(DaemonConfigCommand),
+}
+
+/// `hangar daemon config <verb>`.
+///
+/// The full user-configurable daemon knob surface — the CLI leg of the same
+/// `daemon_config` registry the TUI Settings → Daemon section edits. Every verb
+/// iterates [`ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY`], so a
+/// knob added to the registry is listed/gettable/settable here with no new code.
+/// Writes land straight in the `daemon_config` table; the watcher reloads its
+/// config each scan tick, so an edit takes effect without a restart.
+#[derive(Subcommand, Debug)]
+pub enum DaemonConfigCommand {
+    /// List every configurable: key, current value (or default), default, type.
+    List,
+    /// Print one knob's current value (or its default when unset).
+    Get(DaemonConfigGetArgs),
+    /// Validate + persist one knob's value (rejects unknown keys / bad values).
+    Set(DaemonConfigSetArgs),
+}
+
+/// Arguments for `hangar daemon config get`.
+#[derive(Args, Debug)]
+pub struct DaemonConfigGetArgs {
+    /// The config key (e.g. `autostandup.stagnant_min`). Must be a known knob.
+    pub key: String,
+}
+
+/// Arguments for `hangar daemon config set`.
+#[derive(Args, Debug)]
+pub struct DaemonConfigSetArgs {
+    /// The config key to write (must be a known knob).
+    pub key: String,
+    /// The new value; validated against the knob's type/range before persisting.
+    pub value: String,
 }
 
 /// Dispatch a parsed [`HangarCommand`] to its backing service.
@@ -1172,7 +1209,7 @@ pub async fn dispatch(cmd: HangarCommand, format: OutputFormat) -> Result<()> {
         HangarCommand::Issue(c) => dispatch_issue(c, format).await,
         HangarCommand::Task(c) => dispatch_task(c, format).await,
         HangarCommand::Beads(BeadsCommand::Reconcile(args)) => run_beads_reconcile(args).await,
-        HangarCommand::Daemon(c) => dispatch_daemon(c).await,
+        HangarCommand::Daemon(c) => dispatch_daemon(c, format).await,
         HangarCommand::Auth(c) => dispatch_auth(c, format).await,
         HangarCommand::Config(c) => dispatch_config(c, format),
         HangarCommand::Skills(c) => dispatch_skills(c, format).await,
@@ -2934,7 +2971,7 @@ fn find_on_path(name: &str) -> Option<std::path::PathBuf> {
 }
 
 /// Dispatch a `hangar daemon <verb>`.
-async fn dispatch_daemon(cmd: DaemonCommand) -> Result<()> {
+async fn dispatch_daemon(cmd: DaemonCommand, format: OutputFormat) -> Result<()> {
     match cmd {
         DaemonCommand::Status => run_daemon_status().await,
         DaemonCommand::Run => run_daemon_run().await,
@@ -2942,7 +2979,136 @@ async fn dispatch_daemon(cmd: DaemonCommand) -> Result<()> {
         DaemonCommand::Stop => run_daemon_stop(),
         DaemonCommand::Restart => run_daemon_restart(),
         DaemonCommand::Setup => run_daemon_setup().await,
+        DaemonCommand::Config(c) => dispatch_daemon_config(c, format).await,
     }
+}
+
+/// Dispatch the `hangar daemon config` verbs against the `daemon_config` table.
+///
+/// Opens the store directly (matching the other store-backed `hangar` verbs) and
+/// drives [`DaemonConfigRepo`] + the registry. Writes take effect on the daemon's
+/// next scan tick (it reloads config each tick), so no restart is needed.
+async fn dispatch_daemon_config(cmd: DaemonConfigCommand, format: OutputFormat) -> Result<()> {
+    let store = Store::open_default().await.context("open hangar database")?;
+    match cmd {
+        DaemonConfigCommand::List => run_daemon_config_list(&store, format).await,
+        DaemonConfigCommand::Get(args) => run_daemon_config_get(&store, args, format).await,
+        DaemonConfigCommand::Set(args) => run_daemon_config_set(&store, args).await,
+    }
+}
+
+/// `hangar daemon config list`: every configurable's key, current value (or
+/// `(default)`), default, and type/range. Iterates the registry so a new knob is
+/// listed automatically. `--format json` emits one object per knob.
+async fn run_daemon_config_list(store: &Store, format: OutputFormat) -> Result<()> {
+    use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    // Read each knob's stored value once, preserving registry order.
+    let mut rows = Vec::with_capacity(DAEMON_CONFIG_REGISTRY.len());
+    for desc in DAEMON_CONFIG_REGISTRY {
+        let stored = DaemonConfigRepo::get(store.pool(), desc.key)
+            .await
+            .with_context(|| format!("read daemon_config `{}`", desc.key))?;
+        rows.push((desc, stored));
+    }
+
+    match format {
+        OutputFormat::Json => {
+            let arr: Vec<_> = rows
+                .iter()
+                .map(|(desc, stored)| {
+                    serde_json::json!({
+                        "key": desc.key,
+                        "value": stored,
+                        "is_default": stored.is_none(),
+                        "default": desc.default,
+                        "type": desc.type_hint(),
+                        "help": desc.help,
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&arr).context("render config json")?
+            );
+        }
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
+            for (desc, stored) in &rows {
+                let shown = match stored {
+                    Some(v) => v.clone(),
+                    None => format!("{} (default)", desc.default),
+                };
+                println!(
+                    "{:<28} {:<20} [{}]  {}",
+                    desc.key,
+                    shown,
+                    desc.type_hint(),
+                    desc.help
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `hangar daemon config get <key>`: print one knob's current value, or its
+/// coded default when unset. Rejects an unknown key.
+async fn run_daemon_config_get(
+    store: &Store,
+    args: DaemonConfigGetArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    use ainb_hangar_core::daemon_config::descriptor;
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let desc =
+        descriptor(&args.key).with_context(|| format!("unknown config key `{}`", args.key))?;
+    let stored = DaemonConfigRepo::get(store.pool(), desc.key)
+        .await
+        .with_context(|| format!("read daemon_config `{}`", desc.key))?;
+    let value = stored.clone().unwrap_or_else(|| desc.default.to_string());
+
+    match format {
+        OutputFormat::Json => {
+            let v = serde_json::json!({
+                "key": desc.key,
+                "value": value,
+                "is_default": stored.is_none(),
+                "default": desc.default,
+            });
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&v).context("render config json")?
+            );
+        }
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
+            println!("{value}");
+        }
+    }
+    Ok(())
+}
+
+/// `hangar daemon config set <key> <value>`: validate the value against the
+/// knob's descriptor (rejecting an unknown key, out-of-range int, bad bool, or
+/// bad enum with a clear message) and persist the normalized form.
+async fn run_daemon_config_set(store: &Store, args: DaemonConfigSetArgs) -> Result<()> {
+    use ainb_hangar_core::daemon_config::descriptor;
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let desc =
+        descriptor(&args.key).with_context(|| format!("unknown config key `{}`", args.key))?;
+    // Validation is the registry's single gate — the same one the RPC uses — so
+    // the CLI and TUI reject identical bad input and store an identical form.
+    let value = desc
+        .validate(&args.value)
+        .map_err(|e| anyhow::anyhow!(e))
+        .context("invalid config value")?;
+    DaemonConfigRepo::set(store.pool(), desc.key, &value)
+        .await
+        .with_context(|| format!("write daemon_config `{}`", desc.key))?;
+    println!("set {} = {value}", desc.key);
+    Ok(())
 }
 
 /// `hangar daemon status`: report the daemon's run state from the PID file +
@@ -4506,6 +4672,162 @@ mod tests {
                 "`daemon {verb}` parsed to the wrong verb"
             );
         }
+    }
+
+    #[test]
+    fn parses_daemon_config_verbs() {
+        // list
+        let cmd = parse_hangar(&["ainb", "hangar", "daemon", "config", "list"]);
+        assert!(matches!(
+            cmd,
+            HangarCommand::Daemon(DaemonCommand::Config(DaemonConfigCommand::List))
+        ));
+        // get <key>
+        let cmd = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "daemon",
+            "config",
+            "get",
+            "autostandup.enabled",
+        ]);
+        let HangarCommand::Daemon(DaemonCommand::Config(DaemonConfigCommand::Get(args))) = cmd
+        else {
+            panic!("expected daemon config get");
+        };
+        assert_eq!(args.key, "autostandup.enabled");
+        // set <key> <value>
+        let cmd = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "daemon",
+            "config",
+            "set",
+            "autostandup.stagnant_min",
+            "30",
+        ]);
+        let HangarCommand::Daemon(DaemonCommand::Config(DaemonConfigCommand::Set(args))) = cmd
+        else {
+            panic!("expected daemon config set");
+        };
+        assert_eq!(args.key, "autostandup.stagnant_min");
+        assert_eq!(args.value, "30");
+    }
+
+    /// The CLI `list` iterates the registry directly, so its row count is exactly
+    /// the registry length — a knob added to the registry can never silently miss
+    /// the CLI surface. (The TUI has the mirror-image parity test.)
+    #[test]
+    fn cli_list_covers_every_registry_knob() {
+        use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+        assert!(
+            !DAEMON_CONFIG_REGISTRY.is_empty(),
+            "registry must not be empty"
+        );
+        // Every registry key must resolve back through the CLI's lookup gate.
+        for desc in DAEMON_CONFIG_REGISTRY {
+            assert!(
+                ainb_hangar_core::daemon_config::descriptor(desc.key).is_some(),
+                "registry key {} not resolvable",
+                desc.key
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn config_set_get_round_trips_and_rejects_bad_input() {
+        use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+
+        // set autostandup.stagnant_min 30 → persists the normalized value.
+        run_daemon_config_set(
+            &store,
+            DaemonConfigSetArgs {
+                key: "autostandup.stagnant_min".to_string(),
+                value: "30".to_string(),
+            },
+        )
+        .await
+        .expect("set stagnant_min");
+        assert_eq!(
+            DaemonConfigRepo::get(store.pool(), "autostandup.stagnant_min")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("30"),
+            "set then read returns the written value"
+        );
+
+        // An out-of-range int is rejected and leaves the stored value untouched.
+        let err = run_daemon_config_set(
+            &store,
+            DaemonConfigSetArgs {
+                key: "autostandup.stagnant_min".to_string(),
+                value: "99999".to_string(),
+            },
+        )
+        .await
+        .expect_err("out-of-range must be rejected");
+        assert!(format!("{err:#}").contains("between 1 and 1440"));
+        assert_eq!(
+            DaemonConfigRepo::get(store.pool(), "autostandup.stagnant_min")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("30"),
+            "a rejected write must not overwrite the prior value"
+        );
+
+        // An unknown key is rejected before any write.
+        run_daemon_config_set(
+            &store,
+            DaemonConfigSetArgs {
+                key: "autostandup.bogus".to_string(),
+                value: "1".to_string(),
+            },
+        )
+        .await
+        .expect_err("unknown key must be rejected");
+
+        // Enum normalization: `CODEX` stores as `codex`.
+        run_daemon_config_set(
+            &store,
+            DaemonConfigSetArgs {
+                key: "card_agent.default".to_string(),
+                value: "CODEX".to_string(),
+            },
+        )
+        .await
+        .expect("set enum");
+        assert_eq!(
+            DaemonConfigRepo::get(store.pool(), "card_agent.default")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("codex"),
+        );
+
+        // get on an unset key errors on an unknown key but not on a known-unset one.
+        run_daemon_config_get(
+            &store,
+            DaemonConfigGetArgs {
+                key: "autostandup.cooldown_min".to_string(),
+            },
+            OutputFormat::Text,
+        )
+        .await
+        .expect("get a known but unset key falls back to the default");
+        run_daemon_config_get(
+            &store,
+            DaemonConfigGetArgs {
+                key: "nope.nope".to_string(),
+            },
+            OutputFormat::Text,
+        )
+        .await
+        .expect_err("get on an unknown key is rejected");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2999,7 +2999,7 @@ async fn dispatch_daemon_config(cmd: DaemonConfigCommand, format: OutputFormat) 
 
 /// `hangar daemon config list`: every configurable's key, current value (or
 /// `(default)`), default, and type/range. Iterates the registry so a new knob is
-/// listed automatically. `--format json` emits one object per knob.
+/// listed automatically, in every output format.
 async fn run_daemon_config_list(store: &Store, format: OutputFormat) -> Result<()> {
     use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
     use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
@@ -3012,7 +3012,26 @@ async fn run_daemon_config_list(store: &Store, format: OutputFormat) -> Result<(
             .with_context(|| format!("read daemon_config `{}`", desc.key))?;
         rows.push((desc, stored));
     }
+    print!("{}", render_daemon_config_list(&rows, format)?);
+    Ok(())
+}
 
+/// One `config list` row: the knob's descriptor and its stored value (`None` when
+/// the key has no row, i.e. the coded default is in force).
+type ConfigRow = (&'static ainb_hangar_core::daemon_config::ConfigDescriptor, Option<String>);
+
+/// Render the `config list` rows in `format`, returning the exact text to print.
+///
+/// Split from the IO so the rendering is directly testable: the parity test counts
+/// the rows this emits against the registry length, which a test that merely
+/// re-queried the registry could never do.
+///
+/// # Errors
+///
+/// Returns an error only when the JSON form fails to serialize.
+fn render_daemon_config_list(rows: &[ConfigRow], format: OutputFormat) -> Result<String> {
+    use std::fmt::Write as _;
+    let mut out = String::new();
     match format {
         OutputFormat::Json => {
             let arr: Vec<_> = rows
@@ -3028,28 +3047,64 @@ async fn run_daemon_config_list(store: &Store, format: OutputFormat) -> Result<(
                     })
                 })
                 .collect();
-            println!(
+            let _ = writeln!(
+                out,
                 "{}",
                 serde_json::to_string_pretty(&arr).context("render config json")?
             );
         }
-        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
-            for (desc, stored) in &rows {
-                let shown = match stored {
-                    Some(v) => v.clone(),
-                    None => format!("{} (default)", desc.default),
-                };
-                println!(
+        OutputFormat::Csv => {
+            let _ = writeln!(out, "key,value,is_default,default,type,help");
+            for (desc, stored) in rows {
+                let _ = writeln!(
+                    out,
+                    "{},{},{},{},{},{}",
+                    csv_field(desc.key),
+                    csv_field(stored.as_deref().unwrap_or(desc.default)),
+                    csv_field(&stored.is_none().to_string()),
+                    csv_field(desc.default),
+                    csv_field(&desc.type_hint()),
+                    csv_field(desc.help),
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            let _ = writeln!(out, "| key | value | default | type | help |");
+            let _ = writeln!(out, "| --- | --- | --- | --- | --- |");
+            for (desc, stored) in rows {
+                let _ = writeln!(
+                    out,
+                    "| {} | {} | {} | {} | {} |",
+                    md_cell(desc.key),
+                    md_cell(&config_shown_value(desc, stored.as_deref())),
+                    md_cell(desc.default),
+                    md_cell(&desc.type_hint()),
+                    md_cell(desc.help),
+                );
+            }
+        }
+        OutputFormat::Text => {
+            for (desc, stored) in rows {
+                let _ = writeln!(
+                    out,
                     "{:<28} {:<20} [{}]  {}",
                     desc.key,
-                    shown,
+                    config_shown_value(desc, stored.as_deref()),
                     desc.type_hint(),
                     desc.help
                 );
             }
         }
     }
-    Ok(())
+    Ok(out)
+}
+
+/// A knob's display value: the stored string, or the coded default marked as such.
+fn config_shown_value(
+    desc: &ainb_hangar_core::daemon_config::ConfigDescriptor,
+    stored: Option<&str>,
+) -> String {
+    stored.map_or_else(|| format!("{} (default)", desc.default), ToString::to_string)
 }
 
 /// `hangar daemon config get <key>`: print one knob's current value, or its
@@ -3085,7 +3140,28 @@ async fn run_daemon_config_get(
                 serde_json::to_string_pretty(&v).context("render config json")?
             );
         }
-        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
+        OutputFormat::Csv => {
+            println!("key,value,is_default,default");
+            println!(
+                "{},{},{},{}",
+                csv_field(desc.key),
+                csv_field(&value),
+                csv_field(&stored.is_none().to_string()),
+                csv_field(desc.default),
+            );
+        }
+        OutputFormat::Markdown => {
+            println!("| key | value | default |");
+            println!("| --- | --- | --- |");
+            println!(
+                "| {} | {} | {} |",
+                md_cell(desc.key),
+                md_cell(&value),
+                md_cell(desc.default),
+            );
+        }
+        // Text stays the bare value: `get` is the scriptable read.
+        OutputFormat::Text => {
             println!("{value}");
         }
     }
@@ -4745,6 +4821,38 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_in(dir.path()).await.expect("open store");
 
+
+        // CSV: a header plus one row per knob.
+        let csv = render_daemon_config_list(&rows, OutputFormat::Csv).unwrap();
+        assert_eq!(csv.lines().count(), n + 1, "csv rows:\n{csv}");
+        assert!(csv.starts_with("key,value,is_default,default,type,help"));
+
+        // Markdown: a header + separator plus one row per knob.
+        let md = render_daemon_config_list(&rows, OutputFormat::Markdown).unwrap();
+        let md_rows = md.lines().filter(|l| l.starts_with("| ") && !l.contains("---")).count();
+        assert_eq!(md_rows - 1, n, "markdown body rows:\n{md}");
+
+        // JSON: one object per knob.
+        let json = render_daemon_config_list(&rows, OutputFormat::Json).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed.as_array().expect("json array").len(), n);
+    }
+
+    /// `csv` and `markdown` used to fall through to the plain-text arm and emit
+    /// neither format — the flag was silently ignored.
+    #[test]
+    fn cli_list_csv_and_markdown_are_not_plain_text() {
+        use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+        let rows: Vec<ConfigRow> = DAEMON_CONFIG_REGISTRY.iter().map(|d| (d, None)).collect();
+
+        let text = render_daemon_config_list(&rows, OutputFormat::Text).unwrap();
+        let csv = render_daemon_config_list(&rows, OutputFormat::Csv).unwrap();
+        let md = render_daemon_config_list(&rows, OutputFormat::Markdown).unwrap();
+
+        assert_ne!(csv, text, "csv must not be the plain-text arm");
+        assert_ne!(md, text, "markdown must not be the plain-text arm");
+        assert!(csv.contains(','), "csv must be comma-separated");
+        assert!(md.contains('|'), "markdown must be a pipe table");
         // set autostandup.stagnant_min 30 → persists the normalized value.
         run_daemon_config_set(
             &store,

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -4794,33 +4794,33 @@ mod tests {
         assert_eq!(args.value, "30");
     }
 
-    /// The CLI `list` iterates the registry directly, so its row count is exactly
-    /// the registry length — a knob added to the registry can never silently miss
-    /// the CLI surface. (The TUI has the mirror-image parity test.)
+    /// The CLI `list` must EMIT one row per registry knob, in every format — a
+    /// knob added to the registry can never silently miss the CLI surface.
+    ///
+    /// This counts the rendered OUTPUT. The test it replaces asserted
+    /// `descriptor(desc.key).is_some()` for each registry entry, which is true by
+    /// definition (the registry is what `descriptor` searches) and never touched
+    /// the rendering at all — it would have passed against a `list` that printed
+    /// nothing.
     #[test]
-    fn cli_list_covers_every_registry_knob() {
+    fn cli_list_emits_one_row_per_registry_knob_in_every_format() {
         use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
-        assert!(
-            !DAEMON_CONFIG_REGISTRY.is_empty(),
-            "registry must not be empty"
-        );
-        // Every registry key must resolve back through the CLI's lookup gate.
+
+        let rows: Vec<ConfigRow> = DAEMON_CONFIG_REGISTRY.iter().map(|d| (d, None)).collect();
+        let n = DAEMON_CONFIG_REGISTRY.len();
+        assert!(n > 0, "registry must not be empty");
+
+        // Text: exactly one line per knob, each naming its key.
+        let text = render_daemon_config_list(&rows, OutputFormat::Text).unwrap();
+        let text_lines: Vec<&str> = text.lines().collect();
+        assert_eq!(text_lines.len(), n, "text rows:\n{text}");
         for desc in DAEMON_CONFIG_REGISTRY {
             assert!(
-                ainb_hangar_core::daemon_config::descriptor(desc.key).is_some(),
-                "registry key {} not resolvable",
+                text_lines.iter().any(|l| l.contains(desc.key)),
+                "`{}` missing from text output:\n{text}",
                 desc.key
             );
         }
-    }
-
-    #[tokio::test]
-    async fn config_set_get_round_trips_and_rejects_bad_input() {
-        use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let store = Store::open_in(dir.path()).await.expect("open store");
-
 
         // CSV: a header plus one row per knob.
         let csv = render_daemon_config_list(&rows, OutputFormat::Csv).unwrap();
@@ -4853,6 +4853,15 @@ mod tests {
         assert_ne!(md, text, "markdown must not be the plain-text arm");
         assert!(csv.contains(','), "csv must be comma-separated");
         assert!(md.contains('|'), "markdown must be a pipe table");
+    }
+
+    #[tokio::test]
+    async fn config_set_get_round_trips_and_rejects_bad_input() {
+        use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+
         // set autostandup.stagnant_min 30 → persists the normalized value.
         run_daemon_config_set(
             &store,

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -3062,8 +3062,11 @@ async fn run_daemon_config_get(
     use ainb_hangar_core::daemon_config::descriptor;
     use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
-    let desc =
-        descriptor(&args.key).with_context(|| format!("unknown config key `{}`", args.key))?;
+    // Trim the key: `validate` already trims the VALUE, so a shell-quoted
+    // `get " autostandup.enabled"` failing with "unknown config key" while the
+    // matching set succeeded was pure asymmetry.
+    let key = args.key.trim();
+    let desc = descriptor(key).with_context(|| format!("unknown config key `{key}`"))?;
     let stored = DaemonConfigRepo::get(store.pool(), desc.key)
         .await
         .with_context(|| format!("read daemon_config `{}`", desc.key))?;
@@ -3096,8 +3099,9 @@ async fn run_daemon_config_set(store: &Store, args: DaemonConfigSetArgs) -> Resu
     use ainb_hangar_core::daemon_config::descriptor;
     use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
-    let desc =
-        descriptor(&args.key).with_context(|| format!("unknown config key `{}`", args.key))?;
+    // Trim the key, matching `validate`'s treatment of the value.
+    let key = args.key.trim();
+    let desc = descriptor(key).with_context(|| format!("unknown config key `{key}`"))?;
     // Validation is the registry's single gate — the same one the RPC uses — so
     // the CLI and TUI reject identical bad input and store an identical form.
     let value = desc
@@ -5335,5 +5339,44 @@ mod tests {
         assert!(autopilot_line(&ap, None).contains("last_run=-"));
         assert!(autopilot_to_json(&ap, None).contains("\"enabled\":false"));
         assert!(autopilot_to_json(&ap, None).contains("\"last_run\":null"));
+    }
+
+    /// The key is trimmed like the value is. `validate` trims the VALUE, so a
+    /// padded key failing with "unknown config key" while the same padding on the
+    /// value was silently accepted was pure asymmetry — and easy to hit from a
+    /// shell quoting mistake.
+    #[tokio::test]
+    async fn config_get_and_set_trim_the_key() {
+        use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+
+        run_daemon_config_set(
+            &store,
+            DaemonConfigSetArgs {
+                key: " autostandup.enabled ".to_string(),
+                value: "true".to_string(),
+            },
+        )
+        .await
+        .expect("a padded key must be accepted, not reported unknown");
+        assert_eq!(
+            DaemonConfigRepo::get(store.pool(), "autostandup.enabled")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("true"),
+            "the trimmed key is what gets written"
+        );
+
+        run_daemon_config_get(
+            &store,
+            DaemonConfigGetArgs {
+                key: " autostandup.enabled".to_string(),
+            },
+            OutputFormat::Text,
+        )
+        .await
+        .expect("a padded key must resolve on get too");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -3018,7 +3018,10 @@ async fn run_daemon_config_list(store: &Store, format: OutputFormat) -> Result<(
 
 /// One `config list` row: the knob's descriptor and its stored value (`None` when
 /// the key has no row, i.e. the coded default is in force).
-type ConfigRow = (&'static ainb_hangar_core::daemon_config::ConfigDescriptor, Option<String>);
+type ConfigRow = (
+    &'static ainb_hangar_core::daemon_config::ConfigDescriptor,
+    Option<String>,
+);
 
 /// Render the `config list` rows in `format`, returning the exact text to print.
 ///
@@ -3104,7 +3107,10 @@ fn config_shown_value(
     desc: &ainb_hangar_core::daemon_config::ConfigDescriptor,
     stored: Option<&str>,
 ) -> String {
-    stored.map_or_else(|| format!("{} (default)", desc.default), ToString::to_string)
+    stored.map_or_else(
+        || format!("{} (default)", desc.default),
+        ToString::to_string,
+    )
 }
 
 /// `hangar daemon config get <key>`: print one knob's current value, or its

--- a/ainb-tui/crates/ainb-hangar-core/src/daemon_config.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/daemon_config.rs
@@ -1,0 +1,306 @@
+//! The single source of truth for the daemon's user-configurable knobs.
+//!
+//! Every genuine USER config value the daemon reads from the `daemon_config`
+//! key/value table is described exactly once here as a [`ConfigDescriptor`]
+//! (key, label, [`ConfigKind`], default, help). Both surfaces that expose the
+//! set — the TUI Settings → Daemon section and the `ainb hangar daemon config`
+//! CLI — iterate [`DAEMON_CONFIG_REGISTRY`] rather than hand-listing the fields,
+//! so adding a knob here surfaces it in both places at once (and the parity
+//! tests in each surface fail loudly if a surface ever falls behind the
+//! registry).
+//!
+//! # What belongs here
+//!
+//! Only USER config — a knob a human deliberately sets. Internal STATE the
+//! daemon writes for its own bookkeeping (e.g. `card_agent.last_used`, the
+//! most-recently-picked agent) is **not** config and is deliberately excluded:
+//! surfacing it as an editable row would let a human "set" a value the daemon
+//! overwrites on the next dispatch, which reads as a broken control.
+//!
+//! # Validation
+//!
+//! [`ConfigDescriptor::validate`] is the one gate every write passes — the RPC
+//! `hangar/daemon_config_set` handler, the CLI `set` verb, and the TUI editor
+//! all call it. It parses + range/membership-checks the raw input and returns
+//! the **normalized** string actually persisted (`true`/`false` for bools, a
+//! trimmed integer for ints, the canonical lower-case token for enums), so the
+//! stored value can never disagree with what the daemon's tolerant typed
+//! accessors decode.
+
+/// `daemon_config` key: the global auto-standup toggle (default OFF — opt-in).
+pub const KEY_AUTOSTANDUP_ENABLED: &str = "autostandup.enabled";
+/// `daemon_config` key: minutes a session must be stagnant before firing.
+pub const KEY_AUTOSTANDUP_STAGNANT_MIN: &str = "autostandup.stagnant_min";
+/// `daemon_config` key: per-session cooldown window in minutes.
+pub const KEY_AUTOSTANDUP_COOLDOWN_MIN: &str = "autostandup.cooldown_min";
+/// `daemon_config` key: max simultaneous in-flight standups.
+pub const KEY_AUTOSTANDUP_MAX_CONCURRENT: &str = "autostandup.max_concurrent";
+/// `daemon_config` key: the host-wide default card agent (F4 global tier).
+pub const KEY_CARD_AGENT_DEFAULT: &str = "card_agent.default";
+
+/// Coded default: auto-standup is OFF (opt-in).
+pub const DEFAULT_AUTOSTANDUP_ENABLED: bool = false;
+/// Coded default: 15 minutes stagnant before a standup fires.
+pub const DEFAULT_AUTOSTANDUP_STAGNANT_MIN: i64 = 15;
+/// Coded default: 60-minute per-session cooldown.
+pub const DEFAULT_AUTOSTANDUP_COOLDOWN_MIN: i64 = 60;
+/// Coded default: at most one concurrent standup.
+pub const DEFAULT_AUTOSTANDUP_MAX_CONCURRENT: i64 = 1;
+/// Coded default: the host-wide default card agent is `claude`.
+pub const DEFAULT_CARD_AGENT_DEFAULT: &str = "claude";
+
+/// The shape of one configurable value — drives both the editor UI and the
+/// validation gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigKind {
+    /// A boolean toggle. Accepts the tolerant token family
+    /// (`1`/`true`/`yes`/`on` and their negatives), normalized to
+    /// `true`/`false`.
+    Bool,
+    /// An integer bounded to `[min, max]`, editable in `step` increments (the
+    /// step is the UI nudge size; any in-range integer is still accepted).
+    Int {
+        /// Inclusive lower bound.
+        min: i64,
+        /// Inclusive upper bound.
+        max: i64,
+        /// The increment a UI step applies.
+        step: i64,
+    },
+    /// A closed set of string variants (case-insensitive on input, normalized
+    /// to the listed spelling).
+    Enum {
+        /// The permitted variants, in cycle order.
+        variants: &'static [&'static str],
+    },
+}
+
+/// One user-configurable daemon knob: its key, human label, [`ConfigKind`],
+/// default (as the canonical stored string), and one-line help.
+#[derive(Debug, Clone, Copy)]
+pub struct ConfigDescriptor {
+    /// The `daemon_config` table key this describes.
+    pub key: &'static str,
+    /// A short human label for the row.
+    pub label: &'static str,
+    /// The value's shape (drives editing + validation).
+    pub kind: ConfigKind,
+    /// The default value, as the canonical stored string, applied when the key
+    /// has no row (matches the daemon's coded default).
+    pub default: &'static str,
+    /// One-line help describing what the knob does.
+    pub help: &'static str,
+}
+
+impl ConfigDescriptor {
+    /// Validate + normalize `raw` for this descriptor, returning the exact
+    /// string to persist, or a human-readable error explaining the rejection.
+    ///
+    /// This is the single validation gate: bools normalize to `true`/`false`,
+    /// ints are range-checked and trimmed, enums are matched case-insensitively
+    /// and normalized to their canonical spelling.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` with a caller-facing message when `raw` is not a legal
+    /// value for the descriptor's [`ConfigKind`] (bad bool token, out-of-range
+    /// or non-integer int, or an enum value outside the variant set).
+    pub fn validate(&self, raw: &str) -> Result<String, String> {
+        let trimmed = raw.trim();
+        match self.kind {
+            ConfigKind::Bool => parse_bool_token(trimmed)
+                .map(|b| if b { "true" } else { "false" }.to_string())
+                .ok_or_else(|| {
+                    format!(
+                        "`{}` expects a boolean (true/false/1/0/yes/no/on/off), got {raw:?}",
+                        self.key
+                    )
+                }),
+            ConfigKind::Int { min, max, .. } => {
+                let n: i64 = trimmed
+                    .parse()
+                    .map_err(|_| format!("`{}` expects an integer, got {raw:?}", self.key))?;
+                if n < min || n > max {
+                    return Err(format!(
+                        "`{}` must be between {min} and {max}, got {n}",
+                        self.key
+                    ));
+                }
+                Ok(n.to_string())
+            }
+            ConfigKind::Enum { variants } => variants
+                .iter()
+                .find(|v| v.eq_ignore_ascii_case(trimmed))
+                .map(|v| (*v).to_string())
+                .ok_or_else(|| {
+                    format!(
+                        "`{}` must be one of [{}], got {raw:?}",
+                        self.key,
+                        variants.join(", ")
+                    )
+                }),
+        }
+    }
+
+    /// A short type/range descriptor for the CLI `list` column (e.g. `bool`,
+    /// `int 1..1440`, `enum claude|codex|copilot`).
+    #[must_use]
+    pub fn type_hint(&self) -> String {
+        match self.kind {
+            ConfigKind::Bool => "bool".to_string(),
+            ConfigKind::Int { min, max, .. } => format!("int {min}..{max}"),
+            ConfigKind::Enum { variants } => format!("enum {}", variants.join("|")),
+        }
+    }
+}
+
+/// Parse a boolean token, tolerating the common spellings (matches the store's
+/// `daemon_config` decode so display + validation never disagree with the
+/// daemon). `None` for an unrecognized token.
+#[must_use]
+pub fn parse_bool_token(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// The card-agent enum variants (`claude`/`codex`/`copilot`), matching
+/// [`crate::agent_kind::AgentKind::all`]. Kept as a `const` so the registry
+/// entry is `const`; a unit test asserts it stays in lock-step with `AgentKind`.
+const CARD_AGENT_VARIANTS: &[&str] = &["claude", "codex", "copilot"];
+
+/// The authoritative list of user-configurable daemon knobs. Both the TUI and
+/// the CLI iterate this; adding an entry surfaces the knob in both.
+pub const DAEMON_CONFIG_REGISTRY: &[ConfigDescriptor] = &[
+    ConfigDescriptor {
+        key: KEY_AUTOSTANDUP_ENABLED,
+        label: "Auto-standup",
+        kind: ConfigKind::Bool,
+        default: "false",
+        help: "Globally enable the auto-standup watcher (opt-in).",
+    },
+    ConfigDescriptor {
+        key: KEY_AUTOSTANDUP_STAGNANT_MIN,
+        label: "Stagnant minutes",
+        kind: ConfigKind::Int {
+            min: 1,
+            max: 1440,
+            step: 5,
+        },
+        default: "15",
+        help: "Minutes a session must be idle before a standup fires.",
+    },
+    ConfigDescriptor {
+        key: KEY_AUTOSTANDUP_COOLDOWN_MIN,
+        label: "Cooldown minutes",
+        kind: ConfigKind::Int {
+            min: 0,
+            max: 1440,
+            step: 5,
+        },
+        default: "60",
+        help: "Per-session minutes between successive standups.",
+    },
+    ConfigDescriptor {
+        key: KEY_AUTOSTANDUP_MAX_CONCURRENT,
+        label: "Max concurrent",
+        kind: ConfigKind::Int {
+            min: 1,
+            max: 64,
+            step: 1,
+        },
+        default: "1",
+        help: "Maximum simultaneous in-flight standups.",
+    },
+    ConfigDescriptor {
+        key: KEY_CARD_AGENT_DEFAULT,
+        label: "Default agent",
+        kind: ConfigKind::Enum {
+            variants: CARD_AGENT_VARIANTS,
+        },
+        default: DEFAULT_CARD_AGENT_DEFAULT,
+        help: "Host-wide default provider backend for new cards.",
+    },
+];
+
+/// Look up the descriptor for `key`, or `None` when the key is not a known
+/// user-config knob (an internal-state key, or an unknown key).
+#[must_use]
+pub fn descriptor(key: &str) -> Option<&'static ConfigDescriptor> {
+    DAEMON_CONFIG_REGISTRY.iter().find(|d| d.key == key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_kind::AgentKind;
+
+    #[test]
+    fn every_default_passes_its_own_validation() {
+        // A descriptor whose default fails its own gate would ship a knob that
+        // can't round-trip — assert every default is a legal, normalized value.
+        for d in DAEMON_CONFIG_REGISTRY {
+            let normalized = d
+                .validate(d.default)
+                .unwrap_or_else(|e| panic!("default for `{}` rejected: {e}", d.key));
+            assert_eq!(
+                normalized, d.default,
+                "default for `{}` not normalized",
+                d.key
+            );
+        }
+    }
+
+    #[test]
+    fn keys_are_unique() {
+        for (i, a) in DAEMON_CONFIG_REGISTRY.iter().enumerate() {
+            for b in &DAEMON_CONFIG_REGISTRY[i + 1..] {
+                assert_ne!(a.key, b.key, "duplicate registry key {}", a.key);
+            }
+        }
+    }
+
+    #[test]
+    fn card_agent_variants_match_agent_kind() {
+        let from_kind: Vec<&str> = AgentKind::all().iter().map(|k| k.as_str()).collect();
+        assert_eq!(CARD_AGENT_VARIANTS, from_kind.as_slice());
+    }
+
+    #[test]
+    fn bool_validation_is_tolerant_and_normalizes() {
+        let d = descriptor(KEY_AUTOSTANDUP_ENABLED).unwrap();
+        for on in ["1", "true", "YES", "On"] {
+            assert_eq!(d.validate(on).unwrap(), "true");
+        }
+        for off in ["0", "false", "no", "OFF"] {
+            assert_eq!(d.validate(off).unwrap(), "false");
+        }
+        assert!(d.validate("maybe").is_err());
+    }
+
+    #[test]
+    fn int_validation_enforces_range() {
+        let d = descriptor(KEY_AUTOSTANDUP_STAGNANT_MIN).unwrap();
+        assert_eq!(d.validate(" 30 ").unwrap(), "30");
+        assert!(d.validate("0").is_err(), "below min");
+        assert!(d.validate("99999").is_err(), "above max");
+        assert!(d.validate("abc").is_err(), "not an integer");
+    }
+
+    #[test]
+    fn enum_validation_normalizes_case() {
+        let d = descriptor(KEY_CARD_AGENT_DEFAULT).unwrap();
+        assert_eq!(d.validate("CODEX").unwrap(), "codex");
+        assert_eq!(d.validate("Claude").unwrap(), "claude");
+        assert!(d.validate("gemini").is_err());
+    }
+
+    #[test]
+    fn descriptor_lookup_excludes_internal_state() {
+        // `card_agent.last_used` is internal state, never a registry knob.
+        assert!(descriptor("card_agent.last_used").is_none());
+        assert!(descriptor(KEY_CARD_AGENT_DEFAULT).is_some());
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/daemon_config.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/daemon_config.rs
@@ -38,15 +38,43 @@ pub const KEY_AUTOSTANDUP_MAX_CONCURRENT: &str = "autostandup.max_concurrent";
 /// `daemon_config` key: the host-wide default card agent (F4 global tier).
 pub const KEY_CARD_AGENT_DEFAULT: &str = "card_agent.default";
 
-/// Coded default: auto-standup is OFF (opt-in).
-pub const DEFAULT_AUTOSTANDUP_ENABLED: bool = false;
-/// Coded default: 15 minutes stagnant before a standup fires.
-pub const DEFAULT_AUTOSTANDUP_STAGNANT_MIN: i64 = 15;
-/// Coded default: 60-minute per-session cooldown.
-pub const DEFAULT_AUTOSTANDUP_COOLDOWN_MIN: i64 = 60;
-/// Coded default: at most one concurrent standup.
-pub const DEFAULT_AUTOSTANDUP_MAX_CONCURRENT: i64 = 1;
-/// Coded default: the host-wide default card agent is `claude`.
+/// Declare a coded default ONCE, emitting both forms it has to exist in: the
+/// typed const the daemon reads, and the canonical stored string the registry
+/// descriptor displays.
+///
+/// The two forms previously duplicated the literal (`default: "false"` next to
+/// `DEFAULT_AUTOSTANDUP_ENABLED = false`), which is a live drift vector: nothing
+/// tied them together, so the registry could advertise a default the daemon does
+/// not run. Deriving the string via `stringify!` makes that unrepresentable —
+/// there is one literal, in one place.
+macro_rules! coded_default {
+    ($(#[$meta:meta])* $konst:ident: $ty:ty = $value:literal => $string:ident) => {
+        $(#[$meta])*
+        pub const $konst: $ty = $value;
+        #[doc = concat!("[`", stringify!($konst), "`] as the canonical stored string,")]
+        #[doc = "derived from the same literal so the two can never disagree."]
+        const $string: &str = stringify!($value);
+    };
+}
+
+coded_default! {
+    /// Coded default: auto-standup is OFF (opt-in).
+    DEFAULT_AUTOSTANDUP_ENABLED: bool = false => DEFAULT_AUTOSTANDUP_ENABLED_STR
+}
+coded_default! {
+    /// Coded default: 15 minutes stagnant before a standup fires.
+    DEFAULT_AUTOSTANDUP_STAGNANT_MIN: i64 = 15 => DEFAULT_AUTOSTANDUP_STAGNANT_MIN_STR
+}
+coded_default! {
+    /// Coded default: 60-minute per-session cooldown.
+    DEFAULT_AUTOSTANDUP_COOLDOWN_MIN: i64 = 60 => DEFAULT_AUTOSTANDUP_COOLDOWN_MIN_STR
+}
+coded_default! {
+    /// Coded default: at most one concurrent standup.
+    DEFAULT_AUTOSTANDUP_MAX_CONCURRENT: i64 = 1 => DEFAULT_AUTOSTANDUP_MAX_CONCURRENT_STR
+}
+/// Coded default: the host-wide default card agent is `claude`. Already a string,
+/// so the registry wires this const through directly.
 pub const DEFAULT_CARD_AGENT_DEFAULT: &str = "claude";
 
 /// The shape of one configurable value — drives both the editor UI and the
@@ -178,7 +206,7 @@ pub const DAEMON_CONFIG_REGISTRY: &[ConfigDescriptor] = &[
         key: KEY_AUTOSTANDUP_ENABLED,
         label: "Auto-standup",
         kind: ConfigKind::Bool,
-        default: "false",
+        default: DEFAULT_AUTOSTANDUP_ENABLED_STR,
         help: "Globally enable the auto-standup watcher (opt-in).",
     },
     ConfigDescriptor {
@@ -189,7 +217,7 @@ pub const DAEMON_CONFIG_REGISTRY: &[ConfigDescriptor] = &[
             max: 1440,
             step: 5,
         },
-        default: "15",
+        default: DEFAULT_AUTOSTANDUP_STAGNANT_MIN_STR,
         help: "Minutes a session must be idle before a standup fires.",
     },
     ConfigDescriptor {
@@ -200,7 +228,7 @@ pub const DAEMON_CONFIG_REGISTRY: &[ConfigDescriptor] = &[
             max: 1440,
             step: 5,
         },
-        default: "60",
+        default: DEFAULT_AUTOSTANDUP_COOLDOWN_MIN_STR,
         help: "Per-session minutes between successive standups.",
     },
     ConfigDescriptor {
@@ -211,7 +239,7 @@ pub const DAEMON_CONFIG_REGISTRY: &[ConfigDescriptor] = &[
             max: 64,
             step: 1,
         },
-        default: "1",
+        default: DEFAULT_AUTOSTANDUP_MAX_CONCURRENT_STR,
         help: "Maximum simultaneous in-flight standups.",
     },
     ConfigDescriptor {
@@ -251,6 +279,44 @@ mod tests {
                 d.key
             );
         }
+    }
+
+    /// The loop the branch left open: `every_default_passes_its_own_validation`
+    /// only checks a default against ITSELF, so it stays green even if the
+    /// registry advertises `"false"` while the daemon runs `true`. Decode each
+    /// descriptor's default string back to the TYPED const the daemon actually
+    /// reads and assert they agree — that is the drift this closes.
+    ///
+    /// Auto-standup is the reason this matters: it writes `/standup` into live
+    /// sessions, a recent change made it opt-in, and a stale registry string would
+    /// silently tell users the opposite of what the daemon does.
+    #[test]
+    fn every_default_string_decodes_to_the_daemons_typed_const() {
+        assert_eq!(
+            parse_bool_token(descriptor(KEY_AUTOSTANDUP_ENABLED).unwrap().default),
+            Some(DEFAULT_AUTOSTANDUP_ENABLED),
+            "autostandup.enabled default must decode to the daemon's const"
+        );
+        assert!(
+            !DEFAULT_AUTOSTANDUP_ENABLED,
+            "auto-standup must stay OFF by default — it writes into live sessions"
+        );
+        assert_eq!(
+            descriptor(KEY_AUTOSTANDUP_STAGNANT_MIN).unwrap().default.parse::<i64>(),
+            Ok(DEFAULT_AUTOSTANDUP_STAGNANT_MIN)
+        );
+        assert_eq!(
+            descriptor(KEY_AUTOSTANDUP_COOLDOWN_MIN).unwrap().default.parse::<i64>(),
+            Ok(DEFAULT_AUTOSTANDUP_COOLDOWN_MIN)
+        );
+        assert_eq!(
+            descriptor(KEY_AUTOSTANDUP_MAX_CONCURRENT).unwrap().default.parse::<i64>(),
+            Ok(DEFAULT_AUTOSTANDUP_MAX_CONCURRENT)
+        );
+        assert_eq!(
+            descriptor(KEY_CARD_AGENT_DEFAULT).unwrap().default,
+            DEFAULT_CARD_AGENT_DEFAULT
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-core/src/daemon_config.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/daemon_config.rs
@@ -77,6 +77,20 @@ coded_default! {
 /// so the registry wires this const through directly.
 pub const DEFAULT_CARD_AGENT_DEFAULT: &str = "claude";
 
+/// The minimum legal per-session cooldown, in minutes.
+///
+/// A cooldown of `0` is NOT merely "no cooldown" — it disarms auto-standup's two
+/// safety gates at once. The cooldown check (`now - last < 0`) can never trip, and
+/// the daemon derives its stale-in-flight window from the same value
+/// (`cooldown * 60_000 * multiple`), so `0` makes every in-flight slot instantly
+/// reclaimable and the concurrency cap meaningless. The watcher then writes
+/// `/standup` into the session on EVERY reconcile tick, forever — exactly the
+/// write-mode blast radius the D13 gates exist to bound. Floor it at 1.
+///
+/// The daemon clamps to this on load as well, so a row written before this bound
+/// existed (or by hand) cannot resurrect the behaviour.
+pub const MIN_AUTOSTANDUP_COOLDOWN_MIN: i64 = 1;
+
 /// The shape of one configurable value — drives both the editor UI and the
 /// validation gate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -224,7 +238,7 @@ pub const DAEMON_CONFIG_REGISTRY: &[ConfigDescriptor] = &[
         key: KEY_AUTOSTANDUP_COOLDOWN_MIN,
         label: "Cooldown minutes",
         kind: ConfigKind::Int {
-            min: 0,
+            min: MIN_AUTOSTANDUP_COOLDOWN_MIN,
             max: 1440,
             step: 5,
         },
@@ -317,6 +331,31 @@ mod tests {
             descriptor(KEY_CARD_AGENT_DEFAULT).unwrap().default,
             DEFAULT_CARD_AGENT_DEFAULT
         );
+    }
+
+    /// The cooldown floor is a SAFETY bound, not a UI nicety: `0` defeats both the
+    /// cooldown gate and the stale-in-flight reclaim window the daemon derives
+    /// from it, degenerating auto-standup into writing `/standup` into the session
+    /// every tick. The registry must refuse to express it.
+    #[test]
+    fn cooldown_zero_is_rejected_by_the_registry_gate() {
+        let d = descriptor(KEY_AUTOSTANDUP_COOLDOWN_MIN).unwrap();
+        assert!(
+            d.validate("0").is_err(),
+            "cooldown 0 makes auto-standup fire every tick — it must not validate"
+        );
+        assert_eq!(
+            d.validate("1").unwrap(),
+            "1",
+            "the floor itself is still settable"
+        );
+        assert!(matches!(
+            d.kind,
+            ConfigKind::Int {
+                min: MIN_AUTOSTANDUP_COOLDOWN_MIN,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -22,6 +22,10 @@ pub mod autopilot;
 pub mod channel;
 /// Wall-clock injection (`HangarClock` + `SystemClock` / `FixedClock`).
 pub mod clock;
+/// The single source of truth for the daemon's user-configurable knobs — the
+/// typed descriptor registry both the TUI Settings pane and the
+/// `ainb hangar daemon config` CLI iterate (keys, kinds, defaults, validation).
+pub mod daemon_config;
 /// Environment allowlist policy (P5.3): allowlist passthrough with a hardcoded
 /// deny family that always overrides. Pure + IO-free; the TOML loader and
 /// daemon wiring live in `ainb-hangar-daemon`.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3853,6 +3853,11 @@ async fn handle_daemon_config_get(
     })
 }
 
+/// The largest `daemon_config` value the set RPC will look at. Every registry
+/// kind (bool / bounded int / enum token) is far shorter, so this only bounds
+/// absurd input, never a legal one.
+const MAX_DAEMON_CONFIG_VALUE_LEN: usize = 256;
+
 /// Dispatch `hangar/daemon_config_set` (D13): write one `daemon_config` value by
 /// key. Mutating + idempotent (re-writing the same value is a no-op replace). A
 /// blank key is a client error. Split out of [`handle`] to keep that dispatcher
@@ -3869,15 +3874,30 @@ async fn handle_daemon_config_set(
     if key.is_empty() {
         return Err(invalid_params("daemon_config key must not be empty"));
     }
-    // A known registry knob is validated + normalized through its descriptor so
-    // an out-of-range int / bad bool / unknown enum is rejected the same way the
-    // CLI rejects it, and the stored string is the canonical form the daemon's
-    // typed accessors decode. Non-registry keys (internal state like
-    // `card_agent.last_used`) pass through unchanged — this table is generic.
-    let value = match ainb_hangar_core::daemon_config::descriptor(key) {
-        Some(desc) => desc.validate(&params.value).map_err(|e| invalid_params(&e))?,
-        None => params.value,
-    };
+    // Bound the value before doing anything with it. Every registry kind (bool /
+    // bounded int / enum) rejects a long value anyway, so this cannot change which
+    // values are accepted — it just stops an absurd payload being echoed back in a
+    // rejection message. (The allocation itself already happened during JSON
+    // parsing; a true bound belongs at the frame layer, not here.)
+    if params.value.len() > MAX_DAEMON_CONFIG_VALUE_LEN {
+        return Err(invalid_params(&format!(
+            "daemon_config value must be at most {MAX_DAEMON_CONFIG_VALUE_LEN} bytes"
+        )));
+    }
+    // Every write passes the registry's descriptor gate — the SAME gate the CLI
+    // uses — so an out-of-range int / bad bool / unknown enum is rejected
+    // identically on both legs, and the stored string is the canonical form the
+    // daemon's typed accessors decode.
+    //
+    // An unknown key is REJECTED rather than passed through. This used to be a
+    // generic escape hatch, which meant the two legs of the "single gate"
+    // disagreed: the CLI refused `unknown config key`, the RPC silently stored it.
+    // The daemon's own internal state (`card_agent.last_used`) is written straight
+    // through DaemonConfigRepo in-process and never travels this RPC, so nothing
+    // legitimate needs the hatch.
+    let desc = ainb_hangar_core::daemon_config::descriptor(key)
+        .ok_or_else(|| invalid_params(&format!("unknown config key `{key}`")))?;
+    let value = desc.validate(&params.value).map_err(|e| invalid_params(&e))?;
     DaemonConfigRepo::set(pool, key, &value).await.map_err(|e| store_err(&e))?;
     to_value(&ainb_hangar_proto::snapshots::DaemonConfigSetResult {
         key: key.to_string(),
@@ -5882,5 +5902,73 @@ mod tests {
         .await;
         assert!(ok.error.is_none(), "{ok:?}");
         assert_eq!(ok.result.unwrap()["value"], serde_json::json!("codex"));
+    }
+
+    /// The set RPC and the CLI are meant to be ONE gate, so they must agree on
+    /// what a legal key is. The RPC used to pass unknown keys straight through to
+    /// the table while the CLI rejected them with `unknown config key` — the two
+    /// legs disagreed, and anything could be written into `daemon_config`.
+    #[tokio::test]
+    async fn daemon_config_set_rejects_unknown_keys_like_the_cli() {
+        use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        for key in ["not.a.knob", "card_agent.last_used"] {
+            let got = dispatch(
+                pool,
+                &req(
+                    methods::HANGAR_DAEMON_CONFIG_SET,
+                    serde_json::json!({"key": key, "value": "x"}),
+                ),
+                &health(),
+                &sink(),
+            )
+            .await;
+            assert_eq!(
+                got.error.as_ref().map(|e| e.code),
+                Some(INVALID_PARAMS),
+                "`{key}` is not a registry knob and must be refused, got {got:?}"
+            );
+            assert_eq!(
+                DaemonConfigRepo::get(pool, key).await.unwrap(),
+                None,
+                "a refused key must not be written"
+            );
+        }
+
+        // `card_agent.last_used` is internal state the daemon writes in-process
+        // through the repo — refusing it over RPC does not disturb that path.
+        DaemonConfigRepo::set(pool, "card_agent.last_used", "codex").await.unwrap();
+        assert_eq!(
+            DaemonConfigRepo::get(pool, "card_agent.last_used").await.unwrap(),
+            Some("codex".to_string())
+        );
+    }
+
+    /// An absurdly long value is refused up front rather than echoed back.
+    #[tokio::test]
+    async fn daemon_config_set_bounds_the_value_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let huge = "9".repeat(MAX_DAEMON_CONFIG_VALUE_LEN + 1);
+        let got = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "autostandup.stagnant_min", "value": huge}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        let err = got.error.expect("an over-long value is refused");
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            !err.message.contains("999999"),
+            "the rejection must not echo the payload back: {}",
+            err.message
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5783,4 +5783,104 @@ mod tests {
         .await;
         assert_eq!(set.error.unwrap().code, INVALID_PARAMS);
     }
+
+    /// `daemon_config_list` returns one entry per registry knob (unset → null),
+    /// and reflects a prior write.
+    #[tokio::test]
+    async fn daemon_config_list_covers_registry_and_reflects_writes() {
+        use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        let listed = dispatch(
+            pool,
+            &req(methods::HANGAR_DAEMON_CONFIG_LIST, serde_json::json!({})),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(listed.error.is_none(), "{listed:?}");
+        let entries = listed.result.unwrap()["entries"].as_array().unwrap().clone();
+        assert_eq!(
+            entries.len(),
+            DAEMON_CONFIG_REGISTRY.len(),
+            "one list entry per registry knob"
+        );
+
+        // Write one knob, then confirm the list reflects it.
+        dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "autostandup.stagnant_min", "value": "30"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        let relisted = dispatch(
+            pool,
+            &req(methods::HANGAR_DAEMON_CONFIG_LIST, serde_json::json!({})),
+            &health(),
+            &sink(),
+        )
+        .await;
+        let entries = relisted.result.unwrap()["entries"].as_array().unwrap().clone();
+        let row = entries
+            .iter()
+            .find(|e| e["key"] == "autostandup.stagnant_min")
+            .expect("stagnant_min listed");
+        assert_eq!(row["value"], serde_json::json!("30"));
+    }
+
+    /// A registry-validated set rejects an out-of-range int / bad enum with
+    /// INVALID_PARAMS, and normalizes a tolerant/mixed-case value it accepts.
+    #[tokio::test]
+    async fn daemon_config_set_validates_registry_knobs() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        // Out-of-range int → rejected.
+        let bad = dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "autostandup.stagnant_min", "value": "99999"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert_eq!(bad.error.unwrap().code, INVALID_PARAMS);
+
+        // Bad enum → rejected.
+        let bad_enum = dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "card_agent.default", "value": "gemini"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert_eq!(bad_enum.error.unwrap().code, INVALID_PARAMS);
+
+        // Mixed-case enum → accepted + normalized to the canonical spelling.
+        let ok = dispatch(
+            pool,
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_SET,
+                serde_json::json!({"key": "card_agent.default", "value": "CODEX"}),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(ok.error.is_none(), "{ok:?}");
+        assert_eq!(ok.result.unwrap()["value"], serde_json::json!("codex"));
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -709,6 +709,7 @@ async fn handle(
         methods::HANGAR_NOTIFY_RULE_SET => handle_notify_rule_set(pool, req).await,
         methods::HANGAR_DAEMON_CONFIG_GET => handle_daemon_config_get(pool, req).await,
         methods::HANGAR_DAEMON_CONFIG_SET => handle_daemon_config_set(pool, req).await,
+        methods::HANGAR_DAEMON_CONFIG_LIST => handle_daemon_config_list(pool).await,
         other => Err(RpcError {
             code: METHOD_NOT_FOUND,
             message: format!("unknown method: {other}"),
@@ -3840,8 +3841,7 @@ async fn handle_daemon_config_get(
 ) -> Result<serde_json::Value, RpcError> {
     use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
-    let params: ainb_hangar_proto::snapshots::DaemonConfigGetParams =
-        parse_params(req, "{ key }")?;
+    let params: ainb_hangar_proto::snapshots::DaemonConfigGetParams = parse_params(req, "{ key }")?;
     let key = params.key.trim();
     if key.is_empty() {
         return Err(invalid_params("daemon_config key must not be empty"));
@@ -3869,11 +3869,40 @@ async fn handle_daemon_config_set(
     if key.is_empty() {
         return Err(invalid_params("daemon_config key must not be empty"));
     }
-    DaemonConfigRepo::set(pool, key, &params.value).await.map_err(|e| store_err(&e))?;
+    // A known registry knob is validated + normalized through its descriptor so
+    // an out-of-range int / bad bool / unknown enum is rejected the same way the
+    // CLI rejects it, and the stored string is the canonical form the daemon's
+    // typed accessors decode. Non-registry keys (internal state like
+    // `card_agent.last_used`) pass through unchanged — this table is generic.
+    let value = match ainb_hangar_core::daemon_config::descriptor(key) {
+        Some(desc) => desc.validate(&params.value).map_err(|e| invalid_params(&e))?,
+        None => params.value,
+    };
+    DaemonConfigRepo::set(pool, key, &value).await.map_err(|e| store_err(&e))?;
     to_value(&ainb_hangar_proto::snapshots::DaemonConfigSetResult {
         key: key.to_string(),
-        value: params.value,
+        value,
     })
+}
+
+/// Dispatch `hangar/daemon_config_list`: read every user-config knob's stored
+/// value in one round trip. Iterates
+/// [`ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY`] so a new registry
+/// knob is listed without any handler change; a key with no row reports `value =
+/// None` (the caller applies the descriptor's coded default).
+async fn handle_daemon_config_list(pool: &SqlitePool) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let mut entries = Vec::with_capacity(DAEMON_CONFIG_REGISTRY.len());
+    for desc in DAEMON_CONFIG_REGISTRY {
+        let value = DaemonConfigRepo::get(pool, desc.key).await.map_err(|e| store_err(&e))?;
+        entries.push(ainb_hangar_proto::snapshots::DaemonConfigEntry {
+            key: desc.key.to_string(),
+            value,
+        });
+    }
+    to_value(&ainb_hangar_proto::snapshots::DaemonConfigListResult { entries })
 }
 
 /// Dispatch `atc/unregister` (spec P9, D12): disable a registered ATC instance's
@@ -5733,7 +5762,10 @@ mod tests {
         let store = Store::open_in(dir.path()).await.unwrap();
         let get = dispatch(
             store.pool(),
-            &req(methods::HANGAR_DAEMON_CONFIG_GET, serde_json::json!({"key": "  "})),
+            &req(
+                methods::HANGAR_DAEMON_CONFIG_GET,
+                serde_json::json!({"key": "  "}),
+            ),
             &health(),
             &sink(),
         )

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5856,7 +5856,7 @@ mod tests {
     }
 
     /// A registry-validated set rejects an out-of-range int / bad enum with
-    /// INVALID_PARAMS, and normalizes a tolerant/mixed-case value it accepts.
+    /// `INVALID_PARAMS`, and normalizes a tolerant/mixed-case value it accepts.
     #[tokio::test]
     async fn daemon_config_set_validates_registry_knobs() {
         let dir = tempfile::tempdir().unwrap();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
@@ -137,7 +137,7 @@ impl StandupConfig {
     /// arms the watcher, and a `0` here disarms both the cooldown check and the
     /// stale-in-flight window derived from it — making the daemon write
     /// `/standup` into the session every tick. A row predating the bound, or
-    /// written straight to SQLite, must not be able to do that.
+    /// written straight to `SQLite`, must not be able to do that.
     ///
     /// # Errors
     ///
@@ -854,7 +854,7 @@ mod tests {
     ///
     /// The registry now refuses to write a 0, but this is the value that actually
     /// arms the gates, and a row written before that bound existed (or straight to
-    /// SQLite) would otherwise make the cooldown check unfireable AND zero the
+    /// `SQLite`) would otherwise make the cooldown check unfireable AND zero the
     /// stale-in-flight window — writing `/standup` into the session every tick.
     #[tokio::test]
     async fn config_load_floors_a_zero_cooldown() {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
@@ -56,15 +56,21 @@ use tokio_util::sync::CancellationToken;
 
 use crate::events::EventSink;
 
+// The auto-standup keys + coded defaults are owned by the daemon-config registry
+// (`ainb_hangar_core::daemon_config`) so the TUI/CLI config surfaces and this
+// watcher read one authoritative definition. These re-exports keep the existing
+// `standup::KEY_ENABLED` / `DEFAULT_ENABLED` call sites unchanged.
+use ainb_hangar_core::daemon_config as cfg;
+
 /// `daemon_config` key: the global auto-standup toggle (default OFF — opt-in via
 /// the Settings screen or an explicit `daemon_config` write).
-pub const KEY_ENABLED: &str = "autostandup.enabled";
+pub const KEY_ENABLED: &str = cfg::KEY_AUTOSTANDUP_ENABLED;
 /// `daemon_config` key: minutes a session must be stagnant before firing.
-pub const KEY_STAGNANT_MIN: &str = "autostandup.stagnant_min";
+pub const KEY_STAGNANT_MIN: &str = cfg::KEY_AUTOSTANDUP_STAGNANT_MIN;
 /// `daemon_config` key: per-session cooldown window in minutes.
-pub const KEY_COOLDOWN_MIN: &str = "autostandup.cooldown_min";
+pub const KEY_COOLDOWN_MIN: &str = cfg::KEY_AUTOSTANDUP_COOLDOWN_MIN;
 /// `daemon_config` key: max simultaneous in-flight standups.
-pub const KEY_MAX_CONCURRENT: &str = "autostandup.max_concurrent";
+pub const KEY_MAX_CONCURRENT: &str = cfg::KEY_AUTOSTANDUP_MAX_CONCURRENT;
 
 /// Coded default: auto-standup is OFF (opt-in).
 ///
@@ -72,13 +78,13 @@ pub const KEY_MAX_CONCURRENT: &str = "autostandup.max_concurrent";
 /// session) stays quiet on a fresh daemon, or one with no config row, until the
 /// operator enables it — via the Settings screen toggle or an explicit
 /// `autostandup.enabled` write.
-pub const DEFAULT_ENABLED: bool = false;
+pub const DEFAULT_ENABLED: bool = cfg::DEFAULT_AUTOSTANDUP_ENABLED;
 /// Coded default: 15 minutes stagnant.
-pub const DEFAULT_STAGNANT_MIN: i64 = 15;
+pub const DEFAULT_STAGNANT_MIN: i64 = cfg::DEFAULT_AUTOSTANDUP_STAGNANT_MIN;
 /// Coded default: 60-minute per-session cooldown.
-pub const DEFAULT_COOLDOWN_MIN: i64 = 60;
+pub const DEFAULT_COOLDOWN_MIN: i64 = cfg::DEFAULT_AUTOSTANDUP_COOLDOWN_MIN;
 /// Coded default: at most one concurrent standup.
-pub const DEFAULT_MAX_CONCURRENT: i64 = 1;
+pub const DEFAULT_MAX_CONCURRENT: i64 = cfg::DEFAULT_AUTOSTANDUP_MAX_CONCURRENT;
 
 /// How often the watcher scans the fleet for standup candidates.
 const TICK: Duration = Duration::from_secs(60);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
@@ -132,6 +132,13 @@ impl StandupConfig {
     /// Load the config from `daemon_config`, falling back to the coded defaults
     /// key-by-key (a missing/garbage value never errors — the default holds).
     ///
+    /// The cooldown is floored at [`cfg::MIN_AUTOSTANDUP_COOLDOWN_MIN`]. The
+    /// registry gate refuses to WRITE a `0`, but this is the value that actually
+    /// arms the watcher, and a `0` here disarms both the cooldown check and the
+    /// stale-in-flight window derived from it — making the daemon write
+    /// `/standup` into the session every tick. A row predating the bound, or
+    /// written straight to SQLite, must not be able to do that.
+    ///
     /// # Errors
     ///
     /// Returns a [`sqlx::Error`] only if the underlying config reads fail.
@@ -149,7 +156,8 @@ impl StandupConfig {
                 KEY_COOLDOWN_MIN,
                 DEFAULT_COOLDOWN_MIN,
             )
-            .await?,
+            .await?
+            .max(cfg::MIN_AUTOSTANDUP_COOLDOWN_MIN),
             max_concurrent: DaemonConfigRepo::get_i64(
                 pool,
                 KEY_MAX_CONCURRENT,
@@ -840,6 +848,45 @@ mod tests {
         // …and an explicit disable turns it back off.
         DaemonConfigRepo::set(store.pool(), KEY_ENABLED, "false").await.unwrap();
         assert!(!StandupConfig::load(store.pool()).await.unwrap().enabled);
+    }
+
+    /// A stored `cooldown_min = 0` must not be able to disarm the watcher.
+    ///
+    /// The registry now refuses to write a 0, but this is the value that actually
+    /// arms the gates, and a row written before that bound existed (or straight to
+    /// SQLite) would otherwise make the cooldown check unfireable AND zero the
+    /// stale-in-flight window — writing `/standup` into the session every tick.
+    #[tokio::test]
+    async fn config_load_floors_a_zero_cooldown() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        DaemonConfigRepo::set(store.pool(), KEY_COOLDOWN_MIN, "0").await.unwrap();
+
+        let cfg = StandupConfig::load(store.pool()).await.unwrap();
+        assert_eq!(
+            cfg.cooldown_minutes, cfg::MIN_AUTOSTANDUP_COOLDOWN_MIN,
+            "a legacy 0 cooldown must be floored, not honoured"
+        );
+
+        // The gate is armed again: a session that just fired is held off, where a
+        // 0 cooldown would have fired another `/standup` immediately.
+        let now = 10_000_000;
+        let enabled = StandupConfig {
+            enabled: true,
+            ..cfg
+        };
+        let input = SessionGateInput {
+            idle_at_prompt: true,
+            idle_minutes: enabled.stagnant_minutes + 1,
+            opted_out: false,
+            last_standup_at: Some(now),
+            in_flight: false,
+        };
+        assert_eq!(
+            decide_standup(&enabled, &input, 0, now),
+            StandupDecision::Skip(SkipReason::Cooldown),
+            "the cooldown gate must trip for a session that just fired"
+        );
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/standup.rs
@@ -864,7 +864,8 @@ mod tests {
 
         let cfg = StandupConfig::load(store.pool()).await.unwrap();
         assert_eq!(
-            cfg.cooldown_minutes, cfg::MIN_AUTOSTANDUP_COOLDOWN_MIN,
+            cfg.cooldown_minutes,
+            cfg::MIN_AUTOSTANDUP_COOLDOWN_MIN,
             "a legacy 0 cooldown must be floored, not honoured"
         );
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -857,6 +857,16 @@ pub const HANGAR_DAEMON_CONFIG_GET: &str = "hangar/daemon_config_get";
 /// The Settings auto-standup toggle persists `autostandup.enabled` through this.
 pub const HANGAR_DAEMON_CONFIG_SET: &str = "hangar/daemon_config_set";
 
+/// `hangar/daemon_config_list` — read EVERY user-config knob in one round trip.
+///
+/// Params: none (`{}`). Result: [`crate::snapshots::DaemonConfigListResult`]
+/// (`{ entries: [{ key, value }] }`), one entry per
+/// [`ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY`] descriptor, whose
+/// `value` is `None` when the key has no stored row. The Settings Daemon-section
+/// editor reads the whole configurable set through this rather than a get per
+/// key, so a new registry knob surfaces without new wiring.
+pub const HANGAR_DAEMON_CONFIG_LIST: &str = "hangar/daemon_config_list";
+
 /// `auth/hello` — authenticate a freshly-opened socket connection.
 ///
 /// Params: [`crate::auth::HelloParams`] (`{ token: String }` — the plaintext
@@ -976,6 +986,7 @@ pub const ALL_METHODS: &[&str] = &[
     // catalogue is append-only.
     HANGAR_DAEMON_CONFIG_GET,
     HANGAR_DAEMON_CONFIG_SET,
+    HANGAR_DAEMON_CONFIG_LIST,
 ];
 
 #[cfg(test)]
@@ -1169,6 +1180,7 @@ mod tests {
             HANGAR_NOTIFY_RULE_SET,
             HANGAR_DAEMON_CONFIG_GET,
             HANGAR_DAEMON_CONFIG_SET,
+            HANGAR_DAEMON_CONFIG_LIST,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1855,6 +1855,28 @@ pub struct DaemonConfigSetResult {
     pub value: String,
 }
 
+/// One entry in a [`DaemonConfigListResult`]: a registry key and its currently
+/// stored value (`None` when the key has no row — the caller applies the coded
+/// default from the descriptor).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfigEntry {
+    /// The `daemon_config` registry key.
+    pub key: String,
+    /// The stored value, or `None` when no row exists (use the coded default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// Result of [`crate::methods::HANGAR_DAEMON_CONFIG_LIST`]: every user-config
+/// knob's current stored value, one entry per registry descriptor in registry
+/// order. Lets a surface read the whole configurable set in one round trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfigListResult {
+    /// One entry per [`ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY`]
+    /// descriptor, in registry order.
+    pub entries: Vec<DaemonConfigEntry>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_parity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_parity.rs
@@ -25,9 +25,16 @@ use sqlx::SqlitePool;
 use super::daemon_config::DaemonConfigRepo;
 
 /// `daemon_config` key holding the host-wide default card agent (F4 global tier).
-pub const AGENT_GLOBAL_DEFAULT_KEY: &str = "card_agent.default";
+///
+/// This is a USER-config knob, so its key is owned by the daemon-config registry
+/// (`ainb_hangar_core::daemon_config`) — the config surfaces (TUI/CLI) and this
+/// cascade read one authoritative key.
+pub const AGENT_GLOBAL_DEFAULT_KEY: &str = ainb_hangar_core::daemon_config::KEY_CARD_AGENT_DEFAULT;
 /// `daemon_config` key holding the most-recently-picked card agent (F4 last-used
 /// tier). Updated on every card create/run so the next overlay pre-selects it.
+///
+/// Deliberately NOT a config-registry knob: this is internal STATE the daemon
+/// overwrites on each dispatch, so it is never surfaced as an editable row.
 pub const AGENT_LAST_USED_KEY: &str = "card_agent.last_used";
 
 /// Stateless accessor over the migration-0032 card-parity columns + the F4

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -208,9 +208,11 @@ const NOTIFY_RULES_REQ_ID: i64 = 47;
 /// JSON-RPC id for a `hangar/notify_rule_set` upsert raised by a toggled routing
 /// cell (tcp T5). Its reply re-fetches the grid so the pane reflects the write.
 const NOTIFY_RULE_SET_REQ_ID: i64 = 48;
-/// `hangar/daemon_config_get` for the Settings auto-standup toggle (D13).
-const DAEMON_CONFIG_GET_REQ_ID: i64 = 49;
-/// `hangar/daemon_config_set` write from the auto-standup toggle (D13).
+/// `hangar/daemon_config_list` for the Settings Daemon-section config rows: reads
+/// every daemon-config knob's live value in one round trip.
+const DAEMON_CONFIG_LIST_REQ_ID: i64 = 49;
+/// `hangar/daemon_config_set` write from a Daemon-section knob edit; its reply
+/// re-fetches the whole config so the pane reflects the persisted value.
 const DAEMON_CONFIG_SET_REQ_ID: i64 = 50;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
@@ -806,10 +808,11 @@ impl HangarPlugin {
                     Some(crate::screen::app_screens::NotifyAction::Refresh { scope });
                 self.conn.on_event();
             }
-            // D13: the Settings auto-standup toggle's live value.
-            RpcId::Number(DAEMON_CONFIG_GET_REQ_ID) => self.apply_autostandup(resp),
+            // Every daemon-config knob's live value for the Settings pane.
+            RpcId::Number(DAEMON_CONFIG_LIST_REQ_ID) => self.apply_daemon_config_list(resp),
             RpcId::Number(DAEMON_CONFIG_SET_REQ_ID) => {
-                // Re-read after the write so the pane reflects the persisted value.
+                // Re-read the whole config after the write so the pane reflects the
+                // persisted value (reconciling the optimistic edit).
                 self.fetch_pending = true;
                 self.conn.on_event();
             }
@@ -914,25 +917,17 @@ impl HangarPlugin {
         self.conn.on_event();
     }
 
-    /// Populate the Settings auto-standup toggle from a `hangar/daemon_config_get`
-    /// result (D13): the daemon's persisted `autostandup.enabled` value.
-    fn apply_autostandup(&mut self, resp: &RpcResponse) {
+    /// Populate the Settings Daemon-section config rows from a
+    /// `hangar/daemon_config_list` result: every knob's persisted value (or `None`
+    /// for an unset knob, where the pane shows the descriptor's coded default).
+    fn apply_daemon_config_list(&mut self, resp: &RpcResponse) {
         if let Some(result) = &resp.result {
             if let Ok(r) = serde_json::from_value::<
-                ainb_hangar_proto::snapshots::DaemonConfigGetResult,
+                ainb_hangar_proto::snapshots::DaemonConfigListResult,
             >(result.clone())
             {
-                // Absent row / unrecognized value => the coded default OFF.
-                // Mirror the daemon's tolerant `parse_bool` (1/true/yes/on,
-                // case-insensitive) so the toggle can never disagree with what
-                // the daemon actually does.
-                let on = r.value.as_deref().is_some_and(|v| {
-                    matches!(
-                        v.trim().to_ascii_lowercase().as_str(),
-                        "1" | "true" | "yes" | "on"
-                    )
-                });
-                self.screens.set_autostandup_enabled(on);
+                let entries = r.entries.into_iter().map(|e| (e.key, e.value)).collect::<Vec<_>>();
+                self.screens.set_daemon_config_entries(entries);
             }
         }
         self.conn.on_event();
@@ -1642,11 +1637,11 @@ impl HangarPlugin {
                 daemon_methods::HANGAR_MEMBERS_LIST,
                 scoped.clone(),
             ),
-            // D13: the Settings auto-standup toggle's live value.
+            // Every daemon-config knob's live value for the Settings Daemon section.
             (
-                DAEMON_CONFIG_GET_REQ_ID,
-                daemon_methods::HANGAR_DAEMON_CONFIG_GET,
-                serde_json::json!({ "key": "autostandup.enabled" }),
+                DAEMON_CONFIG_LIST_REQ_ID,
+                daemon_methods::HANGAR_DAEMON_CONFIG_LIST,
+                serde_json::json!({}),
             ),
             (
                 INBOX_LIST_REQ_ID,
@@ -3756,26 +3751,24 @@ impl Plugin for HangarPlugin {
         if let Some(action) = self.screens.take_pending_notify_action() {
             self.apply_notify_action(host, action).await;
         }
-        // D13: drain a deferred auto-standup toggle write and fire it over the
-        // daemon socket; the reply re-fetches so the pane reflects the persisted
-        // value.
-        if let Some(on) = self.screens.take_pending_autostandup_set() {
+        // Drain a deferred daemon-config write (bool/enum/int edit) and fire it over
+        // the daemon socket; the reply re-fetches the whole config so the pane
+        // reflects the persisted value.
+        if let Some((key, value)) = self.screens.take_pending_daemon_config_set() {
             let mut sent = false;
             if let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) {
                 let body = encode_request(
                     DAEMON_CONFIG_SET_REQ_ID,
                     daemon_methods::HANGAR_DAEMON_CONFIG_SET,
-                    serde_json::json!({
-                        "key": "autostandup.enabled",
-                        "value": if on { "true" } else { "false" },
-                    }),
+                    serde_json::json!({ "key": key, "value": value }),
                 );
                 if let Ok(body) = body {
                     match host.unix_socket_send(stream_id, body).await {
                         Ok(()) => sent = true,
                         Err(e) => {
-                            let _ =
-                                host.log_info(format!("hangar: autostandup set failed: {e}")).await;
+                            let _ = host
+                                .log_info(format!("hangar: daemon_config set failed: {e}"))
+                                .await;
                         }
                     }
                 }
@@ -3783,7 +3776,7 @@ impl Plugin for HangarPlugin {
             // On a successful send the SET reply re-fetches (via `fetch_pending`).
             // If the write never left the plugin (disconnected / encode / send
             // error), re-fetch here so the pane reconciles to the persisted value
-            // instead of showing the optimistic flip forever.
+            // instead of showing the optimistic edit forever.
             if !sent {
                 self.fetch_pending = true;
                 self.conn.on_event();

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3771,7 +3771,7 @@ impl Plugin for HangarPlugin {
         // Drain a deferred daemon-config write (bool/enum/int edit) and fire it over
         // the daemon socket; the reply re-fetches the whole config so the pane
         // reflects the persisted value.
-        if let Some((key, value)) = self.screens.take_pending_daemon_config_set() {
+        for (key, value) in self.screens.take_pending_daemon_config_sets() {
             let mut sent = false;
             if let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) {
                 let body = encode_request(
@@ -5384,6 +5384,49 @@ mod tests {
             "digits accumulate in the overlay"
         );
         assert!(matches!(p.app_state().screen, Screen::Settings));
+    }
+
+    /// REGRESSION: two config edits landing before a render pass must BOTH be
+    /// written. The pending write used to be a single slot, so the second edit
+    /// overwrote the first — the first key was silently never persisted while the
+    /// pane happily showed it applied (the optimistic edit stays either way).
+    /// Keys arrive far faster than render passes, and the registry generalised
+    /// this surface from one knob to five, so this is reachable by simply typing.
+    #[test]
+    fn two_config_edits_before_a_render_both_queue() {
+        use ainb_hangar_core::daemon_config::{
+            DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_ENABLED, KEY_CARD_AGENT_DEFAULT,
+        };
+        let mut p = plugin_on_daemon_settings();
+
+        // Edit 1: `a` toggles auto-standup from anywhere in the section.
+        p.on_key(&char_press('a'));
+        // Edit 2: cycle the enum knob, with NO render pass in between.
+        let enum_idx = DAEMON_CONFIG_REGISTRY
+            .iter()
+            .position(|d| d.key == KEY_CARD_AGENT_DEFAULT)
+            .expect("enum knob present");
+        for _ in 0..enum_idx {
+            p.on_key(&key_press(KeyCode::Down));
+        }
+        p.on_key(&key_press(KeyCode::Enter));
+
+        let queued = &p.screens.pending_daemon_config_set;
+        assert_eq!(
+            queued.len(),
+            2,
+            "both edits must be queued, got {queued:?} — a dropped write is invisible"
+        );
+        assert_eq!(queued[0], (KEY_AUTOSTANDUP_ENABLED.to_string(), "true".to_string()));
+        assert_eq!(queued[1], (KEY_CARD_AGENT_DEFAULT.to_string(), "codex".to_string()));
+
+        // Draining hands them over in edit order and leaves the queue empty.
+        let drained = p.screens.take_pending_daemon_config_sets();
+        assert_eq!(drained.len(), 2, "the drain yields every queued write");
+        assert!(
+            p.screens.take_pending_daemon_config_sets().is_empty(),
+            "a drained queue is empty — no write fires twice"
+        );
     }
 
     /// REGRESSION: while the numeric overlay is open the plugin must DECLARE text

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -5343,7 +5343,9 @@ mod tests {
     /// BEFORE `route_key`), not `reduce_settings`, or the bug is invisible.
     #[test]
     fn digits_type_into_the_daemon_config_overlay_not_tab_switch() {
-        use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
+        use ainb_hangar_core::daemon_config::{
+            DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN,
+        };
         let mut p = plugin_on_daemon_settings();
 
         // Move the cursor onto `autostandup.stagnant_min` (an Int knob) and open
@@ -5417,8 +5419,14 @@ mod tests {
             2,
             "both edits must be queued, got {queued:?} — a dropped write is invisible"
         );
-        assert_eq!(queued[0], (KEY_AUTOSTANDUP_ENABLED.to_string(), "true".to_string()));
-        assert_eq!(queued[1], (KEY_CARD_AGENT_DEFAULT.to_string(), "codex".to_string()));
+        assert_eq!(
+            queued[0],
+            (KEY_AUTOSTANDUP_ENABLED.to_string(), "true".to_string())
+        );
+        assert_eq!(
+            queued[1],
+            (KEY_CARD_AGENT_DEFAULT.to_string(), "codex".to_string())
+        );
 
         // Draining hands them over in edit order and leaves the queue empty.
         let drained = p.screens.take_pending_daemon_config_sets();

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -2661,8 +2661,18 @@ impl HangarPlugin {
             }
             return;
         }
+        // The Settings screen has TWO text-capture surfaces: the key-entry
+        // (API-key) modal and the Daemon-section numeric-config overlay. Both must
+        // be listed here — the config overlay's realistic values (30, 120, 240,
+        // 1440) all contain a digit the routing layer claims as a tab switch, so
+        // omitting it makes typing a number teleport the user to another tab and
+        // drop the keystroke. Keep this in sync with `is_capturing_text`.
         if matches!(app.screen, Screen::Settings)
-            && self.screens.settings.as_ref().is_some_and(|s| s.key_entry_open())
+            && self
+                .screens
+                .settings
+                .as_ref()
+                .is_some_and(|s| s.key_entry_open() || s.config_input_buffer().is_some())
         {
             if let Some(nav) = route_key(&app, &mut self.screens, key) {
                 self.apply_nav(&app, nav);
@@ -3729,7 +3739,14 @@ impl Plugin for HangarPlugin {
                 .task_detail
                 .as_ref()
                 .is_some_and(|td| td.compose_buffer().is_some()),
-            Screen::Settings => self.screens.settings.as_ref().is_some_and(|s| s.key_entry_open()),
+            // Both Settings capture surfaces: the key-entry modal AND the
+            // Daemon-section numeric-config overlay (kept in sync with the
+            // routing guard in `on_key`).
+            Screen::Settings => self
+                .screens
+                .settings
+                .as_ref()
+                .is_some_and(|s| s.key_entry_open() || s.config_input_buffer().is_some()),
             Screen::Squads => self.screens.squads.is_creating(),
             // Every open Boards overlay (create-title / profile-pick / column
             // rename / `Run ▾`) consumes all keys as input, per its routing guard.
@@ -5291,5 +5308,118 @@ mod tests {
             p.screens.settings.as_ref().is_some_and(|s| s.key_entry_open()),
             "the key-entry modal stays open while typing the key"
         );
+    }
+
+    /// Seed a plugin sitting on the Settings screen's Daemon section.
+    fn plugin_on_daemon_settings() -> HangarPlugin {
+        use crate::screen::settings::SettingsState;
+        use ainb_hangar_proto::settings::HealthSnapshot;
+        let mut p = connected_plugin_with_issue();
+        let health = HealthSnapshot {
+            socket_path: "/tmp/x.sock".into(),
+            pid: 1,
+            uptime_secs: 0,
+            version: "test".into(),
+            connected: true,
+        };
+        p.screens.settings = Some(SettingsState::new(
+            health,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        ));
+        let mut app = p.app_state().clone();
+        app.screen = Screen::Settings;
+        p.app = Some(app);
+        p
+    }
+
+    /// REGRESSION (routing level, not the pure reducer): the Daemon-section
+    /// numeric-config overlay is a text-capture surface. Every realistic value for
+    /// an int knob (30, 120, 240, 1440) contains a digit `routing_event` claims as
+    /// a tab switch, so without the capture guard typing `3` teleported the user to
+    /// the Skill Manager and dropped the keystroke — the headline editing path did
+    /// not work at all. Drive the real `on_key` (which consults `routing_event`
+    /// BEFORE `route_key`), not `reduce_settings`, or the bug is invisible.
+    #[test]
+    fn digits_type_into_the_daemon_config_overlay_not_tab_switch() {
+        use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
+        let mut p = plugin_on_daemon_settings();
+
+        // Move the cursor onto `autostandup.stagnant_min` (an Int knob) and open
+        // the numeric overlay with Enter.
+        let target = DAEMON_CONFIG_REGISTRY
+            .iter()
+            .position(|d| d.key == KEY_AUTOSTANDUP_STAGNANT_MIN)
+            .expect("stagnant_min is a registry knob");
+        for _ in 0..target {
+            p.on_key(&key_press(KeyCode::Down));
+        }
+        p.on_key(&key_press(KeyCode::Enter));
+        assert_eq!(
+            p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()),
+            Some(""),
+            "Enter on an int knob opens an empty numeric overlay"
+        );
+
+        // THE REGRESSION: `3` must extend the buffer, not switch to the Skill
+        // Manager tab (`routing_event` maps '3' → Screen::SkillManager).
+        p.on_key(&key_press(KeyCode::Char { ch: '3' }));
+        assert!(
+            matches!(p.app_state().screen, Screen::Settings),
+            "typing `3` in the config overlay must NOT switch tabs, got {:?}",
+            p.app_state().screen
+        );
+        assert_eq!(
+            p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()),
+            Some("3"),
+            "`3` must land in the overlay buffer"
+        );
+
+        // `0` completes `30`; the overlay is still open on Settings.
+        p.on_key(&key_press(KeyCode::Char { ch: '0' }));
+        assert_eq!(
+            p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()),
+            Some("30"),
+            "digits accumulate in the overlay"
+        );
+        assert!(matches!(p.app_state().screen, Screen::Settings));
+    }
+
+    /// REGRESSION: while the numeric overlay is open the plugin must DECLARE text
+    /// capture to the host, which is what stops the host eating a bare `q` (quit)
+    /// or `?` as its own global shortcut instead of forwarding it.
+    ///
+    /// Asserting on screen state alone would be VACUOUS here: `on_key` discards
+    /// the routing layer's `Intent::Quit`, so a `q` that leaked to the nav layer
+    /// leaves `app.screen` on Settings either way. `captures_text` is the seam the
+    /// host actually reads, so that is what this pins.
+    #[test]
+    fn the_daemon_config_overlay_declares_text_capture_to_the_host() {
+        use ainb_plugin_sdk::Plugin;
+        let mut p = plugin_on_daemon_settings();
+        assert!(
+            !p.captures_text(),
+            "no capture surface open on the bare Daemon section"
+        );
+
+        p.on_key(&key_press(KeyCode::Down));
+        p.on_key(&key_press(KeyCode::Enter));
+        assert!(
+            p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()).is_some(),
+            "the numeric overlay is open"
+        );
+        assert!(
+            p.captures_text(),
+            "an open config overlay must declare capture, else the host eats `q`/`?`"
+        );
+
+        // Esc closes it and capture is released.
+        p.on_key(&key_press(KeyCode::Esc));
+        assert!(
+            p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()).is_none(),
+            "Esc cancels the overlay in a single press"
+        );
+        assert!(!p.captures_text(), "capture is released with the overlay");
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -536,10 +536,16 @@ pub struct ScreenStates {
     /// arrival order and survives a `set_health` rebuild (each is replayed into the
     /// rebuilt state). Empty until the first list reply lands.
     pub daemon_config_cache: Vec<(String, Option<String>)>,
-    /// A deferred daemon-config write raised by a Daemon-section edit (bool toggle,
-    /// enum cycle, or committed int overlay): the `(key, value)` awaiting the
-    /// `render` pass to fire `hangar/daemon_config_set`. `None` when idle.
-    pub pending_daemon_config_set: Option<(String, String)>,
+    /// Deferred daemon-config writes raised by Daemon-section edits (bool toggle,
+    /// enum cycle, or committed int overlay): the `(key, value)` pairs awaiting the
+    /// `render` pass to fire `hangar/daemon_config_set`, in edit order. Empty when
+    /// idle.
+    ///
+    /// A QUEUE, not a slot: the registry generalised this surface from one knob to
+    /// N, and keys land faster than render passes. With a single slot, toggling
+    /// auto-standup and then cycling the default agent before the next frame
+    /// silently dropped the first write while the pane still showed it applied.
+    pub pending_daemon_config_set: Vec<(String, String)>,
     /// Set when the logs screen's level filter changed (P8.6), asking the glue
     /// to re-read the structured-log file under the new `--level` floor. Drained
     /// by the `render` pass. `false` when idle.
@@ -870,9 +876,10 @@ impl ScreenStates {
         }
     }
 
-    /// Take the pending daemon-config write raised by a Daemon-section edit, if any.
-    pub fn take_pending_daemon_config_set(&mut self) -> Option<(String, String)> {
-        self.pending_daemon_config_set.take()
+    /// Drain every pending daemon-config write raised by Daemon-section edits, in
+    /// edit order. Returns an empty vec when idle.
+    pub fn take_pending_daemon_config_sets(&mut self) -> Vec<(String, String)> {
+        std::mem::take(&mut self.pending_daemon_config_set)
     }
 
     /// The Notifications grid's current edit scope (global/workspace,
@@ -1278,7 +1285,7 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
                     // knob: defer the `hangar/daemon_config_set` write for the
                     // render pass, which re-reads the whole config afterwards.
                     Some(SettingsIntent::SetDaemonConfig { key, value }) => {
-                        states.pending_daemon_config_set = Some((key, value));
+                        states.pending_daemon_config_set.push((key, value));
                     }
                     // KeychainWrite / New / Rename land in their own beads.
                     _ => {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -531,14 +531,15 @@ pub struct ScreenStates {
     /// A deferred notify-rule RPC raised by the Notifications grid (tcp T5),
     /// drained by the `render` pass. `None` when idle.
     pub pending_notify_action: Option<NotifyAction>,
-    /// Cached live `autostandup.enabled` value from `hangar/daemon_config_get`
-    /// (D13). Seeds the Settings Daemon-section toggle regardless of arrival order,
-    /// and survives a `set_health` rebuild. Defaults OFF (the coded server default).
-    pub autostandup_enabled: bool,
-    /// A deferred `autostandup.enabled` write raised by the Daemon-section toggle
-    /// (`a`, D13): the NEW value awaiting the `render` pass to fire
-    /// `hangar/daemon_config_set` over the daemon socket. `None` when idle.
-    pub pending_autostandup_set: Option<bool>,
+    /// Cached live daemon-config values from `hangar/daemon_config_list` as
+    /// `(key, value)` pairs. Seeds the Settings Daemon-section rows regardless of
+    /// arrival order and survives a `set_health` rebuild (each is replayed into the
+    /// rebuilt state). Empty until the first list reply lands.
+    pub daemon_config_cache: Vec<(String, Option<String>)>,
+    /// A deferred daemon-config write raised by a Daemon-section edit (bool toggle,
+    /// enum cycle, or committed int overlay): the `(key, value)` awaiting the
+    /// `render` pass to fire `hangar/daemon_config_set`. `None` when idle.
+    pub pending_daemon_config_set: Option<(String, String)>,
     /// Set when the logs screen's level filter changed (P8.6), asking the glue
     /// to re-read the structured-log file under the new `--level` floor. Drained
     /// by the `render` pass. `false` when idle.
@@ -806,9 +807,11 @@ impl ScreenStates {
         state.set_members(self.member_rows.clone());
         // Carry any cached notification grid too (tcp T5), same rebuild survival.
         state.set_notify_rules(self.notify_rule_rows.clone());
-        // Carry the cached auto-standup toggle (D13) so a `set_health` rebuild keeps
-        // the live value rather than snapping the row back to OFF.
-        state.set_autostandup_enabled(self.autostandup_enabled);
+        // Replay the cached daemon-config values so a `set_health` rebuild keeps
+        // every live knob rather than snapping the rows back to their defaults.
+        for (key, value) in &self.daemon_config_cache {
+            state.set_config_value(key, value.clone());
+        }
         self.settings = Some(state);
     }
 
@@ -855,21 +858,21 @@ impl ScreenStates {
         self.pending_notify_action.take()
     }
 
-    /// Refresh the Settings Daemon-section auto-standup toggle from a
-    /// `hangar/daemon_config_get` result (D13). Caches the value so a later
-    /// `set_health` rebuild keeps it, and overlays the live settings state when it
-    /// already exists (mirrors [`Self::set_notify_rules`]).
-    pub const fn set_autostandup_enabled(&mut self, on: bool) {
-        self.autostandup_enabled = on;
+    /// Apply a full `hangar/daemon_config_list` result: cache every `(key, value)`
+    /// so a later `set_health` rebuild keeps them, and overlay the live settings
+    /// state when it already exists (mirrors [`Self::set_notify_rules`]).
+    pub fn set_daemon_config_entries(&mut self, entries: Vec<(String, Option<String>)>) {
+        self.daemon_config_cache.clone_from(&entries);
         if let Some(s) = self.settings.as_mut() {
-            s.set_autostandup_enabled(on);
+            for (key, value) in entries {
+                s.set_config_value(&key, value);
+            }
         }
     }
 
-    /// Take the pending `autostandup.enabled` write raised by the Daemon-section
-    /// toggle (`a`, D13), if any.
-    pub const fn take_pending_autostandup_set(&mut self) -> Option<bool> {
-        self.pending_autostandup_set.take()
+    /// Take the pending daemon-config write raised by a Daemon-section edit, if any.
+    pub fn take_pending_daemon_config_set(&mut self) -> Option<(String, String)> {
+        self.pending_daemon_config_set.take()
     }
 
     /// The Notifications grid's current edit scope (global/workspace,
@@ -1267,10 +1270,11 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
                             scope: notify_scope,
                         });
                     }
-                    // `a` on the Daemon section flipped the auto-standup toggle (D13):
-                    // defer the `hangar/daemon_config_set` write for the render pass.
-                    Some(SettingsIntent::ToggleAutostandup(on)) => {
-                        states.pending_autostandup_set = Some(on);
+                    // A Daemon-section edit (bool/enum/int) asked to persist one
+                    // knob: defer the `hangar/daemon_config_set` write for the
+                    // render pass, which re-reads the whole config afterwards.
+                    Some(SettingsIntent::SetDaemonConfig { key, value }) => {
+                        states.pending_daemon_config_set = Some((key, value));
                     }
                     // KeychainWrite / New / Rename land in their own beads.
                     _ => {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -1229,6 +1229,10 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
                 // (else the settings screen goes dead and stops navigating).
                 let ev = if matches!(key.code, KeyCode::Esc) {
                     SettingsEvent::Esc
+                } else if matches!(key.code, KeyCode::Up) {
+                    SettingsEvent::CursorUp
+                } else if matches!(key.code, KeyCode::Down) {
+                    SettingsEvent::CursorDown
                 } else if let Some(c) = key_char(key) {
                     SettingsEvent::Key(c)
                 } else {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -433,6 +433,15 @@ pub enum SettingsEvent {
     /// A printable key. While the key-entry modal is open, printable chars
     /// extend the in-flight key value.
     Key(char),
+    /// Move the in-section cursor up one row (the `↑` arrow).
+    ///
+    /// The cursor is bound to the arrows rather than a printable char because the
+    /// routing layer claims every uppercase tab-switch char (`K` → Kanban, …)
+    /// BEFORE the screen reducer sees it, so a `J`/`K` cursor could only ever move
+    /// one way. Arrows are unclaimed, so both directions reach this reducer.
+    CursorUp,
+    /// Move the in-section cursor down one row (the `↓` arrow).
+    CursorDown,
     /// Escape — aborts whichever modal is open.
     Esc,
     /// The daemon stream dropped (flips the connection status to red).
@@ -506,6 +515,25 @@ pub fn reduce_settings(state: &SettingsState, ev: SettingsEvent) -> SettingsRedu
         SettingsEvent::Esc => reduce_esc(state),
         SettingsEvent::DaemonDisconnected => daemon_disconnected(state),
         SettingsEvent::Key(c) => reduce_key(state, c),
+        SettingsEvent::CursorUp => reduce_cursor(state, -1),
+        SettingsEvent::CursorDown => reduce_cursor(state, 1),
+    }
+}
+
+/// Move the active section's row cursor by `delta`. On the Daemon section that is
+/// the config-knob cursor; on Workspaces/Keys it is the in-section list
+/// selection. A cursor key is inert while a modal owns the keyboard — the
+/// key-entry modal and the numeric overlay both capture the arrows rather than
+/// let them scroll the pane underneath. The Notifications grid keeps its own
+/// 2D cursor keys (`J`/`K` × `h`/`l`) and is left alone here.
+fn reduce_cursor(state: &SettingsState, delta: i32) -> SettingsReduction {
+    if state.key_entry.is_some() || state.config_input.is_some() {
+        return unchanged(state);
+    }
+    match state.section {
+        SettingsSection::Daemon => move_config_sel(state, delta),
+        SettingsSection::Notifications => unchanged(state),
+        _ => move_list(state, delta),
     }
 }
 
@@ -571,15 +599,19 @@ fn workspace_intent(
 }
 
 /// Handle a key on the Daemon section: `j`/`k` leave to the adjacent section,
-/// `J`/`K` move the config-row cursor, Enter/Space edit the selected knob, and
-/// `a` is the auto-standup shortcut (toggles `autostandup.enabled` from anywhere
-/// in the section, regardless of the cursor).
+/// Enter/Space edit the selected knob, and `a` is the auto-standup shortcut
+/// (toggles `autostandup.enabled` from anywhere in the section, regardless of the
+/// cursor).
+///
+/// The config-row cursor is NOT bound here: it is [`SettingsEvent::CursorUp`] /
+/// [`SettingsEvent::CursorDown`] (the arrows). A `J`/`K` pair looks natural but
+/// cannot work — the routing layer maps `K` to the Kanban tab before the key ever
+/// reaches this reducer, so `K` would yank the user off Settings while `J` moved
+/// the cursor: a cursor that only travels one way.
 fn reduce_daemon_key(state: &SettingsState, c: char) -> SettingsReduction {
     match c {
         'j' => move_section(state, SettingsSection::next),
         'k' => move_section(state, SettingsSection::prev),
-        'J' => move_config_sel(state, 1),
-        'K' => move_config_sel(state, -1),
         '\n' | '\r' | ' ' => edit_config_row(state, state.config_sel),
         'a' => edit_autostandup_shortcut(state),
         _ => unchanged(state),
@@ -1024,7 +1056,7 @@ fn render_daemon_body(
             buf,
             4,
             row,
-            "J/K move · enter/space edit · [a] auto-standup",
+            "↑/↓ move · enter/space edit · [a] auto-standup",
             MUTED,
         );
         row += 1;

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -24,6 +24,7 @@
 //! [`KeyMaterial::expose`] reveals the raw bytes, at the single call site that
 //! performs the actual keychain write.
 
+use ainb_hangar_core::daemon_config::{ConfigKind, DAEMON_CONFIG_REGISTRY, parse_bool_token};
 use ainb_hangar_proto::settings::{HealthSnapshot, KeyRow, ProviderRow, WorkspaceRow};
 use ainb_hangar_proto::snapshots::{MemberWireRow, NotifyRuleWireRow};
 use ainb_hangar_proto::{Channel, ChannelSet};
@@ -228,18 +229,38 @@ pub struct SettingsState {
     connection: ConnectionStatus,
     /// The key-entry modal's in-flight value, present while the modal is open.
     key_entry: Option<KeyMaterial>,
-    /// The live `autostandup.enabled` daemon-config toggle (D13). Read from the
-    /// daemon's `daemon_config` via `hangar/daemon_config_get` and flipped with `a`
-    /// on the Daemon section (writing back via `hangar/daemon_config_set`). Defaults
-    /// OFF until the daemon snapshot lands — matching the coded server default.
-    autostandup_enabled: bool,
+    /// The live stored value of every daemon-config knob, indexed 1:1 to
+    /// [`DAEMON_CONFIG_REGISTRY`]. `None` means the knob has no stored row (the
+    /// descriptor's coded default applies). Read from the daemon via
+    /// `hangar/daemon_config_list` and written back per-knob via
+    /// `hangar/daemon_config_set`.
+    config_values: Vec<Option<String>>,
+    /// The cursor over the Daemon-section config rows (0..registry len). Only
+    /// meaningful while the Daemon section is active.
+    config_sel: usize,
+    /// The in-flight numeric-input overlay for an `Int` knob (opened with
+    /// Enter/Space on an int row). `None` when no overlay is open.
+    config_input: Option<ConfigInput>,
+}
+
+/// The in-flight numeric-input overlay for editing an `Int` daemon-config knob.
+///
+/// Holds the registry index being edited and the digits typed so far. Enter
+/// commits (validated against the descriptor's range); Esc cancels in a single
+/// press (clearing this — never a partial step-back).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfigInput {
+    /// The [`DAEMON_CONFIG_REGISTRY`] index being edited.
+    reg_index: usize,
+    /// The digits typed so far.
+    buffer: String,
 }
 
 impl SettingsState {
     /// A fresh settings state from the four daemon snapshots, landing on the
     /// daemon section with connection status derived from `health.connected`.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         health: HealthSnapshot,
         providers: Vec<ProviderRow>,
         keys: Vec<KeyRow>,
@@ -264,8 +285,49 @@ impl SettingsState {
             list_selected: 0,
             connection,
             key_entry: None,
-            autostandup_enabled: false,
+            config_values: vec![None; DAEMON_CONFIG_REGISTRY.len()],
+            config_sel: 0,
+            config_input: None,
         }
+    }
+
+    /// The effective value string for the config knob at registry `idx`: the
+    /// stored value when set, else the descriptor's coded default. Panics only on
+    /// an out-of-range index, which the reducer/render never produce (both clamp
+    /// to the registry length).
+    #[must_use]
+    fn config_effective(&self, idx: usize) -> &str {
+        self.config_values[idx]
+            .as_deref()
+            .unwrap_or(DAEMON_CONFIG_REGISTRY[idx].default)
+    }
+
+    /// Overwrite one knob's live value by key (from a `daemon_config_list`/`_set`
+    /// reply). An unknown key is ignored so a stray/legacy key can't panic.
+    pub fn set_config_value(&mut self, key: &str, value: Option<String>) {
+        if let Some(idx) = DAEMON_CONFIG_REGISTRY.iter().position(|d| d.key == key) {
+            self.config_values[idx] = value;
+        }
+    }
+
+    /// The live config values, indexed to [`DAEMON_CONFIG_REGISTRY`] (for tests +
+    /// the glue's `set_health` carry-over).
+    #[must_use]
+    pub fn config_values(&self) -> &[Option<String>] {
+        &self.config_values
+    }
+
+    /// The Daemon-section config-row cursor (for tests).
+    #[must_use]
+    pub const fn config_sel(&self) -> usize {
+        self.config_sel
+    }
+
+    /// The in-flight numeric overlay's buffer, or `None` when no overlay is open
+    /// (for tests + render).
+    #[must_use]
+    pub fn config_input_buffer(&self) -> Option<&str> {
+        self.config_input.as_ref().map(|c| c.buffer.as_str())
     }
 
     /// The active section.
@@ -344,18 +406,24 @@ impl SettingsState {
         self.key_entry.is_some()
     }
 
-    /// The live `autostandup.enabled` toggle value (D13). Read from the daemon and
-    /// flipped with `a` on the Daemon section.
+    /// The live `autostandup.enabled` value, decoded from the generic config map
+    /// (the single internal source) with the daemon's tolerant bool parse — a
+    /// convenience view kept for the `a` shortcut + call sites that want the bool.
     #[must_use]
-    pub const fn autostandup_enabled(&self) -> bool {
-        self.autostandup_enabled
+    pub fn autostandup_enabled(&self) -> bool {
+        DAEMON_CONFIG_REGISTRY
+            .iter()
+            .position(|d| d.key == ainb_hangar_core::daemon_config::KEY_AUTOSTANDUP_ENABLED)
+            .is_some_and(|idx| parse_bool_token(self.config_effective(idx)).unwrap_or(false))
     }
 
-    /// Overwrite the `autostandup.enabled` toggle from a `hangar/daemon_config_get`
-    /// snapshot (or a post-write re-read). Keeps the live pane in sync with the
-    /// daemon's stored value.
-    pub const fn set_autostandup_enabled(&mut self, on: bool) {
-        self.autostandup_enabled = on;
+    /// Overwrite the `autostandup.enabled` value from a snapshot/re-read, writing
+    /// through the generic config map so there is one internal source of truth.
+    pub fn set_autostandup_enabled(&mut self, on: bool) {
+        self.set_config_value(
+            ainb_hangar_core::daemon_config::KEY_AUTOSTANDUP_ENABLED,
+            Some(if on { "true" } else { "false" }.to_string()),
+        );
     }
 }
 
@@ -404,11 +472,17 @@ pub enum SettingsIntent {
         /// The new push-channel set after the toggle.
         channels: ChannelSet,
     },
-    /// Toggle the global `autostandup.enabled` daemon-config value (`a` on the
-    /// Daemon section, D13). Carries the NEW value; the glue maps it to a
-    /// `hangar/daemon_config_set` write (key `autostandup.enabled`), whose reply
-    /// re-reads the value so the pane reflects the persisted state.
-    ToggleAutostandup(bool),
+    /// Persist one daemon-config knob (edited on the Daemon section: a bool
+    /// toggle, an enum cycle, or a committed int overlay). Carries the registry
+    /// `key` + the NEW normalized `value`; the glue maps it to a
+    /// `hangar/daemon_config_set` write, whose reply re-reads the whole config so
+    /// the pane reflects the persisted state.
+    SetDaemonConfig {
+        /// The `daemon_config` registry key being written.
+        key: String,
+        /// The new value to persist (already normalized by the editor).
+        value: String,
+    },
     /// Re-fetch the Notifications grid for the current scope (`g` flipped the
     /// grid's global/workspace scope, agents-in-a-box-cqh). The glue maps it to a
     /// `hangar/notify_rules_list` scoped to the state's [`SettingsState::notify_scope`]
@@ -440,10 +514,19 @@ fn reduce_key(state: &SettingsState, c: char) -> SettingsReduction {
     if state.key_entry.is_some() {
         return reduce_key_entry_key(state, c);
     }
+    // The numeric-input overlay owns the keyboard while open (digits/commit/cancel).
+    if state.config_input.is_some() {
+        return reduce_config_input_key(state, c);
+    }
     // The Notifications grid owns a 2D cursor (kind × channel) + a toggle, so it
     // handles its own keys; `j`/`k` still move between sections.
     if state.section == SettingsSection::Notifications {
         return reduce_notify_key(state, c);
+    }
+    // The Daemon section is a cursor over the config knobs (J/K move, Enter/Space
+    // edit) plus the `a` auto-standup shortcut; `j`/`k` still leave the section.
+    if state.section == SettingsSection::Daemon {
+        return reduce_daemon_key(state, c);
     }
     match c {
         'j' => move_section(state, SettingsSection::next),
@@ -452,9 +535,6 @@ fn reduce_key(state: &SettingsState, c: char) -> SettingsReduction {
         'J' => move_list(state, 1),
         'K' => move_list(state, -1),
         'n' if state.section == SettingsSection::Keys => open_key_entry(state),
-        // `a` on the Daemon section flips the global auto-standup toggle (D13):
-        // optimistic local flip + a `ToggleAutostandup` intent the glue persists.
-        'a' if state.section == SettingsSection::Daemon => toggle_autostandup(state),
         // Workspace pane controls (P5.5): s set-active, d toggle-default,
         // n new, r rename. All scoped to the Workspaces section.
         's' if state.section == SettingsSection::Workspaces => {
@@ -490,17 +570,137 @@ fn workspace_intent(
     )
 }
 
-/// Flip the global `autostandup.enabled` toggle (`a` on the Daemon section, D13):
-/// update the pane optimistically so the row flips immediately, and emit a
-/// [`SettingsIntent::ToggleAutostandup`] carrying the NEW value for the glue to
-/// persist (`hangar/daemon_config_set`). The post-write re-read reconciles.
-fn toggle_autostandup(state: &SettingsState) -> SettingsReduction {
+/// Handle a key on the Daemon section: `j`/`k` leave to the adjacent section,
+/// `J`/`K` move the config-row cursor, Enter/Space edit the selected knob, and
+/// `a` is the auto-standup shortcut (toggles `autostandup.enabled` from anywhere
+/// in the section, regardless of the cursor).
+fn reduce_daemon_key(state: &SettingsState, c: char) -> SettingsReduction {
+    match c {
+        'j' => move_section(state, SettingsSection::next),
+        'k' => move_section(state, SettingsSection::prev),
+        'J' => move_config_sel(state, 1),
+        'K' => move_config_sel(state, -1),
+        '\n' | '\r' | ' ' => edit_config_row(state, state.config_sel),
+        'a' => edit_autostandup_shortcut(state),
+        _ => unchanged(state),
+    }
+}
+
+/// Move the Daemon-section config-row cursor by `delta`, clamped to the registry.
+fn move_config_sel(state: &SettingsState, delta: i32) -> SettingsReduction {
     let mut next = state.clone();
-    let new_value = !next.autostandup_enabled;
-    next.autostandup_enabled = new_value;
+    let max = DAEMON_CONFIG_REGISTRY.len().saturating_sub(1);
+    if delta < 0 {
+        next.config_sel = next.config_sel.saturating_sub(1);
+    } else {
+        next.config_sel = (next.config_sel + 1).min(max);
+    }
+    no_intent(next)
+}
+
+/// Edit the config knob at registry `idx`: toggle a bool, cycle an enum, or open
+/// the numeric overlay for an int. Bool/enum edits flip the pane optimistically
+/// and emit a [`SettingsIntent::SetDaemonConfig`] the glue persists; the int case
+/// opens the overlay and emits nothing until Enter commits.
+fn edit_config_row(state: &SettingsState, idx: usize) -> SettingsReduction {
+    let Some(desc) = DAEMON_CONFIG_REGISTRY.get(idx) else {
+        return unchanged(state);
+    };
+    match desc.kind {
+        ConfigKind::Bool => {
+            let now = parse_bool_token(state.config_effective(idx)).unwrap_or(false);
+            let value = if now { "false" } else { "true" };
+            commit_config(state, idx, value.to_string())
+        }
+        ConfigKind::Enum { variants } => {
+            let cur = state.config_effective(idx);
+            // Cycle to the next variant after the current one (wrapping); default
+            // to the first when the current value is not a known variant.
+            let pos = variants.iter().position(|v| v.eq_ignore_ascii_case(cur)).unwrap_or(0);
+            let next_variant = variants[(pos + 1) % variants.len()];
+            commit_config(state, idx, next_variant.to_string())
+        }
+        ConfigKind::Int { .. } => {
+            let mut next = state.clone();
+            next.config_input = Some(ConfigInput {
+                reg_index: idx,
+                buffer: state.config_effective(idx).to_string(),
+            });
+            no_intent(next)
+        }
+    }
+}
+
+/// The `a` shortcut: toggle `autostandup.enabled` from anywhere in the Daemon
+/// section (independent of the cursor), matching the long-standing hotkey.
+fn edit_autostandup_shortcut(state: &SettingsState) -> SettingsReduction {
+    match DAEMON_CONFIG_REGISTRY
+        .iter()
+        .position(|d| d.key == ainb_hangar_core::daemon_config::KEY_AUTOSTANDUP_ENABLED)
+    {
+        Some(idx) => edit_config_row(state, idx),
+        None => unchanged(state),
+    }
+}
+
+/// Optimistically set knob `idx` to `value` and emit the persist intent. The
+/// glue writes it via `hangar/daemon_config_set`, then re-reads the whole config
+/// so the pane reconciles to the daemon's stored value.
+fn commit_config(state: &SettingsState, idx: usize, value: String) -> SettingsReduction {
+    let mut next = state.clone();
+    next.config_values[idx] = Some(value.clone());
     SettingsReduction {
         state: next,
-        intent: Some(SettingsIntent::ToggleAutostandup(new_value)),
+        intent: Some(SettingsIntent::SetDaemonConfig {
+            key: DAEMON_CONFIG_REGISTRY[idx].key.to_string(),
+            value,
+        }),
+    }
+}
+
+/// Handle a key while the numeric-input overlay is open: Enter commits (only when
+/// the typed value passes the descriptor's range validation — an invalid value
+/// simply closes the overlay without a write), Backspace trims, a digit extends
+/// the buffer, and every other key is ignored. Esc is handled by [`reduce_esc`]
+/// and cancels in a single press.
+fn reduce_config_input_key(state: &SettingsState, c: char) -> SettingsReduction {
+    let Some(input) = &state.config_input else {
+        return unchanged(state);
+    };
+    match c {
+        '\n' | '\r' => {
+            let idx = input.reg_index;
+            let desc = &DAEMON_CONFIG_REGISTRY[idx];
+            // Validate against the descriptor; a valid value commits + closes, an
+            // invalid one just closes (no write) so a bad number never persists.
+            match desc.validate(&input.buffer) {
+                Ok(value) => {
+                    let mut committed = commit_config(state, idx, value);
+                    committed.state.config_input = None;
+                    committed
+                }
+                Err(_) => {
+                    let mut next = state.clone();
+                    next.config_input = None;
+                    no_intent(next)
+                }
+            }
+        }
+        '\u{8}' | '\u{7f}' => {
+            let mut next = state.clone();
+            if let Some(inp) = next.config_input.as_mut() {
+                inp.buffer.pop();
+            }
+            no_intent(next)
+        }
+        d if d.is_ascii_digit() => {
+            let mut next = state.clone();
+            if let Some(inp) = next.config_input.as_mut() {
+                inp.buffer.push(d);
+            }
+            no_intent(next)
+        }
+        _ => unchanged(state),
     }
 }
 
@@ -612,9 +812,12 @@ fn reduce_key_entry_key(state: &SettingsState, c: char) -> SettingsReduction {
     }
 }
 
-/// Esc: abort the key-entry modal if open; otherwise a no-op.
+/// Esc: cancel whichever overlay is open in a SINGLE press — the numeric config
+/// input or the key-entry modal — clearing it outright (never a partial
+/// step-back that would leave the overlay half-open). A no-op when neither is up.
 fn reduce_esc(state: &SettingsState) -> SettingsReduction {
     let mut next = state.clone();
+    next.config_input = None;
     next.key_entry = None;
     no_intent(next)
 }
@@ -737,10 +940,12 @@ fn render_member_rows(
 }
 
 /// Paint the Daemon section body: the socket-path + connection-status line, then
-/// the global auto-standup toggle (D13). ON paints in `SELECTION_GREEN` with a
-/// `▶` indicator + filled dot; OFF is muted with a hollow dot. `[a] toggle` names
-/// the key right by the control (house rule). Returns the next free row. Split out
-/// of [`render_settings`] to keep that function within the line cap.
+/// EVERY daemon-config knob (one row per [`DAEMON_CONFIG_REGISTRY`] descriptor)
+/// showing its label + live value. The `▶` cursor (in `SELECTION_GREEN`) marks
+/// the selected row; a bool ON row also paints green with a filled dot. The key
+/// hints (`J/K move · enter edit · [a] auto-standup`) sit right by the control
+/// (house rule). Returns the next free row. Split out of [`render_settings`] to
+/// keep that function within the line cap.
 fn render_daemon_body(
     buf: &mut WireBuffer,
     area_w: u16,
@@ -752,10 +957,12 @@ fn render_daemon_body(
     const GREEN: Color = Color::rgb(100, 200, 100);
     const RED: Color = Color::rgb(220, 100, 100);
     const TEXT: Color = Color::rgb(220, 220, 230);
+    const MUTED: Color = Color::rgb(120, 120, 140);
     const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
 
-    let put = |buf: &mut WireBuffer, row: u16, s: &str, color: Color| {
-        for (ch, cx) in s.chars().zip(4..area_w) {
+    let section_active = state.section == SettingsSection::Daemon;
+    let put = |buf: &mut WireBuffer, x: u16, row: u16, s: &str, color: Color| {
+        for (ch, cx) in s.chars().zip(x..area_w) {
             let mut cell = Cell::new(ch.to_string());
             cell.fg = Some(color);
             buf.push(Coord::new(cx, row), cell);
@@ -769,23 +976,56 @@ fn render_daemon_body(
         };
         put(
             buf,
+            4,
             row,
             &format!("{} · {status}", state.health.socket_path),
             color,
         );
         row += 1;
     }
-    if row < bottom {
-        let (mark, dot, label, tog_color) = if state.autostandup_enabled {
-            ("▶ ", "●", "on", SELECTION_GREEN)
-        } else {
-            ("  ", "○", "off", TEXT)
+
+    for (idx, desc) in DAEMON_CONFIG_REGISTRY.iter().enumerate() {
+        if row >= bottom {
+            break;
+        }
+        let selected = section_active && idx == state.config_sel;
+        let cursor = if selected { "▶ " } else { "  " };
+        let value = state.config_effective(idx);
+        // A bool row shows a ●/○ dot; other kinds show the raw value. A selected
+        // row (or a bool that is ON) accents green; the rest are plain text.
+        let (shown, color) = match desc.kind {
+            ConfigKind::Bool => {
+                let on = parse_bool_token(value).unwrap_or(false);
+                let dot = if on { "● on" } else { "○ off" };
+                let color = if on { SELECTION_GREEN } else { TEXT };
+                (
+                    dot.to_string(),
+                    if selected { SELECTION_GREEN } else { color },
+                )
+            }
+            _ => (
+                value.to_string(),
+                if selected { SELECTION_GREEN } else { TEXT },
+            ),
         };
         put(
             buf,
+            4,
             row,
-            &format!("{mark}Auto-standup: {dot} {label}  ·  [a] toggle"),
-            tog_color,
+            &format!("{cursor}{}: {shown}", desc.label),
+            color,
+        );
+        row += 1;
+    }
+
+    // Key hints right by the control (house rule).
+    if row < bottom {
+        put(
+            buf,
+            4,
+            row,
+            "J/K move · enter/space edit · [a] auto-standup",
+            MUTED,
         );
         row += 1;
     }
@@ -1021,4 +1261,65 @@ pub fn render_settings(
     if let Some(km) = &state.key_entry {
         render_key_entry_modal(buf, area_w, area_h, km.expose().chars().count());
     }
+    if let Some(input) = &state.config_input {
+        render_config_input_overlay(buf, area_w, area_h, input);
+    }
+}
+
+/// Render the numeric-input overlay for editing an int daemon-config knob: a
+/// centred box showing the knob's label, its range, and the digits typed so far
+/// with a caret. `enter` commits, `esc` cancels — both named in the box. Never
+/// masks the value (unlike the key-entry modal, an int is not a secret).
+fn render_config_input_overlay(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    area_h: u16,
+    input: &ConfigInput,
+) {
+    use ainb_plugin_sdk::{Cell, Color, Coord};
+    const CORNFLOWER: Color = Color::rgb(100, 149, 237);
+    const GOLD: Color = Color::rgb(255, 215, 0);
+    const TEXT: Color = Color::rgb(220, 220, 230);
+    const MUTED: Color = Color::rgb(120, 120, 140);
+
+    let desc = &DAEMON_CONFIG_REGISTRY[input.reg_index];
+    let range = desc.type_hint();
+    let title = format!(" {} ", desc.label);
+    let value_line = format!("{}_", input.buffer);
+    let hint = "enter commit · esc cancel";
+
+    // A box sized to the widest line, centred in the area.
+    let inner_w = title.len().max(range.len()).max(value_line.len()).max(hint.len());
+    let box_w = u16::try_from(inner_w + 4).unwrap_or(24).min(area_w);
+    let box_h: u16 = 6;
+    let x0 = area_w.saturating_sub(box_w) / 2;
+    let y0 = area_h.saturating_sub(box_h) / 2;
+
+    let put = |buf: &mut WireBuffer, x: u16, y: u16, s: &str, color: Color| {
+        for (i, ch) in s.chars().enumerate() {
+            let cx = x + u16::try_from(i).unwrap_or(0);
+            if cx >= area_w {
+                break;
+            }
+            let mut cell = Cell::new(ch.to_string());
+            cell.fg = Some(color);
+            buf.push(Coord::new(cx, y), cell);
+        }
+    };
+
+    // Rounded border.
+    let top = format!("╭{}╮", "─".repeat(box_w.saturating_sub(2) as usize));
+    let bot = format!("╰{}╯", "─".repeat(box_w.saturating_sub(2) as usize));
+    put(buf, x0, y0, &top, CORNFLOWER);
+    for row in 1..box_h.saturating_sub(1) {
+        put(buf, x0, y0 + row, "│", CORNFLOWER);
+        put(buf, x0 + box_w.saturating_sub(1), y0 + row, "│", CORNFLOWER);
+    }
+    put(buf, x0, y0 + box_h.saturating_sub(1), &bot, CORNFLOWER);
+
+    let tx = x0 + 2;
+    put(buf, tx, y0 + 1, &title, GOLD);
+    put(buf, tx, y0 + 2, &range, MUTED);
+    put(buf, tx, y0 + 3, &value_line, TEXT);
+    put(buf, tx, y0 + 4, hint, MUTED);
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -248,12 +248,24 @@ pub struct SettingsState {
 /// Holds the registry index being edited and the digits typed so far. Enter
 /// commits (validated against the descriptor's range); Esc cancels in a single
 /// press (clearing this — never a partial step-back).
+///
+/// The buffer opens EMPTY rather than seeded with the current value: digits
+/// append, so a seeded `15` turned a user typing `3` into `153` — the opposite of
+/// the intent. The current value is shown as a ghost hint instead (see
+/// [`render_config_input_overlay`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ConfigInput {
     /// The [`DAEMON_CONFIG_REGISTRY`] index being edited.
     reg_index: usize,
     /// The digits typed so far.
     buffer: String,
+    /// The value in force while the overlay is open, shown as a ghost hint so
+    /// the human can see what they are replacing.
+    current: String,
+    /// The rejection message from the last failed Enter, painted in the box. The
+    /// overlay stays open on an invalid value so the human can correct it rather
+    /// than silently losing the edit.
+    error: Option<String>,
 }
 
 impl SettingsState {
@@ -328,6 +340,13 @@ impl SettingsState {
     #[must_use]
     pub fn config_input_buffer(&self) -> Option<&str> {
         self.config_input.as_ref().map(|c| c.buffer.as_str())
+    }
+
+    /// The rejection message shown in the open numeric overlay, if the last Enter
+    /// was refused by the descriptor's validation (for tests + render).
+    #[must_use]
+    pub fn config_input_error(&self) -> Option<&str> {
+        self.config_input.as_ref().and_then(|c| c.error.as_deref())
     }
 
     /// The active section.
@@ -656,7 +675,9 @@ fn edit_config_row(state: &SettingsState, idx: usize) -> SettingsReduction {
             let mut next = state.clone();
             next.config_input = Some(ConfigInput {
                 reg_index: idx,
-                buffer: state.config_effective(idx).to_string(),
+                buffer: String::new(),
+                current: state.config_effective(idx).to_string(),
+                error: None,
             });
             no_intent(next)
         }
@@ -692,9 +713,10 @@ fn commit_config(state: &SettingsState, idx: usize, value: String) -> SettingsRe
 
 /// Handle a key while the numeric-input overlay is open: Enter commits (only when
 /// the typed value passes the descriptor's range validation — an invalid value
-/// simply closes the overlay without a write), Backspace trims, a digit extends
-/// the buffer, and every other key is ignored. Esc is handled by [`reduce_esc`]
-/// and cancels in a single press.
+/// keeps the overlay OPEN and paints the descriptor's own rejection message, so a
+/// mistyped number is correctable rather than silently discarded), Backspace
+/// trims, a digit extends the buffer, and every other key is ignored. Esc is
+/// handled by [`reduce_esc`] and cancels in a single press.
 fn reduce_config_input_key(state: &SettingsState, c: char) -> SettingsReduction {
     let Some(input) = &state.config_input else {
         return unchanged(state);
@@ -703,17 +725,21 @@ fn reduce_config_input_key(state: &SettingsState, c: char) -> SettingsReduction 
         '\n' | '\r' => {
             let idx = input.reg_index;
             let desc = &DAEMON_CONFIG_REGISTRY[idx];
-            // Validate against the descriptor; a valid value commits + closes, an
-            // invalid one just closes (no write) so a bad number never persists.
+            // Validate against the descriptor; a valid value commits + closes. An
+            // invalid one keeps the overlay open carrying `validate`'s human error
+            // (e.g. "must be between 1 and 1440, got 99999") — never a silent
+            // close, and never a write.
             match desc.validate(&input.buffer) {
                 Ok(value) => {
                     let mut committed = commit_config(state, idx, value);
                     committed.state.config_input = None;
                     committed
                 }
-                Err(_) => {
+                Err(msg) => {
                     let mut next = state.clone();
-                    next.config_input = None;
+                    if let Some(inp) = next.config_input.as_mut() {
+                        inp.error = Some(msg);
+                    }
                     no_intent(next)
                 }
             }
@@ -722,6 +748,9 @@ fn reduce_config_input_key(state: &SettingsState, c: char) -> SettingsReduction 
             let mut next = state.clone();
             if let Some(inp) = next.config_input.as_mut() {
                 inp.buffer.pop();
+                // Editing clears the stale rejection: the message described the
+                // value the human is now changing.
+                inp.error = None;
             }
             no_intent(next)
         }
@@ -729,6 +758,7 @@ fn reduce_config_input_key(state: &SettingsState, c: char) -> SettingsReduction 
             let mut next = state.clone();
             if let Some(inp) = next.config_input.as_mut() {
                 inp.buffer.push(d);
+                inp.error = None;
             }
             no_intent(next)
         }
@@ -1299,9 +1329,14 @@ pub fn render_settings(
 }
 
 /// Render the numeric-input overlay for editing an int daemon-config knob: a
-/// centred box showing the knob's label, its range, and the digits typed so far
-/// with a caret. `enter` commits, `esc` cancels — both named in the box. Never
-/// masks the value (unlike the key-entry modal, an int is not a secret).
+/// centred box showing the knob's label, its range, the current value as a ghost
+/// hint, and the digits typed so far with a caret. A rejected Enter paints the
+/// descriptor's error in place of the hint line. `enter` commits, `esc` cancels —
+/// both named in the box. Never masks the value (unlike the key-entry modal, an
+/// int is not a secret).
+///
+/// Clips on BOTH axes: a pane shorter than the box must drop the overflowing rows
+/// rather than paint `Coord`s below the area ([`WireBuffer::push`] does not clip).
 fn render_config_input_overlay(
     buf: &mut WireBuffer,
     area_w: u16,
@@ -1313,21 +1348,40 @@ fn render_config_input_overlay(
     const GOLD: Color = Color::rgb(255, 215, 0);
     const TEXT: Color = Color::rgb(220, 220, 230);
     const MUTED: Color = Color::rgb(120, 120, 140);
+    const RED: Color = Color::rgb(220, 100, 100);
 
     let desc = &DAEMON_CONFIG_REGISTRY[input.reg_index];
     let range = desc.type_hint();
     let title = format!(" {} ", desc.label);
     let value_line = format!("{}_", input.buffer);
+    // The status line is the rejection when there is one, else the ghost hint
+    // naming the value being replaced.
+    let (status, status_color) = match &input.error {
+        Some(msg) => (msg.clone(), RED),
+        None => (format!("current: {}", input.current), MUTED),
+    };
     let hint = "enter commit · esc cancel";
 
-    // A box sized to the widest line, centred in the area.
-    let inner_w = title.len().max(range.len()).max(value_line.len()).max(hint.len());
+    // A box sized to the widest line, centred in the area. Width is measured in
+    // CHARS, not bytes — a non-ASCII label (`.len()`) would over-size the box and
+    // push the border off the pane.
+    let inner_w = title
+        .chars()
+        .count()
+        .max(range.chars().count())
+        .max(value_line.chars().count())
+        .max(status.chars().count())
+        .max(hint.chars().count());
     let box_w = u16::try_from(inner_w + 4).unwrap_or(24).min(area_w);
-    let box_h: u16 = 6;
+    // One row per line (title/range/value/status/hint) plus the two borders.
+    let box_h: u16 = 7.min(area_h);
     let x0 = area_w.saturating_sub(box_w) / 2;
     let y0 = area_h.saturating_sub(box_h) / 2;
 
     let put = |buf: &mut WireBuffer, x: u16, y: u16, s: &str, color: Color| {
+        if y >= area_h {
+            return;
+        }
         for (i, ch) in s.chars().enumerate() {
             let cx = x + u16::try_from(i).unwrap_or(0);
             if cx >= area_w {
@@ -1353,5 +1407,6 @@ fn render_config_input_overlay(
     put(buf, tx, y0 + 1, &title, GOLD);
     put(buf, tx, y0 + 2, &range, MUTED);
     put(buf, tx, y0 + 3, &value_line, TEXT);
-    put(buf, tx, y0 + 4, hint, MUTED);
+    put(buf, tx, y0 + 4, &status, status_color);
+    put(buf, tx, y0 + 5, hint, MUTED);
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -1001,20 +1001,28 @@ fn render_member_rows(
     row
 }
 
-/// Paint the Daemon section body: the socket-path + connection-status line, then
-/// EVERY daemon-config knob (one row per [`DAEMON_CONFIG_REGISTRY`] descriptor)
-/// showing its label + live value. The `▶` cursor (in `SELECTION_GREEN`) marks
-/// the selected row; a bool ON row also paints green with a filled dot. The key
-/// hints (`J/K move · enter edit · [a] auto-standup`) sit right by the control
-/// (house rule). Returns the next free row. Split out of [`render_settings`] to
-/// keep that function within the line cap.
+/// Paint the Daemon section body and return `(next free row, cursor row)`.
+///
+/// The body is PROGRESSIVE: only the focused section shows its editor.
+///
+/// - Inactive: the socket line plus a one-line auto-standup summary. The config
+///   rows carry a cursor that only the focused section can move, so painting five
+///   of them from an unfocused section is both unusable and (at seven rows) enough
+///   to push whole sections below the fold.
+/// - Active: the socket line, EVERY knob (one row per [`DAEMON_CONFIG_REGISTRY`]
+///   descriptor) with its label + live value, and the key hints. The `▶` cursor
+///   (in `SELECTION_GREEN`) marks the selected row; a bool ON row also paints
+///   green with a filled dot.
+///
+/// The returned cursor row is `Some` only when the section is active, and lets
+/// [`render_settings`] keep the selected knob in view when the pane scrolls.
 fn render_daemon_body(
     buf: &mut WireBuffer,
     area_w: u16,
     mut row: u16,
     bottom: u16,
     state: &SettingsState,
-) -> u16 {
+) -> (u16, Option<u16>) {
     use ainb_plugin_sdk::{Cell, Color, Coord};
     const GREEN: Color = Color::rgb(100, 200, 100);
     const RED: Color = Color::rgb(220, 100, 100);
@@ -1023,6 +1031,7 @@ fn render_daemon_body(
     const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
 
     let section_active = state.section == SettingsSection::Daemon;
+    let mut cursor_row = None;
     let put = |buf: &mut WireBuffer, x: u16, row: u16, s: &str, color: Color| {
         for (ch, cx) in s.chars().zip(x..area_w) {
             let mut cell = Cell::new(ch.to_string());
@@ -1046,11 +1055,36 @@ fn render_daemon_body(
         row += 1;
     }
 
+    // Unfocused: collapse the editor to the auto-standup summary. `a` still works
+    // from anywhere in the section, so the summary names the key that drives it.
+    if !section_active {
+        if row < bottom {
+            let on = state.autostandup_enabled();
+            let (dot, color) = if on {
+                ("● on", SELECTION_GREEN)
+            } else {
+                ("○ off", TEXT)
+            };
+            put(
+                buf,
+                6,
+                row,
+                &format!("Auto-standup: {dot}  ·  [a] toggle"),
+                color,
+            );
+            row += 1;
+        }
+        return (row, None);
+    }
+
     for (idx, desc) in DAEMON_CONFIG_REGISTRY.iter().enumerate() {
         if row >= bottom {
             break;
         }
         let selected = section_active && idx == state.config_sel;
+        if selected {
+            cursor_row = Some(row);
+        }
         let cursor = if selected { "▶ " } else { "  " };
         let value = state.config_effective(idx);
         // A bool row shows a ●/○ dot; other kinds show the raw value. A selected
@@ -1091,7 +1125,7 @@ fn render_daemon_body(
         );
         row += 1;
     }
-    row
+    (row, cursor_row)
 }
 
 /// A compact display label for an attention-kind wire token (the grid's row
@@ -1216,12 +1250,57 @@ fn render_notify_grid(
     row
 }
 
+/// Where each section landed in the unscrolled (virtual) paint, so
+/// [`render_settings`] can pick a scroll offset without re-deriving the layout.
+struct SectionLayout {
+    /// Total painted height of every section.
+    total: u16,
+    /// The active section's first row (its header).
+    active_start: u16,
+    /// One past the active section's last row.
+    active_end: u16,
+    /// The active section's selected row, when it has a cursor.
+    cursor_row: Option<u16>,
+}
+
+/// The scroll offset that keeps the active section — and its cursor — in view.
+///
+/// The pane paints top-down from a fixed origin, so with no offset a section far
+/// enough down the stack simply falls off the bottom and becomes unreachable
+/// (invisible AND unusable, since the keys that drive it give no feedback).
+///
+/// Rules, in order: show everything when it fits; otherwise scroll just far
+/// enough to reveal the active section's tail, never past its header, and finally
+/// keep the cursor row on screen when the active section is itself taller than
+/// the viewport.
+fn scroll_offset(layout: &SectionLayout, viewport_h: u16) -> u16 {
+    if viewport_h == 0 || layout.total <= viewport_h {
+        return 0;
+    }
+    let mut offset = layout.active_end.saturating_sub(viewport_h);
+    offset = offset.min(layout.active_start);
+    if let Some(cursor) = layout.cursor_row {
+        if cursor < offset {
+            offset = cursor;
+        } else if cursor >= offset + viewport_h {
+            offset = cursor + 1 - viewport_h;
+        }
+    }
+    offset.min(layout.total.saturating_sub(viewport_h))
+}
+
 /// Render the settings screen into `buf` between rows `top` and `bottom`.
 ///
-/// The five sections paint stacked top-down; the active one is accent-highlighted.
-/// When the key-entry modal is open it overlays a centred password-style input
-/// (masked, never the raw value). Width-aware: each row's value column is clipped
-/// at `area_w`.
+/// The six sections paint stacked top-down; the active one is accent-highlighted
+/// and is the only one that expands its editor. When the key-entry modal is open
+/// it overlays a centred password-style input (masked, never the raw value).
+/// Width-aware: each row's value column is clipped at `area_w`.
+///
+/// Sections are painted at VIRTUAL rows into a scratch buffer first, then the
+/// visible window is blitted in at `top`. That keeps the scroll offset a single
+/// decision made against the real layout ([`scroll_offset`]) instead of duplicating
+/// each section's height here — the sections' own painters stay the one place that
+/// knows how tall they are.
 pub fn render_settings(
     buf: &mut WireBuffer,
     area_w: u16,
@@ -1230,12 +1309,42 @@ pub fn render_settings(
     bottom: u16,
     state: &SettingsState,
 ) {
+    use ainb_plugin_sdk::Coord;
+
+    let viewport_h = bottom.saturating_sub(top);
+    let mut scratch = WireBuffer::new(area_w, u16::MAX);
+    let layout = paint_sections(&mut scratch, area_w, state);
+    let offset = scroll_offset(&layout, viewport_h);
+
+    for (coord, cell) in scratch.cells {
+        if coord.y >= offset && coord.y - offset < viewport_h {
+            buf.push(Coord::new(coord.x, top + (coord.y - offset)), cell);
+        }
+    }
+
+    // Modal overlays sit above the scrolled pane, centred on the whole area.
+    if let Some(km) = &state.key_entry {
+        render_key_entry_modal(buf, area_w, area_h, km.expose().chars().count());
+    }
+    if let Some(input) = &state.config_input {
+        render_config_input_overlay(buf, area_w, area_h, input);
+    }
+}
+
+/// Paint every section stacked from virtual row 0, reporting the resulting
+/// [`SectionLayout`]. Unbounded in height on purpose — the caller clips.
+fn paint_sections(buf: &mut WireBuffer, area_w: u16, state: &SettingsState) -> SectionLayout {
     use ainb_plugin_sdk::{Cell, Color, Coord};
     const TITLE: Color = Color::rgb(255, 215, 0);
     const TEXT: Color = Color::rgb(220, 220, 230);
     // Active-workspace indicator colour (TUI palette SELECTION_GREEN).
     const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
 
+    let top = 0;
+    let bottom = u16::MAX;
+    let mut active_start = 0;
+    let mut active_end = 0;
+    let mut cursor_row = None;
     let mut row = top;
     let put = |buf: &mut WireBuffer, x: u16, row: u16, s: &str, color: Color| {
         for (ch, cx) in s.chars().zip(x..area_w) {
@@ -1256,11 +1365,11 @@ pub fn render_settings(
         if row >= bottom {
             break;
         }
-        let marker = if section == state.section {
-            "▶ "
-        } else {
-            "  "
-        };
+        let is_active = section == state.section;
+        if is_active {
+            active_start = row;
+        }
+        let marker = if is_active { "▶ " } else { "  " };
         put(buf, 0, row, &format!("{marker}{}", section.title()), TITLE);
         row += 1;
         if row >= bottom {
@@ -1268,7 +1377,9 @@ pub fn render_settings(
         }
         match section {
             SettingsSection::Daemon => {
-                row = render_daemon_body(buf, area_w, row, bottom, state);
+                let (next, cursor) = render_daemon_body(buf, area_w, row, bottom, state);
+                row = next;
+                cursor_row = cursor.or(cursor_row);
             }
             SettingsSection::Providers => {
                 for p in &state.providers {
@@ -1317,14 +1428,16 @@ pub fn render_settings(
                 row = render_notify_grid(buf, area_w, row, bottom, state, selected);
             }
         }
+        if is_active {
+            active_end = row;
+        }
     }
 
-    // Modal overlays.
-    if let Some(km) = &state.key_entry {
-        render_key_entry_modal(buf, area_w, area_h, km.expose().chars().count());
-    }
-    if let Some(input) = &state.config_input {
-        render_config_input_overlay(buf, area_w, area_h, input);
+    SectionLayout {
+        total: row,
+        active_start,
+        active_end,
+        cursor_row,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -687,13 +687,10 @@ fn edit_config_row(state: &SettingsState, idx: usize) -> SettingsReduction {
 /// The `a` shortcut: toggle `autostandup.enabled` from anywhere in the Daemon
 /// section (independent of the cursor), matching the long-standing hotkey.
 fn edit_autostandup_shortcut(state: &SettingsState) -> SettingsReduction {
-    match DAEMON_CONFIG_REGISTRY
+    DAEMON_CONFIG_REGISTRY
         .iter()
         .position(|d| d.key == ainb_hangar_core::daemon_config::KEY_AUTOSTANDUP_ENABLED)
-    {
-        Some(idx) => edit_config_row(state, idx),
-        None => unchanged(state),
-    }
+        .map_or_else(|| unchanged(state), |idx| edit_config_row(state, idx))
 }
 
 /// Optimistically set knob `idx` to `value` and emit the persist intent. The
@@ -1469,10 +1466,10 @@ fn render_config_input_overlay(
     let value_line = format!("{}_", input.buffer);
     // The status line is the rejection when there is one, else the ghost hint
     // naming the value being replaced.
-    let (status, status_color) = match &input.error {
-        Some(msg) => (msg.clone(), RED),
-        None => (format!("current: {}", input.current), MUTED),
-    };
+    let (status, status_color) = input.error.as_ref().map_or_else(
+        || (format!("current: {}", input.current), MUTED),
+        |msg| (msg.clone(), RED),
+    );
     let hint = "enter commit · esc cancel";
 
     // A box sized to the widest line, centred in the area. Width is measured in

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
@@ -80,21 +80,23 @@ fn tui_renders_members_with_roles() {
     render_settings(&mut buf, 60, 14, 0, 14, &s);
 
     let map = glyph_map(&buf, 60);
-    // POSITIVE: both members render under the Members section as `email · role`.
+    // POSITIVE: the Daemon section lists every config knob, and both members render
+    // under the Members section as `email · role`.
     insta::assert_snapshot!(map, @r###"
       Daemon
         /tmp/hangar.sock · ● connected
-          Auto-standup: ○ off  ·  [a] toggle
+          Auto-standup: ○ off
+          Stagnant minutes: 15
+          Cooldown minutes: 60
+          Max concurrent: 1
+          Default agent: claude
+        J/K move · enter/space edit · [a] auto-standup
       Providers
       LLM Keys
       Workspaces
     ▶ Members
         amy@x.io · owner
         bob@x.io · admin
-      Notifications
-        scope: global · [g] toggle
-                      phone   web     os      atc
-        J/K kind · h/l channel · space toggle
     "###);
 
     // NON-VACUOUS COLOUR CHECK: the owner row's glyphs paint in `SELECTION_GREEN`.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
@@ -80,23 +80,28 @@ fn tui_renders_members_with_roles() {
     render_settings(&mut buf, 60, 14, 0, 14, &s);
 
     let map = glyph_map(&buf, 60);
-    // POSITIVE: the Daemon section lists every config knob, and both members render
-    // under the Members section as `email · role`.
+    // POSITIVE: both members render under the Members section as `email · role`.
+    //
+    // REGRESSION GUARD: every section below the focused one must still be on
+    // screen. When the Daemon section grew from 2 body rows to 7, this 14-row pane
+    // silently lost the ENTIRE Notifications section — a shipped feature became
+    // invisible. The unfocused Daemon section now collapses to its summary, so the
+    // `Notifications` header, `scope: global · [g] toggle`, the channel grid and
+    // its hint stay visible. Do not re-baseline those rows away.
     insta::assert_snapshot!(map, @r###"
       Daemon
         /tmp/hangar.sock · ● connected
-          Auto-standup: ○ off
-          Stagnant minutes: 15
-          Cooldown minutes: 60
-          Max concurrent: 1
-          Default agent: claude
-        ↑/↓ move · enter/space edit · [a] auto-standup
+          Auto-standup: ○ off  ·  [a] toggle
       Providers
       LLM Keys
       Workspaces
     ▶ Members
         amy@x.io · owner
         bob@x.io · admin
+      Notifications
+        scope: global · [g] toggle
+                      phone   web     os      atc
+        J/K kind · h/l channel · space toggle
     "###);
 
     // NON-VACUOUS COLOUR CHECK: the owner row's glyphs paint in `SELECTION_GREEN`.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
@@ -90,7 +90,7 @@ fn tui_renders_members_with_roles() {
           Cooldown minutes: 60
           Max concurrent: 1
           Default agent: claude
-        J/K move · enter/space edit · [a] auto-standup
+        ↑/↓ move · enter/space edit · [a] auto-standup
       Providers
       LLM Keys
       Workspaces

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -244,7 +244,11 @@ fn daemon_cursor_is_not_bound_to_j_or_k() {
     let s = reduce_settings(&state(), SettingsEvent::CursorDown).state;
     assert_eq!(s.config_sel(), 1);
     let after_k = reduce_settings(&s, SettingsEvent::Key('K')).state;
-    assert_eq!(after_k.config_sel(), 1, "`K` is a routing key, not a cursor key");
+    assert_eq!(
+        after_k.config_sel(),
+        1,
+        "`K` is a routing key, not a cursor key"
+    );
     let after_j = reduce_settings(&s, SettingsEvent::Key('J')).state;
     assert_eq!(after_j.config_sel(), 1, "`J` is not a cursor key either");
 }
@@ -265,8 +269,15 @@ fn arrows_do_not_move_the_cursor_under_an_open_overlay() {
     let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
     assert!(s.config_input_buffer().is_some(), "overlay open");
     let out = reduce_settings(&s, SettingsEvent::CursorDown);
-    assert_eq!(out.state.config_sel(), idx, "cursor frozen under the overlay");
-    assert!(out.state.config_input_buffer().is_some(), "overlay stays open");
+    assert_eq!(
+        out.state.config_sel(),
+        idx,
+        "cursor frozen under the overlay"
+    );
+    assert!(
+        out.state.config_input_buffer().is_some(),
+        "overlay stays open"
+    );
 }
 
 /// Editing the enum knob (card_agent.default) cycles to the next variant and
@@ -373,7 +384,11 @@ fn int_overlay_rejects_out_of_range_and_keeps_the_overlay_open() {
     let s = reduce_settings(&s, SettingsEvent::Key('3')).state;
     let s = reduce_settings(&s, SettingsEvent::Key('0')).state;
     let out = reduce_settings(&s, SettingsEvent::Key('\n'));
-    assert_eq!(out.state.config_input_buffer(), None, "a valid value closes it");
+    assert_eq!(
+        out.state.config_input_buffer(),
+        None,
+        "a valid value closes it"
+    );
     assert_eq!(out.state.config_values()[idx].as_deref(), Some("30"));
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -255,12 +255,11 @@ fn int_overlay_commits_valid_value() {
     for _ in 0..idx {
         s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
-    // Enter opens the overlay seeded with the current value (default "15").
+    // Enter opens the overlay EMPTY (the current value is a ghost hint, not a
+    // seed — digits append, so a seeded "15" would turn typing `3` into "153").
     let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
-    assert_eq!(s.config_input_buffer(), Some("15"));
-    // Clear the seed and type 30.
-    let s = reduce_settings(&s, SettingsEvent::Key('\u{8}')).state;
-    let s = reduce_settings(&s, SettingsEvent::Key('\u{8}')).state;
+    assert_eq!(s.config_input_buffer(), Some(""));
+    // Type 30.
     let s = reduce_settings(&s, SettingsEvent::Key('3')).state;
     let s = reduce_settings(&s, SettingsEvent::Key('0')).state;
     assert_eq!(s.config_input_buffer(), Some("30"));
@@ -277,10 +276,11 @@ fn int_overlay_commits_valid_value() {
     );
 }
 
-/// An out-of-range int is rejected on Enter: the overlay closes with NO write and
-/// NO intent (the optimistic edit never persists a bad value).
+/// An out-of-range int is rejected on Enter: NO write, NO intent, and the overlay
+/// STAYS OPEN carrying the descriptor's human error so the human can correct the
+/// number. A silent close would discard the edit with no explanation.
 #[test]
-fn int_overlay_rejects_out_of_range() {
+fn int_overlay_rejects_out_of_range_and_keeps_the_overlay_open() {
     use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
     let idx = DAEMON_CONFIG_REGISTRY
         .iter()
@@ -290,17 +290,38 @@ fn int_overlay_rejects_out_of_range() {
     for _ in 0..idx {
         s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
-    let s = reduce_settings(&s, SettingsEvent::Key('\n')).state; // open, seed "15"
-    // Append digits to make "159999" (out of the 1..1440 range).
+    let s = reduce_settings(&s, SettingsEvent::Key('\n')).state; // open, empty
+    // Type 99999 (out of the 1..1440 range).
     let mut s = s;
-    for d in ['9', '9', '9', '9'] {
+    for d in ['9', '9', '9', '9', '9'] {
         s = reduce_settings(&s, SettingsEvent::Key(d)).state;
     }
     let out = reduce_settings(&s, SettingsEvent::Key('\n'));
-    assert_eq!(out.state.config_input_buffer(), None, "overlay closed");
+    assert_eq!(
+        out.state.config_input_buffer(),
+        Some("99999"),
+        "the overlay stays open with the typed value intact"
+    );
+    assert_eq!(
+        out.state.config_input_error(),
+        Some("`autostandup.stagnant_min` must be between 1 and 1440, got 99999"),
+        "the descriptor's own message is surfaced, not discarded"
+    );
     assert_eq!(out.intent, None, "no write on an invalid value");
     // The persisted value is unchanged (still unset → default).
     assert_eq!(out.state.config_values()[idx], None);
+
+    // Correcting the value clears the error and commits.
+    let mut s = out.state;
+    for _ in 0..5 {
+        s = reduce_settings(&s, SettingsEvent::Key('\u{8}')).state;
+    }
+    assert_eq!(s.config_input_error(), None, "editing clears the rejection");
+    let s = reduce_settings(&s, SettingsEvent::Key('3')).state;
+    let s = reduce_settings(&s, SettingsEvent::Key('0')).state;
+    let out = reduce_settings(&s, SettingsEvent::Key('\n'));
+    assert_eq!(out.state.config_input_buffer(), None, "a valid value closes it");
+    assert_eq!(out.state.config_values()[idx].as_deref(), Some("30"));
 }
 
 /// Esc cancels the numeric overlay in a SINGLE press — no partial step-back that

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -280,7 +280,7 @@ fn arrows_do_not_move_the_cursor_under_an_open_overlay() {
     );
 }
 
-/// Editing the enum knob (card_agent.default) cycles to the next variant and
+/// Editing the enum knob (`card_agent.default`) cycles to the next variant and
 /// emits a `SetDaemonConfig` intent carrying the normalized value.
 #[test]
 fn enter_on_enum_row_cycles_variant_and_emits_intent() {

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -101,8 +101,8 @@ fn state() -> SettingsState {
     SettingsState::new(health(), providers(), keys(), workspaces())
 }
 
-/// `a` on the Daemon section flips the auto-standup toggle (D13): the local value
-/// inverts AND a `ToggleAutostandup` intent carries the NEW value for the glue to
+/// `a` on the Daemon section flips the auto-standup toggle: the local value
+/// inverts AND a `SetDaemonConfig` intent carries the NEW value for the glue to
 /// persist. A second `a` flips it back.
 #[test]
 fn a_on_daemon_section_toggles_autostandup_and_emits_intent() {
@@ -110,11 +110,23 @@ fn a_on_daemon_section_toggles_autostandup_and_emits_intent() {
     assert!(!s.autostandup_enabled());
     let out = reduce_settings(&s, SettingsEvent::Key('a'));
     assert!(out.state.autostandup_enabled(), "optimistic flip to ON");
-    assert_eq!(out.intent, Some(SettingsIntent::ToggleAutostandup(true)));
+    assert_eq!(
+        out.intent,
+        Some(SettingsIntent::SetDaemonConfig {
+            key: "autostandup.enabled".to_string(),
+            value: "true".to_string(),
+        })
+    );
     // Toggling again flips back to OFF and emits the matching intent.
     let out2 = reduce_settings(&out.state, SettingsEvent::Key('a'));
     assert!(!out2.state.autostandup_enabled());
-    assert_eq!(out2.intent, Some(SettingsIntent::ToggleAutostandup(false)));
+    assert_eq!(
+        out2.intent,
+        Some(SettingsIntent::SetDaemonConfig {
+            key: "autostandup.enabled".to_string(),
+            value: "false".to_string(),
+        })
+    );
 }
 
 /// The auto-standup toggle is Daemon-section-scoped: `a` on another section never
@@ -128,13 +140,157 @@ fn a_off_the_daemon_section_does_not_toggle_autostandup() {
     assert_eq!(out.intent, None);
 }
 
-/// A `hangar/daemon_config_get` snapshot sets the live toggle value the pane shows.
+/// A `hangar/daemon_config_list` snapshot sets the live toggle value the pane shows.
 #[test]
 fn set_autostandup_enabled_reflects_live_value() {
     let mut s = state();
     assert!(!s.autostandup_enabled());
     s.set_autostandup_enabled(true);
     assert!(s.autostandup_enabled());
+}
+
+/// The Daemon section renders exactly one row per registry knob — a knob added
+/// to the registry can never silently miss the TUI surface (mirror of the CLI's
+/// `cli_list_covers_every_registry_knob`).
+#[test]
+fn daemon_section_row_count_matches_registry() {
+    use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    let s = state();
+    // The live config vector is sized to the registry, so every knob has a row.
+    assert_eq!(s.config_values().len(), DAEMON_CONFIG_REGISTRY.len());
+    assert!(!DAEMON_CONFIG_REGISTRY.is_empty());
+}
+
+/// `J`/`K` move the Daemon-section cursor over the config rows, clamped at both
+/// ends.
+#[test]
+fn daemon_cursor_moves_and_clamps() {
+    use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    let s = state();
+    assert_eq!(s.config_sel(), 0);
+    let s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    assert_eq!(s.config_sel(), 1);
+    // `K` past the top clamps at 0.
+    let s = reduce_settings(&s, SettingsEvent::Key('K')).state;
+    let s = reduce_settings(&s, SettingsEvent::Key('K')).state;
+    assert_eq!(s.config_sel(), 0);
+    // `J` past the end clamps at the last row.
+    let mut s = s;
+    for _ in 0..DAEMON_CONFIG_REGISTRY.len() + 3 {
+        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    }
+    assert_eq!(s.config_sel(), DAEMON_CONFIG_REGISTRY.len() - 1);
+}
+
+/// Editing the enum knob (card_agent.default) cycles to the next variant and
+/// emits a `SetDaemonConfig` intent carrying the normalized value.
+#[test]
+fn enter_on_enum_row_cycles_variant_and_emits_intent() {
+    use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_CARD_AGENT_DEFAULT};
+    let idx = DAEMON_CONFIG_REGISTRY
+        .iter()
+        .position(|d| d.key == KEY_CARD_AGENT_DEFAULT)
+        .expect("enum knob present");
+    // Move the cursor onto the enum row.
+    let mut s = state();
+    for _ in 0..idx {
+        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    }
+    // Default is `claude`; one cycle → `codex`.
+    let out = reduce_settings(&s, SettingsEvent::Key('\n'));
+    assert_eq!(
+        out.intent,
+        Some(SettingsIntent::SetDaemonConfig {
+            key: KEY_CARD_AGENT_DEFAULT.to_string(),
+            value: "codex".to_string(),
+        })
+    );
+    assert_eq!(out.state.config_values()[idx].as_deref(), Some("codex"));
+}
+
+/// Editing an int knob opens the numeric overlay; typing digits then Enter
+/// commits the in-range value and emits a `SetDaemonConfig` intent.
+#[test]
+fn int_overlay_commits_valid_value() {
+    use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
+    let idx = DAEMON_CONFIG_REGISTRY
+        .iter()
+        .position(|d| d.key == KEY_AUTOSTANDUP_STAGNANT_MIN)
+        .expect("int knob present");
+    let mut s = state();
+    for _ in 0..idx {
+        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    }
+    // Enter opens the overlay seeded with the current value (default "15").
+    let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
+    assert_eq!(s.config_input_buffer(), Some("15"));
+    // Clear the seed and type 30.
+    let s = reduce_settings(&s, SettingsEvent::Key('\u{8}')).state;
+    let s = reduce_settings(&s, SettingsEvent::Key('\u{8}')).state;
+    let s = reduce_settings(&s, SettingsEvent::Key('3')).state;
+    let s = reduce_settings(&s, SettingsEvent::Key('0')).state;
+    assert_eq!(s.config_input_buffer(), Some("30"));
+    // Enter commits: overlay closes, value persists, intent emitted.
+    let out = reduce_settings(&s, SettingsEvent::Key('\n'));
+    assert_eq!(out.state.config_input_buffer(), None, "overlay closed");
+    assert_eq!(out.state.config_values()[idx].as_deref(), Some("30"));
+    assert_eq!(
+        out.intent,
+        Some(SettingsIntent::SetDaemonConfig {
+            key: KEY_AUTOSTANDUP_STAGNANT_MIN.to_string(),
+            value: "30".to_string(),
+        })
+    );
+}
+
+/// An out-of-range int is rejected on Enter: the overlay closes with NO write and
+/// NO intent (the optimistic edit never persists a bad value).
+#[test]
+fn int_overlay_rejects_out_of_range() {
+    use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
+    let idx = DAEMON_CONFIG_REGISTRY
+        .iter()
+        .position(|d| d.key == KEY_AUTOSTANDUP_STAGNANT_MIN)
+        .unwrap();
+    let mut s = state();
+    for _ in 0..idx {
+        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    }
+    let s = reduce_settings(&s, SettingsEvent::Key('\n')).state; // open, seed "15"
+    // Append digits to make "159999" (out of the 1..1440 range).
+    let mut s = s;
+    for d in ['9', '9', '9', '9'] {
+        s = reduce_settings(&s, SettingsEvent::Key(d)).state;
+    }
+    let out = reduce_settings(&s, SettingsEvent::Key('\n'));
+    assert_eq!(out.state.config_input_buffer(), None, "overlay closed");
+    assert_eq!(out.intent, None, "no write on an invalid value");
+    // The persisted value is unchanged (still unset → default).
+    assert_eq!(out.state.config_values()[idx], None);
+}
+
+/// Esc cancels the numeric overlay in a SINGLE press — no partial step-back that
+/// would leave the overlay half-open (the regression guard).
+#[test]
+fn esc_cancels_int_overlay_in_one_press() {
+    use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
+    let idx = DAEMON_CONFIG_REGISTRY
+        .iter()
+        .position(|d| d.key == KEY_AUTOSTANDUP_STAGNANT_MIN)
+        .unwrap();
+    let mut s = state();
+    for _ in 0..idx {
+        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    }
+    let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
+    assert!(s.config_input_buffer().is_some(), "overlay open");
+    let out = reduce_settings(&s, SettingsEvent::Esc);
+    assert_eq!(
+        out.state.config_input_buffer(),
+        None,
+        "one Esc fully cancels"
+    );
+    assert_eq!(out.intent, None);
 }
 
 /// j/k cycle through the six settings sections.
@@ -344,11 +500,17 @@ fn notify_grid_space_toggles_cell_and_emits_set_intent() {
 }
 
 /// tcp T5: the Notifications keys are section-scoped — a `space` on the Daemon
-/// section never emits a rule change, and `j`/`k` still leave the grid.
+/// section edits a daemon-config knob (never a rule change), and `j`/`k` still
+/// leave the grid.
 #[test]
 fn notify_keys_are_section_scoped_and_j_k_still_navigate() {
-    // space on Daemon does nothing.
-    assert!(reduce_settings(&state(), SettingsEvent::Key(' ')).intent.is_none());
+    // space on Daemon edits the selected config knob — it emits a SetDaemonConfig
+    // (the first row's bool toggle), never a SetNotifyRule.
+    let out = reduce_settings(&state(), SettingsEvent::Key(' '));
+    assert!(
+        matches!(out.intent, Some(SettingsIntent::SetDaemonConfig { .. })),
+        "space on Daemon edits a config knob, not a notify rule"
+    );
     // j/k move between sections even from the grid.
     let s = notify_state();
     let up = reduce_settings(&s, SettingsEvent::Key('k')).state;

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -161,25 +161,59 @@ fn daemon_section_row_count_matches_registry() {
     assert!(!DAEMON_CONFIG_REGISTRY.is_empty());
 }
 
-/// `J`/`K` move the Daemon-section cursor over the config rows, clamped at both
-/// ends.
+/// The arrows move the Daemon-section cursor over the config rows, clamped at
+/// both ends. The cursor is arrow-bound because the routing layer claims `K` for
+/// the Kanban tab before the reducer sees it — see `reduce_daemon_key`.
 #[test]
 fn daemon_cursor_moves_and_clamps() {
     use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
     let s = state();
     assert_eq!(s.config_sel(), 0);
-    let s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    let s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     assert_eq!(s.config_sel(), 1);
-    // `K` past the top clamps at 0.
-    let s = reduce_settings(&s, SettingsEvent::Key('K')).state;
-    let s = reduce_settings(&s, SettingsEvent::Key('K')).state;
+    // Up past the top clamps at 0.
+    let s = reduce_settings(&s, SettingsEvent::CursorUp).state;
+    let s = reduce_settings(&s, SettingsEvent::CursorUp).state;
     assert_eq!(s.config_sel(), 0);
-    // `J` past the end clamps at the last row.
+    // Down past the end clamps at the last row.
     let mut s = s;
     for _ in 0..DAEMON_CONFIG_REGISTRY.len() + 3 {
-        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+        s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
     assert_eq!(s.config_sel(), DAEMON_CONFIG_REGISTRY.len() - 1);
+}
+
+/// REGRESSION: `K` must NOT move the Daemon cursor. It is claimed by the routing
+/// layer (→ Kanban tab) and can never reach this reducer, so a `K` binding here
+/// would be dead code that the on-screen hint then advertises as working.
+#[test]
+fn daemon_cursor_is_not_bound_to_j_or_k() {
+    let s = reduce_settings(&state(), SettingsEvent::CursorDown).state;
+    assert_eq!(s.config_sel(), 1);
+    let after_k = reduce_settings(&s, SettingsEvent::Key('K')).state;
+    assert_eq!(after_k.config_sel(), 1, "`K` is a routing key, not a cursor key");
+    let after_j = reduce_settings(&s, SettingsEvent::Key('J')).state;
+    assert_eq!(after_j.config_sel(), 1, "`J` is not a cursor key either");
+}
+
+/// The arrows are inert while the numeric overlay owns the keyboard: an arrow
+/// must not scroll the config cursor underneath an open editor.
+#[test]
+fn arrows_do_not_move_the_cursor_under_an_open_overlay() {
+    use ainb_hangar_core::daemon_config::{DAEMON_CONFIG_REGISTRY, KEY_AUTOSTANDUP_STAGNANT_MIN};
+    let idx = DAEMON_CONFIG_REGISTRY
+        .iter()
+        .position(|d| d.key == KEY_AUTOSTANDUP_STAGNANT_MIN)
+        .unwrap();
+    let mut s = state();
+    for _ in 0..idx {
+        s = reduce_settings(&s, SettingsEvent::CursorDown).state;
+    }
+    let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
+    assert!(s.config_input_buffer().is_some(), "overlay open");
+    let out = reduce_settings(&s, SettingsEvent::CursorDown);
+    assert_eq!(out.state.config_sel(), idx, "cursor frozen under the overlay");
+    assert!(out.state.config_input_buffer().is_some(), "overlay stays open");
 }
 
 /// Editing the enum knob (card_agent.default) cycles to the next variant and
@@ -194,7 +228,7 @@ fn enter_on_enum_row_cycles_variant_and_emits_intent() {
     // Move the cursor onto the enum row.
     let mut s = state();
     for _ in 0..idx {
-        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+        s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
     // Default is `claude`; one cycle → `codex`.
     let out = reduce_settings(&s, SettingsEvent::Key('\n'));
@@ -219,7 +253,7 @@ fn int_overlay_commits_valid_value() {
         .expect("int knob present");
     let mut s = state();
     for _ in 0..idx {
-        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+        s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
     // Enter opens the overlay seeded with the current value (default "15").
     let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
@@ -254,7 +288,7 @@ fn int_overlay_rejects_out_of_range() {
         .unwrap();
     let mut s = state();
     for _ in 0..idx {
-        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+        s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
     let s = reduce_settings(&s, SettingsEvent::Key('\n')).state; // open, seed "15"
     // Append digits to make "159999" (out of the 1..1440 range).
@@ -280,7 +314,7 @@ fn esc_cancels_int_overlay_in_one_press() {
         .unwrap();
     let mut s = state();
     for _ in 0..idx {
-        s = reduce_settings(&s, SettingsEvent::Key('J')).state;
+        s = reduce_settings(&s, SettingsEvent::CursorDown).state;
     }
     let s = reduce_settings(&s, SettingsEvent::Key('\n')).state;
     assert!(s.config_input_buffer().is_some(), "overlay open");

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -149,16 +149,69 @@ fn set_autostandup_enabled_reflects_live_value() {
     assert!(s.autostandup_enabled());
 }
 
-/// The Daemon section renders exactly one row per registry knob — a knob added
-/// to the registry can never silently miss the TUI surface (mirror of the CLI's
-/// `cli_list_covers_every_registry_knob`).
+/// The focused Daemon section RENDERS exactly one row per registry knob, each
+/// labelled — a knob added to the registry can never silently miss the TUI
+/// surface (mirror of the CLI's `cli_list_emits_one_row_per_registry_knob...`).
+///
+/// This paints into a `WireBuffer` and counts the labelled rows. The test it
+/// replaces asserted `config_values().len() == DAEMON_CONFIG_REGISTRY.len()`,
+/// which is constructed as `vec![None; DAEMON_CONFIG_REGISTRY.len()]` — it could
+/// not fail, and never touched `render_daemon_body` at all.
 #[test]
-fn daemon_section_row_count_matches_registry() {
+fn daemon_section_renders_one_row_per_registry_knob() {
     use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    use ainb_plugin_hangar::screen::settings::render_settings;
+    use ainb_plugin_sdk::WireBuffer;
+
+    // Focused, and tall enough that nothing is clipped.
     let s = state();
-    // The live config vector is sized to the registry, so every knob has a row.
-    assert_eq!(s.config_values().len(), DAEMON_CONFIG_REGISTRY.len());
-    assert!(!DAEMON_CONFIG_REGISTRY.is_empty());
+    assert_eq!(s.section(), SettingsSection::Daemon, "starts focused");
+    let mut buf = WireBuffer::new(80, 40);
+    render_settings(&mut buf, 80, 40, 0, 40, &s);
+    let map = glyph_map(&buf, 80);
+
+    for desc in DAEMON_CONFIG_REGISTRY {
+        assert!(
+            map.lines().any(|l| l.contains(desc.label)),
+            "`{}` ({}) has no rendered row:\n{map}",
+            desc.label,
+            desc.key
+        );
+    }
+    // One labelled row per knob — no more, no fewer — and exactly one of them
+    // carries the cursor. (`▶` also marks the section header and the active
+    // workspace, so count it only among the knob rows.)
+    let knob_lines = || {
+        map.lines()
+            .filter(|l| DAEMON_CONFIG_REGISTRY.iter().any(|d| l.contains(d.label)))
+    };
+    assert_eq!(
+        knob_lines().filter(|l| l.contains('▶')).count(),
+        1,
+        "exactly one knob row carries the cursor:\n{map}"
+    );
+    let knob_rows = knob_lines().count();
+    assert_eq!(
+        knob_rows,
+        DAEMON_CONFIG_REGISTRY.len(),
+        "one row per knob:\n{map}"
+    );
+}
+
+/// Flatten a `WireBuffer` to a glyph map for row assertions.
+fn glyph_map(buf: &ainb_plugin_sdk::WireBuffer, cols: u16) -> String {
+    let mut grid = vec![vec![' '; cols as usize]; buf.height.min(60) as usize];
+    for (coord, cell) in &buf.cells {
+        if (coord.y as usize) < grid.len() && coord.x < cols {
+            if let Some(ch) = cell.symbol.chars().next() {
+                grid[coord.y as usize][coord.x as usize] = ch;
+            }
+        }
+    }
+    grid.into_iter()
+        .map(|r| r.into_iter().collect::<String>().trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// The arrows move the Daemon-section cursor over the config rows, clamped at

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
@@ -9,7 +9,7 @@ expression: map
       Cooldown minutes: 60
       Max concurrent: 1
       Default agent: claude
-    J/K move · enter/space edit · [a] auto-standup
+    ↑/↓ move · enter/space edit · [a] auto-standup
   Providers
   LLM Keys
   Workspaces

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
@@ -4,7 +4,12 @@ expression: map
 ---
   Daemon
     /tmp/hangar.sock · ● connected
-      Auto-standup: ○ off  ·  [a] toggle
+      Auto-standup: ○ off
+      Stagnant minutes: 15
+      Cooldown minutes: 60
+      Max concurrent: 1
+      Default agent: claude
+    J/K move · enter/space edit · [a] auto-standup
   Providers
   LLM Keys
   Workspaces

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
@@ -4,12 +4,7 @@ expression: map
 ---
   Daemon
     /tmp/hangar.sock · ● connected
-      Auto-standup: ○ off
-      Stagnant minutes: 15
-      Cooldown minutes: 60
-      Max concurrent: 1
-      Default agent: claude
-    ↑/↓ move · enter/space edit · [a] auto-standup
+      Auto-standup: ○ off  ·  [a] toggle
   Providers
   LLM Keys
   Workspaces


### PR DESCRIPTION
## Why
Only `autostandup.enabled` was reachable from the UI; the other daemon knobs could be changed only by hand-editing the `daemon_config` table.

## What
One typed **registry** (`ainb-hangar-core/src/daemon_config.rs`) is the single source of truth — key, label, kind (Bool/Int{min,max,step}/Enum), default and validation — consumed by three surfaces so a knob cannot silently miss one:
- **TUI**: `[,]`Settings → Daemon renders every knob (↑/↓ cursor, Enter/Space edit; bool toggle, enum cycle, int overlay with single-press Esc cancel).
- **CLI**: `ainb hangar daemon config list|get <key>|set <key> <value>` with `--format json|csv|markdown` and per-type validation.
- **RPC**: new `hangar/daemon_config_list`; `daemon_config_set` validates against the descriptor.

Knobs surfaced: the four auto-standup values + the agent global default. (`card_agent.last_used` is deliberately excluded — it's state the daemon overwrites on every dispatch, not config.)

## Review round (1 Critical + 4 Major + 5 minors — all fixed)
- **Critical**: the int overlay had no text-capture guard, so `routing_event` ate digits **1–4** and `q` before the overlay saw them — typing `30` switched tabs. The headline edit path did not work. Guarded at both sites + a routing-level test.
- `K` was unreachable (jumped to Kanban) while the hint promised `J/K move` → cursor moved to ↑/↓, hint made truthful.
- Descriptor defaults duplicated the typed `DEFAULT_*` consts → `coded_default!` now emits both from one literal, so drift is unrepresentable.
- `autostandup.cooldown_min: 0` was one keystroke away and degenerated the D13 gate into writing `/standup` every 60s forever → floored at 1 in both the registry and `StandupConfig::load`.
- Settings had no scroll: the grown Daemon section pushed Notifications off a 14-row pane and the snapshot had been updated to accept it → scroll/cursor-follow added; **all three snapshots now match pre-branch content byte-for-byte** (the render was fixed, not the snapshots regenerated).
- Plus: real (non-tautological) parity tests, RPC unknown-key rejection, `Vec` drain so concurrent edits can't drop a write, CLI key trim, csv/markdown implemented, overlay clipping.

## Proof
Every fix **mutation-proved** — reverted in isolation to confirm its test fails. 1477 tests pass (`--no-fail-fast`); workspace build + `cargo test --no-run` green; clippy clean on all added lines.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R
