### PR TITLE
chore(dev): add `just dev` — rebuild both binaries + restart daemon + run TUI

### DIFF
--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -16,6 +16,23 @@ build-release:
 run *args:
     cargo run -- {{args}}
 
+# Rebuild both binaries + restart the daemon onto the fresh build, then run the TUI
+#
+# Fixes the stale-daemon trap: `daemon start` no-ops when a daemon is already
+# running, so a rebuild alone leaves the OLD process serving the DB. This
+# restarts it explicitly so the running daemon always matches the code you just
+# built. `AINB_BIN` is pinned so every self-spawn resolves to the fresh binary
+# regardless of a brew `ainb` on $PATH.
+dev *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo build -p ainb --bin ainb -p ainb-hangar-daemon
+    AINB="$(pwd)/target/debug/ainb"
+    export AINB_BIN="$AINB"
+    "$AINB" hangar daemon restart
+    "$AINB" hangar daemon status
+    exec "$AINB" {{args}}
+
 # Run tests
 test:
     cargo test


### PR DESCRIPTION
## Why
The stale-daemon trap, packaged into one command. A rebuild alone doesn't fix a running daemon: `daemon start` no-ops on a live pid, so the OLD process keeps serving the DB until explicitly restarted (this is what showed a blank board earlier — a brew 1.15.0 daemon serving a source-migrated DB).

## What
`just dev [args]`:
1. `cargo build -p ainb --bin ainb -p ainb-hangar-daemon` — both binaries
2. `daemon restart` onto the fresh build — so the health pane never shows drift
3. pins `AINB_BIN` to the just-built binary — every self-spawn resolves to it regardless of a brew `ainb` on `$PATH`
4. `exec` the TUI

## Proof
Ran locally: builds both, swapped the running daemon (pid 22479 → 42451), status `database: reachable (migrations applied)`.