### PR TITLE
feat(hangar): detect a version-skewed daemon after upgrade (TUI banner + status warning)

### DIFF
--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -125,7 +125,7 @@ ainb-hangar-core = { path = "../ainb-hangar-core", version = "0.1.0" }
 # routes answers through `attention/answer` on the control plane (D18).
 ainb-hangar-proto = { path = "../ainb-hangar-proto", version = "0.1.0" }
 ainb-hangar-store = { path = "../ainb-hangar-store", version = "0.1.0" }
-ainb-hangar-daemon = { path = "../ainb-hangar-daemon", version = "0.1.0" }
+ainb-hangar-daemon = { path = "../ainb-hangar-daemon" }
 # sqlx — the hangar CLI workspace-bootstrap path issues raw SQL against the
 # store's pool (`Store::pool`) for the default-workspace seed and lookups.
 sqlx = { version = "0.8", default-features = false, features = [

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -3008,6 +3008,31 @@ fn daemon_pid_path() -> Result<std::path::PathBuf> {
     Ok(home.join("hangar").join("daemon.pid"))
 }
 
+/// Path to the file recording the version of the binary that started the
+/// running daemon, written beside the pid file at launch.
+///
+/// A running daemon is never auto-restarted, so after `brew upgrade` (or any
+/// rebuild) the OLD daemon keeps serving while the CLI/TUI is new. This file
+/// lets `status` name the running daemon's version and flag the skew — without
+/// a socket dial (the CLI opens the store directly and never RPCs the daemon).
+fn daemon_version_path() -> Result<std::path::PathBuf> {
+    let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
+    Ok(home.join("hangar").join("daemon.version"))
+}
+
+/// Compare the recorded running-daemon version to `mine`, returning
+/// `Some(running)` when they disagree (the skew to warn about), else `None`.
+///
+/// `None` also when the running version is unknown (no file / empty) — an
+/// absent record is not proof of skew, so it degrades to "no warning" rather
+/// than a false positive. A pure function so the precedence is unit-testable.
+fn daemon_version_skew(running: Option<&str>, mine: &str) -> Option<String> {
+    match running {
+        Some(v) if !v.is_empty() && v != mine => Some(v.to_string()),
+        _ => None,
+    }
+}
+
 /// Read the recorded daemon pid, or `None` if the file is absent/empty/garbage.
 fn read_daemon_pid(path: &std::path::Path) -> Option<u32> {
     let text = std::fs::read_to_string(path).ok()?;
@@ -3375,6 +3400,23 @@ async fn run_daemon_status() -> Result<()> {
                 "socket not yet bound"
             };
             println!("hangar daemon: running (pid {pid}, {sock})");
+            // Version-skew check: a running daemon is never auto-restarted, so
+            // after an upgrade an OLD daemon can still be serving. Compare the
+            // recorded running-daemon version to THIS binary's and flag it.
+            let running = daemon_version_path()
+                .ok()
+                .and_then(|p| std::fs::read_to_string(p).ok())
+                .map(|s| s.trim().to_string());
+            match daemon_version_skew(running.as_deref(), env!("CARGO_PKG_VERSION")) {
+                Some(running_v) => {
+                    println!(
+                        "  ⚠ version skew: daemon {running_v} vs this binary {} — \
+                         run `ainb hangar daemon restart`",
+                        env!("CARGO_PKG_VERSION")
+                    );
+                }
+                None => println!("  version: {}", env!("CARGO_PKG_VERSION")),
+            }
         }
         Some(pid) => {
             println!("hangar daemon: stopped (stale pid {pid}, process gone)");
@@ -3509,6 +3551,14 @@ fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     std::fs::write(&pid_path, format!("{pid}\n"))
         .with_context(|| format!("write pid file {}", pid_path.display()))?;
 
+    // Record the version of the binary now serving, beside the pid. The launcher
+    // and the daemon it spawns share the workspace version, so this is the
+    // running daemon's version. Best-effort: a write failure must not fail the
+    // start (the skew check just degrades to "unknown").
+    if let Ok(vpath) = daemon_version_path() {
+        std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
+    }
+
     if announce {
         println!("hangar daemon: started (pid {pid})");
     }
@@ -3522,6 +3572,11 @@ fn start_daemon_if_stopped(announce: bool) -> Result<()> {
 /// is cleaned up; an absent file is reported as "not running".
 fn run_daemon_stop() -> Result<()> {
     let pid_path = daemon_pid_path()?;
+    // Drop the version record too — a stopped daemon has no running version, and
+    // a lingering file would make `status` compare against a dead daemon.
+    if let Ok(vpath) = daemon_version_path() {
+        std::fs::remove_file(&vpath).ok();
+    }
     match read_daemon_pid(&pid_path) {
         Some(pid) if pid_is_running(pid) => {
             use nix::sys::signal::{Signal, kill};
@@ -4594,6 +4649,19 @@ mod tests {
     use super::*;
     use crate::cli::registry::CommandRegistry;
     use clap::FromArgMatches;
+
+    /// The skew helper flags a differing recorded version, and stays quiet for
+    /// a match, an absent record, or an empty one (absence is not skew).
+    #[test]
+    fn daemon_version_skew_flags_only_a_known_mismatch() {
+        assert_eq!(
+            daemon_version_skew(Some("1.15.0"), "1.16.0"),
+            Some("1.15.0".to_string())
+        );
+        assert_eq!(daemon_version_skew(Some("1.16.0"), "1.16.0"), None);
+        assert_eq!(daemon_version_skew(None, "1.16.0"), None);
+        assert_eq!(daemon_version_skew(Some(""), "1.16.0"), None);
+    }
 
     /// Build the real `ainb` clap surface (root + every registered command,
     /// including the `hangar` subtree) and parse `argv` through it.

--- a/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ainb-hangar-daemon"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ainb-tui/crates/ainb-plugin-hangar/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-hangar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ainb-plugin-hangar"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/daemon_health.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/daemon_health.rs
@@ -29,6 +29,23 @@ const ONLINE_GREEN: Color = Color::rgb(100, 200, 100);
 /// Disconnected runtime presence dot.
 const OFFLINE_RED: Color = Color::rgb(220, 120, 100);
 
+/// This client build's version — the workspace release version, since the
+/// plugin crate now inherits `version.workspace`. Compared against the
+/// daemon's reported version to catch a post-`brew upgrade` skew where an OLD
+/// daemon is still resident (a running daemon is never auto-restarted).
+const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Whether the daemon's reported version disagrees with this client's — the
+/// signal that a stale daemon is still serving after the binary was upgraded.
+///
+/// An empty `daemon` is NOT skew here: that case (a daemon predating version
+/// reporting) has its own dedicated warning. Only two known, differing
+/// versions count, so a daemon that simply hasn't answered yet never
+/// false-positives.
+fn version_skew(daemon: &str, client: &str) -> bool {
+    !daemon.is_empty() && daemon != client
+}
+
 /// The render-state cache for the daemon-health screen.
 ///
 /// A flattened, render-ready view of the wire [`DaemonHealthSnapshot`]. Default
@@ -136,9 +153,33 @@ pub fn render_daemon_health(
             );
         } else {
             let x = put_str(buf, 0, row, "daemon: ", MUTED_GRAY, area_w);
-            put_str(buf, x, row, &state.daemon_version, SOFT_WHITE, area_w);
+            let vcolor = if version_skew(&state.daemon_version, CLIENT_VERSION) {
+                OFFLINE_RED
+            } else {
+                SOFT_WHITE
+            };
+            put_str(buf, x, row, &state.daemon_version, vcolor, area_w);
         }
         row += 1;
+    }
+
+    // Version-skew banner (red): a running daemon is never auto-restarted, so
+    // after `brew upgrade` (or any rebuild) an OLD daemon keeps serving while
+    // this client is new. The stats below come from the stale daemon — say so,
+    // and give the exact fix.
+    if version_skew(&state.daemon_version, CLIENT_VERSION) {
+        if row <= bottom {
+            put_str(buf, 0, row, "✗ DAEMON VERSION SKEW", OFFLINE_RED, area_w);
+            row += 1;
+        }
+        if row <= bottom {
+            let msg = format!(
+                "daemon {} vs client {CLIENT_VERSION} — run `ainb hangar daemon restart`",
+                state.daemon_version
+            );
+            put_str(buf, 2, row, &msg, OFFLINE_RED, area_w);
+            row += 1;
+        }
     }
 
     // Database-drift banner (red, ABOVE the stats): when the daemon reports its

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_daemon_health.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_daemon_health.rs
@@ -66,7 +66,9 @@ fn seeded_snapshot() -> DaemonHealthSnapshot {
         },
         concurrent_tasks: 3,
         task_throughput_60s: throughput,
-        daemon_version: "1.16.0 (abc1234, source)".into(),
+        // Match THIS build's version so the baseline fixture never trips the
+        // version-skew banner — the skew case is exercised by its own test.
+        daemon_version: env!("CARGO_PKG_VERSION").into(),
         db_error: None,
     }
 }
@@ -231,8 +233,7 @@ const OFFLINE_RED: ainb_plugin_sdk::Color = ainb_plugin_sdk::Color::rgb(220, 120
 #[test]
 fn db_error_renders_red_banner() {
     let mut snap = seeded_snapshot();
-    snap.db_error =
-        Some("database schema (migration 41) is AHEAD of this daemon binary".into());
+    snap.db_error = Some("database schema (migration 41) is AHEAD of this daemon binary".into());
     let state = DaemonHealthState::from_snapshot(snap);
     let mut buf = WireBuffer::new(100, 24);
     render_daemon_health(&mut buf, 100, 0, 24, &state);
@@ -285,12 +286,59 @@ fn healthy_snapshot_renders_version_no_banner() {
     let full = glyph_map(&buf, 100);
 
     assert!(
-        full.contains("daemon: 1.16.0 (abc1234, source)"),
+        full.contains(&format!("daemon: {}", env!("CARGO_PKG_VERSION"))),
         "version line:\n{full}"
     );
     assert!(
         !full.contains("DATABASE UNREACHABLE"),
         "no banner on healthy:\n{full}"
     );
+    assert!(
+        !full.contains("VERSION SKEW"),
+        "no skew banner on match:\n{full}"
+    );
     assert!(!full.contains("stale binary"), "no stale warning:\n{full}");
+}
+
+/// A daemon whose reported version differs from this client build renders the
+/// red VERSION SKEW banner with both versions + the restart command. This is
+/// the post-`brew upgrade` case: an OLD daemon still serving a NEW client.
+#[test]
+fn version_skew_renders_red_banner() {
+    let mut snap = seeded_snapshot();
+    snap.daemon_version = "1.14.0 (oldsha, ci)".into(); // != this build's version
+    let state = DaemonHealthState::from_snapshot(snap);
+    let mut buf = WireBuffer::new(100, 24);
+    render_daemon_health(&mut buf, 100, 0, 24, &state);
+    let full = glyph_map(&buf, 100);
+
+    assert!(
+        full.contains("DAEMON VERSION SKEW"),
+        "skew headline:\n{full}"
+    );
+    assert!(
+        full.contains("1.14.0"),
+        "banner names the daemon version:\n{full}"
+    );
+    assert!(
+        full.contains("ainb hangar daemon restart"),
+        "banner gives the fix:\n{full}"
+    );
+}
+
+/// A daemon reporting THIS client's exact version renders NO skew banner (the
+/// banner must not false-positive when versions agree).
+#[test]
+fn matching_version_renders_no_skew_banner() {
+    let mut snap = seeded_snapshot();
+    snap.daemon_version = env!("CARGO_PKG_VERSION").into();
+    let state = DaemonHealthState::from_snapshot(snap);
+    let mut buf = WireBuffer::new(100, 24);
+    render_daemon_health(&mut buf, 100, 0, 24, &state);
+    let full = glyph_map(&buf, 100);
+
+    assert!(
+        !full.contains("VERSION SKEW"),
+        "no skew banner on match:\n{full}"
+    );
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/snapshot_daemon_health__render_full_health_pane_snapshot.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/snapshot_daemon_health__render_full_health_pane_snapshot.snap
@@ -3,7 +3,7 @@ source: crates/ainb-plugin-hangar/tests/snapshot_daemon_health.rs
 expression: full
 ---
 Daemon health
-daemon: 1.16.0 (abc1234, source)
+daemon: 1.15.0
 
 runtime: claude  ● connected  pid 14829
 


### PR DESCRIPTION
## Why
Answering "after `brew upgrade ainb`, does the daemon auto-upgrade?" — **no.** A running daemon is never auto-restarted (`start_daemon_if_stopped` no-ops on a live pid, `hangar/mod.rs`), and nothing compared the client's version to the daemon's. So an OLD daemon keeps serving a NEW client silently. Worse: the daemon reported `env!(CARGO_PKG_VERSION)` = its crate's **frozen `0.1.0`**, so the #415 health line literally showed `daemon: 0.1.0` and no skew was even detectable.

## What (3 parts)
1. **daemon + plugin inherit `version.workspace`** — both now report the real release version (1.15.0…) instead of the frozen `0.1.0`. Prerequisite for any skew detection; also fixes the #415 banner.
2. **TUI health pane** — compares the daemon's reported version to this client build; on mismatch paints the version line red + renders `✗ DAEMON VERSION SKEW … run \`ainb hangar daemon restart\`` above the stats.
3. **CLI `daemon status`** — the launcher records the running binary's version in `hangar/daemon.version` (beside the pid, removed on stop); `status` compares + prints `⚠ version skew …` or the version. No socket dial (the CLI opens the store directly).

**Not auto-restart, by design:** a running daemon may have in-flight agent dispatches; auto-killing it would strand live work. Detect + warn; operator restarts at a safe moment (or `just dev` does it).

## Proof
- Live: real restart writes `1.15.0` (not `0.1.0`); clean `status` → `version: 1.15.0`; inject `1.14.0-OLD` → `⚠ version skew: daemon 1.14.0-OLD vs this binary 1.15.0 — run ainb hangar daemon restart`.
- Unit: `version_skew` (plugin) + `daemon_version_skew` (CLI) pure helpers, each tested for match / mismatch / empty / absent. Both **mutation-proven RED** (force the helper false/None → the skew test fails).
- TUI render tests: skew banner present on mismatch, absent on match; full-pane insta re-accepted.

## Coverage note
Version-string comparison catches the **release-bump** case (the brew scenario). Same-version-different-git-sha (dev) is not caught by this — that's handled operationally by `just dev` force-restarting. Documented.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R