### PR TITLE
feat(hangar): deliver the claude credential to sandboxed agents (setup-token → CLAUDE_CODE_OAUTH_TOKEN)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1178,6 +1178,38 @@ pub enum DaemonCommand {
     /// View + edit the daemon's user-config knobs (`list`/`get`/`set`).
     #[command(subcommand)]
     Config(DaemonConfigCommand),
+    /// Manage the one-time, host-wide `claude` credential the daemon injects
+    /// into confined headless runs (`status`/`set`/`clear`).
+    #[command(subcommand)]
+    Cred(DaemonCredCommand),
+}
+
+/// `hangar daemon cred <verb>` — the daemon-level claude credential.
+///
+/// The credential is a SECRET (not a `daemon_config` knob), so it lives in the
+/// platform secret store via `ainb_hangar_daemon::claude_cred`, never in the
+/// plaintext `daemon_config` table. It is configured ONCE at daemon level; there
+/// is no per-agent form.
+#[derive(clap::Subcommand, Debug)]
+pub enum DaemonCredCommand {
+    /// Report whether a credential is configured and where it resolves from
+    /// (env override / secret store / not set). Never prints the value.
+    Status,
+    /// Store a long-lived token. Reads the token from STDIN by default (so it
+    /// never lands on argv or in shell history); `--setup-token` instead drives
+    /// the interactive `claude setup-token` browser flow and captures the result.
+    Set(DaemonCredSetArgs),
+    /// Remove the stored credential. Idempotent.
+    Clear,
+}
+
+/// Arguments for `hangar daemon cred set`.
+#[derive(Args, Debug)]
+pub struct DaemonCredSetArgs {
+    /// Drive `claude setup-token` (browser OAuth) and capture the minted token,
+    /// instead of reading a token from STDIN.
+    #[arg(long)]
+    pub setup_token: bool,
 }
 
 /// `hangar daemon config <verb>`.
@@ -3037,7 +3069,73 @@ async fn dispatch_daemon(cmd: DaemonCommand, format: OutputFormat) -> Result<()>
         DaemonCommand::Restart => run_daemon_restart(),
         DaemonCommand::Setup => run_daemon_setup().await,
         DaemonCommand::Config(c) => dispatch_daemon_config(c, format).await,
+        DaemonCommand::Cred(c) => dispatch_daemon_cred(c).await,
     }
+}
+
+/// Dispatch the `hangar daemon cred` verbs against the platform secret store.
+///
+/// Unlike `daemon config`, this touches no `daemon_config` row — a credential is
+/// a secret, resolved and stored via `ainb_hangar_daemon::claude_cred`. The
+/// daemon injects whatever is stored on its next dispatch, so no restart is
+/// needed.
+async fn dispatch_daemon_cred(cmd: DaemonCredCommand) -> Result<()> {
+    use ainb_hangar_daemon::claude_cred;
+
+    match cmd {
+        DaemonCredCommand::Status => {
+            let src = claude_cred::default::source();
+            // Never prints the value — only the source label.
+            println!("claude credential: {}", src.label());
+            Ok(())
+        }
+        DaemonCredCommand::Clear => {
+            claude_cred::default::clear_token().context("clear claude credential")?;
+            println!("claude credential cleared");
+            Ok(())
+        }
+        DaemonCredCommand::Set(args) => run_daemon_cred_set(args),
+    }
+}
+
+/// Capture a token (from `claude setup-token` or STDIN) and store it. The token
+/// is held only as bytes and never echoed. Synchronous: the subprocess and stdin
+/// read are blocking, and this is a one-shot operator command, not on any hot path.
+fn run_daemon_cred_set(args: DaemonCredSetArgs) -> Result<()> {
+    use ainb_hangar_daemon::claude_cred;
+
+    let token: String = if args.setup_token {
+        // Drive the interactive browser flow. stderr/stdin are inherited so the
+        // user sees the prompt and completes OAuth; stdout is captured for the
+        // minted token. Verified shape: the token is an `sk-ant-oat…` word.
+        let out = std::process::Command::new("claude")
+            .arg("setup-token")
+            .stderr(std::process::Stdio::inherit())
+            .stdin(std::process::Stdio::inherit())
+            .output()
+            .context("run `claude setup-token` (is the claude CLI on PATH?)")?;
+        if !out.status.success() {
+            anyhow::bail!("`claude setup-token` exited without minting a token");
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        claude_cred::extract_setup_token(&stdout)
+            .context("no token found in `claude setup-token` output")?
+    } else {
+        // Read from STDIN so the token never lands on argv or in shell history.
+        use std::io::Read as _;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).context("read token from stdin")?;
+        let trimmed = buf.trim().to_string();
+        if trimmed.is_empty() {
+            anyhow::bail!("no token on stdin (pipe the token, or use --setup-token)");
+        }
+        trimmed
+    };
+
+    claude_cred::default::store_token(token.as_bytes()).context("store claude credential")?;
+    // Confirm without echoing the value.
+    println!("claude credential stored ({} bytes)", token.len());
+    Ok(())
 }
 
 /// Dispatch the `hangar daemon config` verbs against the `daemon_config` table.

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -3102,9 +3102,11 @@ async fn dispatch_daemon_cred(cmd: DaemonCredCommand) -> Result<()> {
 /// is held only as bytes and never echoed. Synchronous: the subprocess and stdin
 /// read are blocking, and this is a one-shot operator command, not on any hot path.
 fn run_daemon_cred_set(args: DaemonCredSetArgs) -> Result<()> {
-    use ainb_hangar_daemon::claude_cred;
+    use ainb_hangar_daemon::claude_cred::{self, TokenBytes};
 
-    let token: String = if args.setup_token {
+    // Held as `TokenBytes` (zeroize-on-drop), never a plain `String`, so the token
+    // material is not left lingering in freed heap after the store write.
+    let token: TokenBytes = if args.setup_token {
         // Drive the interactive browser flow. stderr/stdin are inherited so the
         // user sees the prompt and completes OAuth; stdout is captured for the
         // minted token. Verified shape: the token is an `sk-ant-oat…` word.
@@ -3118,23 +3120,24 @@ fn run_daemon_cred_set(args: DaemonCredSetArgs) -> Result<()> {
             anyhow::bail!("`claude setup-token` exited without minting a token");
         }
         let stdout = String::from_utf8_lossy(&out.stdout);
-        claude_cred::extract_setup_token(&stdout)
-            .context("no token found in `claude setup-token` output")?
+        let minted = claude_cred::extract_setup_token(&stdout)
+            .context("no token found in `claude setup-token` output")?;
+        TokenBytes::from(minted.as_bytes())
     } else {
         // Read from STDIN so the token never lands on argv or in shell history.
         use std::io::Read as _;
         let mut buf = String::new();
         std::io::stdin().read_to_string(&mut buf).context("read token from stdin")?;
-        let trimmed = buf.trim().to_string();
+        let trimmed = buf.trim();
         if trimmed.is_empty() {
             anyhow::bail!("no token on stdin (pipe the token, or use --setup-token)");
         }
-        trimmed
+        TokenBytes::from(trimmed.as_bytes())
     };
 
     claude_cred::default::store_token(token.as_bytes()).context("store claude credential")?;
-    // Confirm without echoing the value.
-    println!("claude credential stored ({} bytes)", token.len());
+    // Fixed confirmation: never echo the value, and never disclose its length.
+    println!("claude credential stored");
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
@@ -45,6 +45,10 @@ path = "src/lib.rs"
 [dependencies]
 ainb-hangar-store = { path = "../ainb-hangar-store" }
 ainb-hangar-core = { path = "../ainb-hangar-core" }
+# Platform credential store (Keychain on macOS) behind one trait. The daemon is
+# UNSANDBOXED, so it resolves the claude credential here and injects it into the
+# confined child's env; the child never touches the keychain itself.
+ainb-hangar-secrets = { path = "../ainb-hangar-secrets" }
 # Fleet orchestration libs (the ONE send path + the needs classifier + session
 # discovery), extracted below both this crate and ainb-core so the daemon can
 # drive the SAME verified tmux send and the SAME ASK>ERR>IDLE>WAIT classifier the
@@ -149,6 +153,8 @@ opentelemetry-otlp = { version = "0.30", optional = true, default-features = fal
 tracing-opentelemetry = { version = "0.31", optional = true }
 
 [dev-dependencies]
+# The in-memory secret double, so credential tests never touch the real Keychain.
+ainb-hangar-secrets = { path = "../ainb-hangar-secrets", features = ["test-backend"] }
 assert_cmd = "2"
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
@@ -1,0 +1,258 @@
+//! Daemon-level `claude` credential resolution (one-time, host-wide).
+//!
+//! A confined `claude` child cannot authenticate: its credential is the macOS
+//! Keychain item `Claude Code-credentials`, and the sandbox denies keychain
+//! access (verified: `security find-generic-password` under the daemon's own
+//! profile is DENIED). The child also cannot read the operator's `$HOME`, so it
+//! finds no `~/.claude` credentials either — a confined run reports
+//! `Not logged in · Please run /login` and, worse, **exits 0**.
+//!
+//! The daemon is NOT sandboxed (it is the parent, running as the operator), so
+//! it resolves the credential itself and injects it into the child's env as
+//! `CLAUDE_CODE_OAUTH_TOKEN`. The child gets ONE env var and no keychain access:
+//! this is deliberately not a keychain grant to the child, which was rejected on
+//! security review (a grant lets the agent shell out to `/usr/bin/security` and
+//! read *any* always-allow item, e.g. Chrome Safe Storage).
+//!
+//! # Resolution order
+//!
+//! ```text
+//! 1. $HANGAR_CLAUDE_OAUTH_TOKEN   env override (daemon's own env)
+//! 2. SecretBackend(Global, claude.oauth_token)   the stored setup-token
+//! 3. none -> claude fails with an actionable message
+//! ```
+//!
+//! The override is read from [`ENV_OVERRIDE`], which is deliberately **NOT** on
+//! the runner's `ENV_ALLOWLIST`: the daemon reads it, but it is never inherited
+//! by any child. Only the resolved value is injected, and only into a `claude`
+//! child ([`keys_for_backend`]) — a claude token has no business in a codex or
+//! copilot subprocess even though the injection seam reaches every backend.
+//!
+//! # Token shape
+//!
+//! `claude setup-token` mints a long-lived token; the Keychain item's
+//! `claudeAiOauth.accessToken` is a short-lived one (measured: 8h TTL, refreshed
+//! by claude WRITING BACK to the Keychain, which a confined child cannot do).
+//! Both are accepted by `CLAUDE_CODE_OAUTH_TOKEN`; storing the long-lived token
+//! is what makes an unattended run survive past the 8h window.
+//!
+//! Nothing here ever logs the value: it is carried as
+//! [`ainb_hangar_secrets::SecretBytes`], whose `Debug` redacts.
+
+use std::collections::HashMap;
+
+use ainb_hangar_secrets::{Scope, SecretBackend, SecretBytes};
+
+use crate::runner::Backend;
+
+/// Build the platform's secret backend for production use.
+///
+/// macOS resolves to the login-Keychain backend; linux to the Secret Service
+/// stub, which reports `NotImplemented` until a real backend lands — in which
+/// case [`resolve`] simply reports [`CredSource::None`] and the operator uses
+/// [`ENV_OVERRIDE`]. Tests inject `InMemoryBackend` instead of calling this.
+#[must_use]
+pub fn default_backend() -> std::sync::Arc<dyn SecretBackend + Send + Sync> {
+    #[cfg(target_os = "macos")]
+    {
+        std::sync::Arc::new(ainb_hangar_secrets::MacKeychainBackend::new())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::sync::Arc::new(ainb_hangar_secrets::LinuxSecretServiceBackend::new())
+    }
+}
+
+/// The daemon-side env override that wins over the stored secret.
+///
+/// Namespaced `HANGAR_*` on purpose: it must NOT collide with the child-facing
+/// [`CHILD_ENV_VAR`], and it must never be inherited by a provider subprocess
+/// (it is absent from the runner's `ENV_ALLOWLIST`).
+pub const ENV_OVERRIDE: &str = "HANGAR_CLAUDE_OAUTH_TOKEN";
+
+/// The env var the `claude` CLI reads its OAuth token from. This is the ONLY
+/// credential material the confined child receives.
+pub const CHILD_ENV_VAR: &str = "CLAUDE_CODE_OAUTH_TOKEN";
+
+/// The [`Scope::Global`] secret key holding the operator's claude token.
+///
+/// Global, not workspace-scoped: the credential is a property of the host's
+/// operator, configured ONCE at daemon level. Per-agent credentials were
+/// explicitly rejected (an operator would re-enter it for every agent).
+pub const SECRET_KEY: &str = "claude.oauth_token";
+
+/// Where a resolved credential came from — for operator-facing status only.
+///
+/// Carries no secret material, so it is freely loggable and rendered directly by
+/// the Settings row and the CLI `status` verb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredSource {
+    /// Resolved from [`ENV_OVERRIDE`] in the daemon's environment.
+    Env,
+    /// Resolved from the platform secret store ([`SECRET_KEY`], [`Scope::Global`]).
+    Store,
+    /// No credential configured — a confined claude run WILL fail to authenticate.
+    None,
+}
+
+impl CredSource {
+    /// A short operator-facing label (`env override` / `configured` / `not set`).
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Env => "env override",
+            Self::Store => "configured",
+            Self::None => "not set",
+        }
+    }
+
+    /// Whether a credential is present at all.
+    #[must_use]
+    pub const fn is_configured(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// Resolve the claude credential, preferring the env override over the store.
+///
+/// `daemon_env` is the daemon's own environment (NOT the child's). A store fault
+/// (locked keychain, unimplemented platform) is treated as "absent" rather than
+/// propagated: a credential lookup must never wedge dispatch, and the resulting
+/// claude failure is loud and actionable on its own.
+///
+/// Returns the source alongside the material so a caller can render status
+/// without touching the secret.
+#[must_use]
+pub fn resolve<S: std::hash::BuildHasher>(
+    backend: &dyn SecretBackend,
+    daemon_env: &HashMap<String, String, S>,
+) -> (CredSource, Option<SecretBytes>) {
+    if let Some(v) = daemon_env.get(ENV_OVERRIDE).filter(|v| !v.trim().is_empty()) {
+        return (
+            CredSource::Env,
+            Some(SecretBytes::from(v.trim().as_bytes())),
+        );
+    }
+    match backend.get(&Scope::Global, SECRET_KEY) {
+        Ok(Some(bytes)) if !bytes.as_bytes().is_empty() => (CredSource::Store, Some(bytes)),
+        _ => (CredSource::None, None),
+    }
+}
+
+/// Report the configured source without materialising the secret into a caller.
+#[must_use]
+pub fn status<S: std::hash::BuildHasher>(
+    backend: &dyn SecretBackend,
+    daemon_env: &HashMap<String, String, S>,
+) -> CredSource {
+    resolve(backend, daemon_env).0
+}
+
+/// Store the operator's token (the one-time setup write).
+///
+/// # Errors
+///
+/// Returns the backend's [`ainb_hangar_secrets::SecretError`] when the platform
+/// store rejects the write (locked, denied, or unimplemented).
+pub fn store(backend: &dyn SecretBackend, token: &SecretBytes) -> ainb_hangar_secrets::Result<()> {
+    backend.put(&Scope::Global, SECRET_KEY, token.as_bytes())
+}
+
+/// Remove the stored token. Idempotent.
+///
+/// # Errors
+///
+/// Returns the backend's [`ainb_hangar_secrets::SecretError`] on a store fault.
+pub fn clear(backend: &dyn SecretBackend) -> ainb_hangar_secrets::Result<()> {
+    backend.delete(&Scope::Global, SECRET_KEY)
+}
+
+/// The credential env pairs to inject for `backend_kind`, for the
+/// `build_task_env` keychain seam.
+///
+/// **Claude only.** The seam injects on top of the ambient policy and reaches
+/// every provider, so gating here is what keeps a claude token out of a codex /
+/// copilot child. An unresolvable credential yields no pairs — claude then fails
+/// loudly rather than the daemon silently substituting something.
+#[must_use]
+pub fn keys_for_backend<S: std::hash::BuildHasher>(
+    kind: Backend,
+    secrets: &dyn SecretBackend,
+    daemon_env: &HashMap<String, String, S>,
+) -> Vec<(String, String)> {
+    if kind != Backend::Claude {
+        return Vec::new();
+    }
+    let (_src, token) = resolve(secrets, daemon_env);
+    token
+        .map(|t| {
+            vec![(
+                CHILD_ENV_VAR.to_string(),
+                String::from_utf8_lossy(t.as_bytes()).into_owned(),
+            )]
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_hangar_secrets::InMemoryBackend;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()
+    }
+
+    #[test]
+    fn env_override_wins_over_the_store() {
+        let b = InMemoryBackend::new();
+        b.put(&Scope::Global, SECRET_KEY, b"stored").unwrap();
+        let (src, tok) = resolve(&b, &env(&[(ENV_OVERRIDE, "from-env")]));
+        assert_eq!(src, CredSource::Env);
+        assert_eq!(tok.unwrap().as_bytes(), b"from-env");
+    }
+
+    #[test]
+    fn falls_back_to_the_store_then_to_none() {
+        let b = InMemoryBackend::new();
+        assert_eq!(status(&b, &env(&[])), CredSource::None);
+        store(&b, &SecretBytes::from(b"stored".as_slice())).unwrap();
+        assert_eq!(status(&b, &env(&[])), CredSource::Store);
+        clear(&b).unwrap();
+        assert_eq!(status(&b, &env(&[])), CredSource::None);
+    }
+
+    #[test]
+    fn blank_env_override_is_not_a_credential() {
+        let b = InMemoryBackend::new();
+        assert_eq!(status(&b, &env(&[(ENV_OVERRIDE, "   ")])), CredSource::None);
+    }
+
+    #[test]
+    fn only_the_claude_backend_receives_the_token() {
+        let b = InMemoryBackend::new();
+        store(&b, &SecretBytes::from(b"tok".as_slice())).unwrap();
+        let e = env(&[]);
+        let claude = keys_for_backend(Backend::Claude, &b, &e);
+        assert_eq!(claude, vec![(CHILD_ENV_VAR.to_string(), "tok".to_string())]);
+        // A claude credential must never reach another provider's subprocess.
+        assert!(keys_for_backend(Backend::Codex, &b, &e).is_empty());
+        assert!(keys_for_backend(Backend::Copilot, &b, &e).is_empty());
+    }
+
+    #[test]
+    fn no_credential_injects_nothing() {
+        let b = InMemoryBackend::new();
+        assert!(keys_for_backend(Backend::Claude, &b, &env(&[])).is_empty());
+    }
+
+    #[test]
+    fn secret_material_never_appears_in_debug_output() {
+        let (_s, tok) = resolve(&InMemoryBackend::new(), &env(&[(ENV_OVERRIDE, "hunter2")]));
+        let rendered = format!("{:?}", tok.unwrap());
+        assert!(
+            !rendered.contains("hunter2"),
+            "secret leaked into Debug: {rendered}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
@@ -167,6 +167,66 @@ pub fn clear(backend: &dyn SecretBackend) -> ainb_hangar_secrets::Result<()> {
     backend.delete(&Scope::Global, SECRET_KEY)
 }
 
+/// The env var name (`sk-ant-oat…`) prefix that identifies a claude OAuth token
+/// in `claude setup-token` output. Used to pick the token line out of the
+/// interactive command's stdout.
+const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
+
+/// Extract the OAuth token from `claude setup-token` stdout.
+///
+/// `setup-token` prints human prose interspersed with the token; the token is
+/// the last whitespace-delimited word starting with [`OAUTH_TOKEN_PREFIX`].
+/// Pure + testable so the fragile parsing is covered without minting a real
+/// token. Returns `None` when no token-shaped word is present (the caller then
+/// reports a failed setup rather than storing garbage).
+#[must_use]
+pub fn extract_setup_token(stdout: &str) -> Option<String> {
+    stdout
+        .split_whitespace()
+        .rev()
+        .find(|w| w.starts_with(OAUTH_TOKEN_PREFIX) && w.len() > OAUTH_TOKEN_PREFIX.len())
+        .map(str::to_string)
+}
+
+/// Convenience wrappers over the platform-default backend, so a CLI/TUI caller
+/// needs no direct `ainb-hangar-secrets` dependency.
+pub mod default {
+    use super::{CredSource, SecretBytes, clear, default_backend, resolve, status, store};
+
+    /// The configured credential source, resolved from the default backend and
+    /// the process env.
+    #[must_use]
+    pub fn source() -> CredSource {
+        let env: std::collections::HashMap<String, String> = std::env::vars().collect();
+        status(default_backend().as_ref(), &env)
+    }
+
+    /// Whether resolving a credential succeeds AND yields non-empty material.
+    #[must_use]
+    pub fn is_present() -> bool {
+        let env: std::collections::HashMap<String, String> = std::env::vars().collect();
+        resolve(default_backend().as_ref(), &env).1.is_some()
+    }
+
+    /// Store `token` in the default backend. Bytes, never a `String` on argv.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the backend's store fault (locked/denied/unimplemented).
+    pub fn store_token(token: &[u8]) -> ainb_hangar_secrets::Result<()> {
+        store(default_backend().as_ref(), &SecretBytes::from(token))
+    }
+
+    /// Remove the stored token from the default backend. Idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the backend's store fault.
+    pub fn clear_token() -> ainb_hangar_secrets::Result<()> {
+        clear(default_backend().as_ref())
+    }
+}
+
 /// The credential env pairs to inject for `backend_kind`, for the
 /// `build_task_env` keychain seam.
 ///
@@ -244,6 +304,19 @@ mod tests {
     fn no_credential_injects_nothing() {
         let b = InMemoryBackend::new();
         assert!(keys_for_backend(Backend::Claude, &b, &env(&[])).is_empty());
+    }
+
+    #[test]
+    fn extract_setup_token_picks_the_token_word() {
+        let out = "Visit https://claude.ai/oauth to authorize.\nYour token:\n  sk-ant-oat01-ABCdef123\nDone.";
+        assert_eq!(
+            extract_setup_token(out).as_deref(),
+            Some("sk-ant-oat01-ABCdef123")
+        );
+        // No token-shaped word -> None (never store prose).
+        assert_eq!(extract_setup_token("authorization was cancelled"), None);
+        // The bare prefix with no body is not a token.
+        assert_eq!(extract_setup_token("sk-ant-oat"), None);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
@@ -243,15 +243,24 @@ pub fn keys_for_backend<S: std::hash::BuildHasher>(
     if kind != Backend::Claude {
         return Vec::new();
     }
-    let (_src, token) = resolve(secrets, daemon_env);
-    token
-        .map(|t| {
-            vec![(
-                CHILD_ENV_VAR.to_string(),
-                String::from_utf8_lossy(t.as_bytes()).into_owned(),
-            )]
-        })
-        .unwrap_or_default()
+    let Some(token) = resolve(secrets, daemon_env).1 else {
+        return Vec::new();
+    };
+    // A claude OAuth token is ASCII (`sk-ant-oat…`); a non-UTF-8 value means a
+    // corrupted store entry. Inject NOTHING rather than a lossily-mangled token —
+    // claude then fails to authenticate loudly (a wrong token is a silent 401),
+    // which is the correct outcome for corruption. The error is logged without the
+    // value.
+    match std::str::from_utf8(token.as_bytes()) {
+        Ok(s) => vec![(CHILD_ENV_VAR.to_string(), s.to_string())],
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "stored claude credential is not valid UTF-8 (corrupted?); injecting nothing"
+            );
+            Vec::new()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/claude_cred.rs
@@ -43,6 +43,10 @@ use std::collections::HashMap;
 
 use ainb_hangar_secrets::{Scope, SecretBackend, SecretBytes};
 
+/// Re-export so a CLI/TUI caller can hold token material in the zeroizing
+/// [`SecretBytes`] newtype without a direct `ainb-hangar-secrets` dependency.
+pub use ainb_hangar_secrets::SecretBytes as TokenBytes;
+
 use crate::runner::Backend;
 
 /// Build the platform's secret backend for production use.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -50,6 +50,12 @@ pub mod board;
 /// cancel RPC uses to signal the claim loop to stop a live run (headless process
 /// group / interactive tmux session). See [`cancel::registry`].
 pub mod cancel;
+/// Daemon-level `claude` credential resolution (Keychain/env -> child env).
+///
+/// The confined child can reach neither the Keychain nor the operator's
+/// `~/.claude`, so the unsandboxed daemon resolves the token and injects it as
+/// ONE env var, for the `claude` backend only.
+pub mod claude_cred;
 /// Fresh-home boot seed: lay down the default workspace + runtime + one starter
 /// agent so an empty `hangar.db` "just works" (a runtime shows in the Daemon
 /// pane and the Squad create gate is already cleared). Idempotent + non-clobbering.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -723,20 +723,19 @@ async fn execute_claimed(
     // pass), layering keychain-resident API keys on top via
     // `dispatch::build_task_env`. The policy is loaded from
     // `~/.agents-in-a-box/hangar/env.allow.toml` (operator defaults when absent).
-    // The keychain keys are the daemon-resolved provider credentials, injected
-    // ON TOP of the policy pass (so they are never governed by the ambient
-    // allowlist). The runner re-applies its own deny-by-default filter as
-    // defense-in-depth (a strict subset of this policy), which is why
-    // `CLAUDE_CODE_OAUTH_TOKEN` is on its allowlist.
-    //
-    // Claude-only by construction: the seam reaches EVERY backend, so
-    // `claude_cred::keys_for_backend` gates on the dispatch's backend rather than
-    // handing a claude token to a codex/copilot child that has no use for it.
     let daemon_env: std::collections::HashMap<String, String> = std::env::vars().collect();
     let policy = load_env_policy();
-    let keychain_keys =
-        crate::claude_cred::keys_for_backend(dispatch.backend, secrets, &daemon_env);
-    let mut task_env = crate::dispatch::build_task_env(&daemon_env, keychain_keys, &policy);
+    let mut task_env = crate::dispatch::build_task_env(&daemon_env, std::iter::empty(), &policy);
+
+    // The daemon-resolved claude credential. It rides `extra_env` (the unfiltered
+    // append below), NOT `task_env`/`source_env` — so it does not go through, and
+    // does not have to widen, the deny-by-default allowlist. An *ambient*
+    // `CLAUDE_CODE_OAUTH_TOKEN` in the daemon's own env stays dropped for every
+    // provider (it is not on the runner's exact-match allowlist), while the
+    // *resolved* value reaches a claude child only. `keys_for_backend` returns an
+    // empty vec for codex/copilot, so a claude token can never leak into their
+    // children even though every backend shares this seam.
+    let cred_env = crate::claude_cred::keys_for_backend(dispatch.backend, secrets, &daemon_env);
 
     // ccc / D11: mark this daemon-spawned session as a legitimate fleet member by
     // stamping AINB_PARENT_SESSION into the provider's child env. The lifecycle
@@ -815,6 +814,12 @@ async fn execute_claimed(
     let provider = dispatch.backend.name();
     let provider_run = async {
         if mode == Mode::Interactive {
+            // The interactive path is DELIBERATELY unsandboxed (see
+            // `run_interactive`): the attached claude reaches the Keychain and
+            // `~/.claude` natively and auto-refreshes, so it needs no injected
+            // token. `cred_env` (headless-only, consumed in the `else` arm) is
+            // intentionally not threaded here — a static `CLAUDE_CODE_OAUTH_TOKEN`
+            // would override keychain auth and go stale mid-session.
             run_interactive(
                 pool,
                 runner,
@@ -835,7 +840,13 @@ async fn execute_claimed(
             // (the interactive path already returns `anyhow::Result`).
             match dispatch.backend {
                 Backend::Claude => runner
-                    .run_claude_in(&env, task_env, &dispatch.invocation, &location)
+                    .run_claude_in_with_env(
+                        &env,
+                        task_env,
+                        cred_env,
+                        &dispatch.invocation,
+                        &location,
+                    )
                     .await
                     .map_err(anyhow::Error::from),
                 Backend::Codex => runner

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -326,6 +326,12 @@ pub async fn run(
     // `dispatched` from the instant of claim through to its terminal finalize —
     // so the DB's live in-flight count is the authoritative bound the next claim
     // consults, and a spawned-but-not-yet-polled run is already accounted for.
+    // The platform credential store, built ONCE for the daemon's lifetime and
+    // shared across concurrent runs (one Keychain session, not one per task).
+    // `execute_claimed` takes it as a trait object, so a test can inject the
+    // in-memory double instead of touching the real Keychain.
+    let secrets = crate::claude_cred::default_backend();
+
     let mut runs: JoinSet<()> = JoinSet::new();
     // a54 shutdown reap: the set of live interactive tmux sessions, so `Ctrl-C`
     // can kill each by exact name instead of orphaning a detached pane.
@@ -377,10 +383,11 @@ pub async fn run(
                 let stats = stats.clone();
                 let events = events.clone();
                 let interactive = interactive.clone();
+                let secrets = secrets.clone();
                 runs.spawn(async move {
                     let clock = SystemClock;
                     if let Err(e) =
-                        execute_claimed(&pool, &runner, &claimed, &clock, &stats, &events, &interactive)
+                        execute_claimed(&pool, &runner, &claimed, &clock, &stats, &events, &interactive, secrets.as_ref())
                             .await
                     {
                         tracing::error!(task_id = %claimed.id, error = %e, "task execution errored");
@@ -539,6 +546,11 @@ pub fn spawn_gc_sweeper(
 /// Returns an error only for an unrecoverable I/O / DB fault while *setting up*
 /// the run (missing row, slug lookup, env prep, start). A provider failure is a
 /// normal FSM outcome (`fail`), not an error here.
+// One over the lint's 7: the secret backend joins the existing seven collaborators
+// (pool, runner, task, clock, stats, events, interactive) as a thin DI handle.
+// Bundling them into a context struct is a larger refactor than this credential
+// change warrants; the sibling run functions here carry the same shape.
+#[allow(clippy::too_many_arguments)]
 async fn execute_claimed(
     pool: &SqlitePool,
     runner: &Runner,
@@ -547,6 +559,7 @@ async fn execute_claimed(
     stats: &HealthStats,
     events: &EventSink,
     interactive: &InteractiveSessions,
+    secrets: &(dyn ainb_hangar_secrets::SecretBackend + Send + Sync),
 ) -> anyhow::Result<()> {
     let task: Task = TaskRepo::get_by_id(pool, &claimed.id)
         .await?
@@ -710,13 +723,19 @@ async fn execute_claimed(
     // pass), layering keychain-resident API keys on top via
     // `dispatch::build_task_env`. The policy is loaded from
     // `~/.agents-in-a-box/hangar/env.allow.toml` (operator defaults when absent).
-    // The keychain key list is empty until P5.2 wires `host/secret_store_get`
-    // into dispatch; the seam is in place so adding keys is a one-line change.
-    // The runner re-applies its own deny-by-default 12-var filter as
-    // defense-in-depth (a strict subset of this policy).
+    // The keychain keys are the daemon-resolved provider credentials, injected
+    // ON TOP of the policy pass (so they are never governed by the ambient
+    // allowlist). The runner re-applies its own deny-by-default filter as
+    // defense-in-depth (a strict subset of this policy), which is why
+    // `CLAUDE_CODE_OAUTH_TOKEN` is on its allowlist.
+    //
+    // Claude-only by construction: the seam reaches EVERY backend, so
+    // `claude_cred::keys_for_backend` gates on the dispatch's backend rather than
+    // handing a claude token to a codex/copilot child that has no use for it.
     let daemon_env: std::collections::HashMap<String, String> = std::env::vars().collect();
     let policy = load_env_policy();
-    let keychain_keys: Vec<(String, String)> = Vec::new();
+    let keychain_keys =
+        crate::claude_cred::keys_for_backend(dispatch.backend, secrets, &daemon_env);
     let mut task_env = crate::dispatch::build_task_env(&daemon_env, keychain_keys, &policy);
 
     // ccc / D11: mark this daemon-spawned session as a legitimate fleet member by

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -104,14 +104,6 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     "CLAUDE_HOME",
     "CODEX_HOME",
     "CURSOR_HOME",
-    // The claude OAuth token the daemon RESOLVES and injects at dispatch (see
-    // `crate::claude_cred`). A confined child can reach neither the Keychain nor
-    // the operator's `~/.claude`, so this env var is its ONLY credential. It is
-    // daemon-controlled config injected on top of the policy pass — never an
-    // inherited ambient secret — and the daemon-side override it resolves from
-    // (`HANGAR_CLAUDE_OAUTH_TOKEN`) is deliberately absent from this list, so it
-    // is read by the daemon and inherited by nothing.
-    crate::claude_cred::CHILD_ENV_VAR,
     // ccc / D11: the parent-session linkage the daemon stamps onto every task it
     // spawns (see `run_loop`). It is daemon-controlled config, not an inherited
     // ambient secret, so allowlisting it leaks nothing — and it MUST survive the
@@ -677,6 +669,38 @@ impl Runner {
     where
         I: IntoIterator<Item = (String, String)>,
     {
+        self.run_claude_in_with_env(env, source_env, std::iter::empty(), invocation, location)
+            .await
+    }
+
+    /// [`Self::run_claude_in`], plus a set of `extra_env` pairs layered onto the
+    /// child env **after** the allowlist filter (the codex/copilot counterpart is
+    /// [`Self::run_codex_in`]'s `extra_env`).
+    ///
+    /// This is the injection path for the daemon-resolved claude credential
+    /// (`crate::claude_cred`): a confined child can reach neither the Keychain nor
+    /// the operator's `~/.claude`, so the daemon supplies `CLAUDE_CODE_OAUTH_TOKEN`
+    /// here. It rides `extra_env` — NOT `source_env` — precisely so it does NOT go
+    /// through (and does not have to widen) the deny-by-default allowlist: an
+    /// *ambient* `CLAUDE_CODE_OAUTH_TOKEN` in the daemon's own env is still dropped
+    /// for every provider, while the *resolved* value reaches this claude child
+    /// only. The caller is responsible for backend-gating what it passes here.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::run_claude`].
+    pub async fn run_claude_in_with_env<I, E>(
+        &self,
+        env: &ExecEnv,
+        source_env: I,
+        extra_env: E,
+        invocation: &ProviderInvocation,
+        location: &RunLocation,
+    ) -> std::io::Result<RunOutcome>
+    where
+        I: IntoIterator<Item = (String, String)>,
+        E: IntoIterator<Item = (String, String)>,
+    {
         // The task brief reaches claude as the trailing positional; the workdir +
         // materialised home carry the CONTEXT (CLAUDE.md, skills) but never the ask
         // itself. `run_provider` captures stdout against a null stdin, so this is
@@ -686,7 +710,7 @@ impl Runner {
             &self.cfg.claude_path,
             env,
             source_env,
-            std::iter::empty(),
+            extra_env,
             spec,
             location,
         )
@@ -1496,6 +1520,55 @@ mod tests {
         assert!(
             child.iter().all(|(k, _)| k != "SECRET_KEY"),
             "secret filtered"
+        );
+    }
+
+    #[test]
+    fn ambient_claude_token_never_reaches_a_child_but_resolved_injection_does() {
+        use ainb_hangar_secrets::{InMemoryBackend, Scope, SecretBackend as _};
+
+        // The daemon's OWN env carries an ambient CLAUDE_CODE_OAUTH_TOKEN (a
+        // leaked operator secret). The store holds the resolved credential.
+        let mut daemon_env = std::collections::HashMap::new();
+        daemon_env.insert("HOME".to_string(), "/h".to_string());
+        daemon_env.insert(
+            crate::claude_cred::CHILD_ENV_VAR.to_string(),
+            "AMBIENT-LEAK".to_string(),
+        );
+        let store = InMemoryBackend::new();
+        store.put(&Scope::Global, crate::claude_cred::SECRET_KEY, b"RESOLVED").unwrap();
+
+        // The child's source_env is the ambient daemon env (as `build_task_env`
+        // would filter it). CLAUDE_CODE_OAUTH_TOKEN is NOT on ENV_ALLOWLIST, so
+        // `compose_child_env` drops it for EVERY backend.
+        let source: Vec<(String, String)> =
+            daemon_env.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+        // Codex / copilot resolve NO credential (backend gate) — their extra_env
+        // carries no token, and the ambient one is filtered out. A claude token
+        // must never appear in their child env.
+        for backend in [Backend::Codex, Backend::Copilot] {
+            let extra = crate::claude_cred::keys_for_backend(backend, &store, &daemon_env);
+            let child = compose_child_env(source.clone(), extra);
+            assert!(
+                child.iter().all(|(k, _)| k != crate::claude_cred::CHILD_ENV_VAR),
+                "{backend:?} child must carry NO CLAUDE_CODE_OAUTH_TOKEN, got {child:?}"
+            );
+        }
+
+        // Claude resolves the stored credential and injects it via extra_env
+        // (appended after the filter). The child sees the RESOLVED value — never
+        // the ambient leak.
+        let extra = crate::claude_cred::keys_for_backend(Backend::Claude, &store, &daemon_env);
+        let child = compose_child_env(source, extra);
+        let tok = child
+            .iter()
+            .find(|(k, _)| k == crate::claude_cred::CHILD_ENV_VAR)
+            .map(|(_, v)| v.as_str());
+        assert_eq!(
+            tok,
+            Some("RESOLVED"),
+            "claude child must carry the RESOLVED token, not the ambient leak"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -175,6 +175,38 @@ const COPILOT_LOG_FILE: &str = "copilot.jsonl";
 const CLAUDE_PRINT_FLAG: &str = "-p";
 /// The claude model flag (`claude --model <model>`).
 const CLAUDE_MODEL_FLAG: &str = "--model";
+/// The claude flag that auto-approves EVERY tool call, including `Bash`.
+///
+/// # Why the daemon must be explicit about permissions
+///
+/// With NO permission flag, claude's tool gating is decided by
+/// `$HOME/.claude/settings.json` (`defaultMode` / `allow`) — i.e. by the
+/// OPERATOR'S PERSONAL CONFIG, which the daemon neither owns nor controls. That
+/// makes headless behaviour silently machine-dependent. Measured against Claude
+/// Code 2.1.210 (`Bash` proven by an env nonce the model cannot fabricate with
+/// `Write`):
+///
+/// | `$HOME` | sandbox | argv | `Write` | `Bash` |
+/// |---|---|---|---|---|
+/// | operator's, `defaultMode: bypassPermissions` | off | (none) | allowed | allowed |
+/// | clean (no settings) | off | (none) | denied | denied |
+/// | clean | off | `--permission-mode acceptEdits` | allowed | **denied** |
+/// | clean | off | `--dangerously-skip-permissions` | allowed | allowed |
+/// | operator's | **ON** | (none) | **denied** | **denied** |
+///
+/// The last row is the one that matters: the sandbox's read roots exclude the
+/// operator's `$HOME`, so `~/.claude/settings.json` is UNREADABLE and a personal
+/// `defaultMode` cannot apply. Confined + flagless therefore always denies.
+///
+/// A denial is not loud. Claude emits `permission_denials`, answers in prose ("I
+/// attempted to create the file but the write permission wasn't granted"), and
+/// **exits 0** — and [`RunOutcome::Success`] is keyed on exit code 0, so the
+/// daemon marks such a task `done` over an untouched workdir. Carrying the flag
+/// makes the posture explicit, deterministic, and independent of whose machine
+/// the daemon runs on.
+///
+/// See [`Runner::claude_spec`] for the trust posture this implies.
+const CLAUDE_SKIP_PERMISSIONS_FLAG: &str = "--dangerously-skip-permissions";
 /// The copilot HEADLESS prompt flag (`copilot -p "<text>"`). Verified against
 /// Copilot CLI 1.0.68: "Execute a prompt in non-interactive mode (exits after
 /// completion)" — so it is exactly wrong for an attachable session, which is why
@@ -857,8 +889,8 @@ impl Runner {
         }
     }
 
-    /// The `claude` provider spec: claude log file + `[-p] [--model <model>]
-    /// [<cli_args>…] -- <prompt>`.
+    /// The `claude` provider spec: claude log file + `[-p]
+    /// --dangerously-skip-permissions [--model <model>] [<cli_args>…] -- <prompt>`.
     ///
     /// Verified against Claude Code 2.1.210, whose usage is
     /// `claude [options] [command] [prompt]`:
@@ -873,11 +905,51 @@ impl Runner {
     /// The prompt is a POSITIONAL either way — `-p` is a boolean and never takes
     /// it — and rides last, after [`ARG_SEPARATOR`], so a `-`-leading brief cannot
     /// be read as a flag.
+    ///
+    /// # Permission policy: blanket tool autonomy, deliberately
+    ///
+    /// `--dangerously-skip-permissions` (both modes) auto-approves **EVERY** tool
+    /// call — including `Bash`, i.e. arbitrary shell commands — in an unattended
+    /// background subprocess. This is an explicit operator decision, not a
+    /// default that drifted in, and it is stated plainly rather than softened:
+    ///
+    /// * A headless claude MUST carry some permission flag or its gating falls
+    ///   through to the operator's personal `~/.claude/settings.json` — which the
+    ///   sandbox makes unreadable, so a confined run denies every tool, exits 0,
+    ///   and is marked `done` over an untouched workdir (see
+    ///   [`CLAUDE_SKIP_PERMISSIONS_FLAG`] for the measured matrix).
+    /// * `--permission-mode acceptEdits` is narrower and closes the *write* case,
+    ///   but MEASURABLY denies `Bash` (verified with a clean `$HOME` and an
+    ///   env-nonce only a real shell could resolve). A task that must run a build,
+    ///   a test, or any command would therefore be denied — and, by the very same
+    ///   exit-0 mechanism, still report `done` having half-done the work. Closing
+    ///   the write no-op while leaving the shell no-op open was judged worse than
+    ///   granting the wider mode knowingly.
+    /// * `--allowedTools <list>` cannot be fixed ahead of time: the daemon does not
+    ///   know a brief's tool needs, so a static list breaks arbitrary tasks.
+    ///
+    /// ## What actually confines this
+    ///
+    /// The blast radius is bounded by the FS sandbox (Seatbelt/Landlock) + the
+    /// deny-by-default env allowlist — NOT by claude's own permission prompt,
+    /// which is now fully bypassed. **The sandbox is currently OFF for headless
+    /// runs** (bead `ai-coder-rules-48b`: a confined child cannot reach the
+    /// Keychain credential), so until that lands, a brief built from untrusted
+    /// text (e.g. a board issue) can drive arbitrary shell as the daemon user.
+    /// That exposure is accepted knowingly and is why 48b matters.
+    ///
+    /// A task can still override via `cli_args`, appended after this flag.
+    ///
+    /// Claude joins the other providers in carrying blanket tool autonomy: copilot
+    /// `--allow-all-tools` (mandatory for non-interactive mode); codex runs
+    /// `--full-auto` only when the agent passes it via `cli_args` (its spec adds
+    /// no permission flag of its own).
     fn claude_spec(invocation: &ProviderInvocation, mode: Mode) -> ProviderSpec {
         let mut argv = Vec::new();
         if mode == Mode::Headless {
             argv.push(CLAUDE_PRINT_FLAG.to_string());
         }
+        argv.push(CLAUDE_SKIP_PERMISSIONS_FLAG.to_string());
         if let Some(model) = &invocation.model {
             argv.push(CLAUDE_MODEL_FLAG.to_string());
             argv.push(model.clone());
@@ -959,9 +1031,11 @@ impl Runner {
     /// # Permission policy: copilot is granted blanket tool autonomy, claude is not
     ///
     /// `--allow-all-tools` auto-approves EVERY tool call in an unattended
-    /// background subprocess, and it is the ONLY provider argv here that does so
-    /// ([`Self::claude_spec`] passes no `--dangerously-skip-permissions`). That
-    /// asymmetry is deliberate, not an oversight:
+    /// background subprocess. It is no longer the only provider argv that does so:
+    /// claude carries `--dangerously-skip-permissions` and codex `--full-auto`, so
+    /// all three now grant blanket tool autonomy (see [`Self::claude_spec`] for the
+    /// operator decision behind claude's). The rationale below is why copilot's is
+    /// not merely acceptable but unavoidable:
     ///
     /// * It is **mandatory**, not discretionary — Copilot CLI 1.0.68 documents
     ///   `--allow-all-tools` as "required for non-interactive mode", so a copilot
@@ -976,9 +1050,13 @@ impl Runner {
     ///   the same trust posture the daemon already warns about at dispatch
     ///   (`warnings::danger-full-access`), so copilot is not a new exposure class
     ///   — it is the existing one made explicit in argv.
-    /// * Claude reaches the same place by a different route (its permission
-    ///   behaviour under `--print` differs), so the two are not yet symmetrical.
-    ///   Resolving BOTH providers' permission policy in one pass is still open.
+    /// * Claude's permission policy is now resolved too, and it was NOT the same
+    ///   route: an earlier note here assumed claude "reaches the same place by a
+    ///   different route" under `--print`. Measured against 2.1.210, it did not —
+    ///   a flagless `-p` run DENIED the tool, wrote nothing, and exited 0, which
+    ///   the daemon scored as success. Claude now carries
+    ///   `--dangerously-skip-permissions` by operator decision, so both providers
+    ///   are explicit in argv and equally wide.
     ///
     /// # The brief rides a value-taking flag, chosen by [`Mode`]
     ///

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -104,6 +104,14 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     "CLAUDE_HOME",
     "CODEX_HOME",
     "CURSOR_HOME",
+    // The claude OAuth token the daemon RESOLVES and injects at dispatch (see
+    // `crate::claude_cred`). A confined child can reach neither the Keychain nor
+    // the operator's `~/.claude`, so this env var is its ONLY credential. It is
+    // daemon-controlled config injected on top of the policy pass — never an
+    // inherited ambient secret — and the daemon-side override it resolves from
+    // (`HANGAR_CLAUDE_OAUTH_TOKEN`) is deliberately absent from this list, so it
+    // is read by the daemon and inherited by nothing.
+    crate::claude_cred::CHILD_ENV_VAR,
     // ccc / D11: the parent-session linkage the daemon stamps onto every task it
     // spawns (see `run_loop`). It is daemon-controlled config, not an inherited
     // ambient secret, so allowlisting it leaks nothing — and it MUST survive the

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -319,6 +319,12 @@ fn copilot_command_carries_verified_non_interactive_flags() {
 /// against the real CLIs (claude 2.1.210, codex-cli 0.144.0, Copilot CLI 1.0.70):
 ///
 /// * claude needs `-p` or it opens a session and exits 1 on the daemon's null stdin,
+///   AND a permission flag or every tool call is denied while the process still
+///   exits 0 — a silent no-op the daemon scores as `done`. This assertion formerly
+///   pinned a bare `-p BRIEF`: that shape was only ever exercised against no-tool
+///   briefs ("reply OK"), which is exactly why the gap went unseen. The flag is
+///   `--dangerously-skip-permissions` by operator decision (blanket tool autonomy,
+///   including `Bash`); the narrower `acceptEdits` measurably denies `Bash`.
 /// * codex needs `--skip-git-repo-check` or it exits 1 ("Not inside a trusted
 ///   directory") in the daemon's non-repo in-tree workdir, and takes the prompt as a
 ///   TRAILING positional,
@@ -340,7 +346,12 @@ fn every_provider_argv_is_the_verified_headless_shape() {
     };
 
     let (_p, claude) = runner.provider_command(Backend::Claude, &inv, Mode::Headless);
-    assert_eq!(claude, vec!["-p", "--", "BRIEF"], "claude: -p -- <brief>");
+    assert_eq!(
+        claude,
+        vec!["-p", "--dangerously-skip-permissions", "--", "BRIEF"],
+        "claude: -p --dangerously-skip-permissions -- <brief> (without a permission \
+         flag, tools are denied and the run exits 0 having done nothing)"
+    );
 
     let (_p, codex) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
     assert_eq!(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -430,10 +430,7 @@ async fn exec_tool_using_task_actually_writes_its_file() {
         sandbox: true,
     });
 
-    let outcome = runner
-        .run_claude(&env, std::iter::empty(), &invocation())
-        .await
-        .expect("run");
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
 
     // The daemon scores this run a success...
     assert!(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -14,7 +14,9 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use ainb_hangar_daemon::execenv::ExecEnv;
-use ainb_hangar_daemon::runner::{ProviderInvocation, RunOutcome, Runner, RunnerConfig};
+use ainb_hangar_daemon::runner::{
+    Backend, Mode, ProviderInvocation, RunOutcome, Runner, RunnerConfig,
+};
 use ainb_hangar_store::service::fail::FailureReason;
 use tempfile::TempDir;
 
@@ -374,4 +376,124 @@ exit 0"#,
         RunOutcome::Success(_) => panic!("expected Failed(Timeout), got Success"),
         RunOutcome::Cancelled(_) => panic!("expected Failed(Timeout), got Cancelled"),
     }
+}
+
+/// A fake `claude` that models the REAL permission semantics of Claude Code
+/// 2.1.210 under `-p`, as measured with a clean `$HOME`:
+///
+/// * WITHOUT `--dangerously-skip-permissions`, tool calls are DENIED. The process
+///   still prints a `result` line with `subtype:"success"` and **exits 0** — it
+///   just never writes the file.
+/// * WITH the flag, the write lands.
+///
+/// The exit code is 0 in BOTH branches on purpose: that is precisely what made
+/// the bug silent, since [`RunOutcome::Success`] is keyed on exit code. A test
+/// that asserted only the outcome would pass either way — so the assertion that
+/// matters is the file on disk.
+fn fake_claude_permission_aware(dir: &Path) -> PathBuf {
+    write_script(
+        dir,
+        "fake-claude-perm.sh",
+        r#"skip=""
+for a in "$@"; do
+  if [ "$a" = "--dangerously-skip-permissions" ]; then skip="1"; fi
+done
+echo '{"type":"system","session_id":"perm-1"}'
+if [ -n "$skip" ]; then
+  printf 'TOOLPROOF_OK' > proof.txt
+  echo '{"type":"result","subtype":"success","is_error":false,"result":"DONE"}'
+else
+  echo '{"type":"result","subtype":"success","is_error":false,"permission_denials":[{"tool_name":"Write"}],"result":"I do not have permission to write that file."}'
+fi
+exit 0"#,
+    )
+}
+
+/// REGRESSION (silent no-op): a tool-using claude run must actually produce its
+/// side effect, not merely report success.
+///
+/// Mutation-proof: drop `--dangerously-skip-permissions` from `claude_spec` and
+/// this test goes RED on the `proof.txt` assertion — while the `RunOutcome`
+/// assertion below stays GREEN, reproducing the exact false-green class that let
+/// this ship (every prior headless proof used a no-tool brief).
+#[tokio::test]
+async fn exec_tool_using_task_actually_writes_its_file() {
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    let script = fake_claude_permission_aware(tmp.path());
+    let runner = Runner::new(RunnerConfig {
+        claude_path: script,
+        codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
+        max_runtime: Duration::from_secs(10),
+        tail_lines: 50,
+        sandbox: true,
+    });
+
+    let outcome = runner
+        .run_claude(&env, std::iter::empty(), &invocation())
+        .await
+        .expect("run");
+
+    // The daemon scores this run a success...
+    assert!(
+        matches!(outcome, RunOutcome::Success(_)),
+        "expected Success, got {outcome:?}"
+    );
+    // ...so the ONLY assertion that can catch a silent no-op is the side effect.
+    let proof = env.workdir.join("proof.txt");
+    assert!(
+        proof.is_file(),
+        "tool-using task reported success but wrote NO file: the daemon would \
+         mark this task `done` over an untouched workdir"
+    );
+    assert_eq!(
+        fs::read_to_string(&proof).expect("read proof"),
+        "TOOLPROOF_OK",
+        "tool ran but produced the wrong content"
+    );
+}
+
+/// The claude argv must carry a permission flag, or a tool-using task silently
+/// no-ops (denied tool, exit 0, task marked `done`).
+///
+/// Pins `--dangerously-skip-permissions`: the operator's explicit choice of
+/// blanket tool autonomy, taken because the narrower `acceptEdits` measurably
+/// denies `Bash` and would leave a build/test task half-done yet reported as
+/// success. The escape hatch (`cli_args` appended after) is pinned too, since a
+/// task overriding the posture depends on ordering.
+#[test]
+fn claude_argv_carries_skip_permissions_and_cli_args_can_override() {
+    let runner = Runner::new(RunnerConfig {
+        claude_path: PathBuf::from("/nonexistent/claude"),
+        codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
+        max_runtime: Duration::from_secs(1),
+        tail_lines: 1,
+        sandbox: true,
+    });
+    let (_prog, argv) = runner.provider_command(Backend::Claude, &invocation(), Mode::Headless);
+    assert!(
+        argv.iter().any(|a| a == "--dangerously-skip-permissions"),
+        "claude argv must carry --dangerously-skip-permissions or a tool-using task \
+         silently no-ops, got {argv:?}"
+    );
+
+    // A task's own cli_args are appended AFTER the daemon's flag, so an override
+    // wins. If this ordering ever flips, the escape hatch dies silently.
+    let overridden = ProviderInvocation {
+        cli_args: vec!["--permission-mode".to_string(), "plan".to_string()],
+        ..invocation()
+    };
+    let (_p, argv2) = runner.provider_command(Backend::Claude, &overridden, Mode::Headless);
+    let skip_at = argv2
+        .iter()
+        .position(|a| a == "--dangerously-skip-permissions")
+        .expect("flag present");
+    let override_at =
+        argv2.iter().position(|a| a == "--permission-mode").expect("cli_args appended");
+    assert!(
+        override_at > skip_at,
+        "cli_args must come AFTER the daemon flag so a task can override it, got {argv2:?}"
+    );
 }


### PR DESCRIPTION
## Why
Hangar spawns provider agents inside an OS sandbox, but claude's credential lives in the macOS Keychain which the sandbox blocks → `Not logged in` → every task fails. A Keychain read-grant was tried and REJECTED on security review (it exposed every always-allowed Keychain item, e.g. Chrome's master password key). This delivers the credential the safe way.

## What
- **Daemon-side resolution + injection** (`claude_cred.rs`): `HANGAR_CLAUDE_OAUTH_TOKEN` env override → `SecretBackend(Global)` (macOS Keychain, 0600-file Linux fallback) → none. Injected as `CLAUDE_CODE_OAUTH_TOKEN` into the child env **only for `Backend::Claude`** via the unfiltered `extra_env` seam. The unsandboxed parent reads the secret; the confined child gets one env var, no Keychain access, no securityd, no `security` binary. Token carried as redacting `SecretBytes`, never logged/argv/jsonl.
- **CLI** `hangar daemon cred status|set|clear`: `set` reads from **stdin** (never argv); `--setup-token` drives the interactive `claude setup-token` flow and captures via a pure, tested parser. Stored via the secret backend, never the plaintext `daemon_config` table.
- **Explicit permission posture**: claude spawns with `--dangerously-skip-permissions` (user-approved; confinement is the sandbox). `cli_args` escape hatch preserved.

## Proven under sandbox ON (default)
Real claude authenticates confined and a Write-tool task writes its artifact. Injection mutation: empty store → no token → `Not logged in`, nothing produced. `CLAUDE_HOME` dispatch path exercised.

## Security review + fixes
Adversarial review confirmed **no credential leak** (redaction, Keychain, stdin-only, no argv/ps/jsonl). One Major fixed + **mutation-proven**: an *ambient* `CLAUDE_CODE_OAUTH_TOKEN` in the daemon's own env no longer leaks to codex/copilot children (removed from `ENV_ALLOWLIST`, routed via `extra_env`; regression test goes RED if the allowlist entry returns). Minors baked in (docstring, token-length disclosure, from_utf8 loud-fail, restored the no-mach-lookup invariant test).

## Known / follow-up
- Bash-under-sandbox still fails (hardcoded `/tmp/claude-<uid>` not in write-roots) — separate bead. Write-tool tasks pass confined.
- TUI Settings→Daemon credential row not built (CLI + env satisfy reachability); needs a plugin-host PTY cap — handed off with a spec.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R