### PR TITLE
fix(cli): preserve provider launch settings

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -10768,9 +10768,8 @@ impl AppState {
     /// Restart Claude in an existing tmux session (for Idle sessions)
     async fn restart_cli_in_tmux(&mut self, session_id: Uuid) -> anyhow::Result<String> {
         use crate::config::CliProvider;
+        use crate::interactive::InteractiveSessionManager;
         use crate::models::session::SessionAgentType;
-        use anyhow::Context;
-        use std::process::Command;
 
         let session = self
             .find_session(session_id)
@@ -10805,77 +10804,34 @@ impl AppState {
             .and_then(crate::interactive::SessionMetadata::launch_model)
             .or_else(|| session.model.clone());
 
-        // Restart continues the existing conversation, for parity with the
-        // Stopped-session resume path: Claude `--continue`, Codex `resume
-        // --last`, Copilot `--continue`. `has_history` gates Claude's
-        // `--continue` (no prior transcript → fresh, avoids a dead pane).
-        let has_history = agent_type == SessionAgentType::Claude
-            && metadata
-                .map(|m| Self::find_latest_transcript(&m.worktree_path).is_some())
-                .unwrap_or(false);
-
-        let cmd_parts =
-            crate::interactive::session_manager::InteractiveSessionManager::build_cli_cmd_parts(
-                &provider,
-                agent_type,
-                skip_permissions,
-                model.as_deref(),
-                true, // resume_requested — restart continues the conversation
-                has_history,
-            );
-
-        // Preserve per-session Headroom routing across restart. `send-keys`
-        // bypasses build_env_setup_for_provider, so re-derive the proxy export
-        // from the persisted SessionMetadata (keyed by tmux name) and prepend
-        // it — otherwise a restarted HR session would silently stop routing
-        // through the proxy.
-        //
-        // Mirror the launch path (`start_cli_in_tmux`): the stored flag is
-        // *intent*; only inject the base URL when the proxy is actually
-        // healthy. Injecting a dead-port URL would brick the restarted CLI on
-        // connection-refused. Ensure the proxy first; degrade to direct on
-        // failure rather than pointing the session at a closed port.
-        let mut headroom_active = metadata.map(|m| m.headroom_enabled).unwrap_or(false)
-            && matches!(
-                agent_type,
-                SessionAgentType::Claude | SessionAgentType::Codex
-            );
-        if headroom_active {
-            if let Err(e) = crate::headroom::ensure_proxy_running().await {
-                warn!(
-                    "headroom proxy unavailable on restart — running DIRECT, no compression: {e}"
-                );
-                headroom_active = false;
-            }
-        }
-        let escaped_cmd = cmd_parts
-            .iter()
-            .map(|part| shell_escape::escape(part.into()).into_owned())
-            .collect::<Vec<_>>()
-            .join(" ");
-        let cli_cmd = format!(
-            "{}{}",
-            crate::interactive::session_manager::headroom_env_prefix(agent_type, headroom_active),
-            escaped_cmd
-        );
+        // Reuse the launch/resume path: it replaces even a dead
+        // remain-on-exit pane with `respawn-pane -k`, restores provider argv,
+        // and reapplies Headroom/API-key/OTEL environment consistently.
+        let resume_transcript = if agent_type == SessionAgentType::Claude {
+            metadata.and_then(|m| Self::find_latest_transcript(&m.worktree_path))
+        } else {
+            None
+        };
+        let headroom_enabled = metadata.map(|m| m.headroom_enabled).unwrap_or(false);
 
         info!(
-            "Restarting {} in tmux session '{}' for workspace '{}' (cmd: {})",
+            "Restarting {} in tmux session '{}' for workspace '{}'",
             provider.display_name(),
             tmux_session_name,
-            workspace_path,
-            cli_cmd
+            workspace_path
         );
 
-        let output = Command::new("tmux")
-            .args(&["send-keys", "-t", &tmux_session_name, &cli_cmd, "C-m"])
-            .output()
-            .context("Failed to send CLI restart command to tmux")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Failed to send command to tmux: {}", stderr);
-        }
+        InteractiveSessionManager::new()?
+            .start_cli_in_tmux(
+                &tmux_session_name,
+                skip_permissions,
+                model,
+                agent_type,
+                resume_transcript,
+                true,
+                headroom_enabled,
+            )
+            .await?;
 
         if let Some(session) = self.find_session_mut(session_id) {
             session.set_status(crate::models::SessionStatus::Running);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -17,7 +17,7 @@ use crate::docker::LogStreamingCoordinator;
 use crate::editors;
 // Phase 6 (new-session redesign): ParsedRepo / RemoteBranch / legacy
 // `RepoSource` import retired with the legacy remote-clone flow.
-use crate::models::{Session, SessionAgentType, Workspace};
+use crate::models::{Session, SessionAgentType, Workspace, is_default_model};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -7339,7 +7339,7 @@ impl AppState {
             SessionAgentType::Claude | SessionAgentType::Codex
         ) {
             let model = preset.agent_model.trim();
-            (!model.is_empty() && !model.eq_ignore_ascii_case("default")).then(|| model.to_string())
+            (!is_default_model(model)).then(|| model.to_string())
         } else {
             None
         };
@@ -10808,7 +10808,10 @@ impl AppState {
         // remain-on-exit pane with `respawn-pane -k`, restores provider argv,
         // and reapplies Headroom/API-key/OTEL environment consistently.
         let resume_transcript = if agent_type == SessionAgentType::Claude {
-            metadata.and_then(|m| Self::find_latest_transcript(&m.worktree_path))
+            let worktree_path = metadata
+                .map(|m| m.worktree_path.as_path())
+                .unwrap_or_else(|| std::path::Path::new(&workspace_path));
+            Self::find_latest_transcript(worktree_path)
         } else {
             None
         };

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3348,13 +3348,9 @@ struct ConfigureLaunchSnapshot {
     mode: crate::models::SessionMode,
     boss_prompt: Option<String>,
     agent_type: crate::models::SessionAgentType,
-    /// Claude model for Claude-agent sessions. `Some(SystemDefault)` / `None`
-    /// both omit `--model` from the spawned `claude` command (the CLI's own
-    /// default applies). Set only when `agent_type == Claude`.
-    session_model: Option<crate::models::ClaudeModel>,
-    /// Codex model for Codex-agent sessions. Same omit-on-default semantics
-    /// as `session_model`. Set only when `agent_type == Codex`.
-    codex_model: Option<crate::models::CodexModel>,
+    /// Raw provider model ID. AINB passes this through unchanged to Claude or
+    /// Codex; provider CLI owns validation and model catalog updates.
+    model: Option<String>,
     /// The base-branch popup pick (2026-06). `None` = legacy base policy:
     /// HEAD for local repos, origin/HEAD for remote/star launches.
     base: Option<crate::components::new_session::configure::BaseSelection>,
@@ -5483,9 +5479,8 @@ impl AppState {
             SessionMode::Interactive,
             None,
             metadata.agent_type,
-            metadata.model,
+            metadata.launch_model(),
         );
-        session.codex_model = metadata.codex_model;
         session.id = metadata.session_id;
         session.tmux_session_name = Some(metadata.tmux_session_name.clone());
         session.status = SessionStatus::Stopped;
@@ -7323,7 +7318,7 @@ impl AppState {
         &mut self,
         spec: crate::components::new_session::configure::LaunchSpec,
     ) {
-        use crate::models::{ClaudeModel, CodexModel, SessionAgentType, SessionMode};
+        use crate::models::{SessionAgentType, SessionMode};
 
         // Finding #7: `LaunchSpec` is the single source of truth — no more
         // reaching back into `configure_state` to re-derive what the
@@ -7339,18 +7334,12 @@ impl AppState {
             "copilot" => SessionAgentType::Copilot,
             _ => SessionAgentType::Claude,
         };
-        // Per-agent model parsing. `preset.agent_model` is a free-form String
-        // (TOML schema stability) — each enum's `parse()` accepts aliases,
-        // canonical IDs, and `""` / `"default"` (→ SystemDefault). For
-        // non-Claude / non-Codex agents the model concept doesn't apply at
-        // CLI launch time, so we leave both as `None`.
-        let session_model = if agent_type == SessionAgentType::Claude {
-            Some(ClaudeModel::parse(&preset.agent_model))
-        } else {
-            None
-        };
-        let codex_model = if agent_type == SessionAgentType::Codex {
-            Some(CodexModel::parse(&preset.agent_model))
+        let model = if matches!(
+            agent_type,
+            SessionAgentType::Claude | SessionAgentType::Codex
+        ) {
+            let model = preset.agent_model.trim();
+            (!model.is_empty() && !model.eq_ignore_ascii_case("default")).then(|| model.to_string())
         } else {
             None
         };
@@ -7367,8 +7356,7 @@ impl AppState {
             mode,
             boss_prompt,
             agent_type,
-            session_model,
-            codex_model,
+            model,
             base: spec.base.clone(),
             headroom_enabled: spec.headroom_enabled,
             rtk_enabled: spec.rtk_enabled,
@@ -7522,8 +7510,7 @@ impl AppState {
                 snapshot.mode,
                 snapshot.boss_prompt,
                 snapshot.agent_type,
-                snapshot.session_model,
-                snapshot.codex_model,
+                snapshot.model,
                 existing_worktree,
                 base_start_point,
                 snapshot.headroom_enabled,
@@ -8383,8 +8370,7 @@ impl AppState {
         mode: crate::models::SessionMode,
         boss_prompt: Option<String>,
         agent_type: crate::models::SessionAgentType,
-        model: Option<crate::models::ClaudeModel>,
-        codex_model: Option<crate::models::CodexModel>,
+        model: Option<String>,
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
         base_start_point: Option<String>,
         headroom_enabled: bool,
@@ -8400,7 +8386,6 @@ impl AppState {
                     skip_permissions,
                     agent_type,
                     model,
-                    codex_model,
                     existing_worktree,
                     base_start_point,
                     headroom_enabled,
@@ -8441,8 +8426,7 @@ impl AppState {
         session_id: Uuid,
         skip_permissions: bool,
         agent_type: crate::models::SessionAgentType,
-        model: Option<crate::models::ClaudeModel>,
-        codex_model: Option<crate::models::CodexModel>,
+        model: Option<String>,
         existing_worktree: Option<(std::path::PathBuf, std::path::PathBuf)>,
         base_start_point: Option<String>,
         headroom_enabled: bool,
@@ -8504,8 +8488,7 @@ impl AppState {
                     branch_name.to_string(),
                     skip_permissions,
                     agent_type,
-                    model,
-                    codex_model,
+                    model.clone(),
                     headroom_enabled,
                     rtk_enabled,
                 )
@@ -8523,7 +8506,6 @@ impl AppState {
                     skip_permissions,
                     agent_type,
                     model,
-                    codex_model,
                     headroom_enabled,
                     rtk_enabled,
                 )
@@ -9164,10 +9146,10 @@ impl AppState {
         // metadata predating the field) → default to yolo
         // (`--dangerously-skip-permissions`), per the "default dangerously-skip"
         // requirement. `Some(v)` preserves the value the session was started with.
-        let (skip_permissions, model, codex_model) = metadata
+        let (skip_permissions, model) = metadata
             .as_ref()
-            .map(|m| (m.skip_permissions.unwrap_or(true), m.model, m.codex_model))
-            .unwrap_or((true, None, None));
+            .map(|m| (m.skip_permissions.unwrap_or(true), m.launch_model()))
+            .unwrap_or((true, None));
 
         // Capture audit context before any fallible step so we can record both
         // success and failure with the same fields.
@@ -9228,7 +9210,6 @@ impl AppState {
                     &metadata.tmux_session_name,
                     skip_permissions,
                     model,
-                    codex_model,
                     metadata.agent_type,
                     transcript.clone(),
                     true, // resume_requested — Enter/r on a Stopped session
@@ -10802,10 +10783,7 @@ impl AppState {
             .clone();
 
         let workspace_path = session.workspace_path.clone();
-        let skip_permissions = session.skip_permissions;
         let agent_type = session.agent_type;
-        let model = session.model;
-        let codex_model = session.codex_model;
 
         let provider = match agent_type {
             SessionAgentType::Claude => CliProvider::Claude,
@@ -10821,6 +10799,11 @@ impl AppState {
         // (Claude, keyed off the worktree cwd) and the Headroom routing flag.
         let store = crate::interactive::SessionStore::load();
         let metadata = store.sessions.get(&tmux_session_name);
+        let skip_permissions =
+            metadata.and_then(|m| m.skip_permissions).unwrap_or(session.skip_permissions);
+        let model = metadata
+            .and_then(crate::interactive::SessionMetadata::launch_model)
+            .or_else(|| session.model.clone());
 
         // Restart continues the existing conversation, for parity with the
         // Stopped-session resume path: Claude `--continue`, Codex `resume
@@ -10836,8 +10819,7 @@ impl AppState {
                 &provider,
                 agent_type,
                 skip_permissions,
-                model,
-                codex_model,
+                model.as_deref(),
                 true, // resume_requested — restart continues the conversation
                 has_history,
             );
@@ -10866,10 +10848,15 @@ impl AppState {
                 headroom_active = false;
             }
         }
+        let escaped_cmd = cmd_parts
+            .iter()
+            .map(|part| shell_escape::escape(part.into()).into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
         let cli_cmd = format!(
             "{}{}",
             crate::interactive::session_manager::headroom_env_prefix(agent_type, headroom_active),
-            cmd_parts.join(" ")
+            escaped_cmd
         );
 
         info!(
@@ -10908,13 +10895,12 @@ impl AppState {
     /// 1. Resolve the session and validate it is Claude or Codex.
     /// 2. Load the SessionStore; check that headroom_enabled is true.
     /// 3. Set headroom_enabled = false and save the store.
-    /// 4. Build the resume command: `[provider] [--skip-perms] [--continue for Claude]`.
+    /// 4. Rebuild the provider command from persisted launch settings.
     ///    No env prefix (headroom is now off → `headroom_env_prefix(…, false)` == "").
     /// 5. Replace the running CLI with `tmux respawn-pane -k` using the same
     ///    `sh -c '…exec cli …'` shape as `start_cli_in_tmux`.
     ///    `respawn-pane -k` kills the running process and starts fresh in-place,
     ///    which is the only way to clear env vars from a running process.
-    ///    Codex has no `--continue` flag — it restarts fresh (noted in notification).
     async fn downgrade_headroom_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
         use crate::config::CliProvider;
         use crate::models::session::SessionAgentType;
@@ -10933,7 +10919,8 @@ impl AppState {
             .clone();
 
         let agent_type = session.agent_type;
-        let skip_permissions = session.skip_permissions;
+        let session_skip_permissions = session.skip_permissions;
+        let session_model = session.model.clone();
 
         // --- 1a. Only Claude/Codex are Headroom-capable ---
         let provider = match agent_type {
@@ -10956,12 +10943,12 @@ impl AppState {
         // The lock is best-effort: on failure we proceed unlocked rather than
         // abort the downgrade. The early-return paths drop the guard (unlock)
         // as they leave the block.
-        {
+        let (skip_permissions, model, has_history) = {
             let _lock = crate::interactive::SessionStore::lock()
                 .map_err(|e| warn!("Failed to lock sessions.json for Headroom flip: {e}"))
                 .ok();
             let mut store = crate::interactive::SessionStore::load();
-            match store.sessions.get(&tmux_session_name) {
+            let launch_settings = match store.sessions.get(&tmux_session_name) {
                 None => {
                     self.add_warning_notification(
                         "Session not found in store — Headroom state unknown".to_string(),
@@ -10974,8 +10961,13 @@ impl AppState {
                     );
                     return Ok(());
                 }
-                _ => {}
-            }
+                Some(meta) => (
+                    meta.skip_permissions.unwrap_or(session_skip_permissions),
+                    meta.launch_model().or(session_model),
+                    agent_type == SessionAgentType::Claude
+                        && Self::find_latest_transcript(&meta.worktree_path).is_some(),
+                ),
+            };
 
             if let Some(meta) = store.sessions.get_mut(&tmux_session_name) {
                 meta.headroom_enabled = false;
@@ -10988,7 +10980,8 @@ impl AppState {
                     tmux_session_name, e
                 );
             }
-        }
+            launch_settings
+        };
 
         // --- 4. Build the resume command (no env prefix — headroom is off) ---
         //
@@ -10996,20 +10989,20 @@ impl AppState {
         // and we are not injecting an API key here (the original launch path
         // already injected it into the pane's environment; `respawn-pane -k`
         // inherits from the ainb-tui process which has the correct key).
-        let mut cmd_parts: Vec<String> = vec![provider.command().to_string()];
-        if skip_permissions {
-            cmd_parts.push(provider.skip_permissions_flag().to_string());
-        }
-        // Claude: `--continue` (-c) resumes the most recent conversation in the cwd.
-        // Codex: no continue/resume flag exists — restarts fresh.
-        let codex_fresh_note = if agent_type == SessionAgentType::Claude {
-            cmd_parts.push("--continue".to_string());
-            ""
-        } else {
-            " (Codex restarted fresh — no --continue flag)"
-        };
-
-        let cli_cmd = cmd_parts.join(" ");
+        let cmd_parts =
+            crate::interactive::session_manager::InteractiveSessionManager::build_cli_cmd_parts(
+                &provider,
+                agent_type,
+                skip_permissions,
+                model.as_deref(),
+                true,
+                has_history,
+            );
+        let cli_cmd = cmd_parts
+            .iter()
+            .map(|part| shell_escape::escape(part.into()).into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
 
         info!(
             "Downgrading Headroom for {} in '{}': cmd={}",
@@ -11064,8 +11057,7 @@ impl AppState {
         }
 
         self.add_success_notification(format!(
-            "Headroom OFF for this session — resumed direct (no compression){}",
-            codex_fresh_note
+            "Headroom OFF for this session — resumed direct (no compression)"
         ));
 
         info!(

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn test_stopped_session_from_metadata_preserves_launch_settings() {
         use crate::interactive::SessionMetadata;
-        use crate::models::{ClaudeModel, SessionAgentType};
+        use crate::models::SessionAgentType;
         use std::path::PathBuf;
 
         let metadata = SessionMetadata {
@@ -324,7 +324,7 @@ mod tests {
             headroom_enabled: false,
             rtk_enabled: false,
             skip_permissions: Some(false),
-            model: Some(ClaudeModel::Opus),
+            model: Some("claude-opus-4-8".to_string()),
             codex_model: None,
         };
 
@@ -333,7 +333,7 @@ mod tests {
             !session.skip_permissions,
             "Some(false) must be preserved, not defaulted to yolo"
         );
-        assert_eq!(session.model, Some(ClaudeModel::Opus));
+        assert_eq!(session.model.as_deref(), Some("claude-opus-4-8"));
     }
 
     // -- SessionFilter tests ------------------------------------------------

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -336,6 +336,112 @@ mod tests {
         assert_eq!(session.model.as_deref(), Some("claude-opus-4-8"));
     }
 
+    #[tokio::test]
+    async fn idle_restart_respawns_a_dead_codex_pane_with_launch_settings() {
+        use crate::models::{Session, SessionStatus, Workspace};
+        use std::process::Command;
+        use std::time::Duration;
+
+        if Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("skip: tmux unavailable");
+            return;
+        }
+
+        struct ExactTmuxSession(String);
+        impl Drop for ExactTmuxSession {
+            fn drop(&mut self) {
+                let _ = Command::new("tmux").args(["kill-session", "-t", &self.0]).output();
+            }
+        }
+
+        let home = tempfile::tempdir().expect("temp home");
+
+        let tmux_name = format!("ainb-idle-restart-{}", uuid::Uuid::new_v4());
+        let _tmux = ExactTmuxSession(tmux_name.clone());
+        assert!(
+            Command::new("tmux")
+                .args(["new-session", "-d", "-s", &tmux_name])
+                .status()
+                .expect("create tmux session")
+                .success()
+        );
+        assert!(
+            Command::new("tmux")
+                .args(["set-option", "-w", "-t", &tmux_name, "remain-on-exit", "on"])
+                .status()
+                .expect("set remain-on-exit")
+                .success()
+        );
+        assert!(
+            Command::new("tmux")
+                .args(["respawn-pane", "-k", "-t", &tmux_name, "sh", "-c", "exit 0"])
+                .status()
+                .expect("make pane dead")
+                .success()
+        );
+
+        let mut pane_dead = false;
+        for _ in 0..20 {
+            let dead = Command::new("tmux")
+                .args(["display-message", "-p", "-t", &tmux_name, "#{pane_dead}"])
+                .output()
+                .expect("read pane state");
+            if String::from_utf8_lossy(&dead.stdout).trim() == "1" {
+                pane_dead = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert!(pane_dead, "precondition: pane must be dead before restart");
+
+        let session_id = uuid::Uuid::new_v4();
+        let worktree = home.path().join("worktree");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        let model = "gpt-5.6-luna".to_string();
+
+        let mut session = Session::new_with_options(
+            "idle-restart".to_string(),
+            worktree.to_string_lossy().to_string(),
+            true,
+            SessionMode::Interactive,
+            None,
+            SessionAgentType::Codex,
+            Some(model),
+        );
+        session.id = session_id;
+        session.status = SessionStatus::Idle;
+        session.tmux_session_name = Some(tmux_name.clone());
+
+        let mut workspace = Workspace::new("idle-restart".to_string(), worktree);
+        workspace.add_session(session);
+        let mut state = AppState::new();
+        state.workspaces.push(workspace);
+
+        state.restart_cli_in_tmux(session_id).await.expect("idle restart");
+
+        let pane = Command::new("tmux")
+            .args([
+                "list-panes",
+                "-t",
+                &tmux_name,
+                "-F",
+                "#{pane_start_command}",
+            ])
+            .output()
+            .expect("read pane command");
+        let pane_command = String::from_utf8_lossy(&pane.stdout);
+        assert!(
+            pane_command.contains(
+                "codex resume --last --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox"
+            ),
+            "idle restart must replace dead pane with persisted Codex argv, got: {pane_command}"
+        );
+    }
+
     // -- SessionFilter tests ------------------------------------------------
 
     use crate::app::state::SessionFilter;

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -287,6 +287,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 
@@ -325,6 +326,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: Some(false),
             model: Some("claude-opus-4-8".to_string()),
+            model_source: Default::default(),
             codex_model: None,
         };
 

--- a/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
@@ -466,6 +466,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/list.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/list.rs
@@ -194,6 +194,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 
@@ -214,6 +215,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 
@@ -234,6 +236,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 
@@ -269,6 +272,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -155,9 +155,9 @@ pub struct RunArgs {
     #[arg(long, value_enum, default_value_t = Tool::Claude)]
     pub tool: Tool,
 
-    /// Model to use (sonnet, opus, haiku)
-    #[arg(long, default_value = "sonnet")]
-    pub model: String,
+    /// Provider model ID to pass through unchanged
+    #[arg(long)]
+    pub model: Option<String>,
 
     /// Initial prompt to send
     #[arg(long, short)]

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -396,6 +396,7 @@ fn execute_resume(session: &str) -> Result<()> {
         rtk_enabled: false,
         skip_permissions: None,
         model: None,
+        model_source: Default::default(),
         codex_model: None,
     };
 
@@ -627,6 +628,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -17,7 +17,6 @@ use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{SessionMetadata, SessionStore};
-use crate::models::ClaudeModel;
 use crate::models::session::SessionAgentType;
 use crate::tmux::TmuxSession;
 
@@ -73,8 +72,8 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         format!("{workspace_name}-{short_id}")
     });
 
-    // Step 5: Parse model
-    let model = parse_model(&args.model);
+    // Step 5: Keep model opaque. Provider CLI owns model validation/catalog.
+    let model = requested_model(args.model.as_deref());
 
     // Step 5.5: Wire shared MCP pool (Claude only; never blocks creation).
     // Ensures the pool daemon is up and merge-writes the worktree's
@@ -85,7 +84,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     }
 
     // Step 6: Build Claude command
-    let claude_cmd = build_agent_command(&args, Some(model));
+    let claude_cmd = build_agent_command(&args);
 
     // Step 6b: Parent linkage (event-driven plumbing). When spawned with
     // `--parent <id>`, this session is a child of an orchestrator (e.g. ATC).
@@ -142,7 +141,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         headroom_enabled: false,
         rtk_enabled: false,
         skip_permissions: Some(args.dangerously_skip_permissions),
-        model: Some(model),
+        model: model.clone(),
         codex_model: None,
     };
 
@@ -160,7 +159,10 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     println!("  Tmux Session: {tmux_name}");
     println!("  Working Dir:  {}", work_dir.display());
     println!("  Branch:       {branch_name}");
-    println!("  Model:        {}", model.display_name());
+    println!(
+        "  Model:        {}",
+        model.as_deref().unwrap_or("system default")
+    );
     println!();
     println!("To attach to this session:");
     println!("  tmux attach -t {tmux_name}");
@@ -351,13 +353,10 @@ fn get_current_branch(repo_path: &std::path::Path) -> Option<String> {
     }
 }
 
-/// Parse model string to `ClaudeModel` enum.
-///
-/// Delegates to `ClaudeModel::parse` so the alias / canonical-id mapping lives
-/// in exactly one place. Unknown / empty values resolve to `SystemDefault`,
-/// which means the spawned `claude` command will omit `--model` entirely.
-fn parse_model(model_str: &str) -> ClaudeModel {
-    ClaudeModel::parse(model_str)
+/// Normalize only AINB's no-model sentinels. Every other value stays opaque.
+fn requested_model(model: Option<&str>) -> Option<String> {
+    let model = model?.trim();
+    (!model.is_empty() && !model.eq_ignore_ascii_case("default")).then(|| model.to_string())
 }
 
 /// Validate that the selected provider's CLI binary is installed and on PATH
@@ -382,39 +381,20 @@ fn validate_provider_installed(provider: &CliProvider) -> Result<()> {
 
 /// Build the agent CLI command with appropriate flags for the selected provider.
 ///
-/// **Model emission semantics (2026-05 refresh):**
-///   * Claude — `--model <canonical-id>` (e.g. `claude-opus-4-8`) emitted ONLY
-///     when `model` resolves to a non-`SystemDefault` variant. The
-///     `ClaudeModel::SystemDefault` variant (or `None`) causes the flag to be
-///     omitted entirely so the installed `claude` CLI's default applies.
-///   * Codex — when the caller's raw `args.model` string parses into a
-///     non-`SystemDefault` `CodexModel`, `--model <id>` is emitted (e.g.
-///     `--model gpt-5.4`). Default / empty / unknown strings → no flag.
+/// **Model emission semantics:**
+///   * Claude / Codex — pass any non-empty, non-`default` value through
+///     unchanged. Provider CLI owns model validation and future model IDs.
 ///   * Gemini / Copilot — never emit `--model` (those CLIs don't accept it
 ///     in this codebase).
-fn build_agent_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
-    use crate::models::CodexModel;
-
+fn build_agent_command(args: &RunArgs) -> String {
     let provider = args.tool.to_cli_provider();
     let mut cmd_parts = vec![provider.command().to_string()];
 
     match provider {
-        CliProvider::Claude => {
-            if let Some(m) = model {
-                if let Some(id) = m.cli_value() {
-                    cmd_parts.push("--model".to_string());
-                    cmd_parts.push(id.to_string());
-                }
-            }
-        }
-        CliProvider::Codex => {
-            // Codex no longer hard-blocks `--model`. Parse the raw `--model`
-            // string into a CodexModel; emit only when it's not the
-            // SystemDefault sentinel (covers `""` and `"default"`).
-            let cm = CodexModel::parse(&args.model);
-            if let Some(id) = cm.cli_value() {
+        CliProvider::Claude | CliProvider::Codex => {
+            if let Some(model) = requested_model(args.model.as_deref()) {
                 cmd_parts.push("--model".to_string());
-                cmd_parts.push(id.to_string());
+                cmd_parts.push(model);
             }
         }
         CliProvider::Gemini | CliProvider::Copilot => {
@@ -427,7 +407,11 @@ fn build_agent_command(args: &RunArgs, model: Option<ClaudeModel>) -> String {
         cmd_parts.push(provider.skip_permissions_flag().to_string());
     }
 
-    cmd_parts.join(" ")
+    cmd_parts
+        .iter()
+        .map(|part| shell_escape::escape(part.into()).into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Send a prompt to the tmux session
@@ -472,27 +456,6 @@ mod tests {
     use crate::cli::Tool;
 
     #[test]
-    fn test_parse_model() {
-        // Aliases (back-compat with on-disk user presets) still resolve.
-        assert_eq!(parse_model("sonnet"), ClaudeModel::Sonnet);
-        assert_eq!(parse_model("SONNET"), ClaudeModel::Sonnet);
-        assert_eq!(parse_model("opus"), ClaudeModel::Opus);
-        assert_eq!(parse_model("haiku"), ClaudeModel::Haiku);
-        assert_eq!(parse_model("claude-sonnet"), ClaudeModel::Sonnet);
-        // Canonical IDs (2026-06 refresh) also resolve.
-        assert_eq!(parse_model("claude-fable-5"), ClaudeModel::Fable);
-        assert_eq!(parse_model("claude-opus-4-8"), ClaudeModel::Opus);
-        assert_eq!(parse_model("claude-opus-4-7"), ClaudeModel::Opus47);
-        assert_eq!(parse_model("claude-sonnet-4-6"), ClaudeModel::Sonnet);
-        assert_eq!(parse_model("claude-haiku-4-5"), ClaudeModel::Haiku);
-        assert_eq!(parse_model("opusplan"), ClaudeModel::OpusPlan);
-        // Empty / default / unknown all map to SystemDefault (omit --model).
-        assert_eq!(parse_model(""), ClaudeModel::SystemDefault);
-        assert_eq!(parse_model("default"), ClaudeModel::SystemDefault);
-        assert_eq!(parse_model("unknown"), ClaudeModel::SystemDefault);
-    }
-
-    #[test]
     fn test_build_agent_command() {
         let args = RunArgs {
             remote_repo: None,
@@ -500,7 +463,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Claude,
-            model: "sonnet".to_string(),
+            model: Some("sonnet".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: true,
@@ -509,14 +472,37 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        let cmd = build_agent_command(&args);
         assert!(cmd.contains("claude"));
-        // Full canonical ID, not the `sonnet` alias.
         assert!(
-            cmd.contains("--model claude-sonnet-4-6"),
-            "expected full canonical id, got: {cmd}"
+            cmd.contains("--model sonnet"),
+            "AINB must pass Claude's raw model value through, got: {cmd}"
         );
         assert!(cmd.contains("--dangerously-skip-permissions"));
+    }
+
+    #[test]
+    fn test_build_claude_command_passes_unknown_model_through() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: Tool::Claude,
+            model: Some("claude-next-9".to_string()),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+            parent: None,
+        };
+
+        let cmd = build_agent_command(&args);
+        assert!(
+            cmd.contains("--model claude-next-9"),
+            "AINB must not reject future Claude model IDs, got: {cmd}"
+        );
     }
 
     #[test]
@@ -527,7 +513,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Claude,
-            model: "opus".to_string(),
+            model: Some("opus".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -536,9 +522,9 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::Opus));
+        let cmd = build_agent_command(&args);
         assert!(cmd.contains("claude"));
-        assert!(cmd.contains("--model claude-opus-4-8"));
+        assert!(cmd.contains("--model opus"));
         assert!(!cmd.contains("--dangerously-skip-permissions"));
     }
 
@@ -550,7 +536,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Claude,
-            model: String::new(),
+            model: Some(String::new()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -559,7 +545,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::SystemDefault));
+        let cmd = build_agent_command(&args);
         assert!(cmd.starts_with("claude"));
         assert!(
             !cmd.contains("--model"),
@@ -576,7 +562,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Claude,
-            model: "default".to_string(),
+            model: None,
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -585,7 +571,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, None);
+        let cmd = build_agent_command(&args);
         assert!(!cmd.contains("--model"));
     }
 
@@ -601,7 +587,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Codex,
-            model: "default".to_string(),
+            model: None,
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -610,7 +596,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        let cmd = build_agent_command(&args);
         assert!(
             cmd.starts_with("codex"),
             "Command should start with codex, got: {}",
@@ -633,7 +619,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Codex,
-            model: "gpt-5.4".to_string(),
+            model: Some("gpt-5.4".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -642,11 +628,35 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, None);
+        let cmd = build_agent_command(&args);
         assert!(cmd.starts_with("codex"));
         assert!(
             cmd.contains("--model gpt-5.4"),
             "Codex with explicit gpt-5.4 must emit --model, got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn test_build_codex_command_passes_unknown_model_through() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: Tool::Codex,
+            model: Some("gpt-5.6-luna".to_string()),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+            parent: None,
+        };
+
+        let cmd = build_agent_command(&args);
+        assert!(
+            cmd.contains("--model gpt-5.6-luna"),
+            "AINB must not reject future Codex model IDs, got: {cmd}"
         );
     }
 
@@ -658,7 +668,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Codex,
-            model: "default".to_string(),
+            model: None,
             prompt: None,
             attach: false,
             dangerously_skip_permissions: true,
@@ -667,7 +677,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        let cmd = build_agent_command(&args);
         assert!(
             cmd.starts_with("codex"),
             "Command should start with codex, got: {}",
@@ -692,7 +702,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Gemini,
-            model: "sonnet".to_string(),
+            model: Some("sonnet".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -701,7 +711,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        let cmd = build_agent_command(&args);
         assert!(
             cmd.starts_with("gemini"),
             "Command should start with gemini, got: {}",
@@ -721,7 +731,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Copilot,
-            model: "sonnet".to_string(),
+            model: Some("sonnet".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -730,7 +740,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, Some(ClaudeModel::Sonnet));
+        let cmd = build_agent_command(&args);
         assert!(
             cmd.starts_with("copilot"),
             "Command should start with copilot, got: {}",
@@ -746,7 +756,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Copilot,
-            model: "sonnet".to_string(),
+            model: Some("sonnet".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -755,7 +765,7 @@ mod tests {
             parent: None,
         };
 
-        let cmd = build_agent_command(&args, None);
+        let cmd = build_agent_command(&args);
         assert_eq!(
             cmd, "copilot",
             "Copilot with no flags should just be 'copilot'"

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
-use crate::interactive::session_manager::{SessionMetadata, SessionStore};
+use crate::interactive::session_manager::{ModelSource, SessionMetadata, SessionStore};
 use crate::models::session::SessionAgentType;
 use crate::tmux::TmuxSession;
 
@@ -142,6 +142,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         rtk_enabled: false,
         skip_permissions: Some(args.dangerously_skip_permissions),
         model: model.clone(),
+        model_source: ModelSource::Raw,
         codex_model: None,
     };
 

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -17,7 +17,7 @@ use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{ModelSource, SessionMetadata, SessionStore};
-use crate::models::session::SessionAgentType;
+use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
 
 /// Execute the run command
@@ -357,7 +357,7 @@ fn get_current_branch(repo_path: &std::path::Path) -> Option<String> {
 /// Normalize only AINB's no-model sentinels. Every other value stays opaque.
 fn requested_model(model: Option<&str>) -> Option<String> {
     let model = model?.trim();
-    (!model.is_empty() && !model.eq_ignore_ascii_case("default")).then(|| model.to_string())
+    (!is_default_model(model)).then(|| model.to_string())
 }
 
 /// Validate that the selected provider's CLI binary is installed and on PATH

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -207,6 +207,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/util.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/util.rs
@@ -143,6 +143,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 
@@ -157,6 +158,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -873,8 +873,7 @@ impl SessionRecoveryState {
                     &provider,
                     agent_type,
                     true, // skip_permissions — recovery launches yolo, as before
-                    None, // claude_model
-                    None, // codex_model
+                    None, // model
                     true, // resume_requested — orphan recovery is a resume
                     has_history,
                 )

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -821,6 +821,7 @@ impl SessionRecoveryState {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 

--- a/ainb-tui/crates/ainb-core/src/docker/session_lifecycle.rs
+++ b/ainb-tui/crates/ainb-core/src/docker/session_lifecycle.rs
@@ -173,7 +173,7 @@ impl SessionLifecycleManager {
             request.mode.clone(),
             request.boss_prompt.clone(),
             request.agent_type,
-            request.model,
+            request.model.and_then(|model| model.cli_value().map(str::to_string)),
         );
         session.id = request.session_id;
         session.branch_name = request.branch_name.clone();
@@ -1037,7 +1037,7 @@ impl SessionLifecycleManager {
             request.mode.clone(),
             request.boss_prompt.clone(),
             request.agent_type,
-            request.model,
+            request.model.and_then(|model| model.cli_value().map(str::to_string)),
         );
         session.id = request.session_id;
         session.branch_name = request.branch_name.clone();
@@ -1097,7 +1097,7 @@ impl SessionLifecycleManager {
             request.mode.clone(),
             request.boss_prompt.clone(),
             request.agent_type,
-            request.model,
+            request.model.and_then(|model| model.cli_value().map(str::to_string)),
         );
         session.id = request.session_id;
         session.branch_name = request.branch_name.clone();

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -13,7 +13,9 @@
 
 use crate::audit::{self, AuditResult, AuditTrigger};
 use crate::git::WorktreeManager;
-use crate::models::{CodexModel, Session, SessionAgentType, SessionMode, SessionStatus};
+use crate::models::{
+    CodexModel, Session, SessionAgentType, SessionMode, SessionStatus, is_default_model,
+};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -132,7 +134,7 @@ impl SessionMetadata {
 
 fn normalize_raw_model(value: &str) -> Option<String> {
     let trimmed = value.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") {
+    if is_default_model(trimmed) {
         return None;
     }
 
@@ -141,7 +143,7 @@ fn normalize_raw_model(value: &str) -> Option<String> {
 
 fn normalize_legacy_model(agent_type: SessionAgentType, value: &str) -> Option<String> {
     let trimmed = value.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") || trimmed == "SystemDefault" {
+    if is_default_model(trimmed) || trimmed == "SystemDefault" {
         return None;
     }
 
@@ -1426,10 +1428,7 @@ impl InteractiveSessionManager {
             agent_type,
             SessionAgentType::Claude | SessionAgentType::Codex
         ) {
-            if let Some(model) = model
-                .map(str::trim)
-                .filter(|model| !model.is_empty() && !model.eq_ignore_ascii_case("default"))
-            {
+            if let Some(model) = model.map(str::trim).filter(|model| !is_default_model(model)) {
                 cmd_parts.push("--model".to_string());
                 cmd_parts.push(model.to_string());
             }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -13,9 +13,7 @@
 
 use crate::audit::{self, AuditResult, AuditTrigger};
 use crate::git::WorktreeManager;
-use crate::models::{
-    ClaudeModel, CodexModel, Session, SessionAgentType, SessionMode, SessionStatus,
-};
+use crate::models::{CodexModel, Session, SessionAgentType, SessionMode, SessionStatus};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -61,7 +59,8 @@ pub struct InteractiveSession {
     pub workspace_name: String,
     pub created_at: DateTime<Utc>,
     pub agent_type: SessionAgentType, // The AI agent or shell for this session
-    pub model: Option<ClaudeModel>,   // Claude model for this session (only for Claude agent)
+    pub skip_permissions: bool,       // Provider-specific dangerous/yolo launch flag
+    pub model: Option<String>,        // Raw provider model ID passed through to the CLI
     pub headroom_enabled: bool,       // Route this session's CLI through the local Headroom proxy
     pub rtk_enabled: bool,            // RTK PreToolUse hook wired in session's worktree
 }
@@ -93,9 +92,46 @@ pub struct SessionMetadata {
     #[serde(default)]
     pub skip_permissions: Option<bool>,
     #[serde(default)]
-    pub model: Option<ClaudeModel>,
+    pub model: Option<String>,
+    /// Legacy Codex-only field. New writes use provider-agnostic `model`.
     #[serde(default)]
     pub codex_model: Option<CodexModel>,
+}
+
+impl SessionMetadata {
+    /// Resolve the raw model value used for launch/restart.
+    ///
+    /// New metadata stores the exact CLI value in `model`. Legacy enum values
+    /// serialized as strings are translated to their historical canonical IDs.
+    /// Old Codex records stored their model in `codex_model`, so retain that
+    /// fallback until the on-disk corpus has naturally migrated.
+    pub fn launch_model(&self) -> Option<String> {
+        if let Some(model) = self.model.as_deref() {
+            return normalize_persisted_model(self.agent_type, model);
+        }
+
+        self.codex_model.and_then(|model| model.cli_value()).map(str::to_string)
+    }
+}
+
+fn normalize_persisted_model(agent_type: SessionAgentType, value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") || trimmed == "SystemDefault" {
+        return None;
+    }
+
+    let legacy = match (agent_type, trimmed) {
+        (SessionAgentType::Claude, "Fable") => Some("claude-fable-5"),
+        (SessionAgentType::Claude, "Opus") => Some("claude-opus-4-8"),
+        (SessionAgentType::Claude, "Opus47") => Some("claude-opus-4-7"),
+        (SessionAgentType::Claude, "Opus46") => Some("claude-opus-4-6"),
+        (SessionAgentType::Claude, "Sonnet") => Some("claude-sonnet-4-6"),
+        (SessionAgentType::Claude, "Haiku") => Some("claude-haiku-4-5"),
+        (SessionAgentType::Claude, "OpusPlan") => Some("opusplan"),
+        _ => None,
+    };
+
+    Some(legacy.unwrap_or(trimmed).to_string())
 }
 
 /// Storage for all persisted session metadata
@@ -339,20 +375,13 @@ impl InteractiveSessionManager {
         base_branch: Option<String>,
         skip_permissions: bool,
         agent_type: SessionAgentType,
-        model: Option<ClaudeModel>,
-        codex_model: Option<CodexModel>,
+        model: Option<String>,
         headroom_enabled: bool,
         rtk_enabled: bool,
     ) -> Result<InteractiveSession, InteractiveSessionError> {
         info!(
-            "Creating Interactive session {} for branch '{}' in workspace '{}' (agent={:?}, model={:?}, codex_model={:?}, skip_permissions={})",
-            session_id,
-            branch_name,
-            workspace_name,
-            agent_type,
-            model,
-            codex_model,
-            skip_permissions
+            "Creating Interactive session {} for branch '{}' in workspace '{}' (agent={:?}, model={:?}, skip_permissions={})",
+            session_id, branch_name, workspace_name, agent_type, model, skip_permissions
         );
 
         // Check if session already exists
@@ -399,14 +428,13 @@ impl InteractiveSessionManager {
             | SessionAgentType::Gemini
             | SessionAgentType::Copilot => {
                 info!(
-                    "Starting {:?} CLI in tmux session (model={:?}, codex_model={:?}, skip_permissions={})",
-                    agent_type, model, codex_model, skip_permissions
+                    "Starting {:?} CLI in tmux session (model={:?}, skip_permissions={})",
+                    agent_type, model, skip_permissions
                 );
                 self.start_cli_in_tmux(
                     &tmux_session_name,
                     skip_permissions,
-                    model,
-                    codex_model,
+                    model.clone(),
                     agent_type,
                     None,
                     false, // resume_requested — fresh launch
@@ -430,7 +458,8 @@ impl InteractiveSessionManager {
             workspace_name: workspace_name.clone(),
             created_at,
             agent_type,
-            model,
+            skip_permissions,
+            model: model.clone(),
             headroom_enabled,
             rtk_enabled,
         };
@@ -449,7 +478,7 @@ impl InteractiveSessionManager {
             rtk_enabled,
             skip_permissions: Some(skip_permissions),
             model,
-            codex_model,
+            codex_model: None,
         };
         // Locked RMW so a concurrent `ainb kill` / recovery / daemon register
         // can't lost-update this upsert (pu4).
@@ -499,18 +528,16 @@ impl InteractiveSessionManager {
         branch_name: String,
         skip_permissions: bool,
         agent_type: SessionAgentType,
-        model: Option<ClaudeModel>,
-        codex_model: Option<CodexModel>,
+        model: Option<String>,
         headroom_enabled: bool,
         rtk_enabled: bool,
     ) -> Result<InteractiveSession, InteractiveSessionError> {
         info!(
-            "Creating Interactive session {} with existing worktree at '{}' (agent={:?}, model={:?}, codex_model={:?})",
+            "Creating Interactive session {} with existing worktree at '{}' (agent={:?}, model={:?})",
             session_id,
             existing_worktree_path.display(),
             agent_type,
-            model,
-            codex_model
+            model
         );
 
         // Check if session already exists
@@ -568,14 +595,13 @@ impl InteractiveSessionManager {
             | SessionAgentType::Gemini
             | SessionAgentType::Copilot => {
                 info!(
-                    "Starting {:?} CLI in tmux session (model={:?}, codex_model={:?}, skip_permissions={})",
-                    agent_type, model, codex_model, skip_permissions
+                    "Starting {:?} CLI in tmux session (model={:?}, skip_permissions={})",
+                    agent_type, model, skip_permissions
                 );
                 self.start_cli_in_tmux(
                     &tmux_session_name,
                     skip_permissions,
-                    model,
-                    codex_model,
+                    model.clone(),
                     agent_type,
                     None,
                     false, // resume_requested — fresh launch
@@ -600,7 +626,8 @@ impl InteractiveSessionManager {
             workspace_name: workspace_name.clone(),
             created_at,
             agent_type,
-            model,
+            skip_permissions,
+            model: model.clone(),
             headroom_enabled,
             rtk_enabled,
         };
@@ -619,7 +646,7 @@ impl InteractiveSessionManager {
             rtk_enabled,
             skip_permissions: Some(skip_permissions),
             model,
-            codex_model,
+            codex_model: None,
         };
         // Locked RMW (pu4): serialise against concurrent kill/recovery writers.
         if let Err(e) = SessionStore::mutate(|store| store.upsert(metadata)) {
@@ -744,7 +771,8 @@ impl InteractiveSessionManager {
                     workspace_name,
                     created_at: metadata.created_at,
                     agent_type,
-                    model: None,
+                    skip_permissions: metadata.skip_permissions.unwrap_or(true),
+                    model: metadata.launch_model(),
                     headroom_enabled: metadata.headroom_enabled,
                     rtk_enabled: metadata.rtk_enabled,
                 });
@@ -794,6 +822,7 @@ impl InteractiveSessionManager {
                     workspace_name,
                     created_at: Utc::now(),
                     agent_type,
+                    skip_permissions: true,
                     model: None,
                     headroom_enabled: false,
                     rtk_enabled: false,
@@ -1346,8 +1375,7 @@ impl InteractiveSessionManager {
         provider: &crate::config::CliProvider,
         agent_type: SessionAgentType,
         skip_permissions: bool,
-        claude_model: Option<ClaudeModel>,
-        codex_model: Option<CodexModel>,
+        model: Option<&str>,
         resume_requested: bool,
         has_history: bool,
     ) -> Vec<String> {
@@ -1365,28 +1393,19 @@ impl InteractiveSessionManager {
             cmd_parts.push("--last".to_string());
         }
 
-        // Add `--model` only when the provider's model resolves to a
-        // non-`SystemDefault` variant. SystemDefault → no flag (CLI default
-        // applies). Gemini / Copilot: never emit `--model` today. For codex
-        // resume these land after `resume --last`, a valid option position.
-        match agent_type {
-            SessionAgentType::Claude => {
-                if let Some(m) = claude_model {
-                    if let Some(id) = m.cli_value() {
-                        cmd_parts.push("--model".to_string());
-                        cmd_parts.push(id.to_string());
-                    }
-                }
+        // AINB does not own provider model catalogs. Pass any non-default raw
+        // value through unchanged; provider CLI performs validation.
+        if matches!(
+            agent_type,
+            SessionAgentType::Claude | SessionAgentType::Codex
+        ) {
+            if let Some(model) = model
+                .map(str::trim)
+                .filter(|model| !model.is_empty() && !model.eq_ignore_ascii_case("default"))
+            {
+                cmd_parts.push("--model".to_string());
+                cmd_parts.push(model.to_string());
             }
-            SessionAgentType::Codex => {
-                if let Some(m) = codex_model {
-                    if let Some(id) = m.cli_value() {
-                        cmd_parts.push("--model".to_string());
-                        cmd_parts.push(id.to_string());
-                    }
-                }
-            }
-            _ => {}
         }
 
         // Add skip permissions flag if specified (provider-specific). Valid
@@ -1433,19 +1452,15 @@ impl InteractiveSessionManager {
     ///   * Copilot: emits `--continue` (most recent copilot session; unguarded).
     ///   * Gemini: no resume flag wired — always starts fresh.
     ///
-    /// **Model flag emission (2026-05 refresh):**
-    ///   * Claude: `--model <id>` only when `claude_model` is a non-default
-    ///     `ClaudeModel`. `None` / `Some(SystemDefault)` ⇒ flag omitted (CLI
-    ///     default applies).
-    ///   * Codex: `--model <id>` only when `codex_model` is a non-default
-    ///     `CodexModel`. Same omit-on-default semantics as Claude.
+    /// **Model flag emission:**
+    ///   * Claude / Codex: pass the raw persisted value through unchanged.
+    ///     `None`, empty, or `default` omits the flag.
     ///   * Gemini / Copilot: never emit `--model`.
     pub async fn start_cli_in_tmux(
         &self,
         session_name: &str,
         skip_permissions: bool,
-        claude_model: Option<ClaudeModel>,
-        codex_model: Option<CodexModel>,
+        model: Option<String>,
         agent_type: SessionAgentType,
         resume_transcript: Option<PathBuf>,
         resume_requested: bool,
@@ -1514,14 +1529,12 @@ impl InteractiveSessionManager {
             &provider,
             agent_type,
             skip_permissions,
-            claude_model,
-            codex_model,
+            model.as_deref(),
             resume_requested,
             resume_transcript.is_some(),
         );
 
         let cli_cmd = cmd_parts.join(" ");
-        let full_cmd = format!("{}{}", env_setup, cli_cmd);
 
         info!(
             "Starting {} with command: {}",
@@ -1573,7 +1586,12 @@ impl InteractiveSessionManager {
         } else {
             // Env-setup path: wrap in `sh -c` so the inline `export FOO=bar; …`
             // gets evaluated. Use sh (not zsh) — no .zshrc, no race.
-            let full_line = format!("{env_setup}exec {cli_cmd}");
+            let escaped_cmd = cmd_parts
+                .iter()
+                .map(|part| shell_escape::escape(part.into()).into_owned())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let full_line = format!("{env_setup}exec {escaped_cmd}");
             Command::new("tmux")
                 .args(["respawn-pane", "-k", "-t", &target, "sh", "-c", &full_line])
                 .output()
@@ -1590,11 +1608,10 @@ impl InteractiveSessionManager {
         }
 
         info!(
-            "Started {} CLI in tmux session: {} (claude_model={:?}, codex_model={:?}, skip_permissions={})",
+            "Started {} CLI in tmux session: {} (model={:?}, skip_permissions={})",
             provider.display_name(),
             session_name,
-            claude_model,
-            codex_model,
+            model,
             skip_permissions
         );
         Ok(())
@@ -1681,11 +1698,11 @@ impl InteractiveSession {
         let mut session = Session::new_with_options(
             self.workspace_name.clone(),
             self.worktree_path.to_string_lossy().to_string(),
-            false, // skip_permissions
+            self.skip_permissions,
             SessionMode::Interactive,
             None, // boss_prompt
             self.agent_type,
-            self.model,
+            self.model.clone(),
         );
 
         session.id = self.session_id;
@@ -2060,6 +2077,85 @@ mod tests {
         std::env::remove_var("AINB_HOME");
     }
 
+    #[tokio::test]
+    async fn persisted_launch_settings_survive_live_session_discovery() {
+        use crate::models::session::SessionAgentType;
+        use chrono::Utc;
+        use tempfile::TempDir;
+
+        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+
+        let dir = TempDir::new().expect("tempdir");
+        std::env::set_var("AINB_HOME", dir.path());
+
+        let worktree = dir.path().join("worktree");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        let tmux_name = "tmux_persisted_launch_settings";
+
+        SessionStore::mutate(|store| {
+            store.upsert(SessionMetadata {
+                session_id: uuid::Uuid::new_v4(),
+                tmux_session_name: tmux_name.to_string(),
+                worktree_path: worktree,
+                workspace_name: "test".to_string(),
+                created_at: Utc::now(),
+                agent_type: SessionAgentType::Codex,
+                headroom_enabled: false,
+                rtk_enabled: false,
+                skip_permissions: Some(true),
+                model: Some("gpt-5.6-luna".to_string()),
+                codex_model: Some(CodexModel::Gpt55),
+            });
+        })
+        .expect("save");
+
+        let manager = InteractiveSessionManager::new().expect("manager");
+        let discovered = manager
+            .discover_session_from_tmux(tmux_name)
+            .await
+            .expect("discover persisted session");
+        let session = discovered.to_session_model();
+
+        assert!(
+            session.skip_permissions,
+            "live discovery must preserve dangerous-permissions launch setting"
+        );
+        assert_eq!(
+            session.model.as_deref(),
+            Some("gpt-5.6-luna"),
+            "live discovery must preserve model used by idle restart"
+        );
+
+        std::env::remove_var("AINB_HOME");
+    }
+
+    #[test]
+    fn legacy_typed_model_metadata_resolves_to_launch_ids() {
+        let claude: SessionMetadata = serde_json::from_value(serde_json::json!({
+            "session_id": uuid::Uuid::new_v4(),
+            "tmux_session_name": "tmux_legacy_claude",
+            "worktree_path": "/tmp/legacy-claude",
+            "workspace_name": "legacy",
+            "created_at": "2026-07-16T00:00:00Z",
+            "agent_type": "Claude",
+            "model": "Opus"
+        }))
+        .expect("legacy Claude metadata");
+        assert_eq!(claude.launch_model().as_deref(), Some("claude-opus-4-8"));
+
+        let codex: SessionMetadata = serde_json::from_value(serde_json::json!({
+            "session_id": uuid::Uuid::new_v4(),
+            "tmux_session_name": "tmux_legacy_codex",
+            "worktree_path": "/tmp/legacy-codex",
+            "workspace_name": "legacy",
+            "created_at": "2026-07-16T00:00:00Z",
+            "agent_type": "Codex",
+            "codex_model": "Gpt55"
+        }))
+        .expect("legacy Codex metadata");
+        assert_eq!(codex.launch_model().as_deref(), Some("gpt-5.5"));
+    }
+
     /// pu4: `SessionStore::mutate` must serialise concurrent load-modify-save
     /// through the cross-process lock so racing writers never lost-update the
     /// store. Two thread pools each upsert a disjoint set of keys into the SAME
@@ -2206,14 +2302,13 @@ mod tests {
     // ---- build_cli_cmd_parts: launch/resume argv assembly ------------------
 
     use crate::config::CliProvider;
-    use crate::models::{ClaudeModel, CodexModel, SessionAgentType};
+    use crate::models::{CodexModel, SessionAgentType};
 
     fn parts(
         provider: CliProvider,
         agent: SessionAgentType,
         skip: bool,
-        claude_model: Option<ClaudeModel>,
-        codex_model: Option<CodexModel>,
+        model: Option<&str>,
         resume: bool,
         has_history: bool,
     ) -> Vec<String> {
@@ -2221,8 +2316,7 @@ mod tests {
             &provider,
             agent,
             skip,
-            claude_model,
-            codex_model,
+            model,
             resume,
             has_history,
         )
@@ -2234,7 +2328,6 @@ mod tests {
             CliProvider::Claude,
             SessionAgentType::Claude,
             true,
-            None,
             None,
             false,
             false,
@@ -2248,7 +2341,6 @@ mod tests {
             CliProvider::Claude,
             SessionAgentType::Claude,
             true,
-            None,
             None,
             true,
             true,
@@ -2268,7 +2360,6 @@ mod tests {
             SessionAgentType::Claude,
             true,
             None,
-            None,
             true,
             false,
         );
@@ -2282,7 +2373,6 @@ mod tests {
             SessionAgentType::Claude,
             false,
             None,
-            None,
             true,
             true,
         );
@@ -2295,8 +2385,7 @@ mod tests {
             CliProvider::Claude,
             SessionAgentType::Claude,
             true,
-            Some(ClaudeModel::Opus),
-            None,
+            Some("opus"),
             true,
             true,
         );
@@ -2305,7 +2394,7 @@ mod tests {
             vec![
                 "claude",
                 "--model",
-                "claude-opus-4-8",
+                "opus",
                 "--dangerously-skip-permissions",
                 "--continue",
             ]
@@ -2319,7 +2408,6 @@ mod tests {
             CliProvider::Codex,
             SessionAgentType::Codex,
             true,
-            None,
             None,
             true,
             false,
@@ -2341,8 +2429,7 @@ mod tests {
             CliProvider::Codex,
             SessionAgentType::Codex,
             true,
-            None,
-            Some(CodexModel::Gpt55),
+            Some("gpt-5.6-luna"),
             true,
             false,
         );
@@ -2353,7 +2440,7 @@ mod tests {
                 "resume",
                 "--last",
                 "--model",
-                "gpt-5.5",
+                "gpt-5.6-luna",
                 "--dangerously-bypass-approvals-and-sandbox",
             ]
         );
@@ -2365,7 +2452,6 @@ mod tests {
             CliProvider::Codex,
             SessionAgentType::Codex,
             true,
-            None,
             None,
             false,
             false,
@@ -2384,7 +2470,6 @@ mod tests {
             SessionAgentType::Copilot,
             true,
             None,
-            None,
             true,
             false, // has_history irrelevant for copilot (no cwd probe)
         );
@@ -2397,7 +2482,6 @@ mod tests {
             CliProvider::Copilot,
             SessionAgentType::Copilot,
             true,
-            None,
             None,
             false,
             false,

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -65,7 +65,17 @@ pub struct InteractiveSession {
     pub rtk_enabled: bool,            // RTK PreToolUse hook wired in session's worktree
 }
 
-/// Persisted session metadata for discovery across restarts
+/// How the persisted model value should be interpreted.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelSource {
+    /// Metadata written before provider model IDs were stored verbatim.
+    #[default]
+    LegacyTyped,
+    /// Provider model ID supplied by the user and passed through unchanged.
+    Raw,
+}
+
+/// Persisted session metadata for discovery across restarts.
 ///
 /// This solves the branch-mismatch problem: when a user changes branches in a worktree,
 /// the old tmux session name no longer matches the current branch. By persisting the
@@ -93,6 +103,9 @@ pub struct SessionMetadata {
     pub skip_permissions: Option<bool>,
     #[serde(default)]
     pub model: Option<String>,
+    /// Distinguishes legacy typed model names from raw provider model IDs.
+    #[serde(default)]
+    pub model_source: ModelSource,
     /// Legacy Codex-only field. New writes use provider-agnostic `model`.
     #[serde(default)]
     pub codex_model: Option<CodexModel>,
@@ -101,20 +114,32 @@ pub struct SessionMetadata {
 impl SessionMetadata {
     /// Resolve the raw model value used for launch/restart.
     ///
-    /// New metadata stores the exact CLI value in `model`. Legacy enum values
-    /// serialized as strings are translated to their historical canonical IDs.
+    /// New metadata stores the exact CLI value in `model` and marks it `Raw`.
+    /// Legacy enum values serialized as strings are translated to historical IDs.
     /// Old Codex records stored their model in `codex_model`, so retain that
     /// fallback until the on-disk corpus has naturally migrated.
     pub fn launch_model(&self) -> Option<String> {
         if let Some(model) = self.model.as_deref() {
-            return normalize_persisted_model(self.agent_type, model);
+            return match self.model_source {
+                ModelSource::Raw => normalize_raw_model(model),
+                ModelSource::LegacyTyped => normalize_legacy_model(self.agent_type, model),
+            };
         }
 
         self.codex_model.and_then(|model| model.cli_value()).map(str::to_string)
     }
 }
 
-fn normalize_persisted_model(agent_type: SessionAgentType, value: &str) -> Option<String> {
+fn normalize_raw_model(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") {
+        return None;
+    }
+
+    Some(trimmed.to_string())
+}
+
+fn normalize_legacy_model(agent_type: SessionAgentType, value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") || trimmed == "SystemDefault" {
         return None;
@@ -478,6 +503,7 @@ impl InteractiveSessionManager {
             rtk_enabled,
             skip_permissions: Some(skip_permissions),
             model,
+            model_source: ModelSource::Raw,
             codex_model: None,
         };
         // Locked RMW so a concurrent `ainb kill` / recovery / daemon register
@@ -646,6 +672,7 @@ impl InteractiveSessionManager {
             rtk_enabled,
             skip_permissions: Some(skip_permissions),
             model,
+            model_source: ModelSource::Raw,
             codex_model: None,
         };
         // Locked RMW (pu4): serialise against concurrent kill/recovery writers.
@@ -2054,6 +2081,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         });
         store.save().expect("save");
@@ -2104,6 +2132,7 @@ mod tests {
                 rtk_enabled: false,
                 skip_permissions: Some(true),
                 model: Some("gpt-5.6-luna".to_string()),
+                model_source: ModelSource::Raw,
                 codex_model: Some(CodexModel::Gpt55),
             });
         })
@@ -2156,6 +2185,23 @@ mod tests {
         assert_eq!(codex.launch_model().as_deref(), Some("gpt-5.5"));
     }
 
+    #[test]
+    fn raw_model_metadata_preserves_provider_value() {
+        let metadata: SessionMetadata = serde_json::from_value(serde_json::json!({
+            "session_id": uuid::Uuid::new_v4(),
+            "tmux_session_name": "tmux_raw_claude",
+            "worktree_path": "/tmp/raw-claude",
+            "workspace_name": "raw",
+            "created_at": "2026-07-23T00:00:00Z",
+            "agent_type": "Claude",
+            "model": "Opus",
+            "model_source": "Raw"
+        }))
+        .expect("raw Claude metadata");
+
+        assert_eq!(metadata.launch_model().as_deref(), Some("Opus"));
+    }
+
     /// pu4: `SessionStore::mutate` must serialise concurrent load-modify-save
     /// through the cross-process lock so racing writers never lost-update the
     /// store. Two thread pools each upsert a disjoint set of keys into the SAME
@@ -2187,6 +2233,7 @@ mod tests {
             rtk_enabled: false,
             skip_permissions: None,
             model: None,
+            model_source: Default::default(),
             codex_model: None,
         };
 

--- a/ainb-tui/crates/ainb-core/src/models/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/models/mod.rs
@@ -11,6 +11,7 @@ pub mod usage_dir_watcher;
 pub mod workspace;
 
 pub use other_tmux::OtherTmuxSession;
+pub(crate) use session::is_default_model;
 pub use session::{
     ClaudeModel, CodexModel, GitChanges, Session, SessionAgentType, SessionMode, SessionStatus,
     ShellSession, ShellSessionStatus, SshTarget,

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -488,11 +488,9 @@ pub struct Session {
     #[serde(default)]
     pub agent_type: SessionAgentType, // The AI agent or shell for this session
     #[serde(default)]
-    pub model: Option<ClaudeModel>, // Claude model for this session (only for Claude agent)
-    /// Codex model (only meaningful when `agent_type == Codex`). Mirrors
-    /// `model` for the Claude agent: `Some(SystemDefault)` and `None` both
-    /// cause `--model` to be omitted from the spawned `codex` command;
-    /// anything else emits `--model <id>`.
+    pub model: Option<String>, // Raw provider model ID passed through to the CLI
+    /// Legacy Codex model field retained for old serialized Session values.
+    /// New launch paths use the provider-agnostic raw `model` field.
     #[serde(default)]
     pub codex_model: Option<CodexModel>,
     #[serde(default)]
@@ -710,7 +708,7 @@ impl Session {
         mode: SessionMode,
         boss_prompt: Option<String>,
         agent_type: SessionAgentType,
-        model: Option<ClaudeModel>,
+        model: Option<String>,
     ) -> Self {
         let now = Utc::now();
         let branch_name = format!("ainb/{}", name.replace(' ', "-").to_lowercase());

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -6,6 +6,12 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Whether a model value requests the provider's configured default.
+pub(crate) fn is_default_model(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default")
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SessionMode {
     // PascalCase variants are the canonical wire format for
@@ -815,5 +821,17 @@ impl Session {
     pub fn set_tmux_session_name(&mut self, name: String) {
         self.tmux_session_name = Some(name);
         self.update_last_accessed();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_default_model;
+
+    #[test]
+    fn default_model_sentinels_are_recognized_after_trimming() {
+        assert!(is_default_model(""));
+        assert!(is_default_model("  DEFAULT  "));
+        assert!(!is_default_model("claude-opus-4-8"));
     }
 }

--- a/ainb-tui/crates/ainb-core/tests/behavioral/session_lifecycle.rs
+++ b/ainb-tui/crates/ainb-core/tests/behavioral/session_lifecycle.rs
@@ -68,7 +68,7 @@ fn test_session_serialization_roundtrip_preserves_all_fields() {
         SessionMode::Boss,
         Some("Implement feature X".to_string()), // boss_prompt
         SessionAgentType::Claude,
-        Some(ClaudeModel::Opus),
+        Some("claude-opus-4-8".to_string()),
     );
 
     // Manually set additional fields that new_with_options doesn't set

--- a/ainb-tui/crates/ainb-core/tests/behavioral/session_persistence.rs
+++ b/ainb-tui/crates/ainb-core/tests/behavioral/session_persistence.rs
@@ -25,6 +25,7 @@ fn create_session_metadata(
         rtk_enabled: false,
         skip_permissions: None,
         model: None,
+        model_source: Default::default(),
         codex_model: None,
     }
 }
@@ -47,6 +48,7 @@ fn create_session_metadata_with_id(
         rtk_enabled: false,
         skip_permissions: None,
         model: None,
+        model_source: Default::default(),
         codex_model: None,
     }
 }

--- a/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
+++ b/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
@@ -57,6 +57,7 @@ async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
         rtk_enabled: false,
         skip_permissions: None,
         model: None,
+        model_source: Default::default(),
         codex_model: None,
     });
     store.upsert(SessionMetadata {
@@ -70,6 +71,7 @@ async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
         rtk_enabled: false,
         skip_permissions: None,
         model: None,
+        model_source: Default::default(),
         codex_model: None,
     });
     store.save()?;

--- a/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
+++ b/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
@@ -50,6 +50,7 @@ fn kill(name: &str) {
 async fn launched_command(
     name: &str,
     agent: SessionAgentType,
+    model: Option<&str>,
     resume_transcript: Option<PathBuf>,
     resume_requested: bool,
 ) -> String {
@@ -57,8 +58,7 @@ async fn launched_command(
     mgr.start_cli_in_tmux(
         name,
         true, // skip_permissions (yolo)
-        None, // claude_model
-        None, // codex_model
+        model.map(str::to_string),
         agent,
         resume_transcript,
         resume_requested,
@@ -82,6 +82,7 @@ async fn claude_resume_launches_continue_not_resume_path() {
     let cmd = launched_command(
         &name,
         SessionAgentType::Claude,
+        None,
         Some(PathBuf::from("/tmp/whatever.jsonl")),
         true,
     )
@@ -112,7 +113,14 @@ async fn codex_resume_launches_resume_last() {
     let name = format!("ainb-verify-codex-{}", std::process::id());
     new_session(&name);
     // Codex gets no transcript path; resume_requested drives `resume --last`.
-    let cmd = launched_command(&name, SessionAgentType::Codex, None, true).await;
+    let cmd = launched_command(
+        &name,
+        SessionAgentType::Codex,
+        Some("gpt-5.6-luna"),
+        None,
+        true,
+    )
+    .await;
     kill(&name);
 
     assert!(
@@ -122,6 +130,10 @@ async fn codex_resume_launches_resume_last() {
     assert!(
         cmd.contains("--dangerously-bypass-approvals-and-sandbox"),
         "codex yolo flag must survive resume, got: {cmd}"
+    );
+    assert!(
+        cmd.contains("--model gpt-5.6-luna"),
+        "raw Codex model must survive resume, got: {cmd}"
     );
 }
 
@@ -133,7 +145,7 @@ async fn copilot_resume_launches_continue() {
     }
     let name = format!("ainb-verify-copilot-{}", std::process::id());
     new_session(&name);
-    let cmd = launched_command(&name, SessionAgentType::Copilot, None, true).await;
+    let cmd = launched_command(&name, SessionAgentType::Copilot, None, None, true).await;
     kill(&name);
 
     assert!(
@@ -154,7 +166,7 @@ async fn claude_fresh_launch_has_no_resume() {
     }
     let name = format!("ainb-verify-fresh-{}", std::process::id());
     new_session(&name);
-    let cmd = launched_command(&name, SessionAgentType::Claude, None, false).await;
+    let cmd = launched_command(&name, SessionAgentType::Claude, None, None, false).await;
     kill(&name);
 
     assert!(

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -88,7 +88,7 @@ Options:
       --create-branch <CREATE_BRANCH>  Create a new branch with this name
       --worktree                       Use git worktree for isolation
       --tool <TOOL>                    AI tool to use [default: claude] [possible values: claude, codex, gemini, copilot]
-      --model <MODEL>                  Model to use (sonnet, opus, haiku) [default: sonnet]
+      --model <MODEL>                  Provider model ID to pass through unchanged
   -p, --prompt <PROMPT>                Initial prompt to send
   -a, --attach                         Attach to session after creation
       --dangerously-skip-permissions   Skip permission prompts (dangerous!)
@@ -3174,6 +3174,8 @@ Commands:
   stop     Stop the running daemon: signal the exact recorded PID, then remove the PID file
   restart  Restart the daemon: `stop` (if running) then `start`
   setup    One-command bring-up: ensure the store + socket-auth token, then `start`
+  config   View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+  cred     Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3281,6 +3283,48 @@ $ ainb hangar daemon setup --help
 One-command bring-up: ensure the store + socket-auth token, then `start`
 
 Usage: ainb hangar daemon setup [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar daemon config`
+
+View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+
+```console
+$ ainb hangar daemon config --help
+View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+
+Usage: ainb hangar daemon config [OPTIONS] <COMMAND>
+
+Commands:
+  list  List every configurable: key, current value (or default), default, type
+  get   Print one knob's current value (or its default when unset)
+  set   Validate + persist one knob's value (rejects unknown keys / bad values)
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar daemon cred`
+
+Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
+
+```console
+$ ainb hangar daemon cred --help
+Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
+
+Usage: ainb hangar daemon cred [OPTIONS] <COMMAND>
+
+Commands:
+  status  Report whether a credential is configured and where it resolves from (env override / secret store / not set). Never prints the value
+  set     Store a long-lived token. Reads the token from STDIN by default (so it never lands on argv or in shell history); `--setup-token` instead drives the interactive `claude setup-token` browser flow and captures the result
+  clear   Remove the stored credential. Idempotent
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -3526,6 +3570,7 @@ Edit, archive, and list workspace agents
 Usage: ainb hangar agent [OPTIONS] <COMMAND>
 
 Commands:
+  create     Create a new agent from scratch (fills workspace/runtime/owner behind the scenes)
   list       List the workspace's agents (active by default; `--all` includes archived)
   edit       Edit an agent's config knobs (model / args / MCP / thinking / env / name)
   archive    Archive an agent (hide it from the active picker)
@@ -3535,6 +3580,25 @@ Commands:
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
   -h, --help             Print help
+```
+
+#### `ainb hangar agent create`
+
+Create a new agent from scratch (fills workspace/runtime/owner behind the scenes)
+
+```console
+$ ainb hangar agent create --help
+Create a new agent from scratch (fills workspace/runtime/owner behind the scenes)
+
+Usage: ainb hangar agent create [OPTIONS] --name <NAME>
+
+Options:
+      --format <format>              Output format [default: text] [possible values: text, json, csv, markdown]
+      --name <NAME>                  The new agent's name
+      --provider <PROVIDER>          Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`
+      --instructions <INSTRUCTIONS>  Optional instructions / system prompt for the agent
+      --workspace <WORKSPACE>        Workspace slug to create the agent in. Defaults to the bootstrapped `default` workspace (created if absent)
+  -h, --help                         Print help
 ```
 
 #### `ainb hangar agent list`


### PR DESCRIPTION
## Summary

- pass arbitrary Claude and Codex model IDs through unchanged instead of mapping them through local closed enums
- persist model and permission settings in session metadata, including legacy metadata fallback
- replay original launch settings when stopped, idle, or downgraded sessions restart
- resume Codex with `--dangerously-bypass-approvals-and-sandbox` when session originally used skipped permissions

## Verification

- `cargo check -p ainb --lib`
- targeted CLI command, metadata compatibility, discovery, resume-order, stopped-session, and serialization tests
- real tmux integration verified restarted Codex pane argv contains `resume --last --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox`

## Known baseline failures

Full library suite reached 1594 passed, 8 failed, 2 ignored. Failures are unrelated existing onboarding/headroom tests; six cascade from poisoned `HEADROOM_ENV_LOCK`. `cargo check -p ainb --tests` also reaches an unrelated existing `SourceRow` initializer drift in `tripwire_core_skill_manager_drift_column.rs`.

Closes agents-in-a-box-cpy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `ainb run --model` to accept provider-agnostic raw model IDs (including future identifiers) and preserve them through creation, recovery, resume, restart, and discovery.
  * Updated CLI help/docs to reflect the new `--model` behavior.
* **Bug Fixes**
  * Improved tmux resume/restart safety by escaping command arguments; restart now correctly respawns dead panes with the proper saved model settings.
* **Refactor**
  * Unified model handling across launch, persistence, and session recovery using a single raw model identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->