### PR TITLE
test(hangar): codex leg of live e2e + fix codex read-only-sandbox no-op

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -2289,6 +2289,65 @@ mod tests {
         );
     }
 
+    /// A HEADLESS codex row must carry the `-s danger-full-access` sandbox
+    /// policy, and an INTERACTIVE one must not.
+    ///
+    /// This locks the dispatch-path fix for the class of bug the codex live
+    /// tripwire surfaced: `codex exec` defaults to a read-only sandbox, so a
+    /// headless run with no `-s` flag lets the model invoke a shell tool yet
+    /// silently drops its write — the task exits 0 having produced no artifact.
+    /// The headless argv MUST therefore pin `danger-full-access` (the daemon's
+    /// own FS sandbox is the confinement boundary); the interactive TUI, which
+    /// has a human attached to answer trust prompts and no FS sandbox, must keep
+    /// codex's own default confinement.
+    #[test]
+    fn headless_codex_argv_pins_danger_full_access_sandbox() {
+        let runner = Runner::new(RunnerConfig {
+            claude_path: "claude".into(),
+            codex_path: "codex".into(),
+            copilot_path: "copilot".into(),
+            max_runtime: Duration::from_secs(1),
+            tail_lines: 1,
+            sandbox: false,
+        });
+        let inv = ProviderInvocation {
+            prompt: "write the nonce".to_string(),
+            model: None,
+            cli_args: Vec::new(),
+        };
+
+        // Headless: exec + skip-git-repo-check + `-s danger-full-access`, in order.
+        let (_p, argv) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
+        let sandbox_at = argv.iter().position(|a| a == "-s").unwrap_or_else(|| {
+            panic!("headless codex argv must carry a `-s` sandbox flag: {argv:?}")
+        });
+        assert_eq!(
+            argv.get(sandbox_at + 1).map(String::as_str),
+            Some("danger-full-access"),
+            "headless codex must run `-s danger-full-access` or its writes are dropped: {argv:?}"
+        );
+        assert!(
+            argv.contains(&"exec".to_string())
+                && argv.contains(&"--skip-git-repo-check".to_string()),
+            "headless codex must still lead with `exec --skip-git-repo-check`: {argv:?}"
+        );
+
+        // Interactive: no exec, no sandbox override — codex keeps its own default.
+        let (_p, argv) = interactive_command(
+            &runner,
+            &ResolvedDispatch {
+                backend: Backend::Codex,
+                mode: dispatch_mode("interactive"),
+                invocation: inv.clone(),
+                agent_env: Vec::new(),
+            },
+        );
+        assert!(
+            !argv.contains(&"danger-full-access".to_string()),
+            "an interactive codex session must not be forced to danger-full-access: {argv:?}"
+        );
+    }
+
     /// The RESOLVE-FAULT path must also be promptless-proof.
     ///
     /// `build_prompt` guarantees "never promptless", but the fault path does not

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -161,6 +161,37 @@ const CODEX_MODEL_FLAG: &str = "-m";
 /// --skip-git-repo-check` → "unexpected argument", exit 2). See
 /// [`Runner::codex_spec`] for why that is also the right security posture.
 const CODEX_SKIP_GIT_CHECK_FLAG: &str = "--skip-git-repo-check";
+/// The codex sandbox-policy flag (`codex exec -s <mode>`), verified against
+/// codex-cli 0.144.0 (`-s, --sandbox <SANDBOX_MODE>`, possible values
+/// `read-only`, `workspace-write`, `danger-full-access`).
+const CODEX_SANDBOX_FLAG: &str = "-s";
+/// The sandbox policy the daemon selects for a HEADLESS codex `exec` run:
+/// `danger-full-access` — codex applies NO internal FS/network confinement.
+///
+/// This is not a convenience toggle; without it a codex agent can do no work.
+/// `codex exec` DEFAULTS to a read-only sandbox, so a headless run with no `-s`
+/// flag lets the model *invoke* a tool yet silently drops the write — the task
+/// exits 0 having produced nothing (verified against codex-cli 0.144.0: a brief
+/// instructing `printf … > file` ran the tool, exited 0, and wrote NO file with
+/// no `-s`; the identical brief under `-s workspace-write` and
+/// `-s danger-full-access` both wrote the file and exited 0). That is precisely
+/// the "reaches `done` having done no real work" bug class the live tripwire
+/// exists to catch, and it is a total functional break for the codex provider,
+/// not a subtle policy choice.
+///
+/// Why `danger-full-access` rather than `workspace-write`: the daemon's OWN
+/// OS-level FS sandbox (Seatbelt/Landlock, e38.23) is the confinement boundary —
+/// the same justification already documented for [`CODEX_SKIP_GIT_CHECK_FLAG`].
+/// Layering codex's internal Seatbelt UNDER the daemon's Seatbelt on macOS nests
+/// two sandboxes and breaks path resolution; `danger-full-access` disables
+/// codex's own confinement so the daemon's is the single boundary. This mirrors
+/// copilot's mandatory `--allow-all-tools` exactly (both delegate confinement to
+/// the daemon FS sandbox + env allowlist, both surfaced by the P5.6
+/// `warnings::danger-full-access` operator warning). HEADLESS ONLY: the
+/// interactive path deliberately has no FS sandbox and a human is attached to
+/// answer codex's own trust/approval prompts, so it keeps codex's default
+/// confinement (see [`Runner::codex_spec`]).
+const CODEX_SANDBOX_HEADLESS: &str = "danger-full-access";
 /// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
 /// provider. Its own log keeps a copilot transcript separate from claude/codex.
 const COPILOT_LOG_FILE: &str = "copilot.jsonl";
@@ -892,16 +923,19 @@ impl Runner {
         }
     }
 
-    /// The `codex` provider spec: codex log file + `[exec --skip-git-repo-check]
-    /// [-m <model>] [<cli_args>…] -- <prompt>` (e38.16).
+    /// The `codex` provider spec: codex log file + `[exec --skip-git-repo-check
+    /// -s danger-full-access] [-m <model>] [<cli_args>…] -- <prompt>` (e38.16).
     ///
     /// Verified against codex-cli 0.144.0, whose usage is both
     /// `codex [OPTIONS] [PROMPT]` (interactive TUI) and `codex exec …`
     /// ("Run Codex non-interactively"):
     ///
     /// * [`Mode::Headless`] leads with the `exec` subcommand, plus
-    ///   [`CODEX_SKIP_GIT_CHECK_FLAG`].
-    /// * [`Mode::Interactive`] omits BOTH, so the top-level TUI starts with the
+    ///   [`CODEX_SKIP_GIT_CHECK_FLAG`] and the [`CODEX_SANDBOX_FLAG`]
+    ///   `danger-full-access` policy — without the latter, codex's default
+    ///   read-only `exec` sandbox drops every write and the agent produces
+    ///   nothing (see [`CODEX_SANDBOX_HEADLESS`]).
+    /// * [`Mode::Interactive`] omits ALL THREE, so the top-level TUI starts with the
     ///   brief as its opening prompt. `codex exec` in a tmux pane would stream and
     ///   exit rather than give the operator a session.
     ///
@@ -931,6 +965,8 @@ impl Runner {
         if mode == Mode::Headless {
             argv.push(CODEX_EXEC_SUBCOMMAND.to_string());
             argv.push(CODEX_SKIP_GIT_CHECK_FLAG.to_string());
+            argv.push(CODEX_SANDBOX_FLAG.to_string());
+            argv.push(CODEX_SANDBOX_HEADLESS.to_string());
         }
         if let Some(model) = &invocation.model {
             argv.push(CODEX_MODEL_FLAG.to_string());

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -187,7 +187,11 @@ const CODEX_SANDBOX_FLAG: &str = "-s";
 /// codex's own confinement so the daemon's is the single boundary. This mirrors
 /// copilot's mandatory `--allow-all-tools` exactly (both delegate confinement to
 /// the daemon FS sandbox + env allowlist, both surfaced by the P5.6
-/// `warnings::danger-full-access` operator warning). HEADLESS ONLY: the
+/// `warnings::danger-full-access` operator warning). NOTE: "the daemon's is the
+/// single boundary" holds only while the daemon FS sandbox is ON; in the current
+/// `HANGAR_DAEMON_DISABLE_SANDBOX` interim there is no boundary for ANY provider
+/// (claude/codex/copilot alike) — the real confinement floor is turning the daemon
+/// sandbox on, tracked separately, not hardening codex in isolation. HEADLESS ONLY: the
 /// interactive path deliberately has no FS sandbox and a human is attached to
 /// answer codex's own trust/approval prompts, so it keeps codex's default
 /// confinement (see [`Runner::codex_spec`]).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
@@ -223,6 +223,167 @@ async fn live_dispatch_writes_nonce_artifact() {
     eprintln!("LIVE E2E OK: task {task_id} done; nonce artifact verified at {artifact:?}");
 }
 
+/// The codex leg of the same tripwire: the REAL daemon dispatching the REAL
+/// `codex` binary through the REAL CLI path, proven by an on-disk nonce artifact.
+///
+/// Identical law to [`live_dispatch_writes_nonce_artifact`], one provider over:
+///
+/// ```text
+///  ainb hangar agent create --provider codex
+///         │
+///         ▼
+///  ainb hangar issue create --assign <agent>  ──▶ queued task
+///         │                                            │
+///         ▼                              real ainb-hangar-daemon (this binary)
+///  claim ─▶ dispatch ─▶ `codex exec --skip-git-repo-check -s danger-full-access
+///                        -- <brief>` ─▶ done
+///                                            │
+///                              agent runs a shell command: writes NONCE → file
+/// ```
+///
+/// # Two codex facts this leg pins that a fake could never surface
+///
+/// 1. **No model flag.** codex-cli 0.144.0 runs `codex exec` on its default model
+///    with no `-m`, so — unlike the claude leg's `--model haiku` pin — no
+///    `agent edit --model` step is needed (verified: a bare `codex exec -- …`
+///    ran and exited 0). Threading a guessed model id would be the bug.
+/// 2. **The sandbox flag is load-bearing.** `codex exec` DEFAULTS to a read-only
+///    sandbox; before the `-s danger-full-access` fix (this branch), a codex task
+///    ran a shell tool yet its write was silently dropped and the task still
+///    exited 0 — a `done` with no artifact. This leg is the live proof of that
+///    fix: the nonce lands only because the daemon now pins the sandbox policy.
+///
+/// # Mutation self-check
+///
+/// `LIVE_E2E_BREAK_CODEX=1` points the daemon at a no-op codex stand-in that
+/// exits 0 WITHOUT writing the nonce — a provider that reaches `done` having done
+/// no real work. The test then goes RED on the MISSING ARTIFACT (not on task
+/// state), proving the artifact — not the FSM status — is the trusted signal.
+#[tokio::test]
+async fn live_dispatch_codex_writes_nonce_artifact() {
+    // ---- Skip gates (a skip prints LOUD and returns clean — never a pass) ----
+    let Some(ainb) = ainb_bin() else {
+        eprintln!("SKIPPED: ainb binary not built (run `cargo build -p ainb --bin ainb`)");
+        return;
+    };
+    let Some(codex) = real_codex() else {
+        eprintln!("SKIPPED: no codex binary on PATH");
+        return;
+    };
+    if !codex_alive(&codex) {
+        eprintln!(
+            "SKIPPED: codex on PATH is not authenticated / did not answer the liveness probe"
+        );
+        return;
+    }
+
+    let tag = format!("{}-{}", std::process::id(), now_ms());
+    let nonce = format!("HANGAR-LIVE-CODEX-NONCE-{tag}");
+    let agent_name = format!("live-e2e-codex-{tag}");
+
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    // 1. Create a CODEX agent via the real CLI. No `agent edit --model` follows:
+    //    codex runs on its default model with no `-m`, so pinning one is neither
+    //    needed nor desirable here (see the fn doc).
+    run_ainb(
+        &ainb,
+        home.path(),
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            &agent_name,
+            "--provider",
+            "codex",
+        ],
+    );
+
+    let pool = open_pool(&db_path).await;
+    let (agent_id, runtime_id) = agent_ids_by_name(&pool, &agent_name).await;
+
+    // 2. Spawn the REAL daemon pointed at the real codex (or the mutation stand-in
+    //    that reaches `done` WITHOUT writing the nonce).
+    let effective_codex = if std::env::var_os("LIVE_E2E_BREAK_CODEX").is_some() {
+        eprintln!(
+            "MUTATION: LIVE_E2E_BREAK_CODEX set — daemon uses a no-op codex that reaches \
+             `done` without writing the nonce"
+        );
+        write_noop_codex(home.path())
+    } else {
+        codex.clone()
+    };
+    let daemon = LiveDaemon::spawn_codex(
+        &home.path().join("daemon.log"),
+        home.path(),
+        &runtime_id,
+        &effective_codex,
+    );
+
+    // 3. Enqueue via the real user path. The brief tells codex to write the nonce
+    //    with a shell command — exercising codex's REAL tool use, not a fabricated
+    //    echo. The nonce is unguessable text handed to it here.
+    let brief = format!(
+        "Run exactly this one shell command and nothing else: \
+         printf '%s' '{nonce}' > {ARTIFACT_NAME}  \
+         Once the command has run, stop."
+    );
+    let stdout = run_ainb_capture(
+        &ainb,
+        home.path(),
+        &[
+            "hangar", "issue", "create", "--title", &brief, "--assign", &agent_id,
+        ],
+    );
+    let task_id = parse_queued_task_id(&stdout);
+
+    // 4. Poll to terminal, STOP the daemon by exact pid, THEN assert the artifact.
+    let row = wait_for_terminal(&pool, &task_id, TASK_BUDGET, home.path()).await;
+    let status: String = row.get("status");
+    drop(daemon);
+
+    // 5. THE side-effect assertion, FIRST. A codex task that reaches a terminal
+    //    state WITHOUT the artifact fails here — exactly the read-only-sandbox bug
+    //    class (done, exit 0, no write) this leg exists to catch.
+    let work_dir: Option<String> = row.get("work_dir");
+    let work_dir = work_dir.unwrap_or_else(|| {
+        panic!(
+            "codex task {task_id} reached status={status} but recorded NO work_dir. \
+             daemon log:\n{}",
+            read_log(home.path())
+        )
+    });
+    let artifact = Path::new(&work_dir).join(ARTIFACT_NAME);
+    let got = std::fs::read_to_string(&artifact).unwrap_or_else(|e| {
+        panic!(
+            "NONCE ARTIFACT MISSING at {artifact:?} ({e}); codex task status={status}. \
+             A codex task that reaches a terminal state WITHOUT the artifact is the exact \
+             bug class this tripwire exists to catch (exit 0 / done != real work — and, \
+             specifically here, codex's default read-only exec sandbox dropping the write). \
+             daemon log:\n{}",
+            read_log(home.path())
+        )
+    });
+    assert_eq!(
+        got.trim(),
+        nonce,
+        "artifact exists but nonce mismatch — codex wrote the WRONG bytes"
+    );
+
+    // 6. Only NOW is the status trustworthy: the artifact proved real work.
+    assert_eq!(
+        status,
+        "done",
+        "nonce artifact is present and correct, but the codex task status is {status:?}, not \
+         done — a finalize-path inconsistency. daemon log:\n{}",
+        read_log(home.path())
+    );
+
+    eprintln!("LIVE E2E CODEX OK: task {task_id} done; nonce artifact verified at {artifact:?}");
+}
+
 // ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
@@ -238,15 +399,47 @@ struct LiveDaemon {
 }
 
 impl LiveDaemon {
+    /// Spawn the claude leg's daemon: overrides `HANGAR_CLAUDE_PATH`.
     fn spawn(log_path: &Path, home: &Path, runtime_id: &str, claude_path: &Path) -> Self {
+        Self::spawn_with(
+            log_path,
+            home,
+            runtime_id,
+            &[("HANGAR_CLAUDE_PATH", claude_path)],
+        )
+    }
+
+    /// Spawn the codex leg's daemon: overrides `HANGAR_CODEX_PATH` so the runner's
+    /// `codex exec` path resolves the real codex binary (or the mutation stand-in).
+    fn spawn_codex(log_path: &Path, home: &Path, runtime_id: &str, codex_path: &Path) -> Self {
+        Self::spawn_with(
+            log_path,
+            home,
+            runtime_id,
+            &[("HANGAR_CODEX_PATH", codex_path)],
+        )
+    }
+
+    /// The shared spawn core: one plain child that inherits this process's
+    /// environment (so the spawned provider sees the real `$HOME` credentials),
+    /// overriding only the hangar knobs plus the given provider-path env pairs.
+    fn spawn_with(
+        log_path: &Path,
+        home: &Path,
+        runtime_id: &str,
+        provider_env: &[(&str, &Path)],
+    ) -> Self {
         let log = std::fs::File::create(log_path).expect("create daemon log");
         let err = log.try_clone().expect("clone daemon log handle");
-        let child = Command::new(daemon_bin())
-            .env("AINB_HANGAR_HOME", home)
+        let mut cmd = Command::new(daemon_bin());
+        cmd.env("AINB_HANGAR_HOME", home)
             .env("HANGAR_DAEMON_RUNTIME_ID", runtime_id)
-            .env("HANGAR_CLAUDE_PATH", claude_path)
             .env("HANGAR_DAEMON_DISABLE_SANDBOX", "1")
-            .env("HANGAR_DAEMON_POLL_MS", "200")
+            .env("HANGAR_DAEMON_POLL_MS", "200");
+        for (key, path) in provider_env {
+            cmd.env(key, path);
+        }
+        let child = cmd
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::from(log))
             .stderr(std::process::Stdio::from(err))
@@ -289,6 +482,11 @@ fn real_claude() -> Option<PathBuf> {
     which::which("claude").ok()
 }
 
+/// The real `codex` binary on PATH, if any.
+fn real_codex() -> Option<PathBuf> {
+    which::which("codex").ok()
+}
+
 /// Write an executable no-op stand-in for `claude` used ONLY by the mutation
 /// self-check. It emits the exact `system`+`result` JSONL the headless runner
 /// pins (so the run finalizes cleanly to `done`) but writes NO nonce file — a
@@ -302,14 +500,35 @@ fn write_noop_claude(dir: &Path) -> PathBuf {
          echo '{\"type\":\"result\",\"content\":\"ok\"}'\n\
          exit 0\n";
     std::fs::write(&path, body).expect("write noop-claude");
+    make_executable(&path);
+    path
+}
+
+/// The codex counterpart of [`write_noop_claude`]: an executable no-op stand-in
+/// for `codex` used ONLY by the codex mutation self-check. The daemon keys a
+/// codex run's success on its exit code (JSONL parsing is best-effort for codex),
+/// so this simply prints a line and exits 0 — a provider that reaches `done`
+/// having written NO nonce file. The live artifact assertion must catch it.
+/// Returns the script path to hand the daemon as `HANGAR_CODEX_PATH`.
+fn write_noop_codex(dir: &Path) -> PathBuf {
+    let path = dir.join("noop-codex.sh");
+    let body = "#!/bin/sh\n\
+         echo 'noop codex: reached done without writing the nonce'\n\
+         exit 0\n";
+    std::fs::write(&path, body).expect("write noop-codex");
+    make_executable(&path);
+    path
+}
+
+/// Mark a stand-in script executable (0o755) on unix so the daemon can spawn it.
+fn make_executable(path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&path).expect("stat noop-claude").permissions();
+        let mut perms = std::fs::metadata(path).expect("stat stand-in").permissions();
         perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms).expect("chmod noop-claude");
+        std::fs::set_permissions(path, perms).expect("chmod stand-in");
     }
-    path
 }
 
 /// Liveness + auth probe: `claude -p "reply PONG"` under a short timeout. An
@@ -329,6 +548,38 @@ fn claude_alive(claude: &Path) -> bool {
         return false;
     };
     out.status.success() && String::from_utf8_lossy(&out.stdout).to_uppercase().contains("PONG")
+}
+
+/// Codex liveness + auth probe: `codex exec --skip-git-repo-check -- "reply
+/// PONG"`, bounded by a hard wall-clock timeout. codex's non-interactive `exec`
+/// never prompts (null stdin), so an unauthenticated codex errors instead of
+/// hanging — but the probe is still bounded so a wedged CLI can never stall the
+/// suite. Runs the child on a helper thread and joins with `recv_timeout`; a
+/// timeout, spawn error, non-zero exit, or a reply without `PONG` all read as
+/// "not alive" and drive a LOUD skip, never a pass. `exec`'s output is drained
+/// via `output()` so a chatty codex cannot deadlock on a full stdout pipe.
+fn codex_alive(codex: &Path) -> bool {
+    let codex = codex.to_owned();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let out = Command::new(&codex)
+            .args([
+                "exec",
+                "--skip-git-repo-check",
+                "--",
+                "reply with the single word PONG",
+            ])
+            .stdin(std::process::Stdio::null())
+            .output();
+        let _ = tx.send(out);
+    });
+    match rx.recv_timeout(Duration::from_secs(90)) {
+        Ok(Ok(out)) => {
+            out.status.success()
+                && String::from_utf8_lossy(&out.stdout).to_uppercase().contains("PONG")
+        }
+        _ => false,
+    }
 }
 
 /// Run an `ainb` subcommand under the isolated hangar home; panic on non-zero.

--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -42,7 +42,41 @@ test-live:
         exit 0
     fi
     cargo build -p ainb --bin ainb
-    cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e -- --nocapture --test-threads=1
+    cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e live_dispatch_writes_nonce_artifact -- --nocapture --test-threads=1
+
+# Run the LIVE, no-mock e2e tripwire against the REAL codex binary.
+#
+# The codex leg of `test-live`: same law (assert the on-disk nonce artifact
+# FIRST, task=done only as a cross-check), one provider over. Skips CLEAN + LOUD
+# (exit 0) when there is no authenticated `codex` on PATH, via a bounded
+# liveness probe (`codex exec -- "reply PONG"`) — macOS has no `timeout`, so a
+# background killer bounds it. The Rust test carries the same skip gate, so this
+# recipe only fast-fails the build when codex is plainly absent.
+test-live-codex:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v codex >/dev/null 2>&1; then
+        echo "SKIPPED: no codex binary on PATH"
+        exit 0
+    fi
+    probe=$(mktemp)
+    codex exec --skip-git-repo-check -- "reply with the single word PONG" >"$probe" 2>/dev/null &
+    pid=$!
+    ( sleep 90; kill "$pid" 2>/dev/null || true ) &
+    killer=$!
+    wait "$pid" 2>/dev/null && rc=0 || rc=$?
+    kill "$killer" 2>/dev/null || true
+    if [ "$rc" -ne 0 ] || ! grep -qi PONG "$probe"; then
+        echo "SKIPPED: codex on PATH is not authenticated / did not answer the liveness probe"
+        rm -f "$probe"
+        exit 0
+    fi
+    rm -f "$probe"
+    cargo build -p ainb --bin ainb
+    cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e live_dispatch_codex_writes_nonce_artifact -- --nocapture --test-threads=1
+
+# Run BOTH live e2e legs (claude + codex); each self-skips CLEAN + LOUD.
+test-live-all: test-live test-live-codex
 
 # Format code
 fmt:


### PR DESCRIPTION
## Why
Extending the live e2e harness (#406) to codex surfaced a real dispatch bug: `codex exec` **defaults to a read-only sandbox**, and the daemon passed no `-s` flag — so a codex agent would *invoke* a shell tool but its write was silently dropped, exiting 0 with **no artifact**. A total functional break for the codex provider, and the exact "reaches done having done no real work" class this harness exists to catch. Verified against real codex-cli 0.144.0.

## Fix
Thread `-s danger-full-access` onto the **headless** codex `exec` argv only (interactive keeps codex's own confinement — a human is attached). Posture confirmed by review: `workspace-write` is a trap — it silently blocks network (`curl` → exit 0, nothing written), the same no-op class, and nests badly under the daemon's Seatbelt. `danger-full-access` matches claude (`--dangerously-skip-permissions`) and copilot (`--allow-all-tools`): the daemon FS sandbox is the single confinement boundary. Doc notes that boundary only holds once the daemon sandbox is ON (bead 48b) — the real floor.

## Proof
- `live_dispatch_codex_writes_nonce_artifact`: real daemon + real codex, asserts the nonce artifact on disk FIRST, `done` only as cross-check. Green (18–30s).
- **Mutation** (`LIVE_E2E_BREAK_CODEX=1`, re-verified by review): task driven to `done`, test RED on the **missing artifact**, not on status.
- Unit test pins the flag to the headless path (position + value; interactive negative case).
- `just test-live-codex` / `test-live-all`; skip-clean loud if codex absent.

## Review
Merge-recommended. Correctness, argv ordering, headless-only, no claude regression all verified empirically; posture recommendation `danger-full-access` (not workspace-write). Follow-up (not this PR): derive the codex `-s` mode from `self.cfg.sandbox` once the daemon sandbox is enabled, to avoid nested Seatbelt.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R