### PR TITLE
fix(hangar-daemon): per-mode provider argv (no Keychain grant)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -57,7 +57,7 @@ use crate::events::EventSink;
 use crate::execenv::{prepare_env, write_context_prompt};
 use crate::health_stats::HealthStats;
 use crate::progress_comment;
-use crate::runner::{Backend, ProviderInvocation, RunOutcome, Runner, RunnerConfig};
+use crate::runner::{Backend, Mode, ProviderInvocation, RunOutcome, Runner, RunnerConfig};
 use crate::sweeper::{
     SweeperConfig, reclaim_orphaned_on_startup, sweep_expired_queued, sweep_stale_dispatched,
     sweep_stale_running,
@@ -573,12 +573,30 @@ async fn execute_claimed(
 
     // e38.16: resolve which provider exec path this task routes to (agent →
     // runtime → provider) and the per-agent config (model / cli_args / agent_env)
-    // the runner threads into that provider's argv + env. A resolve fault
-    // defaults the dispatch to `claude` with empty config so a misconfigured
-    // agent still runs rather than stranding the task.
-    let dispatch = resolve_dispatch(pool, &task.agent_id, task.issue_id.as_deref())
-        .await
-        .unwrap_or_default();
+    // the runner threads into that provider's argv + env. A resolve fault falls
+    // back to the default provider WITH the fallback prompt, so a misconfigured
+    // agent still runs rather than stranding the task — the prompt is what makes
+    // that true (see `ResolvedDispatch::fallback`). The fault is logged rather
+    // than swallowed: silently substituting a different agent's behaviour is
+    // exactly the kind of thing an operator needs to see.
+    // The ONE place the task row's `mode` column becomes a `Mode`: it is resolved
+    // here, carried on the `ResolvedDispatch`, and read from there by both the
+    // branch that picks the exec path and the argv built for it — so the two can
+    // never disagree.
+    let mode = dispatch_mode(&task.mode);
+    let dispatch =
+        match resolve_dispatch(pool, &task.agent_id, task.issue_id.as_deref(), mode).await {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    task_id = %task.id,
+                    agent_id = %task.agent_id,
+                    "dispatch resolve failed; falling back to the default provider + prompt"
+                );
+                ResolvedDispatch::fallback(mode)
+            }
+        };
 
     // F5: provision the run's working directory from the card's `repo_ref`.
     //
@@ -777,7 +795,7 @@ async fn execute_claimed(
     // `cancel_guard` was registered up front (before the start transition).
     let provider = dispatch.backend.name();
     let provider_run = async {
-        if task.mode == "interactive" {
+        if mode == Mode::Interactive {
             run_interactive(
                 pool,
                 runner,
@@ -829,7 +847,7 @@ async fn execute_claimed(
         // over a provider future that became ready in the same poll.
         biased;
         () = cancel_guard.cancelled() => {
-            if task.mode == "interactive" {
+            if mode == Mode::Interactive {
                 // The detached session survives `run_interactive`'s dropped `wait`,
                 // so kill it by its EXACT name and clear the shutdown-reap entry the
                 // dropped future would otherwise leave registered (keeps the set
@@ -874,6 +892,24 @@ async fn execute_claimed(
     Ok(())
 }
 
+/// The program + argv [`run_interactive`] spawns into the tmux pane.
+///
+/// Trivial by design, and extracted for exactly one reason: it is the ONLY place
+/// the interactive argv is derived, and it is reachable from a test without
+/// tmux, a provider binary, or a database. The mode comes off the
+/// [`ResolvedDispatch`] the task row produced — this function has no mode of its
+/// own to get wrong, which is the whole point.
+///
+/// The previous shape passed the mode at the call site inside `run_interactive`,
+/// and its test re-derived the argv *beside* that call rather than through it.
+/// Hardcoding `Mode::Headless` in `run_interactive` therefore kept 254 lib tests
+/// and every integration test GREEN while reintroducing the exact regression this
+/// module exists to fix — the only coverage was a tmux tripwire that SKIPs when
+/// tmux is absent.
+fn interactive_command(runner: &Runner, dispatch: &ResolvedDispatch) -> (PathBuf, Vec<String>) {
+    runner.provider_command(dispatch.backend, &dispatch.invocation, dispatch.mode)
+}
+
 /// Launch a task's provider inside a REAL, attachable tmux session and await
 /// its completion (ccc / D6 interactive mode).
 ///
@@ -907,8 +943,12 @@ async fn run_interactive(
     // Landlock). Confining a live terminal the user attaches to and drives would
     // defeat the interactive feature; the human operator is present and in control,
     // which is the trust model D6 chose for interactive over headless.
+    //
+    // That claim is only true because the argv below is built for `Mode::Interactive`
+    // — a headless argv would make this a print-and-exit process wearing a tmux
+    // session's clothes.
     let session_name = crate::interactive::session_name_for(&task.id);
-    let (program, argv) = runner.provider_command(dispatch.backend, &dispatch.invocation);
+    let (program, argv) = interactive_command(runner, dispatch);
     // Mirror the headless env composition: the codex / copilot paths layer the
     // agent's `agent_env`; the claude path layers nothing (parity with
     // `execute_claimed`).
@@ -1519,18 +1559,77 @@ async fn materialise_agent_profile(
 /// The resolved provider routing for one task (e38.16): which exec path to take
 /// plus the per-agent config to thread into it.
 ///
-/// [`Default`] is the safe fallback (`claude`, no model/args/env) used when the
-/// agent/runtime resolve fails — a misconfigured agent still dispatches to the
-/// default provider rather than stranding the task.
-#[derive(Debug, Clone, Default)]
+/// Deliberately NOT [`Default`]: see [`ResolvedDispatch::fallback`]. A derived
+/// default would carry an empty prompt, which is not a degraded run but a
+/// guaranteed non-run.
+#[derive(Debug, Clone)]
 struct ResolvedDispatch {
     /// Which provider exec path [`execute_claimed`] routes to.
     backend: Backend,
+    /// Which CONTRACT that exec path is spawned for, resolved once from the
+    /// task row (see [`dispatch_mode`]) and carried beside `backend`.
+    ///
+    /// It lives here rather than being re-derived at each use so the pane a task
+    /// gets and the argv spawned into it cannot disagree. They did: the
+    /// interactive path built its argv with the headless call, so a `mode =
+    /// "interactive"` task spawned `claude -p` ("Print response and exit") into a
+    /// pane the operator was meant to attach to and drive. Re-deriving is what
+    /// gave that bug somewhere to live.
+    mode: Mode,
     /// The `model` + `cli_args` the provider threads onto its argv.
     invocation: ProviderInvocation,
     /// The agent's per-agent env (`agent_env`), layered onto the child env
     /// after the deny-by-default ambient allowlist.
     agent_env: Vec<(String, String)>,
+}
+
+/// The `tasks.mode` column value that asks for an attachable session (ccc / D6,
+/// the board's "Run ▾" affordance). Anything else is headless.
+const INTERACTIVE_TASK_MODE: &str = "interactive";
+
+/// The provider contract a task's `mode` column is asking for.
+///
+/// The ONE place a task row's mode becomes a [`Mode`]. Both the branch that picks
+/// the exec path and the argv built for it read it, so the pane a task gets and
+/// the argv spawned into it cannot disagree — which they did: a `mode =
+/// "interactive"` task was handed the print-and-exit headless argv and died in a
+/// pane the operator was meant to drive.
+fn dispatch_mode(task_mode: &str) -> Mode {
+    if task_mode == INTERACTIVE_TASK_MODE {
+        Mode::Interactive
+    } else {
+        Mode::Headless
+    }
+}
+
+impl ResolvedDispatch {
+    /// The fault fallback: the default provider, no per-agent config, and the
+    /// [`FALLBACK_PROMPT`] — used when the agent/runtime resolve fails so a
+    /// misconfigured agent still RUNS rather than stranding the task.
+    ///
+    /// The prompt is the entire point of this constructor existing instead of a
+    /// derived [`Default`]. `..Default::default()` here would hand the provider an
+    /// empty brief, and a promptless provider does not "run in a degraded way" —
+    /// it exits non-zero immediately, which is the very bug this fault path
+    /// claimed to avoid. The "never promptless" guarantee lives in
+    /// [`build_prompt`], and this path does not call it, so the invariant has to
+    /// be restated here.
+    ///
+    /// `mode` is still the task row's own — a resolve fault says nothing about
+    /// which contract the operator asked for, and defaulting it would spawn a
+    /// print-and-exit process into an interactive pane.
+    fn fallback(mode: Mode) -> Self {
+        Self {
+            backend: Backend::default(),
+            mode,
+            invocation: ProviderInvocation {
+                prompt: FALLBACK_PROMPT.to_string(),
+                model: None,
+                cli_args: Vec::new(),
+            },
+            agent_env: Vec::new(),
+        }
+    }
 }
 
 /// Resolve the provider routing for a task's agent (e38.16).
@@ -1548,11 +1647,12 @@ struct ResolvedDispatch {
 /// # Errors
 ///
 /// Returns an error if the agent id is malformed or the agent / runtime row is
-/// missing — the caller falls back to the [`ResolvedDispatch::default`].
+/// missing — the caller falls back to [`ResolvedDispatch::fallback`].
 async fn resolve_dispatch(
     pool: &SqlitePool,
     agent_id: &str,
     issue_id: Option<&str>,
+    mode: Mode,
 ) -> anyhow::Result<ResolvedDispatch> {
     use ainb_hangar_store::repo::agent::AgentRepo;
     use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
@@ -1567,6 +1667,7 @@ async fn resolve_dispatch(
     let provider = agent.provider.as_deref().unwrap_or(&runtime.provider);
     Ok(ResolvedDispatch {
         backend: Backend::from_provider(provider),
+        mode,
         invocation: ProviderInvocation {
             prompt,
             model: agent.model,
@@ -2037,13 +2138,16 @@ mod tests {
         .await
         .unwrap();
 
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id)).await.unwrap();
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
+            .await
+            .unwrap();
         assert_eq!(
             disp.invocation.prompt, "Fix the login bug\n\nIt 500s on empty password.",
             "the issue title + description must become the brief"
         );
 
-        // …and it lands on the argv as `-p <brief>` (not just in the struct).
+        // …and it lands on the argv as the trailing positional (not just in the
+        // struct), behind `-p` so the run is non-interactive.
         let runner = Runner::new(RunnerConfig {
             claude_path: "claude".into(),
             codex_path: "codex".into(),
@@ -2052,13 +2156,16 @@ mod tests {
             tail_lines: 1,
             sandbox: false,
         });
-        let (_p, argv) = runner.provider_command(disp.backend, &disp.invocation);
+        let (_p, argv) = runner.provider_command(disp.backend, &disp.invocation, Mode::Headless);
         assert_eq!(
             argv.first().map(String::as_str),
             Some("-p"),
             "claude must be invoked non-interactively: {argv:?}"
         );
-        assert!(argv.contains(&"Fix the login bug\n\nIt 500s on empty password.".to_string()));
+        assert!(argv.ends_with(&[
+            "--".to_string(),
+            "Fix the login bug\n\nIt 500s on empty password.".to_string()
+        ]));
 
         // (2) No issue → the agent's own instructions are the brief.
         let instructed = bootstrap::create_agent(
@@ -2070,16 +2177,139 @@ mod tests {
         )
         .await
         .unwrap();
-        let disp = resolve_dispatch(pool, &instructed.id, None).await.unwrap();
+        let disp = resolve_dispatch(pool, &instructed.id, None, Mode::Headless).await.unwrap();
         assert_eq!(disp.invocation.prompt, "Triage the inbox.");
 
         // (3) Neither → a non-empty fallback, never a promptless spawn.
-        let disp = resolve_dispatch(pool, &agent.id, None).await.unwrap();
+        let disp = resolve_dispatch(pool, &agent.id, None, Mode::Headless).await.unwrap();
         assert!(
             !disp.invocation.prompt.is_empty(),
             "a prompt is never empty"
         );
         assert_eq!(disp.invocation.prompt, FALLBACK_PROMPT);
+    }
+
+    /// A task row whose `mode` says "interactive" must never be handed a
+    /// print-and-exit argv.
+    ///
+    /// This is the regression that shipped: `run_interactive` built its argv with
+    /// the same call the headless path used, so a D6 "Run ▾" task spawned
+    /// `claude -p …` ("Print response and exit") into a tmux pane the operator was
+    /// meant to attach to and drive. It escaped because the only coverage was a
+    /// tmux e2e tripwire that SKIPs cleanly when tmux/the provider binaries are
+    /// absent — so this asserts the row→argv contract with no tmux at all.
+    ///
+    /// It drives [`interactive_command`], which is the function `run_interactive`
+    /// itself calls. That indirection is the point: the FIRST version of this test
+    /// re-derived the argv beside `run_interactive` instead of through it, so
+    /// hardcoding `Mode::Headless` inside `run_interactive` left this test — and
+    /// all 254 lib tests, and every integration test — GREEN. A test that
+    /// reimplements the code under test asserts nothing about that code.
+    #[test]
+    fn interactive_task_mode_never_produces_a_print_and_exit_argv() {
+        assert_eq!(dispatch_mode("interactive"), Mode::Interactive);
+        // Everything else is headless — including the empty/unknown values a row
+        // can carry.
+        assert_eq!(dispatch_mode("headless"), Mode::Headless);
+        assert_eq!(dispatch_mode(""), Mode::Headless);
+        assert_eq!(dispatch_mode("Interactive"), Mode::Headless);
+
+        let runner = Runner::new(RunnerConfig {
+            claude_path: "claude".into(),
+            codex_path: "codex".into(),
+            copilot_path: "copilot".into(),
+            max_runtime: Duration::from_secs(1),
+            tail_lines: 1,
+            sandbox: false,
+        });
+        let inv = ProviderInvocation {
+            prompt: "do the thing".to_string(),
+            model: None,
+            cli_args: Vec::new(),
+        };
+        // A dispatch resolved from a row whose `mode` column says "interactive",
+        // exactly as `execute_claimed` resolves it.
+        let interactive_dispatch = |backend| ResolvedDispatch {
+            backend,
+            mode: dispatch_mode("interactive"),
+            invocation: inv.clone(),
+            agent_env: Vec::new(),
+        };
+
+        // The argv an INTERACTIVE task row actually gets, through the same
+        // function `run_interactive` calls.
+        let (_p, argv) = interactive_command(&runner, &interactive_dispatch(Backend::Claude));
+        assert!(
+            !argv.contains(&"-p".to_string()),
+            "an interactive task must not spawn claude in print-and-exit mode: {argv:?}"
+        );
+        assert!(
+            argv.ends_with(&["--".to_string(), "do the thing".to_string()]),
+            "an interactive task must still be seeded with its brief: {argv:?}"
+        );
+        let (_p, argv) = interactive_command(&runner, &interactive_dispatch(Backend::Copilot));
+        assert!(
+            !argv.contains(&"-p".to_string()),
+            "an interactive task must not spawn copilot in exits-after-completion mode: {argv:?}"
+        );
+        let (_p, argv) = interactive_command(&runner, &interactive_dispatch(Backend::Codex));
+        assert!(
+            !argv.contains(&"exec".to_string()),
+            "an interactive task must not spawn codex's non-interactive exec: {argv:?}"
+        );
+
+        // …and the headless row still gets the headless shape (the fix must not
+        // simply disable non-interactive execution).
+        let (_p, argv) = runner.provider_command(Backend::Claude, &inv, dispatch_mode("headless"));
+        assert!(
+            argv.contains(&"-p".to_string()),
+            "a headless task MUST print-and-exit: {argv:?}"
+        );
+    }
+
+    /// The RESOLVE-FAULT path must also be promptless-proof.
+    ///
+    /// `build_prompt` guarantees "never promptless", but the fault path does not
+    /// go through it — a failed `resolve_dispatch` (missing/malformed agent) is
+    /// caught by `execute_claimed` and substituted with `ResolvedDispatch::fallback`.
+    /// That substitution used to be `unwrap_or_default()`, whose empty prompt
+    /// recreated the exact bug the prompt threading fixed: the provider spawns and
+    /// exits 1 instead of running. The comment claimed a misconfigured agent
+    /// "still runs"; it could not.
+    #[tokio::test]
+    async fn dispatch_fault_still_yields_a_runnable_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        // A task whose agent does not exist: resolve MUST fail, which is what
+        // drives `execute_claimed` onto the fallback.
+        let err = resolve_dispatch(pool, "agent-that-does-not-exist", None, Mode::Headless).await;
+        assert!(err.is_err(), "a missing agent must fail to resolve");
+
+        let disp = ResolvedDispatch::fallback(Mode::Headless);
+        assert!(
+            !disp.invocation.prompt.trim().is_empty(),
+            "the fault fallback must carry a real brief, or the provider exits 1 \
+             without doing any work"
+        );
+        assert_eq!(disp.invocation.prompt, FALLBACK_PROMPT);
+
+        // …and it survives all the way onto the argv, which is what the provider
+        // actually sees.
+        let runner = Runner::new(RunnerConfig {
+            claude_path: "claude".into(),
+            codex_path: "codex".into(),
+            copilot_path: "copilot".into(),
+            max_runtime: Duration::from_secs(1),
+            tail_lines: 1,
+            sandbox: false,
+        });
+        let (_p, argv) = runner.provider_command(disp.backend, &disp.invocation, Mode::Headless);
+        assert!(
+            argv.ends_with(&["--".to_string(), FALLBACK_PROMPT.to_string()]),
+            "the fallback brief must reach the provider argv: {argv:?}"
+        );
     }
 
     /// Provider-honoring proof: `resolve_dispatch` selects the backend from the
@@ -2104,7 +2334,7 @@ mod tests {
 
         // A codex agent on that claude-advertised runtime → codex backend.
         let codex = bootstrap::create_agent(pool, &ws, "coder", "codex", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &codex.id, None).await.unwrap();
+        let disp = resolve_dispatch(pool, &codex.id, None, Mode::Headless).await.unwrap();
         assert_eq!(
             disp.backend,
             Backend::Codex,
@@ -2114,7 +2344,7 @@ mod tests {
         // A copilot agent on that claude-advertised runtime → copilot backend
         // (no more silent claude fallback).
         let copilot = bootstrap::create_agent(pool, &ws, "helper", "copilot", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &copilot.id, None).await.unwrap();
+        let disp = resolve_dispatch(pool, &copilot.id, None, Mode::Headless).await.unwrap();
         assert_eq!(
             disp.backend,
             Backend::Copilot,
@@ -2123,7 +2353,7 @@ mod tests {
 
         // A claude agent on the same runtime → claude backend.
         let claude = bootstrap::create_agent(pool, &ws, "writer", "claude", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &claude.id, None).await.unwrap();
+        let disp = resolve_dispatch(pool, &claude.id, None, Mode::Headless).await.unwrap();
         assert_eq!(disp.backend, Backend::Claude);
 
         // An agent with NO provider override falls back to the runtime's provider.
@@ -2145,7 +2375,7 @@ mod tests {
             provider: None,
         };
         AgentRepo::insert(pool, &bare).await.unwrap();
-        let disp = resolve_dispatch(pool, "bare-agent", None).await.unwrap();
+        let disp = resolve_dispatch(pool, "bare-agent", None, Mode::Headless).await.unwrap();
         assert_eq!(
             disp.backend,
             Backend::Claude,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -144,19 +144,78 @@ const CODEX_MODEL_FLAG: &str = "-m";
 /// would exit instantly there. The daemon supplies its own confinement (per-task
 /// isolated dir + FS sandbox + teardown), which is what codex's check is proxying
 /// for, so skip it rather than strand every non-repo codex task.
+///
+/// That justification is only honest while the FS sandbox is actually ON, and
+/// TODAY IT IS NOT. A confined provider cannot reach its own credential, so a
+/// headless run fails "Not logged in" and completes only with
+/// `HANGAR_DAEMON_DISABLE_SANDBOX=1` — i.e. in the one configuration codex
+/// actually runs, its own guard is skipped AND the confinement offered in
+/// exchange is absent. This flag is currently spending protection the daemon is
+/// not providing. That is a known, accepted interim state, not a claim of
+/// safety: the credential is being moved to a parent-injected env var
+/// (`CLAUDE_CODE_OAUTH_TOKEN`), after which confinement is re-enabled by default
+/// and this rationale becomes true again (bead `ai-coder-rules-48b`).
+///
+/// HEADLESS ONLY: it is an `exec` subcommand flag, and passing it to the
+/// interactive top-level command is a hard parse error (verified: `codex
+/// --skip-git-repo-check` → "unexpected argument", exit 2). See
+/// [`Runner::codex_spec`] for why that is also the right security posture.
 const CODEX_SKIP_GIT_CHECK_FLAG: &str = "--skip-git-repo-check";
 /// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
 /// provider. Its own log keeps a copilot transcript separate from claude/codex.
 const COPILOT_LOG_FILE: &str = "copilot.jsonl";
-/// The claude non-interactive prompt flag. Verified against Claude Code 2.1.210:
-/// "starts an interactive session by default, use -p/--print for non-interactive
-/// output".
-const CLAUDE_PROMPT_FLAG: &str = "-p";
+/// The claude flag that makes a run non-interactive. Verified against Claude
+/// Code 2.1.210, whose usage is `claude [options] [command] [prompt]` and whose
+/// help reads `-p, --print   Print response and exit (useful for pipes)`.
+///
+/// It is a BOOLEAN that takes no value — the brief is a trailing POSITIONAL, not
+/// this flag's argument. (Contrast [`COPILOT_HEADLESS_PROMPT_FLAG`], which looks
+/// identical (`-p`) but genuinely takes the prompt as its value. Same spelling,
+/// opposite grammar — hence the deliberately different names.)
+const CLAUDE_PRINT_FLAG: &str = "-p";
 /// The claude model flag (`claude --model <model>`).
 const CLAUDE_MODEL_FLAG: &str = "--model";
-/// The copilot non-interactive prompt flag (`copilot -p "<text>"`). Verified
-/// against Copilot CLI 1.0.68: "Execute a prompt in non-interactive mode".
-const COPILOT_PROMPT_FLAG: &str = "-p";
+/// The copilot HEADLESS prompt flag (`copilot -p "<text>"`). Verified against
+/// Copilot CLI 1.0.68: "Execute a prompt in non-interactive mode (exits after
+/// completion)" — so it is exactly wrong for an attachable session, which is why
+/// [`Mode`] picks between this and [`COPILOT_INTERACTIVE_PROMPT_FLAG`].
+const COPILOT_HEADLESS_PROMPT_FLAG: &str = "-p";
+/// The copilot INTERACTIVE prompt flag (`copilot -i "<text>"`). Verified against
+/// Copilot CLI 1.0.68: "-i, --interactive <prompt>   Start interactive mode and
+/// automatically execute this prompt" — a real session, seeded with the brief.
+///
+/// Copilot has NO positional prompt (`copilot [options] [command]`; a bare
+/// positional is rejected with "Invalid command format"), so this value-taking
+/// flag is the only way to seed an interactive copilot.
+const COPILOT_INTERACTIVE_PROMPT_FLAG: &str = "-i";
+/// The end-of-options separator: everything after it is a positional, never a
+/// flag.
+///
+/// The brief is arbitrary issue text, so it can start with `-` (an issue titled
+/// `- fix the login bug` is ordinary bullet-style prose). Without this separator
+/// the provider's parser reads the brief as flags. Verified against the real
+/// binaries:
+///
+/// * `codex exec "-fix the login bug"` → `error: unexpected argument '-f' found`
+///   (clap itself suggests "to pass '-f' as a value, use '-- -f'"); with `--` it
+///   parses.
+/// * `claude -p "-reply with …"` → the leading `-r` is silently absorbed as
+///   claude's own `-r/--resume`, which then fails on the REST of the brief
+///   ("Provided value \"eply with …\" is not a UUID"). A misparse into a
+///   different flag, not merely a rejection; with `--` the brief is delivered
+///   verbatim (verified: a `-`-leading brief round-tripped its answer back).
+///
+/// It also settles two adjacent hazards for free: a value-taking flag in the
+/// agent's `cli_args` can no longer swallow the brief (the separator terminates
+/// option parsing first), and a brief that is exactly a subcommand name can no
+/// longer hijack it (verified: `codex exec review` → "Specify --uncommitted …";
+/// `codex exec -- review` treats it as the prompt).
+///
+/// It is NOT used for copilot: its brief rides a value-taking flag (`-p`/`-i`),
+/// which already consumes a dash-leading value verbatim, and inserting `--`
+/// there BREAKS it — `copilot -p -- "-fix the login bug"` makes `--` the prompt
+/// value and then rejects the brief as `error: unknown option` (verified).
+const ARG_SEPARATOR: &str = "--";
 /// The copilot flag that permits tool use without an interactive confirmation
 /// prompt. Verified against GitHub Copilot CLI 1.0.68: `--allow-all-tools` is
 /// documented as "required for non-interactive mode", so a headless run without
@@ -351,23 +410,61 @@ impl Backend {
     }
 }
 
+/// Which contract a provider's argv is built for.
+///
+/// The two are OPPOSITE asks of the same binary, and every provider spells them
+/// differently, so the mode is an explicit argument rather than an implied
+/// default: one argv must never serve both. Passing a headless argv to the
+/// interactive path spawns a print-and-exit process into a pane the operator is
+/// meant to attach to and drive (claude's `-p/--print` is literally "Print
+/// response and exit"; copilot's `-p` is "exits after completion").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// A captured subprocess with a null stdin: the provider must do the work
+    /// unattended and exit. Nobody can answer a prompt or drive a REPL.
+    Headless,
+    /// A REAL, attachable tmux terminal (ccc / D6): the provider must start a
+    /// live session, seeded with the brief, that the operator can take over.
+    Interactive,
+}
+
 /// What to invoke a provider with for ONE run: the task's prompt plus the
 /// per-agent config (e38.16, from the agent row's migration-0015 columns).
 ///
 /// `prompt` / `model` / `cli_args` flow onto the provider's command line; the
 /// agent's `agent_env` is threaded separately (it goes into the child env, not
 /// the argv) via the `extra_env` argument of [`Runner::run_codex_with_env`].
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+///
+/// # No `Default`
+///
+/// Deliberately NOT [`Default`]: a defaulted invocation is a promptless one, and
+/// a promptless provider does not run — it exits non-zero at once (verified:
+/// bare `claude` with a null stdin exits 1, "Input must be provided either
+/// through stdin or as a prompt argument when using --print"). A `..default()`
+/// fault path therefore does not degrade gracefully, it just fails later and
+/// less legibly. Callers must state the prompt, even if it is only a fallback
+/// (see `run_loop`'s `ResolvedDispatch::fallback`).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderInvocation {
-    /// The task brief handed to the provider non-interactively (`claude -p <x>`,
-    /// `copilot -p <x>`, `codex exec <x>`).
+    /// The task brief. Reaches the provider as a positional after
+    /// [`ARG_SEPARATOR`] (claude / codex) or as the value of a prompt flag
+    /// (copilot); [`Mode`] decides the surrounding shape.
     ///
-    /// EVERY agent CLI starts an interactive session when given no prompt, and the
-    /// daemon spawns them with a null stdin — so an empty prompt means the provider
-    /// exits immediately instead of doing the work (verified: bare `claude` with a
-    /// null stdin exits 1 with "Input must be provided either through stdin or as a
-    /// prompt argument when using --print"). An empty string omits the flag, which
-    /// is only correct for callers that have nothing to ask.
+    /// MUST be non-empty — see the type-level "No `Default`" note. The specs do
+    /// not guard against an empty prompt: a caller that manufactures one gets a
+    /// loud provider-level failure rather than a silent interactive hang.
+    ///
+    /// # Visible in `ps`
+    ///
+    /// This lands in the child's argv, so it is world-readable via `ps` on the
+    /// host. Accepted deliberately: the brief is the operator's own issue text,
+    /// and `model` / `cli_args` already ride the same argv. It is a real (if
+    /// small) widening of what a local user can see versus keeping the brief on
+    /// stdin — noted here so the next reader knows it was a decision, not an
+    /// oversight. The repo's threat model does care about other local users (see
+    /// the 0o700 wrapper rationale in `interactive.rs`), so if a brief ever
+    /// carries something more sensitive than an issue title, stdin is the seam
+    /// to move it to.
     pub prompt: String,
     /// Optional model override (e.g. `gpt-5-codex`); `None` = provider default.
     pub model: Option<String>,
@@ -384,9 +481,9 @@ pub struct ProviderInvocation {
 /// (see [`Runner::claude_spec`] / [`Runner::codex_spec`] / [`Runner::copilot_spec`])
 /// rather than a new copy of the run loop.
 struct ProviderSpec {
-    /// The provider's wire name (`"claude"`, `"codex"`, `"copilot"`), for
-    /// logs/tracing.
-    name: &'static str,
+    /// Which provider this is — its wire name for logs/tracing
+    /// ([`Backend::name`]).
+    backend: Backend,
     /// The provider-log file under [`ExecEnv::logs`].
     log_file: &'static str,
     /// The argv to append after the program path (subcommand + flags + args).
@@ -441,6 +538,21 @@ impl Runner {
     /// network egress to the model API stays allowed. With the sandbox off, or on
     /// an unsupported platform, the command is the bare provider binary (the env
     /// allowlist + process-group kill still apply).
+    ///
+    /// # No credential grant
+    ///
+    /// The confined child is granted NOTHING under the operator's `$HOME` —
+    /// including the provider's own credential store. That is deliberate, and it
+    /// means a provider whose token lives in the macOS Keychain cannot
+    /// authenticate here: a real headless run fails "Not logged in · Please run
+    /// /login" and needs `HANGAR_DAEMON_DISABLE_SANDBOX=1` to complete. An
+    /// earlier attempt to grant the Keychain instead handed the child every
+    /// Chrome-saved password — see the rationale on
+    /// [`ainb_hangar_sandbox::SandboxPolicy`]. The fix is to inject the
+    /// credential as an env var from the UNSANDBOXED parent daemon
+    /// (`claude setup-token` -> `CLAUDE_CODE_OAUTH_TOKEN`), which needs no grant
+    /// into `$HOME` at all; until that lands, sandboxed headless runs are
+    /// unauthenticated by design.
     ///
     /// # Errors
     ///
@@ -525,9 +637,11 @@ impl Runner {
     where
         I: IntoIterator<Item = (String, String)>,
     {
-        // The task brief reaches claude as `-p <prompt>`; the workdir + materialised
-        // home carry the CONTEXT (CLAUDE.md, skills) but never the ask itself.
-        let spec = Self::claude_spec(invocation);
+        // The task brief reaches claude as the trailing positional; the workdir +
+        // materialised home carry the CONTEXT (CLAUDE.md, skills) but never the ask
+        // itself. `run_provider` captures stdout against a null stdin, so this is
+        // unambiguously the headless contract.
+        let spec = Self::claude_spec(invocation, Mode::Headless);
         self.run_provider(
             &self.cfg.claude_path,
             env,
@@ -620,7 +734,7 @@ impl Runner {
         I: IntoIterator<Item = (String, String)>,
         E: IntoIterator<Item = (String, String)>,
     {
-        let spec = Self::codex_spec(invocation);
+        let spec = Self::codex_spec(invocation, Mode::Headless);
         self.run_provider(
             &self.cfg.codex_path,
             env,
@@ -699,7 +813,7 @@ impl Runner {
         I: IntoIterator<Item = (String, String)>,
         E: IntoIterator<Item = (String, String)>,
     {
-        let spec = Self::copilot_spec(invocation);
+        let spec = Self::copilot_spec(invocation, Mode::Headless);
         self.run_provider(
             &self.cfg.copilot_path,
             env,
@@ -711,79 +825,122 @@ impl Runner {
         .await
     }
 
-    /// The program path + argv for a provider run, WITHOUT spawning it (ccc / D6).
+    /// The program path + argv for a provider run in `mode`, WITHOUT spawning it
+    /// (ccc / D6).
     ///
     /// The interactive tmux path ([`crate::interactive`]) needs the exact program
-    /// and arguments the headless path would exec, but launched inside a tmux
-    /// session instead of a captured subprocess. Returning them from here keeps the
-    /// per-provider argv shape (`codex exec [-m …]`) in one place rather than
-    /// re-deriving it at the call site.
+    /// and arguments to exec inside a tmux session rather than a captured
+    /// subprocess. Deriving them here keeps each provider's argv shape in one
+    /// place — but the shape DIFFERS by [`Mode`], so the caller must say which
+    /// contract it is spawning for; the headless argv is print-and-exit and would
+    /// hand the operator a dead pane.
     #[must_use]
     pub fn provider_command(
         &self,
         backend: Backend,
         invocation: &ProviderInvocation,
+        mode: Mode,
     ) -> (PathBuf, Vec<String>) {
         match backend {
             Backend::Claude => (
                 self.cfg.claude_path.clone(),
-                Self::claude_spec(invocation).argv,
+                Self::claude_spec(invocation, mode).argv,
             ),
             Backend::Codex => (
                 self.cfg.codex_path.clone(),
-                Self::codex_spec(invocation).argv,
+                Self::codex_spec(invocation, mode).argv,
             ),
             Backend::Copilot => (
                 self.cfg.copilot_path.clone(),
-                Self::copilot_spec(invocation).argv,
+                Self::copilot_spec(invocation, mode).argv,
             ),
         }
     }
 
-    /// The `claude` provider spec: claude log file + the non-interactive
-    /// `-p <prompt>` [+ `--model <model>`] [+ `<cli_args>`].
+    /// The `claude` provider spec: claude log file + `[-p] [--model <model>]
+    /// [<cli_args>…] -- <prompt>`.
     ///
-    /// `-p/--print` is what makes claude non-interactive; verified against Claude
-    /// Code 2.1.210, whose help reads "starts an interactive session by default,
-    /// use -p/--print for non-interactive output". Without it the daemon's spawn
-    /// (null stdin, captured stdout) exits 1 without doing any work.
-    fn claude_spec(invocation: &ProviderInvocation) -> ProviderSpec {
+    /// Verified against Claude Code 2.1.210, whose usage is
+    /// `claude [options] [command] [prompt]`:
+    ///
+    /// * [`Mode::Headless`] adds `-p/--print` ("Print response and exit"). Without
+    ///   it the daemon's spawn (null stdin, captured stdout) exits 1 having done
+    ///   nothing.
+    /// * [`Mode::Interactive`] OMITS it: the brief is still delivered (as the same
+    ///   trailing positional), but claude starts the real session the operator
+    ///   attaches to. `-p` here would print and exit into an empty pane.
+    ///
+    /// The prompt is a POSITIONAL either way — `-p` is a boolean and never takes
+    /// it — and rides last, after [`ARG_SEPARATOR`], so a `-`-leading brief cannot
+    /// be read as a flag.
+    fn claude_spec(invocation: &ProviderInvocation, mode: Mode) -> ProviderSpec {
         let mut argv = Vec::new();
-        if !invocation.prompt.is_empty() {
-            argv.push(CLAUDE_PROMPT_FLAG.to_string());
-            argv.push(invocation.prompt.clone());
+        if mode == Mode::Headless {
+            argv.push(CLAUDE_PRINT_FLAG.to_string());
         }
         if let Some(model) = &invocation.model {
             argv.push(CLAUDE_MODEL_FLAG.to_string());
             argv.push(model.clone());
         }
         argv.extend(invocation.cli_args.iter().cloned());
+        argv.push(ARG_SEPARATOR.to_string());
+        argv.push(invocation.prompt.clone());
         ProviderSpec {
-            name: "claude",
+            backend: Backend::Claude,
             log_file: CLAUDE_LOG_FILE,
             argv,
         }
     }
 
-    /// The `codex` provider spec: codex log file + the non-interactive argv
-    /// `exec [-m <model>] [<cli_args>…]` (e38.16).
-    fn codex_spec(invocation: &ProviderInvocation) -> ProviderSpec {
-        let mut argv = vec![
-            CODEX_EXEC_SUBCOMMAND.to_string(),
-            CODEX_SKIP_GIT_CHECK_FLAG.to_string(),
-        ];
+    /// The `codex` provider spec: codex log file + `[exec --skip-git-repo-check]
+    /// [-m <model>] [<cli_args>…] -- <prompt>` (e38.16).
+    ///
+    /// Verified against codex-cli 0.144.0, whose usage is both
+    /// `codex [OPTIONS] [PROMPT]` (interactive TUI) and `codex exec …`
+    /// ("Run Codex non-interactively"):
+    ///
+    /// * [`Mode::Headless`] leads with the `exec` subcommand, plus
+    ///   [`CODEX_SKIP_GIT_CHECK_FLAG`].
+    /// * [`Mode::Interactive`] omits BOTH, so the top-level TUI starts with the
+    ///   brief as its opening prompt. `codex exec` in a tmux pane would stream and
+    ///   exit rather than give the operator a session.
+    ///
+    /// # Why the git-repo check is skipped headlessly but not interactively
+    ///
+    /// This is not a judgement call — the CLI settles it. `--skip-git-repo-check`
+    /// is an `exec`-only flag: `codex --skip-git-repo-check …` at the top level is
+    /// a hard parse error ("unexpected argument '--skip-git-repo-check' found",
+    /// exit 2, verified), so an interactive session CANNOT carry it and would
+    /// refuse to start if it did.
+    ///
+    /// That happens to match the security reasoning. The flag's justification is
+    /// that the daemon supplies the confinement codex's check proxies for
+    /// (per-task isolated dir + FS sandbox + teardown) — but the interactive path
+    /// DELIBERATELY has no FS sandbox (see `run_loop::run_interactive`), so that
+    /// justification does not hold there. It does not need to: a human is attached
+    /// to the session and can answer codex's trust prompt themselves, which is
+    /// exactly the review the check exists to secure.
+    ///
+    /// The prompt is a trailing POSITIONAL in both shapes, after every option and
+    /// after [`ARG_SEPARATOR`] (which also stops a value-taking flag in `cli_args`
+    /// from swallowing it, and stops a brief like `review` from hijacking
+    /// `codex exec`'s `review` subcommand). Verified to compose:
+    /// `codex exec --skip-git-repo-check -- "-fix the login bug"` parses and runs.
+    fn codex_spec(invocation: &ProviderInvocation, mode: Mode) -> ProviderSpec {
+        let mut argv = Vec::new();
+        if mode == Mode::Headless {
+            argv.push(CODEX_EXEC_SUBCOMMAND.to_string());
+            argv.push(CODEX_SKIP_GIT_CHECK_FLAG.to_string());
+        }
         if let Some(model) = &invocation.model {
             argv.push(CODEX_MODEL_FLAG.to_string());
             argv.push(model.clone());
         }
         argv.extend(invocation.cli_args.iter().cloned());
-        // `codex exec [OPTIONS] [PROMPT]` — the prompt is a trailing POSITIONAL, so
-        // it must come after every option (verified: `codex exec --help`).
-        if !invocation.prompt.is_empty() {
-            argv.push(invocation.prompt.clone());
-        }
+        argv.push(ARG_SEPARATOR.to_string());
+        argv.push(invocation.prompt.clone());
         ProviderSpec {
-            name: "codex",
+            backend: Backend::Codex,
             log_file: CODEX_LOG_FILE,
             argv,
         }
@@ -821,19 +978,31 @@ impl Runner {
     ///   — it is the existing one made explicit in argv.
     /// * Claude reaches the same place by a different route (its permission
     ///   behaviour under `--print` differs), so the two are not yet symmetrical.
-    ///   When the `-p` gap below is closed, claude will need this decision too —
-    ///   resolve BOTH providers' permission policy in one pass then, rather than
-    ///   inventing a half-policy here.
+    ///   Resolving BOTH providers' permission policy in one pass is still open.
     ///
-    /// The brief is handed over as `-p <prompt>` (verified against Copilot CLI
-    /// 1.0.68: "Execute a prompt in non-interactive mode"). Bare `copilot` would
-    /// start an INTERACTIVE session against the daemon's null stdin and do nothing.
-    fn copilot_spec(invocation: &ProviderInvocation) -> ProviderSpec {
-        let mut argv = Vec::new();
-        if !invocation.prompt.is_empty() {
-            argv.push(COPILOT_PROMPT_FLAG.to_string());
-            argv.push(invocation.prompt.clone());
-        }
+    /// # The brief rides a value-taking flag, chosen by [`Mode`]
+    ///
+    /// Copilot has NO positional prompt (`copilot [options] [command]`; a bare
+    /// positional is rejected with "Invalid command format"), so — unlike claude
+    /// and codex — the brief is the VALUE of a flag, and which flag is the whole
+    /// interactive/headless distinction (verified against Copilot CLI 1.0.68):
+    ///
+    /// * [`Mode::Headless`] → `-p <prompt>`: "Execute a prompt in non-interactive
+    ///   mode (exits after completion)".
+    /// * [`Mode::Interactive`] → `-i <prompt>`: "Start interactive mode and
+    ///   automatically execute this prompt" — a real session, seeded with the
+    ///   brief, which is what an attachable tmux pane needs.
+    ///
+    /// Because the brief is a flag VALUE, it needs no [`ARG_SEPARATOR`]: the
+    /// parser consumes a `-`-leading value verbatim (verified: `copilot -p
+    /// "-fix the login bug"` parses). Adding `--` would BREAK it — `--` becomes
+    /// the prompt value and the brief is then rejected as an unknown option.
+    fn copilot_spec(invocation: &ProviderInvocation, mode: Mode) -> ProviderSpec {
+        let prompt_flag = match mode {
+            Mode::Headless => COPILOT_HEADLESS_PROMPT_FLAG,
+            Mode::Interactive => COPILOT_INTERACTIVE_PROMPT_FLAG,
+        };
+        let mut argv = vec![prompt_flag.to_string(), invocation.prompt.clone()];
         argv.push(COPILOT_ALLOW_ALL_TOOLS_FLAG.to_string());
         if let Some(model) = &invocation.model {
             argv.push(COPILOT_MODEL_FLAG.to_string());
@@ -841,7 +1010,7 @@ impl Runner {
         }
         argv.extend(invocation.cli_args.iter().cloned());
         ProviderSpec {
-            name: "copilot",
+            backend: Backend::Copilot,
             log_file: COPILOT_LOG_FILE,
             argv,
         }
@@ -982,7 +1151,11 @@ impl Runner {
         };
 
         let outcome = if timed_out {
-            tracing::warn!(provider = spec.name, reason = "timeout", "runner_failed");
+            tracing::warn!(
+                provider = spec.backend.name(),
+                reason = "timeout",
+                "runner_failed"
+            );
             RunOutcome::Failed {
                 reason: FailureReason::Timeout,
                 result,
@@ -995,7 +1168,7 @@ impl Runner {
             // re-dispatches a child task, rather than treating it as a terminal
             // agent error.
             tracing::warn!(
-                provider = spec.name,
+                provider = spec.backend.name(),
                 reason = "runtime_offline",
                 "runner_failed"
             );
@@ -1004,7 +1177,7 @@ impl Runner {
                 result,
             }
         } else {
-            tracing::warn!(provider = spec.name, reason = "agent_error", exit_code = ?exit_code, "runner_failed");
+            tracing::warn!(provider = spec.backend.name(), reason = "agent_error", exit_code = ?exit_code, "runner_failed");
             RunOutcome::Failed {
                 reason: FailureReason::AgentError,
                 result,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -1326,6 +1326,79 @@ mod tests {
         (k.to_string(), v.to_string())
     }
 
+    /// The Seatbelt profile the daemon actually generates for a confined task
+    /// must grant NOTHING under the operator's `$HOME` and no mach service.
+    ///
+    /// This reads the profile back off the real `sandbox-exec -p <profile>` argv
+    /// [`Runner::build_command`] builds, rather than re-deriving it — so it
+    /// asserts what the provider is actually spawned under.
+    ///
+    /// A per-provider "credential grant" (a securityd `mach-lookup` +
+    /// `~/Library/Keychains/login.keychain-db`) was briefly shipped here to get a
+    /// confined claude authenticated. It handed the child every Chrome-saved
+    /// password: under this exact profile,
+    /// `security find-generic-password -s 'Chrome Safe Storage' -w` returned the
+    /// secret silently. `process-exec*` is allowed, so a confined agent reaches
+    /// `/usr/bin/security` on its own, and securityd does NOT arbitrate per-item
+    /// for ACL-permissive items. It is gone; this pins that it stays gone.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn confined_task_profile_grants_no_home_path_and_no_mach_service() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("task");
+        let env = ExecEnv {
+            workdir: root.join("workdir"),
+            output: root.join("output"),
+            logs: root.join("logs"),
+            gc_meta: root.join(".gc_meta.json"),
+        };
+        let runner = Runner::new(RunnerConfig {
+            claude_path: "claude".into(),
+            codex_path: "codex".into(),
+            copilot_path: "copilot".into(),
+            max_runtime: Duration::from_secs(1),
+            tail_lines: 1,
+            sandbox: true,
+        });
+        let cmd = runner.build_command(Path::new("/bin/sh"), &env, None).unwrap();
+
+        // `sandbox-exec -p <profile> -- <program>`: the profile is the arg after `-p`.
+        let args: Vec<String> =
+            cmd.as_std().get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        let profile = args
+            .iter()
+            .position(|a| a == "-p")
+            .and_then(|i| args.get(i + 1))
+            .expect("the confined command must carry an inline -p profile");
+
+        assert!(
+            !profile.contains("mach-lookup"),
+            "no mach service may be granted — securityd least of all:\n{profile}"
+        );
+        assert!(
+            !profile.contains("SecurityServer"),
+            "the Keychain grant must stay gone:\n{profile}"
+        );
+        assert!(
+            !profile.contains("keychain"),
+            "no keychain file may be granted:\n{profile}"
+        );
+        assert!(
+            !profile.contains(".credentials.json"),
+            "no credential file may be granted:\n{profile}"
+        );
+
+        // Nothing under the operator's real home is reachable. The task root is
+        // a tempdir, so every granted path is a system root or the task itself.
+        if let Some(home) = dirs::home_dir() {
+            let home = home.to_string_lossy().to_string();
+            assert!(
+                !profile.contains(&home),
+                "no path under the operator's $HOME ({home}) may be granted:\n{profile}"
+            );
+        }
+    }
+
     #[test]
     fn compose_child_env_filters_source_to_the_allowlist() {
         // A non-allowlisted ambient var (a leaked secret) is dropped; HOME survives.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -24,8 +24,21 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use ainb_hangar_daemon::execenv::ExecEnv;
-use ainb_hangar_daemon::runner::{Backend, ProviderInvocation, RunOutcome, Runner, RunnerConfig};
+use ainb_hangar_daemon::runner::{
+    Backend, Mode, ProviderInvocation, RunOutcome, Runner, RunnerConfig,
+};
 use tempfile::TempDir;
+
+/// A minimal invocation carrying only a brief — the shape every real dispatch
+/// has (`ProviderInvocation` has no `Default`: a promptless provider exits
+/// non-zero instead of running).
+fn invocation(prompt: &str) -> ProviderInvocation {
+    ProviderInvocation {
+        prompt: prompt.to_string(),
+        model: None,
+        cli_args: Vec::new(),
+    }
+}
 
 fn exec_env_in(dir: &Path) -> ExecEnv {
     let workdir = dir.join("workdir");
@@ -124,15 +137,15 @@ fn runner_with_all(dir: &Path) -> (Runner, PathBuf) {
 async fn dispatch(runner: &Runner, backend: Backend, env: &ExecEnv) -> RunOutcome {
     match backend {
         Backend::Claude => runner
-            .run_claude(env, std::iter::empty(), &ProviderInvocation::default())
+            .run_claude(env, std::iter::empty(), &invocation("do the thing"))
             .await
             .expect("run claude"),
         Backend::Codex => runner
-            .run_codex(env, std::iter::empty(), &ProviderInvocation::default())
+            .run_codex(env, std::iter::empty(), &invocation("do the thing"))
             .await
             .expect("run codex"),
         Backend::Copilot => runner
-            .run_copilot(env, std::iter::empty(), &ProviderInvocation::default())
+            .run_copilot(env, std::iter::empty(), &invocation("do the thing"))
             .await
             .expect("run copilot"),
     }
@@ -229,8 +242,11 @@ async fn copilot_backend_takes_copilot_path() {
         "copilot backend must spawn the COPILOT binary, not another provider's"
     );
     // The program the runner would exec is the configured copilot path.
-    let (program, _argv) =
-        runner.provider_command(Backend::Copilot, &ProviderInvocation::default());
+    let (program, _argv) = runner.provider_command(
+        Backend::Copilot,
+        &invocation("do the thing"),
+        Mode::Headless,
+    );
     assert_eq!(
         program.file_name().unwrap(),
         "fake-copilot.sh",
@@ -263,11 +279,22 @@ fn copilot_command_carries_verified_non_interactive_flags() {
     let tmp = TempDir::new().expect("tmp");
     let (runner, _marker) = runner_with_all(tmp.path());
 
-    let (_program, argv) =
-        runner.provider_command(Backend::Copilot, &ProviderInvocation::default());
+    let (_program, argv) = runner.provider_command(
+        Backend::Copilot,
+        &invocation("do the thing"),
+        Mode::Headless,
+    );
     assert!(
         argv.contains(&"--allow-all-tools".to_string()),
         "copilot needs --allow-all-tools for non-interactive mode: {argv:?}"
+    );
+    // The BRIEF must actually reach copilot. Asserted explicitly because a fixture
+    // that merely SETS a prompt proves nothing: this test used to pass a prompt and
+    // check only the flags, so deleting copilot_spec's prompt push left the whole
+    // suite green while every real copilot run did nothing.
+    assert!(
+        argv.join(" ").contains("-p do the thing"),
+        "copilot must receive the brief as the value of -p: {argv:?}"
     );
 
     // The agent's configured model is threaded (copilot DOES support --model).
@@ -276,7 +303,7 @@ fn copilot_command_carries_verified_non_interactive_flags() {
         model: Some("gpt-5.4".to_string()),
         cli_args: vec!["--add-dir".to_string(), "/tmp/x".to_string()],
     };
-    let (_program, argv) = runner.provider_command(Backend::Copilot, &invocation);
+    let (_program, argv) = runner.provider_command(Backend::Copilot, &invocation, Mode::Headless);
     let joined = argv.join(" ");
     assert!(
         joined.contains("--model gpt-5.4"),
@@ -296,6 +323,12 @@ fn copilot_command_carries_verified_non_interactive_flags() {
 ///   directory") in the daemon's non-repo in-tree workdir, and takes the prompt as a
 ///   TRAILING positional,
 /// * copilot needs `-p` + `--allow-all-tools` ("required for non-interactive mode").
+///
+/// claude and codex now fence the brief behind `--`, because their briefs are
+/// POSITIONALS and issue text can start with `-` (see
+/// `dash_leading_brief_is_delivered_as_text_to_every_provider`). Copilot's is a
+/// flag VALUE and must NOT be fenced. Verified to compose:
+/// `codex exec --skip-git-repo-check -- "-fix the login bug"` parses and runs.
 #[test]
 fn every_provider_argv_is_the_verified_headless_shape() {
     let tmp = TempDir::new().expect("tmp");
@@ -306,21 +339,175 @@ fn every_provider_argv_is_the_verified_headless_shape() {
         cli_args: Vec::new(),
     };
 
-    let (_p, claude) = runner.provider_command(Backend::Claude, &inv);
-    assert_eq!(claude, vec!["-p", "BRIEF"], "claude: -p <brief>");
+    let (_p, claude) = runner.provider_command(Backend::Claude, &inv, Mode::Headless);
+    assert_eq!(claude, vec!["-p", "--", "BRIEF"], "claude: -p -- <brief>");
 
-    let (_p, codex) = runner.provider_command(Backend::Codex, &inv);
+    let (_p, codex) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
     assert_eq!(
         codex,
-        vec!["exec", "--skip-git-repo-check", "BRIEF"],
-        "codex: exec --skip-git-repo-check <brief> (prompt is a trailing positional)"
+        vec!["exec", "--skip-git-repo-check", "--", "BRIEF"],
+        "codex: exec --skip-git-repo-check -- <brief> (prompt is a trailing positional)"
     );
 
-    let (_p, copilot) = runner.provider_command(Backend::Copilot, &inv);
+    let (_p, copilot) = runner.provider_command(Backend::Copilot, &inv, Mode::Headless);
     assert_eq!(
         copilot,
         vec!["-p", "BRIEF", "--allow-all-tools"],
         "copilot: -p <brief> --allow-all-tools"
+    );
+}
+
+/// The INTERACTIVE argv must never be the headless one.
+///
+/// `Mode::Interactive` backs an attachable tmux pane the operator drives, so the
+/// flags that mean "do it and exit" are exactly wrong there — but they are the
+/// same providers and the same builders, so one shared argv silently served both
+/// contracts and shipped a print-and-exit process into a live pane. Shapes
+/// verified against the real binaries (claude 2.1.210 / codex-cli 0.144.0 /
+/// Copilot CLI 1.0.68).
+#[test]
+fn interactive_argv_seeds_a_real_session_never_print_and_exit() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _marker) = runner_with_all(tmp.path());
+    let inv = invocation("do the thing");
+
+    // claude: `-p/--print` is "Print response and exit" — fatal for a pane the
+    // user attaches to. The brief still arrives, as the same trailing positional.
+    let (_p, argv) = runner.provider_command(Backend::Claude, &inv, Mode::Interactive);
+    assert!(
+        !argv.contains(&"-p".to_string()),
+        "interactive claude must NOT print-and-exit: {argv:?}"
+    );
+    assert!(
+        argv.ends_with(&["--".to_string(), "do the thing".to_string()]),
+        "interactive claude must still carry the brief: {argv:?}"
+    );
+    // The headless counterpart is the one that DOES print and exit.
+    let (_p, argv) = runner.provider_command(Backend::Claude, &inv, Mode::Headless);
+    assert!(
+        argv.contains(&"-p".to_string()),
+        "headless claude must print-and-exit: {argv:?}"
+    );
+
+    // codex: `exec` is the non-interactive subcommand; the interactive TUI is the
+    // bare top-level command with the brief as its opening positional.
+    let (_p, argv) = runner.provider_command(Backend::Codex, &inv, Mode::Interactive);
+    assert!(
+        !argv.contains(&"exec".to_string()),
+        "interactive codex must NOT use the exec subcommand: {argv:?}"
+    );
+    assert!(
+        argv.ends_with(&["--".to_string(), "do the thing".to_string()]),
+        "interactive codex must still carry the brief: {argv:?}"
+    );
+    let (_p, argv) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
+    assert_eq!(argv.first().map(String::as_str), Some("exec"));
+
+    // copilot: `-p` "exits after completion"; `-i` "Start interactive mode and
+    // automatically execute this prompt".
+    let (_p, argv) = runner.provider_command(Backend::Copilot, &inv, Mode::Interactive);
+    assert!(
+        !argv.contains(&"-p".to_string()),
+        "interactive copilot must NOT use the exits-after-completion flag: {argv:?}"
+    );
+    assert!(
+        argv.join(" ").contains("-i do the thing"),
+        "interactive copilot must seed the session with the brief via -i: {argv:?}"
+    );
+}
+
+/// A brief is arbitrary issue text, so it can start with `-` (an issue titled
+/// `- fix the login bug` is ordinary bullet prose). It must reach the provider as
+/// TEXT, never as flags.
+///
+/// Verified against the real binaries: `codex exec "-fix the login bug"` →
+/// "unexpected argument '-f' found"; `claude -p "-reply …"` silently absorbs the
+/// leading `-r` as its own `--resume` and then fails on the remainder. Both parse
+/// correctly once the brief sits after `--`. Copilot is the exception BY DESIGN —
+/// its brief is a flag VALUE, which takes a dash-leading string verbatim, and a
+/// `--` there would be consumed AS the value and break it.
+#[test]
+fn dash_leading_brief_is_delivered_as_text_to_every_provider() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _marker) = runner_with_all(tmp.path());
+    let brief = "-fix the login bug";
+    let inv = invocation(brief);
+
+    for mode in [Mode::Headless, Mode::Interactive] {
+        // claude + codex: the brief is a positional, so it MUST be fenced off by
+        // the end-of-options separator immediately before it.
+        for backend in [Backend::Claude, Backend::Codex] {
+            let (_p, argv) = runner.provider_command(backend, &inv, mode);
+            assert!(
+                argv.ends_with(&["--".to_string(), brief.to_string()]),
+                "{backend:?}/{mode:?} must fence a dash-leading brief behind `--`: {argv:?}"
+            );
+        }
+
+        // copilot: the brief rides a value-taking flag and must NOT be fenced —
+        // `copilot -p -- "-fix…"` makes `--` the prompt and rejects the brief.
+        let (_p, argv) = runner.provider_command(Backend::Copilot, &inv, mode);
+        assert!(
+            !argv.contains(&"--".to_string()),
+            "copilot must NOT get an `--` separator (it would become the prompt value): {argv:?}"
+        );
+        let flag = if mode == Mode::Headless { "-p" } else { "-i" };
+        assert_eq!(
+            argv.iter().position(|a| a == brief),
+            argv.iter().position(|a| a == flag).map(|i| i + 1),
+            "copilot/{mode:?} must pass the dash-leading brief as {flag}'s value: {argv:?}"
+        );
+    }
+}
+
+/// A brief that happens to spell a subcommand is still a brief.
+///
+/// Verified: `codex exec review` hijacks codex's `review` subcommand and dies
+/// ("Specify --uncommitted, --base, --commit, or provide custom review
+/// instructions"); `codex exec -- review` treats it as the prompt.
+#[test]
+fn brief_that_names_a_subcommand_does_not_hijack_it() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _marker) = runner_with_all(tmp.path());
+    let (_p, argv) = runner.provider_command(Backend::Codex, &invocation("review"), Mode::Headless);
+    assert_eq!(
+        argv,
+        vec![
+            "exec".to_string(),
+            "--skip-git-repo-check".to_string(),
+            "--".to_string(),
+            "review".to_string()
+        ],
+        "a `review` brief must be codex's PROMPT, not its review subcommand: {argv:?}"
+    );
+}
+
+/// A value-taking flag in the agent's `cli_args` must not swallow the brief.
+///
+/// `cli_args` are appended verbatim before the prompt, so a trailing flag that
+/// expects a value would eat the brief as that value. The `--` separator ends
+/// option parsing first, so the brief stays a positional.
+#[test]
+fn value_taking_cli_arg_cannot_swallow_the_brief() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _marker) = runner_with_all(tmp.path());
+    let inv = ProviderInvocation {
+        prompt: "do the thing".to_string(),
+        model: None,
+        // A flag whose value the agent forgot to supply.
+        cli_args: vec!["--add-dir".to_string()],
+    };
+    let (_p, argv) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
+    assert_eq!(
+        argv,
+        vec![
+            "exec".to_string(),
+            "--skip-git-repo-check".to_string(),
+            "--add-dir".to_string(),
+            "--".to_string(),
+            "do the thing".to_string()
+        ],
+        "`--` must separate cli_args from the brief: {argv:?}"
     );
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -18,6 +18,18 @@ use ainb_hangar_daemon::runner::{ProviderInvocation, RunOutcome, Runner, RunnerC
 use ainb_hangar_store::service::fail::FailureReason;
 use tempfile::TempDir;
 
+/// A minimal invocation carrying only a brief — the shape every real dispatch
+/// has. `ProviderInvocation` has no `Default` on purpose: a promptless provider
+/// exits non-zero instead of running, so these tests must state a brief rather
+/// than quietly assert against an argv no real run ever produces.
+fn invocation() -> ProviderInvocation {
+    ProviderInvocation {
+        prompt: "do the thing".to_string(),
+        model: None,
+        cli_args: Vec::new(),
+    }
+}
+
 /// Build a per-task [`ExecEnv`] rooted in `dir` (workdir/output/logs created).
 fn exec_env_in(dir: &Path) -> ExecEnv {
     let workdir = dir.join("workdir");
@@ -97,11 +109,7 @@ exit 0"#,
     ];
 
     let outcome = runner
-        .run_claude(
-            &env,
-            overrides.iter().cloned(),
-            &ProviderInvocation::default(),
-        )
+        .run_claude(&env, overrides.iter().cloned(), &invocation())
         .await
         .expect("run");
     let result = outcome.result();
@@ -134,10 +142,7 @@ async fn exec_captures_exit_code() {
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
 
     assert_eq!(outcome.result().exit_code, Some(0));
     assert!(matches!(outcome, RunOutcome::Success(_)));
@@ -167,10 +172,7 @@ exit 0"#,
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
     let usage = outcome.result().usage.clone().expect("usage captured from result line");
     assert_eq!(usage.input_tokens, 1200);
     assert_eq!(usage.output_tokens, 340);
@@ -193,10 +195,7 @@ async fn exec_no_result_usage_leaves_usage_none() {
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
     assert!(
         outcome.result().usage.is_none(),
         "a result line without usage leaves usage None"
@@ -224,10 +223,7 @@ exit 1"#,
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
 
     match outcome {
         RunOutcome::Failed { reason, result } => {
@@ -262,10 +258,7 @@ exit 75"#,
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
 
     match outcome {
         RunOutcome::Failed { reason, result } => {
@@ -300,10 +293,7 @@ exit 0"#,
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
 
     assert_eq!(
         outcome.result().session_id.as_deref(),
@@ -335,10 +325,7 @@ exit 0"#,
         sandbox: true,
     });
 
-    runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
 
     let jsonl = env.logs.join("claude.jsonl");
     assert!(jsonl.exists(), "expected claude.jsonl at {jsonl:?}");
@@ -375,10 +362,7 @@ exit 0"#,
     });
 
     let started = std::time::Instant::now();
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &ProviderInvocation::default())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
     let elapsed = started.elapsed();
 
     assert!(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
@@ -20,6 +20,18 @@ use ainb_hangar_daemon::runner::{ProviderInvocation, RunOutcome, Runner, RunnerC
 use ainb_hangar_store::service::fail::FailureReason;
 use tempfile::TempDir;
 
+/// A minimal invocation carrying only a brief — the shape every real dispatch
+/// has. `ProviderInvocation` has no `Default` on purpose: a promptless provider
+/// exits non-zero instead of running, so these tests must state a brief rather
+/// than quietly assert against an argv no real run ever produces.
+fn brief_invocation() -> ProviderInvocation {
+    ProviderInvocation {
+        prompt: "do the thing".to_string(),
+        model: None,
+        cli_args: Vec::new(),
+    }
+}
+
 /// Build a per-task [`ExecEnv`] rooted in `dir` (workdir/output/logs created).
 fn exec_env_in(dir: &Path) -> ExecEnv {
     let workdir = dir.join("workdir");
@@ -85,7 +97,7 @@ async fn codex_exec_captures_exit_code_and_pins_session() {
     let runner = Runner::new(cfg_with_codex(script));
 
     let outcome = runner
-        .run_codex(&env, std::iter::empty(), &ProviderInvocation::default())
+        .run_codex(&env, std::iter::empty(), &brief_invocation())
         .await
         .expect("run");
 
@@ -102,7 +114,7 @@ async fn codex_exec_streams_jsonl_to_codex_log() {
     let runner = Runner::new(cfg_with_codex(script));
 
     runner
-        .run_codex(&env, std::iter::empty(), &ProviderInvocation::default())
+        .run_codex(&env, std::iter::empty(), &brief_invocation())
         .await
         .expect("run");
 
@@ -132,7 +144,10 @@ exit 0"#,
     );
     let runner = Runner::new(cfg_with_codex(script));
     let invocation = ProviderInvocation {
-        prompt: String::new(),
+        // A REAL brief. This used to be `String::new()`, which dodged the only
+        // thing that matters: deleting codex_spec's prompt push left this test —
+        // and the whole suite — green while every real codex run did nothing.
+        prompt: "do the thing".to_string(),
         model: Some("gpt-5-codex".to_string()),
         cli_args: vec!["--full-auto".to_string()],
     };
@@ -151,6 +166,22 @@ exit 0"#,
     assert!(
         tail.contains("--full-auto"),
         "argv must carry the agent's cli_args, got: {tail}"
+    );
+    // The BRIEF reaches codex, as the trailing positional after every option
+    // (`codex exec [OPTIONS] [PROMPT]`), fenced by `--`. Asserted on the argv the
+    // fake actually received, so it fails if the prompt is dropped OR misplaced
+    // ahead of the options.
+    let argv_line = tail
+        .lines()
+        .find(|l| l.starts_with("ARGV="))
+        .expect("fake codex must echo its argv");
+    assert!(
+        argv_line.ends_with("-- do the thing"),
+        "codex must receive the brief as the trailing positional after `--`, got: {argv_line}"
+    );
+    assert!(
+        argv_line.contains("--full-auto -- do the thing"),
+        "the brief must follow the agent's cli_args, not precede them: {argv_line}"
     );
 }
 
@@ -171,7 +202,7 @@ exit 0"#,
     // the child (it is not in the allowlist). The agent's explicit per-agent env
     // (FOO) is a deliberate override that MUST reach the child.
     let source = [("SECRET_KEY".to_string(), "leak".to_string())];
-    let invocation = ProviderInvocation::default();
+    let invocation = brief_invocation();
     let extra_env = [("FOO".to_string(), "bar".to_string())];
 
     let outcome = runner
@@ -208,7 +239,7 @@ exit 1"#,
     let runner = Runner::new(cfg_with_codex(script));
 
     let outcome = runner
-        .run_codex(&env, std::iter::empty(), &ProviderInvocation::default())
+        .run_codex(&env, std::iter::empty(), &brief_invocation())
         .await
         .expect("run");
 
@@ -239,7 +270,7 @@ exit 0"#,
 
     let started = std::time::Instant::now();
     let outcome = runner
-        .run_codex(&env, std::iter::empty(), &ProviderInvocation::default())
+        .run_codex(&env, std::iter::empty(), &brief_invocation())
         .await
         .expect("run");
     let elapsed = started.elapsed();
@@ -278,7 +309,7 @@ exit 0"#,
     let source = [("HOME".to_string(), tmp.path().display().to_string())];
 
     let outcome = runner
-        .run_codex(&env, source.iter().cloned(), &ProviderInvocation::default())
+        .run_codex(&env, source.iter().cloned(), &brief_invocation())
         .await
         .expect("run");
 

--- a/ainb-tui/crates/ainb-hangar-sandbox/src/imp_macos.rs
+++ b/ainb-tui/crates/ainb-hangar-sandbox/src/imp_macos.rs
@@ -100,6 +100,10 @@ fn render_profile(program: &Path, policy: &SandboxPolicy) -> String {
         p.push_str("(allow network*)\n");
     }
 
+    // No `mach-lookup` is ever emitted — see the "no Keychain / securityd grant"
+    // section on `SandboxPolicy`. `deny default` covers mach services, so the
+    // absence of a rule here IS the denial.
+
     p
 }
 
@@ -144,6 +148,44 @@ mod tests {
         assert!(prof.contains("(allow network*)"));
         // The operator home must NOT be a blanket read root.
         assert!(!prof.contains("(subpath \"/Users\")"));
+    }
+
+    /// No profile this crate can generate reaches a mach service — in
+    /// particular securityd, which is the macOS Keychain.
+    ///
+    /// A `mach-lookup` on `com.apple.SecurityServer` was briefly shipped as an
+    /// opt-in "credential grant". It is not per-item: under this exact profile it
+    /// also hands over `Chrome Safe Storage` (the master key for every
+    /// Chrome-saved password) silently and with no prompt, and `process-exec*`
+    /// means a confined agent reaches it by spawning `/usr/bin/security`. Pin the
+    /// absence so it cannot come back by accident — see the rationale on
+    /// `SandboxPolicy`.
+    #[test]
+    fn profile_never_grants_mach_lookup() {
+        let policy = SandboxPolicy {
+            read_roots: vec![PathBuf::from("/usr")],
+            write_roots: vec![PathBuf::from("/tmp/task")],
+            allow_network: true,
+            disabled: false,
+        };
+        let prof = render_profile(Path::new("/bin/sh"), &policy);
+        assert!(
+            !prof.contains("mach-lookup"),
+            "no mach service may be re-allowed — securityd least of all: {prof}"
+        );
+        assert!(
+            !prof.contains("SecurityServer"),
+            "the Keychain grant must stay gone: {prof}"
+        );
+        // The full confined policy a real task gets must be just as silent.
+        let prof = render_profile(
+            Path::new("/bin/sh"),
+            &SandboxPolicy::confined_to(Path::new("/tmp/task")),
+        );
+        assert!(
+            !prof.contains("mach-lookup"),
+            "the default task policy must grant no mach service: {prof}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-sandbox/src/policy.rs
+++ b/ainb-tui/crates/ainb-hangar-sandbox/src/policy.rs
@@ -11,6 +11,31 @@ use std::path::{Path, PathBuf};
 /// and read/write only the task's isolated roots — it CANNOT read the operator's
 /// `$HOME`, `~/.ssh`, `~/.aws`, etc., which is the exfiltration path this bead
 /// closes.
+///
+/// # There is deliberately no Keychain / securityd grant
+///
+/// A confined provider whose credential lives in the macOS login Keychain cannot
+/// reach it (`deny default` blocks the securityd mach-lookup), so a headless run
+/// fails "Not logged in". Do NOT fix that by re-allowing
+/// `mach-lookup (global-name "com.apple.SecurityServer")`. That grant was built,
+/// measured, and removed:
+///
+/// * It is not per-item. Under this exact profile,
+///   `security find-generic-password -s 'Chrome Safe Storage' -w` goes from
+///   `DENIED rc=44` to returning the secret, silently and with no prompt — and
+///   that item is the master key for every Chrome-saved password, not the
+///   agent's own token. "securityd still arbitrates which items the caller may
+///   have" FAILS OPEN for any item that is ACL-permissive (`-A`) or was ever
+///   marked "Always Allow".
+/// * It cannot be scoped to one caller: the profile allows `process-exec*`, so a
+///   confined agent simply spawns `/usr/bin/security`.
+/// * With `allow_network` also on, and briefs built from board issue text, the
+///   chain prompt-injection -> `security` -> egress is complete.
+///
+/// The supported path is to inject the credential as an env var from the
+/// UNSANDBOXED parent daemon (`claude setup-token` ->
+/// `CLAUDE_CODE_OAUTH_TOKEN`), which needs no grant into `$HOME` at all. Until
+/// that lands, a headless run needs `HANGAR_DAEMON_DISABLE_SANDBOX=1`.
 #[derive(Debug, Clone)]
 pub struct SandboxPolicy {
     /// Paths the child may read (and execute). Includes the system roots a real


### PR DESCRIPTION
## Why
Post-merge review of #403 found a live regression plus unproven claims. This fixes them.

## Fixes
- **Critical regression (was live on main)**: `run_interactive` shared `provider_command` with the headless path, so `-p <brief>` leaked into the **interactive tmux argv**. For claude `-p/--print` means *print response and exit* — the board's "Run ▾" attachable sessions were spawning print-and-exit processes. Argv is now built per-`Mode`, and `mode` is carried on `ResolvedDispatch` (resolved once from the task row) so `provider_command` has no third argument a caller can silently get wrong.
- **Promptless fault path**: `unwrap_or_default()` yielded `prompt: ""` → bare `claude` → the original bug. `Default` removed.
- **False greens**: codex + copilot prompt delivery had zero coverage — deleting either prompt push left the suite green. Now 5 RED / **4 RED** respectively.
- **Leading-dash briefs**: an issue titled `- fix the login bug` misparsed (claude silently into `-r/--resume`). `--` separator added where the CLI supports it (copilot excluded — `--` *breaks* it).

## Verified argv matrix (claude 2.1.210 / codex-cli 0.144.0 / Copilot CLI 1.0.70)
| | headless | interactive |
|---|---|---|
| claude | `-p [--model M] [args] -- <brief>` | `[--model M] [args] -- <brief>` |
| codex | `exec --skip-git-repo-check [-m M] [args] -- <brief>` | `[-m M] [args] -- <brief>` |
| copilot | `-p <brief> --allow-all-tools` | `-i <brief> --allow-all-tools` |

## The Keychain grant was REMOVED, not shipped
An earlier revision granted the sandboxed claude read access to the login Keychain so it could authenticate. A security review disproved its central claim empirically — with the daemon's exact profile, `security find-generic-password -s 'Chrome Safe Storage' -w` was **DENIED** without the grant and **returned the secret silently with it**. That is Chrome's master password key, not Claude's. The profile allows `process-exec*`, so a confined agent simply spawns `/usr/bin/security`; "securityd arbitrates per-item access" fails open for any `-A`/Always-Allow item.

The grant was **rebuilt out of history** rather than reverted, so it never lands. Two tests now pin its *absence* (mutation-proved: re-adding the mach-lookup turns both RED).

## Known interim state — stated plainly, not papered over
With the grant gone, headless again requires `HANGAR_DAEMON_DISABLE_SANDBOX=1`. That is deliberate: validate the flow unsandboxed first, then re-enable confinement via `claude setup-token` + `CLAUDE_CODE_OAUTH_TOKEN` injected by the unsandboxed parent daemon (child gets one env var, zero Keychain access). Tracked as bead `ai-coder-rules-48b`.

## Proof
The `run_interactive` mode gap was a **proven** false green — hardcoding `Mode::Headless` there previously left all 254 tests green. It is now mutation-proved RED. Touched suites: 560 passed / 0 failed (`--no-fail-fast`, untruncated). Generated seatbelt profile for a claude task contains no `mach-lookup`, no `SecurityServer`, no keychain paths — only the task's own isolated roots.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved interactive and headless task handling across supported providers.
  - Interactive tasks now receive the correct commands and prompts.
  - Prompts and command-line options are passed more reliably, including edge cases involving leading dashes.

- **Security**
  - Sandboxed processes continue to have no access to operator credentials, Keychain services, or related macOS security services.

- **Documentation**
  - Clarified sandbox credential behavior and available credential-injection workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->