### PR TITLE
fix(hangar-daemon): finalize task to failed on provider spawn error (was stranded running)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -860,7 +860,29 @@ async fn execute_claimed(
             // `kill_on_drop(true)`, SIGKILLing the provider's process group.
             RunOutcome::Cancelled(crate::runner::RunnerResult::default())
         }
-        res = provider_run => res?,
+        res = provider_run => match res {
+            Ok(outcome) => outcome,
+            // The provider process could not be spawned / executed (the
+            // configured `claude` / `codex` path does not resolve → ENOENT, or an
+            // OS-level exec/wait fault). The task is already `running` here, so
+            // propagating this error out of `execute_claimed` left the row frozen
+            // `running` until the multi-hour running TTL sweep — a task that
+            // already died sitting `running` indefinitely, well past any dispatch
+            // budget. Convert it to a terminal FAILED outcome so it flows through
+            // the SAME `finalize_failure` seam the agent-error path uses
+            // (teardown / run-history / event / retry taxonomy), finalising the
+            // row to `failed` immediately. `SpawnError` is `NoRetry`: a
+            // misconfigured binary path will not self-heal on a re-dispatch. The
+            // running-TTL sweeper stays as the backstop for a genuine crash that
+            // never reaches this arm at all.
+            Err(e) => {
+                tracing::error!(task_id = %task.id, error = %e, "provider spawn/exec failed; failing task");
+                RunOutcome::Failed {
+                    reason: ainb_hangar_store::service::fail::FailureReason::SpawnError,
+                    result: crate::runner::RunnerResult::default(),
+                }
+            }
+        },
     };
     // The guard is dropped once the run is decided so the registry stays bounded
     // to genuinely-live runs (its `Drop` deregisters this task).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_spawn_error_fails_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_spawn_error_fails_task.rs
@@ -1,0 +1,150 @@
+//! Regression tripwire: a provider whose binary cannot be spawned (ENOENT) must
+//! drive the task to `failed` WITHIN the dispatch budget — never leave it frozen
+//! `running` until the multi-hour running-TTL sweep.
+//!
+//! ```text
+//!  seed DB (ws+user+rt+agent)        spawn daemon in tmux
+//!         │                       HANGAR_CLAUDE_PATH = <non-existent path>
+//!         ▼                                  │
+//!  INSERT queued task ──▶ claim ─▶ dispatched ─▶ running ─▶ (spawn ENOENT)
+//!                                                              │
+//!                                                              ▼
+//!                                        finalize_failure ─▶ failed
+//!                                        failure_reason = "spawn_error"
+//! ```
+//!
+//! # The bug this pins
+//!
+//! When `execute_claimed` reached the provider spawn and it returned `Err`
+//! (`claude` / `codex` path does not resolve → ENOENT), the claim loop only
+//! logged `task execution errored` and CONTINUED — the task was already
+//! `running`, so it sat `running` forever until the reference running-TTL (2.5h)
+//! sweep. A user saw a task that had already died sitting `running` indefinitely,
+//! well past any dispatch budget. The fix converts the provider spawn `Err` into
+//! a terminal FAILED outcome routed through the SAME `finalize_failure` seam the
+//! agent-error path uses, so the row reaches `failed` (reason `spawn_error`)
+//! immediately. The running-TTL sweeper stays as the backstop for a crash that
+//! never reaches this arm.
+//!
+//! # Why no real provider is needed
+//!
+//! A NON-EXISTENT binary path IS the whole test — there is nothing to run, so it
+//! needs no auth, no spend, and no `live-e2e` gate. It exercises the GENUINE
+//! `execute_claimed` → provider spawn → `finalize_failure` path in the real
+//! daemon binary (no mock of the loop), and asserts the DB task ROW transitions
+//! to `failed` — not merely that a log line was emitted.
+//!
+//! # Sandbox
+//!
+//! Sandbox is OFF (`HANGAR_DAEMON_DISABLE_SANDBOX=1`) so the daemon spawns the
+//! provider path DIRECTLY. With the sandbox ON the program spawned is the
+//! (existing) `sandbox-exec` wrapper, which would spawn fine and the missing
+//! `claude` would surface as a non-zero EXIT rather than the spawn `Err` this
+//! test pins.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::time::Duration;
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
+use tripwire_support::{DaemonSession, daemon_bin, seed_world, wait_for_db};
+
+#[tokio::test]
+async fn provider_spawn_enoent_fails_task_within_budget() {
+    // Skip cleanly when tmux is unavailable (CI image lacking tmux), so the
+    // tripwire never produces a false failure on a host without the tool.
+    if !tripwire_support::tmux_available() {
+        eprintln!("SKIPPED: tmux not available; skipping spawn-error tripwire");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    // 1. Bring the DB up to schema and seed the minimal (claude-backed) world.
+    let pool = open_pool(&db_path).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    // 2. Point the daemon's `claude` at a path that DOES NOT EXIST, so the direct
+    //    (sandbox-off) spawn hits ENOENT — the exact production stranding trigger.
+    let bogus_claude = home.path().join("no_such_claude_binary");
+    assert!(
+        !bogus_claude.exists(),
+        "the bogus claude path must not exist"
+    );
+
+    // 3. Spawn the real daemon binary in a uniquely-named tmux session, sandbox
+    //    OFF so the bogus path is spawned directly (see module docs).
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", home.path().to_str().unwrap()),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_CLAUDE_PATH", bogus_claude.to_str().unwrap()),
+            ("HANGAR_DAEMON_DISABLE_SANDBOX", "1"),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+        ],
+    );
+
+    // 4. Enqueue a queued task via direct SQL (the daemon is the only claimer).
+    //    `created_at` must be ~now so the queued-TTL sweeper does not reap it
+    //    before the claim loop sees it.
+    let task_id = "task-spawn-err-1";
+    sqlx::query(
+        "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, created_at) \
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(task_id)
+    .bind(&ids.workspace_id)
+    .bind(&ids.runtime_id)
+    .bind(&ids.agent_id)
+    .bind(tripwire_support::now_ms())
+    .execute(&pool)
+    .await
+    .expect("enqueue task");
+
+    // 5. Poll for `failed` within a bounded DISPATCH budget. Before the fix this
+    //    times out (task stranded `running`) and `wait_for_db` panics loudly with
+    //    `last=Some(("running", None))`; after the fix it returns the failed row.
+    //    30s is far below the 2.5h running-TTL, so a pass here can only come from
+    //    the finalize-on-spawn-error path, never the sweeper backstop.
+    let row = wait_for_db(&pool, task_id, "failed", Duration::from_secs(30)).await;
+    drop(session); // kill the tmux session by exact name before assertions
+
+    let status: String = row.get("status");
+    assert_eq!(
+        status, "failed",
+        "spawn ENOENT must finalize the task to failed"
+    );
+
+    // The reason is captured on the row (not just logged): the operator sees a
+    // provider that could not be spawned, distinct from an agent that gave up.
+    let reason: Option<String> = row.get("failure_reason");
+    assert_eq!(
+        reason.as_deref(),
+        Some("spawn_error"),
+        "failed row must carry the spawn_error reason"
+    );
+
+    // `finished_at` is stamped by the finalize seam — the row is genuinely
+    // terminal, not merely relabelled.
+    let finished_at: Option<i64> = row.get("finished_at");
+    assert!(
+        finished_at.is_some(),
+        "a finalized failed row stamps finished_at"
+    );
+}
+
+/// Open a `SQLite` WAL pool at `db_path` (creating the file if absent).
+async fn open_pool(db_path: &std::path::Path) -> SqlitePool {
+    let opts = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+    SqlitePoolOptions::new().connect_with(opts).await.expect("open pool")
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
@@ -58,6 +58,12 @@ pub enum FailureReason {
     /// The run stalled with no semantic progress (no new tool calls / output) —
     /// conversation-poisoning, retried *fresh* rather than resuming the stall.
     SemanticInactivity,
+    /// The provider subprocess could not be spawned or its OS-level execution
+    /// faulted — e.g. the configured `claude` / `codex` path does not resolve
+    /// (ENOENT). Distinct from [`Self::AgentError`] (the agent ran and gave up):
+    /// here the agent never started. Terminal (no retry): a misconfigured binary
+    /// path will not self-heal on a re-dispatch with the same daemon config.
+    SpawnError,
     /// An unclassified failure.
     Unknown,
 }
@@ -80,6 +86,7 @@ impl FailureReason {
             Self::IterationLimit => "iteration_limit",
             Self::ApiInvalidRequest => "api_invalid_request",
             Self::SemanticInactivity => "semantic_inactivity",
+            Self::SpawnError => "spawn_error",
             Self::Unknown => "unknown",
         }
     }
@@ -143,6 +150,7 @@ mod tests {
             FailureReason::IterationLimit,
             FailureReason::ApiInvalidRequest,
             FailureReason::SemanticInactivity,
+            FailureReason::SpawnError,
             FailureReason::Unknown,
         ] {
             let serde_token = serde_json::to_value(reason)

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -28,7 +28,8 @@
 //!   from the resume hint so an auto-retry never inherits a stuck conversation.
 //! - **[`RetryDisposition::NoRetry`]** — [`FailureReason::AgentError`] (the LLM
 //!   mis-tooled / gave up), [`FailureReason::UserCancel`] (terminal by intent),
-//!   and [`FailureReason::Timeout`] / [`FailureReason::Unknown`]: no child row.
+//!   [`FailureReason::SpawnError`] (provider binary missing / unspawnable), and
+//!   [`FailureReason::Timeout`] / [`FailureReason::Unknown`]: no child row.
 //!
 //! `attempt >= max_attempts` caps the chain regardless of disposition.
 //!
@@ -242,10 +243,13 @@ impl RetryService {
             FailureReason::IterationLimit
             | FailureReason::ApiInvalidRequest
             | FailureReason::SemanticInactivity => RetryDisposition::FreshRetry,
-            // Agent / user / sweeper / unclassified terminals — no retry.
+            // Agent / user / sweeper / spawn / unclassified terminals — no retry.
+            // `SpawnError` is a misconfigured / missing provider binary: a
+            // re-dispatch under the same daemon config would only re-fail.
             FailureReason::AgentError
             | FailureReason::UserCancel
             | FailureReason::Timeout
+            | FailureReason::SpawnError
             | FailureReason::Unknown => RetryDisposition::NoRetry,
         }
     }
@@ -275,6 +279,7 @@ const FAILURE_REASONS: &[FailureReason] = &[
     FailureReason::IterationLimit,
     FailureReason::ApiInvalidRequest,
     FailureReason::SemanticInactivity,
+    FailureReason::SpawnError,
     FailureReason::Unknown,
 ];
 
@@ -298,6 +303,7 @@ mod tests {
             FailureReason::IterationLimit,
             FailureReason::ApiInvalidRequest,
             FailureReason::SemanticInactivity,
+            FailureReason::SpawnError,
             FailureReason::Unknown,
         ] {
             assert!(
@@ -307,7 +313,7 @@ mod tests {
         }
         assert_eq!(
             FAILURE_REASONS.len(),
-            9,
+            10,
             "FAILURE_REASONS length drifted from the FailureReason variant count",
         );
     }


### PR DESCRIPTION
## Why
The live e2e harness (#406) surfaced this: when the provider binary can't be spawned (ENOENT / exec fault), the claim loop logged the error and continued, leaving the task stuck in `running` until the 2.5h running-TTL sweep. A user sees a task that already died sitting in `running` indefinitely. Distinct from the "no-op marked done" class.

## Fix
Convert the provider `Err` (was `res?`, which propagated out and left the row `running`) into `RunOutcome::Failed { reason: SpawnError }`, routed through the **existing** `finalize_failure` seam — same teardown / run-history / terminal-event / retry handling as `AgentError`. New `FailureReason::SpawnError` (`"spawn_error"`), classified `NoRetry` (a missing binary is permanent under fixed config). `running → failed` is already a legal transition; no migration (`failure_reason` is plain TEXT).

## Proof
- New ungated tripwire `tripwire_spawn_error_fails_task.rs`: spawns the **real daemon** at a non-existent claude path, asserts the DB **row** reaches `failed`/`spawn_error`/`finished_at` within budget (not a log line). Green in 0.38s.
- **Mutation-proven** (verified independently by review): revert the finalize → task stays `running`, test fails after 30s. Restore → green.
- Store + daemon suites green; taxonomy coverage guards updated 9→10.

## Scope
Setup faults BEFORE the `running` transition (prepare_env / worktree provision) still propagate and leave the row `dispatched` for the stale-dispatch sweeper — pre-existing, intentional, untouched. Only the post-`running` spawn/exec stranding is fixed.

## Follow-up (non-blocking)
`spawn_error` labels all `provider_run` errors including rare mid-run faults (wait io-error, reader-task panic); slightly broad but any label beats stranding. Optional future narrowing.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R