### PR TITLE
fix(hangar-daemon): finalize tasks on the provider's structured result, not exit 0 (48c/48d)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -19,16 +19,23 @@
 //! # Outcome classification
 //!
 //! The runner does **not** itself touch the database. It returns a
-//! [`RunOutcome`] the daemon's claim loop maps onto the FSM:
-//! - clean exit (code 0)        → [`RunOutcome::Success`] → daemon `CompleteTask`,
-//! - exit [`EX_TEMPFAIL`] (75)   → [`RunOutcome::Failed`] with
-//!   [`FailureReason::RuntimeOffline`] — a provider's POSIX `sysexits.h`
-//!   "temporary failure, retry later" code, the infra/retryable failure the
+//! [`RunOutcome`] the daemon's claim loop maps onto the FSM. It finalizes on the
+//! provider's OWN structured terminal event (beads 48c/48d) — parsed from the
+//! `--output-format stream-json` (claude) / `--json` (codex) stream — NOT the
+//! bare exit code, because an agent CLI exits 0 on refusals and empty runs:
+//! - structured success + clean exit → [`RunOutcome::Success`] → daemon
+//!   `CompleteTask`,
+//! - structured error / refusal / max-turns (any exit code, incl. 0) →
+//!   [`RunOutcome::Failed`] with the mapped reason ([`FailureReason::IterationLimit`]
+//!   for `error_max_turns`, else [`FailureReason::AgentError`]),
+//! - **exit 0 with NO success terminal** → [`RunOutcome::Failed`] with
+//!   [`FailureReason::AgentError`] — the "done over no work" hole (48d),
+//! - exit [`EX_TEMPFAIL`] (75) with no success terminal → [`RunOutcome::Failed`]
+//!   with [`FailureReason::RuntimeOffline`] — the infra/retryable failure the
 //!   daemon's retry chain (e38.28) re-dispatches as a child task,
-//! - any other non-zero exit    → [`RunOutcome::Failed`] with
-//!   [`FailureReason::AgentError`] (the agent itself errored / gave up — terminal,
-//!   not retried),
-//! - deadline exceeded → kill   → [`RunOutcome::Failed`] with
+//! - any other non-zero exit with no success terminal → [`RunOutcome::Failed`]
+//!   with [`FailureReason::AgentError`],
+//! - deadline exceeded → kill → [`RunOutcome::Failed`] with
 //!   [`FailureReason::Timeout`].
 
 use std::path::{Path, PathBuf};
@@ -196,6 +203,15 @@ const CODEX_SANDBOX_FLAG: &str = "-s";
 /// answer codex's own trust/approval prompts, so it keeps codex's default
 /// confinement (see [`Runner::codex_spec`]).
 const CODEX_SANDBOX_HEADLESS: &str = "danger-full-access";
+/// The codex flag selecting its machine-readable event stream (bead 48c). `codex
+/// exec --json` emits one JSON event per line — a `thread.started` carrying the
+/// `thread_id` (codex's session handle), and a TERMINAL `turn.completed`
+/// (success, with `usage`) or `turn.failed` (error, with the provider's error
+/// message). WITHOUT it codex prints human text the runner cannot classify, so —
+/// exactly like claude pre-fix — the daemon can only trust the exit code.
+/// Verified against codex-cli 0.144.0. Headless-only (the interactive TUI has no
+/// `exec` subcommand to attach it to).
+const CODEX_JSON_FLAG: &str = "--json";
 /// The provider-log file written under [`ExecEnv::logs`] for the `copilot`
 /// provider. Its own log keeps a copilot transcript separate from claude/codex.
 const COPILOT_LOG_FILE: &str = "copilot.jsonl";
@@ -242,6 +258,22 @@ const CLAUDE_MODEL_FLAG: &str = "--model";
 ///
 /// See [`Runner::claude_spec`] for the trust posture this implies.
 const CLAUDE_SKIP_PERMISSIONS_FLAG: &str = "--dangerously-skip-permissions";
+/// The claude flag selecting the machine-readable event stream (bead 48c). Under
+/// `--print`, `--output-format stream-json` makes claude emit one JSON event per
+/// line — a `system` line carrying `session_id`, per-turn `assistant` lines, and
+/// a TERMINAL `{"type":"result",…}` line whose `subtype`/`is_error` report
+/// genuine success vs refusal/error/max-turns. WITHOUT it, `claude -p` prints
+/// PLAIN TEXT (~5 bytes), so `session_id`/`usage` never parse and the daemon has
+/// only the exit code to trust — the exact hole behind beads 48c/48d. Verified
+/// against Claude Code 2.1.211.
+const CLAUDE_OUTPUT_FORMAT_FLAG: &str = "--output-format";
+/// The `--output-format` value for the per-line JSON event stream (bead 48c).
+const CLAUDE_STREAM_JSON_FORMAT: &str = "stream-json";
+/// `--output-format stream-json` under `--print` HARD-REQUIRES `--verbose`
+/// (verified against Claude Code 2.1.211: without it claude errors "When using
+/// --print, --output-format=stream-json requires --verbose"). Headless-only,
+/// paired with the stream-json flag.
+const CLAUDE_VERBOSE_FLAG: &str = "--verbose";
 /// The copilot HEADLESS prompt flag (`copilot -p "<text>"`). Verified against
 /// Copilot CLI 1.0.68: "Execute a prompt in non-interactive mode (exits after
 /// completion)" — so it is exactly wrong for an attachable session, which is why
@@ -395,40 +427,113 @@ impl RunOutcome {
     }
 }
 
-/// A `system`-type JSONL line, the only shape the runner needs to decode (to pin
-/// `session_id`). Other line types are streamed to the log verbatim and ignored
-/// here.
-#[derive(Debug, Deserialize)]
-struct SystemLine {
-    #[serde(rename = "type")]
-    kind: String,
-    #[serde(default)]
-    session_id: Option<String>,
+/// The provider's OWN reported terminal outcome, parsed from its structured
+/// event stream (beads 48c/48d) — the signal the runner finalizes on INSTEAD of
+/// the bare exit code.
+///
+/// An agent CLI exits 0 on refusals and (for some shapes) errors, so exit 0
+/// alone is not success. A structured error / `turn.failed`, or the ABSENCE of
+/// any success terminal, is a failure even when the process exited 0 — closing
+/// the "exit 0 → done over no work" hole (48d).
+#[derive(Debug, Clone, PartialEq)]
+enum TerminalSignal {
+    /// Genuine success: claude `result` with `subtype:"success"` and
+    /// `is_error:false` (or a fake's `result` carrying no error), or codex
+    /// `turn.completed`.
+    Success,
+    /// The provider itself reported non-success: claude `result` with
+    /// `is_error:true` / an `error_*` subtype, or codex `turn.failed`. Carries the
+    /// FSM failure reason the subtype maps to.
+    Failure(FailureReason),
 }
 
-/// A `result`-type JSONL line, decoded to pin token/cost usage (e38.35).
+/// One structured stream line, decoded across BOTH provider shapes (bead 48c).
 ///
-/// The agent CLI's terminal `{"type":"result",…}` line carries a `usage` object
-/// and `total_cost_usd`. Every field is `#[serde(default)]` so a result line that
-/// omits usage (or a future shape change) decodes to zeros rather than failing
-/// the whole run.
-#[derive(Debug, Deserialize)]
-struct ResultLine {
-    #[serde(rename = "type")]
+/// A single struct so the stream reader is one pass, not a per-backend fork:
+/// claude emits `system` / `result`, codex emits `thread.started` /
+/// `turn.completed` / `turn.failed`, and each carries only its own fields. Every
+/// field is `#[serde(default)]` so a line of another type — or a future shape
+/// change — decodes to empties rather than failing the whole run.
+#[derive(Debug, Default, Deserialize)]
+struct StreamLine {
+    #[serde(rename = "type", default)]
     kind: String,
+    /// claude `system` line session handle.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// codex `thread.started` session handle.
+    #[serde(default)]
+    thread_id: Option<String>,
+    /// claude `result` outcome discriminator (`success` / `error_max_turns` / …).
+    #[serde(default)]
+    subtype: Option<String>,
+    /// claude `result` hard-error flag.
+    #[serde(default)]
+    is_error: bool,
+    /// claude `result` total cost in USD (codex reports none → 0).
     #[serde(default)]
     total_cost_usd: f64,
+    /// token tallies: claude `result.usage` or codex `turn.completed.usage`.
     #[serde(default)]
     usage: Option<UsageBlock>,
 }
 
-/// The `usage` sub-object of a [`ResultLine`]: the token tallies (e38.35).
-#[derive(Debug, Default, Deserialize)]
+/// The `usage` sub-object of a [`StreamLine`]: the token tallies (e38.35). Field
+/// names are shared by claude's `result.usage` and codex's `turn.completed.usage`.
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
 struct UsageBlock {
     #[serde(default)]
     input_tokens: i64,
     #[serde(default)]
     output_tokens: i64,
+}
+
+/// Map a claude `result` line's `subtype`/`is_error` onto a [`TerminalSignal`]
+/// (beads 48c/48d).
+///
+/// `error_max_turns` is the iteration-budget exhaustion the daemon retries FRESH
+/// ([`FailureReason::IterationLimit`]); any other error is a terminal agent
+/// error. A `result` with no subtype and no error — the routing fakes'
+/// `{"type":"result","content":"ok"}` — is treated as success so existing
+/// dispatch tests stay valid.
+fn classify_claude_result(subtype: Option<&str>, is_error: bool) -> TerminalSignal {
+    match subtype {
+        Some("error_max_turns") => TerminalSignal::Failure(FailureReason::IterationLimit),
+        Some(s) if is_error || s.starts_with("error") => {
+            TerminalSignal::Failure(FailureReason::AgentError)
+        }
+        _ if is_error => TerminalSignal::Failure(FailureReason::AgentError),
+        _ => TerminalSignal::Success,
+    }
+}
+
+/// Build a [`ProviderUsage`] from a stream line's token block + cost, or `None`
+/// when it reports nothing worth recording (all-zero) — the "no usage → record
+/// nothing" contract shared by claude `result` and codex `turn.completed`.
+fn provider_usage(block: Option<UsageBlock>, cost_usd: f64) -> Option<ProviderUsage> {
+    let block = block.unwrap_or_default();
+    let reported = block.input_tokens != 0 || block.output_tokens != 0 || cost_usd != 0.0;
+    reported.then_some(ProviderUsage {
+        input_tokens: block.input_tokens,
+        output_tokens: block.output_tokens,
+        cost_usd,
+    })
+}
+
+/// What one provider-stdout stream reader pinned (bead 48c): the session handle,
+/// token/cost usage, the provider's structured terminal outcome, and a bounded
+/// tail.
+struct StreamCapture {
+    /// First session handle seen (claude `system.session_id` / codex
+    /// `thread.started.thread_id`).
+    session_id: Option<String>,
+    /// Last usage tally seen (claude `result` / codex `turn.completed`).
+    usage: Option<ProviderUsage>,
+    /// The provider's OWN reported terminal outcome, or `None` if the stream
+    /// ended without one (the exit-0-no-terminal hole, 48d).
+    terminal: Option<TerminalSignal>,
+    /// Trailing stdout lines (up to the configured tail).
+    stdout_tail: String,
 }
 
 /// Which provider exec path the daemon routes a task to (e38.16).
@@ -1017,6 +1122,15 @@ impl Runner {
             argv.push(CLAUDE_PRINT_FLAG.to_string());
         }
         argv.push(CLAUDE_SKIP_PERMISSIONS_FLAG.to_string());
+        if mode == Mode::Headless {
+            // bead 48c: emit the structured event stream so the runner can pin
+            // session_id + usage and finalize on claude's OWN reported outcome,
+            // not the exit code. Headless-only — an interactive pane needs
+            // claude's normal TUI, and stream-json requires `--print`.
+            argv.push(CLAUDE_OUTPUT_FORMAT_FLAG.to_string());
+            argv.push(CLAUDE_STREAM_JSON_FORMAT.to_string());
+            argv.push(CLAUDE_VERBOSE_FLAG.to_string());
+        }
         if let Some(model) = &invocation.model {
             argv.push(CLAUDE_MODEL_FLAG.to_string());
             argv.push(model.clone());
@@ -1075,6 +1189,10 @@ impl Runner {
             argv.push(CODEX_SKIP_GIT_CHECK_FLAG.to_string());
             argv.push(CODEX_SANDBOX_FLAG.to_string());
             argv.push(CODEX_SANDBOX_HEADLESS.to_string());
+            // bead 48c: structured event stream so the runner can pin the
+            // thread_id + usage and finalize on codex's `turn.completed` /
+            // `turn.failed`, not the exit code. Headless-only (see the const).
+            argv.push(CODEX_JSON_FLAG.to_string());
         }
         if let Some(model) = &invocation.model {
             argv.push(CODEX_MODEL_FLAG.to_string());
@@ -1275,7 +1393,12 @@ impl Runner {
             }
         };
 
-        let (session_id, usage, stdout_tail) = stdout_task
+        let StreamCapture {
+            session_id,
+            usage,
+            terminal,
+            stdout_tail,
+        } = stdout_task
             .await
             .map_err(|e| std::io::Error::other(format!("stdout task join: {e}")))??;
         let stderr_tail = stderr_task
@@ -1300,40 +1423,94 @@ impl Runner {
             stderr_tail,
         };
 
-        let outcome = if timed_out {
-            tracing::warn!(
-                provider = spec.backend.name(),
-                reason = "timeout",
-                "runner_failed"
-            );
-            RunOutcome::Failed {
-                reason: FailureReason::Timeout,
-                result,
-            }
-        } else if exit_code == Some(0) {
-            RunOutcome::Success(result)
-        } else if exit_code == Some(EX_TEMPFAIL) {
-            // `EX_TEMPFAIL` (75): the provider signalled a transient runtime
-            // failure. Classify as infra/retryable so the daemon's retry chain
-            // re-dispatches a child task, rather than treating it as a terminal
-            // agent error.
-            tracing::warn!(
-                provider = spec.backend.name(),
-                reason = "runtime_offline",
-                "runner_failed"
-            );
-            RunOutcome::Failed {
-                reason: FailureReason::RuntimeOffline,
-                result,
-            }
-        } else {
-            tracing::warn!(provider = spec.backend.name(), reason = "agent_error", exit_code = ?exit_code, "runner_failed");
-            RunOutcome::Failed {
-                reason: FailureReason::AgentError,
-                result,
-            }
+        Ok(finalize_outcome(
+            spec.backend,
+            timed_out,
+            terminal.as_ref(),
+            exit_code,
+            result,
+        ))
+    }
+}
+
+/// Map a completed run's structured terminal signal + exit code onto a
+/// [`RunOutcome`] (beads 48c/48d).
+///
+/// Split out of [`Runner::run_provider`] so the finalize policy — *the
+/// provider's OWN reported outcome wins over the bare exit code* — reads as one
+/// self-contained decision. An agent CLI exits 0 on refusals and empty runs, so
+/// exit 0 is not a completion signal; the terminal `result` / `turn.*` event is.
+/// Precedence:
+///   1. timeout kill                        → [`FailureReason::Timeout`],
+///   2. structured failure (ANY exit code)  → the mapped reason — a
+///      provider-reported error/refusal/max-turns is a failure even at exit 0
+///      (the 48d hole),
+///   3. structured success AND a clean exit → [`RunOutcome::Success`],
+///   4. otherwise fall back to the exit code, where a bare exit 0 with NO
+///      success terminal is itself a failure (the other 48d hole), and
+///      [`EX_TEMPFAIL`] stays the retryable [`FailureReason::RuntimeOffline`].
+fn finalize_outcome(
+    backend: Backend,
+    timed_out: bool,
+    terminal: Option<&TerminalSignal>,
+    exit_code: Option<i32>,
+    result: RunnerResult,
+) -> RunOutcome {
+    if timed_out {
+        tracing::warn!(
+            provider = backend.name(),
+            reason = "timeout",
+            "runner_failed"
+        );
+        return RunOutcome::Failed {
+            reason: FailureReason::Timeout,
+            result,
         };
-        Ok(outcome)
+    }
+    match terminal {
+        Some(TerminalSignal::Failure(reason)) => {
+            let reason = *reason;
+            tracing::warn!(provider = backend.name(), ?reason, exit_code = ?exit_code, "runner_failed_structured");
+            RunOutcome::Failed { reason, result }
+        }
+        Some(TerminalSignal::Success) if exit_code == Some(0) => RunOutcome::Success(result),
+        // No structured success terminal (absent entirely, or a success terminal
+        // the process then contradicted with a non-zero exit).
+        _ => match exit_code {
+            Some(0) => {
+                // 48d: exit 0 but the provider never reported success — never
+                // mark this `done` over work that did not happen.
+                tracing::warn!(
+                    provider = backend.name(),
+                    reason = "no_success_terminal",
+                    "runner_failed"
+                );
+                RunOutcome::Failed {
+                    reason: FailureReason::AgentError,
+                    result,
+                }
+            }
+            Some(EX_TEMPFAIL) => {
+                // Transient runtime failure — infra/retryable so the daemon's
+                // retry chain re-dispatches a child task.
+                tracing::warn!(
+                    provider = backend.name(),
+                    reason = "runtime_offline",
+                    "runner_failed"
+                );
+                RunOutcome::Failed {
+                    reason: FailureReason::RuntimeOffline,
+                    result,
+                }
+            }
+            _ => {
+                tracing::warn!(provider = backend.name(), reason = "agent_error", exit_code = ?exit_code, "runner_failed");
+                RunOutcome::Failed {
+                    reason: FailureReason::AgentError,
+                    result,
+                }
+            }
+        },
     }
 }
 
@@ -1369,59 +1546,76 @@ where
 }
 
 /// Read the child's stdout line-by-line, appending each line to `log_file`,
-/// pinning the first `system` line's `session_id` and the last `result` line's
-/// token/cost `usage` (e38.35), and retaining a bounded tail.
+/// and pinning — across BOTH provider stream shapes (bead 48c) — the first
+/// session handle, the last usage tally, and the provider's structured terminal
+/// outcome.
 ///
-/// Returns `(first_session_id, last_usage, stdout_tail)`. The usage is taken from
-/// the LAST `result` line (a multi-result stream's final tally wins), mirroring
-/// how `session_id` takes the FIRST `system` line.
+/// The session handle takes the FIRST `system`/`thread.started` line; usage and
+/// the terminal signal take the LAST `result`/`turn.*` line (a multi-turn
+/// stream's final tally/outcome wins). A `result` reporting neither tokens nor
+/// cost (e.g. a bare `{"type":"result","content":"ok"}`) leaves `usage` `None`.
 async fn stream_stdout(
     stdout: tokio::process::ChildStdout,
     mut log_file: std::fs::File,
     tail_lines: usize,
-) -> std::io::Result<(Option<String>, Option<ProviderUsage>, String)> {
+) -> std::io::Result<StreamCapture> {
     use std::io::Write;
 
     let mut reader = BufReader::new(stdout).lines();
     let mut session_id: Option<String> = None;
     let mut usage: Option<ProviderUsage> = None;
+    let mut terminal: Option<TerminalSignal> = None;
     let mut tail: std::collections::VecDeque<String> = std::collections::VecDeque::new();
 
     while let Some(line) = reader.next_line().await? {
         writeln!(log_file, "{line}")?;
-        if session_id.is_none() {
-            if let Ok(parsed) = serde_json::from_str::<SystemLine>(&line) {
-                if parsed.kind == "system" {
-                    if let Some(sid) = parsed.session_id {
-                        session_id = Some(sid);
+        if let Ok(parsed) = serde_json::from_str::<StreamLine>(&line) {
+            match parsed.kind.as_str() {
+                // claude session handle — first wins.
+                "system" => {
+                    if session_id.is_none() {
+                        session_id = parsed.session_id;
                     }
                 }
-            }
-        }
-        // Pin token/cost usage from a `result` line. The last result line wins so
-        // a stream that ends with a corrected tally reflects the final figure. A
-        // result line that reports neither tokens nor cost (e.g. a bare
-        // `{"type":"result","content":"ok"}`) carries nothing to record, so it
-        // leaves `usage` as `None`.
-        if let Ok(parsed) = serde_json::from_str::<ResultLine>(&line) {
-            if parsed.kind == "result" {
-                let block = parsed.usage.unwrap_or_default();
-                let reported = block.input_tokens != 0
-                    || block.output_tokens != 0
-                    || parsed.total_cost_usd != 0.0;
-                if reported {
-                    usage = Some(ProviderUsage {
-                        input_tokens: block.input_tokens,
-                        output_tokens: block.output_tokens,
-                        cost_usd: parsed.total_cost_usd,
-                    });
+                // codex session handle — first wins.
+                "thread.started" => {
+                    if session_id.is_none() {
+                        session_id = parsed.thread_id;
+                    }
                 }
+                // claude terminal: pin usage + the structured success/error.
+                "result" => {
+                    if let Some(u) = provider_usage(parsed.usage, parsed.total_cost_usd) {
+                        usage = Some(u);
+                    }
+                    terminal = Some(classify_claude_result(
+                        parsed.subtype.as_deref(),
+                        parsed.is_error,
+                    ));
+                }
+                // codex terminal success: pin usage (codex reports no cost → 0).
+                "turn.completed" => {
+                    if let Some(u) = provider_usage(parsed.usage, 0.0) {
+                        usage = Some(u);
+                    }
+                    terminal = Some(TerminalSignal::Success);
+                }
+                // codex terminal failure.
+                "turn.failed" => {
+                    terminal = Some(TerminalSignal::Failure(FailureReason::AgentError));
+                }
+                _ => {}
             }
         }
         push_tail(&mut tail, line, tail_lines);
     }
     log_file.flush()?;
-    Ok((session_id, usage, join_tail(tail)))
+    Ok(StreamCapture {
+        session_id,
+        usage,
+        terminal,
+        stdout_tail: join_tail(tail),
+    })
 }
 
 /// Read a child pipe to EOF, retaining only a bounded trailing tail.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -348,16 +348,35 @@ fn every_provider_argv_is_the_verified_headless_shape() {
     let (_p, claude) = runner.provider_command(Backend::Claude, &inv, Mode::Headless);
     assert_eq!(
         claude,
-        vec!["-p", "--dangerously-skip-permissions", "--", "BRIEF"],
-        "claude: -p --dangerously-skip-permissions -- <brief> (without a permission \
-         flag, tools are denied and the run exits 0 having done nothing)"
+        vec![
+            "-p",
+            "--dangerously-skip-permissions",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--",
+            "BRIEF"
+        ],
+        "claude: -p --dangerously-skip-permissions --output-format stream-json --verbose \
+         -- <brief> (the stream-json flags — bead 48c — make claude emit the structured \
+         terminal event the daemon finalizes on; stream-json requires --verbose under -p)"
     );
 
     let (_p, codex) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
     assert_eq!(
         codex,
-        vec!["exec", "--skip-git-repo-check", "--", "BRIEF"],
-        "codex: exec --skip-git-repo-check -- <brief> (prompt is a trailing positional)"
+        vec![
+            "exec",
+            "--skip-git-repo-check",
+            "-s",
+            "danger-full-access",
+            "--json",
+            "--",
+            "BRIEF"
+        ],
+        "codex: exec --skip-git-repo-check -s danger-full-access --json -- <brief> \
+         (--json — bead 48c — emits the structured turn.completed/turn.failed terminal; \
+         prompt is a trailing positional)"
     );
 
     let (_p, copilot) = runner.provider_command(Backend::Copilot, &inv, Mode::Headless);
@@ -486,6 +505,9 @@ fn brief_that_names_a_subcommand_does_not_hijack_it() {
         vec![
             "exec".to_string(),
             "--skip-git-repo-check".to_string(),
+            "-s".to_string(),
+            "danger-full-access".to_string(),
+            "--json".to_string(),
             "--".to_string(),
             "review".to_string()
         ],
@@ -514,6 +536,9 @@ fn value_taking_cli_arg_cannot_swallow_the_brief() {
         vec![
             "exec".to_string(),
             "--skip-git-repo-check".to_string(),
+            "-s".to_string(),
+            "danger-full-access".to_string(),
+            "--json".to_string(),
             "--add-dir".to_string(),
             "--".to_string(),
             "do the thing".to_string()

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
@@ -220,7 +220,35 @@ async fn live_dispatch_writes_nonce_artifact() {
         read_log(home.path())
     );
 
-    eprintln!("LIVE E2E OK: task {task_id} done; nonce artifact verified at {artifact:?}");
+    // 8. bead 48c: `--output-format stream-json` makes claude emit the structured
+    //    terminal the runner pins session_id + usage from. Before it, `claude -p`
+    //    printed ~5 bytes of plain text and BOTH were silently `None` despite the
+    //    runner's session-pin doc promising otherwise. A real success must now
+    //    populate them end-to-end — asserted on the DB row + the usage table, the
+    //    live proof 48c is closed.
+    let session_id: Option<String> = row.get("session_id");
+    assert!(
+        session_id.as_deref().is_some_and(|s| !s.is_empty()),
+        "48c: a real claude success must persist a session_id (got {session_id:?}); it was None \
+         while claude emitted plain text. daemon log:\n{}",
+        read_log(home.path())
+    );
+    let usage = fetch_usage(&pool, &task_id).await.unwrap_or_else(|| {
+        panic!(
+            "48c: a real claude success must record token usage in task_usage for {task_id}; \
+             usage was None while claude emitted plain text. daemon log:\n{}",
+            read_log(home.path())
+        )
+    });
+    assert!(
+        usage.output_tokens > 0,
+        "48c: recorded usage must carry real output tokens, got {usage:?}"
+    );
+
+    eprintln!(
+        "LIVE E2E OK: task {task_id} done; nonce artifact verified at {artifact:?}; \
+         48c session_id={session_id:?} usage={usage:?}"
+    );
 }
 
 /// The codex leg of the same tripwire: the REAL daemon dispatching the REAL
@@ -384,6 +412,113 @@ async fn live_dispatch_codex_writes_nonce_artifact() {
     eprintln!("LIVE E2E CODEX OK: task {task_id} done; nonce artifact verified at {artifact:?}");
 }
 
+/// bead 48d (the DB-row proof): the REAL daemon must NOT mark a task `done` when
+/// the provider EXITS 0 but its structured stream reports non-success.
+///
+/// ```text
+///  issue create ──▶ queued task
+///        │                    │
+///        ▼         real ainb-hangar-daemon (this binary)
+///  claim ─▶ dispatch ─▶ stand-in claude: emits `result subtype=error_max_turns`
+///                        then `exit 0`   ─▶ status=failed reason=iteration_limit
+/// ```
+///
+/// # Why a stand-in, not the real CLI, for THIS leg
+///
+/// Empirically (verified against Claude Code 2.1.211 / codex-cli 0.144.0), both
+/// real CLIs exit *non-zero* on their hard failures: claude `--max-turns 1`
+/// exits 1, codex `turn.failed` exits 1. A refusal exits 0 but self-reports
+/// `subtype:"success"` (a SEMANTIC problem, out of scope here). So the exact 48d
+/// hole — a provider that EXITS 0 while its OWN terminal reports an error — cannot
+/// be induced with the live CLI; a stand-in emitting claude's real
+/// `error_max_turns` result and exiting 0 is the only way to exercise it. The
+/// daemon under test is REAL, and the assertion is the DB ROW (status +
+/// failure_reason), never a log line.
+///
+/// # Mutation self-check
+///
+/// Revert the finalize-on-structured-result change in `runner::run_provider`
+/// (the `match terminal { … }` block) and this task reaches `done` — the exit-0
+/// fallback scores it `Success` — turning the `failed` + `iteration_limit`
+/// assertions RED. Restore → green. That flip IS the bug 48c/48d closes.
+#[tokio::test]
+async fn live_exit0_structured_error_finalizes_failed_not_done() {
+    let Some(ainb) = ainb_bin() else {
+        eprintln!("SKIPPED: ainb binary not built (run `cargo build -p ainb --bin ainb`)");
+        return;
+    };
+    // No claude/PATH/auth gate: the provider is a deterministic stand-in and the
+    // DAEMON is real, so this leg runs whenever the live-e2e feature + binaries
+    // are built (no spend, no provider dependency).
+    let tag = format!("{}-{}", std::process::id(), now_ms());
+    let agent_name = format!("live-e2e-exit0err-{tag}");
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    run_ainb(
+        &ainb,
+        home.path(),
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            &agent_name,
+            "--provider",
+            "claude",
+        ],
+    );
+    let pool = open_pool(&db_path).await;
+    let (agent_id, runtime_id) = agent_ids_by_name(&pool, &agent_name).await;
+
+    // A stand-in `claude` that emits claude's REAL max-turns terminal, then exits
+    // 0 — the exact exit-0-structured-failure shape the live CLI never produces.
+    let standin = write_exit0_structured_error_claude(home.path());
+    let daemon = LiveDaemon::spawn(
+        &home.path().join("daemon.log"),
+        home.path(),
+        &runtime_id,
+        &standin,
+    );
+
+    let stdout = run_ainb_capture(
+        &ainb,
+        home.path(),
+        &[
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            "structured-error tripwire brief",
+            "--assign",
+            &agent_id,
+        ],
+    );
+    let task_id = parse_queued_task_id(&stdout);
+
+    let row = wait_for_terminal(&pool, &task_id, TASK_BUDGET, home.path()).await;
+    let status: String = row.get("status");
+    let reason: Option<String> = row.get("failure_reason");
+    drop(daemon);
+
+    assert_eq!(
+        status,
+        "failed",
+        "the provider EXITED 0 but reported error_max_turns — the task must be `failed`, not \
+         `done` over no work (bead 48d). daemon log:\n{}",
+        read_log(home.path())
+    );
+    assert_eq!(
+        reason.as_deref(),
+        Some("iteration_limit"),
+        "error_max_turns must persist the retry-fresh iteration_limit reason, got {reason:?}. \
+         daemon log:\n{}",
+        read_log(home.path())
+    );
+
+    eprintln!("LIVE E2E OK: exit-0 structured error → task {task_id} failed/iteration_limit");
+}
+
 // ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
@@ -505,19 +640,62 @@ fn write_noop_claude(dir: &Path) -> PathBuf {
 }
 
 /// The codex counterpart of [`write_noop_claude`]: an executable no-op stand-in
-/// for `codex` used ONLY by the codex mutation self-check. The daemon keys a
-/// codex run's success on its exit code (JSONL parsing is best-effort for codex),
-/// so this simply prints a line and exits 0 — a provider that reaches `done`
-/// having written NO nonce file. The live artifact assertion must catch it.
-/// Returns the script path to hand the daemon as `HANGAR_CODEX_PATH`.
+/// for `codex` used ONLY by the codex mutation self-check. It emits codex's
+/// structured `turn.completed` success terminal (bead 48c: the daemon now
+/// finalizes a codex run on that event, not its exit code) but writes NO nonce
+/// file — a provider that reaches `done` having done no real work. The live
+/// artifact assertion must catch it. Returns the script path to hand the daemon
+/// as `HANGAR_CODEX_PATH`.
 fn write_noop_codex(dir: &Path) -> PathBuf {
     let path = dir.join("noop-codex.sh");
     let body = "#!/bin/sh\n\
-         echo 'noop codex: reached done without writing the nonce'\n\
+         echo '{\"type\":\"thread.started\",\"thread_id\":\"noop-codex\"}'\n\
+         echo '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}'\n\
          exit 0\n";
     std::fs::write(&path, body).expect("write noop-codex");
     make_executable(&path);
     path
+}
+
+/// A stand-in `claude` for [`live_exit0_structured_error_finalizes_failed_not_done`]:
+/// it emits claude's REAL `error_max_turns` terminal (bead 48d) and then exits 0
+/// — the exit-0-structured-failure shape the live CLI never produces (real claude
+/// exits 1 on max-turns). The daemon must finalize this `failed`/`iteration_limit`,
+/// never `done`. Returns the script path to hand the daemon as `HANGAR_CLAUDE_PATH`.
+fn write_exit0_structured_error_claude(dir: &Path) -> PathBuf {
+    let path = dir.join("exit0-error-claude.sh");
+    let body = "#!/bin/sh\n\
+         echo '{\"type\":\"system\",\"session_id\":\"exit0-err\"}'\n\
+         echo '{\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"num_turns\":2}'\n\
+         exit 0\n";
+    std::fs::write(&path, body).expect("write exit0-error claude");
+    make_executable(&path);
+    path
+}
+
+/// A `task_usage` row's token/cost tallies, for the 48c capture assertion.
+#[derive(Debug)]
+struct UsageRow {
+    #[allow(dead_code)]
+    input_tokens: i64,
+    output_tokens: i64,
+    #[allow(dead_code)]
+    cost_usd: f64,
+}
+
+/// Fetch the recorded usage for a task from `task_usage`, or `None` if the run
+/// reported none (the pre-48c state for claude).
+async fn fetch_usage(pool: &SqlitePool, task_id: &str) -> Option<UsageRow> {
+    sqlx::query("SELECT input_tokens, output_tokens, cost_usd FROM task_usage WHERE task_id = ?")
+        .bind(task_id)
+        .fetch_optional(pool)
+        .await
+        .expect("query task_usage")
+        .map(|r| UsageRow {
+            input_tokens: r.get("input_tokens"),
+            output_tokens: r.get("output_tokens"),
+            cost_usd: r.get("cost_usd"),
+        })
 }
 
 /// Mark a stand-in script executable (0o755) on unix so the daemon can spawn it.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -238,6 +238,101 @@ exit 1"#,
 }
 
 #[tokio::test]
+async fn exec_exit0_with_structured_error_marks_failed() {
+    // bead 48d: a provider that EXITS 0 but whose structured terminal reports an
+    // error (claude's `error_max_turns`) must finalize `Failed`, NOT `Success` —
+    // the exit code is not the completion signal. The reason is the one the
+    // subtype maps to (`error_max_turns` → the retry-fresh IterationLimit), and
+    // the session_id from the stream is still captured (48c).
+    //
+    // Mutation-proof: revert the finalize-on-structured-result change in
+    // `run_provider::run_provider` and this goes RED — exit 0 falls back to
+    // `Success` and the daemon marks the task `done` over an incomplete run.
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    let script = write_script(
+        tmp.path(),
+        "fake-claude.sh",
+        r#"echo '{"type":"system","session_id":"sid-maxturns"}'
+echo '{"type":"result","subtype":"error_max_turns","is_error":true,"num_turns":2}'
+exit 0"#,
+    );
+    let runner = Runner::new(RunnerConfig {
+        claude_path: script,
+        codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
+        max_runtime: Duration::from_secs(10),
+        tail_lines: 50,
+        sandbox: true,
+    });
+
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
+
+    match outcome {
+        RunOutcome::Failed { reason, result } => {
+            assert_eq!(
+                reason,
+                FailureReason::IterationLimit,
+                "error_max_turns must map to the retry-fresh IterationLimit reason"
+            );
+            assert_eq!(
+                result.exit_code,
+                Some(0),
+                "the process exited 0 — the STRUCTURED error, not the exit code, drove the failure"
+            );
+            assert_eq!(
+                result.session_id.as_deref(),
+                Some("sid-maxturns"),
+                "session_id must still be pinned from the stream-json system line (48c)"
+            );
+        }
+        other => panic!("exit-0 structured error must be Failed(IterationLimit), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn exec_exit0_without_success_terminal_marks_failed() {
+    // bead 48d (the other half): a provider that exits 0 having emitted NO
+    // terminal success event — a truncated / empty structured stream — must
+    // finalize `Failed`, never `Success`. The daemon must not mark a task `done`
+    // over work that never reported completion.
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    // A `system` line (so session_id is pinned) but NO `result` terminal — the
+    // stream ended before any outcome, yet the process exited 0.
+    let script = write_script(
+        tmp.path(),
+        "fake-claude.sh",
+        r#"echo '{"type":"system","session_id":"sid-noterm"}'
+exit 0"#,
+    );
+    let runner = Runner::new(RunnerConfig {
+        claude_path: script,
+        codex_path: PathBuf::from("/nonexistent/codex"),
+        copilot_path: PathBuf::from("/nonexistent/copilot"),
+        max_runtime: Duration::from_secs(10),
+        tail_lines: 50,
+        sandbox: true,
+    });
+
+    let outcome = runner.run_claude(&env, std::iter::empty(), &invocation()).await.expect("run");
+
+    match outcome {
+        RunOutcome::Failed { reason, result } => {
+            assert_eq!(reason, FailureReason::AgentError);
+            assert_eq!(
+                result.exit_code,
+                Some(0),
+                "exit 0 with no success terminal is still a failure (48d)"
+            );
+        }
+        other => {
+            panic!("exit-0 with no success terminal must be Failed(AgentError), got {other:?}")
+        }
+    }
+}
+
+#[tokio::test]
 async fn exec_extempfail_75_marks_runtime_offline() {
     // EX_TEMPFAIL (75) is the provider's "transient runtime failure, retry later"
     // signal — it must classify as the infra/retryable RuntimeOffline reason

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
@@ -301,8 +301,9 @@ async fn codex_run_is_sandbox_confined() {
     let script = write_script(
         tmp.path(),
         "fake-codex.sh",
-        r#"echo '{"type":"system","session_id":"s"}'
+        r#"echo '{"type":"thread.started","thread_id":"s"}'
 echo "HOME=${HOME:-<absent>}"
+echo '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
 exit 0"#,
     );
     let runner = Runner::new(cfg_with_codex(script));
@@ -321,4 +322,76 @@ exit 0"#,
         outcome.result().stdout_tail.contains(&format!("HOME={}", tmp.path().display())),
         "HOME (allowlisted) must pass through the confined run"
     );
+}
+
+/// bead 48c: the codex `--json` terminal drives session + usage capture. A
+/// `thread.started` pins the session handle, and a `turn.completed` pins the
+/// token usage AND is the structured success signal — so a genuine codex success
+/// finalizes `Success` with both populated (they were silently dead before, when
+/// codex emitted un-parsed human text).
+#[tokio::test]
+async fn codex_turn_completed_captures_thread_id_and_usage() {
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    let script = write_script(
+        tmp.path(),
+        "fake-codex.sh",
+        r#"echo '{"type":"thread.started","thread_id":"cdx-thread-9"}'
+echo '{"type":"turn.completed","usage":{"input_tokens":900,"output_tokens":120}}'
+exit 0"#,
+    );
+    let runner = Runner::new(cfg_with_codex(script));
+
+    let outcome = runner
+        .run_codex(&env, std::iter::empty(), &brief_invocation())
+        .await
+        .expect("run");
+
+    assert!(
+        matches!(outcome, RunOutcome::Success(_)),
+        "turn.completed is success, got {outcome:?}"
+    );
+    let result = outcome.result();
+    assert_eq!(
+        result.session_id.as_deref(),
+        Some("cdx-thread-9"),
+        "session_id must be pinned from codex's thread.started.thread_id (48c)"
+    );
+    let usage = result.usage.clone().expect("usage captured from turn.completed (48c)");
+    assert_eq!(usage.input_tokens, 900);
+    assert_eq!(usage.output_tokens, 120);
+}
+
+/// bead 48d: a codex run that EXITS 0 but emits a structured `turn.failed` must
+/// finalize `Failed`, not `Success`. The daemon no longer trusts codex's exit
+/// code alone — the provider's own reported outcome is authoritative.
+#[tokio::test]
+async fn codex_exit0_turn_failed_marks_failed() {
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    let script = write_script(
+        tmp.path(),
+        "fake-codex.sh",
+        r#"echo '{"type":"thread.started","thread_id":"cdx-fail"}'
+echo '{"type":"turn.failed","error":{"message":"model refused"}}'
+exit 0"#,
+    );
+    let runner = Runner::new(cfg_with_codex(script));
+
+    let outcome = runner
+        .run_codex(&env, std::iter::empty(), &brief_invocation())
+        .await
+        .expect("run");
+
+    match outcome {
+        RunOutcome::Failed { reason, result } => {
+            assert_eq!(reason, FailureReason::AgentError);
+            assert_eq!(
+                result.exit_code,
+                Some(0),
+                "exit 0 with a structured turn.failed is still a failure (48d)"
+            );
+        }
+        other => panic!("exit-0 turn.failed must be Failed(AgentError), got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Why
The daemon marked a task `done` on process exit 0 — but agent CLIs exit 0 on refusals, `Not logged in`, permission-denials, and errors narrated in prose, so tasks reached `done` having done nothing. It trusted exit 0 because `claude -p` emitted plain text (48c): `claude.jsonl` was ~5 bytes and `session_id`/`usage`/cost capture were silently dead despite the module doc claiming otherwise.

## Fix (48c + 48d together)
- Emit each provider's **structured stream**: `claude -p --output-format stream-json --verbose`, codex `exec --json` (both verified against real claude 2.1.211 / codex 0.144.0; stream-json requires `--verbose`).
- Unified `StreamLine` parsing pins `session_id` (claude `session_id` / codex `thread_id`) + `usage` from the terminal event — **fixes 48c** (cost/session capture restored).
- `finalize_outcome` keys completion on the provider's **structured result**, not exit code: `Success` requires a structured success terminal AND exit 0; `error_max_turns`→`Failed(IterationLimit)`, codex `turn.failed`→`Failed`, **exit 0 with no success terminal → `failed`** (closes the `Not logged in`/permission-denied holes). Exit-nonzero / EX_TEMPFAIL / spawn-error (#407) paths preserved.

## Honest scope
Real claude/codex EXIT NONZERO on hard failures (the bead's "exit 0 on max_turns" premise was wrong) — so the residual exit-0-structured-error case is exercised via a stand-in; the real value is the structured capture + closing the exit-0-no-terminal hole we actually observed. **Refusals self-report `subtype:"success"` at exit 0 → semantic AI-judges-AI verification, deliberately out of scope, beaded `2jb`.** No overclaim of "no more lying about completion" — scoped to the provider's own reported non-success.

## Proof
- Live: real claude success → `done` with `session_id`/`usage` now populated (`cost $0.052`) — both were `None` before. Real-daemon exit-0-structured-error → DB row `failed`/`iteration_limit`.
- **Mutation-proven** (re-verified by review, both directions): revert the finalize → induced-failure task flips `failed`→`done` (RED); restore → green.
- Full daemon suite green (267 unit + integration). Direction check: no genuine-success path can be mis-finalized as `failed` (fails loud + CI tripwire catches shape drift).

## Follow-ups (beaded, optional Minors)
allowlist `success` vs denylist `error*`; preserve codex `turn.failed.error` + retryable disposition; a drift-canary comment.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured outcome reporting for Claude and Codex executions.
  * Session identifiers and token usage are now captured from provider event streams.
* **Bug Fixes**
  * Provider-reported failures are correctly recorded even when the process exits successfully.
  * Runs without a successful completion event are no longer incorrectly marked as completed.
  * Timeout and runtime-offline outcomes are classified more accurately.
* **Tests**
  * Expanded coverage for structured failures, usage tracking, session capture, and command-line routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->