### PR TITLE
fix(hangar-daemon): fail closed + observably on future provider CLI shape drift

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -673,6 +673,14 @@ struct ProviderSpec {
     log_file: &'static str,
     /// The argv to append after the program path (subcommand + flags + args).
     argv: Vec<String>,
+    /// Whether this argv requests the provider's STRUCTURED event stream (claude
+    /// `--output-format stream-json`, codex `exec --json`) — i.e. whether the run
+    /// PROMISES a machine terminal event. When `true`, a clean exit that produced
+    /// no recognised success/error terminal is CONTRACT DRIFT, not a plain agent
+    /// error: the stream shape the parser was pinned against changed. When `false`
+    /// (copilot, which emits no structured terminal), a missing terminal stays a
+    /// generic agent error. See [`finalize_outcome`].
+    structured: bool,
 }
 
 /// A provider that can be exec'd as an agent CLI subprocess.
@@ -1155,6 +1163,9 @@ impl Runner {
             backend: Backend::Claude,
             log_file: CLAUDE_LOG_FILE,
             argv,
+            // Only the headless argv carries `--output-format stream-json`, so
+            // only it promises a structured terminal to finalize on.
+            structured: mode == Mode::Headless,
         }
     }
 
@@ -1218,6 +1229,9 @@ impl Runner {
             backend: Backend::Codex,
             log_file: CODEX_LOG_FILE,
             argv,
+            // Only the headless `exec --json` argv promises the structured
+            // turn.completed / turn.failed terminal to finalize on.
+            structured: mode == Mode::Headless,
         }
     }
 
@@ -1294,6 +1308,9 @@ impl Runner {
             backend: Backend::Copilot,
             log_file: COPILOT_LOG_FILE,
             argv,
+            // Copilot emits no structured terminal stream, so a missing terminal
+            // stays a generic agent error (never contract drift).
+            structured: false,
         }
     }
 
@@ -1438,6 +1455,7 @@ impl Runner {
 
         Ok(finalize_outcome(
             spec.backend,
+            spec.structured,
             timed_out,
             terminal.as_ref(),
             exit_code,
@@ -1462,8 +1480,16 @@ impl Runner {
 ///   4. otherwise fall back to the exit code, where a bare exit 0 with NO
 ///      success terminal is itself a failure (the other 48d hole), and
 ///      [`EX_TEMPFAIL`] stays the retryable [`FailureReason::RuntimeOffline`].
+///
+/// The exit-0-no-terminal failure splits on `structured`: a run that PROMISED a
+/// machine terminal (claude `--output-format stream-json` / codex `exec --json`)
+/// yet produced none is [`FailureReason::ProviderContractDrift`] — the CLI shape
+/// the parser was pinned against drifted — held DISTINCT from the
+/// [`FailureReason::AgentError`] a non-structured provider (copilot) gets, so an
+/// operator can tell "the provider contract changed" from "the agent gave up".
 fn finalize_outcome(
     backend: Backend,
+    structured: bool,
     timed_out: bool,
     terminal: Option<&TerminalSignal>,
     exit_code: Option<i32>,
@@ -1492,16 +1518,23 @@ fn finalize_outcome(
         _ => match exit_code {
             Some(0) => {
                 // 48d: exit 0 but the provider never reported success — never
-                // mark this `done` over work that did not happen.
+                // mark this `done` over work that did not happen. A provider that
+                // PROMISED a structured terminal (claude/codex headless) yet
+                // emitted none is contract drift: its terminal shape drifted from
+                // the pinned parser. A non-structured provider (copilot) has no
+                // terminal to miss, so it stays a generic agent error.
+                let reason = if structured {
+                    FailureReason::ProviderContractDrift
+                } else {
+                    FailureReason::AgentError
+                };
                 tracing::warn!(
                     provider = backend.name(),
-                    reason = "no_success_terminal",
+                    ?reason,
+                    reason_detail = "no_success_terminal",
                     "runner_failed"
                 );
-                RunOutcome::Failed {
-                    reason: FailureReason::AgentError,
-                    result,
-                }
+                RunOutcome::Failed { reason, result }
             }
             Some(EX_TEMPFAIL) => {
                 // Transient runtime failure — infra/retryable so the daemon's
@@ -1803,6 +1836,116 @@ mod tests {
         assert_eq!(
             classify_claude_result(Some("finished_ok"), false),
             TerminalSignal::Failure(FailureReason::ProviderContractDrift),
+        );
+    }
+
+    /// A bare captured result with the given exit code and empty tails.
+    fn result_with_exit(exit_code: Option<i32>) -> RunnerResult {
+        RunnerResult {
+            exit_code,
+            session_id: None,
+            usage: None,
+            stdout_tail: String::new(),
+            stderr_tail: String::new(),
+        }
+    }
+
+    /// A genuine structured success on a clean exit MUST still reach Success —
+    /// the fail-closed changes must not mis-fail real work.
+    #[test]
+    fn structured_success_clean_exit_reaches_success() {
+        let outcome = finalize_outcome(
+            Backend::Claude,
+            true,
+            false,
+            Some(&TerminalSignal::Success),
+            Some(0),
+            result_with_exit(Some(0)),
+        );
+        assert!(
+            matches!(outcome, RunOutcome::Success(_)),
+            "genuine success must stay done, got {outcome:?}"
+        );
+    }
+
+    /// FAIL-CLOSED: a structured provider (claude/codex headless) that exits 0 but
+    /// emitted NO recognised terminal — a renamed/absent terminal event — must fail
+    /// closed to the DISTINCT ProviderContractDrift reason, never `done`.
+    ///
+    /// Mutation check: reverting the `if structured { ProviderContractDrift }` split
+    /// back to an unconditional `FailureReason::AgentError` makes this see
+    /// `AgentError` and flip RED (drift becomes indistinguishable from agent error);
+    /// reverting the whole arm to `RunOutcome::Success` makes it flip RED as `done`.
+    #[test]
+    fn structured_no_terminal_exit0_fails_closed_as_contract_drift() {
+        let outcome = finalize_outcome(
+            Backend::Claude,
+            true,
+            false,
+            None,
+            Some(0),
+            result_with_exit(Some(0)),
+        );
+        assert!(
+            matches!(
+                outcome,
+                RunOutcome::Failed {
+                    reason: FailureReason::ProviderContractDrift,
+                    ..
+                }
+            ),
+            "structured exit-0 no-terminal must be ProviderContractDrift, got {outcome:?}"
+        );
+    }
+
+    /// Codex under `exec --json` is a structured stream: an unrecognised terminal
+    /// (parsed to `None`) on a clean exit fails closed to contract drift, same as
+    /// claude — not exit-code-trust `done`.
+    #[test]
+    fn codex_structured_unknown_terminal_fails_closed_as_contract_drift() {
+        let outcome = finalize_outcome(
+            Backend::Codex,
+            true,
+            false,
+            None,
+            Some(0),
+            result_with_exit(Some(0)),
+        );
+        assert!(
+            matches!(
+                outcome,
+                RunOutcome::Failed {
+                    reason: FailureReason::ProviderContractDrift,
+                    ..
+                }
+            ),
+            "codex structured exit-0 no-terminal must be ProviderContractDrift, got {outcome:?}"
+        );
+    }
+
+    /// A NON-structured provider (copilot emits no terminal stream) that exits 0
+    /// without a terminal stays a generic AgentError — NOT contract drift. This
+    /// pins the boundary so copilot is never mislabelled as a claude/codex shape
+    /// change.
+    #[test]
+    fn non_structured_no_terminal_exit0_is_agent_error_not_drift() {
+        let outcome = finalize_outcome(
+            Backend::Copilot,
+            false,
+            false,
+            None,
+            Some(0),
+            result_with_exit(Some(0)),
+        );
+        assert!(
+            matches!(
+                outcome,
+                RunOutcome::Failed {
+                    reason: FailureReason::AgentError,
+                    ..
+                }
+            ),
+            "non-structured exit-0 no-terminal must be AgentError, got {outcome:?}"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -1487,6 +1487,27 @@ impl Runner {
 /// the parser was pinned against drifted — held DISTINCT from the
 /// [`FailureReason::AgentError`] a non-structured provider (copilot) gets, so an
 /// operator can tell "the provider contract changed" from "the agent gave up".
+/// Emit the LOUD, operator-actionable WARN for a provider contract drift: the
+/// provider name, WHY it drifted, and a bounded raw tail of the stream so an
+/// operator can read the actual (renamed / unknown) terminal line and update the
+/// parser.
+///
+/// The raw tail is the diagnostic instead of a captured CLI version: probing
+/// `<provider> --version` was rejected as fragile — it means an extra subprocess
+/// exec per dispatch, which corrupts side-effecting stand-ins (the retry tests'
+/// invocation-counter fake increments on EVERY exec) and its output format rots
+/// across releases. The recognised-terminal versions the parser is pinned against
+/// (claude 2.1.211 / codex 0.144.0) are documented at the const definitions, and
+/// the raw tail carries whatever version banner the provider itself emitted.
+fn log_contract_drift(backend: Backend, why: &str, stdout_tail: &str) {
+    tracing::warn!(
+        provider = backend.name(),
+        why,
+        raw_terminal_tail = %stdout_tail,
+        "provider_contract_drift: the provider's terminal-event shape drifted from the pinned parser — inspect the raw tail and update StreamLine/classify"
+    );
+}
+
 fn finalize_outcome(
     backend: Backend,
     structured: bool,
@@ -1509,7 +1530,11 @@ fn finalize_outcome(
     match terminal {
         Some(TerminalSignal::Failure(reason)) => {
             let reason = *reason;
-            tracing::warn!(provider = backend.name(), ?reason, exit_code = ?exit_code, "runner_failed_structured");
+            if reason == FailureReason::ProviderContractDrift {
+                log_contract_drift(backend, "unrecognised result subtype", &result.stdout_tail);
+            } else {
+                tracing::warn!(provider = backend.name(), ?reason, exit_code = ?exit_code, "runner_failed_structured");
+            }
             RunOutcome::Failed { reason, result }
         }
         Some(TerminalSignal::Success) if exit_code == Some(0) => RunOutcome::Success(result),
@@ -1528,12 +1553,20 @@ fn finalize_outcome(
                 } else {
                     FailureReason::AgentError
                 };
-                tracing::warn!(
-                    provider = backend.name(),
-                    ?reason,
-                    reason_detail = "no_success_terminal",
-                    "runner_failed"
-                );
+                if reason == FailureReason::ProviderContractDrift {
+                    log_contract_drift(
+                        backend,
+                        "no recognised terminal event",
+                        &result.stdout_tail,
+                    );
+                } else {
+                    tracing::warn!(
+                        provider = backend.name(),
+                        ?reason,
+                        reason_detail = "no_success_terminal",
+                        "runner_failed"
+                    );
+                }
                 RunOutcome::Failed { reason, result }
             }
             Some(EX_TEMPFAIL) => {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -1656,7 +1656,7 @@ where
 /// `done`. The live tripwire `live_dispatch_writes_nonce_artifact` (in
 /// `tests/live_e2e.rs`, `live-e2e` feature) is the CI/scheduled test that catches
 /// that drift: it dispatches a REAL claude and asserts the run reaches `done` with
-/// a session_id + usage captured from a RECOGNISED terminal — so a shape drift
+/// a `session_id` + usage captured from a RECOGNISED terminal — so a shape drift
 /// turns it RED (failed / no usage), signalling the parser here needs updating.
 async fn stream_stdout(
     stdout: tokio::process::ChildStdout,
@@ -1865,7 +1865,7 @@ mod tests {
     }
 
     /// The known error subtypes keep their mapped reasons — `error_max_turns`
-    /// retries FRESH (IterationLimit), other errors are terminal AgentError.
+    /// retries FRESH (`IterationLimit`), other errors are terminal `AgentError`.
     #[test]
     fn claude_error_subtypes_keep_their_reasons() {
         assert_eq!(
@@ -1884,7 +1884,7 @@ mod tests {
 
     /// FAIL-CLOSED: a `result` line carrying an UNKNOWN, non-error subtype (a
     /// future CLI renaming/adding a terminal shape) must NOT be guessed "success".
-    /// It fails closed to the distinct ProviderContractDrift reason.
+    /// It fails closed to the distinct `ProviderContractDrift` reason.
     ///
     /// Mutation check: reverting the final `Some(_) => ProviderContractDrift` arm
     /// back to the old denylist default (`_ => Success`) makes this assertion see
@@ -1932,7 +1932,7 @@ mod tests {
 
     /// FAIL-CLOSED: a structured provider (claude/codex headless) that exits 0 but
     /// emitted NO recognised terminal — a renamed/absent terminal event — must fail
-    /// closed to the DISTINCT ProviderContractDrift reason, never `done`.
+    /// closed to the DISTINCT `ProviderContractDrift` reason, never `done`.
     ///
     /// Mutation check: reverting the `if structured { ProviderContractDrift }` split
     /// back to an unconditional `FailureReason::AgentError` makes this see
@@ -1986,7 +1986,7 @@ mod tests {
     }
 
     /// A NON-structured provider (copilot emits no terminal stream) that exits 0
-    /// without a terminal stays a generic AgentError — NOT contract drift. This
+    /// without a terminal stays a generic `AgentError` — NOT contract drift. This
     /// pins the boundary so copilot is never mislabelled as a claude/codex shape
     /// change.
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -489,21 +489,34 @@ struct UsageBlock {
 }
 
 /// Map a claude `result` line's `subtype`/`is_error` onto a [`TerminalSignal`]
-/// (beads 48c/48d).
+/// (beads 48c/48d) as an ALLOWLIST — fail-closed on any shape not pinned against
+/// claude 2.1.211.
 ///
 /// `error_max_turns` is the iteration-budget exhaustion the daemon retries FRESH
-/// ([`FailureReason::IterationLimit`]); any other error is a terminal agent
-/// error. A `result` with no subtype and no error — the routing fakes'
-/// `{"type":"result","content":"ok"}` — is treated as success so existing
-/// dispatch tests stay valid.
+/// ([`FailureReason::IterationLimit`]); any other `error*` subtype (or the
+/// `is_error` flag) is a terminal agent error. The ONLY success tokens are
+/// claude's pinned `subtype:"success"` and a subtype-less `result` (the routing
+/// fakes' `{"type":"result","content":"ok"}`; real claude 2.1.211 always stamps a
+/// subtype, so `None` is never a live claude success line). Anything else — a
+/// `result` carrying an UNKNOWN, non-error subtype — is
+/// [`FailureReason::ProviderContractDrift`]: a future CLI that renames or adds a
+/// terminal shape MUST fail closed and stay observable, never be guessed
+/// "success" and marked `done` over work that may not have happened (the denylist
+/// hole this replaces).
 fn classify_claude_result(subtype: Option<&str>, is_error: bool) -> TerminalSignal {
     match subtype {
+        // Iteration-budget exhaustion retries FRESH — kept first so an
+        // `is_error:true` on the same line cannot swallow its distinct reason.
         Some("error_max_turns") => TerminalSignal::Failure(FailureReason::IterationLimit),
-        Some(s) if is_error || s.starts_with("error") => {
-            TerminalSignal::Failure(FailureReason::AgentError)
-        }
+        // Any explicit `error*` subtype => terminal agent error.
+        Some(s) if s.starts_with("error") => TerminalSignal::Failure(FailureReason::AgentError),
+        // The hard-error flag with a non-error / absent subtype => agent error.
         _ if is_error => TerminalSignal::Failure(FailureReason::AgentError),
-        _ => TerminalSignal::Success,
+        // ALLOWLIST: the only recognised success signals.
+        Some("success") | None => TerminalSignal::Success,
+        // Fail-closed: a `result` with an unknown, non-error subtype is a shape
+        // this parser was never pinned against — flag drift, do not guess success.
+        Some(_) => TerminalSignal::Failure(FailureReason::ProviderContractDrift),
     }
 }
 
@@ -1741,6 +1754,56 @@ mod tests {
                 "no path under the operator's $HOME ({home}) may be granted:\n{profile}"
             );
         }
+    }
+
+    /// The pinned genuine-success shapes MUST still classify as success: real
+    /// claude 2.1.211 stamps `subtype:"success"`, and the routing fakes emit a
+    /// subtype-less `result`. This guards the allowlist against mis-failing real
+    /// work.
+    #[test]
+    fn claude_success_and_fake_result_classify_success() {
+        assert_eq!(
+            classify_claude_result(Some("success"), false),
+            TerminalSignal::Success,
+        );
+        assert_eq!(classify_claude_result(None, false), TerminalSignal::Success);
+    }
+
+    /// The known error subtypes keep their mapped reasons — `error_max_turns`
+    /// retries FRESH (IterationLimit), other errors are terminal AgentError.
+    #[test]
+    fn claude_error_subtypes_keep_their_reasons() {
+        assert_eq!(
+            classify_claude_result(Some("error_max_turns"), true),
+            TerminalSignal::Failure(FailureReason::IterationLimit),
+        );
+        assert_eq!(
+            classify_claude_result(Some("error_during_execution"), true),
+            TerminalSignal::Failure(FailureReason::AgentError),
+        );
+        assert_eq!(
+            classify_claude_result(None, true),
+            TerminalSignal::Failure(FailureReason::AgentError),
+        );
+    }
+
+    /// FAIL-CLOSED: a `result` line carrying an UNKNOWN, non-error subtype (a
+    /// future CLI renaming/adding a terminal shape) must NOT be guessed "success".
+    /// It fails closed to the distinct ProviderContractDrift reason.
+    ///
+    /// Mutation check: reverting the final `Some(_) => ProviderContractDrift` arm
+    /// back to the old denylist default (`_ => Success`) makes this assertion see
+    /// `TerminalSignal::Success` and flip RED.
+    #[test]
+    fn claude_unknown_subtype_fails_closed_as_contract_drift() {
+        assert_eq!(
+            classify_claude_result(Some("completed"), false),
+            TerminalSignal::Failure(FailureReason::ProviderContractDrift),
+        );
+        assert_eq!(
+            classify_claude_result(Some("finished_ok"), false),
+            TerminalSignal::Failure(FailureReason::ProviderContractDrift),
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -476,6 +476,19 @@ struct StreamLine {
     /// token tallies: claude `result.usage` or codex `turn.completed.usage`.
     #[serde(default)]
     usage: Option<UsageBlock>,
+    /// codex `turn.failed.error` object — its `message` is the provider's own
+    /// reason string, logged so a codex failure is observable rather than a bare
+    /// `AgentError`.
+    #[serde(default)]
+    error: Option<StreamError>,
+}
+
+/// The `error` sub-object of a codex `turn.failed` [`StreamLine`]: carries the
+/// provider's human-readable failure `message`.
+#[derive(Debug, Default, Clone, Deserialize)]
+struct StreamError {
+    #[serde(default)]
+    message: Option<String>,
 }
 
 /// The `usage` sub-object of a [`StreamLine`]: the token tallies (e38.35). Field
@@ -1633,6 +1646,18 @@ where
 /// the terminal signal take the LAST `result`/`turn.*` line (a multi-turn
 /// stream's final tally/outcome wins). A `result` reporting neither tokens nor
 /// cost (e.g. a bare `{"type":"result","content":"ok"}`) leaves `usage` `None`.
+///
+/// # Drift canary
+///
+/// The terminal shapes matched here are pinned against claude 2.1.211 / codex
+/// 0.144.0. If a future CLI renames its terminal event or adds a new non-error
+/// `result` subtype, [`classify_claude_result`] / [`finalize_outcome`] fail
+/// CLOSED to [`FailureReason::ProviderContractDrift`] rather than mark the task
+/// `done`. The live tripwire `live_dispatch_writes_nonce_artifact` (in
+/// `tests/live_e2e.rs`, `live-e2e` feature) is the CI/scheduled test that catches
+/// that drift: it dispatches a REAL claude and asserts the run reaches `done` with
+/// a session_id + usage captured from a RECOGNISED terminal — so a shape drift
+/// turns it RED (failed / no usage), signalling the parser here needs updating.
 async fn stream_stdout(
     stdout: tokio::process::ChildStdout,
     mut log_file: std::fs::File,
@@ -1679,8 +1704,12 @@ async fn stream_stdout(
                     }
                     terminal = Some(TerminalSignal::Success);
                 }
-                // codex terminal failure.
+                // codex terminal failure — surface the provider's own message
+                // (was previously discarded, leaving only a bare AgentError).
                 "turn.failed" => {
+                    if let Some(msg) = parsed.error.and_then(|e| e.message) {
+                        tracing::warn!(provider = "codex", error = %msg, "codex_turn_failed");
+                    }
                     terminal = Some(TerminalSignal::Failure(FailureReason::AgentError));
                 }
                 _ => {}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_claude.rs
@@ -292,10 +292,18 @@ exit 0"#,
 
 #[tokio::test]
 async fn exec_exit0_without_success_terminal_marks_failed() {
-    // bead 48d (the other half): a provider that exits 0 having emitted NO
-    // terminal success event — a truncated / empty structured stream — must
-    // finalize `Failed`, never `Success`. The daemon must not mark a task `done`
-    // over work that never reported completion.
+    // bead 48d (the other half): a claude headless run (structured `stream-json`)
+    // that exits 0 having emitted NO terminal event — a truncated / renamed /
+    // empty structured stream — must finalize `Failed`, never `Success`. Because
+    // this run PROMISED a structured terminal yet produced none, the reason is the
+    // DISTINCT ProviderContractDrift (the CLI shape drifted from the pinned
+    // parser), not a generic AgentError — so an operator can tell a parser-update
+    // need from a real agent give-up. The daemon must not mark a task `done` over
+    // work that never reported completion.
+    //
+    // Integration mutation proof: reverting finalize_outcome's exit-0-no-terminal
+    // arm to `Success` flips this to `done` (RED as `done over no work`);
+    // dropping the `structured` split flips `reason` to AgentError (RED here).
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
     // A `system` line (so session_id is pinned) but NO `result` terminal — the
@@ -319,7 +327,7 @@ exit 0"#,
 
     match outcome {
         RunOutcome::Failed { reason, result } => {
-            assert_eq!(reason, FailureReason::AgentError);
+            assert_eq!(reason, FailureReason::ProviderContractDrift);
             assert_eq!(
                 result.exit_code,
                 Some(0),
@@ -327,7 +335,9 @@ exit 0"#,
             );
         }
         other => {
-            panic!("exit-0 with no success terminal must be Failed(AgentError), got {other:?}")
+            panic!(
+                "exit-0 with no success terminal must be Failed(ProviderContractDrift), got {other:?}"
+            )
         }
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
@@ -64,6 +64,19 @@ pub enum FailureReason {
     /// here the agent never started. Terminal (no retry): a misconfigured binary
     /// path will not self-heal on a re-dispatch with the same daemon config.
     SpawnError,
+    /// The provider's structured event contract drifted from the pinned CLI
+    /// shape: the runner ran a provider under its structured-output flag
+    /// (claude `--output-format stream-json`, codex `exec --json`) but the stream
+    /// carried NO recognised success/error terminal — an unknown non-error
+    /// `result` subtype, or no terminal event at all despite a clean exit. This is
+    /// held DISTINCT from [`Self::AgentError`] on purpose: it means "a future CLI
+    /// renamed / added a terminal shape the parser does not know", NOT "the agent
+    /// genuinely failed", so an operator can tell a parser-update need apart from a
+    /// real agent give-up. Fail-closed (never silently `done` over a shape we
+    /// cannot read) and terminal (no retry): the same CLI version re-drifts
+    /// identically, so a retry only burns the chain — the fix is updating the
+    /// parser, not re-running.
+    ProviderContractDrift,
     /// An unclassified failure.
     Unknown,
 }
@@ -87,6 +100,7 @@ impl FailureReason {
             Self::ApiInvalidRequest => "api_invalid_request",
             Self::SemanticInactivity => "semantic_inactivity",
             Self::SpawnError => "spawn_error",
+            Self::ProviderContractDrift => "provider_contract_drift",
             Self::Unknown => "unknown",
         }
     }
@@ -151,6 +165,7 @@ mod tests {
             FailureReason::ApiInvalidRequest,
             FailureReason::SemanticInactivity,
             FailureReason::SpawnError,
+            FailureReason::ProviderContractDrift,
             FailureReason::Unknown,
         ] {
             let serde_token = serde_json::to_value(reason)

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -243,13 +243,16 @@ impl RetryService {
             FailureReason::IterationLimit
             | FailureReason::ApiInvalidRequest
             | FailureReason::SemanticInactivity => RetryDisposition::FreshRetry,
-            // Agent / user / sweeper / spawn / unclassified terminals — no retry.
-            // `SpawnError` is a misconfigured / missing provider binary: a
-            // re-dispatch under the same daemon config would only re-fail.
+            // Agent / user / sweeper / spawn / drift / unclassified terminals — no
+            // retry. `SpawnError` is a misconfigured / missing provider binary,
+            // and `ProviderContractDrift` is a CLI shape the parser cannot read: a
+            // re-dispatch under the same daemon config / CLI version would only
+            // re-fail identically, so a retry burns the chain for nothing.
             FailureReason::AgentError
             | FailureReason::UserCancel
             | FailureReason::Timeout
             | FailureReason::SpawnError
+            | FailureReason::ProviderContractDrift
             | FailureReason::Unknown => RetryDisposition::NoRetry,
         }
     }
@@ -280,6 +283,7 @@ const FAILURE_REASONS: &[FailureReason] = &[
     FailureReason::ApiInvalidRequest,
     FailureReason::SemanticInactivity,
     FailureReason::SpawnError,
+    FailureReason::ProviderContractDrift,
     FailureReason::Unknown,
 ];
 
@@ -304,6 +308,7 @@ mod tests {
             FailureReason::ApiInvalidRequest,
             FailureReason::SemanticInactivity,
             FailureReason::SpawnError,
+            FailureReason::ProviderContractDrift,
             FailureReason::Unknown,
         ] {
             assert!(
@@ -313,7 +318,7 @@ mod tests {
         }
         assert_eq!(
             FAILURE_REASONS.len(),
-            10,
+            11,
             "FAILURE_REASONS length drifted from the FailureReason variant count",
         );
     }
@@ -342,6 +347,11 @@ mod tests {
         assert_eq!(RetryService::retry_disposition(AgentError), NoRetry);
         assert_eq!(RetryService::retry_disposition(UserCancel), NoRetry);
         assert_eq!(RetryService::retry_disposition(Timeout), NoRetry);
+        assert_eq!(RetryService::retry_disposition(SpawnError), NoRetry);
+        assert_eq!(
+            RetryService::retry_disposition(ProviderContractDrift),
+            NoRetry
+        );
         assert_eq!(RetryService::retry_disposition(Unknown), NoRetry);
     }
 }


### PR DESCRIPTION
## Why
#410 made the daemon finalize on the provider's structured terminal event. But the recognized shapes are pinned to claude 2.1.211 / codex 0.144.0 — a FUTURE CLI that renames its terminal event or adds a new non-error subtype could silently mark a task `done` having done nothing (drift → no recognized terminal → exit-0 → done; or unknown subtype → denylist default → done). This hardens it so drift **fails closed** and is **observable**, without mis-failing genuine success today.

## What (ultracode: 2 independent designs → synthesize → adversarial verify)
- **Allowlist claude classification** (`classify_claude_result`): only `subtype:"success"` (or the subtype-less test fake) → Success; error subtypes → their mapped failure; **any unknown non-error subtype → fail-closed `ProviderContractDrift`** (was: denylist default → Success).
- **No-terminal hole closed**: a `structured` flag (true iff the stream-json/`--json` argv is present, i.e. claude/codex headless) → exit-0-with-no-recognized-terminal finalizes `ProviderContractDrift`; copilot (non-structured) stays `AgentError` — boundary preserved.
- **Distinct, observable drift reason**: new `FailureReason::ProviderContractDrift` (`NoRetry`) — a spike of it in the DB = the CLI contract moved, not a real agent failure. Retry-taxonomy match has no `_` wildcard, so a future variant won't compile until classified; count-guard 10→11.
- **Loud diagnostics**: `log_contract_drift` WARN with provider + reason + bounded raw terminal tail (no fragile `--version` probe — it corrupts the retry-counter fakes; the tail is the diagnostic).
- **codex `turn.failed.error.message`** now preserved + logged.
- **Drift canary**: `stream_stdout` doc names `live_dispatch_writes_nonce_artifact` as the CI test that goes red on provider-shape drift.

## The design tension, resolved
Two independent design agents (robustness-first vs. don't-break-real-work). Kept `None → Success` (real claude always stamps a subtype; `None` only occurs in test fakes) so production fail-closed holds via `Some(unknown) → Drift` with zero fixture churn; kept `StreamLine` field-permissive (a harmless new field never false-fails).

## Proof
- No genuine-success regression: verified empirically — real-shape success still → `done` with session_id+usage; both mutations flip RED (allowlist revert → unknown subtype wrongly `done`; structured-split collapse → drift wrongly `AgentError`); restored green. Full daemon+store suites green.
- Decision table + 6 new unit tests cover every input shape.

## Known / follow-up
- The **live canary** (`live_dispatch_writes_nonce_artifact`) needs a real authenticated claude — run once to confirm claude 2.1.211 emits only `subtype:"success"` on success (documented contract). No code change.
- Residual fail-OPEN: if a future claude renames the `subtype` FIELD itself (not its value), a `result` line parses `None → Success`. Documented; the live canary's session_id/usage asserts are the backstop.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of incomplete or unexpected responses from supported AI providers.
  - Runs that finish without a recognized success signal are now reported as provider contract errors instead of being incorrectly marked successful.
  - Provider-reported failure messages are captured and included in diagnostic logs.
  - Provider contract errors are now classified as non-retryable to avoid repeating runs that are unlikely to succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->