### PR TITLE
fix(fleet): discover shells current_exe, not a stale $PATH ainb

### DIFF
--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/ainb.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/ainb.rs
@@ -5,9 +5,34 @@ use tokio::process::Command;
 
 use crate::fleet::types::{AinbSession, Session, SessionSource};
 
-/// Override the binary used (test seam).
+/// Resolve the `ainb` binary to shell out to: `$AINB_BIN` if set (tests point it
+/// at a fake / the test binary), else THIS executable, else the literal `ainb`
+/// on `$PATH`.
+///
+/// The `current_exe()` step is load-bearing, not cosmetic: `cargo run` and a
+/// stale `brew`-installed `ainb` can coexist on one machine, and a bare `"ainb"`
+/// resolved against `$PATH` picks up the stale binary even when the running
+/// process is the fresh one — yielding a different `list --format json` shape or
+/// a different session store, i.e. silently wrong discovery. Mirrors
+/// `atc_bin()` / `resolve_ainb_bin()` so every self-spawn prefers self.
 fn ainb_bin() -> String {
-    std::env::var("AINB_BIN").unwrap_or_else(|_| "ainb".to_string())
+    resolve_ainb_bin(std::env::var("AINB_BIN").ok(), std::env::current_exe().ok())
+}
+
+/// Pure resolver behind [`ainb_bin`]: pick the `$AINB_BIN` override (when
+/// non-empty), else `current_exe`, else the bare `"ainb"` name. Split out so the
+/// three-way precedence is testable without mutating process env (the crate
+/// denies `unsafe`, and edition-2024 `set_var` is unsafe).
+fn resolve_ainb_bin(
+    override_var: Option<String>,
+    current_exe: Option<std::path::PathBuf>,
+) -> String {
+    if let Some(v) = override_var.filter(|s| !s.is_empty()) {
+        return v;
+    }
+    current_exe
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| "ainb".to_string())
 }
 
 pub async fn list_ainb_sessions() -> Result<Vec<AinbSession>> {
@@ -53,4 +78,47 @@ pub async fn discover_from_ainb() -> Result<Vec<Session>> {
 
 fn parse_iso8601_ms(s: &str) -> Option<i64> {
     chrono::DateTime::parse_from_rfc3339(s).ok().map(|dt| dt.timestamp_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_ainb_bin;
+    use std::path::PathBuf;
+
+    /// A non-empty `$AINB_BIN` wins over everything.
+    #[test]
+    fn override_wins() {
+        assert_eq!(
+            resolve_ainb_bin(
+                Some("/tmp/fake-ainb".into()),
+                Some(PathBuf::from("/usr/bin/ainb"))
+            ),
+            "/tmp/fake-ainb"
+        );
+    }
+
+    /// With no (or empty) override, resolve to `current_exe` — NOT the bare
+    /// `"ainb"` name that `$PATH` could resolve to a stale sibling binary. This
+    /// is the whole point of the fix: the fresh running process discovers via
+    /// itself, never a stale brew `ainb`.
+    #[test]
+    fn falls_back_to_current_exe_not_bare_name() {
+        let resolved = resolve_ainb_bin(None, Some(PathBuf::from("/repo/target/debug/ainb")));
+        assert_eq!(resolved, "/repo/target/debug/ainb");
+        assert_ne!(resolved, "ainb");
+
+        // An empty override string is treated as unset.
+        let empty = resolve_ainb_bin(
+            Some(String::new()),
+            Some(PathBuf::from("/repo/target/debug/ainb")),
+        );
+        assert_eq!(empty, "/repo/target/debug/ainb");
+    }
+
+    /// Only when BOTH override and current_exe are unavailable does it degrade
+    /// to the bare name (effectively unreachable in practice).
+    #[test]
+    fn last_resort_bare_name() {
+        assert_eq!(resolve_ainb_bin(None, None), "ainb");
+    }
 }


### PR DESCRIPTION
## Why
Follow-up from a workspace-wide sweep of every self-referential `ainb` spawn (does each resolve to the FRESH running binary, or can it pick up a stale brew `ainb` on `$PATH`?). 12 sites were FRESH-SAFE (hangar daemon, mcp-pool daemon, notifyd, ATC, fleet bridge, provisioner — all prefer `current_exe`). **One was not:** fleet session discovery.

`crates/ainb-fleet-core/src/fleet/discover/ainb.rs` resolved its binary as bare `"ainb"` on `$PATH` whenever `AINB_BIN` was unset — the normal case — unlike its own ATC siblings `atc_bin()` / `timer::ainb_bin()`, which prefer `current_exe()`. On a machine with both a `cargo run` binary and a stale `brew` install, the fresh process shells the OLD `ainb` for `list --format json`, reading a different session store / JSON shape and silently returning wrong or empty discovery.

## What
- Extract a pure `resolve_ainb_bin(override, current_exe)` with `override → current_exe → bare-name` precedence (mirrors `atc_bin`, `resolve_ainb_bin`, `resolve_daemon_launch`).
- The env read stays in a thin `ainb_bin()` wrapper — the crate denies `unsafe`, and edition-2024 `set_var` is unsafe, so the pure split is what makes it testable without env mutation.

## Proof
- 3 unit tests: override wins; unset/empty → `current_exe` (asserts `!= "ainb"`); both-absent → bare name.
- **Mutation-proven**: dropping the `current_exe` step → `falls_back_to_current_exe_not_bare_name` goes RED. Restored green.

## Sweep result (context)
| Class | Count |
|---|---|
| FRESH-SAFE | 12 |
| PATH-RISK (this PR) | 1 |
| N/A (filesystem lookups / external tools) | 5 |

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable resolution for fleet operations by prioritizing an explicitly configured binary, then the currently running executable.
  * Added a reliable fallback when no configured or current executable is available.
  * Empty executable configuration values are now handled as unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->