### PR TITLE
fix(hangar-daemon): codex needs --skip-git-repo-check to run headless

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -136,6 +136,15 @@ const CODEX_LOG_FILE: &str = "codex.jsonl";
 const CODEX_EXEC_SUBCOMMAND: &str = "exec";
 /// The codex model flag (`codex exec -m <model> …`).
 const CODEX_MODEL_FLAG: &str = "-m";
+/// Codex refuses to run outside a git repo ("Not inside a trusted directory and
+/// --skip-git-repo-check was not specified", exit 1) — a guard against turning an
+/// agent loose where its edits cannot be reviewed or reverted. A task's workdir is
+/// only a git worktree on the F5 repo path; a chat / autopilot task runs in the
+/// daemon's own freshly-created in-tree workdir, which is NOT a repo, so codex
+/// would exit instantly there. The daemon supplies its own confinement (per-task
+/// isolated dir + FS sandbox + teardown), which is what codex's check is proxying
+/// for, so skip it rather than strand every non-repo codex task.
+const CODEX_SKIP_GIT_CHECK_FLAG: &str = "--skip-git-repo-check";
 /// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
 /// provider. Its own log keeps a copilot transcript separate from claude/codex.
 const COPILOT_LOG_FILE: &str = "copilot.jsonl";
@@ -759,7 +768,10 @@ impl Runner {
     /// The `codex` provider spec: codex log file + the non-interactive argv
     /// `exec [-m <model>] [<cli_args>…]` (e38.16).
     fn codex_spec(invocation: &ProviderInvocation) -> ProviderSpec {
-        let mut argv = vec![CODEX_EXEC_SUBCOMMAND.to_string()];
+        let mut argv = vec![
+            CODEX_EXEC_SUBCOMMAND.to_string(),
+            CODEX_SKIP_GIT_CHECK_FLAG.to_string(),
+        ];
         if let Some(model) = &invocation.model {
             argv.push(CODEX_MODEL_FLAG.to_string());
             argv.push(model.clone());

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -288,6 +288,42 @@ fn copilot_command_carries_verified_non_interactive_flags() {
     );
 }
 
+/// Each provider's argv must be the shape that ACTUALLY runs headless — verified
+/// against the real CLIs (claude 2.1.210, codex-cli 0.144.0, Copilot CLI 1.0.70):
+///
+/// * claude needs `-p` or it opens a session and exits 1 on the daemon's null stdin,
+/// * codex needs `--skip-git-repo-check` or it exits 1 ("Not inside a trusted
+///   directory") in the daemon's non-repo in-tree workdir, and takes the prompt as a
+///   TRAILING positional,
+/// * copilot needs `-p` + `--allow-all-tools` ("required for non-interactive mode").
+#[test]
+fn every_provider_argv_is_the_verified_headless_shape() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _m) = runner_with_all(tmp.path());
+    let inv = ProviderInvocation {
+        prompt: "BRIEF".to_string(),
+        model: None,
+        cli_args: Vec::new(),
+    };
+
+    let (_p, claude) = runner.provider_command(Backend::Claude, &inv);
+    assert_eq!(claude, vec!["-p", "BRIEF"], "claude: -p <brief>");
+
+    let (_p, codex) = runner.provider_command(Backend::Codex, &inv);
+    assert_eq!(
+        codex,
+        vec!["exec", "--skip-git-repo-check", "BRIEF"],
+        "codex: exec --skip-git-repo-check <brief> (prompt is a trailing positional)"
+    );
+
+    let (_p, copilot) = runner.provider_command(Backend::Copilot, &inv);
+    assert_eq!(
+        copilot,
+        vec!["-p", "BRIEF", "--allow-all-tools"],
+        "copilot: -p <brief> --allow-all-tools"
+    );
+}
+
 #[test]
 fn wired_providers_route_and_unknown_defaults_to_claude() {
     // Every WIRED provider routes to its own exec path — copilot included; it no


### PR DESCRIPTION
Follow-up to #403. Verified all three providers against their **real CLIs**.

| provider | version | daemon form | result |
|---|---|---|---|
| claude | 2.1.210 | `-p <brief>` | ✅ `done`, `HEADLESS_FIXED` |
| codex | 0.144.0 | `exec --skip-git-repo-check <brief>` | ✅ `done`, `CODEX_OK` (this PR) |
| copilot | 1.0.70 | `-p <brief> --allow-all-tools` | ⚠️ **unverifiable** — org policy blocks the CLI |

## The codex bug
After #403 codex still failed: it refuses to run outside a git repo (`Not inside a trusted directory and --skip-git-repo-check was not specified`, exit 1). The daemon's in-tree workdir (chat/autopilot tasks) is not a repo. The daemon already provides the confinement codex's check proxies for (isolated workdir + sandbox + teardown), so we skip it.

Proven: `task-codex2 status=done`, `codex.jsonl: CODEX_OK` (was 0 bytes).

## Copilot
Cannot verify in this environment — `copilot -p ... --allow-all-tools` exits 1 with *"Your organization has restricted Copilot access"*. Argv shape matches the documented/verified 1.0.70 flags, but the **end-to-end run is unproven**. Stating plainly rather than inferring.

855 passed / 0 failed; clippy + fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex tasks now run successfully in working directories that are not Git repositories.

* **Tests**
  * Added coverage to verify correct non-interactive command invocation across Claude, Codex, and Copilot providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->