### PR TITLE
fix(codex-statusline): route wham windows by limit_window_seconds

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
@@ -130,6 +130,11 @@ struct WhamWindow {
     /// payloads → the TUI just omits the `↻ <reset>` affordance.
     #[serde(default)]
     reset_at: Option<i64>,
+    /// Length of the rate-limit window in seconds (`18000` = 5h,
+    /// `604800` = weekly). This is what tells the 5h window apart from the
+    /// weekly one — the position in the payload does NOT (see `parse_usage`).
+    #[serde(default)]
+    limit_window_seconds: Option<i64>,
 }
 
 impl WhamWindow {
@@ -143,25 +148,53 @@ impl WhamWindow {
     }
 }
 
+/// Windows at or above this length (seconds) are the weekly bucket;
+/// shorter ones are the 5h bucket. Splits `18000` (5h) from `604800`
+/// (weekly) with a full day of slack on either side.
+const WEEKLY_WINDOW_MIN_SECONDS: i64 = 86_400;
+
 /// Parse a `wham/usage` response body into a populated `CodexLiveCache`.
 ///
-/// `primary_window` → 5h, `secondary_window` → weekly (matches the
-/// endpoint's window semantics: primary `limit_window_seconds` 18000,
-/// secondary 604800). Returns `Err` only when the body is not valid JSON;
-/// a well-formed body that simply lacks `rate_limit` yields a cache with
-/// both windows `None` (a valid "logged in but no quota data" state).
+/// Windows are routed by `limit_window_seconds`, NOT by position: the
+/// endpoint moves the sole window between `primary_window` and
+/// `secondary_window` across plan tiers (e.g. `prolite` returns a
+/// weekly-only window in `primary_window` with `secondary_window: null`),
+/// so a positional map mislabels the weekly window as 5h. A window whose
+/// length is `>= WEEKLY_WINDOW_MIN_SECONDS` fills the weekly slot, else the
+/// 5h slot; when `limit_window_seconds` is absent we fall back to position
+/// (primary → 5h, secondary → weekly).
+///
+/// Returns `Err` only when the body is not valid JSON; a well-formed body
+/// that simply lacks `rate_limit` yields a cache with both windows `None`
+/// (a valid "logged in but no quota data" state).
 ///
 /// `now_rfc3339` is injected so tests are deterministic; production passes
 /// `chrono::Utc::now().to_rfc3339()`.
 pub fn parse_usage(body: &str, now_rfc3339: String) -> Result<CodexLiveCache> {
     let usage: WhamUsage = serde_json::from_str(body)?;
-    let (five_hour, seven_day) = match usage.rate_limit {
-        Some(rl) => (
-            rl.primary_window.and_then(|w| w.to_rate_window()),
-            rl.secondary_window.and_then(|w| w.to_rate_window()),
-        ),
-        None => (None, None),
-    };
+    let mut five_hour = None;
+    let mut seven_day = None;
+    if let Some(rl) = usage.rate_limit {
+        for (window, is_primary) in [(rl.primary_window, true), (rl.secondary_window, false)] {
+            let Some(w) = window else { continue };
+            let is_weekly = match w.limit_window_seconds {
+                Some(secs) => secs >= WEEKLY_WINDOW_MIN_SECONDS,
+                None => !is_primary,
+            };
+            let Some(rw) = w.to_rate_window() else {
+                continue;
+            };
+            let slot = if is_weekly {
+                &mut seven_day
+            } else {
+                &mut five_hour
+            };
+            // First window to claim a slot keeps it: if the API ever put two
+            // windows in the same bucket, the earlier (primary) one wins
+            // rather than being overwritten by the later one.
+            slot.get_or_insert(rw);
+        }
+    }
     Ok(CodexLiveCache {
         version: CODEX_CACHE_SCHEMA_VERSION,
         updated_at: now_rfc3339,

--- a/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
@@ -418,6 +418,37 @@ mod tests {
         );
     }
 
+    /// The live `prolite` shape as of 2026-07: a single weekly-only window
+    /// in `primary_window` (`limit_window_seconds` 604800) with
+    /// `secondary_window: null`. Positional mapping would mislabel this as
+    /// 5h; routing by `limit_window_seconds` puts it in the weekly slot.
+    const PROLITE_WEEKLY_ONLY_BODY: &str = r#"{
+        "plan_type": "prolite",
+        "rate_limit": {
+            "allowed": true,
+            "primary_window": {
+                "used_percent": 1,
+                "limit_window_seconds": 604800,
+                "reset_at": 1784718621
+            },
+            "secondary_window": null
+        }
+    }"#;
+
+    #[test]
+    fn parse_usage_routes_weekly_only_window_to_weekly_slot() {
+        let c = parse_usage(PROLITE_WEEKLY_ONLY_BODY, "now".to_string()).expect("parses");
+        assert!(c.five_hour.is_none(), "no 5h window on this tier");
+        let wk = c.seven_day.expect("weekly present in primary_window");
+        assert_eq!(wk.pct, 1);
+        assert_eq!(
+            chrono::DateTime::parse_from_rfc3339(wk.resets_at.as_ref().unwrap())
+                .unwrap()
+                .timestamp(),
+            1784718621
+        );
+    }
+
     #[test]
     fn parse_usage_rounds_fractional_percent() {
         let body =

--- a/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
@@ -17,9 +17,11 @@
 //       originator: codex_cli_rs                 (else Cloudflare 403s)
 //
 //   → `rate_limit.{primary_window,secondary_window}.{used_percent,
-//      reset_at}` where primary = 5h (limit_window_seconds 18000),
-//      secondary = weekly (604800), and `reset_at` is an absolute Unix
-//      epoch.
+//      reset_at,limit_window_seconds}` where `reset_at` is an absolute
+//      Unix epoch. The 5h vs weekly window is identified by
+//      `limit_window_seconds` (18000 vs 604800), NOT by primary/secondary
+//      position: some tiers (e.g. prolite) return a weekly-only window in
+//      `primary_window` with `secondary_window: null`. See `parse_usage`.
 //
 // Design constraints:
 //   - This is the single pull command; both drivers (the Codex `stop`

--- a/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
@@ -442,9 +442,11 @@ mod tests {
         let wk = c.seven_day.expect("weekly present in primary_window");
         assert_eq!(wk.pct, 1);
         assert_eq!(
-            chrono::DateTime::parse_from_rfc3339(wk.resets_at.as_ref().unwrap())
-                .unwrap()
-                .timestamp(),
+            chrono::DateTime::parse_from_rfc3339(
+                wk.resets_at.as_ref().expect("weekly reset_at present")
+            )
+            .expect("resets_at is valid RFC3339")
+            .timestamp(),
             1784718621
         );
     }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
@@ -84,6 +84,30 @@ fn seed_codex_cache(home: &Path, five_pct: u8, week_pct: u8) {
     fs::write(cache_dir.join("codex-live.json"), json).unwrap();
 }
 
+/// Write a `codex-live.json` with ONLY a `seven_day` (weekly) window —
+/// no `five_hour` key at all. Reproduces the real prolite bug: a plan
+/// where the five-hour window is simply absent from the cache.
+fn seed_codex_cache_weekly_only(home: &Path, week_pct: u8) {
+    let cache_dir = if cfg!(target_os = "macos") {
+        home.join("Library").join("Caches").join("ainb")
+    } else {
+        home.join(".cache").join("ainb")
+    };
+    fs::create_dir_all(&cache_dir).unwrap();
+    let now = chrono::Utc::now();
+    let updated = now.to_rfc3339();
+    let reset_wk = (now + chrono::Duration::days(4)).to_rfc3339();
+    let json = format!(
+        r#"{{
+  "version": 1,
+  "updated_at": "{updated}",
+  "seven_day": {{ "pct": {week_pct}, "resets_at": "{reset_wk}" }},
+  "plan_type": "prolite"
+}}"#
+    );
+    fs::write(cache_dir.join("codex-live.json"), json).unwrap();
+}
+
 fn is_on_sessions_screen(c: &str) -> bool {
     c.contains("Session Details")
         || c.contains("Select a session to view details")
@@ -247,5 +271,57 @@ fn tui_top_bar_hides_codex_when_no_cache() {
     assert!(
         !cap.contains("codex 5h"),
         "codex segment rendered despite no cache / no auth (hide-on-fail broken).\n{cap}"
+    );
+}
+
+/// The real prolite bug: a cache with ONLY `seven_day` (weekly) present,
+/// no `five_hour` key at all. The status bar must render `codex wk NN% ↻`
+/// and MUST NOT emit any `codex 5h` segment.
+#[test]
+fn tui_top_bar_shows_codex_weekly_only() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+    seed_codex_cache_weekly_only(home_tmp.path(), 7);
+
+    let session = format!("tripwire-codex-wkonly-{}", std::process::id());
+    let _guard = TmuxSessionGuard {
+        name: session.clone(),
+    };
+
+    launch_and_goto_sessions(home_tmp.path(), &session);
+
+    // The watcher refreshes the snapshot every 5s; give it a few ticks to
+    // overlay the seeded codex cache and the status bar to repaint. The
+    // rendered cluster should be `codex wk 7% ↻ …` with no `5h` segment.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let shown = poll(&session, deadline, |c| {
+        c.contains("codex") && c.contains("wk") && c.contains("7%")
+    });
+
+    let final_cap = shown.unwrap_or_else(|| capture(&session));
+    assert!(
+        final_cap.contains("codex"),
+        "codex cluster never rendered on the top bar.\n{final_cap}"
+    );
+    assert!(
+        final_cap.contains("wk"),
+        "codex weekly window (wk) not rendered.\n{final_cap}"
+    );
+    assert!(
+        final_cap.contains("7%"),
+        "codex weekly percentage (7%) not visible.\n{final_cap}"
+    );
+    assert!(
+        final_cap.contains('↻'),
+        "codex reset stamp (↻) not visible.\n{final_cap}"
+    );
+    assert!(
+        !final_cap.contains("codex 5h"),
+        "weekly-only cache must never produce a 5h segment.\n{final_cap}"
     );
 }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
@@ -85,8 +85,8 @@ fn seed_codex_cache(home: &Path, five_pct: u8, week_pct: u8) {
 }
 
 /// Write a `codex-live.json` with ONLY a `seven_day` (weekly) window —
-/// no `five_hour` key at all. Reproduces the real prolite bug: a plan
-/// where the five-hour window is simply absent from the cache.
+/// no `five_hour` key at all: the cache shape a prolite plan produces
+/// once `parse_usage` routes windows by `limit_window_seconds`.
 fn seed_codex_cache_weekly_only(home: &Path, week_pct: u8) {
     let cache_dir = if cfg!(target_os = "macos") {
         home.join("Library").join("Caches").join("ainb")
@@ -274,9 +274,11 @@ fn tui_top_bar_hides_codex_when_no_cache() {
     );
 }
 
-/// The real prolite bug: a cache with ONLY `seven_day` (weekly) present,
-/// no `five_hour` key at all. The status bar must render `codex wk NN% ↻`
-/// and MUST NOT emit any `codex 5h` segment.
+/// Render-path assertion for a weekly-only cache (the prolite shape):
+/// ONLY `seven_day` present, no `five_hour` key. The status bar must
+/// render `codex wk NN% ↻` and MUST NOT emit any `codex 5h` segment.
+/// The parse-side regression guard is the unit test
+/// `parse_usage_routes_weekly_only_window_to_weekly_slot`.
 #[test]
 fn tui_top_bar_shows_codex_weekly_only() {
     if !tmux_available() {

--- a/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
@@ -60,34 +60,10 @@ git_directories = []
 /// Write a fresh `codex-live.json` into the isolated cache dir (macOS:
 /// `~/Library/Caches/ainb`, Linux: `~/.cache/ainb`). `updated_at` is set
 /// to now so the reader treats it as fresh AND the poller throttle skips a
-/// clobbering write.
-fn seed_codex_cache(home: &Path, five_pct: u8, week_pct: u8) {
-    let cache_dir = if cfg!(target_os = "macos") {
-        home.join("Library").join("Caches").join("ainb")
-    } else {
-        home.join(".cache").join("ainb")
-    };
-    fs::create_dir_all(&cache_dir).unwrap();
-    let now = chrono::Utc::now();
-    let updated = now.to_rfc3339();
-    let reset_5h = (now + chrono::Duration::hours(3)).to_rfc3339();
-    let reset_wk = (now + chrono::Duration::days(4)).to_rfc3339();
-    let json = format!(
-        r#"{{
-  "version": 1,
-  "updated_at": "{updated}",
-  "five_hour": {{ "pct": {five_pct}, "resets_at": "{reset_5h}" }},
-  "seven_day": {{ "pct": {week_pct}, "resets_at": "{reset_wk}" }},
-  "plan_type": "prolite"
-}}"#
-    );
-    fs::write(cache_dir.join("codex-live.json"), json).unwrap();
-}
-
-/// Write a `codex-live.json` with ONLY a `seven_day` (weekly) window —
-/// no `five_hour` key at all: the cache shape a prolite plan produces
-/// once `parse_usage` routes windows by `limit_window_seconds`.
-fn seed_codex_cache_weekly_only(home: &Path, week_pct: u8) {
+/// clobbering write. `five_pct: None` omits the `five_hour` key entirely —
+/// the cache shape a prolite plan produces once `parse_usage` routes
+/// windows by `limit_window_seconds`.
+fn seed_codex_cache(home: &Path, five_pct: Option<u8>, week_pct: u8) {
     let cache_dir = if cfg!(target_os = "macos") {
         home.join("Library").join("Caches").join("ainb")
     } else {
@@ -97,10 +73,16 @@ fn seed_codex_cache_weekly_only(home: &Path, week_pct: u8) {
     let now = chrono::Utc::now();
     let updated = now.to_rfc3339();
     let reset_wk = (now + chrono::Duration::days(4)).to_rfc3339();
+    let five_hour_line = five_pct
+        .map(|pct| {
+            let reset_5h = (now + chrono::Duration::hours(3)).to_rfc3339();
+            format!("\n  \"five_hour\": {{ \"pct\": {pct}, \"resets_at\": \"{reset_5h}\" }},")
+        })
+        .unwrap_or_default();
     let json = format!(
         r#"{{
   "version": 1,
-  "updated_at": "{updated}",
+  "updated_at": "{updated}",{five_hour_line}
   "seven_day": {{ "pct": {week_pct}, "resets_at": "{reset_wk}" }},
   "plan_type": "prolite"
 }}"#
@@ -200,7 +182,7 @@ fn tui_top_bar_shows_codex_quota_when_cache_present() {
 
     let home_tmp = tempfile::tempdir().expect("home tempdir");
     seed_isolated_home(home_tmp.path());
-    seed_codex_cache(home_tmp.path(), 24, 50);
+    seed_codex_cache(home_tmp.path(), Some(24), 50);
 
     let session = format!("tripwire-codex-{}", std::process::id());
     let _guard = TmuxSessionGuard {
@@ -288,7 +270,7 @@ fn tui_top_bar_shows_codex_weekly_only() {
 
     let home_tmp = tempfile::tempdir().expect("home tempdir");
     seed_isolated_home(home_tmp.path());
-    seed_codex_cache_weekly_only(home_tmp.path(), 7);
+    seed_codex_cache(home_tmp.path(), None, 7);
 
     let session = format!("tripwire-codex-wkonly-{}", std::process::id());
     let _guard = TmuxSessionGuard {


### PR DESCRIPTION
## Problem
TUI top bar showed Codex weekly quota as a 5h window. The wham/usage endpoint moves the sole rate-limit window between `primary_window` and `secondary_window` across plan tiers: prolite returns a weekly-only window (`limit_window_seconds` 604800) in `primary_window` with `secondary_window: null`. The positional primary→5h / secondary→weekly map mislabeled it.

## Fix
Route each window by `limit_window_seconds` (>= 86400 → weekly, else 5h); positional fallback when the field is absent; first non-empty window wins each slot.

## Validation
- 11/11 unit tests incl. new prolite weekly-only regression; old positional fixture still routes correctly (backward compat)
- Live pull: `ainb codex statusline --force` now writes `seven_day`, no `five_hour`
- New tmux tripwire: real TUI renders `codex wk 7% ↻ …`, never a bogus `codex 5h`
- Adversarial review: SHIP; threshold 86400 splits 18000/604800 with a day of slack each side

https://claude.ai/code/session_018iq2MJFQzjo8dTrdayqNAc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex rate-limit window detection across 5-hour and weekly usage periods.
  * Correctly supports weekly-only usage data and displays the weekly status without showing an unavailable 5-hour limit.
  * Preserved accurate usage percentages and reset indicators in the status bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->