### PR TITLE
feat(hangar): daemon-health pane screams on db drift instead of silent zeros

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4029,6 +4029,10 @@ async fn daemon_health_snapshot(
         claim_cache: health.stats.claim_cache(concurrent_tasks),
         concurrent_tasks,
         task_throughput_60s: health.stats.throughput_window(now_sec),
+        daemon_version: health.version.clone(),
+        // Live drift probe: a stale daemon serving a newer database (or a dead
+        // database file) must surface as a loud banner, not silent zero stats.
+        db_error: ainb_hangar_store::schema_drift(pool).await,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/settings.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/settings.rs
@@ -138,6 +138,21 @@ pub struct DaemonHealthSnapshot {
     /// The rolling per-second throughput window — exactly [`THROUGHPUT_WINDOW`]
     /// samples, oldest-first, the last sample being the most recent whole second.
     pub task_throughput_60s: Vec<ThroughputSample>,
+    /// The answering daemon's version string.
+    ///
+    /// `#[serde(default)]` so a snapshot from a daemon that predates this field
+    /// still decodes — the empty string is itself the signal the pane renders as
+    /// "stale daemon binary".
+    #[serde(default)]
+    pub daemon_version: String,
+    /// Live database-drift diagnosis, `None` when healthy.
+    ///
+    /// `Some` when the applied schema is AHEAD of the answering binary's
+    /// embedded migrations (a stale daemon serving a newer database — every
+    /// pane silently renders zeros) or when the probe query fails outright.
+    /// The pane renders this as a loud red banner instead of empty stats.
+    #[serde(default)]
+    pub db_error: Option<String>,
 }
 
 #[cfg(test)]
@@ -166,12 +181,32 @@ mod tests {
                     failed: u32::from(i == 30),
                 })
                 .collect(),
+            daemon_version: "1.16.0 (abc1234, 2026-07-17, source)".into(),
+            db_error: Some("database schema (migration 41) is AHEAD".into()),
         };
         let s = serde_json::to_string(&snap).unwrap();
         let back: DaemonHealthSnapshot = serde_json::from_str(&s).unwrap();
         assert_eq!(back, snap);
         assert_eq!(back.task_throughput_60s.len(), THROUGHPUT_WINDOW);
         assert_eq!(back.task_throughput_60s[30].failed, 1);
+    }
+
+    /// A snapshot from a daemon that PREDATES the `daemon_version` / `db_error`
+    /// fields still decodes — with the empty-version sentinel the pane renders
+    /// as "stale daemon binary". Tolerant decode is the whole point of the
+    /// serde defaults: the old-daemon case is exactly the one that must not
+    /// fail to parse.
+    #[test]
+    fn daemon_health_snapshot_decodes_pre_version_wire() {
+        let old_wire = r#"{
+            "runtimes": [],
+            "claim_cache": {"used": 0, "capacity": 64},
+            "concurrent_tasks": 0,
+            "task_throughput_60s": []
+        }"#;
+        let back: DaemonHealthSnapshot = serde_json::from_str(old_wire).unwrap();
+        assert_eq!(back.daemon_version, "");
+        assert_eq!(back.db_error, None);
     }
 
     /// The settings snapshots round-trip through JSON.

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -93,3 +93,40 @@ pub async fn apply_migrations(pool: &SqlitePool) -> anyhow::Result<()> {
     sqlx::migrate!("./migrations").run(pool).await?;
     Ok(())
 }
+
+/// Probe whether the LIVE database has drifted away from the schema this
+/// binary was compiled against, returning a human-readable description of the
+/// drift (or the probe failure) — `None` means healthy.
+///
+/// The trap this catches: a stale daemon binary keeps serving a database that
+/// a NEWER binary has since migrated forward. `sqlx` only validates migrations
+/// at pool-open, so the running daemon never notices — its queries half-work
+/// against the newer schema and every surface renders empty zeros instead of
+/// an error. The daemon-health snapshot calls this on demand so the TUI can
+/// scream "restart the daemon" instead of rendering a silently-blank pane.
+///
+/// Two signals, both folded into the returned string:
+/// - the applied `MAX(version)` in `_sqlx_migrations` is AHEAD of the newest
+///   migration embedded in this binary → stale binary;
+/// - the probe query itself fails (file deleted, corrupt, locked) → the
+///   database is unreachable outright.
+pub async fn schema_drift(pool: &SqlitePool) -> Option<String> {
+    let embedded_max = sqlx::migrate!("./migrations")
+        .iter()
+        .map(|m| m.version)
+        .max()
+        .unwrap_or(0);
+    let applied_max: Result<Option<i64>, sqlx::Error> =
+        sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations")
+            .fetch_one(pool)
+            .await;
+    match applied_max {
+        Ok(Some(applied)) if applied > embedded_max => Some(format!(
+            "database schema (migration {applied}) is AHEAD of this daemon binary \
+             (migration {embedded_max}) — stale binary; restart the daemon from the \
+             current build"
+        )),
+        Ok(_) => None,
+        Err(e) => Some(format!("database unreachable: {e}")),
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/schema_drift.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/schema_drift.rs
@@ -1,0 +1,75 @@
+//! Tripwire for [`ainb_hangar_store::schema_drift`] — the stale-daemon
+//! detector behind the daemon-health pane's red banner.
+//!
+//! The trap it guards: a stale daemon binary keeps serving a database a NEWER
+//! binary has migrated forward. `sqlx` only validates at pool-open, so the old
+//! daemon never errors — every pane just renders silent zeros. The probe must
+//! flag "applied schema AHEAD of this binary"; deleting the probe (or stubbing
+//! it to `None`) turns `applied_ahead_of_binary_is_drift` RED.
+
+use ainb_hangar_store::{apply_migrations, schema_drift};
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use std::str::FromStr;
+
+/// Open a fresh on-disk `SQLite` pool inside a tempdir and apply all migrations.
+async fn fresh_pool(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", db_path.display()))
+        .expect("valid sqlite url")
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+    apply_migrations(&pool).await.expect("migrations apply");
+    pool
+}
+
+/// A freshly migrated database is exactly at this binary's schema: no drift.
+#[tokio::test]
+async fn fresh_database_reports_no_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = fresh_pool(dir.path()).await;
+    assert_eq!(schema_drift(&pool).await, None);
+}
+
+/// A database whose applied `MAX(version)` is AHEAD of this binary's embedded
+/// migrations (i.e. a newer binary migrated it) is flagged as drift, naming
+/// both versions so the banner tells the operator exactly what happened.
+#[tokio::test]
+async fn applied_ahead_of_binary_is_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = fresh_pool(dir.path()).await;
+
+    // Simulate a newer binary having migrated the DB forward: record a future
+    // migration version directly in the sqlx ledger.
+    sqlx::query(
+        "INSERT INTO _sqlx_migrations \
+         (version, description, installed_on, success, checksum, execution_time) \
+         VALUES (999999, 'from_the_future', CURRENT_TIMESTAMP, TRUE, x'00', 0)",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert future migration row");
+
+    let drift = schema_drift(&pool).await.expect("future schema must be flagged");
+    assert!(
+        drift.contains("999999") && drift.contains("AHEAD"),
+        "drift message must name the future version: {drift}"
+    );
+}
+
+/// A dead database (probe query cannot run) is drift too — the banner must
+/// fire on outright unreachability, not only on version skew.
+#[tokio::test]
+async fn missing_ledger_is_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = fresh_pool(dir.path()).await;
+    sqlx::query("DROP TABLE _sqlx_migrations")
+        .execute(&pool)
+        .await
+        .expect("drop ledger");
+    let drift = schema_drift(&pool).await.expect("dead ledger must be flagged");
+    assert!(
+        drift.contains("unreachable"),
+        "probe failure must read as unreachable: {drift}"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/daemon_health.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/daemon_health.rs
@@ -45,6 +45,14 @@ pub struct DaemonHealthState {
     concurrent_tasks: u32,
     /// The rolling per-second throughput window (oldest-first).
     throughput: Vec<ThroughputSample>,
+    /// The answering daemon's version string. Empty when the daemon predates
+    /// version reporting — rendered as a loud "stale daemon binary" warning,
+    /// because a pre-field daemon is by definition an old build.
+    daemon_version: String,
+    /// Live database-drift diagnosis from the daemon (`None` = healthy).
+    /// `Some` renders as a red banner ABOVE the stats: zeros under a dead
+    /// database are lies, and the banner says so.
+    db_error: Option<String>,
 }
 
 impl DaemonHealthState {
@@ -57,7 +65,15 @@ impl DaemonHealthState {
             claim_capacity: snap.claim_cache.capacity,
             concurrent_tasks: snap.concurrent_tasks,
             throughput: snap.task_throughput_60s,
+            daemon_version: snap.daemon_version,
+            db_error: snap.db_error,
         }
+    }
+
+    /// The database-drift banner text, if any (read accessor for tests / glue).
+    #[must_use]
+    pub fn db_error(&self) -> Option<&str> {
+        self.db_error.as_deref()
     }
 
     /// The registered runtimes (read accessor for tests / glue).
@@ -103,7 +119,42 @@ pub fn render_daemon_health(
 ) {
     let mut row = top;
     put_str(buf, 0, row, "Daemon health", GOLD, area_w);
-    row += 2;
+    row += 1;
+
+    // Daemon version line — the eyeball check for "am I talking to the build I
+    // think I am?". An EMPTY version means the daemon predates version
+    // reporting, which is by definition a stale binary: warn loudly.
+    if row <= bottom {
+        if state.daemon_version.is_empty() {
+            put_str(
+                buf,
+                0,
+                row,
+                "⚠ daemon predates version reporting — stale binary; restart the daemon",
+                OFFLINE_RED,
+                area_w,
+            );
+        } else {
+            let x = put_str(buf, 0, row, "daemon: ", MUTED_GRAY, area_w);
+            put_str(buf, x, row, &state.daemon_version, SOFT_WHITE, area_w);
+        }
+        row += 1;
+    }
+
+    // Database-drift banner (red, ABOVE the stats): when the daemon reports its
+    // database is dead or ahead of its binary, the zeros below are lies — say
+    // so instead of rendering a silently-blank pane.
+    if let Some(err) = &state.db_error {
+        if row <= bottom {
+            put_str(buf, 0, row, "✗ DATABASE UNREACHABLE", OFFLINE_RED, area_w);
+            row += 1;
+        }
+        if row <= bottom {
+            put_str(buf, 2, row, err, OFFLINE_RED, area_w);
+            row += 1;
+        }
+    }
+    row += 1;
 
     // Runtimes list (one row each): `runtime: <provider>  ● <status>  pid <pid>`.
     if state.runtimes.is_empty() {

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_daemon_health.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_daemon_health.rs
@@ -66,6 +66,8 @@ fn seeded_snapshot() -> DaemonHealthSnapshot {
         },
         concurrent_tasks: 3,
         task_throughput_60s: throughput,
+        daemon_version: "1.16.0 (abc1234, source)".into(),
+        db_error: None,
     }
 }
 
@@ -218,4 +220,77 @@ fn connected_runtime_dot_is_green() {
         green_dot,
         "the connected runtime's `●` presence dot must be painted ONLINE_GREEN"
     );
+}
+
+/// `OFFLINE_RED` — the warning/banner colour on the daemon-health pane.
+const OFFLINE_RED: ainb_plugin_sdk::Color = ainb_plugin_sdk::Color::rgb(220, 120, 100);
+
+/// A `db_error` in the snapshot renders the red DATABASE UNREACHABLE banner
+/// with the daemon's diagnosis — the stale-binary-serving-a-newer-database trap
+/// must scream, never render silently-blank zeros.
+#[test]
+fn db_error_renders_red_banner() {
+    let mut snap = seeded_snapshot();
+    snap.db_error =
+        Some("database schema (migration 41) is AHEAD of this daemon binary".into());
+    let state = DaemonHealthState::from_snapshot(snap);
+    let mut buf = WireBuffer::new(100, 24);
+    render_daemon_health(&mut buf, 100, 0, 24, &state);
+    let full = glyph_map(&buf, 100);
+
+    assert!(
+        full.contains("DATABASE UNREACHABLE"),
+        "banner headline:\n{full}"
+    );
+    assert!(
+        full.contains("migration 41"),
+        "banner carries the daemon's diagnosis:\n{full}"
+    );
+    // Non-vacuous colour check: the banner glyphs are painted OFFLINE_RED.
+    let red_banner = buf
+        .cells
+        .iter()
+        .any(|(_, cell)| cell.symbol == "✗" && cell.fg == Some(OFFLINE_RED));
+    assert!(red_banner, "the banner `✗` must be painted OFFLINE_RED");
+}
+
+/// An EMPTY `daemon_version` (a daemon that predates version reporting) renders
+/// the stale-binary warning instead of a version line.
+#[test]
+fn empty_version_renders_stale_daemon_warning() {
+    let mut snap = seeded_snapshot();
+    snap.daemon_version = String::new();
+    let state = DaemonHealthState::from_snapshot(snap);
+    let mut buf = WireBuffer::new(100, 24);
+    render_daemon_health(&mut buf, 100, 0, 24, &state);
+    let full = glyph_map(&buf, 100);
+
+    assert!(
+        full.contains("stale binary"),
+        "pre-version daemon must be flagged stale:\n{full}"
+    );
+    assert!(
+        !full.contains("daemon: 1.16"),
+        "no version line when the daemon reported none:\n{full}"
+    );
+}
+
+/// The healthy path renders the version line and NO banner (the banner must
+/// never false-positive on a healthy daemon).
+#[test]
+fn healthy_snapshot_renders_version_no_banner() {
+    let state = DaemonHealthState::from_snapshot(seeded_snapshot());
+    let mut buf = WireBuffer::new(100, 24);
+    render_daemon_health(&mut buf, 100, 0, 24, &state);
+    let full = glyph_map(&buf, 100);
+
+    assert!(
+        full.contains("daemon: 1.16.0 (abc1234, source)"),
+        "version line:\n{full}"
+    );
+    assert!(
+        !full.contains("DATABASE UNREACHABLE"),
+        "no banner on healthy:\n{full}"
+    );
+    assert!(!full.contains("stale binary"), "no stale warning:\n{full}");
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/snapshot_daemon_health__render_full_health_pane_snapshot.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/snapshot_daemon_health__render_full_health_pane_snapshot.snap
@@ -1,9 +1,9 @@
 ---
-source: "../plugins/hangar-tui/tests/snapshot_daemon_health.rs"
-assertion_line: 104
+source: crates/ainb-plugin-hangar/tests/snapshot_daemon_health.rs
 expression: full
 ---
 Daemon health
+daemon: 1.16.0 (abc1234, source)
 
 runtime: claude  ● connected  pid 14829
 


### PR DESCRIPTION
## Why
Today's field failure: a stale brew daemon (Jul 14) kept serving a database that newer source builds had migrated forward. sqlx only validates migrations at pool-open, so the running daemon never errored — every RPC half-failed, the board rendered blank, card-create silently persisted nothing, and Daemon Health showed innocent zeros ("no runtimes registered"). The only diagnostic lived in `ainb hangar daemon status` on the CLI.

## What
- **store**: `schema_drift(pool)` — compares applied `MAX(version)` in `_sqlx_migrations` vs the newest embedded migration. DB ahead of binary → named drift string; probe failure → "database unreachable". Covers today's exact case (applied 41 > embedded max when the binary lacks 41). The modified-checksum case still fails at pool-open before the daemon serves, so the runtime probe only needs the AHEAD direction.
- **proto**: `DaemonHealthSnapshot` + `daemon_version` + `db_error`, both `serde(default)` — a pre-field daemon still decodes, and the empty version is itself the stale-binary signal.
- **daemon**: fills both on every `hangar/daemon_health` answer (one cheap scalar query per poll).
- **TUI (`D` screen)**: red `✗ DATABASE UNREACHABLE` banner + the daemon's diagnosis ABOVE the stats; `daemon: <version>` line on the healthy path; loud "stale binary; restart the daemon" warning when the version is missing (old daemon).

## Proof
- `schema_drift` tripwire: fresh DB → None; future ledger row → AHEAD named; dropped ledger → unreachable. **Mutation-proven**: probe stubbed to `None` → both drift tests RED.
- Render tests pin all three pane states (healthy w/ version + no banner; db_error → red banner with diagnosis; empty version → stale warning). **Mutation-proven**: banner render deleted → test RED.
- Proto tolerant-decode test: pre-field wire JSON still parses.
- Full store/proto/daemon/plugin suites green; clippy clean on all four touched crates (hangar-core doc-lint noise is pre-existing main drift).

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R