### PR TITLE
chore(dev): `just dev` restages ALL plugins via build-plugins.sh

### DIFF
--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -16,16 +16,21 @@ build-release:
 run *args:
     cargo run -- {{args}}
 
-# Rebuild both binaries + restart the daemon onto the fresh build, then run the TUI
+# Rebuild plugins + both binaries + restart the daemon, then run the TUI
 #
-# Fixes the stale-daemon trap: `daemon start` no-ops when a daemon is already
-# running, so a rebuild alone leaves the OLD process serving the DB. This
-# restarts it explicitly so the running daemon always matches the code you just
-# built. `AINB_BIN` is pinned so every self-spawn resolves to the fresh binary
-# regardless of a brew `ainb` on $PATH.
+# The complete dev launch (replaces `./scripts/build-plugins.sh && cargo run`):
+#   1. build-plugins.sh — restages every subprocess plugin (the hangar TUI is
+#      one; `cargo run` alone never rebuilds it → you'd get a STALE plugin).
+#   2. build ainb + ainb-hangar-daemon.
+#   3. daemon restart — `daemon start` no-ops on a live pid, so a rebuild alone
+#      leaves the OLD daemon serving the DB (the blank-board trap). Restarting
+#      puts the fresh binary in charge; the health pane then shows no drift.
+#   4. run the TUI. AINB_BIN is pinned so every self-spawn resolves to the fresh
+#      binary regardless of a brew `ainb` on $PATH.
 dev *args:
     #!/usr/bin/env bash
     set -euo pipefail
+    ./scripts/build-plugins.sh
     cargo build -p ainb --bin ainb -p ainb-hangar-daemon
     AINB="$(pwd)/target/debug/ainb"
     export AINB_BIN="$AINB"


### PR DESCRIPTION
## Why
Follow-up to #417. The `just dev` recipe launched the TUI without rebuilding the **subprocess plugins**. The hangar TUI is one of six (burndown, session-reader, witr, learnings, abtop, hangar-tui), and `cargo run` never rebuilds/restages them — so `just dev` would run against a STALE plugin set. `./scripts/build-plugins.sh && cargo run` is the correct flow; the recipe was missing the first half.

## What
Prepend `./scripts/build-plugins.sh` (the existing staging + macOS ad-hoc re-sign source of truth) to `just dev`, so the recipe == `build-plugins.sh && cargo run` plus the daemon restart + `AINB_BIN` pin.

## Proof
Ran locally: all 6 plugins staged to `dist/plugins/`, ainb + daemon built, daemon swapped (42451 → 74479).
```
staged ainb-plugin-burndown       -> dist/plugins/burndown/burndown
staged ainb-plugin-session-reader -> dist/plugins/session-reader/session-reader
staged ainb-plugin-witr           -> dist/plugins/witr/witr
staged ainb-plugin-learnings      -> dist/plugins/learnings/learnings
staged ainb-plugin-abtop          -> dist/plugins/abtop/abtop
staged ainb-plugin-hangar         -> dist/plugins/hangar-tui/hangar-tui
```