### PR TITLE
fix(hangar-daemon): deliver the task brief to the provider (headless never worked)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -68,6 +68,12 @@ const DEFAULT_POLL_MS: u64 = 1_000;
 /// Provider runtime deadline (reference running TTL: 2.5h).
 const PROVIDER_MAX_RUNTIME: Duration = Duration::from_secs(9_000);
 /// Trailing stdout/stderr lines retained on each run for the audit tail.
+/// The brief used when a task has neither an issue nor agent instructions.
+///
+/// Never empty: a provider spawned with no prompt starts an interactive session
+/// against the daemon's null stdin and exits non-zero without working.
+const FALLBACK_PROMPT: &str = "Review the repository in your working directory and \
+     continue the work described in its context files (e.g. CLAUDE.md).";
 const TAIL_LINES: usize = 200;
 
 /// The parent-session identity the daemon stamps onto every task it spawns
@@ -570,7 +576,9 @@ async fn execute_claimed(
     // the runner threads into that provider's argv + env. A resolve fault
     // defaults the dispatch to `claude` with empty config so a misconfigured
     // agent still runs rather than stranding the task.
-    let dispatch = resolve_dispatch(pool, &task.agent_id).await.unwrap_or_default();
+    let dispatch = resolve_dispatch(pool, &task.agent_id, task.issue_id.as_deref())
+        .await
+        .unwrap_or_default();
 
     // F5: provision the run's working directory from the card's `repo_ref`.
     //
@@ -790,7 +798,7 @@ async fn execute_claimed(
             // (the interactive path already returns `anyhow::Result`).
             match dispatch.backend {
                 Backend::Claude => runner
-                    .run_claude_in(&env, task_env, &location)
+                    .run_claude_in(&env, task_env, &dispatch.invocation, &location)
                     .await
                     .map_err(anyhow::Error::from),
                 Backend::Codex => runner
@@ -1541,12 +1549,17 @@ struct ResolvedDispatch {
 ///
 /// Returns an error if the agent id is malformed or the agent / runtime row is
 /// missing — the caller falls back to the [`ResolvedDispatch::default`].
-async fn resolve_dispatch(pool: &SqlitePool, agent_id: &str) -> anyhow::Result<ResolvedDispatch> {
+async fn resolve_dispatch(
+    pool: &SqlitePool,
+    agent_id: &str,
+    issue_id: Option<&str>,
+) -> anyhow::Result<ResolvedDispatch> {
     use ainb_hangar_store::repo::agent::AgentRepo;
     use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
     let agent = AgentRepo::get(pool, agent_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("agent {agent_id} not found"))?;
+    let prompt = build_prompt(pool, issue_id, agent.instructions.as_deref()).await;
     let runtime = AgentRuntimeRepo::get(pool, &agent.runtime_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("runtime {} not found", agent.runtime_id))?;
@@ -1555,11 +1568,47 @@ async fn resolve_dispatch(pool: &SqlitePool, agent_id: &str) -> anyhow::Result<R
     Ok(ResolvedDispatch {
         backend: Backend::from_provider(provider),
         invocation: ProviderInvocation {
+            prompt,
             model: agent.model,
             cli_args: agent.cli_args,
         },
         agent_env: agent.agent_env,
     })
+}
+
+/// The brief handed to the provider non-interactively for a task.
+///
+/// Every agent CLI needs the ask on its command line — the workdir carries only
+/// CONTEXT (`CLAUDE.md`, materialised skills), never the work itself — so a task
+/// with no prompt runs nothing. Sources, in order:
+///
+/// 1. the task's issue (`title` + `description`) — the normal case,
+/// 2. the agent's own `instructions` — a chat / autopilot task with no issue,
+/// 3. [`FALLBACK_PROMPT`] — so a provider is never spawned promptless (which is
+///    an immediate non-zero exit, not a no-op).
+async fn build_prompt(
+    pool: &SqlitePool,
+    issue_id: Option<&str>,
+    agent_instructions: Option<&str>,
+) -> String {
+    use ainb_hangar_store::repo::issue::IssueRepo;
+
+    if let Some(issue_id) = issue_id {
+        if let Ok(Some(issue)) = IssueRepo::get_by_id(pool, issue_id).await {
+            let mut brief = issue.title;
+            if let Some(desc) = issue.description.filter(|d| !d.trim().is_empty()) {
+                brief.push_str("\n\n");
+                brief.push_str(&desc);
+            }
+            if !brief.trim().is_empty() {
+                return brief;
+            }
+        }
+    }
+    agent_instructions
+        .map(str::trim)
+        .filter(|i| !i.is_empty())
+        .map_or_else(|| FALLBACK_PROMPT.to_string(), ToString::to_string)
 }
 
 /// Resolve the provider wire name and owning workspace for a task's agent
@@ -1943,6 +1992,96 @@ mod tests {
         assert!(InteractiveSessions::default().drain().is_empty());
     }
 
+    /// The task brief MUST reach the provider's argv. Every agent CLI starts an
+    /// interactive session with no prompt and the daemon spawns them with a null
+    /// stdin, so a promptless dispatch runs nothing (verified: bare `claude` exits
+    /// 1 with "Input must be provided..."). Covers the issue source, the
+    /// agent-instructions fallback, and the never-empty guarantee.
+    #[tokio::test]
+    async fn dispatch_carries_the_task_brief_to_the_provider() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+        let agent = bootstrap::create_agent(pool, &ws, "worker", "claude", None).await.unwrap();
+
+        // (1) An issue's title + description become the brief.
+        let issue_id =
+            ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        IssueRepo::insert(
+            pool,
+            &NewIssue {
+                id: issue_id.clone(),
+                workspace_id: ws.clone(),
+                title: "Fix the login bug".into(),
+                description: Some("It 500s on empty password.".into()),
+                state: "open".into(),
+                creator: ainb_hangar_core::actor::ActorRef::new(
+                    ainb_hangar_core::actor::ActorKind::Member,
+                    "stevie",
+                )
+                .unwrap(),
+                created_at: 1,
+                priority: 0,
+                assignee: None,
+                due_date: None,
+                labels: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id)).await.unwrap();
+        assert_eq!(
+            disp.invocation.prompt, "Fix the login bug\n\nIt 500s on empty password.",
+            "the issue title + description must become the brief"
+        );
+
+        // …and it lands on the argv as `-p <brief>` (not just in the struct).
+        let runner = Runner::new(RunnerConfig {
+            claude_path: "claude".into(),
+            codex_path: "codex".into(),
+            copilot_path: "copilot".into(),
+            max_runtime: Duration::from_secs(1),
+            tail_lines: 1,
+            sandbox: false,
+        });
+        let (_p, argv) = runner.provider_command(disp.backend, &disp.invocation);
+        assert_eq!(
+            argv.first().map(String::as_str),
+            Some("-p"),
+            "claude must be invoked non-interactively: {argv:?}"
+        );
+        assert!(argv.contains(&"Fix the login bug\n\nIt 500s on empty password.".to_string()));
+
+        // (2) No issue → the agent's own instructions are the brief.
+        let instructed = bootstrap::create_agent(
+            pool,
+            &ws,
+            "guided",
+            "claude",
+            Some("Triage the inbox.".into()),
+        )
+        .await
+        .unwrap();
+        let disp = resolve_dispatch(pool, &instructed.id, None).await.unwrap();
+        assert_eq!(disp.invocation.prompt, "Triage the inbox.");
+
+        // (3) Neither → a non-empty fallback, never a promptless spawn.
+        let disp = resolve_dispatch(pool, &agent.id, None).await.unwrap();
+        assert!(
+            !disp.invocation.prompt.is_empty(),
+            "a prompt is never empty"
+        );
+        assert_eq!(disp.invocation.prompt, FALLBACK_PROMPT);
+    }
+
     /// Provider-honoring proof: `resolve_dispatch` selects the backend from the
     /// AGENT's provider, overriding the runtime's advertised default. A `codex`
     /// agent bound to the single `claude`-advertised host runtime dispatches the
@@ -1965,7 +2104,7 @@ mod tests {
 
         // A codex agent on that claude-advertised runtime → codex backend.
         let codex = bootstrap::create_agent(pool, &ws, "coder", "codex", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &codex.id).await.unwrap();
+        let disp = resolve_dispatch(pool, &codex.id, None).await.unwrap();
         assert_eq!(
             disp.backend,
             Backend::Codex,
@@ -1975,7 +2114,7 @@ mod tests {
         // A copilot agent on that claude-advertised runtime → copilot backend
         // (no more silent claude fallback).
         let copilot = bootstrap::create_agent(pool, &ws, "helper", "copilot", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &copilot.id).await.unwrap();
+        let disp = resolve_dispatch(pool, &copilot.id, None).await.unwrap();
         assert_eq!(
             disp.backend,
             Backend::Copilot,
@@ -1984,7 +2123,7 @@ mod tests {
 
         // A claude agent on the same runtime → claude backend.
         let claude = bootstrap::create_agent(pool, &ws, "writer", "claude", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &claude.id).await.unwrap();
+        let disp = resolve_dispatch(pool, &claude.id, None).await.unwrap();
         assert_eq!(disp.backend, Backend::Claude);
 
         // An agent with NO provider override falls back to the runtime's provider.
@@ -2006,7 +2145,7 @@ mod tests {
             provider: None,
         };
         AgentRepo::insert(pool, &bare).await.unwrap();
-        let disp = resolve_dispatch(pool, "bare-agent").await.unwrap();
+        let disp = resolve_dispatch(pool, "bare-agent", None).await.unwrap();
         assert_eq!(
             disp.backend,
             Backend::Claude,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -139,6 +139,15 @@ const CODEX_MODEL_FLAG: &str = "-m";
 /// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
 /// provider. Its own log keeps a copilot transcript separate from claude/codex.
 const COPILOT_LOG_FILE: &str = "copilot.jsonl";
+/// The claude non-interactive prompt flag. Verified against Claude Code 2.1.210:
+/// "starts an interactive session by default, use -p/--print for non-interactive
+/// output".
+const CLAUDE_PROMPT_FLAG: &str = "-p";
+/// The claude model flag (`claude --model <model>`).
+const CLAUDE_MODEL_FLAG: &str = "--model";
+/// The copilot non-interactive prompt flag (`copilot -p "<text>"`). Verified
+/// against Copilot CLI 1.0.68: "Execute a prompt in non-interactive mode".
+const COPILOT_PROMPT_FLAG: &str = "-p";
 /// The copilot flag that permits tool use without an interactive confirmation
 /// prompt. Verified against GitHub Copilot CLI 1.0.68: `--allow-all-tools` is
 /// documented as "required for non-interactive mode", so a headless run without
@@ -333,14 +342,24 @@ impl Backend {
     }
 }
 
-/// The per-agent provider config the runner threads into a provider's argv
-/// (e38.16). Sourced from the agent row's migration-0015 config columns.
+/// What to invoke a provider with for ONE run: the task's prompt plus the
+/// per-agent config (e38.16, from the agent row's migration-0015 columns).
 ///
-/// `model` and `cli_args` flow onto the provider's command line; the agent's
-/// `agent_env` is threaded separately (it goes into the child env, not the
-/// argv) via the `extra_env` argument of [`Runner::run_codex_with_env`].
+/// `prompt` / `model` / `cli_args` flow onto the provider's command line; the
+/// agent's `agent_env` is threaded separately (it goes into the child env, not
+/// the argv) via the `extra_env` argument of [`Runner::run_codex_with_env`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ProviderInvocation {
+    /// The task brief handed to the provider non-interactively (`claude -p <x>`,
+    /// `copilot -p <x>`, `codex exec <x>`).
+    ///
+    /// EVERY agent CLI starts an interactive session when given no prompt, and the
+    /// daemon spawns them with a null stdin — so an empty prompt means the provider
+    /// exits immediately instead of doing the work (verified: bare `claude` with a
+    /// null stdin exits 1 with "Input must be provided either through stdin or as a
+    /// prompt argument when using --print"). An empty string omits the flag, which
+    /// is only correct for callers that have nothing to ask.
+    pub prompt: String,
     /// Optional model override (e.g. `gpt-5-codex`); `None` = provider default.
     pub model: Option<String>,
     /// Extra provider CLI arguments appended verbatim after the subcommand
@@ -466,11 +485,17 @@ impl Runner {
     ///
     /// Returns an [`std::io::Error`] if the binary cannot be spawned, the log
     /// file cannot be opened/written, or stdout cannot be read.
-    pub async fn run_claude<I>(&self, env: &ExecEnv, source_env: I) -> std::io::Result<RunOutcome>
+    pub async fn run_claude<I>(
+        &self,
+        env: &ExecEnv,
+        source_env: I,
+        invocation: &ProviderInvocation,
+    ) -> std::io::Result<RunOutcome>
     where
         I: IntoIterator<Item = (String, String)>,
     {
-        self.run_claude_in(env, source_env, &RunLocation::in_task_tree(env)).await
+        self.run_claude_in(env, source_env, invocation, &RunLocation::in_task_tree(env))
+            .await
     }
 
     /// [`Self::run_claude`], but executing in an explicit [`RunLocation`] (F5) —
@@ -485,15 +510,15 @@ impl Runner {
         &self,
         env: &ExecEnv,
         source_env: I,
+        invocation: &ProviderInvocation,
         location: &RunLocation,
     ) -> std::io::Result<RunOutcome>
     where
         I: IntoIterator<Item = (String, String)>,
     {
-        // claude takes no extra argv at v1 (the task is handed to it via its
-        // materialised home + workdir, not the command line), so the spec argv is
-        // empty and there is no per-agent env beyond the allowlisted source env.
-        let spec = Self::claude_spec();
+        // The task brief reaches claude as `-p <prompt>`; the workdir + materialised
+        // home carry the CONTEXT (CLAUDE.md, skills) but never the ask itself.
+        let spec = Self::claude_spec(invocation);
         self.run_provider(
             &self.cfg.claude_path,
             env,
@@ -691,7 +716,10 @@ impl Runner {
         invocation: &ProviderInvocation,
     ) -> (PathBuf, Vec<String>) {
         match backend {
-            Backend::Claude => (self.cfg.claude_path.clone(), Self::claude_spec().argv),
+            Backend::Claude => (
+                self.cfg.claude_path.clone(),
+                Self::claude_spec(invocation).argv,
+            ),
             Backend::Codex => (
                 self.cfg.codex_path.clone(),
                 Self::codex_spec(invocation).argv,
@@ -703,12 +731,28 @@ impl Runner {
         }
     }
 
-    /// The `claude` provider spec: claude log file, no argv.
-    const fn claude_spec() -> ProviderSpec {
+    /// The `claude` provider spec: claude log file + the non-interactive
+    /// `-p <prompt>` [+ `--model <model>`] [+ `<cli_args>`].
+    ///
+    /// `-p/--print` is what makes claude non-interactive; verified against Claude
+    /// Code 2.1.210, whose help reads "starts an interactive session by default,
+    /// use -p/--print for non-interactive output". Without it the daemon's spawn
+    /// (null stdin, captured stdout) exits 1 without doing any work.
+    fn claude_spec(invocation: &ProviderInvocation) -> ProviderSpec {
+        let mut argv = Vec::new();
+        if !invocation.prompt.is_empty() {
+            argv.push(CLAUDE_PROMPT_FLAG.to_string());
+            argv.push(invocation.prompt.clone());
+        }
+        if let Some(model) = &invocation.model {
+            argv.push(CLAUDE_MODEL_FLAG.to_string());
+            argv.push(model.clone());
+        }
+        argv.extend(invocation.cli_args.iter().cloned());
         ProviderSpec {
             name: "claude",
             log_file: CLAUDE_LOG_FILE,
-            argv: Vec::new(),
+            argv,
         }
     }
 
@@ -721,6 +765,11 @@ impl Runner {
             argv.push(model.clone());
         }
         argv.extend(invocation.cli_args.iter().cloned());
+        // `codex exec [OPTIONS] [PROMPT]` — the prompt is a trailing POSITIONAL, so
+        // it must come after every option (verified: `codex exec --help`).
+        if !invocation.prompt.is_empty() {
+            argv.push(invocation.prompt.clone());
+        }
         ProviderSpec {
             name: "codex",
             log_file: CODEX_LOG_FILE,
@@ -764,20 +813,16 @@ impl Runner {
     ///   resolve BOTH providers' permission policy in one pass then, rather than
     ///   inventing a half-policy here.
     ///
-    /// # Known gap: no `-p` prompt (headless copilot cannot run yet)
-    ///
-    /// Copilot only runs non-interactively with `-p/--prompt <text>`; bare
-    /// `copilot` starts an INTERACTIVE session. The daemon has no prompt→argv
-    /// plumbing for ANY provider — [`ExecEnv`] carries no prompt and the task
-    /// brief reaches the agent only as `CLAUDE.md` in the workdir (the same reason
-    /// [`Self::claude_spec`] passes no `-p`). So this argv routes and confines
-    /// copilot correctly, but a REAL copilot run would still open a session rather
-    /// than execute the brief. Closing that needs a prompt on `ExecEnv` +
-    /// [`ProviderSpec`], which is a separate change (it affects claude too —
-    /// verified: bare `claude` with a null stdin exits 1 with "Input must be
-    /// provided either through stdin or as a prompt argument when using --print").
+    /// The brief is handed over as `-p <prompt>` (verified against Copilot CLI
+    /// 1.0.68: "Execute a prompt in non-interactive mode"). Bare `copilot` would
+    /// start an INTERACTIVE session against the daemon's null stdin and do nothing.
     fn copilot_spec(invocation: &ProviderInvocation) -> ProviderSpec {
-        let mut argv = vec![COPILOT_ALLOW_ALL_TOOLS_FLAG.to_string()];
+        let mut argv = Vec::new();
+        if !invocation.prompt.is_empty() {
+            argv.push(COPILOT_PROMPT_FLAG.to_string());
+            argv.push(invocation.prompt.clone());
+        }
+        argv.push(COPILOT_ALLOW_ALL_TOOLS_FLAG.to_string());
         if let Some(model) = &invocation.model {
             argv.push(COPILOT_MODEL_FLAG.to_string());
             argv.push(model.clone());

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -123,7 +123,10 @@ fn runner_with_all(dir: &Path) -> (Runner, PathBuf) {
 /// Mirror the daemon's `execute_claimed` routing: backend → exec method.
 async fn dispatch(runner: &Runner, backend: Backend, env: &ExecEnv) -> RunOutcome {
     match backend {
-        Backend::Claude => runner.run_claude(env, std::iter::empty()).await.expect("run claude"),
+        Backend::Claude => runner
+            .run_claude(env, std::iter::empty(), &ProviderInvocation::default())
+            .await
+            .expect("run claude"),
         Backend::Codex => runner
             .run_codex(env, std::iter::empty(), &ProviderInvocation::default())
             .await
@@ -269,6 +272,7 @@ fn copilot_command_carries_verified_non_interactive_flags() {
 
     // The agent's configured model is threaded (copilot DOES support --model).
     let invocation = ProviderInvocation {
+        prompt: "do the thing".to_string(),
         model: Some("gpt-5.4".to_string()),
         cli_args: vec!["--add-dir".to_string(), "/tmp/x".to_string()],
     };

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use ainb_hangar_daemon::execenv::ExecEnv;
-use ainb_hangar_daemon::runner::{RunOutcome, Runner, RunnerConfig};
+use ainb_hangar_daemon::runner::{ProviderInvocation, RunOutcome, Runner, RunnerConfig};
 use ainb_hangar_store::service::fail::FailureReason;
 use tempfile::TempDir;
 
@@ -96,7 +96,14 @@ exit 0"#,
         ("HOME".to_string(), tmp.path().display().to_string()),
     ];
 
-    let outcome = runner.run_claude(&env, overrides.iter().cloned()).await.expect("run");
+    let outcome = runner
+        .run_claude(
+            &env,
+            overrides.iter().cloned(),
+            &ProviderInvocation::default(),
+        )
+        .await
+        .expect("run");
     let result = outcome.result();
 
     assert!(
@@ -127,7 +134,10 @@ async fn exec_captures_exit_code() {
         sandbox: true,
     });
 
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
 
     assert_eq!(outcome.result().exit_code, Some(0));
     assert!(matches!(outcome, RunOutcome::Success(_)));
@@ -157,7 +167,10 @@ exit 0"#,
         sandbox: true,
     });
 
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
     let usage = outcome.result().usage.clone().expect("usage captured from result line");
     assert_eq!(usage.input_tokens, 1200);
     assert_eq!(usage.output_tokens, 340);
@@ -180,7 +193,10 @@ async fn exec_no_result_usage_leaves_usage_none() {
         sandbox: true,
     });
 
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
     assert!(
         outcome.result().usage.is_none(),
         "a result line without usage leaves usage None"
@@ -208,7 +224,10 @@ exit 1"#,
         sandbox: true,
     });
 
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
 
     match outcome {
         RunOutcome::Failed { reason, result } => {
@@ -243,7 +262,10 @@ exit 75"#,
         sandbox: true,
     });
 
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
 
     match outcome {
         RunOutcome::Failed { reason, result } => {
@@ -278,7 +300,10 @@ exit 0"#,
         sandbox: true,
     });
 
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
 
     assert_eq!(
         outcome.result().session_id.as_deref(),
@@ -310,7 +335,10 @@ exit 0"#,
         sandbox: true,
     });
 
-    runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
 
     let jsonl = env.logs.join("claude.jsonl");
     assert!(jsonl.exists(), "expected claude.jsonl at {jsonl:?}");
@@ -347,7 +375,10 @@ exit 0"#,
     });
 
     let started = std::time::Instant::now();
-    let outcome = runner.run_claude(&env, std::iter::empty()).await.expect("run");
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
+        .await
+        .expect("run");
     let elapsed = started.elapsed();
 
     assert!(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
@@ -132,6 +132,7 @@ exit 0"#,
     );
     let runner = Runner::new(cfg_with_codex(script));
     let invocation = ProviderInvocation {
+        prompt: String::new(),
         model: Some("gpt-5-codex".to_string()),
         cli_args: vec!["--full-auto".to_string()],
     };


### PR DESCRIPTION
Follow-up to #401. Headless agent execution has **never run a real agent**.

## The bug
The daemon spawned every provider with **no prompt** and a null stdin, so the CLI
started an interactive session and died instead of working. Verified against the real binary:

```
$ claude < /dev/null
exit=1  Error: Input must be provided either through stdin or as a prompt argument when using --print
```

Nothing ever passed the ask: `ExecEnv` carries only directories, `claude_spec`'s argv was
empty, and every "e2e" tripwire spawns a **fake shell script** — which is why this was invisible.
Pre-existing on main (`claude_spec` is byte-identical there).

## The fix
`ProviderInvocation` now carries the prompt; each spec hands it over in that provider's
**verified** non-interactive shape:

| provider | argv | verified against |
|---|---|---|
| claude | `-p <brief> [--model m] [args]` | Claude Code 2.1.210 |
| codex | `exec [-m m] [args] <brief>` | prompt is a trailing positional |
| copilot | `-p <brief> --allow-all-tools [...]` | Copilot CLI 1.0.68 |

`build_prompt` sources the brief from the task's issue (title + description) → agent
instructions → a non-empty fallback, so a provider is never spawned promptless.

## Proof (real claude, fresh home)
```
task-fix-2  status=done  reason=-
claude.jsonl: HEADLESS_FIXED     # was 0 bytes
```

## Known separate gap (NOT fixed here)
With the FS sandbox ON (default) a real run fails `Not logged in` — the sandbox denies the
provider's credential store. Isolated by variable: the same task with
`HANGAR_DAEMON_DISABLE_SANDBOX=1` completes. That's a security-boundary decision, flagged
rather than silently widened.

Suites: 854 passed / 0 failed. build --workspace, test --no-run, clippy (no new hits), fmt all green.