### PR TITLE
feat(hangar): enriched task+agent model — source/target branch, remote repos, token budget, Issues create wizard

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -930,9 +930,32 @@ pub enum IssueCommand {
     Show(IssueShowArgs),
     /// Edit an existing issue's state, assignee, priority, or due date.
     Update(IssueUpdateArgs),
+    /// Delete an issue and all its history (dry-run without `--yes`).
+    Delete(IssueDeleteArgs),
     /// Attach or detach a label on an issue.
     #[command(subcommand)]
     Label(IssueLabelCommand),
+}
+
+/// Arguments for `hangar issue delete`.
+///
+/// Without `--yes` this is a DRY RUN: it prints the issue title and the counts of
+/// what a real delete would remove (comments / tasks / placements) and exits
+/// WITHOUT deleting. Pass `--yes` to actually perform the cascade. The delete is
+/// workspace-scoped and refuses while any task on the issue is ACTIVE (cancel the
+/// run first), exactly like the `hangar/issue_delete` daemon RPC.
+#[derive(Args, Debug)]
+pub struct IssueDeleteArgs {
+    /// Issue id (ULID) to delete.
+    pub id: String,
+    /// Actually perform the delete. Without this flag the command only PREVIEWS
+    /// what would be removed and exits without touching the database.
+    #[arg(long)]
+    pub yes: bool,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// `hangar issue label <verb>`.
@@ -2621,7 +2644,64 @@ async fn dispatch_issue(cmd: IssueCommand, format: OutputFormat) -> Result<()> {
         IssueCommand::Search(args) => run_issue_search(&store, args, format).await,
         IssueCommand::Show(args) => run_issue_show(&store, args, format).await,
         IssueCommand::Update(args) => run_issue_update(&store, args).await,
+        IssueCommand::Delete(args) => run_issue_delete(&store, args).await,
         IssueCommand::Label(cmd) => run_issue_label(&store, cmd).await,
+    }
+}
+
+/// `hangar issue delete`: preview (default) or perform an issue delete,
+/// workspace-scoped and daemon-less.
+///
+/// Resolves the workspace the same way the other verbs do (`--workspace`, else the
+/// bootstrapped `default`). Without `--yes` it prints the [`IssueDeletePreview`]
+/// (title + dependent counts + active-task warning) and exits without deleting;
+/// with `--yes` it drives the store's single-transaction
+/// [`IssueRepo::delete_cascade`], refusing on an active task exactly like the
+/// daemon RPC. An unknown / foreign-tenant id is a not-found error, never a silent
+/// no-op.
+async fn run_issue_delete(store: &Store, args: IssueDeleteArgs) -> Result<()> {
+    use ainb_hangar_store::repo::issue::{IssueDeleteError, IssueRepo};
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+
+    let Some(preview) = IssueRepo::delete_preview(store.pool(), &workspace_id, &args.id)
+        .await
+        .with_context(|| format!("preview delete of issue {}", args.id))?
+    else {
+        anyhow::bail!("no issue with id {} in this workspace", args.id);
+    };
+
+    if !args.yes {
+        // DRY RUN: report what a real delete would remove and exit untouched.
+        println!("would delete issue {} \"{}\"", args.id, preview.title);
+        println!(
+            "  removes: {} comment(s), {} task(s), {} board placement(s), plus label links, dependency edges, and usage rows",
+            preview.summary.comments, preview.summary.tasks, preview.summary.placements
+        );
+        if preview.active_tasks > 0 {
+            println!(
+                "  WARNING: {} active task(s) — cancel the run first, then re-run with --yes",
+                preview.active_tasks
+            );
+        } else {
+            println!("  re-run with --yes to perform the delete");
+        }
+        return Ok(());
+    }
+
+    match IssueRepo::delete_cascade(store.pool(), &workspace_id, &args.id).await {
+        Ok(summary) => {
+            println!(
+                "deleted issue {} \"{}\" ({} comment(s), {} task(s), {} placement(s))",
+                args.id, preview.title, summary.comments, summary.tasks, summary.placements
+            );
+            Ok(())
+        }
+        Err(IssueDeleteError::NotFound) => {
+            anyhow::bail!("no issue with id {} in this workspace", args.id)
+        }
+        Err(e @ IssueDeleteError::ActiveTasks(_)) => anyhow::bail!("{e}"),
+        Err(IssueDeleteError::Db(e)) => Err(e).with_context(|| format!("delete issue {}", args.id)),
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -495,6 +495,13 @@ pub struct AgentEditArgs {
     /// given the whole env map is REPLACED with the values.
     #[arg(long = "env", value_parser = parse_env_kv, action = clap::ArgAction::Append)]
     pub env: Vec<(String, String)>,
+    /// New token budget (rtk/headroom, migration 0042); omitted leaves it.
+    /// Mutually exclusive with `--clear-token-budget`.
+    #[arg(long = "token-budget", conflicts_with = "clear_token_budget")]
+    pub token_budget: Option<i64>,
+    /// Clear the token budget (back to unlimited); omitted leaves it.
+    #[arg(long = "clear-token-budget")]
+    pub clear_token_budget: bool,
     /// Workspace slug the agent belongs to. Defaults to the bootstrapped
     /// `default` workspace.
     #[arg(long)]
@@ -1835,6 +1842,8 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
     let cli_args = (!args.args.is_empty()).then_some(args.args);
     let agent_env = (!args.env.is_empty()).then_some(args.env);
 
+    let token_budget = clear_or_set(args.clear_token_budget, args.token_budget);
+
     let update = AgentConfigUpdate {
         name: args.name,
         instructions,
@@ -1843,13 +1852,14 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
         mcp_config,
         thinking,
         agent_env,
+        token_budget,
     };
 
     if update.is_empty() {
         anyhow::bail!(
             "nothing to update: pass at least one of --name / --instructions / --clear-instructions \
              / --model / --clear-model / --arg / --mcp / --clear-mcp / --thinking / --clear-thinking \
-             / --env"
+             / --env / --token-budget / --clear-token-budget"
         );
     }
 
@@ -1890,7 +1900,7 @@ async fn run_agent_set_archived(
 /// (`Some(Some(v))`), else leave unchanged (`None`). The clap `conflicts_with`
 /// already bars both at once.
 #[allow(clippy::option_option)] // the nested Option IS the store's 3-state encoding
-fn clear_or_set(clear: bool, value: Option<String>) -> Option<Option<String>> {
+fn clear_or_set<T>(clear: bool, value: Option<T>) -> Option<Option<T>> {
     if clear { Some(None) } else { value.map(Some) }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1052,6 +1052,20 @@ pub struct IssueCreateArgs {
     /// is a separate concern; create just records the labels it is handed.
     #[arg(long = "label", action = clap::ArgAction::Append)]
     pub labels: Vec<String>,
+    /// The repo the run executes in: an absolute checkout path, the literal
+    /// `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`) — a remote
+    /// is cloned once into the shared clone cache and the local path persisted,
+    /// exactly like the board card-create path (migration 0032/0042).
+    #[arg(long)]
+    pub repo: Option<String>,
+    /// The SOURCE branch the run branches FROM (migration 0042); omitted uses
+    /// the repo's default branch. Persisted on the issue AND the enqueued task.
+    #[arg(long = "source-branch")]
+    pub source_branch: Option<String>,
+    /// The TARGET branch a future PR lands INTO (migration 0042); stored on the
+    /// issue for later PR automation.
+    #[arg(long = "target-branch")]
+    pub target_branch: Option<String>,
 }
 
 /// Parse a `--due` value (`YYYY-MM-DD`) into an epoch-millisecond timestamp at
@@ -2784,8 +2798,35 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
     };
     IssueRepo::insert(pool, &new).await.context("insert issue")?;
 
+    // Resolve + persist the repo / branches (0032/0042). A remote repo token is
+    // cloned once into the shared clone cache (the board card-create parity),
+    // and the LOCAL path is what dispatch provisions from.
+    let repo_ref = match args.repo.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(raw) => Some(resolve_cli_repo_ref(raw).await?),
+        None => None,
+    };
+    use ainb_hangar_store::repo::card_parity::CardParityRepo;
+    if repo_ref.is_some() {
+        CardParityRepo::set_issue_repo_agent(pool, &workspace_id, &id, repo_ref.as_deref(), None)
+            .await
+            .context("persist issue repo")?;
+    }
+    if args.source_branch.is_some() || args.target_branch.is_some() {
+        CardParityRepo::set_issue_branches(
+            pool,
+            &workspace_id,
+            &id,
+            args.source_branch.as_deref(),
+            args.target_branch.as_deref(),
+        )
+        .await
+        .context("persist issue branches")?;
+    }
+
     // When assigned, enqueue a task for the agent's runtime so the daemon claims
-    // + dispatches it (materialising the agent's skills first).
+    // + dispatches it (materialising the agent's skills first). One transaction
+    // covers the insert + its dispatch inputs (repo / source branch), so the
+    // claim loop can never observe a half-written task.
     if let Some(a) = assignment {
         let task_id = idgen.new_ulid();
         // Scope the task to the issue's next run generation (migration 0039). A
@@ -2794,8 +2835,22 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         let generation = TaskRepo::next_generation_for_issue(pool, &id)
             .await
             .context("compute run generation for assigned task")?;
-        TaskRepo::insert(
-            pool,
+        // The task's agent_kind mirrors the assignee agent's provider (so a
+        // codex agent's task doesn't read back as the claude column default).
+        let provider: Option<Option<String>> =
+            sqlx::query_scalar("SELECT provider FROM agent WHERE id = ?")
+                .bind(&a.agent_id)
+                .fetch_optional(pool)
+                .await
+                .context("read agent provider")?;
+        let agent_kind = provider
+            .flatten()
+            .as_deref()
+            .and_then(ainb_hangar_core::agent_kind::AgentKind::parse)
+            .unwrap_or(ainb_hangar_core::agent_kind::AgentKind::DEFAULT);
+        let mut tx = pool.begin().await.context("begin enqueue tx")?;
+        TaskRepo::insert_in_tx(
+            &mut tx,
             &ainb_hangar_store::repo::task::NewTask {
                 id: task_id.clone(),
                 workspace_id,
@@ -2811,12 +2866,51 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         )
         .await
         .context("enqueue task for assigned agent")?;
+        if repo_ref.is_some() {
+            CardParityRepo::set_task_repo_agent_in_tx(
+                &mut tx,
+                &task_id,
+                repo_ref.as_deref(),
+                agent_kind,
+            )
+            .await
+            .context("persist task repo")?;
+        }
+        if args.source_branch.is_some() {
+            CardParityRepo::set_task_source_branch_in_tx(
+                &mut tx,
+                &task_id,
+                args.source_branch.as_deref(),
+            )
+            .await
+            .context("persist task source branch")?;
+        }
+        tx.commit().await.context("commit enqueue tx")?;
         println!("created issue {id}");
         println!("queued task {task_id}");
     } else {
         println!("created issue {id}");
     }
     Ok(())
+}
+
+/// Resolve a CLI `--repo` token to the local path dispatch provisions from:
+/// `scratch` and absolute paths pass through; anything else is treated as a
+/// REMOTE and cloned once into the shared clone cache (blocking git work off
+/// the async thread), mirroring the daemon's card-create resolve.
+async fn resolve_cli_repo_ref(raw: &str) -> Result<String> {
+    if raw == "scratch" || std::path::Path::new(raw).is_absolute() {
+        return Ok(raw.to_string());
+    }
+    let ainb_dir = ainb_hangar_core::hangar_home().context("resolve hangar home")?;
+    let remote = raw.to_string();
+    let cloned = tokio::task::spawn_blocking(move || {
+        ainb_fleet_core::repo_clone::ensure_clone(&ainb_dir, &remote)
+    })
+    .await
+    .context("join clone task")?
+    .with_context(|| format!("clone remote repo `{raw}`"))?;
+    Ok(cloned.display().to_string())
 }
 
 /// `hangar issue list`: list issues in the default workspace + state.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -201,7 +201,7 @@ async fn auto_run_dependent(pool: &SqlitePool, ws: &WorkspaceId, issue_id: &str)
     };
     // Board-agnostic (the auto-run seam does not know which board); the F4 board
     // tier is skipped, the cascade still resolves the agent. Headless run.
-    match crate::rpc::run_card(pool, ws, None, &issue, "headless", None, None).await {
+    match crate::rpc::run_card(pool, ws, None, &issue, "headless", None, None, None).await {
         Ok(_) => tracing::info!(issue = %issue_id, "card auto-run launched (last blocker done)"),
         Err(crate::rpc::CardRunError::Blocked(_) | crate::rpc::CardRunError::ActiveRun(_)) => {
             tracing::debug!(issue = %issue_id, "auto-run skipped (not launchable right now)");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -180,6 +180,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -222,6 +222,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -650,6 +650,7 @@ async fn handle(
         methods::HANGAR_TASKS_LIST => handle_tasks_list(pool, req).await,
         methods::HANGAR_TASK_TRANSITION => handle_task_transition(pool, req, events).await,
         methods::HANGAR_ISSUE_CREATE => handle_issue_create(pool, req, events).await,
+        methods::HANGAR_ISSUE_DELETE => handle_issue_delete(pool, req, events).await,
         methods::HANGAR_ISSUE_UPDATE => handle_issue_update(pool, req, events).await,
         methods::HANGAR_ISSUE_LABEL_ATTACH => handle_issue_label(pool, req, events, true).await,
         methods::HANGAR_ISSUE_LABEL_DETACH => handle_issue_label(pool, req, events, false).await,
@@ -1247,6 +1248,48 @@ async fn handle_issue_create(
     // A committed insert announces the new issue to subscribers.
     events.emit(ws.as_str(), HangarEvent::IssueCreated(row.clone()));
     to_value(&row)
+}
+
+/// Dispatch `hangar/issue_delete` (63d): delete one issue and all its history,
+/// push the matching `IssueDeleted` event, and answer with `{}`.
+///
+/// Mirrors [`handle_issue_update`]'s contract: the mutating handler resolves the
+/// workspace and **rejects** a mistyped one with `INVALID_PARAMS`, then drives the
+/// store's single-transaction cascade. A `(id, workspace)` pair that matches no
+/// issue is rejected as a not-found error (never a cross-tenant delete), and an
+/// ACTIVE task on the issue refuses the delete (`INVALID_PARAMS` telling the caller
+/// to cancel the run first). Only a committed delete pushes the event.
+async fn handle_issue_delete(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_core::ids::IssueId;
+    use ainb_hangar_proto::events::HangarEvent;
+    use ainb_hangar_store::repo::issue::{IssueDeleteError, IssueRepo};
+
+    let params: ainb_hangar_proto::snapshots::IssueDeleteParams =
+        parse_params(req, "{ workspace_id, issue_id }")?;
+    // The mutating handler must not silently no-op on a typo'd workspace.
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    IssueRepo::delete_cascade(pool, ws.as_str(), &params.issue_id)
+        .await
+        .map_err(|e| match e {
+            // An unknown id or a cross-tenant issue: reject rather than ack a
+            // delete that never happened.
+            IssueDeleteError::NotFound => {
+                invalid_params(&format!("no issue `{}` in this workspace", params.issue_id))
+            }
+            // A live run blocks the delete — surface the "cancel first" message.
+            IssueDeleteError::ActiveTasks(_) => invalid_params(&e.to_string()),
+            IssueDeleteError::Db(ref db) => store_err(db),
+        })?;
+    // A committed delete announces the removal so a subscribed issue list drops
+    // the row without a full re-pull.
+    let issue_id = IssueId::from_str(params.issue_id.as_str())
+        .map_err(|e| invalid_params(&format!("malformed issue id: {e}")))?;
+    events.emit(ws.as_str(), HangarEvent::IssueDeleted { issue_id });
+    to_value(&serde_json::json!({}))
 }
 
 /// Dispatch `hangar/issue_update` (e38.8): edit one issue's fields, push the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -685,6 +685,7 @@ async fn handle(
         methods::HANGAR_BOARD_CARD_MOVE => handle_board_card(pool, req, false).await,
         methods::HANGAR_BOARD_CARD_CREATE => handle_board_card_create(pool, req).await,
         methods::HANGAR_BOARD_CARD_RUN => handle_board_card_run(pool, req).await,
+        methods::HANGAR_ISSUE_RUN => handle_issue_run(pool, req).await,
         methods::HANGAR_BOARD_CARD_CANCEL => handle_board_card_cancel(pool, req, events).await,
         methods::HANGAR_BOARD_CARD_REORDER => handle_board_card_reorder(pool, req).await,
         methods::HANGAR_BOARD_CARD_REMOVE => handle_board_card_remove(pool, req).await,
@@ -2561,6 +2562,89 @@ async fn handle_board_card_run(
         mode,
         run_override,
         agent_override,
+        params.source_branch.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+    )
+    .await
+    .map_err(card_run_err)?;
+
+    let result = match outcome {
+        CardRunOutcome::Single {
+            task_id,
+            agent_id,
+            runtime_id,
+        } => ainb_hangar_proto::snapshots::BoardCardRunResult {
+            task_id,
+            agent_id,
+            runtime_id,
+            mode: mode.to_string(),
+            member_task_ids: Vec::new(),
+        },
+        CardRunOutcome::Squad {
+            leader_task_id,
+            leader_agent_id,
+            leader_runtime_id,
+            member_task_ids,
+        } => ainb_hangar_proto::snapshots::BoardCardRunResult {
+            task_id: leader_task_id,
+            agent_id: leader_agent_id,
+            runtime_id: leader_runtime_id,
+            mode: mode.to_string(),
+            member_task_ids,
+        },
+    };
+    to_value(&result)
+}
+
+/// `hangar/issue_run`: enqueue a run of one issue WITHOUT a board (the Issues
+/// create-wizard dispatch; plans/hangar-task-agent-model.md).
+///
+/// The board-less sibling of [`handle_board_card_run`]: same mode validation,
+/// same tenant guard, the SAME [`run_card`] launch core (refuse-run guard →
+/// squad fan-out vs single enqueue, repo REQUIRED, F4 cascade with the board
+/// tier skipped via `board_id = None`, 0042 source-branch resolve) — minus the
+/// board-membership check, so an Issues-screen task needs no user board to
+/// exist. Answers the same [`BoardCardRunResult`] shape.
+///
+/// [`BoardCardRunResult`]: ainb_hangar_proto::snapshots::BoardCardRunResult
+async fn handle_issue_run(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_core::agent_kind::AgentKind;
+    use ainb_hangar_store::repo::issue::IssueRepo;
+
+    let params: ainb_hangar_proto::snapshots::IssueRunParams =
+        parse_params(req, "{ workspace_id, issue_id, mode }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let mode = match params.mode.trim() {
+        "" | "headless" => "headless",
+        "interactive" => "interactive",
+        other => {
+            return Err(invalid_params(&format!(
+                "mode must be `headless` or `interactive`, got `{other}`"
+            )));
+        }
+    };
+
+    // Tenant guard: the issue must exist in this workspace.
+    let issue = IssueRepo::get_by_id(pool, &params.issue_id)
+        .await
+        .map_err(|e| store_err(&e))?
+        .filter(|i| i.workspace_id == ws.as_str())
+        .ok_or_else(|| invalid_params("no issue with that id in this workspace"))?;
+
+    let run_override = params.repo_ref.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let agent_override = params.agent.as_deref().and_then(AgentKind::parse);
+    let source_override = params.source_branch.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let outcome = run_card(
+        pool,
+        &ws,
+        None, // board-less: the F4 board tier is skipped
+        &issue,
+        mode,
+        run_override,
+        agent_override,
+        source_override,
     )
     .await
     .map_err(card_run_err)?;
@@ -2728,6 +2812,7 @@ pub(crate) async fn run_card(
     mode: &str,
     repo_override: Option<&str>,
     agent_override: Option<ainb_hangar_core::agent_kind::AgentKind>,
+    source_branch_override: Option<&str>,
 ) -> Result<CardRunOutcome, CardRunError> {
     use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
     use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
@@ -2779,6 +2864,14 @@ pub(crate) async fn run_card(
         .map_err(CardRunError::Db)?
         .unwrap_or((None, None));
     let repo_ref = repo_override.map(str::to_string).or(card_repo).ok_or(CardRunError::NoRepo)?;
+
+    // 3b. Source branch (0042): run-time override, else the card's persisted
+    // source_branch; `None` lets provision branch off the repo's default HEAD.
+    let card_source = CardParityRepo::get_issue_branches(pool, issue_id)
+        .await
+        .map_err(CardRunError::Db)?
+        .and_then(|(source, _target)| source);
+    let source_branch = source_branch_override.map(str::to_string).or(card_source);
 
     // 4. F4 agent cascade + F8 dispatchable check.
     let agent_kind = match agent_override.or(card_agent) {
@@ -2868,6 +2961,9 @@ pub(crate) async fn run_card(
             .map_err(CardRunError::Db)?;
     }
     CardParityRepo::set_task_repo_agent_in_tx(&mut tx, &task_id, Some(&repo_ref), agent_kind)
+        .await
+        .map_err(CardRunError::Db)?;
+    CardParityRepo::set_task_source_branch_in_tx(&mut tx, &task_id, source_branch.as_deref())
         .await
         .map_err(CardRunError::Db)?;
     tx.commit().await.map_err(CardRunError::Db)?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1558,7 +1558,7 @@ async fn handle_agent_create(
         .map_err(|e| invalid_params(&e))?;
     let wire = params.workspace_id.as_deref().unwrap_or("").trim();
     let ws = resolve_or_bootstrap_default(pool, wire).await?;
-    ainb_hangar_store::bootstrap::create_agent(
+    let created = ainb_hangar_store::bootstrap::create_agent(
         pool,
         ws.as_str(),
         name,
@@ -1567,6 +1567,22 @@ async fn handle_agent_create(
     )
     .await
     .map_err(|e| store_err(&e))?;
+    // Optional create-time token budget (0042): applied as a follow-up config
+    // write rather than widening create_agent's signature across every caller.
+    if let Some(budget) = params.token_budget {
+        let update = ainb_hangar_store::repo::agent::AgentConfigUpdate {
+            token_budget: Some(Some(budget)),
+            ..Default::default()
+        };
+        ainb_hangar_store::repo::agent::AgentRepo::update_config(
+            pool,
+            ws.as_str(),
+            &created.id,
+            &update,
+        )
+        .await
+        .map_err(|e| store_err(&e))?;
+    }
     // Answer with the refreshed roster (the same shape agents_list returns) so
     // the plugin folds the new agent into its cached list and the squad gate clears.
     let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;
@@ -1623,6 +1639,7 @@ fn agent_config_update_from_params(
         cli_args: params.cli_args.clone(),
         mcp_config: field_to_nested(&params.mcp_config),
         thinking: field_to_nested(&params.thinking),
+        token_budget: field_to_nested(&params.token_budget),
         agent_env: params.agent_env.clone(),
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -100,6 +100,9 @@ pub async fn issues_list(
             // ch3: the latest completed task's branch, so the task-detail opened
             // from the issue list renders the run-branch line.
             let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
+            // 63d: the card extras (repo/agent/branches + run summary) for the
+            // task-detail card.
+            let extras = issue_card_fields(pool, &issue.id).await?;
             out.push(IssueRow {
                 id,
                 display_id,
@@ -115,10 +118,74 @@ pub async fn issues_list(
                 labels: issue.labels,
                 pr_url,
                 branch,
+                repo_ref: extras.repo_ref,
+                agent: extras.agent,
+                source_branch: extras.source_branch,
+                target_branch: extras.target_branch,
+                run_count: extras.run_count,
+                last_run_status: extras.last_run_status,
+                last_run_at: extras.last_run_at,
             });
         }
     }
     Ok(out)
+}
+
+/// The extra fields a wire [`IssueRow`] carries for the task-detail card (63d):
+/// the migration-0042 card-parity fields plus the run-history summary.
+#[derive(Debug, Default, Clone)]
+struct IssueCardExtras {
+    repo_ref: Option<String>,
+    agent: Option<String>,
+    source_branch: Option<String>,
+    target_branch: Option<String>,
+    run_count: u32,
+    last_run_status: Option<String>,
+    last_run_at: Option<i64>,
+}
+
+/// Read the task-detail card extras for one issue (63d): the `repo_ref` / `agent`
+/// / source+target branches from the issue's migration-0042 columns
+/// ([`CardParityRepo`]), plus a one-query run summary (count + latest task's
+/// status + created_at) from `agent_task_queue`.
+///
+/// A single reader so every IssueRow-building path (list, search, update, create)
+/// fills the card extras identically. `agent` is the lowercase provider wire
+/// token; every field defaults to empty for a card with nothing pinned / never
+/// run.
+async fn issue_card_fields(
+    pool: &SqlitePool,
+    issue_id: &str,
+) -> Result<IssueCardExtras, sqlx::Error> {
+    use ainb_hangar_store::repo::card_parity::CardParityRepo;
+    let (repo_ref, agent) = CardParityRepo::get_issue_repo_agent(pool, issue_id)
+        .await?
+        .unwrap_or((None, None));
+    let (source_branch, target_branch) = CardParityRepo::get_issue_branches(pool, issue_id)
+        .await?
+        .unwrap_or((None, None));
+    // One round-trip for the run summary: total task count + the newest task's
+    // status + created_at (NULL for both when the issue never ran).
+    let (count, last_status, last_at): (i64, Option<String>, Option<i64>) = sqlx::query_as(
+        "SELECT COUNT(*), \
+         (SELECT status FROM agent_task_queue WHERE issue_id = ?1 \
+            ORDER BY created_at DESC, id DESC LIMIT 1), \
+         (SELECT created_at FROM agent_task_queue WHERE issue_id = ?1 \
+            ORDER BY created_at DESC, id DESC LIMIT 1) \
+         FROM agent_task_queue WHERE issue_id = ?1",
+    )
+    .bind(issue_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(IssueCardExtras {
+        repo_ref,
+        agent: agent.map(|a| a.as_str().to_string()),
+        source_branch,
+        target_branch,
+        run_count: u32::try_from(count).unwrap_or(u32::MAX),
+        last_run_status: last_status,
+        last_run_at: last_at,
+    })
 }
 
 /// The `HGR-<n>` display id for one issue, or `None` when the id resolves to no
@@ -172,6 +239,7 @@ pub async fn issues_search(
             issue_display_row(pool, workspace_id, &issue.id, prefix.as_deref()).await?;
         let pr_url = latest_pr_url_for_issue(pool, workspace_id, &issue.id).await?;
         let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
+        let extras = issue_card_fields(pool, &issue.id).await?;
         out.push(IssueRow {
             id,
             display_id,
@@ -187,6 +255,13 @@ pub async fn issues_search(
             labels: issue.labels,
             pr_url,
             branch,
+            repo_ref: extras.repo_ref,
+            agent: extras.agent,
+            source_branch: extras.source_branch,
+            target_branch: extras.target_branch,
+            run_count: extras.run_count,
+            last_run_status: extras.last_run_status,
+            last_run_at: extras.last_run_at,
         });
     }
     Ok(out)
@@ -1427,6 +1502,7 @@ pub async fn issue_row(
     let display_id = issue_display_row(pool, workspace_id, &issue.id, prefix.as_deref()).await?;
     let pr_url = latest_pr_url_for_issue(pool, workspace_id, &issue.id).await?;
     let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
+    let extras = issue_card_fields(pool, &issue.id).await?;
     Ok(Some(IssueRow {
         id,
         display_id,
@@ -1442,6 +1518,13 @@ pub async fn issue_row(
         labels: issue.labels,
         pr_url,
         branch,
+        repo_ref: extras.repo_ref,
+        agent: extras.agent,
+        source_branch: extras.source_branch,
+        target_branch: extras.target_branch,
+        run_count: extras.run_count,
+        last_run_status: extras.last_run_status,
+        last_run_at: extras.last_run_at,
     }))
 }
 
@@ -1520,6 +1603,7 @@ async fn read_issue_row(
     let display_id = issue_display_row(pool, workspace_id, &issue.id, prefix.as_deref()).await?;
     let pr_url = latest_pr_url_for_issue(pool, workspace_id, &issue.id).await?;
     let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
+    let extras = issue_card_fields(pool, &issue.id).await?;
     Ok(Some(IssueRow {
         id,
         display_id,
@@ -1535,6 +1619,13 @@ async fn read_issue_row(
         labels: issue.labels,
         pr_url,
         branch,
+        repo_ref: extras.repo_ref,
+        agent: extras.agent,
+        source_branch: extras.source_branch,
+        target_branch: extras.target_branch,
+        run_count: extras.run_count,
+        last_run_status: extras.last_run_status,
+        last_run_at: extras.last_run_at,
     }))
 }
 
@@ -1670,8 +1761,17 @@ pub async fn issue_create(
         due_date: None,
         labels: Vec::new(),
         pr_url: None,
-        // A freshly-created issue has no tasks yet, so no committed branch.
+        // A freshly-created issue has no tasks yet, so no committed branch, and no
+        // repo / agent / branches pinned until the follow-up issue_update (63d).
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        // A freshly-created issue has never run.
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -2484,6 +2484,7 @@ mod tests {
             thinking: None,
             agent_env: Vec::new(),
             provider: None,
+            token_budget: None,
         };
         AgentRepo::insert(pool, &bare).await.unwrap();
         let disp = resolve_dispatch(pool, "bare-agent", None, Mode::Headless).await.unwrap();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -653,6 +653,7 @@ async fn execute_claimed(
         &scratch_slug,
         &home,
         &env.workdir,
+        task.source_branch.as_deref(),
     )?;
     let location = run_location_for(&run_wd);
     tracing::info!(task_id = %task.id, cwd = %run_wd.path().display(), "run workdir provisioned");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
@@ -196,6 +196,7 @@ async fn seed_runtime_and_agent(pool: &SqlitePool, now: i64) -> Result<(), sqlx:
             thinking: None,
             agent_env: Vec::new(),
             provider: None,
+            token_budget: None,
         },
     )
     .await?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/workdir_provision.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/workdir_provision.rs
@@ -115,7 +115,11 @@ fn ainb_root(home: &Path) -> PathBuf {
 ///   `git init`ed idempotently, run in place. Keyed on the per-CARD `scratch_slug`
 ///   (stable across reruns), NOT the per-run `slug`.
 /// - `Some(path)` naming a git repo → a fresh worktree under
-///   `<home>/.agents-in-a-box/worktrees/<slug>` on branch `ainb/<slug>`.
+///   `<home>/.agents-in-a-box/worktrees/<slug>` on branch `ainb/<slug>`, based on
+///   `source_branch` when given (resolved as `<src>` then `origin/<src>`), else
+///   the repo's current HEAD — the default branch, usually `main`. Hardcoding a
+///   literal `main` default would break `master`-default repos, so HEAD is the
+///   None-case base (migration 0042).
 /// - `None` (or a blank ref) → the `fallback` execenv workdir, untouched.
 ///
 /// Idempotent on resume: a worktree whose path already exists (a recovered task)
@@ -126,13 +130,16 @@ fn ainb_root(home: &Path) -> PathBuf {
 /// # Errors
 ///
 /// Returns an [`io::Error`] if a directory cannot be created, `git init` /
-/// `git worktree add` fails, or a worktree `repo_ref` is not a valid UTF-8 path.
+/// `git worktree add` fails, a given `source_branch` resolves to no ref (neither
+/// local nor `origin/`-prefixed — failing CLOSED beats silently branching off the
+/// wrong base), or a worktree `repo_ref` is not a valid UTF-8 path.
 pub fn provision(
     repo_ref: Option<&str>,
     slug: &str,
     scratch_slug: &str,
     home: &Path,
     fallback: &Path,
+    source_branch: Option<&str>,
 ) -> io::Result<RunWorkdir> {
     let repo_ref = repo_ref.map(str::trim).filter(|s| !s.is_empty());
     match repo_ref {
@@ -140,7 +147,7 @@ pub fn provision(
             path: fallback.to_path_buf(),
         }),
         Some("scratch") => provision_scratch(scratch_slug, home),
-        Some(path) => provision_worktree(Path::new(path), slug, home),
+        Some(path) => provision_worktree(Path::new(path), slug, home, source_branch),
     }
 }
 
@@ -157,7 +164,18 @@ fn provision_scratch(slug: &str, home: &Path) -> io::Result<RunWorkdir> {
 
 /// Add a fresh worktree for `repo` at `<home>/.agents-in-a-box/worktrees/<slug>`
 /// on branch `ainb/<slug>`, or reuse an already-registered one (resume).
-fn provision_worktree(repo: &Path, slug: &str, home: &Path) -> io::Result<RunWorkdir> {
+///
+/// With a `source_branch`, the new branch is based on that ref — resolved as the
+/// local `<src>` first, then `origin/<src>` (a fresh clone materialises only the
+/// default local branch; every other branch lives under `origin/`). An
+/// unresolvable source is an ERROR, never a silent fall-through to HEAD: a run
+/// on the wrong base would produce work against the wrong code.
+fn provision_worktree(
+    repo: &Path,
+    slug: &str,
+    home: &Path,
+    source_branch: Option<&str>,
+) -> io::Result<RunWorkdir> {
     let path = ainb_root(home).join("worktrees").join(slug);
     let branch = worktree_branch(slug);
     let wt = RunWorkdir::Worktree {
@@ -175,8 +193,43 @@ fn provision_worktree(repo: &Path, slug: &str, home: &Path) -> io::Result<RunWor
         std::fs::create_dir_all(parent)?;
     }
     let path_str = path.to_str().ok_or_else(non_utf8_path)?;
-    run_git(repo, &["worktree", "add", path_str, "-b", &branch])?;
+    match source_branch.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(src) => {
+            let start = resolve_start_point(repo, src)?;
+            run_git(repo, &["worktree", "add", path_str, "-b", &branch, &start])?;
+        }
+        // No source chosen: branch off HEAD (the repo's default branch), the
+        // pre-0042 behavior.
+        None => run_git(repo, &["worktree", "add", path_str, "-b", &branch])?,
+    }
     Ok(wt)
+}
+
+/// Resolve a user-chosen source branch to the start-point `git worktree add`
+/// gets: the local `<src>` when it exists, else `origin/<src>` (the shape every
+/// non-default branch of a clone has), else a hard error naming both tries.
+fn resolve_start_point(repo: &Path, src: &str) -> io::Result<String> {
+    for candidate in [src.to_string(), format!("origin/{src}")] {
+        let ok = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args([
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("{candidate}^{{commit}}"),
+            ])
+            .output()?
+            .status
+            .success();
+        if ok {
+            return Ok(candidate);
+        }
+    }
+    Err(io::Error::other(format!(
+        "source branch `{src}` not found in {} (tried `{src}` and `origin/{src}`)",
+        repo.display()
+    )))
 }
 
 /// Tear down a run's working directory (spec F5 keep-if-dirty).
@@ -457,13 +510,132 @@ mod tests {
         run_git(dir, &["commit", "--quiet", "-m", "init"]).unwrap();
     }
 
+    /// A chosen source branch bases the worktree on THAT branch's tree, not the
+    /// repo's HEAD (0042): a sentinel file that exists only on `feature/x` shows
+    /// up in the provisioned worktree, and one that exists only on the default
+    /// branch does not.
+    #[test]
+    fn worktree_bases_on_chosen_source_branch() {
+        let home = tempfile::tempdir().unwrap();
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo = repo_dir.path();
+        init_repo_with_commit(repo);
+        // Default branch gains a HEAD-only file; feature/x gains its sentinel.
+        std::fs::write(repo.join("head-only.txt"), "on-head").unwrap();
+        run_git(repo, &["add", "."]).unwrap();
+        run_git(repo, &["commit", "--quiet", "-m", "head work"]).unwrap();
+        run_git(repo, &["branch", "feature/x", "HEAD~1"]).unwrap();
+        run_git(repo, &["switch", "--quiet", "feature/x"]).unwrap();
+        std::fs::write(repo.join("feature-sentinel.txt"), "on-feature").unwrap();
+        run_git(repo, &["add", "."]).unwrap();
+        run_git(repo, &["commit", "--quiet", "-m", "feature work"]).unwrap();
+        // Leave HEAD back on the default branch, so "off HEAD" would be WRONG.
+        run_git(repo, &["switch", "--quiet", "-"]).unwrap();
+
+        let fallback = home.path().join("fallback");
+        let wd = provision(
+            repo.to_str(),
+            "run-src",
+            "run-src",
+            home.path(),
+            &fallback,
+            Some("feature/x"),
+        )
+        .unwrap();
+        assert!(
+            wd.path().join("feature-sentinel.txt").exists(),
+            "the worktree must hold feature/x's tree"
+        );
+        assert!(
+            !wd.path().join("head-only.txt").exists(),
+            "the worktree must NOT hold the default branch's HEAD-only file"
+        );
+    }
+
+    /// An unknown source branch fails CLOSED (an error naming the ref), never a
+    /// silent fall-through to HEAD — a run on the wrong base is wrong work.
+    #[test]
+    fn unknown_source_branch_fails_closed() {
+        let home = tempfile::tempdir().unwrap();
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_repo_with_commit(repo_dir.path());
+        let fallback = home.path().join("fallback");
+        let err = provision(
+            repo_dir.path().to_str(),
+            "run-bad",
+            "run-bad",
+            home.path(),
+            &fallback,
+            Some("no-such-branch"),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no-such-branch"),
+            "the error must name the missing ref: {err}"
+        );
+    }
+
+    /// A remote-shaped clone (only origin/<branch> exists locally) still resolves
+    /// the source via the origin/ fallback — the ensure_clone case.
+    #[test]
+    fn source_branch_resolves_via_origin_prefix() {
+        let home = tempfile::tempdir().unwrap();
+        let origin_dir = tempfile::tempdir().unwrap();
+        let origin = origin_dir.path();
+        init_repo_with_commit(origin);
+        run_git(origin, &["branch", "feature/y"]).unwrap();
+        run_git(origin, &["switch", "--quiet", "feature/y"]).unwrap();
+        std::fs::write(origin.join("y-sentinel.txt"), "y").unwrap();
+        run_git(origin, &["add", "."]).unwrap();
+        run_git(origin, &["commit", "--quiet", "-m", "y"]).unwrap();
+        run_git(origin, &["switch", "--quiet", "-"]).unwrap();
+
+        // A plain clone materialises only the default local branch; feature/y
+        // exists solely as origin/feature/y — exactly ensure_clone's output.
+        let clone_dir = tempfile::tempdir().unwrap();
+        let clone = clone_dir.path().join("clone");
+        let out = Command::new("git")
+            .args([
+                "clone",
+                "--quiet",
+                origin.to_str().unwrap(),
+                clone.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+
+        let fallback = home.path().join("fallback");
+        let wd = provision(
+            clone.to_str(),
+            "run-origin",
+            "run-origin",
+            home.path(),
+            &fallback,
+            Some("feature/y"),
+        )
+        .unwrap();
+        assert!(
+            wd.path().join("y-sentinel.txt").exists(),
+            "origin/feature‑y must resolve via the origin/ fallback"
+        );
+    }
+
     /// A scratch ref git-inits an isolated repo under the home, idempotently. The
     /// dir is keyed on the per-CARD `scratch_slug`, NOT the per-run slug.
     #[test]
     fn scratch_git_inits_idempotently() {
         let home = tempfile::tempdir().unwrap();
         let fallback = home.path().join("fallback");
-        let a = provision(Some("scratch"), "run-1", "card-1", home.path(), &fallback).unwrap();
+        let a = provision(
+            Some("scratch"),
+            "run-1",
+            "card-1",
+            home.path(),
+            &fallback,
+            None,
+        )
+        .unwrap();
         let RunWorkdir::Scratch { path } = &a else {
             panic!("expected scratch, got {a:?}");
         };
@@ -473,7 +645,15 @@ mod tests {
             "scratch under ~/.agents-in-a-box/scratch/<scratch_slug>: {path:?}"
         );
         // A second provision is a no-op reuse (idempotent), not a re-init error.
-        let b = provision(Some("scratch"), "run-1", "card-1", home.path(), &fallback).unwrap();
+        let b = provision(
+            Some("scratch"),
+            "run-1",
+            "card-1",
+            home.path(),
+            &fallback,
+            None,
+        )
+        .unwrap();
         assert_eq!(a, b);
         // Teardown never removes a scratch repo.
         assert_eq!(teardown(&a).unwrap(), TeardownOutcome::NoOp);
@@ -489,11 +669,27 @@ mod tests {
         let fallback = home.path().join("fallback");
 
         // Run 1 of card-x provisions scratch and leaves a file behind.
-        let first = provision(Some("scratch"), "run-1", "card-x", home.path(), &fallback).unwrap();
+        let first = provision(
+            Some("scratch"),
+            "run-1",
+            "card-x",
+            home.path(),
+            &fallback,
+            None,
+        )
+        .unwrap();
         std::fs::write(first.path().join("notes.txt"), "prior scratch work").unwrap();
 
         // Run 2 of the SAME card (a DIFFERENT per-run slug) reuses the same dir.
-        let second = provision(Some("scratch"), "run-2", "card-x", home.path(), &fallback).unwrap();
+        let second = provision(
+            Some("scratch"),
+            "run-2",
+            "card-x",
+            home.path(),
+            &fallback,
+            None,
+        )
+        .unwrap();
         assert_eq!(
             first.path(),
             second.path(),
@@ -519,6 +715,7 @@ mod tests {
             "card-x-agentA",
             home.path(),
             &fallback,
+            None,
         )
         .unwrap();
         let b = provision(
@@ -527,6 +724,7 @@ mod tests {
             "card-x-agentB",
             home.path(),
             &fallback,
+            None,
         )
         .unwrap();
         assert_ne!(
@@ -551,6 +749,7 @@ mod tests {
             "slug-a",
             &home,
             &fallback,
+            None,
         )
         .unwrap();
         let RunWorkdir::Worktree { path, branch, .. } = &wd else {
@@ -585,8 +784,8 @@ mod tests {
         let fallback = home.join("fallback");
         let repo_ref = repo.to_str().unwrap();
 
-        let a = provision(Some(repo_ref), "slug-a", "slug-a", &home, &fallback).unwrap();
-        let b = provision(Some(repo_ref), "slug-b", "slug-b", &home, &fallback).unwrap();
+        let a = provision(Some(repo_ref), "slug-a", "slug-a", &home, &fallback, None).unwrap();
+        let b = provision(Some(repo_ref), "slug-b", "slug-b", &home, &fallback, None).unwrap();
         assert_ne!(a.path(), b.path(), "distinct worktree dirs");
         let (RunWorkdir::Worktree { branch: ba, .. }, RunWorkdir::Worktree { branch: bb, .. }) =
             (&a, &b)
@@ -613,6 +812,7 @@ mod tests {
             "clean",
             &home,
             &fallback,
+            None,
         )
         .unwrap();
         let path = wd.path().to_path_buf();
@@ -645,6 +845,7 @@ mod tests {
             "dirty",
             &home,
             &fallback,
+            None,
         )
         .unwrap();
         // Leave an uncommitted change in the worktree.
@@ -675,6 +876,7 @@ mod tests {
             "ahead",
             &home,
             &fallback,
+            None,
         )
         .unwrap();
         assert_eq!(commits_ahead(&wd).unwrap(), 0, "a no-commit run is 0 ahead");
@@ -703,9 +905,9 @@ mod tests {
         );
 
         // Scratch + fallback never surface a branch.
-        let scratch = provision(Some("scratch"), "s", "s", &home, &fallback).unwrap();
+        let scratch = provision(Some("scratch"), "s", "s", &home, &fallback, None).unwrap();
         assert_eq!(commits_ahead(&scratch).unwrap(), 0);
-        let fb = provision(None, "c", "c", &home, &fallback).unwrap();
+        let fb = provision(None, "c", "c", &home, &fallback, None).unwrap();
         assert_eq!(commits_ahead(&fb).unwrap(), 0);
     }
 
@@ -714,7 +916,7 @@ mod tests {
     fn no_repo_uses_fallback() {
         let home = tempfile::tempdir().unwrap();
         let fallback = home.path().join("execenv-workdir");
-        let wd = provision(None, "chat", "chat", home.path(), &fallback).unwrap();
+        let wd = provision(None, "chat", "chat", home.path(), &fallback, None).unwrap();
         assert_eq!(
             wd,
             RunWorkdir::Fallback {
@@ -724,7 +926,7 @@ mod tests {
         assert_eq!(wd.path(), fallback);
         assert_eq!(teardown(&wd).unwrap(), TeardownOutcome::NoOp);
         // A blank ref is treated the same as None.
-        let blank = provision(Some("  "), "chat", "chat", home.path(), &fallback).unwrap();
+        let blank = provision(Some("  "), "chat", "chat", home.path(), &fallback, None).unwrap();
         assert_eq!(blank, RunWorkdir::Fallback { path: fallback });
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/execenv_layout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/execenv_layout.rs
@@ -52,6 +52,7 @@ fn task_fixture(id: &str, issue_id: Option<&str>) -> Task {
         finished_at: None,
         autopilot_run_id: None,
         generation: 0,
+        source_branch: None,
         mode: "headless".to_string(),
         session_name: None,
         repo_ref: None,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
@@ -437,6 +437,175 @@ async fn live_dispatch_codex_writes_nonce_artifact() {
 ///
 /// # Mutation self-check
 ///
+/// The remote-repo + source-branch leg (0042, plans/hangar-task-agent-model.md
+/// P3): the REAL daemon clones a REMOTE (`file://` bare) repo, provisions the
+/// run's worktree off a NON-default `feature/x` source branch, and the REAL
+/// claude writes the nonce INTO that worktree.
+///
+/// The assertion ladder, side-effects first:
+///   1. a sentinel file that exists ONLY on `feature/x` is present in the
+///      recorded work_dir → the worktree is based on the chosen source, not the
+///      remote's default HEAD (the exact 0042 claim);
+///   2. the default branch's HEAD-only file is ABSENT → not merely a superset;
+///   3. the nonce artifact → the agent genuinely worked in that tree;
+///   4. only then task=done.
+///
+/// Mutation-proof: `LIVE_E2E_BREAK_SOURCE_BRANCH=1` drops `--source-branch`
+/// from the enqueue, so the worktree lands on the remote's default branch and
+/// assertion 1 goes RED — proving this leg detects a wrong-base dispatch.
+#[tokio::test]
+async fn live_dispatch_remote_repo_source_branch() {
+    let Some(ainb) = ainb_bin() else {
+        eprintln!("SKIPPED: ainb binary not built (run `cargo build -p ainb --bin ainb`)");
+        return;
+    };
+    let Some(claude) = real_claude() else {
+        eprintln!("SKIPPED: no authenticated claude on PATH");
+        return;
+    };
+    if !claude_alive(&claude) {
+        eprintln!("SKIPPED: no authenticated claude on PATH");
+        return;
+    }
+
+    let tag = format!("{}-{}", std::process::id(), now_ms());
+    let nonce = format!("HANGAR-LIVE-NONCE-{tag}");
+    let agent_name = format!("live-e2e-branch-{tag}");
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    // Build the REMOTE: a bare repo whose default branch holds `head-only.txt`
+    // and whose `feature/x` branch holds `feature-sentinel.txt` instead.
+    let remote_dir = tempfile::tempdir().expect("tempdir remote");
+    let remote_url = make_branchy_bare_remote(remote_dir.path());
+
+    run_ainb(
+        &ainb,
+        home.path(),
+        &["hangar", "agent", "create", "--name", &agent_name, "--provider", "claude"],
+    );
+    let pool = open_pool(&db_path).await;
+    let (agent_id, runtime_id) = agent_ids_by_name(&pool, &agent_name).await;
+    run_ainb(
+        &ainb,
+        home.path(),
+        &["hangar", "agent", "edit", &agent_id, "--model", "haiku"],
+    );
+
+    let daemon = LiveDaemon::spawn(&home.path().join("daemon.log"), home.path(), &runtime_id, &claude);
+
+    // Enqueue with the REMOTE repo + the feature source branch. The CLI clones
+    // the remote into the shared cache and persists the LOCAL path + the branch
+    // onto the issue AND the task row (one tx with the enqueue).
+    let brief = format!(
+        "Use the Bash tool to run exactly this one shell command and nothing else: \
+         printf '%s' '{nonce}' > {ARTIFACT_NAME}  \
+         Do not use the Write tool. Once the command has run, stop."
+    );
+    let break_source = std::env::var_os("LIVE_E2E_BREAK_SOURCE_BRANCH").is_some();
+    if break_source {
+        eprintln!(
+            "MUTATION: LIVE_E2E_BREAK_SOURCE_BRANCH set — enqueue omits --source-branch, so \
+             the worktree lands on the remote's default branch and the sentinel assert goes RED"
+        );
+    }
+    let mut args: Vec<&str> = vec![
+        "hangar", "issue", "create", "--title", &brief, "--assign", &agent_id, "--repo",
+        &remote_url,
+    ];
+    if !break_source {
+        args.extend_from_slice(&["--source-branch", "feature/x"]);
+    }
+    let stdout = run_ainb_capture(&ainb, home.path(), &args);
+    let task_id = parse_queued_task_id(&stdout);
+
+    let row = wait_for_terminal(&pool, &task_id, TASK_BUDGET, home.path()).await;
+    let status: String = row.get("status");
+    drop(daemon);
+
+    let work_dir: Option<String> = row.get("work_dir");
+    let work_dir = work_dir.unwrap_or_else(|| {
+        panic!(
+            "task {task_id} reached status={status} but recorded NO work_dir. daemon log:\n{}",
+            read_log(home.path())
+        )
+    });
+    let wd = Path::new(&work_dir);
+
+    // 1+2. THE source-branch assertion, before anything else: the worktree must
+    // hold feature/x's tree, not the default branch's.
+    assert!(
+        wd.join("feature-sentinel.txt").exists(),
+        "SOURCE-BRANCH VIOLATION: the worktree at {wd:?} lacks feature/x's sentinel — \
+         the run was based on the WRONG branch (status={status}). daemon log:\n{}",
+        read_log(home.path())
+    );
+    assert!(
+        !wd.join("head-only.txt").exists(),
+        "the worktree holds the default branch's HEAD-only file — it is NOT feature/x's tree"
+    );
+
+    // 3. The agent's own artifact in that same tree.
+    let artifact = wd.join(ARTIFACT_NAME);
+    let got = std::fs::read_to_string(&artifact).unwrap_or_else(|e| {
+        panic!(
+            "NONCE ARTIFACT MISSING at {artifact:?} ({e}); status={status}. daemon log:\n{}",
+            read_log(home.path())
+        )
+    });
+    assert_eq!(got.trim(), nonce, "artifact exists but nonce mismatch");
+
+    // 4. Only now is `done` trustworthy.
+    assert_eq!(status, "done", "sentinel + nonce present but status={status:?}, not done");
+
+    eprintln!(
+        "LIVE E2E BRANCH OK: task {task_id} done; worktree on feature/x verified at {wd:?}; \
+         nonce verified; remote clone + source-branch dispatch proven"
+    );
+}
+
+/// Build a bare "remote" with a default branch carrying `head-only.txt` and a
+/// `feature/x` branch carrying `feature-sentinel.txt` instead, returning its
+/// `file://` URL (so the CLI treats it as a REMOTE and exercises ensure_clone).
+fn make_branchy_bare_remote(dir: &Path) -> String {
+    let work = dir.join("work");
+    std::fs::create_dir_all(&work).expect("mk work");
+    let git = |args: &[&str]| {
+        let out = Command::new("git").arg("-C").arg(&work).args(args).output().expect("git");
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    };
+    git(&["init", "--quiet"]);
+    git(&["config", "user.email", "t@e.com"]);
+    git(&["config", "user.name", "t"]);
+    std::fs::write(work.join("README.md"), "base").expect("write");
+    git(&["add", "."]);
+    git(&["commit", "--quiet", "-m", "base"]);
+    // feature/x forks BEFORE the default branch gains its HEAD-only file.
+    git(&["branch", "feature/x"]);
+    std::fs::write(work.join("head-only.txt"), "on-default").expect("write");
+    git(&["add", "."]);
+    git(&["commit", "--quiet", "-m", "default work"]);
+    git(&["switch", "--quiet", "feature/x"]);
+    std::fs::write(work.join("feature-sentinel.txt"), "on-feature").expect("write");
+    git(&["add", "."]);
+    git(&["commit", "--quiet", "-m", "feature work"]);
+    git(&["switch", "--quiet", "-"]);
+
+    let bare = dir.join("remote.git");
+    let out = Command::new("git")
+        .args([
+            "clone",
+            "--quiet",
+            "--bare",
+            work.to_str().unwrap(),
+            bare.to_str().unwrap(),
+        ])
+        .output()
+        .expect("bare clone");
+    assert!(out.status.success(), "bare clone: {}", String::from_utf8_lossy(&out.stderr));
+    format!("file://{}", bare.display())
+}
+
 /// Revert the finalize-on-structured-result change in `runner::run_provider`
 /// (the `match terminal { … }` block) and this task reaches `done` — the exit-0
 /// fallback scores it `Success` — turning the `failed` + `iteration_limit`

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -215,6 +215,13 @@ fn issue_event() -> HangarEvent {
         labels: Vec::new(),
         pr_url: None,
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_delete.rs
@@ -1,0 +1,306 @@
+//! Integration: the `hangar/issue_delete` RPC deletes an issue over a real
+//! framed `UnixStream`, pushes the matching `hangar/event` (`issue_deleted`) to
+//! subscribed connections, refuses while a task is ACTIVE, and is
+//! workspace-scoped (63d).
+//!
+//! The seed fixture lays down three open issues in `WS_ID`; here a connection
+//! authenticates, subscribes the workspace, and asserts (a) a delete acks + pushes
+//! `issue_deleted` + drops the row from a follow-up `issues_list`, (b) an issue
+//! with a live task is refused with a "cancel the run first" error, and (c) a
+//! mistyped workspace is rejected, never a silent delete.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_ID, WS_SLUG};
+use ainb_hangar_proto::events::EVENT_METHOD;
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn next_event(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.checked_duration_since(Instant::now())?;
+            let frame = self.read_frame(remaining).await?;
+            if frame.get("id").is_none() && frame["method"] == EVENT_METHOD {
+                return Some(frame["params"].clone());
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    async fn subscribe(&mut self, workspace_id: &str) {
+        let resp = self
+            .call(
+                methods::WORKSPACE_SUBSCRIBE,
+                serde_json::json!({ "workspace_id": workspace_id }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "subscribe must ack: {resp}");
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// An authenticated, subscribed connection deletes a seeded issue: the response
+/// acks, the connection receives the `issue_deleted` push, and the issue is gone
+/// from a fresh snapshot.
+#[tokio::test]
+async fn issue_delete_removes_and_pushes_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    // issue-3 has no task in the fixture (issue-1 carries the running task), so it
+    // is the clean happy-path delete.
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_DELETE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-3" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "delete must ack: {resp}");
+
+    // The subscribed connection received the issue_deleted push. Drain it BEFORE
+    // the next request — `call()` discards interleaved notifications.
+    let event = c
+        .next_event(Duration::from_secs(5))
+        .await
+        .expect("a committed delete must push an issue_deleted event");
+    assert_eq!(event["event"], "issue_deleted", "wrong event: {event}");
+    assert_eq!(event["issue_id"], "issue-3");
+
+    // The delete persisted: a fresh issues_list no longer carries issue-3, while
+    // its siblings remain.
+    let list = c
+        .call(
+            methods::HANGAR_ISSUES_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    let issues = list["result"]["issues"].as_array().unwrap();
+    assert!(
+        issues.iter().all(|i| i["id"] != "issue-3"),
+        "issue-3 gone from the snapshot"
+    );
+    assert!(
+        issues.iter().any(|i| i["id"] == "issue-2"),
+        "sibling issue-2 untouched"
+    );
+}
+
+/// An issue with a live (running) task refuses the delete with a "cancel the run
+/// first" error, and the issue survives.
+#[tokio::test]
+async fn issue_delete_refuses_while_a_task_is_active() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    // Enqueue a task on issue-2 and force it RUNNING (an active status).
+    let (runtime_id, agent_id): (String, String) =
+        sqlx::query_as("SELECT a.runtime_id, a.id FROM agent a WHERE a.workspace_id = ? LIMIT 1")
+            .bind(WS_ID)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at) \
+         VALUES ('t-live', ?, ?, ?, 'issue-2', 'running', 0)",
+    )
+    .bind(WS_ID)
+    .bind(&runtime_id)
+    .bind(&agent_id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_DELETE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-2" }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an active-task issue must refuse deletion: {resp}"
+    );
+    assert!(
+        resp["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cancel the run first"),
+        "refusal must tell the caller to cancel first: {resp}"
+    );
+
+    // issue-2 survives.
+    let list = c
+        .call(
+            methods::HANGAR_ISSUES_LIST,
+            serde_json::json!({ "workspace_id": WS_ID }),
+        )
+        .await;
+    let issues = list["result"]["issues"].as_array().unwrap();
+    assert!(
+        issues.iter().any(|i| i["id"] == "issue-2"),
+        "refused delete left issue-2 in place"
+    );
+}
+
+/// A mistyped / foreign workspace is rejected with an error — never a silent
+/// delete — and the issue is untouched.
+#[tokio::test]
+async fn issue_delete_rejects_unknown_workspace_and_touches_no_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_DELETE,
+            serde_json::json!({
+                "workspace_id": "nope-not-a-workspace",
+                "issue_id": "issue-1",
+            }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an unknown workspace must be rejected, not a silent delete: {resp}"
+    );
+
+    // issue-1 is untouched under its real workspace.
+    let list = c
+        .call(
+            methods::HANGAR_ISSUES_LIST,
+            serde_json::json!({ "workspace_id": WS_ID }),
+        )
+        .await;
+    let issues = list["result"]["issues"].as_array().unwrap();
+    assert!(
+        issues.iter().any(|i| i["id"] == "issue-1"),
+        "rejected delete left issue-1 in place"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
@@ -184,6 +184,7 @@ async fn seed_second_agent(store: &Store) {
             thinking: None,
             agent_env: Vec::new(),
             provider: None,
+            token_budget: None,
         },
     )
     .await
@@ -229,6 +230,7 @@ async fn seed_agent_on(store: &Store, agent_id: &str, runtime_id: &str) {
             thinking: None,
             agent_env: Vec::new(),
             provider: None,
+            token_budget: None,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/worktree_integration.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/worktree_integration.rs
@@ -62,6 +62,7 @@ fn task_fixture(id: &str, issue_id: Option<&str>) -> Task {
         finished_at: None,
         autopilot_run_id: None,
         generation: 0,
+        source_branch: None,
         mode: "headless".to_string(),
         session_name: None,
         repo_ref: None,

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -301,6 +301,44 @@ pub struct IssueRow {
     /// `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+    /// The card's persisted repo reference (`issue.repo_ref`, migration 0042): an
+    /// absolute path, `scratch`, or a remote indicator. `None` when the card has no
+    /// repo pinned yet. Drives the task-detail card's `Repo:` line (63d). Omitted
+    /// from the wire when `None` (`skip_serializing_if`) so the shape only grows for
+    /// a reader that supplies it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_ref: Option<String>,
+    /// The card's persisted provider agent wire token (`issue.agent_kind`, migration
+    /// 0042): `claude` / `codex` / `copilot`, or `None` when unset (the F4 cascade
+    /// decides at run). Drives the task-detail card's `Agent:` line (63d). Omitted
+    /// from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    /// The card's persisted SOURCE branch a run branches FROM (`issue.source_branch`,
+    /// migration 0042), or `None` for the repo default. Drives the task-detail card's
+    /// `Source:` line (63d). Omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_branch: Option<String>,
+    /// The card's persisted TARGET branch a future PR lands INTO
+    /// (`issue.target_branch`, migration 0042), or `None` when unset. Drives the
+    /// task-detail card's `Target:` line (63d). Omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_branch: Option<String>,
+    /// How many tasks (any lifecycle) have ever run against this issue (63d).
+    /// `0` for a never-run issue. Drives the task-detail card's `Runs:` history
+    /// line, shown only when non-zero. `#[serde(default)]` keeps a pre-63d snapshot
+    /// decodable (defaults to `0`).
+    #[serde(default)]
+    pub run_count: u32,
+    /// The lifecycle status of the issue's latest task (`running` / `done` /
+    /// `failed` / …), or `None` when it never ran. Drives the `Runs:` line's
+    /// `(last: <status> …)`. Omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_status: Option<String>,
+    /// When the issue's latest task was created (epoch ms), or `None` when it never
+    /// ran. Drives the `Runs:` line's `<when>`. Omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<i64>,
 }
 
 /// A wire-side actor row for the agent-picker snapshot (`hangar/agents_list`).

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -199,6 +199,26 @@ pub const HANGAR_ISSUE_UPDATE: &str = "hangar/issue_update";
 /// list re-renders the new row without re-pulling the whole snapshot.
 pub const HANGAR_ISSUE_CREATE: &str = "hangar/issue_create";
 
+/// `hangar/issue_delete` — delete one issue and all its history (63d).
+///
+/// Params: [`crate::snapshots::IssueDeleteParams`] (`{ workspace_id, issue_id }`).
+/// Result: `{}`. Cascades the issue's dependent rows in one store transaction
+/// ([`ainb_hangar_store::repo::issue::IssueRepo::delete_cascade`]): comments,
+/// board placements, label links, dependency edges, terminal tasks (+ their usage
+/// rows), while `run_history` survives with its task link nulled (cost accounting
+/// never shrinks).
+///
+/// **Refuses while any task is ACTIVE** (`queued` / `dispatched` / `running`) with
+/// an `INVALID_PARAMS` telling the caller to cancel the run first — a delete never
+/// orphans a live task. Mutating + workspace-scoped, mirroring
+/// [`HANGAR_ISSUE_UPDATE`]: the daemon resolves the workspace and rejects a
+/// mistyped one with `INVALID_PARAMS`, and an issue id owned by another tenant
+/// resolves to no row (a not-found rejection, never a cross-tenant delete). After
+/// a committed delete the daemon pushes the matching
+/// [`crate::events::HangarEvent::IssueDeleted`] so a subscribed issue list drops
+/// the row without a full re-pull.
+pub const HANGAR_ISSUE_DELETE: &str = "hangar/issue_delete";
+
 /// `hangar/issue_run` — enqueue a run of one issue WITHOUT a board (the Issues
 /// screen's create-wizard dispatch; plans/hangar-task-agent-model.md).
 ///
@@ -1018,6 +1038,8 @@ pub const ALL_METHODS: &[&str] = &[
     // Agent create-from-scratch (fresh-home bootstrap), likewise appended.
     HANGAR_AGENT_CREATE,
     HANGAR_DAEMON_CONFIG_LIST,
+    // Issue delete (63d) is APPENDED at the catalogue tail — append-only wire.
+    HANGAR_ISSUE_DELETE,
 ];
 
 #[cfg(test)]
@@ -1121,6 +1143,7 @@ mod tests {
             HANGAR_SQUAD_FANOUT,
             HANGAR_RUN_HISTORY,
             HANGAR_AGENT_CREATE,
+            HANGAR_ISSUE_DELETE,
         ] {
             assert!(m.starts_with("hangar/"), "{m:?} not under hangar/");
         }
@@ -1214,6 +1237,7 @@ mod tests {
             HANGAR_DAEMON_CONFIG_SET,
             HANGAR_AGENT_CREATE,
             HANGAR_DAEMON_CONFIG_LIST,
+            HANGAR_ISSUE_DELETE,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -199,6 +199,17 @@ pub const HANGAR_ISSUE_UPDATE: &str = "hangar/issue_update";
 /// list re-renders the new row without re-pulling the whole snapshot.
 pub const HANGAR_ISSUE_CREATE: &str = "hangar/issue_create";
 
+/// `hangar/issue_run` — enqueue a run of one issue WITHOUT a board (the Issues
+/// screen's create-wizard dispatch; plans/hangar-task-agent-model.md).
+///
+/// The board-less sibling of [`HANGAR_BOARD_CARD_RUN`]: the same launch core
+/// (refuse-run guard → squad fan-out vs single enqueue, repo REQUIRED, F4 agent
+/// cascade, 0042 source-branch resolve) minus the board-membership validation,
+/// with the F4 board tier skipped. Params: [`crate::snapshots::IssueRunParams`];
+/// result: [`crate::snapshots::BoardCardRunResult`] (identical shape — the
+/// caller cares about the enqueued task, not the surface it launched from).
+pub const HANGAR_ISSUE_RUN: &str = "hangar/issue_run";
+
 /// `hangar/issue_label_attach` — attach a label to one issue (e38.10).
 ///
 /// Params: [`crate::snapshots::IssueLabelParams`]

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1607,6 +1607,33 @@ pub struct BoardCardCreateParams {
     pub target_branch: Option<String>,
 }
 
+/// Params for [`crate::methods::HANGAR_ISSUE_RUN`]: enqueue a run of one issue
+/// WITHOUT a board (the Issues create-wizard dispatch).
+///
+/// Same override semantics as [`BoardCardRunParams`], minus the board identity.
+/// Result shape: [`BoardCardRunResult`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueRunParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue to launch.
+    pub issue_id: String,
+    /// The launch mode (`headless` or `interactive`).
+    pub mode: String,
+    /// A run-time REPO override; omitted uses the issue's persisted `repo_ref`
+    /// (repo REQUIRED at run, like `board_card_run`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_ref: Option<String>,
+    /// A run-time AGENT override (`claude`/`codex`/`copilot`); omitted resolves
+    /// via the F4 cascade (board tier skipped — no board).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    /// A run-time SOURCE-BRANCH override (0042); omitted uses the issue's
+    /// persisted `source_branch`, else the repo's default branch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_branch: Option<String>,
+}
+
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_RUN`] (ccc / D6, D16): launch a
 /// card's issue on its assignee profile now.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1634,6 +1634,20 @@ pub struct IssueRunParams {
     pub source_branch: Option<String>,
 }
 
+/// Params for [`crate::methods::HANGAR_ISSUE_DELETE`] (63d): delete one issue and
+/// all its history from a workspace.
+///
+/// Workspace-scoped like every mutation: the daemon rejects a mistyped
+/// `workspace_id` with `INVALID_PARAMS`, and an `issue_id` owned by another tenant
+/// resolves to no row (also rejected, never a cross-tenant delete).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueDeleteParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue to delete.
+    pub issue_id: String,
+}
+
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_RUN`] (ccc / D6, D16): launch a
 /// card's issue on its assignee profile now.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -2020,6 +2034,13 @@ mod tests {
                 labels: Vec::new(),
                 pr_url: None,
                 branch: None,
+                repo_ref: None,
+                agent: None,
+                source_branch: None,
+                target_branch: None,
+                run_count: 0,
+                last_run_status: None,
+                last_run_at: None,
             }],
         };
         let s = serde_json::to_string(&issues).unwrap();

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -947,6 +947,14 @@ pub struct IssueUpdateParams {
     /// cascade then decides), never an error. Append-only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+    /// New SOURCE branch the run branches FROM (migration 0042); `None` leaves
+    /// it. Resolved at dispatch (`main` default when never set). Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_branch: Option<String>,
+    /// New TARGET branch a future PR lands INTO (migration 0042); `None` leaves
+    /// it. Stored now, consumed by later PR automation. Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_branch: Option<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_ISSUE_LABEL_ATTACH`] /
@@ -1039,6 +1047,10 @@ pub struct AgentUpdateParams {
     /// empty list is a valid "no env").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_env: Option<Vec<(String, String)>>,
+    /// New token budget (rtk/headroom); omitted leaves it, `null` clears it
+    /// (back to unlimited), a value sets it (migration 0042).
+    #[serde(default, skip_serializing_if = "FieldUpdate::is_keep")]
+    pub token_budget: FieldUpdate<i64>,
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_CREATE`]: create one agent from
@@ -1065,6 +1077,9 @@ pub struct AgentCreateParams {
     /// Optional free-form system prompt / instructions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Optional token budget (rtk/headroom); absent = unlimited (migration 0042).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<i64>,
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_ARCHIVE`] (e38.15): archive or
@@ -1582,6 +1597,14 @@ pub struct BoardCardCreateParams {
     /// decides), never a hard reject — the wire stays forward-compatible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+    /// The SOURCE branch a run branches FROM (migration 0042). APPEND-ONLY:
+    /// omitted (`None`) resolves to `main` at dispatch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_branch: Option<String>,
+    /// The TARGET branch a future PR lands INTO (migration 0042). APPEND-ONLY:
+    /// stored now, consumed by later PR automation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_branch: Option<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_RUN`] (ccc / D6, D16): launch a
@@ -1608,6 +1631,10 @@ pub struct BoardCardRunParams {
     /// cascade. An unrecognised token is ignored (cascade decides).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+    /// A run-time SOURCE-BRANCH override (migration 0042). APPEND-ONLY: omitted
+    /// (`None`) uses the issue's persisted `source_branch`, else `main`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_branch: Option<String>,
 }
 
 /// Result of [`crate::methods::HANGAR_BOARD_CARD_RUN`] (ccc / D6): the enqueued
@@ -2324,6 +2351,8 @@ mod tests {
             title: Some("Renamed card".into()),
             repo_ref: Some("/repos/app".into()),
             agent: Some("codex".into()),
+            source_branch: Some("develop".into()),
+            target_branch: Some("main".into()),
         };
         let s = serde_json::to_string(&full).unwrap();
         assert_eq!(serde_json::from_str::<IssueUpdateParams>(&s).unwrap(), full);
@@ -2385,6 +2414,7 @@ mod tests {
             mcp_config: FieldUpdate::Set(r#"{"servers":{}}"#.into()),
             thinking: FieldUpdate::Set("high".into()),
             agent_env: Some(vec![("FOO".into(), "bar".into())]),
+            token_budget: FieldUpdate::Set(500_000),
         };
         let s = serde_json::to_string(&full).unwrap();
         assert_eq!(serde_json::from_str::<AgentUpdateParams>(&s).unwrap(), full);
@@ -2434,6 +2464,7 @@ mod tests {
             name: "reviewer".into(),
             provider: Some("codex".into()),
             instructions: Some("be terse".into()),
+            token_budget: Some(250_000),
         };
         let s = serde_json::to_string(&full).unwrap();
         assert_eq!(serde_json::from_str::<AgentCreateParams>(&s).unwrap(), full);

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -45,6 +45,13 @@ fn sample_issue() -> IssueRow {
         labels: Vec::new(),
         pr_url: Some("https://github.com/o/r/pull/42".to_string()),
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0042_task_agent_enrich.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0042_task_agent_enrich.sql
@@ -1,0 +1,15 @@
+-- 0042: enriched task + agent model (plan: plans/hangar-task-agent-model.md).
+--
+-- Agent: optional token budget (rtk/headroom). NULL = unlimited. Stored +
+-- surfaced only in this milestone; dispatch-time enforcement is a later
+-- feature.
+ALTER TABLE agent ADD COLUMN token_budget INTEGER;
+
+-- Task inputs: the branch a run branches FROM (resolved at dispatch,
+-- default `main` when NULL), and the branch a future PR lands INTO
+-- (stored now, consumed by later PR automation). Distinct from
+-- agent_task_queue.branch, which is the PRODUCED `ainb/<slug>` output
+-- branch recorded post-run.
+ALTER TABLE issue ADD COLUMN source_branch TEXT;
+ALTER TABLE issue ADD COLUMN target_branch TEXT;
+ALTER TABLE agent_task_queue ADD COLUMN source_branch TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -310,6 +310,7 @@ pub async fn create_agent(
         thinking: None,
         agent_env: Vec::new(),
         provider: Some(provider.to_string()),
+        token_budget: None,
     };
     AgentRepo::insert(pool, &agent).await?;
     Ok(agent)

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -111,11 +111,7 @@ pub async fn apply_migrations(pool: &SqlitePool) -> anyhow::Result<()> {
 /// - the probe query itself fails (file deleted, corrupt, locked) → the
 ///   database is unreachable outright.
 pub async fn schema_drift(pool: &SqlitePool) -> Option<String> {
-    let embedded_max = sqlx::migrate!("./migrations")
-        .iter()
-        .map(|m| m.version)
-        .max()
-        .unwrap_or(0);
+    let embedded_max = sqlx::migrate!("./migrations").iter().map(|m| m.version).max().unwrap_or(0);
     let applied_max: Result<Option<i64>, sqlx::Error> =
         sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations")
             .fetch_one(pool)

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -76,6 +76,10 @@ pub struct Agent {
     /// and the daemon spawns THIS provider's backend per task, so a `codex` agent
     /// runs codex.
     pub provider: Option<String>,
+    /// Optional token budget (rtk/headroom) for this agent's runs; `None` =
+    /// unlimited (migration 0042). Stored + surfaced only in this milestone —
+    /// dispatch-time enforcement is a later feature.
+    pub token_budget: Option<i64>,
 }
 
 /// A partial-edit instruction for one agent's mutable config (e38.15).
@@ -111,6 +115,9 @@ pub struct AgentConfigUpdate {
     /// New per-agent env map, or `None` to leave it unchanged (an empty `Vec` is
     /// a valid "no env" value, distinct from leaving it).
     pub agent_env: Option<Vec<(String, String)>>,
+    /// New token budget: `None` leaves it, `Some(None)` clears it (back to
+    /// unlimited), `Some(Some(_))` sets it.
+    pub token_budget: Option<Option<i64>>,
 }
 
 impl AgentConfigUpdate {
@@ -125,6 +132,7 @@ impl AgentConfigUpdate {
             && self.mcp_config.is_none()
             && self.thinking.is_none()
             && self.agent_env.is_none()
+            && self.token_budget.is_none()
     }
 }
 
@@ -143,8 +151,9 @@ impl AgentRepo {
         sqlx::query(
             "INSERT INTO agent \
              (id, workspace_id, name, runtime_id, instructions, visibility, owner_id, \
-              archived, model, cli_args, mcp_config, thinking, agent_env, provider) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              archived, model, cli_args, mcp_config, thinking, agent_env, provider, \
+              token_budget) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&agent.id)
         .bind(&agent.workspace_id)
@@ -160,6 +169,7 @@ impl AgentRepo {
         .bind(&agent.thinking)
         .bind(env_to_json(&agent.agent_env))
         .bind(&agent.provider)
+        .bind(agent.token_budget)
         .execute(pool)
         .await?;
         Ok(())
@@ -271,6 +281,9 @@ impl AgentRepo {
         if update.agent_env.is_some() {
             sets.push("agent_env = ?");
         }
+        if update.token_budget.is_some() {
+            sets.push("token_budget = ?");
+        }
         let sql = format!(
             "UPDATE agent SET {} WHERE id = ? AND workspace_id = ?",
             sets.join(", ")
@@ -299,6 +312,9 @@ impl AgentRepo {
         }
         if let Some(agent_env) = &update.agent_env {
             query = query.bind(env_to_json(agent_env));
+        }
+        if let Some(token_budget) = &update.token_budget {
+            query = query.bind(token_budget);
         }
         let res = query.bind(id).bind(workspace_id).execute(pool).await?;
         Ok(res.rows_affected() == 1)
@@ -336,7 +352,8 @@ impl AgentRepo {
 /// The full column list every `SELECT` reads, in [`Agent::from_row`] order. A
 /// single constant keeps the read queries in lockstep with the `FromRow` impl.
 const SELECT_COLS: &str = "SELECT id, workspace_id, name, runtime_id, instructions, visibility, \
-     owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, provider FROM agent";
+     owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, provider, \
+     token_budget FROM agent";
 
 /// Serialize a CLI-args list into the JSON-array text the `cli_args` column
 /// stores. An empty list yields `"[]"` (the column default).
@@ -409,6 +426,7 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Agent {
             thinking: row.try_get("thinking")?,
             agent_env: env_from_json(&row.try_get::<String, _>("agent_env")?)?,
             provider: row.try_get("provider")?,
+            token_budget: row.try_get("token_budget")?,
         })
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_parity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_parity.rs
@@ -112,6 +112,89 @@ impl CardParityRepo {
         Ok(row.map(|(repo, agent)| (repo, agent.as_deref().and_then(AgentKind::parse))))
     }
 
+    /// Persist a card's source and/or target branch onto its issue row
+    /// (migration 0042), workspace-scoped like [`Self::set_issue_repo_agent`].
+    ///
+    /// PARTIAL update with the same contract: a `None` field is left unchanged
+    /// (never cleared), both-`None` is a no-op (`Ok(false)`). `source_branch` is
+    /// the ref a run branches FROM (dispatch defaults `main` when unset);
+    /// `target_branch` is where a future PR lands (stored for later automation).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault. `Ok(false)` when no
+    /// `(issue_id, workspace_id)` row matched or nothing was written.
+    pub async fn set_issue_branches(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        source_branch: Option<&str>,
+        target_branch: Option<&str>,
+    ) -> Result<bool, sqlx::Error> {
+        let mut sets: Vec<&str> = Vec::new();
+        if source_branch.is_some() {
+            sets.push("source_branch = ?");
+        }
+        if target_branch.is_some() {
+            sets.push("target_branch = ?");
+        }
+        if sets.is_empty() {
+            return Ok(false);
+        }
+        let sql = format!(
+            "UPDATE issue SET {} WHERE id = ? AND workspace_id = ?",
+            sets.join(", ")
+        );
+        let mut query = sqlx::query(&sql);
+        if let Some(source) = source_branch {
+            query = query.bind(source);
+        }
+        if let Some(target) = target_branch {
+            query = query.bind(target);
+        }
+        let res = query.bind(issue_id).bind(workspace_id).execute(pool).await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Read a card's persisted `(source_branch, target_branch)` from its issue,
+    /// or `None` when the issue does not exist (migration 0042).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn get_issue_branches(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Option<(Option<String>, Option<String>)>, sqlx::Error> {
+        sqlx::query_as::<_, (Option<String>, Option<String>)>(
+            "SELECT source_branch, target_branch FROM issue WHERE id = ?",
+        )
+        .bind(issue_id)
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// Persist the resolved SOURCE branch onto a task row, WITHIN the enqueue
+    /// transaction (migration 0042) — same atomicity contract as
+    /// [`Self::set_task_repo_agent_in_tx`]: the claim loop can never observe a
+    /// task missing its dispatch inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_task_source_branch_in_tx(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        task_id: &str,
+        source_branch: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE agent_task_queue SET source_branch = ? WHERE id = ?")
+            .bind(source_branch)
+            .bind(task_id)
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }
+
     /// Assign (or clear, with `None`) a card's SQUAD onto its issue row (tcp T4 /
     /// F7). Workspace-scoped so the write is self-guarded at the SQL boundary (a
     /// foreign-tenant issue id matches no row — never a cross-tenant write).
@@ -603,6 +686,79 @@ mod tests {
             CardParityRepo::resolve_agent_cascade(pool, &ws("ws-a"), None).await.unwrap(),
             AgentKind::Codex
         );
+    }
+
+    /// The 0042 branch fields round-trip: issue source/target branches are
+    /// partial + workspace-scoped like repo/agent, and a task's source_branch
+    /// persists through the enqueue-tx setter.
+    #[tokio::test]
+    async fn issue_and_task_branches_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "issue-1").await;
+
+        // Unset by default; missing issue → None.
+        assert_eq!(
+            CardParityRepo::get_issue_branches(pool, "issue-1").await.unwrap(),
+            Some((None, None))
+        );
+        assert_eq!(
+            CardParityRepo::get_issue_branches(pool, "nope").await.unwrap(),
+            None
+        );
+
+        // Set both; then a source-only edit must not drop the target.
+        assert!(
+            CardParityRepo::set_issue_branches(
+                pool,
+                "ws-a",
+                "issue-1",
+                Some("develop"),
+                Some("main")
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            CardParityRepo::set_issue_branches(pool, "ws-a", "issue-1", Some("feature/x"), None)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            CardParityRepo::get_issue_branches(pool, "issue-1").await.unwrap(),
+            Some((Some("feature/x".to_string()), Some("main".to_string()))),
+            "a source-only edit must not drop the target branch"
+        );
+        // Both-None no-op; cross-tenant write misses.
+        assert!(
+            !CardParityRepo::set_issue_branches(pool, "ws-a", "issue-1", None, None)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !CardParityRepo::set_issue_branches(pool, "ws-b", "issue-1", Some("hax"), None)
+                .await
+                .unwrap()
+        );
+
+        // Task-side: enqueue-tx setter persists, and the Task read model carries it.
+        sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u','u@e.com',0)")
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode, status) VALUES ('rt','ws-a','d','claude','local','online')").execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO agent (id, workspace_id, name, runtime_id, instructions, visibility, owner_id) VALUES ('ag','ws-a','A','rt','x','workspace','u')").execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, status, created_at) VALUES ('t1','ws-a','rt','ag','queued',0)").execute(pool).await.unwrap();
+
+        let mut tx = pool.begin().await.unwrap();
+        CardParityRepo::set_task_source_branch_in_tx(&mut tx, "t1", Some("feature/x"))
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+        let task = crate::repo::task::TaskRepo::get_by_id(pool, "t1").await.unwrap().unwrap();
+        assert_eq!(task.source_branch.as_deref(), Some("feature/x"));
     }
 
     /// A card's squad assignment round-trips, defaults None, clears with None, and

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -121,6 +121,104 @@ impl IssueFieldUpdate {
     }
 }
 
+/// Counts of the dependent rows an issue delete removes — the delete summary and
+/// the CLI dry-run preview both carry this (63d).
+///
+/// The three surfaced counts are the ones a human recognises ("this issue has 2
+/// comments, 1 run, and sits on 1 board"); the internal link rows (label links,
+/// dependency edges, usage rows) cascade silently.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IssueDeleteSummary {
+    /// Comment rows on the issue.
+    pub comments: i64,
+    /// Task rows (any lifecycle state) enqueued against the issue.
+    pub tasks: i64,
+    /// Board placements (cards) referencing the issue.
+    pub placements: i64,
+}
+
+/// A dry-run preview of an issue delete: the human title, the dependent counts,
+/// and how many tasks are ACTIVE (which would block the delete) (63d).
+///
+/// The CLI prints this without `--yes`; a non-zero [`Self::active_tasks`] means a
+/// real delete would be refused with [`IssueDeleteError::ActiveTasks`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueDeletePreview {
+    /// The issue title (for the "would delete <title>" line).
+    pub title: String,
+    /// The dependent-row counts a delete would remove.
+    pub summary: IssueDeleteSummary,
+    /// How many of the issue's tasks are ACTIVE (queued / dispatched / running);
+    /// non-zero means a delete is refused until the run is cancelled.
+    pub active_tasks: i64,
+}
+
+/// Failure modes of [`IssueRepo::delete_cascade`] (63d).
+#[derive(Debug)]
+pub enum IssueDeleteError {
+    /// No issue matched `(id, workspace_id)` — an unknown id or a foreign tenant.
+    NotFound,
+    /// One or more tasks on the issue are ACTIVE (queued / dispatched / running);
+    /// the run must be cancelled before the issue can be deleted. Carries the
+    /// active count.
+    ActiveTasks(i64),
+    /// An underlying store fault.
+    Db(sqlx::Error),
+}
+
+impl std::fmt::Display for IssueDeleteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no issue with that id in this workspace"),
+            Self::ActiveTasks(n) => write!(
+                f,
+                "{n} active task(s) on this issue — cancel the run first, then delete"
+            ),
+            Self::Db(e) => write!(f, "store error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for IssueDeleteError {}
+
+impl From<sqlx::Error> for IssueDeleteError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Db(e)
+    }
+}
+
+/// Statuses that make a task ACTIVE — an issue with any active task refuses
+/// deletion. Mirrors the `agent_task_queue.status` CHECK vocabulary (migration
+/// 0004); the terminal states (`done` / `failed` / `cancelled`) do not block.
+const ACTIVE_TASK_STATUSES: &str = "SELECT COUNT(*) FROM agent_task_queue \
+     WHERE issue_id = ? AND status IN ('queued','dispatched','running')";
+
+/// Count the dependent rows a delete would remove, over any connection (the pool
+/// for a preview, or the open transaction for the cascade). Re-borrows `conn`
+/// per query so the same connection drives all three counts.
+async fn count_dependents(
+    conn: &mut sqlx::SqliteConnection,
+    issue_id: &str,
+) -> Result<IssueDeleteSummary, sqlx::Error> {
+    let comments: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM comment WHERE issue_id = ?")
+        .bind(issue_id)
+        .fetch_one(&mut *conn)
+        .await?;
+    let tasks: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?")
+        .bind(issue_id)
+        .fetch_one(&mut *conn)
+        .await?;
+    let placements: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM board_card WHERE issue_id = ?")
+        .bind(issue_id)
+        .fetch_one(&mut *conn)
+        .await?;
+    Ok(IssueDeleteSummary {
+        comments,
+        tasks,
+        placements,
+    })
+}
+
 /// Stateless typed wrapper over the `issue` table.
 pub struct IssueRepo;
 
@@ -418,6 +516,207 @@ impl IssueRepo {
         .fetch_all(pool)
         .await?;
         rows.iter().map(issue_from_row).collect()
+    }
+
+    /// Dry-run preview of an issue delete: the title, the dependent-row counts,
+    /// and the active-task count that would block the delete (63d).
+    ///
+    /// Workspace-scoped: a `(id, workspace_id)` pair that matches no issue (an
+    /// unknown id, or one owned by another tenant) yields `Ok(None)`, so a caller
+    /// can distinguish "absent" from "present with these counts". A read only —
+    /// nothing is mutated.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn delete_preview(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+    ) -> Result<Option<IssueDeletePreview>, sqlx::Error> {
+        let title: Option<String> =
+            sqlx::query_scalar("SELECT title FROM issue WHERE id = ? AND workspace_id = ?")
+                .bind(issue_id)
+                .bind(workspace_id)
+                .fetch_optional(pool)
+                .await?;
+        let Some(title) = title else {
+            return Ok(None);
+        };
+        let mut conn = pool.acquire().await?;
+        let summary = count_dependents(&mut conn, issue_id).await?;
+        let active_tasks: i64 = sqlx::query_scalar(ACTIVE_TASK_STATUSES)
+            .bind(issue_id)
+            .fetch_one(&mut *conn)
+            .await?;
+        Ok(Some(IssueDeletePreview {
+            title,
+            summary,
+            active_tasks,
+        }))
+    }
+
+    /// Delete an issue and every dependent row in one transaction, in FK order
+    /// (63d).
+    ///
+    /// Refuses (leaving everything intact) when any task on the issue is ACTIVE —
+    /// a queued / dispatched / running run must be cancelled first, so a delete
+    /// never orphans a live task. Workspace-scoped: a `(id, workspace_id)` pair
+    /// that matches no issue is [`IssueDeleteError::NotFound`] and touches nothing.
+    ///
+    /// The cascade, in dependency order under a deferred-FK transaction (so a
+    /// retry task's `parent_task_id` self-reference to a sibling task in the same
+    /// delete set never trips mid-statement):
+    ///
+    /// 1. the `inbox_entry` notifications whose `subject_id` is the issue, one of
+    ///    its comments, or one of its tasks go (resolved by subquery WHILE the
+    ///    comment/task rows still exist) — a deleted issue's notifications must
+    ///    not deep-link to nothing.
+    /// 2. `run_history.task_id` is NULLED, not deleted — cost accounting never
+    ///    shrinks; the run row survives, detached from the vanishing task.
+    /// 3. the tasks' `task_usage` rows and `task`-kind `beads_mapping` rows go.
+    /// 4. the `agent_task_queue` task rows go.
+    /// 5. the issue's `issue_label` links, `comment`s, `board_card` placements,
+    ///    `card_dependency` edges (either endpoint), and `issue`-kind
+    ///    `beads_mapping` row go.
+    /// 6. the `issue` row itself goes.
+    ///
+    /// `event_log.entity` refs are DELIBERATELY left untouched: the event log is
+    /// an append-only audit trail (same rationale as keeping `run_history`).
+    ///
+    /// Returns the [`IssueDeleteSummary`] of what fell (the counts captured before
+    /// the deletes).
+    ///
+    /// # Errors
+    ///
+    /// [`IssueDeleteError::NotFound`] (no such issue in the workspace),
+    /// [`IssueDeleteError::ActiveTasks`] (a live run blocks the delete), or
+    /// [`IssueDeleteError::Db`] on a store fault.
+    pub async fn delete_cascade(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+    ) -> Result<IssueDeleteSummary, IssueDeleteError> {
+        let mut tx = pool.begin().await?;
+
+        // Resolve the issue within its workspace; a foreign / unknown id is
+        // NotFound and rolls the (empty) transaction back on drop.
+        let exists: Option<String> =
+            sqlx::query_scalar("SELECT title FROM issue WHERE id = ? AND workspace_id = ?")
+                .bind(issue_id)
+                .bind(workspace_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        if exists.is_none() {
+            return Err(IssueDeleteError::NotFound);
+        }
+
+        // Refuse while any task is live — deleting the issue would orphan the run.
+        let active: i64 = sqlx::query_scalar(ACTIVE_TASK_STATUSES)
+            .bind(issue_id)
+            .fetch_one(&mut *tx)
+            .await?;
+        if active > 0 {
+            return Err(IssueDeleteError::ActiveTasks(active));
+        }
+
+        // Capture the summary BEFORE any delete so the counts reflect what fell.
+        let summary = count_dependents(&mut tx, issue_id).await?;
+
+        // Defer FK enforcement to commit: a retry task chains to its parent via
+        // `parent_task_id`, so a single `DELETE ... WHERE issue_id = ?` over both
+        // would trip an immediate self-FK check depending on row order. The whole
+        // graph is consistent at commit, which is all that matters. `PRAGMA
+        // defer_foreign_keys` is transaction-scoped and resets on commit.
+        sqlx::query("PRAGMA defer_foreign_keys = ON").execute(&mut *tx).await?;
+
+        // 1. Drop the issue's inbox notifications — the entries whose by-value
+        //    `subject_id` (migration 0021) is the issue itself, one of its
+        //    comments, or one of its tasks. MUST run while the comment/task rows
+        //    still exist (the subqueries resolve their ids), and is workspace-
+        //    scoped for hygiene. `event_log.entity` is deliberately NOT cleaned:
+        //    the event log is an append-only audit trail (same rationale as
+        //    keeping `run_history` below).
+        sqlx::query(
+            "DELETE FROM inbox_entry \
+             WHERE workspace_id = ?2 \
+               AND (subject_id = ?1 \
+                    OR subject_id IN (SELECT id FROM comment WHERE issue_id = ?1) \
+                    OR subject_id IN (SELECT id FROM agent_task_queue WHERE issue_id = ?1))",
+        )
+        .bind(issue_id)
+        .bind(workspace_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // 2. Preserve cost history: null the link from surviving run rows to the
+        //    tasks about to vanish (run_history.task_id is a nullable FK).
+        sqlx::query(
+            "UPDATE run_history SET task_id = NULL \
+             WHERE task_id IN (SELECT id FROM agent_task_queue WHERE issue_id = ?)",
+        )
+        .bind(issue_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // 3. The tasks' children: usage rows (FK) + task-kind beads correlations.
+        sqlx::query(
+            "DELETE FROM beads_mapping \
+             WHERE hangar_kind = 'task' \
+               AND hangar_id IN (SELECT id FROM agent_task_queue WHERE issue_id = ?)",
+        )
+        .bind(issue_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "DELETE FROM task_usage \
+             WHERE task_id IN (SELECT id FROM agent_task_queue WHERE issue_id = ?)",
+        )
+        .bind(issue_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // 4. The task rows themselves.
+        sqlx::query("DELETE FROM agent_task_queue WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // 5. The issue's directly-linked rows.
+        sqlx::query("DELETE FROM issue_label WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM comment WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM board_card WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "DELETE FROM card_dependency \
+             WHERE dependent_issue_id = ? OR blocker_issue_id = ?",
+        )
+        .bind(issue_id)
+        .bind(issue_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM beads_mapping WHERE hangar_kind = 'issue' AND hangar_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // 6. The issue row (workspace-scoped again, belt-and-braces).
+        sqlx::query("DELETE FROM issue WHERE id = ? AND workspace_id = ?")
+            .bind(issue_id)
+            .bind(workspace_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(summary)
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -148,6 +148,12 @@ pub struct Task {
     /// [`NewTask::generation`]. Carried on the struct so the infra-retry path
     /// copies it verbatim (a retry is a new attempt of the SAME run generation).
     pub generation: i64,
+    /// The SOURCE branch this run branches FROM (migration 0042); `None`
+    /// resolves to `main` at dispatch. Distinct from [`Self::branch`], the
+    /// PRODUCED `ainb/<slug>` output recorded post-run. Written at enqueue via
+    /// [`super::card_parity::CardParityRepo::set_task_source_branch_in_tx`],
+    /// read back here so dispatch provisions from the claimed row.
+    pub source_branch: Option<String>,
 }
 
 /// Stateless typed wrapper over the `agent_task_queue` table.
@@ -536,7 +542,7 @@ impl TaskRepo {
 const COLUMNS: &str = "id, workspace_id, runtime_id, agent_id, issue_id, status, result, \
      session_id, work_dir, attempt, max_attempts, parent_task_id, failure_reason, \
      priority, created_at, dispatched_at, started_at, finished_at, autopilot_run_id, \
-     mode, session_name, repo_ref, agent_kind, branch, generation";
+     mode, session_name, repo_ref, agent_kind, branch, generation, source_branch";
 
 /// Map one raw `agent_task_queue` row into a [`Task`].
 fn task_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Task, sqlx::Error> {
@@ -566,6 +572,7 @@ fn task_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Task, sqlx::Error> {
         agent_kind: row.try_get("agent_kind")?,
         branch: row.try_get("branch")?,
         generation: row.try_get("generation")?,
+        source_branch: row.try_get("source_branch")?,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -131,8 +131,9 @@ pub enum RetryDecision {
 const SPAWN_CHILD_SQL: &str = "\
 INSERT INTO agent_task_queue \
  (id, workspace_id, runtime_id, agent_id, issue_id, status, work_dir, priority, \
-  attempt, max_attempts, parent_task_id, session_id, repo_ref, agent_kind, generation, created_at) \
- VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+  attempt, max_attempts, parent_task_id, session_id, repo_ref, agent_kind, generation, \
+  source_branch, created_at) \
+ VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 /// Stateless retry service over `agent_task_queue`.
 pub struct RetryService;
@@ -205,6 +206,7 @@ impl RetryService {
             .bind(&failed_task.repo_ref)
             .bind(&failed_task.agent_kind)
             .bind(failed_task.generation)
+            .bind(&failed_task.source_branch)
             .bind(clock.now_ms())
             .execute(pool)
             .await?;

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -484,6 +484,7 @@ mod tests {
                 thinking: None,
                 agent_env: Vec::new(),
                 provider: None,
+                token_budget: None,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -70,6 +70,7 @@ async fn insert_and_get_agent_roundtrip() {
         thinking: None,
         agent_env: Vec::new(),
         provider: None,
+        token_budget: None,
     };
 
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
@@ -107,6 +108,7 @@ async fn update_config_persists_and_is_partial() {
         thinking: None,
         agent_env: Vec::new(),
         provider: None,
+        token_budget: None,
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 
@@ -119,6 +121,7 @@ async fn update_config_persists_and_is_partial() {
         mcp_config: Some(Some(r#"{"servers":{}}"#.to_string())),
         thinking: Some(Some("high".to_string())),
         agent_env: Some(vec![("FOO".to_string(), "bar".to_string())]),
+        token_budget: Some(Some(750_000)),
     };
     let touched = AgentRepo::update_config(store.pool(), &workspace_id, "agent-1", &update)
         .await
@@ -133,6 +136,11 @@ async fn update_config_persists_and_is_partial() {
     assert_eq!(got.mcp_config.as_deref(), Some(r#"{"servers":{}}"#));
     assert_eq!(got.thinking.as_deref(), Some("high"));
     assert_eq!(got.agent_env, vec![("FOO".to_string(), "bar".to_string())]);
+    assert_eq!(
+        got.token_budget,
+        Some(750_000),
+        "budget set via config edit (0042)"
+    );
     assert!(!got.archived, "a config edit does not archive");
 
     // A partial edit (only the model) leaves the other fields alone.
@@ -178,6 +186,7 @@ async fn update_config_is_workspace_scoped_and_empty_is_noop() {
         thinking: None,
         agent_env: Vec::new(),
         provider: None,
+        token_budget: None,
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 
@@ -227,6 +236,7 @@ async fn archive_flips_flag_and_hides_from_active_list() {
         thinking: None,
         agent_env: Vec::new(),
         provider: None,
+        token_budget: None,
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
@@ -1,0 +1,363 @@
+//! Behavioural tests for [`IssueRepo::delete_cascade`] + [`IssueRepo::delete_preview`]:
+//! the one-transaction issue delete removes every dependent row in FK order
+//! (comments, label links, board placements, dependency edges, terminal tasks +
+//! their usage rows), preserves `run_history` (task link nulled — cost
+//! accounting never shrinks), refuses while a task is ACTIVE, and is
+//! workspace-scoped (a foreign-tenant id deletes nothing).
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::issue::{IssueDeleteError, IssueRepo, NewIssue};
+use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
+use sqlx::SqlitePool;
+
+/// Seed a workspace with the runtime + user + agent a task row references.
+async fn seed_workspace(pool: &SqlitePool, ws: &str) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(ws)
+        .bind(ws)
+        .bind(ws)
+        .execute(pool)
+        .await
+        .expect("workspace");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+         VALUES (?, ?, 'd', 'claude', 'local', 'online')",
+    )
+    .bind(format!("rt-{ws}"))
+    .bind(ws)
+    .execute(pool)
+    .await
+    .expect("runtime");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, 0)")
+        .bind(format!("user-{ws}"))
+        .bind(format!("{ws}@x.test"))
+        .execute(pool)
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES (?, ?, ?, ?, 'workspace', ?)",
+    )
+    .bind(format!("agent-{ws}"))
+    .bind(ws)
+    .bind(format!("agent-{ws}"))
+    .bind(format!("rt-{ws}"))
+    .bind(format!("user-{ws}"))
+    .execute(pool)
+    .await
+    .expect("agent");
+}
+
+async fn seed_issue(pool: &SqlitePool, ws: &str, id: &str) {
+    IssueRepo::insert(
+        pool,
+        &NewIssue {
+            id: id.into(),
+            workspace_id: ws.into(),
+            title: format!("issue {id}"),
+            description: None,
+            state: "open".into(),
+            assignee: None,
+            creator: ActorRef::new(ActorKind::Member, "user-1").expect("actor"),
+            created_at: 1_000,
+            priority: 0,
+            due_date: None,
+            labels: Vec::new(),
+        },
+    )
+    .await
+    .expect("insert issue");
+}
+
+/// Insert a task for `issue` and force it into `status`.
+async fn seed_task(pool: &SqlitePool, ws: &str, id: &str, issue: &str, status: &str) {
+    TaskRepo::insert(
+        pool,
+        &NewTask {
+            id: id.into(),
+            workspace_id: ws.into(),
+            runtime_id: format!("rt-{ws}"),
+            agent_id: format!("agent-{ws}"),
+            issue_id: Some(issue.into()),
+            work_dir: None,
+            priority: 0,
+            created_at: 1_000,
+            autopilot_run_id: None,
+            generation: 0,
+        },
+    )
+    .await
+    .expect("insert task");
+    sqlx::query("UPDATE agent_task_queue SET status = ? WHERE id = ?")
+        .bind(status)
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("set status");
+}
+
+async fn count(pool: &SqlitePool, sql: &str, bind: &str) -> i64 {
+    sqlx::query_scalar(sql).bind(bind).fetch_one(pool).await.expect("count")
+}
+
+/// The full cascade: comments, label links, board placement, dependency edges,
+/// terminal tasks + usage all go; run_history survives with its task link
+/// nulled; the issue row itself is gone; the summary counts what fell.
+#[tokio::test]
+async fn delete_cascade_removes_dependents_and_keeps_run_history() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let pool = store.pool();
+    seed_workspace(pool, "ws-a").await;
+    seed_issue(pool, "ws-a", "i-1").await;
+    seed_issue(pool, "ws-a", "i-2").await;
+
+    // Two terminal tasks: a retry child chained to its parent (the self-FK).
+    seed_task(pool, "ws-a", "t-1", "i-1", "failed").await;
+    seed_task(pool, "ws-a", "t-2", "i-1", "done").await;
+    sqlx::query("UPDATE agent_task_queue SET parent_task_id = 't-1' WHERE id = 't-2'")
+        .execute(pool)
+        .await
+        .expect("chain retry");
+    // Usage on one task (FK: task_usage.task_id → agent_task_queue.id).
+    sqlx::query(
+        "INSERT INTO task_usage (task_id, workspace_id, agent_id, created_at) \
+         VALUES ('t-2', 'ws-a', 'agent-ws-a', 1000)",
+    )
+    .execute(pool)
+    .await
+    .expect("usage");
+    // A finalized run in the cost history (FK: run_history.task_id).
+    sqlx::query(
+        "INSERT INTO run_history (run_id, task_id, workspace_id, provider, finished_at, outcome) \
+         VALUES ('r-1', 't-2', 'ws-a', 'claude', 2000, 'completed')",
+    )
+    .execute(pool)
+    .await
+    .expect("run history");
+    // Two comments.
+    for c in ["c-1", "c-2"] {
+        sqlx::query(
+            "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+             VALUES (?, 'i-1', 'member', 'user-1', 'hi', 1000)",
+        )
+        .bind(c)
+        .execute(pool)
+        .await
+        .expect("comment");
+    }
+    // A label link (FK: issue_label.issue_id / .label_id).
+    sqlx::query("INSERT INTO label (id, workspace_id, name) VALUES ('l-1', 'ws-a', 'bug')")
+        .execute(pool)
+        .await
+        .expect("label");
+    sqlx::query("INSERT INTO issue_label (issue_id, label_id) VALUES ('i-1', 'l-1')")
+        .execute(pool)
+        .await
+        .expect("label link");
+    // A board placement + a dependency edge in each direction.
+    sqlx::query(
+        "INSERT INTO board (id, workspace_id, name, created_at) VALUES ('b-1', 'ws-a', 'B', 0)",
+    )
+    .execute(pool)
+    .await
+    .expect("board");
+    sqlx::query("INSERT INTO board_card (board_id, issue_id, added_at) VALUES ('b-1', 'i-1', 0)")
+        .execute(pool)
+        .await
+        .expect("card");
+    sqlx::query(
+        "INSERT INTO card_dependency (workspace_id, dependent_issue_id, blocker_issue_id, created_at) \
+         VALUES ('ws-a', 'i-1', 'i-2', 0), ('ws-a', 'i-2', 'i-1', 0)",
+    )
+    .execute(pool)
+    .await
+    .expect("deps");
+    // A beads correlation row for the issue.
+    sqlx::query(
+        "INSERT INTO beads_mapping (hangar_id, bd_id, hangar_kind, bd_kind, last_synced, source) \
+         VALUES ('i-1', 'bd-9', 'issue', 'issue', 0, 'hangar')",
+    )
+    .execute(pool)
+    .await
+    .expect("beads mapping");
+    // Inbox notifications about the issue, one of its comments, and one of its
+    // tasks (by-value subject refs, migration 0021) — all must fall with the
+    // issue so no notification deep-links to nothing. Plus one about the SIBLING
+    // issue i-2, which must survive.
+    sqlx::query(
+        "INSERT INTO inbox_entry (id, workspace_id, kind, event, subject_id, summary, created_at) \
+         VALUES ('n-issue',   'ws-a', 'issue',   'issue_updated', 'i-1', 's', 0), \
+                ('n-comment', 'ws-a', 'comment', 'comment_added', 'c-1', 's', 0), \
+                ('n-task',    'ws-a', 'task',    'task_finished', 't-2', 's', 0), \
+                ('n-sibling', 'ws-a', 'issue',   'issue_updated', 'i-2', 's', 0)",
+    )
+    .execute(pool)
+    .await
+    .expect("inbox entries");
+
+    // Preview agrees with what the cascade is about to do.
+    let preview = IssueRepo::delete_preview(pool, "ws-a", "i-1")
+        .await
+        .expect("preview")
+        .expect("issue present");
+    assert_eq!(preview.title, "issue i-1");
+    assert_eq!(preview.summary.comments, 2);
+    assert_eq!(preview.summary.tasks, 2);
+    assert_eq!(preview.summary.placements, 1);
+    assert_eq!(preview.active_tasks, 0, "both tasks are terminal");
+
+    let summary = IssueRepo::delete_cascade(pool, "ws-a", "i-1").await.expect("delete");
+    assert_eq!(summary.comments, 2);
+    assert_eq!(summary.tasks, 2);
+    assert_eq!(summary.placements, 1);
+
+    // The issue and every dependent row are gone.
+    assert!(IssueRepo::get_by_id(pool, "i-1").await.expect("get").is_none());
+    for (sql, what) in [
+        (
+            "SELECT COUNT(*) FROM comment WHERE issue_id = ?",
+            "comments",
+        ),
+        (
+            "SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?",
+            "tasks",
+        ),
+        (
+            "SELECT COUNT(*) FROM issue_label WHERE issue_id = ?",
+            "label links",
+        ),
+        (
+            "SELECT COUNT(*) FROM board_card WHERE issue_id = ?",
+            "placements",
+        ),
+        (
+            "SELECT COUNT(*) FROM card_dependency WHERE dependent_issue_id = ? OR blocker_issue_id = ?",
+            "dependency edges",
+        ),
+        (
+            "SELECT COUNT(*) FROM beads_mapping WHERE hangar_id = ?",
+            "beads mapping",
+        ),
+    ] {
+        let n = if what == "dependency edges" {
+            sqlx::query_scalar::<_, i64>(sql)
+                .bind("i-1")
+                .bind("i-1")
+                .fetch_one(pool)
+                .await
+                .expect("count")
+        } else {
+            count(pool, sql, "i-1").await
+        };
+        assert_eq!(n, 0, "{what} cascaded");
+    }
+    assert_eq!(
+        count(
+            pool,
+            "SELECT COUNT(*) FROM task_usage WHERE task_id = ?",
+            "t-2"
+        )
+        .await,
+        0,
+        "usage rows follow their task"
+    );
+    // The issue's inbox notifications fell (issue + comment + task subjects) —
+    // no notification deep-links to a deleted entity — while the sibling
+    // issue's entry survives.
+    let orphaned: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM inbox_entry WHERE id IN ('n-issue', 'n-comment', 'n-task')",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("inbox count");
+    assert_eq!(orphaned, 0, "issue/comment/task inbox entries cascaded");
+    assert_eq!(
+        count(
+            pool,
+            "SELECT COUNT(*) FROM inbox_entry WHERE subject_id = ?",
+            "i-2"
+        )
+        .await,
+        1,
+        "the sibling issue's inbox entry survives"
+    );
+    // Cost history survives, detached from the vanished task.
+    let (runs, linked): (i64, i64) = (
+        count(
+            pool,
+            "SELECT COUNT(*) FROM run_history WHERE run_id = ?",
+            "r-1",
+        )
+        .await,
+        count(
+            pool,
+            "SELECT COUNT(*) FROM run_history WHERE run_id = ? AND task_id IS NOT NULL",
+            "r-1",
+        )
+        .await,
+    );
+    assert_eq!(runs, 1, "run_history row kept");
+    assert_eq!(linked, 0, "task link nulled");
+    // The sibling issue is untouched.
+    assert!(IssueRepo::get_by_id(pool, "i-2").await.expect("get").is_some());
+}
+
+/// An ACTIVE task (queued / dispatched / running) blocks the delete — nothing
+/// is removed, and the error says to cancel the run first.
+#[tokio::test]
+async fn delete_cascade_refuses_while_a_task_is_active() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let pool = store.pool();
+    seed_workspace(pool, "ws-a").await;
+    seed_issue(pool, "ws-a", "i-1").await;
+    seed_task(pool, "ws-a", "t-done", "i-1", "done").await;
+    seed_task(pool, "ws-a", "t-live", "i-1", "running").await;
+
+    let err = IssueRepo::delete_cascade(pool, "ws-a", "i-1").await.expect_err("refused");
+    assert!(
+        matches!(err, IssueDeleteError::ActiveTasks(1)),
+        "active task refusal, got {err:?}"
+    );
+    assert!(err.to_string().contains("cancel the run first"));
+
+    // Nothing was removed — the terminal sibling task included.
+    assert!(IssueRepo::get_by_id(pool, "i-1").await.expect("get").is_some());
+    assert_eq!(
+        count(
+            pool,
+            "SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?",
+            "i-1"
+        )
+        .await,
+        2,
+        "both task rows intact"
+    );
+}
+
+/// The delete is workspace-scoped: a foreign-tenant `(id, workspace)` pair is
+/// NotFound and removes nothing.
+#[tokio::test]
+async fn delete_cascade_is_workspace_scoped() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let pool = store.pool();
+    seed_workspace(pool, "ws-a").await;
+    seed_workspace(pool, "ws-b").await;
+    seed_issue(pool, "ws-a", "i-1").await;
+
+    let err = IssueRepo::delete_cascade(pool, "ws-b", "i-1")
+        .await
+        .expect_err("foreign tenant");
+    assert!(matches!(err, IssueDeleteError::NotFound), "got {err:?}");
+    assert!(
+        IssueRepo::get_by_id(pool, "i-1").await.expect("get").is_some(),
+        "foreign-tenant delete touched nothing"
+    );
+    assert!(
+        IssueRepo::delete_preview(pool, "ws-b", "i-1").await.expect("preview").is_none(),
+        "preview is tenant-scoped too"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
@@ -148,6 +148,7 @@ async fn seed_agent(
             thinking: None,
             agent_env: Vec::new(),
             provider: None,
+            token_budget: None,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -131,7 +131,9 @@ const ISSUE_UPDATE_REQ_ID: i64 = 25;
 /// compose modal (e38.5).
 const COMMENT_ADD_REQ_ID: i64 = 26;
 /// JSON-RPC id for a `hangar/issue_create` request raised by the issue-list
-/// inline create flow (e38.29).
+/// create wizard (Phase 5; formerly the e38.29 inline title-only flow). Its
+/// reply carries the new `IssueRow`, whose id arms the follow-up
+/// `issue_update` + `issue_run` dispatch chain.
 const ISSUE_CREATE_REQ_ID: i64 = 27;
 /// JSON-RPC id for the `hangar/members_list` snapshot request feeding the
 /// settings Members pane (e38.11).
@@ -222,6 +224,11 @@ const DAEMON_CONFIG_SET_REQ_ID: i64 = 50;
 /// 49/50 are the daemon-config get/set pair, which landed on main while this
 /// branch was in review — this id must stay clear of them.
 const AGENT_CREATE_REQ_ID: i64 = 51;
+/// JSON-RPC id for a `hangar/issue_run` request raised by the Issues create
+/// wizard's dispatch (Phase 5). The reply is a `BoardCardRunResult` (same shape
+/// as `board_card_run`), surfaced as a transient issue-list note; an error is
+/// surfaced the same way — never silent.
+const ISSUE_RUN_REQ_ID: i64 = 52;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -366,6 +373,31 @@ pub struct HangarPlugin {
     /// Kanban / Autopilots / Skills card; its leaf binds to the screen's EXISTING
     /// daemon RPC seam. `None` when closed.
     list_context_menu: Option<crate::screen::list_context_menu::ListContextMenuState>,
+    /// The Issues create-wizard payload whose `hangar/issue_create` is in flight
+    /// (Phase 5): the repo / agent / branches to persist + dispatch once the
+    /// create reply hands back the new issue id. `None` when no wizard create is
+    /// pending. Cleared on the create's error reply (nothing to dispatch).
+    wizard_dispatch_in_flight: Option<WizardDispatch>,
+    /// The dispatch armed by a successful wizard `issue_create` reply: the new
+    /// `issue_id` plus the stashed payload, awaiting the next `render` pass (host
+    /// IO is safe there) to fire `issue_update` + `issue_run`. `None` when idle.
+    pending_issue_dispatch: Option<(String, WizardDispatch)>,
+}
+
+/// The Issues create-wizard fields that ride ALONGSIDE the `issue_create` call
+/// (Phase 5): persisted onto the new issue via `hangar/issue_update` and carried
+/// as explicit `hangar/issue_run` overrides, so the dispatch never depends on
+/// the persist landing first.
+#[derive(Debug, Clone)]
+struct WizardDispatch {
+    /// The picked repo (REQUIRED): absolute path, `scratch`, or a remote ref.
+    repo_ref: String,
+    /// The provider agent wire token (`claude` / `codex` / `copilot`).
+    agent: String,
+    /// The source branch the run branches FROM; `None` = repo default.
+    source_branch: Option<String>,
+    /// The target branch a future PR lands INTO; `None` = unset.
+    target_branch: Option<String>,
 }
 
 /// Read the daemon socket-auth token from `{hangar_home}/hangar/daemon.token`.
@@ -424,6 +456,8 @@ impl Default for HangarPlugin {
             board_layout: None,
             pending_board_mouse_intents: Vec::new(),
             list_context_menu: None,
+            wizard_dispatch_in_flight: None,
+            pending_issue_dispatch: None,
         }
     }
 }
@@ -850,6 +884,12 @@ impl HangarPlugin {
                 self.fetch_pending = true;
                 self.conn.on_event();
             }
+            // Phase 5: the wizard's `issue_create` reply hands back the new
+            // issue's id, arming the `issue_update` + `issue_run` follow-ups.
+            RpcId::Number(ISSUE_CREATE_REQ_ID) => self.apply_wizard_issue_created(resp),
+            // Phase 5: the wizard's `issue_run` reply — surfaced as a note either
+            // way (launch feedback or the daemon's rejection), never silent.
+            RpcId::Number(ISSUE_RUN_REQ_ID) => self.apply_issue_run(resp),
             RpcId::Number(INBOX_LIST_REQ_ID) => self.apply_inbox(resp),
             // The attention/subscribe ack carries the open-attention snapshot that
             // seeds the control-center board.
@@ -873,7 +913,6 @@ impl HangarPlugin {
                 | AUTOPILOT_TOGGLE_REQ_ID
                 | TASK_TRANSITION_REQ_ID
                 | ISSUE_UPDATE_REQ_ID
-                | ISSUE_CREATE_REQ_ID
                 | INBOX_MARK_READ_REQ_ID
                 | ATTENTION_ANSWER_REQ_ID
                 // P5: a profile/upsert reply re-fetches the snapshot batch so the
@@ -1140,6 +1179,56 @@ impl HangarPlugin {
                 self.screens.boards.set_note(format!("launched {} on {}", r.mode, r.agent_id));
             }
         }
+    }
+
+    /// Fold the wizard's `hangar/issue_create` reply (Phase 5): a success carries
+    /// the new `IssueRow`, whose id + the stashed
+    /// [`Self::wizard_dispatch_in_flight`] arm the `issue_update` + `issue_run`
+    /// follow-ups (fired on the next `render`, where host IO is safe). An error —
+    /// or an unparseable reply — surfaces as an issue-list note and DROPS the
+    /// stash (nothing was created, nothing to dispatch). Either way the snapshot
+    /// re-pull is armed so the board reflects the daemon's truth.
+    fn apply_wizard_issue_created(&mut self, resp: &RpcResponse) {
+        let dispatch = self.wizard_dispatch_in_flight.take();
+        if let Some(err) = &resp.error {
+            self.screens.issue_list.set_note(format!("create failed: {}", err.message));
+        } else if let Some(row) = resp.result.as_ref().and_then(|result| {
+            serde_json::from_value::<ainb_hangar_proto::events::IssueRow>(result.clone()).ok()
+        }) {
+            if let Some(dispatch) = dispatch {
+                self.pending_issue_dispatch = Some((row.id.as_str().to_string(), dispatch));
+            }
+        } else {
+            // A result that isn't an IssueRow: the issue may exist but its id is
+            // unknown, so the dispatch cannot fire. Say so rather than sit quiet.
+            self.screens
+                .issue_list
+                .set_note("create reply unreadable — issue not dispatched");
+        }
+        self.fetch_pending = true;
+        self.conn.on_event();
+    }
+
+    /// Surface the wizard's `hangar/issue_run` reply (Phase 5): a transient
+    /// issue-list note naming the agent + mode the task launched on, or the
+    /// daemon's rejection (e.g. the copilot F8 dispatch gate) — mirroring
+    /// [`Self::apply_board_card_run`], never silent. The card slides Todo → In
+    /// Progress via the daemon's pushed task lifecycle events.
+    fn apply_issue_run(&mut self, resp: &RpcResponse) {
+        if let Some(err) = &resp.error {
+            self.screens.issue_list.set_note(format!("run failed: {}", err.message));
+        } else if let Some(r) = resp.result.as_ref().and_then(|result| {
+            serde_json::from_value::<ainb_hangar_proto::snapshots::BoardCardRunResult>(
+                result.clone(),
+            )
+            .ok()
+        }) {
+            self.screens
+                .issue_list
+                .set_note(format!("launched {} on {}", r.mode, r.agent_id));
+        }
+        self.fetch_pending = true;
+        self.conn.on_event();
     }
 
     /// Surface a `hangar/board_card_cancel` reply (tcp T3 / F6): a transient note
@@ -2371,26 +2460,30 @@ impl HangarPlugin {
         }
     }
 
-    /// Fire a deferred issue-create RPC raised by the issue-list inline create
-    /// flow (e38.29).
-    ///
-    /// Maps the [`IssueCreateAction::Create`] to `hangar/issue_create`, creating a
-    /// new issue with the typed title authored by the current member, framed over
-    /// the socket cap. The daemon's `IssueCreated` push re-renders the new row
-    /// (mirroring `apply_comment_action` — this fires the RPC only, no separate
-    /// re-pull). A send failure is logged but non-fatal — the issue simply isn't
-    /// created.
+    /// Fire the first leg of the Issues create-wizard chain (Phase 5):
+    /// `hangar/issue_create` with the typed title, stashing the repo / agent /
+    /// branches on [`Self::wizard_dispatch_in_flight`] so the create reply (which
+    /// hands back the new issue id) can arm the `issue_update` + `issue_run`
+    /// follow-ups. Any failure to even SEND is surfaced as an issue-list note —
+    /// never a silent dead end.
     async fn apply_create_action(
         &mut self,
         host: &HostClient,
         action: crate::screen::IssueCreateAction,
     ) {
         use crate::screen::IssueCreateAction;
+        let IssueCreateAction::CreateAndRun {
+            title,
+            repo_ref,
+            source_branch,
+            target_branch,
+            agent,
+        } = action;
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            self.screens.issue_list.set_note("create failed: daemon link is down");
             return;
         };
         let ws = self.app_state().ws_id.as_str().to_string();
-        let IssueCreateAction::Create { title } = action;
         let params = serde_json::json!({
             "workspace_id": ws, "title": title, "creator": SELF_AUTHOR_REF
         });
@@ -2399,10 +2492,81 @@ impl HangarPlugin {
             daemon_methods::HANGAR_ISSUE_CREATE,
             params,
         ) else {
+            self.screens.issue_list.set_note("create failed: could not encode request");
             return;
         };
+        // Stash the dispatch payload BEFORE the send so the reply handler finds
+        // it; a send failure clears it again (nothing will answer).
+        self.wizard_dispatch_in_flight = Some(WizardDispatch {
+            repo_ref,
+            agent,
+            source_branch,
+            target_branch,
+        });
         if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            self.wizard_dispatch_in_flight = None;
+            self.screens.issue_list.set_note(format!("create failed: {e}"));
             let _ = host.log_info(format!("hangar: issue create send failed: {e}")).await;
+        }
+    }
+
+    /// Fire the second leg of the Issues create-wizard chain (Phase 5), armed by
+    /// a successful `issue_create` reply: ONE `hangar/issue_update` persisting
+    /// repo / agent / source / target on the new issue (the append-only F6
+    /// pattern), then `hangar/issue_run` with the SAME values as explicit
+    /// overrides — so the run is correct even if the persist is still in flight.
+    /// A send failure on either leg surfaces as an issue-list note.
+    async fn fire_issue_dispatch(
+        &mut self,
+        host: &HostClient,
+        issue_id: String,
+        dispatch: WizardDispatch,
+    ) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            self.screens.issue_list.set_note("run failed: daemon link is down");
+            return;
+        };
+        let ws = self.app_state().ws_id.as_str().to_string();
+        let update = ainb_hangar_proto::snapshots::IssueUpdateParams {
+            workspace_id: ws.clone(),
+            issue_id: issue_id.clone(),
+            repo_ref: Some(dispatch.repo_ref.clone()),
+            agent: Some(dispatch.agent.clone()),
+            source_branch: dispatch.source_branch.clone(),
+            target_branch: dispatch.target_branch.clone(),
+            ..Default::default()
+        };
+        let run = ainb_hangar_proto::snapshots::IssueRunParams {
+            workspace_id: ws,
+            issue_id,
+            mode: "headless".to_string(),
+            repo_ref: Some(dispatch.repo_ref),
+            agent: Some(dispatch.agent),
+            source_branch: dispatch.source_branch,
+        };
+        for (id, method, params) in [
+            (
+                ISSUE_UPDATE_REQ_ID,
+                daemon_methods::HANGAR_ISSUE_UPDATE,
+                serde_json::to_value(&update).unwrap_or_default(),
+            ),
+            (
+                ISSUE_RUN_REQ_ID,
+                daemon_methods::HANGAR_ISSUE_RUN,
+                serde_json::to_value(&run).unwrap_or_default(),
+            ),
+        ] {
+            let Ok(body) = encode_request(id, method, params) else {
+                self.screens
+                    .issue_list
+                    .set_note(format!("dispatch failed: could not encode {method}"));
+                return;
+            };
+            if let Err(e) = host.unix_socket_send(stream_id.clone(), body).await {
+                self.screens.issue_list.set_note(format!("dispatch failed: {e}"));
+                let _ = host.log_info(format!("hangar: {method} send failed: {e}")).await;
+                return;
+            }
         }
     }
 
@@ -3761,6 +3925,10 @@ impl Plugin for HangarPlugin {
             // input — renders were the only place host IO is safe, and with no
             // frames the daemon coming up was never noticed.
             || self.daemon_start_redial_until.is_some()
+            // Phase 5: a wizard dispatch armed by the `issue_create` reply needs a
+            // render to fire its `issue_update` + `issue_run` (host IO is only
+            // safe there). Consumed (taken) by that render, so not level-held.
+            || self.pending_issue_dispatch.is_some()
     }
 
     fn captures_text(&self) -> bool {
@@ -3890,11 +4058,17 @@ impl Plugin for HangarPlugin {
         if let Some(action) = self.screens.take_pending_comment_action() {
             self.apply_comment_action(host, action).await;
         }
-        // e38.29: drain any deferred issue-create (Enter on a non-blank title in
-        // the issue-list inline create flow) and fire `hangar/issue_create` over
-        // the daemon socket.
+        // Phase 5: drain a deferred wizard create (Enter on the Agent stage) and
+        // fire `hangar/issue_create` over the daemon socket; the reply arms the
+        // follow-up dispatch below.
         if let Some(action) = self.screens.take_pending_create_action() {
             self.apply_create_action(host, action).await;
+        }
+        // Phase 5: drain a dispatch armed by a successful wizard `issue_create`
+        // reply — fire `hangar/issue_update` (persist repo / agent / branches on
+        // the new issue) then `hangar/issue_run` (the actual launch).
+        if let Some((issue_id, dispatch)) = self.pending_issue_dispatch.take() {
+            self.fire_issue_dispatch(host, issue_id, dispatch).await;
         }
         // e38.13: drain any deferred command-palette search (every keystroke in
         // the palette) and fire `hangar/search` over the daemon socket; the read

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -229,6 +229,11 @@ const AGENT_CREATE_REQ_ID: i64 = 51;
 /// as `board_card_run`), surfaced as a transient issue-list note; an error is
 /// surfaced the same way — never silent.
 const ISSUE_RUN_REQ_ID: i64 = 52;
+/// Request id for the issue-list `x` delete (63d). The reply is a bare `{}` ack
+/// (the row is dropped by the daemon's `IssueDeleted` push, not this reply); an
+/// error (e.g. an active task) is surfaced as a transient issue-list note — never
+/// silent.
+const ISSUE_DELETE_REQ_ID: i64 = 53;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -890,6 +895,15 @@ impl HangarPlugin {
             // Phase 5: the wizard's `issue_run` reply — surfaced as a note either
             // way (launch feedback or the daemon's rejection), never silent.
             RpcId::Number(ISSUE_RUN_REQ_ID) => self.apply_issue_run(resp),
+            // 63d: the `x` delete reply. On success the daemon's IssueDeleted push
+            // already dropped the row, so nothing to fold; an error (e.g. an active
+            // task) surfaces as an issue-list note, never silent.
+            RpcId::Number(ISSUE_DELETE_REQ_ID) => {
+                if let Some(e) = &resp.error {
+                    self.screens.issue_list.set_note(format!("delete failed: {}", e.message));
+                }
+                self.conn.on_event();
+            }
             RpcId::Number(INBOX_LIST_REQ_ID) => self.apply_inbox(resp),
             // The attention/subscribe ack carries the open-attention snapshot that
             // seeds the control-center board.
@@ -2510,6 +2524,37 @@ impl HangarPlugin {
         }
     }
 
+    /// Fire the issue-list `x` delete (63d): encode + send one
+    /// `hangar/issue_delete` over the daemon socket. The row is dropped by the
+    /// daemon's `IssueDeleted` push on success; a send failure — or a daemon
+    /// rejection on the reply — surfaces as an issue-list note, never silent.
+    async fn apply_delete_action(
+        &mut self,
+        host: &HostClient,
+        issue_id: ainb_hangar_core::ids::IssueId,
+    ) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            self.screens.issue_list.set_note("delete failed: daemon link is down");
+            return;
+        };
+        let ws = self.app_state().ws_id.as_str().to_string();
+        let params = serde_json::json!({
+            "workspace_id": ws, "issue_id": issue_id.as_str()
+        });
+        let Ok(body) = encode_request(
+            ISSUE_DELETE_REQ_ID,
+            daemon_methods::HANGAR_ISSUE_DELETE,
+            params,
+        ) else {
+            self.screens.issue_list.set_note("delete failed: could not encode request");
+            return;
+        };
+        if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            self.screens.issue_list.set_note(format!("delete failed: {e}"));
+            let _ = host.log_info(format!("hangar: issue delete send failed: {e}")).await;
+        }
+    }
+
     /// Fire the second leg of the Issues create-wizard chain (Phase 5), armed by
     /// a successful `issue_create` reply: ONE `hangar/issue_update` persisting
     /// repo / agent / source / target on the new issue (the append-only F6
@@ -2839,7 +2884,11 @@ impl HangarPlugin {
         // instead of quitting / switching tabs. Esc aborts the create flow.
         if matches!(app.screen, Screen::IssueList) && self.screens.issue_list.is_capturing_text() {
             if matches!(key.code, KeyCode::Esc) {
+                // Esc drops whichever capture surface is open in one press — the
+                // create wizard OR the `x` delete-confirm overlay (both no-op when
+                // not in their mode), never trapping the user (63d).
                 self.screens.issue_list.abort_create();
+                self.screens.issue_list.abort_confirm_delete();
                 return;
             }
             if let Some(nav) = route_key(&app, &mut self.screens, key) {
@@ -3346,6 +3395,15 @@ impl HangarPlugin {
             // The card's run branch (ch3) — mirrored onto the row so the issue
             // carries it too; the detail below is seeded from the same value.
             branch: card.branch.clone(),
+            // 63d: the Kanban-synthesized header carries no card-parity / run
+            // summary of its own (the daemon owns those on the real issue row).
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         };
         // Seed the run's branch (tcp T2, agents-in-a-box-ch3) from the clicked
         // card so the detail view surfaces `ainb/<slug>` exactly as the card does.
@@ -4064,6 +4122,12 @@ impl Plugin for HangarPlugin {
         if let Some(action) = self.screens.take_pending_create_action() {
             self.apply_create_action(host, action).await;
         }
+        // 63d: drain a deferred issue delete (Enter on the `x` confirm overlay) and
+        // fire `hangar/issue_delete` over the daemon socket; the reply's
+        // `IssueDeleted` push drops the row, and an error surfaces as a note.
+        if let Some(issue_id) = self.screens.take_pending_delete_action() {
+            self.apply_delete_action(host, issue_id).await;
+        }
         // Phase 5: drain a dispatch armed by a successful wizard `issue_create`
         // reply — fire `hangar/issue_update` (persist repo / agent / branches on
         // the new issue) then `hangar/issue_run` (the actual launch).
@@ -4685,6 +4749,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }]);
         p
     }
@@ -4826,6 +4897,13 @@ mod tests {
                 labels: Vec::new(),
                 pr_url: None,
                 branch: None,
+                repo_ref: None,
+                agent: None,
+                source_branch: None,
+                target_branch: None,
+                run_count: 0,
+                last_run_status: None,
+                last_run_at: None,
             },
             IssueRow {
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-2").unwrap(),
@@ -4842,6 +4920,13 @@ mod tests {
                 labels: Vec::new(),
                 pr_url: None,
                 branch: None,
+                repo_ref: None,
+                agent: None,
+                source_branch: None,
+                target_branch: None,
+                run_count: 0,
+                last_run_status: None,
+                last_run_at: None,
             },
         ]);
 
@@ -4986,6 +5071,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }]);
         p.rebuild_hit_map(120, 24);
 
@@ -5062,6 +5154,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }]);
         // The card starts in Backlog.
         assert_eq!(p.screens.issue_list.column_count(IssueColumn::Backlog), 1);
@@ -5130,6 +5229,13 @@ mod tests {
                 labels: Vec::new(),
                 pr_url: None,
                 branch: None,
+                repo_ref: None,
+                agent: None,
+                source_branch: None,
+                target_branch: None,
+                run_count: 0,
+                last_run_status: None,
+                last_run_at: None,
             })
             .collect();
         p.screens.set_issues(rows);
@@ -5202,6 +5308,13 @@ mod tests {
                 labels: Vec::new(),
                 pr_url: None,
                 branch: None,
+                repo_ref: None,
+                agent: None,
+                source_branch: None,
+                target_branch: None,
+                run_count: 0,
+                last_run_status: None,
+                last_run_at: None,
             },
             IssueRow {
                 id: ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap(),
@@ -5218,6 +5331,13 @@ mod tests {
                 labels: Vec::new(),
                 pr_url: None,
                 branch: None,
+                repo_ref: None,
+                agent: None,
+                source_branch: None,
+                target_branch: None,
+                run_count: 0,
+                last_run_status: None,
+                last_run_at: None,
             },
         ]);
         p.screens.set_actors(vec![ActorRow {
@@ -5483,6 +5603,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         };
         let tid = ainb_hangar_core::ids::TaskId::from_str("task-1").unwrap();
         p.screens.open_task_detail(tid.clone(), issue, None);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -535,6 +535,10 @@ pub struct ScreenStates {
     /// `hangar/issue_create` (then, on its reply, `issue_update` + `issue_run`)
     /// over the daemon socket (Phase 5). `None` when idle.
     pub pending_create_action: Option<IssueCreateAction>,
+    /// A delete raised by the issue-list `x` confirm overlay (Enter on the RED
+    /// overlay), awaiting the `render` pass to fire `hangar/issue_delete` over the
+    /// daemon socket (63d). Carries the issue to delete. `None` when idle.
+    pub pending_delete_action: Option<ainb_hangar_core::ids::IssueId>,
     /// A search RPC raised by the command-palette modal (each keystroke),
     /// awaiting the `render` pass to fire `hangar/search` over the daemon socket
     /// (e38.13). `None` when idle.
@@ -949,6 +953,12 @@ impl ScreenStates {
     /// flow, if any (e38.29).
     pub const fn take_pending_create_action(&mut self) -> Option<IssueCreateAction> {
         self.pending_create_action.take()
+    }
+
+    /// Take the pending issue delete raised by the `x` confirm overlay, if any
+    /// (63d). The `render` pass drains it and fires `hangar/issue_delete`.
+    pub const fn take_pending_delete_action(&mut self) -> Option<ainb_hangar_core::ids::IssueId> {
+        self.pending_delete_action.take()
     }
 
     /// Take the pending search RPC raised by the command palette, if any
@@ -1418,6 +1428,13 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
                 target_branch,
                 agent,
             });
+            None
+        }
+        // 63d: Enter on the `x` RED confirm overlay lifts into a deferred
+        // `hangar/issue_delete` the `render` pass drains + fires (the sync key
+        // router can't `await`). The daemon's IssueDeleted push then drops the row.
+        Some(IssueListIntent::DeleteIssue(id)) => {
+            states.pending_delete_action = Some(id);
             None
         }
         None => None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -355,19 +355,31 @@ pub enum IssueCommentAction {
     },
 }
 
-/// A deferred daemon RPC raised by the issue-list inline create flow (e38.29).
+/// A deferred daemon RPC chain raised by the issue-list create WIZARD (Phase 5).
 ///
-/// Like [`IssueCommentAction`], the sync key router can't `await`; the create
-/// input stashes the action on [`ScreenStates::pending_create_action`] and the
-/// plugin's `render` pass drains it and fires `hangar/issue_create` over the
-/// daemon socket cap. The daemon's `IssueCreated` push re-renders the new row.
+/// Like [`IssueCommentAction`], the sync key router can't `await`; the wizard's
+/// Agent-stage commit stashes the action on
+/// [`ScreenStates::pending_create_action`] and the plugin's `render` pass drains
+/// it and fires `hangar/issue_create`; on that reply the plugin fires
+/// `hangar/issue_update` (persisting repo / agent / branches on the new issue)
+/// and `hangar/issue_run` (the actual dispatch). Every field is collected by the
+/// wizard, so a create from this screen ALWAYS carries an agent and a repo — the
+/// title-only inert card is unrepresentable here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IssueCreateAction {
-    /// Create a new issue with the typed title (Enter on a non-blank create
-    /// input) — `hangar/issue_create`.
-    Create {
+    /// Create a new issue AND dispatch it (Enter on the wizard's Agent stage).
+    CreateAndRun {
         /// The new issue's title (non-blank).
         title: String,
+        /// The picked repo (REQUIRED): an absolute path, `scratch`, or a remote
+        /// indicator the daemon clones.
+        repo_ref: String,
+        /// The source branch the run branches FROM; `None` = repo default.
+        source_branch: Option<String>,
+        /// The target branch a future PR lands INTO; `None` = unset.
+        target_branch: Option<String>,
+        /// The provider agent wire token (`claude` / `codex` / `copilot`).
+        agent: String,
     },
 }
 
@@ -518,9 +530,10 @@ pub struct ScreenStates {
     /// non-empty buffer), awaiting the `render` pass to fire `hangar/comment_add`
     /// over the daemon socket (e38.5). `None` when idle.
     pub pending_comment_action: Option<IssueCommentAction>,
-    /// An issue-create RPC raised by the issue-list inline create flow (Enter on
-    /// a non-blank title), awaiting the `render` pass to fire `hangar/issue_create`
-    /// over the daemon socket (e38.29). `None` when idle.
+    /// A create-and-dispatch chain raised by the issue-list create wizard (Enter
+    /// on the Agent stage), awaiting the `render` pass to fire
+    /// `hangar/issue_create` (then, on its reply, `issue_update` + `issue_run`)
+    /// over the daemon socket (Phase 5). `None` when idle.
     pub pending_create_action: Option<IssueCreateAction>,
     /// A search RPC raised by the command-palette modal (each keystroke),
     /// awaiting the `render` pass to fire `hangar/search` over the daemon socket
@@ -629,10 +642,12 @@ impl ScreenStates {
         self.boards.set_profiles(profiles);
     }
 
-    /// Inject the `@`-autocomplete repo roster the Boards card-create picker offers
-    /// (spec F3), from the cached `hangar/repo_list` (favorites-first + recency
-    /// order preserved; the reducer prepends `scratch` always).
+    /// Inject the `@`-autocomplete repo roster BOTH card-create pickers offer —
+    /// the Boards overlay (spec F3) and the Issues create wizard's repo stage
+    /// (Phase 5) — from the one cached `hangar/repo_list` (favorites-first +
+    /// recency order preserved; the reducers prepend `scratch` always).
     pub fn set_boards_repos(&mut self, repos: Vec<super::boards::RepoOption>) {
+        self.issue_list.set_repos(repos.clone());
         self.boards.set_repos(repos);
     }
 
@@ -1363,17 +1378,46 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
 /// open-picker intents into [`NavIntent`]s (the routing screen lives on the
 /// plugin's [`AppState`], not in the issue-list reducer).
 fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavIntent> {
-    let c = key_char(key)?;
-    let out = reduce_issue_list(&states.issue_list, IssueListEvent::Key(c));
+    // Phase 5: while the create wizard is open, feed it the STRUCTURED key
+    // vocabulary — its picker stages (repo dropdown, agent chips) need Up/Down,
+    // and Esc must cancel the whole overlay — which the plain-char path can't
+    // carry. Any other key is an unmodelled no-op.
+    let ev = if states.issue_list.wizard().is_some() {
+        let k = match &key.code {
+            KeyCode::Char { ch } => super::issue_list::WizardKey::Char(*ch),
+            KeyCode::Enter => super::issue_list::WizardKey::Enter,
+            KeyCode::Backspace => super::issue_list::WizardKey::Backspace,
+            KeyCode::Esc => super::issue_list::WizardKey::Esc,
+            KeyCode::Up => super::issue_list::WizardKey::Up,
+            KeyCode::Down => super::issue_list::WizardKey::Down,
+            _ => return None,
+        };
+        IssueListEvent::Wizard(k)
+    } else {
+        IssueListEvent::Key(key_char(key)?)
+    };
+    let out = reduce_issue_list(&states.issue_list, ev);
     states.issue_list = out.state;
     match out.intent {
         Some(IssueListIntent::OpenAgentPicker(id)) => Some(NavIntent::OpenAgentPicker(id)),
         Some(IssueListIntent::OpenTaskDetail(id)) => Some(NavIntent::OpenTaskForIssue(id)),
-        // e38.29: a submitted create-title lifts into a deferred
-        // `hangar/issue_create` RPC the `render` pass drains + fires (the sync key
-        // router can't `await`).
-        Some(IssueListIntent::CreateIssue { title }) => {
-            states.pending_create_action = Some(IssueCreateAction::Create { title });
+        // Phase 5: the wizard's Agent-stage commit lifts into a deferred
+        // create-and-dispatch chain the `render` pass drains + fires (the sync
+        // key router can't `await`).
+        Some(IssueListIntent::CreateAndRun {
+            title,
+            repo_ref,
+            source_branch,
+            target_branch,
+            agent,
+        }) => {
+            states.pending_create_action = Some(IssueCreateAction::CreateAndRun {
+                title,
+                repo_ref,
+                source_branch,
+                target_branch,
+                agent,
+            });
             None
         }
         None => None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -346,8 +346,9 @@ impl AgentChip {
         }
     }
 
-    /// The chip's picker label (copilot flags its F8 dispatch gate).
-    const fn label(self) -> &'static str {
+    /// The chip's picker label (copilot flags its F8 dispatch gate). Crate-visible
+    /// so the Issues create-wizard agent stage renders the same labels.
+    pub(crate) const fn label(self) -> &'static str {
         match self {
             Self::Claude => "claude",
             Self::Codex => "codex",
@@ -368,10 +369,11 @@ impl AgentChip {
     }
 
     /// The chips in picker order (claude first — the cascade's safe default).
-    const ALL: [Self; 3] = [Self::Claude, Self::Codex, Self::Copilot];
+    /// Crate-visible so the Issues create-wizard agent stage offers the same roster.
+    pub(crate) const ALL: [Self; 3] = [Self::Claude, Self::Codex, Self::Copilot];
 
     /// The chip at `idx`, clamped to [`AgentChip::Claude`].
-    fn at(idx: usize) -> Self {
+    pub(crate) fn at(idx: usize) -> Self {
         Self::ALL.get(idx).copied().unwrap_or(Self::Claude)
     }
 
@@ -422,7 +424,9 @@ impl RepoOption {
 /// The `@` dropdown candidates for `query`: [`RepoOption::scratch`] first
 /// (ALWAYS, the F2 guaranteed repo), then the injected roster
 /// (favorites-first + recency order preserved) fuzzy-filtered on `query`.
-fn repo_candidates(repos: &[RepoOption], query: &str) -> Vec<RepoOption> {
+/// Crate-visible so the Issues create-wizard repo stage shares the exact same
+/// candidate order + fuzzy filter as the Boards card create.
+pub(crate) fn repo_candidates(repos: &[RepoOption], query: &str) -> Vec<RepoOption> {
     let mut out = vec![RepoOption::scratch()];
     out.extend(
         repos

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -225,6 +225,22 @@ pub enum IssueListMode {
     /// the final Agent stage), Esc cancels the WHOLE wizard from any stage in
     /// one press.
     CreateInput,
+    /// `x` delete-confirm mode (63d): a RED confirm overlay is open over the
+    /// selected row ([`IssueListState::confirm_delete`]). Enter emits
+    /// [`IssueListIntent::DeleteIssue`], Esc cancels in one press; every other key
+    /// is captured (so a stray tab-switch char never fires behind the modal).
+    ConfirmDelete,
+}
+
+/// The target of an open `x` delete-confirm overlay (63d): the issue id the
+/// [`IssueListIntent::DeleteIssue`] will carry, plus a human label
+/// (`<display_id> <title>`) the red overlay renders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingDelete {
+    /// The issue the confirmed delete removes.
+    pub id: IssueId,
+    /// The human label shown in the overlay (`HGR-7 Fix the widget`).
+    pub label: String,
 }
 
 /// A raw key folded into the open create wizard (Phase 5).
@@ -362,6 +378,9 @@ pub struct IssueListState {
     /// card. The card-board render lifts the hovered card's border so the cursor
     /// target reads before a click. Cleared when the pointer moves to empty space.
     hovered_id: Option<String>,
+    /// The open `x` delete-confirm target (63d), set while `mode` is
+    /// [`IssueListMode::ConfirmDelete`]. `None` otherwise.
+    confirm_delete: Option<PendingDelete>,
 }
 
 impl Default for IssueListState {
@@ -379,6 +398,7 @@ impl Default for IssueListState {
             task_issue: HashMap::new(),
             scroll_offsets: [0; COLUMN_COUNT],
             hovered_id: None,
+            confirm_delete: None,
         }
     }
 }
@@ -412,7 +432,7 @@ impl IssueListState {
     pub const fn is_capturing_text(&self) -> bool {
         matches!(
             self.mode,
-            IssueListMode::FilterInput | IssueListMode::CreateInput
+            IssueListMode::FilterInput | IssueListMode::CreateInput | IssueListMode::ConfirmDelete
         )
     }
 
@@ -424,6 +444,22 @@ impl IssueListState {
             self.mode = IssueListMode::Normal;
             self.wizard = None;
         }
+    }
+
+    /// Cancel the `x` delete-confirm overlay (Esc, 63d): drop the RED overlay and
+    /// return to normal navigation in one press. A no-op when not confirming.
+    pub fn abort_confirm_delete(&mut self) {
+        if self.mode == IssueListMode::ConfirmDelete {
+            self.mode = IssueListMode::Normal;
+            self.confirm_delete = None;
+        }
+    }
+
+    /// The open delete-confirm target (63d), or `None` when not confirming — the
+    /// renderer draws the RED overlay from this.
+    #[must_use]
+    pub const fn confirm_delete(&self) -> Option<&PendingDelete> {
+        self.confirm_delete.as_ref()
     }
 
     /// The active filter chip.
@@ -769,6 +805,10 @@ pub enum IssueListIntent {
         /// always a real token, never empty.
         agent: String,
     },
+    /// Delete the confirmed issue (63d): raised ONLY by Enter on the `x` RED
+    /// confirm overlay. The plugin glue lifts it into `hangar/issue_delete`; the
+    /// daemon's `IssueDeleted` push then drops the row from the list.
+    DeleteIssue(IssueId),
 }
 
 /// The result of folding one [`IssueListEvent`] into an [`IssueListState`].
@@ -800,6 +840,7 @@ fn reduce_key(state: &IssueListState, c: char) -> IssueListReduction {
         // legacy `Key(char)` path (Enter as '\n', Backspace as '\u{8}') keeps
         // working alongside the structured [`IssueListEvent::Wizard`] events.
         IssueListMode::CreateInput => reduce_wizard_key(state, wizard_key_from_char(c)),
+        IssueListMode::ConfirmDelete => reduce_confirm_delete_key(state, c),
         IssueListMode::Normal => reduce_normal_key(state, c),
     }
 }
@@ -820,6 +861,7 @@ fn reduce_normal_key(state: &IssueListState, c: char) -> IssueListReduction {
         'k' => move_selection_up(state),
         '/' => enter_filter_mode(state),
         'c' => enter_create_mode(state),
+        'x' => enter_confirm_delete(state),
         'a' => state.selected_row().map_or_else(
             || unchanged(state),
             |row| {
@@ -913,6 +955,63 @@ fn cancel_wizard(state: &IssueListState) -> IssueListReduction {
     let mut next = state.clone();
     next.mode = IssueListMode::Normal;
     next.wizard = None;
+    no_intent(next)
+}
+
+/// Open the `x` delete-confirm overlay over the selected row (63d). No intent yet
+/// — the RED overlay collects the Enter/Esc decision first. A no-op when the list
+/// has no rows (nothing to delete), so `x` on an empty board never traps the user.
+fn enter_confirm_delete(state: &IssueListState) -> IssueListReduction {
+    let Some(row) = state.selected_row() else {
+        return unchanged(state);
+    };
+    // Prefer the human display id (`HGR-7`) with the title; fall back to the raw
+    // id when a pre-63l.3 snapshot lacks a display id.
+    let label = match &row.display_id {
+        Some(display) => format!("{display} {}", row.title),
+        None => row.title.clone(),
+    };
+    let pending = PendingDelete {
+        id: row.id.clone(),
+        label,
+    };
+    let mut next = state.clone();
+    next.mode = IssueListMode::ConfirmDelete;
+    next.confirm_delete = Some(pending);
+    // A fresh confirm supersedes any stale dispatch note.
+    next.note = None;
+    no_intent(next)
+}
+
+/// Delete-confirm key handling (63d): Enter emits [`IssueListIntent::DeleteIssue`]
+/// for the pending target, Esc cancels; every other key is captured (the overlay
+/// is modal). All paths that leave confirm mode reset back to normal navigation.
+fn reduce_confirm_delete_key(state: &IssueListState, c: char) -> IssueListReduction {
+    match c {
+        // Enter (delivered as '\n' / '\r') confirms the delete.
+        '\n' | '\r' => {
+            let Some(pending) = state.confirm_delete.clone() else {
+                // Defensive: no target — just drop back to navigation.
+                return cancel_confirm_delete(state);
+            };
+            let mut next = state.clone();
+            next.mode = IssueListMode::Normal;
+            next.confirm_delete = None;
+            with_intent(next, IssueListIntent::DeleteIssue(pending.id))
+        }
+        // Esc (delivered as the ESC char to the pure reducer) cancels.
+        '\u{1b}' => cancel_confirm_delete(state),
+        // Any other key is swallowed — the modal stays open until Enter / Esc.
+        _ => unchanged(state),
+    }
+}
+
+/// Cancel the delete-confirm overlay (Esc): back to normal navigation, target
+/// dropped, no intent.
+fn cancel_confirm_delete(state: &IssueListState) -> IssueListReduction {
+    let mut next = state.clone();
+    next.mode = IssueListMode::Normal;
+    next.confirm_delete = None;
     no_intent(next)
 }
 
@@ -1305,6 +1404,15 @@ pub fn render_issue_list(
             wizard,
             &state.repos,
         );
+    } else if let Some(pending) = state.confirm_delete() {
+        // 63d: the RED delete-confirm overlay on the two bottom rows.
+        render_confirm_delete(
+            buf,
+            area_w,
+            bottom.saturating_sub(2),
+            bottom.saturating_sub(1),
+            pending,
+        );
     } else if let Some(note) = state.note() {
         put_str(
             buf,
@@ -1339,6 +1447,39 @@ pub fn render_issue_list(
 /// Accent for the create-issue input bar (a calm emerald, distinct from the
 /// gold headers + green selection so the create prompt reads as its own mode).
 const CREATE_ACCENT: Color = Color::rgb(120, 200, 160);
+
+/// The clay-red used across the plugin for destructive / offline states (the
+/// style guide's `OFFLINE_RED`); the `x` delete-confirm overlay paints in it so a
+/// destructive action reads as dangerous at a glance (63d).
+const OFFLINE_RED: Color = Color::rgb(220, 120, 100);
+
+/// Render the RED delete-confirm overlay on the two bottom rows (63d): a prompt
+/// naming the target + the irreversibility, then the key legend. Char-safe via
+/// [`put_str`]. Enter deletes, Esc cancels — both wired in the reducer.
+fn render_confirm_delete(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    row: u16,
+    value_row: u16,
+    pending: &PendingDelete,
+) {
+    put_str(
+        buf,
+        0,
+        row,
+        &format!("Delete issue {}? This removes its history.", pending.label),
+        OFFLINE_RED,
+        area_w,
+    );
+    put_str(
+        buf,
+        0,
+        value_row,
+        "Enter=delete  Esc=cancel",
+        OFFLINE_RED,
+        area_w,
+    );
+}
 
 /// Gold stage-prompt colour for the create wizard (matches the Boards overlay
 /// prompts + the style guide's title gold).
@@ -1533,6 +1674,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }
     }
 
@@ -2094,5 +2242,105 @@ mod tests {
                 coord.y,
             );
         }
+    }
+
+    /// `x` on a selected row opens the RED confirm overlay targeting that issue,
+    /// captures text (so nav keys are swallowed behind the modal), and raises no
+    /// intent yet (63d).
+    #[test]
+    fn x_opens_confirm_delete_for_selected_issue() {
+        let s = IssueListState::with_rows(vec![row("i1", "open", None), row("i2", "open", None)]);
+        let out = reduce_issue_list(&s, IssueListEvent::Key('x'));
+        assert_eq!(out.intent, None, "opening the confirm raises no intent");
+        assert_eq!(out.state.mode(), IssueListMode::ConfirmDelete);
+        assert!(out.state.is_capturing_text(), "confirm is a modal capture");
+        let pending = out.state.confirm_delete().expect("a target is set");
+        assert_eq!(pending.id, IssueId::from_str("i1").unwrap());
+        assert!(pending.label.contains("Issue i1"), "label names the issue");
+    }
+
+    /// Esc cancels the confirm overlay in one press, back to normal navigation
+    /// with the target dropped and no intent (63d).
+    #[test]
+    fn esc_cancels_confirm_delete() {
+        let s = IssueListState::with_rows(vec![row("i1", "open", None)]);
+        let opened = reduce_issue_list(&s, IssueListEvent::Key('x')).state;
+        assert_eq!(opened.mode(), IssueListMode::ConfirmDelete);
+        // Esc is delivered to the pure reducer as the ESC char.
+        let out = reduce_issue_list(&opened, IssueListEvent::Key('\u{1b}'));
+        assert_eq!(out.intent, None, "cancel raises no intent");
+        assert_eq!(out.state.mode(), IssueListMode::Normal);
+        assert!(out.state.confirm_delete().is_none(), "target dropped");
+    }
+
+    /// Enter on the confirm overlay emits the `DeleteIssue` intent for the target
+    /// and returns to normal navigation (63d).
+    #[test]
+    fn enter_confirms_delete_and_emits_intent() {
+        let s = IssueListState::with_rows(vec![row("i1", "open", None), row("i2", "open", None)]);
+        // Select the second row, then confirm-delete it.
+        let s = reduce_issue_list(&s, IssueListEvent::Key('j')).state;
+        let opened = reduce_issue_list(&s, IssueListEvent::Key('x')).state;
+        let out = reduce_issue_list(&opened, IssueListEvent::Key('\n'));
+        assert_eq!(
+            out.intent,
+            Some(IssueListIntent::DeleteIssue(
+                IssueId::from_str("i2").unwrap()
+            )),
+            "Enter emits DeleteIssue for the selected target"
+        );
+        assert_eq!(out.state.mode(), IssueListMode::Normal);
+        assert!(
+            out.state.confirm_delete().is_none(),
+            "target dropped after commit"
+        );
+    }
+
+    /// `x` on an empty list is a no-op — no confirm opens, nothing to delete (63d).
+    #[test]
+    fn x_on_empty_list_is_a_noop() {
+        let s = IssueListState::with_rows(Vec::new());
+        let out = reduce_issue_list(&s, IssueListEvent::Key('x'));
+        assert_eq!(out.intent, None);
+        assert_eq!(out.state.mode(), IssueListMode::Normal, "no confirm opens");
+        assert!(out.state.confirm_delete().is_none());
+    }
+
+    /// `x` does NOT open the confirm while the create wizard is open — the wizard
+    /// captures the keystroke as text, leaving its state machine intact (63d).
+    #[test]
+    fn x_does_not_fire_while_create_wizard_open() {
+        let s = IssueListState::with_rows(vec![row("i1", "open", None)]);
+        let wizard = reduce_issue_list(&s, IssueListEvent::Key('c')).state;
+        assert_eq!(wizard.mode(), IssueListMode::CreateInput);
+        let out = reduce_issue_list(&wizard, IssueListEvent::Key('x'));
+        assert_eq!(
+            out.state.mode(),
+            IssueListMode::CreateInput,
+            "x is typed into the wizard, never opens a delete confirm"
+        );
+        assert!(out.state.confirm_delete().is_none());
+        // The wizard is still on its Title stage with the typed 'x'.
+        assert!(matches!(
+            out.state.wizard(),
+            Some(CreateWizard::Title { .. })
+        ));
+    }
+
+    /// `x` does NOT open the confirm while the `/` filter input is open — it is a
+    /// query character, not the delete shortcut (63d).
+    #[test]
+    fn x_does_not_fire_while_filter_input_open() {
+        let s = IssueListState::with_rows(vec![row("i1", "open", None)]);
+        let filtering = reduce_issue_list(&s, IssueListEvent::Key('/')).state;
+        assert_eq!(filtering.mode(), IssueListMode::FilterInput);
+        let out = reduce_issue_list(&filtering, IssueListEvent::Key('x'));
+        assert_eq!(
+            out.state.mode(),
+            IssueListMode::FilterInput,
+            "x is typed into the filter query, never opens a delete confirm"
+        );
+        assert!(out.state.confirm_delete().is_none());
+        assert_eq!(out.state.query(), "x", "x appended to the filter query");
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -31,6 +31,8 @@ use ainb_hangar_proto::events::{HangarEvent, IssueRow};
 use ainb_hangar_proto::lifecycle::IssueLifecycle;
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
+use super::boards::{AgentChip, RepoOption, repo_candidates};
+
 /// The number of status columns the board renders — the five canonical
 /// lifecycle statuses (63l.3). Kept as a single constant so the column enum, the
 /// card-board render, and the per-column scroll offsets stay in lockstep.
@@ -208,17 +210,111 @@ fn assignee_kind(row: &IssueRow) -> Option<ActorKind> {
 }
 
 /// Whether the screen is in normal navigation, filter-text-entry, or
-/// create-title-entry mode.
+/// the staged create-wizard mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IssueListMode {
     /// Normal row navigation (`j`/`k`, `enter`, `c`, …).
     Normal,
     /// `/` filter-input mode: keystrokes append to the [`IssueListState::query`].
     FilterInput,
-    /// `c` create-input mode (e38.29): keystrokes append to the
-    /// [`IssueListState::create_title`]; Enter submits a non-blank title (raising
-    /// [`IssueListIntent::CreateIssue`]), Esc/empty-Enter abort.
+    /// `c` create-wizard mode (Phase 5): the staged Title → Repo →
+    /// `SourceBranch` → `TargetBranch` → Agent overlay
+    /// ([`IssueListState::wizard`]) is open and captures every key.
+    ///
+    /// Enter advances / commits (raising [`IssueListIntent::CreateAndRun`] at
+    /// the final Agent stage), Esc cancels the WHOLE wizard from any stage in
+    /// one press.
     CreateInput,
+}
+
+/// A raw key folded into the open create wizard (Phase 5).
+///
+/// Mirrors the Boards `BoardsKey` shape: a `Char` is text in an input stage but
+/// ignored in a picker; `Up`/`Down` move a picker cursor but are ignored in an
+/// input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WizardKey {
+    /// A printable character.
+    Char(char),
+    /// Backspace (delete the last input char).
+    Backspace,
+    /// Enter (advance / commit the stage).
+    Enter,
+    /// Escape (cancel the WHOLE wizard, from any stage).
+    Esc,
+    /// Cursor up (move a picker selection up).
+    Up,
+    /// Cursor down (move a picker selection down).
+    Down,
+}
+
+/// The staged Issues create wizard (Phase 5), mirroring the Boards card-create
+/// overlay.
+///
+/// Stages: Title → Repo (`@` fuzzy dropdown, REQUIRED) → `SourceBranch`
+/// (prefilled `main`) → `TargetBranch` (prefilled `main`) → Agent (REQUIRED —
+/// the commit lives ONLY on this stage, so a title-only inert issue is
+/// impossible to create here).
+///
+/// Each stage carries everything collected so far, so the reducer stays pure and
+/// a stage transition is a plain value swap. Esc anywhere drops the whole thing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CreateWizard {
+    /// Stage 1: typing the new issue's title. Enter on a non-blank title advances
+    /// to the repo pick; blank Enter holds.
+    Title {
+        /// The title typed so far.
+        title: String,
+    },
+    /// Stage 2: picking the repo (REQUIRED). `@` opens the fuzzy dropdown over the
+    /// injected roster (scratch always first); Enter with the dropdown closed
+    /// RE-OPENS it (never advances repo-less); Enter on a highlighted candidate
+    /// advances to the source-branch input.
+    Repo {
+        /// The title from stage 1.
+        title: String,
+        /// The post-`@` fuzzy query (empty until `@` opens the dropdown).
+        query: String,
+        /// `Some(cursor)` while the dropdown is open, `None` while closed.
+        dropdown: Option<usize>,
+    },
+    /// Stage 3: the SOURCE branch the run branches FROM, prefilled `main`. Enter
+    /// accepts (blank = unset → the repo default at dispatch).
+    SourceBranch {
+        /// The title from stage 1.
+        title: String,
+        /// The repo picked in stage 2.
+        repo_ref: String,
+        /// The branch text being edited (prefilled `main`).
+        branch: String,
+    },
+    /// Stage 4: the TARGET branch a future PR lands INTO, prefilled `main`. Enter
+    /// accepts (blank = unset).
+    TargetBranch {
+        /// The title from stage 1.
+        title: String,
+        /// The repo picked in stage 2.
+        repo_ref: String,
+        /// The source branch accepted in stage 3 (already trimmed; may be empty).
+        source_branch: String,
+        /// The branch text being edited (prefilled `main`).
+        branch: String,
+    },
+    /// Stage 5: the provider agent (REQUIRED — the whole point). ↑↓ move over
+    /// [`AgentChip::ALL`]; Enter COMMITS the wizard, raising
+    /// [`IssueListIntent::CreateAndRun`]. This is the only commit point.
+    Agent {
+        /// The title from stage 1.
+        title: String,
+        /// The repo picked in stage 2.
+        repo_ref: String,
+        /// The source branch accepted in stage 3 (trimmed; may be empty).
+        source_branch: String,
+        /// The target branch accepted in stage 4 (trimmed; may be empty).
+        target_branch: String,
+        /// The highlighted chip (index into [`AgentChip::ALL`]).
+        cursor: usize,
+    },
 }
 
 /// The render-state cache for the issue list.
@@ -239,11 +335,20 @@ pub struct IssueListState {
     /// The free-text query typed in filter-input mode (case-insensitive
     /// substring over the title).
     query: String,
-    /// Whether we are navigating, typing a filter, or typing a new-issue title.
+    /// Whether we are navigating, typing a filter, or in the create wizard.
     mode: IssueListMode,
-    /// The new-issue title typed in [`IssueListMode::CreateInput`] (e38.29).
-    /// Empty when not creating; cleared on submit / abort.
-    create_title: String,
+    /// The staged create wizard (Phase 5), open while `mode` is
+    /// [`IssueListMode::CreateInput`]. `None` otherwise.
+    wizard: Option<CreateWizard>,
+    /// The `@`-dropdown repo roster for the wizard's repo stage, injected by the
+    /// glue from the same `hangar/repo_list` snapshot the Boards screen gets
+    /// (favorites-first + recency order preserved). `scratch` is NOT in here —
+    /// [`repo_candidates`] prepends it always.
+    repos: Vec<RepoOption>,
+    /// A transient status note (create/run dispatch feedback or failure),
+    /// rendered on the bottom row and replaced by the next note / cleared when a
+    /// new wizard opens. Errors surface HERE, never silently dropped.
+    note: Option<String>,
     /// Maps a queued/running task to the issue it works on, so a `TaskStarted`
     /// event can promote the right issue to In Progress (the event carries only
     /// the task id, the queue carried the issue id).
@@ -268,7 +373,9 @@ impl Default for IssueListState {
             filter: FilterChip::All,
             query: String::new(),
             mode: IssueListMode::Normal,
-            create_title: String::new(),
+            wizard: None,
+            repos: Vec::new(),
+            note: None,
             task_issue: HashMap::new(),
             scroll_offsets: [0; COLUMN_COUNT],
             hovered_id: None,
@@ -309,12 +416,13 @@ impl IssueListState {
         )
     }
 
-    /// Abort the create-input flow (Esc): drop the typed title and return to
-    /// normal navigation (e38.29). A no-op when not creating.
+    /// Abort the create wizard (Esc): drop the WHOLE staged overlay — whatever
+    /// stage it is on — and return to normal navigation in one press (Phase 5,
+    /// never trap the user). A no-op when not creating.
     pub fn abort_create(&mut self) {
         if self.mode == IssueListMode::CreateInput {
             self.mode = IssueListMode::Normal;
-            self.create_title.clear();
+            self.wizard = None;
         }
     }
 
@@ -330,11 +438,30 @@ impl IssueListState {
         &self.query
     }
 
-    /// The new-issue title being typed in [`IssueListMode::CreateInput`] (e38.29),
-    /// or the empty string when not in create mode.
+    /// The open create wizard (Phase 5), or `None` when not creating.
     #[must_use]
-    pub fn create_title(&self) -> &str {
-        &self.create_title
+    pub const fn wizard(&self) -> Option<&CreateWizard> {
+        self.wizard.as_ref()
+    }
+
+    /// Inject the `@`-dropdown repo roster for the wizard's repo stage (Phase 5),
+    /// from the glue's cached `hangar/repo_list` (the same snapshot the Boards
+    /// card-create dropdown draws from).
+    pub fn set_repos(&mut self, repos: Vec<RepoOption>) {
+        self.repos = repos;
+    }
+
+    /// The transient status note (dispatch feedback / failure), if any.
+    #[must_use]
+    pub fn note(&self) -> Option<&str> {
+        self.note.as_deref()
+    }
+
+    /// Surface a transient status note on the bottom row (Phase 5): the glue
+    /// reports every create/update/run reply — success AND failure — through
+    /// this, so a dispatch error is never silent.
+    pub fn set_note(&mut self, note: impl Into<String>) {
+        self.note = Some(note.into());
     }
 
     /// Iterate the rows passing the active chip + query, in daemon order.
@@ -602,6 +729,10 @@ impl IssueListState {
 pub enum IssueListEvent {
     /// A printable key was pressed (`'j'`, `'\n'` for enter, `'/'`, `'c'`, …).
     Key(char),
+    /// A structured key for the open create wizard (Phase 5): unlike [`Self::Key`]
+    /// it carries Up/Down/Esc, which the picker stages (repo dropdown, agent
+    /// chips) need. Ignored when no wizard is open.
+    Wizard(WizardKey),
     /// The active filter chip was changed.
     SetFilter(FilterChip),
     /// A domain event arrived on the subscribed stream.
@@ -618,12 +749,25 @@ pub enum IssueListIntent {
     OpenTaskDetail(IssueId),
     /// Open the agent-picker modal for the issue under the selection.
     OpenAgentPicker(IssueId),
-    /// Submit a new issue with the typed `title` (e38.29). Raised when Enter is
-    /// pressed on a non-blank title in [`IssueListMode::CreateInput`]; the plugin
-    /// glue lifts it into a `hangar/issue_create` RPC.
-    CreateIssue {
-        /// The non-blank title typed in the create input.
+    /// Commit the create wizard (Phase 5): create the issue AND dispatch it.
+    /// Raised ONLY by Enter on the wizard's final Agent stage — there is no path
+    /// to this intent without an agent, so a title-only inert issue (assignee
+    /// `◇ None`, never runs) cannot be created from this screen. The plugin glue
+    /// lifts it into `hangar/issue_create` → `hangar/issue_update` (persist repo /
+    /// agent / branches) → `hangar/issue_run`.
+    CreateAndRun {
+        /// The non-blank title typed in stage 1.
         title: String,
+        /// The repo picked in stage 2 (REQUIRED — an absolute path, `scratch`, or
+        /// a remote indicator the daemon clones).
+        repo_ref: String,
+        /// The source branch the run branches FROM; `None` = the repo default.
+        source_branch: Option<String>,
+        /// The target branch a future PR lands INTO; `None` = unset.
+        target_branch: Option<String>,
+        /// The provider agent wire token (`claude` / `codex` / `copilot`) —
+        /// always a real token, never empty.
+        agent: String,
     },
 }
 
@@ -642,6 +786,7 @@ pub struct IssueListReduction {
 pub fn reduce_issue_list(state: &IssueListState, ev: IssueListEvent) -> IssueListReduction {
     match ev {
         IssueListEvent::Key(c) => reduce_key(state, c),
+        IssueListEvent::Wizard(k) => reduce_wizard_key(state, k),
         IssueListEvent::SetFilter(chip) => set_filter(state, chip),
         IssueListEvent::Event(event) => fold_event(state, event),
     }
@@ -651,8 +796,20 @@ pub fn reduce_issue_list(state: &IssueListState, ev: IssueListEvent) -> IssueLis
 fn reduce_key(state: &IssueListState, c: char) -> IssueListReduction {
     match state.mode {
         IssueListMode::FilterInput => reduce_filter_input_key(state, c),
-        IssueListMode::CreateInput => reduce_create_input_key(state, c),
+        // A plain char while the wizard is open folds in as a wizard key, so the
+        // legacy `Key(char)` path (Enter as '\n', Backspace as '\u{8}') keeps
+        // working alongside the structured [`IssueListEvent::Wizard`] events.
+        IssueListMode::CreateInput => reduce_wizard_key(state, wizard_key_from_char(c)),
         IssueListMode::Normal => reduce_normal_key(state, c),
+    }
+}
+
+/// Map the legacy reducer char vocabulary onto a [`WizardKey`].
+const fn wizard_key_from_char(c: char) -> WizardKey {
+    match c {
+        '\n' | '\r' => WizardKey::Enter,
+        '\u{8}' | '\u{7f}' => WizardKey::Backspace,
+        other => WizardKey::Char(other),
     }
 }
 
@@ -729,40 +886,299 @@ fn enter_filter_mode(state: &IssueListState) -> IssueListReduction {
     no_intent(next)
 }
 
-/// Enter create-input mode (`c`, e38.29): start typing a new-issue title with an
-/// empty buffer. No intent yet — the title is captured first, then Enter submits.
+/// Open the create wizard (`c`, Phase 5) at its Title stage. No intent yet — the
+/// staged inputs are collected first; only the final Agent stage commits.
 fn enter_create_mode(state: &IssueListState) -> IssueListReduction {
     let mut next = state.clone();
     next.mode = IssueListMode::CreateInput;
-    next.create_title = String::new();
+    next.wizard = Some(CreateWizard::Title {
+        title: String::new(),
+    });
+    // A fresh wizard supersedes any stale dispatch note.
+    next.note = None;
     no_intent(next)
 }
 
-/// Create-input-mode key handling (e38.29): Enter submits a non-blank title
-/// (leaving the mode + emitting [`IssueListIntent::CreateIssue`]), Backspace
-/// deletes the last char, any other printable char appends. Enter on a
-/// blank/whitespace title is a no-op that keeps the mode open (never an empty
-/// issue). Esc is handled by the router (it clears the buffer via
-/// [`IssueListState::abort_create`]).
-fn reduce_create_input_key(state: &IssueListState, c: char) -> IssueListReduction {
+/// Swap the open wizard for `wizard`, emitting no intent (a stage edit /
+/// transition).
+fn set_wizard(state: &IssueListState, wizard: CreateWizard) -> IssueListReduction {
     let mut next = state.clone();
-    match c {
-        '\n' | '\r' => {
-            if next.create_title.trim().is_empty() {
-                // Blank title: keep the mode open, submit nothing.
-                return no_intent(next);
-            }
-            let title = next.create_title.trim().to_string();
-            next.mode = IssueListMode::Normal;
-            next.create_title = String::new();
-            return with_intent(next, IssueListIntent::CreateIssue { title });
-        }
-        '\u{8}' | '\u{7f}' => {
-            next.create_title.pop();
-        }
-        other => next.create_title.push(other),
-    }
+    next.wizard = Some(wizard);
     no_intent(next)
+}
+
+/// Cancel the WHOLE wizard (Esc from any stage, Phase 5): back to normal
+/// navigation in one press, everything typed is dropped.
+fn cancel_wizard(state: &IssueListState) -> IssueListReduction {
+    let mut next = state.clone();
+    next.mode = IssueListMode::Normal;
+    next.wizard = None;
+    no_intent(next)
+}
+
+/// Fold one [`WizardKey`] into the open create wizard, dispatching on its stage
+/// (Phase 5). Esc cancels the whole overlay from ANY stage; every other key is
+/// interpreted per stage. A wizard key with no wizard open is a no-op.
+fn reduce_wizard_key(state: &IssueListState, key: WizardKey) -> IssueListReduction {
+    let Some(wizard) = state.wizard.clone() else {
+        return unchanged(state);
+    };
+    if key == WizardKey::Esc {
+        return cancel_wizard(state);
+    }
+    match wizard {
+        CreateWizard::Title { title } => wizard_title_key(state, title, key),
+        CreateWizard::Repo {
+            title,
+            query,
+            dropdown,
+        } => wizard_repo_key(state, title, query, dropdown, key),
+        CreateWizard::SourceBranch {
+            title,
+            repo_ref,
+            branch,
+        } => wizard_source_branch_key(state, title, repo_ref, branch, key),
+        CreateWizard::TargetBranch {
+            title,
+            repo_ref,
+            source_branch,
+            branch,
+        } => wizard_target_branch_key(state, title, repo_ref, source_branch, branch, key),
+        CreateWizard::Agent {
+            title,
+            repo_ref,
+            source_branch,
+            target_branch,
+            cursor,
+        } => wizard_agent_key(
+            state,
+            title,
+            repo_ref,
+            source_branch,
+            target_branch,
+            cursor,
+            key,
+        ),
+    }
+}
+
+/// Wizard stage 1 — Title: type the new issue's title. Enter on a non-blank
+/// title advances to the repo pick; blank Enter HOLDS the stage (never an empty
+/// issue); Backspace edits; Up/Down are no-ops.
+fn wizard_title_key(
+    state: &IssueListState,
+    mut title: String,
+    key: WizardKey,
+) -> IssueListReduction {
+    match key {
+        WizardKey::Backspace => {
+            title.pop();
+        }
+        WizardKey::Char(c) => title.push(c),
+        WizardKey::Enter => {
+            if !title.trim().is_empty() {
+                return set_wizard(
+                    state,
+                    CreateWizard::Repo {
+                        title: title.trim().to_string(),
+                        query: String::new(),
+                        dropdown: None,
+                    },
+                );
+            }
+            // Blank title: hold the stage open.
+        }
+        WizardKey::Up | WizardKey::Down | WizardKey::Esc => {}
+    }
+    set_wizard(state, CreateWizard::Title { title })
+}
+
+/// Wizard stage 2 — Repo (REQUIRED): `@` opens the fuzzy dropdown over the
+/// injected roster (scratch always first, exactly the Boards F2/F3 behaviour);
+/// ↑↓ move the highlight; Enter on a candidate advances to the source-branch
+/// input. Enter with the dropdown CLOSED re-opens it (the pointer at scratch)
+/// rather than ever advancing repo-less.
+fn wizard_repo_key(
+    state: &IssueListState,
+    title: String,
+    mut query: String,
+    dropdown: Option<usize>,
+    key: WizardKey,
+) -> IssueListReduction {
+    let reopen = |state: &IssueListState, query: String, dropdown: Option<usize>| {
+        set_wizard(
+            state,
+            CreateWizard::Repo {
+                title: title.clone(),
+                query,
+                dropdown,
+            },
+        )
+    };
+    match (dropdown, key) {
+        // Field closed: `@` opens the dropdown; Enter re-opens it (repo REQUIRED —
+        // never advance repo-less); anything else holds.
+        (None, WizardKey::Char('@') | WizardKey::Enter) => reopen(state, String::new(), Some(0)),
+        (None, _) => reopen(state, query, None),
+        // Dropdown open: edits re-filter and reset the highlight to the top.
+        (Some(_), WizardKey::Char(c)) => {
+            query.push(c);
+            reopen(state, query, Some(0))
+        }
+        (Some(_), WizardKey::Backspace) => {
+            query.pop();
+            reopen(state, query, Some(0))
+        }
+        (Some(cursor), WizardKey::Up) => reopen(state, query, Some(cursor.saturating_sub(1))),
+        (Some(cursor), WizardKey::Down) => {
+            let n = repo_candidates(&state.repos, &query).len();
+            reopen(state, query, Some((cursor + 1).min(n.saturating_sub(1))))
+        }
+        (Some(cursor), WizardKey::Enter) => {
+            let candidates = repo_candidates(&state.repos, &query);
+            let Some(picked) = candidates.get(cursor).or_else(|| candidates.first()) else {
+                // Impossible (scratch is always present), but never advance repo-less.
+                return reopen(state, query, Some(0));
+            };
+            set_wizard(
+                state,
+                CreateWizard::SourceBranch {
+                    title,
+                    repo_ref: picked.repo_ref.clone(),
+                    branch: "main".to_string(),
+                },
+            )
+        }
+        (Some(cursor), WizardKey::Esc) => reopen(state, query, Some(cursor)),
+    }
+}
+
+/// Wizard stage 3 — `SourceBranch`: a text input prefilled `main`. Enter accepts
+/// the (trimmed) value — blank means "unset, use the repo default at dispatch" —
+/// and advances to the target-branch input.
+fn wizard_source_branch_key(
+    state: &IssueListState,
+    title: String,
+    repo_ref: String,
+    mut branch: String,
+    key: WizardKey,
+) -> IssueListReduction {
+    match key {
+        WizardKey::Backspace => {
+            branch.pop();
+        }
+        WizardKey::Char(c) => branch.push(c),
+        WizardKey::Enter => {
+            return set_wizard(
+                state,
+                CreateWizard::TargetBranch {
+                    title,
+                    repo_ref,
+                    source_branch: branch.trim().to_string(),
+                    branch: "main".to_string(),
+                },
+            );
+        }
+        WizardKey::Up | WizardKey::Down | WizardKey::Esc => {}
+    }
+    set_wizard(
+        state,
+        CreateWizard::SourceBranch {
+            title,
+            repo_ref,
+            branch,
+        },
+    )
+}
+
+/// Wizard stage 4 — `TargetBranch`: a text input prefilled `main`. Enter accepts
+/// the (trimmed) value — blank means unset — and advances to the agent pick.
+fn wizard_target_branch_key(
+    state: &IssueListState,
+    title: String,
+    repo_ref: String,
+    source_branch: String,
+    mut branch: String,
+    key: WizardKey,
+) -> IssueListReduction {
+    match key {
+        WizardKey::Backspace => {
+            branch.pop();
+        }
+        WizardKey::Char(c) => branch.push(c),
+        WizardKey::Enter => {
+            return set_wizard(
+                state,
+                CreateWizard::Agent {
+                    title,
+                    repo_ref,
+                    source_branch,
+                    target_branch: branch.trim().to_string(),
+                    cursor: 0,
+                },
+            );
+        }
+        WizardKey::Up | WizardKey::Down | WizardKey::Esc => {}
+    }
+    set_wizard(
+        state,
+        CreateWizard::TargetBranch {
+            title,
+            repo_ref,
+            source_branch,
+            branch,
+        },
+    )
+}
+
+/// Wizard stage 5 — Agent (REQUIRED, the whole point): ↑↓ move over
+/// [`AgentChip::ALL`] (claude / codex / copilot — copilot is selectable, the F8
+/// gate fires at dispatch, same as Boards); Enter COMMITS the wizard, raising the
+/// one-and-only [`IssueListIntent::CreateAndRun`]. There is no other commit path,
+/// so the intent always carries a real agent token.
+fn wizard_agent_key(
+    state: &IssueListState,
+    title: String,
+    repo_ref: String,
+    source_branch: String,
+    target_branch: String,
+    cursor: usize,
+    key: WizardKey,
+) -> IssueListReduction {
+    let reopen = |state: &IssueListState, cursor: usize| {
+        set_wizard(
+            state,
+            CreateWizard::Agent {
+                title: title.clone(),
+                repo_ref: repo_ref.clone(),
+                source_branch: source_branch.clone(),
+                target_branch: target_branch.clone(),
+                cursor,
+            },
+        )
+    };
+    match key {
+        WizardKey::Up => reopen(state, cursor.saturating_sub(1)),
+        WizardKey::Down => reopen(state, (cursor + 1).min(AgentChip::ALL.len() - 1)),
+        WizardKey::Enter => {
+            let mut next = state.clone();
+            next.mode = IssueListMode::Normal;
+            next.wizard = None;
+            // Blank branch inputs mean "unset" — the daemon resolves the default.
+            let opt = |s: String| if s.is_empty() { None } else { Some(s) };
+            with_intent(
+                next,
+                IssueListIntent::CreateAndRun {
+                    title,
+                    repo_ref,
+                    source_branch: opt(source_branch),
+                    target_branch: opt(target_branch),
+                    agent: AgentChip::at(cursor).wire().to_string(),
+                },
+            )
+        }
+        WizardKey::Char(_) | WizardKey::Backspace | WizardKey::Esc => reopen(state, cursor),
+    }
 }
 
 /// Apply a new filter chip and re-clamp the selection into the new visible set.
@@ -876,11 +1292,28 @@ pub fn render_issue_list(
     // Working-agents avatar stack, right-aligned on the same chip row.
     crate::widgets::working_chip::render_working_chip(buf, top, area_w, working_count);
 
-    // e38.29: the inline create-issue input bar, when active, takes the bottom row
-    // as a single-line text input (`New issue · Title: <typed>▏`). Drawn last so it
-    // overlays the list; the rows above keep rendering as context.
-    if state.mode == IssueListMode::CreateInput {
-        render_create_bar(buf, area_w, bottom.saturating_sub(1), &state.create_title);
+    // Phase 5: the staged create wizard, when open, takes the two bottom rows
+    // (prompt + value) as an overlay. Drawn last so it overlays the list; the
+    // rows above keep rendering as context. When no wizard is open, a transient
+    // dispatch note (launch feedback / failure) paints on the bottom row instead.
+    if let Some(wizard) = state.wizard() {
+        render_wizard(
+            buf,
+            area_w,
+            bottom.saturating_sub(2),
+            bottom.saturating_sub(1),
+            wizard,
+            &state.repos,
+        );
+    } else if let Some(note) = state.note() {
+        put_str(
+            buf,
+            0,
+            bottom.saturating_sub(1),
+            note,
+            CREATE_ACCENT,
+            area_w,
+        );
     }
 
     // 63l.4 — the Issues screen is the headline of the redesign: it renders
@@ -907,17 +1340,161 @@ pub fn render_issue_list(
 /// gold headers + green selection so the create prompt reads as its own mode).
 const CREATE_ACCENT: Color = Color::rgb(120, 200, 160);
 
-/// Render the inline create-issue input bar at `(0, row)` (e38.29):
-/// `New issue · Title: <typed>▏` in the create accent followed by a muted
-/// keybinding hint. The caret `▏` sits after the typed text. Char-safe via
-/// [`put_str`].
-fn render_create_bar(buf: &mut WireBuffer, area_w: u16, row: u16, title: &str) {
-    // `New issue` + `Title:` are the prompt labels the tripwire detects to know
-    // the create input is active.
-    let prompt = format!("New issue · Title: {title}▏");
-    let next = put_str(buf, 0, row, &prompt, CREATE_ACCENT, area_w);
-    let hint = "  (Enter submit · Esc cancel)";
-    put_str(buf, next, row, hint, MUTED_GRAY, area_w);
+/// Gold stage-prompt colour for the create wizard (matches the Boards overlay
+/// prompts + the style guide's title gold).
+const GOLD: Color = Color::rgb(255, 215, 0);
+/// Selection green for the wizard's highlighted picker rows (style guide).
+const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
+
+/// Render the staged create wizard on the two bottom rows (Phase 5): a gold
+/// stage prompt naming the keys, then the green input / picker value line —
+/// mirroring the Boards card-create overlay so the two flows read identically.
+/// Char-safe via [`put_str`].
+fn render_wizard(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    row: u16,
+    value_row: u16,
+    wizard: &CreateWizard,
+    repos: &[RepoOption],
+) {
+    match wizard {
+        CreateWizard::Title { title } => {
+            put_str(
+                buf,
+                0,
+                row,
+                "New task · Title (Enter → repo, Esc cancel):",
+                GOLD,
+                area_w,
+            );
+            put_str(
+                buf,
+                0,
+                value_row,
+                &format!("> {title}\u{2588}"),
+                SELECTION_GREEN,
+                area_w,
+            );
+        }
+        CreateWizard::Repo {
+            title,
+            query,
+            dropdown,
+        } => render_wizard_repo(buf, area_w, row, title, query, *dropdown, repos),
+        CreateWizard::SourceBranch { branch, .. } => {
+            put_str(
+                buf,
+                0,
+                row,
+                "Source branch — run branches FROM (Enter accept, blank = repo default):",
+                GOLD,
+                area_w,
+            );
+            put_str(
+                buf,
+                0,
+                value_row,
+                &format!("> {branch}\u{2588}"),
+                SELECTION_GREEN,
+                area_w,
+            );
+        }
+        CreateWizard::TargetBranch { branch, .. } => {
+            put_str(
+                buf,
+                0,
+                row,
+                "Target branch — PR lands INTO (Enter accept, blank = unset):",
+                GOLD,
+                area_w,
+            );
+            put_str(
+                buf,
+                0,
+                value_row,
+                &format!("> {branch}\u{2588}"),
+                SELECTION_GREEN,
+                area_w,
+            );
+        }
+        CreateWizard::Agent { title, cursor, .. } => {
+            let prompt = format!("Agent for \"{title}\" — REQUIRED (↑↓ pick, Enter create + run):");
+            put_str(buf, 0, row, &prompt, GOLD, area_w);
+            let mut x = 0u16;
+            for (i, chip) in AgentChip::ALL.iter().enumerate() {
+                let sel = i == *cursor;
+                let colour = if sel { SELECTION_GREEN } else { MUTED_GRAY };
+                let marker = if sel { "▶ " } else { "  " };
+                x = put_str(buf, x, value_row, marker, colour, area_w);
+                x = put_str(buf, x, value_row, chip.label(), colour, area_w);
+                x = put_str(buf, x, value_row, "   ", MUTED_GRAY, area_w);
+                if x >= area_w {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Render the wizard's repo stage (Phase 5): the prompt line plus either the
+/// closed-field hint (type `@` to search) or the open `@` dropdown — scratch
+/// always first (★ favorites, ★☁ remote-only), the highlighted candidate in
+/// green. Mirrors the Boards `render_card_repo`; the value line paints directly
+/// under the prompt `row`.
+fn render_wizard_repo(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    row: u16,
+    title: &str,
+    query: &str,
+    dropdown: Option<usize>,
+    repos: &[RepoOption],
+) {
+    let value_row = row.saturating_add(1);
+    let prompt = format!("Repo for \"{title}\" (@ to search, Enter pick — REQUIRED):");
+    put_str(buf, 0, row, &prompt, GOLD, area_w);
+    let Some(cursor) = dropdown else {
+        put_str(
+            buf,
+            0,
+            value_row,
+            "> type @ to pick a repo (scratch always available)",
+            MUTED_GRAY,
+            area_w,
+        );
+        return;
+    };
+    let candidates = repo_candidates(repos, query);
+    let mut x = put_str(
+        buf,
+        0,
+        value_row,
+        &format!("@{query} "),
+        SELECTION_GREEN,
+        area_w,
+    );
+    for (i, repo) in candidates.iter().enumerate() {
+        let sel = i == cursor;
+        let colour = if sel { SELECTION_GREEN } else { MUTED_GRAY };
+        let open = if sel { "[" } else { " " };
+        let close = if sel { "]" } else { " " };
+        let star = if repo.is_remote_only {
+            "★☁"
+        } else if repo.is_favorite {
+            "★"
+        } else {
+            ""
+        };
+        x = put_str(buf, x, value_row, open, colour, area_w);
+        x = put_str(buf, x, value_row, star, colour, area_w);
+        x = put_str(buf, x, value_row, &repo.label, colour, area_w);
+        x = put_str(buf, x, value_row, close, colour, area_w);
+        x = put_str(buf, x, value_row, " ", MUTED_GRAY, area_w);
+        if x >= area_w {
+            break;
+        }
+    }
 }
 
 /// Write `s` at `(x, row)` in `color`, clipping at `area_w`. Returns the next
@@ -1210,6 +1787,46 @@ mod tests {
         let after: Vec<String> =
             s.rows_in_column(IssueColumn::Todo).map(|r| r.id.as_str().to_string()).collect();
         assert_eq!(before, after);
+    }
+
+    /// Phase 5 — the create wizard renders each stage's prompt + value on the two
+    /// bottom rows: the Title input, the REQUIRED repo pick (scratch first in the
+    /// `@` dropdown), the `main`-prefilled branch inputs, and the agent chips with
+    /// the REQUIRED marker. Pins the overlay layout the manual `just dev` walk
+    /// exercises.
+    #[test]
+    fn wizard_overlay_renders_each_stage_prompt() {
+        let assert_paints = |state: &IssueListState, needles: &[&str]| {
+            let mut buf = WireBuffer::new(120, 24);
+            render_issue_list(&mut buf, 120, 1, 23, state, 0);
+            let painted = painted_text(&buf);
+            for needle in needles {
+                assert!(
+                    painted.contains(needle),
+                    "missing {needle:?} in:\n{painted}"
+                );
+            }
+        };
+        // Stage 1: title input.
+        let s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
+        let s = reduce_issue_list(&s, IssueListEvent::Key('F')).state;
+        assert_paints(&s, &["New task · Title", "> F"]);
+        // Stage 2: repo pick — REQUIRED, `@` dropdown with scratch always first.
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Enter)).state;
+        assert_paints(&s, &["Repo for \"F\"", "REQUIRED", "type @ to pick a repo"]);
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
+        assert_paints(&s, &["[scratch]"]);
+        // Stage 3 + 4: branch inputs prefilled `main`.
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Enter)).state;
+        assert_paints(&s, &["Source branch", "> main"]);
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Enter)).state;
+        assert_paints(&s, &["Target branch", "> main"]);
+        // Stage 5: the REQUIRED agent chips, claude highlighted first.
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Enter)).state;
+        assert_paints(
+            &s,
+            &["Agent for \"F\" — REQUIRED", "▶ claude", "codex", "copilot"],
+        );
     }
 
     /// Reconstruct the full painted text of a rendered buffer (every cell, in

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -69,6 +69,16 @@ const STATUS_AMBER: Color = Color::rgb(230, 190, 90);
 /// Cornflower-blue for the run's branch line (tcp T2, agents-in-a-box-ch3) —
 /// distinct from the gold PR badge so the two artifacts never read as one.
 const BRANCH_COLOR: Color = Color::rgb(100, 149, 237);
+/// Cornflower-blue for the detail-card border (63d; the style-guide border hue).
+const CARD_BORDER: Color = Color::rgb(100, 149, 237);
+/// Gold for the detail-card title (63d; the style-guide title/CTA gold).
+const CARD_TITLE: Color = Color::rgb(255, 215, 0);
+/// Soft white for the detail-card field VALUES (63d; the style-guide body ink).
+const CARD_VALUE: Color = Color::rgb(220, 220, 230);
+/// Muted gray for the detail-card field LABELS (63d; the style-guide muted hue).
+const CARD_LABEL: Color = Color::rgb(120, 120, 140);
+/// The em-dash placeholder painted for an unset card field (63d).
+const CARD_UNSET: &str = "—";
 /// The leading glyph + label painted before the branch name (`⎇ branch `).
 const BRANCH_PREFIX: &str = "⎇ branch ";
 /// Accent for the comment-compose input bar (a calm emerald, distinct from the
@@ -665,12 +675,17 @@ pub fn render_task_detail(
     bottom: u16,
     state: &TaskDetailState,
 ) {
-    // The PR badge (P9.2) takes the first row of the whole area when present,
+    // 63d: the issue DETAIL CARD spans the top of the area, so even a never-run
+    // issue reads as a real card. The PR badge / branch / transcript start on the
+    // first row BELOW it (+ its optional `Runs:` line).
+    let card_bottom = render_detail_card(buf, area_w, top, bottom, state.issue());
+
+    // The PR badge (P9.2) takes the first row below the card when present,
     // pushing the transcript + sidebar down one row. When absent there is NO
     // badge row at all (the layout shifts up) — never a `PR: none` placeholder.
-    let mut body_top = state.pr_url().map_or(top, |url| {
-        render_pr_badge(buf, area_w, top, url, state.pr_status());
-        top.saturating_add(1)
+    let mut body_top = state.pr_url().map_or(card_bottom, |url| {
+        render_pr_badge(buf, area_w, card_bottom, url, state.pr_status());
+        card_bottom.saturating_add(1)
     });
 
     // The run's branch line (tcp T2, agents-in-a-box-ch3) sits right under the PR
@@ -808,6 +823,312 @@ fn put_clipped(buf: &mut WireBuffer, x: u16, row: u16, s: &str, color: Color, ri
     cx
 }
 
+/// Render the issue DETAIL CARD at the top of the task-detail screen (63d): a
+/// cornflower-bordered box carrying the issue's status / priority / created /
+/// assignee / agent / repo / branches / labels / description, so a never-run
+/// issue reads as a real card instead of an almost-empty page. Returns the first
+/// row BELOW the card (+ its optional `Runs:` history line) — the caller starts
+/// the PR badge / branch / transcript there.
+///
+/// Width-aware: every value is clipped by **chars** (never bytes — the utf8
+/// truncate trap this file documents), and the description wraps to the inner
+/// width, capped so the card always leaves room for the transcript below.
+///
+/// HEIGHT CONTRACT: the card budgets itself to `available - RESERVED_BELOW`
+/// (badge + branch + a minimum transcript region) and paints nothing (returns
+/// `top` unchanged) when that budget cannot fit a legible card — a short
+/// viewport (e.g. the 8-row snapshot panes) keeps the pre-card layout intact,
+/// with the PR badge / branch / transcript exactly where they always were.
+fn render_detail_card(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    top: u16,
+    bottom: u16,
+    issue: &IssueRow,
+) -> u16 {
+    let card_w = area_w;
+    let available = bottom.saturating_sub(top);
+
+    // The rows the card must LEAVE BELOW itself: the PR badge (1) + branch line
+    // (1) + a minimum legible transcript region (4). The card's whole budget is
+    // what remains after this reservation — the transcript feed is the screen's
+    // job, the card is context, so the card yields, never the feed.
+    const RESERVED_BELOW: u16 = 6;
+    // The card's fixed chrome: top border + 4 field rows + divider + bottom
+    // border = 7 rows; the description adds ≥1 more, a run history line 1 more.
+    const CARD_FIXED_ROWS: u16 = 7;
+    /// The description never exceeds this many wrapped lines, so even a tall
+    /// viewport keeps the card compact (≈40% of a 30-row pane at worst).
+    const DESC_MAX_LINES: u16 = 4;
+
+    let runs_line = issue.run_count > 0;
+    let runs_rows = u16::from(runs_line);
+    let budget = available.saturating_sub(RESERVED_BELOW);
+    let min_needed = CARD_FIXED_ROWS + 1 + runs_rows;
+    // Too narrow, or the viewport can't fit a legible card AND the reserved
+    // badge/branch/transcript region — skip the card entirely (the pre-card
+    // layout), never squeeze the transcript out.
+    if card_w < 16 || budget < min_needed {
+        return top;
+    }
+    let inner_right = card_w.saturating_sub(2); // content clip column (exclusive)
+
+    // Wrap the description (or the "no description" placeholder) to the inner
+    // width, capped to the row budget left after the fixed chrome + runs line —
+    // and to DESC_MAX_LINES absolutely — so the card never eats the transcript.
+    let inner_w = card_w.saturating_sub(4).max(1) as usize;
+    let desc_text = issue.description.as_deref().unwrap_or("no description");
+    let desc_budget = budget
+        .saturating_sub(CARD_FIXED_ROWS)
+        .saturating_sub(runs_rows)
+        .clamp(1, DESC_MAX_LINES) as usize;
+    let desc_lines = wrap_chars(desc_text, inner_w, desc_budget);
+    let mut row = top;
+
+    // --- top border with the gold title overlaid ---
+    draw_card_hline(buf, row, card_w, '╭', '╮');
+    let title = match &issue.display_id {
+        Some(d) => format!(" 📋 {} · {}", d, issue.title),
+        None => format!(" 📋 {}", issue.title),
+    };
+    put_clipped(buf, 2, row, &title, CARD_TITLE, inner_right);
+    row = row.saturating_add(1);
+
+    // --- Status / Priority / Created ---
+    card_field_row(
+        buf,
+        card_w,
+        row,
+        &[
+            ("Status: ", CARD_LABEL),
+            (&issue.state, CARD_VALUE),
+            ("   Priority: ", CARD_LABEL),
+            (&priority_p_label(issue.priority), CARD_VALUE),
+            ("   Created: ", CARD_LABEL),
+            (&fmt_card_date(issue.created_at), CARD_VALUE),
+        ],
+    );
+    row = row.saturating_add(1);
+
+    // --- Assignee / Agent ---
+    let assignee = issue.assignee.as_deref().unwrap_or("unassigned");
+    let agent = issue.agent.as_deref().unwrap_or(CARD_UNSET);
+    card_field_row(
+        buf,
+        card_w,
+        row,
+        &[
+            ("Assignee: ", CARD_LABEL),
+            (assignee, CARD_VALUE),
+            ("   Agent: ", CARD_LABEL),
+            (agent, CARD_VALUE),
+        ],
+    );
+    row = row.saturating_add(1);
+
+    // --- Repo / Source → Target ---
+    let repo = issue.repo_ref.as_deref().unwrap_or(CARD_UNSET);
+    let source = issue.source_branch.as_deref().unwrap_or(CARD_UNSET);
+    let target = issue.target_branch.as_deref().unwrap_or(CARD_UNSET);
+    card_field_row(
+        buf,
+        card_w,
+        row,
+        &[
+            ("Repo: ", CARD_LABEL),
+            (repo, CARD_VALUE),
+            ("   Source: ", CARD_LABEL),
+            (source, CARD_VALUE),
+            (" → Target: ", CARD_LABEL),
+            (target, CARD_VALUE),
+        ],
+    );
+    row = row.saturating_add(1);
+
+    // --- Labels ---
+    let labels = if issue.labels.is_empty() {
+        CARD_UNSET.to_string()
+    } else {
+        issue.labels.iter().map(|l| format!("[{l}]")).collect::<Vec<_>>().join(" ")
+    };
+    card_field_row(
+        buf,
+        card_w,
+        row,
+        &[("Labels: ", CARD_LABEL), (&labels, CARD_VALUE)],
+    );
+    row = row.saturating_add(1);
+
+    // --- divider ---
+    draw_card_divider(buf, row, card_w);
+    row = row.saturating_add(1);
+
+    // --- description (wrapped) ---
+    for line in &desc_lines {
+        card_field_row(buf, card_w, row, &[(line, CARD_VALUE)]);
+        row = row.saturating_add(1);
+    }
+
+    // --- bottom border ---
+    draw_card_hline(buf, row, card_w, '╰', '╯');
+    row = row.saturating_add(1);
+
+    // --- Runs history line (below the card, only when the issue has run) ---
+    if runs_line {
+        let when = issue.last_run_at.map(fmt_card_date);
+        let runs = match (&issue.last_run_status, when) {
+            (Some(status), Some(w)) => {
+                format!("  Runs: {} (last: {status} {w})", issue.run_count)
+            }
+            (Some(status), None) => format!("  Runs: {} (last: {status})", issue.run_count),
+            _ => format!("  Runs: {}", issue.run_count),
+        };
+        put_clipped(buf, 0, row, &runs, CARD_LABEL, card_w);
+        row = row.saturating_add(1);
+    }
+
+    row
+}
+
+/// Draw a card horizontal border row (top or bottom) spanning the full width,
+/// with the given corner glyphs, in the cornflower border colour (63d).
+fn draw_card_hline(buf: &mut WireBuffer, row: u16, card_w: u16, left: char, right: char) {
+    let mut s = String::new();
+    s.push(left);
+    for _ in 1..card_w.saturating_sub(1) {
+        s.push('─');
+    }
+    if card_w >= 2 {
+        s.push(right);
+    }
+    put_clipped(buf, 0, row, &s, CARD_BORDER, card_w);
+}
+
+/// Draw the card's inner divider row: `│` edges with a dashed fill between (63d).
+fn draw_card_divider(buf: &mut WireBuffer, row: u16, card_w: u16) {
+    let mut s = String::new();
+    s.push('│');
+    for _ in 1..card_w.saturating_sub(1) {
+        s.push('─');
+    }
+    if card_w >= 2 {
+        s.push('│');
+    }
+    put_clipped(buf, 0, row, &s, CARD_BORDER, card_w);
+}
+
+/// Draw one card content row: the `│` left+right edges in the border colour, then
+/// the label/value `segments` laid out left-to-right from the inner column,
+/// clipped by **chars** at the right edge (63d, utf8-safe).
+fn card_field_row(buf: &mut WireBuffer, card_w: u16, row: u16, segments: &[(&str, Color)]) {
+    let inner_right = card_w.saturating_sub(2);
+    // Edges first; the content overlays the interior between them.
+    put_clipped(buf, 0, row, "│", CARD_BORDER, card_w);
+    put_clipped(buf, card_w.saturating_sub(1), row, "│", CARD_BORDER, card_w);
+    let mut cx = 2u16;
+    for (text, color) in segments {
+        if cx >= inner_right {
+            break;
+        }
+        cx = put_clipped(buf, cx, row, text, *color, inner_right);
+    }
+}
+
+/// Wrap `text` into at most `max_lines` lines of at most `width` CHARS each
+/// (utf8-safe — never a byte slice). Greedy word wrap, hard-splitting a word
+/// longer than `width`; the last line is ellipsised when the text overflows the
+/// cap so a huge description never blows past the card.
+fn wrap_chars(text: &str, width: usize, max_lines: usize) -> Vec<String> {
+    if width == 0 || max_lines == 0 {
+        return Vec::new();
+    }
+    let mut lines: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut current_len = 0usize;
+    for word in text.split_whitespace() {
+        let word_len = word.chars().count();
+        // A word longer than the line width is hard-split across lines.
+        if word_len > width {
+            if !current.is_empty() {
+                lines.push(std::mem::take(&mut current));
+                current_len = 0;
+            }
+            for ch in word.chars() {
+                if current_len == width {
+                    lines.push(std::mem::take(&mut current));
+                    current_len = 0;
+                }
+                current.push(ch);
+                current_len += 1;
+            }
+            continue;
+        }
+        let sep = usize::from(!current.is_empty());
+        if current_len + sep + word_len > width {
+            lines.push(std::mem::take(&mut current));
+            current_len = 0;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+            current_len += 1;
+        }
+        current.push_str(word);
+        current_len += word_len;
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    // Cap to max_lines, ellipsising the last kept line when we drop content.
+    if lines.len() > max_lines {
+        lines.truncate(max_lines);
+        if let Some(last) = lines.last_mut() {
+            let mut chars: Vec<char> = last.chars().collect();
+            if chars.len() >= width && width >= 1 {
+                chars.truncate(width.saturating_sub(1));
+            }
+            chars.push('…');
+            *last = chars.into_iter().collect();
+        }
+    }
+    lines
+}
+
+/// The `P0..P3` label for a wire priority scalar (63d). The scale is `0..3` with
+/// HIGHER = MORE URGENT (`3` = P0 urgent, `0` = P3 routine, the default), so the
+/// P-number is `3 - priority`.
+fn priority_p_label(priority: i64) -> String {
+    format!("P{}", 3 - priority.clamp(0, 3))
+}
+
+/// Format an epoch-millisecond timestamp as a UTC `YYYY-MM-DD` for the card
+/// (63d). Chrono is a dev-only dep here, so the civil date is derived with
+/// Hinnant's `days_from_civil` inverse — a pure, allocation-free conversion.
+fn fmt_card_date(ms: i64) -> String {
+    let days = ms.div_euclid(86_400_000);
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// The inverse of Howard Hinnant's `days_from_civil`: map a day count since the
+/// Unix epoch (1970-01-01) to a proleptic-Gregorian `(year, month, day)` in UTC.
+/// Exact for the whole i64 range; no leap-second / timezone handling (a calendar
+/// date is all the card shows).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
 /// Convenience accessor re-exporting the transcript glyph for a [`MessageKind`]
 /// so call sites (and tests) can reach the taxonomy mapping without importing the
 /// widget module directly.
@@ -820,4 +1141,196 @@ pub const fn glyph_for(kind: MessageKind) -> char {
 #[must_use]
 pub const fn color_for(kind: MessageKind) -> ainb_plugin_sdk::Color {
     transcript_color(kind)
+}
+
+#[cfg(test)]
+mod card_tests {
+    use super::*;
+    use ainb_hangar_core::ids::{IssueId, TaskId};
+    use ainb_plugin_sdk::WireBuffer;
+
+    /// Reconstruct the full painted text of a rendered buffer (row-major) so a
+    /// render assertion can search for the card's labels / values.
+    fn painted_text(buf: &WireBuffer) -> String {
+        let mut out = String::new();
+        for y in 0..buf.height {
+            for (coord, cell) in &buf.cells {
+                if coord.y == y {
+                    out.push_str(&cell.symbol);
+                }
+            }
+        }
+        out
+    }
+
+    /// A fully-populated issue row for the card render assertions (63d).
+    fn full_issue() -> IssueRow {
+        IssueRow {
+            id: IssueId::from_str("i1").unwrap(),
+            display_id: Some("HGR-1".into()),
+            workspace_id: "ws".into(),
+            title: "Fix the widget".into(),
+            description: Some("The widget breaks on resize.".into()),
+            state: "todo".into(),
+            assignee: Some("agent:alice".into()),
+            creator: "member:me".into(),
+            created_at: 1_700_000_000_000,
+            priority: 1,
+            due_date: None,
+            labels: vec!["bug".into(), "p0".into()],
+            pr_url: None,
+            branch: None,
+            repo_ref: Some("/repos/widget".into()),
+            agent: Some("codex".into()),
+            source_branch: Some("main".into()),
+            target_branch: Some("release".into()),
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
+        }
+    }
+
+    fn state_for(issue: IssueRow) -> TaskDetailState {
+        TaskDetailState::new(TaskId::from_str("task-1").unwrap(), issue)
+    }
+
+    /// A never-run issue renders a full detail card — title, every field row, the
+    /// description — and NO `Runs:` history line (63d, the headline case).
+    #[test]
+    fn detail_card_renders_every_field_for_a_never_run_issue() {
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+
+        assert!(text.contains("📋 HGR-1 · Fix the widget"), "title: {text}");
+        assert!(text.contains("Status: "), "status label");
+        assert!(text.contains("todo"), "status value");
+        assert!(text.contains("Priority: "), "priority label");
+        assert!(text.contains("P2"), "priority 1 → P2");
+        assert!(text.contains("Created: "), "created label");
+        assert!(text.contains("2023-11-14"), "created date: {text}");
+        assert!(text.contains("Assignee: "), "assignee label");
+        assert!(text.contains("agent:alice"), "assignee value");
+        assert!(text.contains("Agent: "), "agent label");
+        assert!(text.contains("codex"), "agent value");
+        assert!(text.contains("Repo: "), "repo label");
+        assert!(text.contains("/repos/widget"), "repo value");
+        assert!(text.contains("Source: "), "source label");
+        assert!(text.contains("Target: "), "target label");
+        assert!(text.contains("release"), "target value");
+        assert!(text.contains("Labels: "), "labels label");
+        assert!(text.contains("[bug]"), "label chip bug");
+        assert!(text.contains("[p0]"), "label chip p0");
+        assert!(text.contains("The widget breaks on resize."), "description");
+        assert!(
+            !text.contains("Runs:"),
+            "a never-run issue has no runs line"
+        );
+    }
+
+    /// An issue with unset card fields renders the em-dash placeholders and
+    /// "no description", never a blank card (63d).
+    #[test]
+    fn detail_card_renders_placeholders_when_unset() {
+        let mut issue = full_issue();
+        issue.description = None;
+        issue.assignee = None;
+        issue.agent = None;
+        issue.repo_ref = None;
+        issue.source_branch = None;
+        issue.target_branch = None;
+        issue.labels = Vec::new();
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+
+        assert!(text.contains("unassigned"), "unset assignee");
+        assert!(
+            text.contains("—"),
+            "em-dash placeholder for unset repo/agent"
+        );
+        assert!(text.contains("no description"), "unset description");
+    }
+
+    /// An issue with run history renders the `Runs:` line below the card with the
+    /// count and latest run summary (63d).
+    #[test]
+    fn detail_card_renders_runs_line_when_issue_has_run() {
+        let mut issue = full_issue();
+        issue.run_count = 3;
+        issue.last_run_status = Some("running".into());
+        issue.last_run_at = Some(1_700_000_000_000);
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+
+        assert!(text.contains("Runs: 3"), "run count: {text}");
+        assert!(text.contains("last: running"), "latest run status");
+        assert!(text.contains("2023-11-14"), "latest run date");
+    }
+
+    /// HEIGHT CONTRACT regression (the coordinator's Finding 1): at a short
+    /// viewport (the 8-row snapshot panes) the card is skipped entirely so the
+    /// PR badge stays on row 0 and the transcript region is preserved — the card
+    /// must never squeeze the feed out.
+    #[test]
+    fn detail_card_yields_to_badge_and_transcript_at_short_viewports() {
+        let mut issue = full_issue();
+        issue.pr_url = Some("https://github.com/o/r/pull/7".into());
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(100, 8);
+        render_task_detail(&mut buf, 100, 0, 8, &s);
+        let text = painted_text(&buf);
+
+        assert!(!text.contains('╭'), "no card border at 8 rows: {text}");
+        assert!(text.contains("▶ PR "), "PR badge still renders: {text}");
+        // The badge sits on row 0 exactly as before the card existed.
+        let row0: String = buf
+            .cells
+            .iter()
+            .filter(|(c, _)| c.y == 0)
+            .map(|(_, cell)| cell.symbol.as_str())
+            .collect();
+        assert!(row0.contains("▶ PR "), "badge pinned to row 0: {row0}");
+    }
+
+    /// `priority_p_label` maps the 0..3 urgency scale to P3..P0 (HIGHER = urgent).
+    #[test]
+    fn priority_p_label_maps_scale() {
+        assert_eq!(priority_p_label(0), "P3");
+        assert_eq!(priority_p_label(1), "P2");
+        assert_eq!(priority_p_label(2), "P1");
+        assert_eq!(priority_p_label(3), "P0");
+        // Out-of-range clamps rather than underflowing.
+        assert_eq!(priority_p_label(9), "P0");
+    }
+
+    /// `fmt_card_date` converts epoch-ms to a UTC calendar date without chrono.
+    #[test]
+    fn fmt_card_date_converts_epoch_ms() {
+        assert_eq!(fmt_card_date(0), "1970-01-01");
+        assert_eq!(fmt_card_date(1_700_000_000_000), "2023-11-14");
+    }
+
+    /// `wrap_chars` wraps on word boundaries, hard-splits an over-long word, and
+    /// ellipsises the last line when the text overflows the cap — all by CHARS.
+    #[test]
+    fn wrap_chars_wraps_and_caps() {
+        let lines = wrap_chars("alpha beta gamma delta", 11, 4);
+        assert!(
+            lines.iter().all(|l| l.chars().count() <= 11),
+            "no line over width"
+        );
+        assert!(lines.len() <= 4);
+        // A single word longer than the width is hard-split, never dropped.
+        let split = wrap_chars("supercalifragilistic", 5, 4);
+        assert!(split.len() > 1, "long word hard-split: {split:?}");
+        // Overflow past the cap ellipsises the last kept line.
+        let capped = wrap_chars("one two three four five six seven eight", 5, 2);
+        assert_eq!(capped.len(), 2);
+        assert!(capped[1].ends_with('…'), "overflow ellipsised: {capped:?}");
+    }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -131,6 +131,13 @@ mod tests {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
@@ -43,6 +43,13 @@ fn row(id: &str, display: &str, state: &str, priority: i64, assignee: Option<&st
         labels: Vec::new(),
         pr_url: None,
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -10,8 +10,8 @@
 use ainb_hangar_core::ids::{AgentId, IssueId, TaskId};
 use ainb_hangar_proto::events::{HangarEvent, IssueRow};
 use ainb_plugin_hangar::screen::issue_list::{
-    FilterChip, IssueColumn, IssueListEvent, IssueListIntent, IssueListMode, IssueListState,
-    reduce_issue_list,
+    CreateWizard, FilterChip, IssueColumn, IssueListEvent, IssueListIntent, IssueListMode,
+    IssueListState, WizardKey, reduce_issue_list,
 };
 
 /// A wire `IssueRow` for tests. `state` drives column grouping (`open` → Todo,
@@ -101,56 +101,235 @@ fn slash_enters_filter_input_mode() {
     assert!(out.intent.is_none());
 }
 
-/// `c` enters the create-input mode (the user types a title); it does not emit an
-/// intent yet — the intent is raised on Enter once a non-blank title is typed
-/// (e38.29).
+// ---------------------------------------------------------------------------
+// Phase 5 — the staged create wizard (Title → Repo → SourceBranch →
+// TargetBranch → Agent), which FORCES an agent assignment before any create
+// can commit. The old title-only quick-create (an inert `◇ None` card) is
+// unreachable from this screen.
+// ---------------------------------------------------------------------------
+
+/// Fold one wizard key.
+fn wiz(
+    s: &IssueListState,
+    k: WizardKey,
+) -> ainb_plugin_hangar::screen::issue_list::IssueListReduction {
+    reduce_issue_list(s, IssueListEvent::Wizard(k))
+}
+
+/// Type a string into the open wizard stage, char by char.
+fn type_str(mut s: IssueListState, text: &str) -> IssueListState {
+    for ch in text.chars() {
+        s = wiz(&s, WizardKey::Char(ch)).state;
+    }
+    s
+}
+
+/// `c` opens the create wizard on its Title stage; no intent yet.
 #[test]
-fn c_enters_create_input_mode() {
+fn c_opens_wizard_on_title_stage() {
     let s = seeded_state();
     assert_eq!(s.mode(), IssueListMode::Normal);
 
     let out = reduce_issue_list(&s, IssueListEvent::Key('c'));
 
     assert_eq!(out.state.mode(), IssueListMode::CreateInput);
+    assert!(matches!(
+        out.state.wizard(),
+        Some(CreateWizard::Title { title }) if title.is_empty()
+    ));
     assert!(out.intent.is_none());
 }
 
-/// Typing a title in create-input mode appends to the create buffer; Enter on a
-/// non-blank title emits the create-issue intent carrying the typed title and
-/// returns to normal navigation (e38.29).
+/// Enter on a blank/whitespace title HOLDS the Title stage open and raises no
+/// intent — never an empty issue.
 #[test]
-fn create_input_enter_emits_create_issue_with_title() {
-    let mut s = reduce_issue_list(&seeded_state(), IssueListEvent::Key('c')).state;
-    for ch in "Fix login".chars() {
-        s = reduce_issue_list(&s, IssueListEvent::Key(ch)).state;
-    }
-    assert_eq!(s.create_title(), "Fix login");
+fn wizard_blank_title_enter_holds() {
+    let s = reduce_issue_list(&seeded_state(), IssueListEvent::Key('c')).state;
+    let s = type_str(s, "  ");
 
-    let out = reduce_issue_list(&s, IssueListEvent::Key('\n'));
+    let out = wiz(&s, WizardKey::Enter);
+
+    assert!(out.intent.is_none());
+    assert!(matches!(
+        out.state.wizard(),
+        Some(CreateWizard::Title { .. })
+    ));
+    assert_eq!(out.state.mode(), IssueListMode::CreateInput);
+}
+
+/// Walk the wizard up to (but not into) the Agent stage: title typed, scratch
+/// repo picked, both branch stages accepted at their `main` prefill.
+fn wizard_at(stage: &str) -> IssueListState {
+    let s = reduce_issue_list(&seeded_state(), IssueListEvent::Key('c')).state;
+    let s = type_str(s, "Fix login");
+    if stage == "title" {
+        return s;
+    }
+    let s = wiz(&s, WizardKey::Enter).state; // → Repo
+    if stage == "repo" {
+        return s;
+    }
+    let s = wiz(&s, WizardKey::Char('@')).state; // open dropdown (cursor at scratch)
+    let s = wiz(&s, WizardKey::Enter).state; // pick scratch → SourceBranch
+    if stage == "source" {
+        return s;
+    }
+    let s = wiz(&s, WizardKey::Enter).state; // accept "main" → TargetBranch
+    if stage == "target" {
+        return s;
+    }
+    wiz(&s, WizardKey::Enter).state // accept "main" → Agent
+}
+
+/// Repo is REQUIRED: Enter with the dropdown closed RE-OPENS the dropdown (the
+/// cursor at scratch) instead of ever advancing repo-less.
+#[test]
+fn wizard_repo_enter_repo_less_reopens_dropdown() {
+    let s = wizard_at("repo");
+    assert!(matches!(
+        s.wizard(),
+        Some(CreateWizard::Repo { dropdown: None, .. })
+    ));
+
+    let out = wiz(&s, WizardKey::Enter);
+
+    // Still on the Repo stage — now with the dropdown open at scratch.
+    assert!(matches!(
+        out.state.wizard(),
+        Some(CreateWizard::Repo {
+            dropdown: Some(0),
+            ..
+        })
+    ));
+    assert!(out.intent.is_none());
+}
+
+/// The branch stages prefill `main` (source first, then target).
+#[test]
+fn wizard_branch_stages_prefill_main() {
+    let s = wizard_at("source");
+    assert!(matches!(
+        s.wizard(),
+        Some(CreateWizard::SourceBranch { branch, .. }) if branch == "main"
+    ));
+
+    let s = wiz(&s, WizardKey::Enter).state;
+    assert!(matches!(
+        s.wizard(),
+        Some(CreateWizard::TargetBranch { branch, source_branch, .. })
+            if branch == "main" && source_branch == "main"
+    ));
+}
+
+/// The full walk commits ONLY on the Agent stage, emitting `CreateAndRun` with
+/// every collected field — and the agent token is always a real provider.
+#[test]
+fn wizard_full_walk_commits_create_and_run_with_agent() {
+    let s = wizard_at("agent");
+    assert!(matches!(s.wizard(), Some(CreateWizard::Agent { .. })));
+
+    // ↓ once: claude → codex.
+    let s = wiz(&s, WizardKey::Down).state;
+    let out = wiz(&s, WizardKey::Enter);
 
     assert_eq!(
         out.intent,
-        Some(IssueListIntent::CreateIssue {
-            title: "Fix login".to_string()
+        Some(IssueListIntent::CreateAndRun {
+            title: "Fix login".to_string(),
+            repo_ref: "scratch".to_string(),
+            source_branch: Some("main".to_string()),
+            target_branch: Some("main".to_string()),
+            agent: "codex".to_string(),
         })
     );
-    // Back to normal navigation with the buffer cleared.
+    // The wizard closed and the screen is back to normal navigation.
     assert_eq!(out.state.mode(), IssueListMode::Normal);
-    assert_eq!(out.state.create_title(), "");
+    assert!(out.state.wizard().is_none());
 }
 
-/// Enter on a blank/whitespace title is a no-op that keeps create mode open and
-/// raises no intent — never an empty issue (e38.29).
+/// Editing the source branch to a custom ref carries it through; blanking a
+/// branch input means "unset" (`None` on the intent).
 #[test]
-fn create_input_blank_enter_is_noop() {
-    let mut s = reduce_issue_list(&seeded_state(), IssueListEvent::Key('c')).state;
-    // Type then erase, leaving the buffer empty (only whitespace remains).
-    s = reduce_issue_list(&s, IssueListEvent::Key(' ')).state;
+fn wizard_branch_edits_and_blanks_round_trip() {
+    // Clear the "main" prefill on source, type a feature ref.
+    let s = wizard_at("source");
+    let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
+    let s = type_str(s, "feature/x");
+    let s = wiz(&s, WizardKey::Enter).state;
+    // Blank the target prefill entirely (→ unset).
+    let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
+    let s = wiz(&s, WizardKey::Enter).state;
 
-    let out = reduce_issue_list(&s, IssueListEvent::Key('\n'));
+    let out = wiz(&s, WizardKey::Enter); // commit on claude (cursor 0)
 
-    assert!(out.intent.is_none());
-    assert_eq!(out.state.mode(), IssueListMode::CreateInput);
+    assert_eq!(
+        out.intent,
+        Some(IssueListIntent::CreateAndRun {
+            title: "Fix login".to_string(),
+            repo_ref: "scratch".to_string(),
+            source_branch: Some("feature/x".to_string()),
+            target_branch: None,
+            agent: "claude".to_string(),
+        })
+    );
+}
+
+/// The commit intent is IMPOSSIBLE before the Agent stage: Enter on every
+/// earlier stage only holds, advances one stage, or re-opens the repo dropdown —
+/// it NEVER emits `CreateAndRun`. Combined with the full-walk test (whose commit
+/// fires only FROM the Agent stage) this proves no path yields an agent-less
+/// create: the intent constructor lives solely on the Agent stage's Enter.
+#[test]
+fn wizard_never_commits_before_agent_stage() {
+    for stage in ["title", "repo", "source", "target"] {
+        let s = wizard_at(stage);
+        let out = wiz(&s, WizardKey::Enter);
+        assert!(
+            !matches!(out.intent, Some(IssueListIntent::CreateAndRun { .. })),
+            "stage {stage:?} must never emit CreateAndRun on Enter"
+        );
+        // Every pre-agent Enter keeps the wizard open (a hold or an advance) —
+        // the only Enter that CLOSES the wizard is the Agent-stage commit.
+        assert!(
+            out.state.wizard().is_some(),
+            "stage {stage:?} Enter must keep the wizard open"
+        );
+    }
+    // And the one commit that IS reachable always carries a real provider token.
+    let out = wiz(&wizard_at("agent"), WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { agent, .. }) => {
+            assert!(["claude", "codex", "copilot"].contains(&agent.as_str()));
+        }
+        other => panic!("agent-stage Enter must commit CreateAndRun, got {other:?}"),
+    }
+}
+
+/// Esc cancels the WHOLE wizard from every stage in ONE press — back to normal
+/// navigation, nothing retained, no intent (the user is never trapped).
+#[test]
+fn wizard_esc_cancels_whole_overlay_from_every_stage() {
+    for stage in ["title", "repo", "source", "target", "agent"] {
+        let s = wizard_at(stage);
+        let out = wiz(&s, WizardKey::Esc);
+        assert_eq!(
+            out.state.mode(),
+            IssueListMode::Normal,
+            "Esc from {stage:?} must return to Normal"
+        );
+        assert!(
+            out.state.wizard().is_none(),
+            "Esc from {stage:?} must drop the wizard"
+        );
+        assert!(out.intent.is_none());
+    }
+    // Esc with the repo DROPDOWN open is still a single-press whole-overlay
+    // cancel (never a trapped inner state).
+    let s = wizard_at("repo");
+    let s = wiz(&s, WizardKey::Char('@')).state;
+    let out = wiz(&s, WizardKey::Esc);
+    assert_eq!(out.state.mode(), IssueListMode::Normal);
+    assert!(out.state.wizard().is_none());
 }
 
 /// An `IssueCreated` host event lands the new row in the Todo column.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -33,6 +33,13 @@ fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
         labels: Vec::new(),
         pr_url: None,
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
@@ -1,0 +1,421 @@
+//! Phase 5 — prove the Issues create WIZARD dispatches over the socket.
+//!
+//! Drives the **real** [`HangarPlugin`] behind the **real** SDK [`Server`], with
+//! the test playing the host that relays the plugin's reverse `unix_socket_*`
+//! calls to a mock daemon recording each `(method, params)`. Walking the wizard
+//! (`c` → title → `@` repo pick → source branch → target branch → agent Enter)
+//! must issue, in cause-and-effect order:
+//!
+//! 1. `hangar/issue_create` with the typed title, then — on its reply's id —
+//! 2. `hangar/issue_update` persisting repo / agent / source / target, and
+//! 3. `hangar/issue_run` with `mode=headless` + the same repo/agent/branch
+//!    overrides.
+//!
+//! This is the **user-visible proof** for the phase: the wizard cannot produce
+//! the old title-only inert card — the create is chained straight into a real
+//! dispatch carrying the forced agent assignment.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ainb_hangar_proto::{RpcRequest, RpcResponse, methods as daemon_methods};
+use ainb_plugin_hangar::HangarPlugin;
+use ainb_plugin_protocol::params::{
+    HandleEventParams, KeyCode, KeyEvent, UnixSocketEvent, UnixSocketEventKind,
+    UnixSocketSendParams,
+};
+use ainb_plugin_protocol::{framing, methods};
+use ainb_plugin_sdk::Server;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+const BUDGET: Duration = Duration::from_secs(20);
+
+/// A recorded daemon call: method + params.
+type Seen = Arc<Mutex<Vec<(String, serde_json::Value)>>>;
+
+async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Option<serde_json::Value> {
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        if r.read_line(&mut line).await.ok()? == 0 {
+            return None;
+        }
+        let trimmed = line.trim_end_matches("\r\n");
+        if trimmed.is_empty() {
+            let len = content_length?;
+            let mut body = vec![0u8; len];
+            r.read_exact(&mut body).await.ok()?;
+            return serde_json::from_slice(&body).ok();
+        }
+        if let Some((n, v)) = trimmed.split_once(':') {
+            if n.trim().eq_ignore_ascii_case("Content-Length") {
+                content_length = v.trim().parse().ok();
+            }
+        }
+    }
+}
+
+async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Option<Vec<u8>> {
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+    let mut content_length: Option<usize> = None;
+    let mut header = Vec::new();
+    loop {
+        let mut line = String::new();
+        if r.read_line(&mut line).await.ok()? == 0 {
+            return None;
+        }
+        header.extend_from_slice(line.as_bytes());
+        let trimmed = line.trim_end_matches("\r\n");
+        if trimmed.is_empty() {
+            let len = content_length?;
+            let mut body = vec![0u8; len];
+            r.read_exact(&mut body).await.ok()?;
+            let mut out = header;
+            out.extend_from_slice(&body);
+            return Some(out);
+        }
+        if let Some((n, v)) = trimmed.split_once(':') {
+            if n.trim().eq_ignore_ascii_case("Content-Length") {
+                content_length = v.trim().parse().ok();
+            }
+        }
+    }
+}
+
+/// A mock daemon that records `(method, params)` and answers every request with
+/// a plausible result. `issue_create` answers with a full `IssueRow` whose id is
+/// `issue-9` — the id the follow-up `issue_update` / `issue_run` must target.
+fn spawn_daemon(listener: UnixListener, seen: Seen) {
+    tokio::spawn(async move {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+        while let Some(raw) = read_frame(&mut reader).await {
+            let Ok(req) = serde_json::from_value::<RpcRequest>(raw) else {
+                return;
+            };
+            seen.lock().unwrap().push((req.method.clone(), req.params.clone()));
+            let resp = RpcResponse {
+                jsonrpc: "2.0".into(),
+                id: req.id,
+                result: Some(result_for(&req.method)),
+                error: None,
+            };
+            let body = serde_json::to_vec(&resp).unwrap();
+            if write_half.write_all(&framing::encode(&body)).await.is_err() {
+                return;
+            }
+            let _ = write_half.flush().await;
+        }
+    });
+}
+
+fn result_for(method: &str) -> serde_json::Value {
+    match method {
+        m if m == daemon_methods::WORKSPACE_SUBSCRIBE => serde_json::json!({ "snapshot": {} }),
+        m if m == daemon_methods::HANGAR_ISSUES_LIST => serde_json::json!({ "issues": [] }),
+        m if m == daemon_methods::HANGAR_AGENTS_LIST => serde_json::json!({ "actors": [] }),
+        m if m == daemon_methods::HANGAR_SKILLS_LIST => serde_json::json!({ "skills": [] }),
+        m if m == daemon_methods::HANGAR_AUTOPILOTS_LIST => serde_json::json!({ "autopilots": [] }),
+        m if m == daemon_methods::HANGAR_TASKS_LIST => serde_json::json!({ "tasks": [] }),
+        // The wizard's create answers with the new row — its id drives the
+        // follow-up update + run.
+        m if m == daemon_methods::HANGAR_ISSUE_CREATE => serde_json::json!({
+            "id":"issue-9","workspace_id":"default","title":"Wizard task",
+            "description":null,"state":"open","assignee":null,
+            "creator":"member:me","priority":0,"created_at":1_700_000_000_000_i64,
+            "due_date":null,"pr_url":null
+        }),
+        m if m == daemon_methods::HANGAR_ISSUE_RUN => serde_json::json!({
+            "task_id":"t-1","agent_id":"agent-claude","runtime_id":"rt-1","mode":"headless"
+        }),
+        m if m == daemon_methods::HANGAR_HEALTH => serde_json::json!({
+            "socket_path":"/tmp/h.sock","pid":1,"uptime_secs":1,"version":"0.1.0","connected":true
+        }),
+        _ => serde_json::json!({}),
+    }
+}
+
+fn host_frame(body: &serde_json::Value) -> Vec<u8> {
+    framing::encode(&serde_json::to_vec(body).unwrap())
+}
+
+async fn init_and_dial<W, R>(
+    host_write: &mut W,
+    host_read: &mut R,
+    socket_path: &std::path::Path,
+    stream_id: &str,
+) -> UnixStream
+where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    host_write
+        .write_all(&host_frame(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": methods::PLUGIN_INIT,
+            "params": {
+                "manifest_path": socket_path.to_str().unwrap(),
+                "granted_capabilities": ["unix_socket_dial", "event_stream_subscribe"],
+                "abi_version": 2,
+            }
+        })))
+        .await
+        .unwrap();
+
+    let mut daemon_conn: Option<UnixStream> = None;
+    loop {
+        let frame = read_frame(host_read).await.expect("plugin link alive");
+        match frame.get("method").and_then(|m| m.as_str()) {
+            Some(methods::HOST_UNIX_SOCKET_DIAL) => {
+                let conn = UnixStream::connect(socket_path).await.expect("dial daemon");
+                daemon_conn = Some(conn);
+                let id = frame["id"].clone();
+                host_write
+                    .write_all(&host_frame(&serde_json::json!({
+                        "jsonrpc": "2.0", "id": id, "result": { "stream_id": stream_id }
+                    })))
+                    .await
+                    .unwrap();
+            }
+            Some(methods::HOST_UNIX_SOCKET_SEND) => {
+                let send: UnixSocketSendParams =
+                    serde_json::from_value(frame["params"].clone()).unwrap();
+                let conn = daemon_conn.as_mut().expect("dialed before send");
+                conn.write_all(&send.bytes).await.unwrap();
+                conn.flush().await.unwrap();
+                return daemon_conn.expect("dialed");
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn push_data<W: tokio::io::AsyncWrite + Unpin>(
+    host_write: &mut W,
+    stream_id: &str,
+    reply: &[u8],
+) {
+    let event = UnixSocketEvent {
+        kind: UnixSocketEventKind::Data,
+        bytes: Some(reply.to_vec().into()),
+        error: None,
+    };
+    let evt = HandleEventParams {
+        topic: format!("socket:{stream_id}"),
+        payload: serde_json::to_vec(&event).unwrap().into(),
+    };
+    host_write
+        .write_all(&host_frame(&serde_json::json!({
+            "jsonrpc": "2.0", "method": methods::PLUGIN_HANDLE_EVENT, "params": evt
+        })))
+        .await
+        .unwrap();
+}
+
+/// Relay the 6 subscribe-snapshot sends + replies (issues / agents / skills /
+/// autopilots / tasks / health).
+async fn pump_snapshots<W, R, DR, DW>(
+    host_write: &mut W,
+    host_read: &mut R,
+    daemon_reader: &mut DR,
+    daemon_write: &mut DW,
+    stream_id: &str,
+) where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: tokio::io::AsyncBufRead + Unpin,
+    DR: tokio::io::AsyncBufRead + Unpin,
+    DW: tokio::io::AsyncWrite + Unpin,
+{
+    let mut relayed = 0;
+    while relayed < 6 {
+        let frame = tokio::time::timeout(Duration::from_secs(2), read_frame(host_read))
+            .await
+            .ok()
+            .flatten()
+            .expect("snapshot send");
+        if frame.get("method").and_then(|m| m.as_str()) == Some(methods::HOST_UNIX_SOCKET_SEND) {
+            let send: UnixSocketSendParams =
+                serde_json::from_value(frame["params"].clone()).unwrap();
+            daemon_write.write_all(&send.bytes).await.unwrap();
+            daemon_write.flush().await.unwrap();
+            if let Some(reply) = read_one_raw_frame(daemon_reader).await {
+                push_data(host_write, stream_id, &reply).await;
+            }
+            relayed += 1;
+        }
+    }
+}
+
+/// Drive one render so the plugin drains its deferred wizard RPCs; relay any
+/// reverse send to the daemon + pump the reply back.
+async fn relay_one_send_or_render<W, R, DR, DW>(
+    host_write: &mut W,
+    host_read: &mut R,
+    daemon_reader: &mut DR,
+    daemon_write: &mut DW,
+    stream_id: &str,
+) where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: tokio::io::AsyncBufRead + Unpin,
+    DR: tokio::io::AsyncBufRead + Unpin,
+    DW: tokio::io::AsyncWrite + Unpin,
+{
+    host_write
+        .write_all(&host_frame(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 99, "method": methods::PLUGIN_RENDER,
+            "params": { "viewport": {"width": 120, "height": 40}, "generation": 0 }
+        })))
+        .await
+        .unwrap();
+    loop {
+        let Some(frame) = read_frame(host_read).await else {
+            return;
+        };
+        if frame.get("method").and_then(|m| m.as_str()) == Some(methods::HOST_UNIX_SOCKET_SEND) {
+            let send: UnixSocketSendParams =
+                serde_json::from_value(frame["params"].clone()).unwrap();
+            daemon_write.write_all(&send.bytes).await.unwrap();
+            daemon_write.flush().await.unwrap();
+            if let Some(reply) = read_one_raw_frame(daemon_reader).await {
+                push_data(host_write, stream_id, &reply).await;
+            }
+            return;
+        }
+        if frame.get("id").and_then(serde_json::Value::as_i64) == Some(99) {
+            return;
+        }
+    }
+}
+
+async fn send_key<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, code: KeyCode) {
+    let key = KeyEvent {
+        code,
+        mods: 0,
+        kind: ainb_plugin_protocol::params::KeyKind::Press,
+    };
+    host_write
+        .write_all(&host_frame(&serde_json::json!({
+            "jsonrpc": "2.0", "method": methods::PLUGIN_HANDLE_KEY,
+            "params": { "screen_id": "hangar", "key": key, "generation": 1 }
+        })))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn wizard_commit_issues_create_update_and_run() {
+    let body = async {
+        let home = tempfile::tempdir().expect("home");
+        std::env::set_var("AINB_HANGAR_HOME", home.path());
+        let stream_id = format!("sock-wizard-{}", std::process::id());
+        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+
+        let state = home.path().join("hangar").join("state.toml");
+        std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
+        std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+
+        let socket_path = home.path().join("hangar.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind daemon");
+        spawn_daemon(listener, seen.clone());
+
+        let (host_side, plugin_side) = tokio::io::duplex(256 * 1024);
+        let (plugin_read, plugin_write) = tokio::io::split(plugin_side);
+        let server = tokio::spawn(Server::new(HangarPlugin::new()).run(plugin_read, plugin_write));
+
+        let (host_read_half, mut host_write) = tokio::io::split(host_side);
+        let mut host_read = BufReader::new(host_read_half);
+
+        let daemon = init_and_dial(&mut host_write, &mut host_read, &socket_path, &stream_id).await;
+        let (daemon_read, mut daemon_write) = daemon.into_split();
+        let mut daemon_reader = BufReader::new(daemon_read);
+
+        let ack = read_one_raw_frame(&mut daemon_reader).await.expect("subscribe ack");
+        push_data(&mut host_write, &stream_id, &ack).await;
+        pump_snapshots(
+            &mut host_write,
+            &mut host_read,
+            &mut daemon_reader,
+            &mut daemon_write,
+            &stream_id,
+        )
+        .await;
+
+        // Walk the wizard: `c` opens it; type the title; Enter → repo stage;
+        // `@` opens the dropdown (cursor at scratch); Enter picks scratch →
+        // source branch (prefilled `main`); Enter accepts → target branch
+        // (prefilled `main`); Enter accepts → agent stage; Enter commits on
+        // claude (cursor 0).
+        send_key(&mut host_write, KeyCode::Char { ch: 'c' }).await;
+        for ch in "Wizard task".chars() {
+            send_key(&mut host_write, KeyCode::Char { ch }).await;
+        }
+        send_key(&mut host_write, KeyCode::Enter).await;
+        send_key(&mut host_write, KeyCode::Char { ch: '@' }).await;
+        send_key(&mut host_write, KeyCode::Enter).await;
+        send_key(&mut host_write, KeyCode::Enter).await;
+        send_key(&mut host_write, KeyCode::Enter).await;
+        send_key(&mut host_write, KeyCode::Enter).await;
+
+        // Pump renders until all three legs of the chain hit the daemon: the
+        // create (with the typed title), the follow-up update persisting
+        // repo/agent/branches on the NEW issue id, and the headless run.
+        let mut done = false;
+        for _ in 0..60 {
+            relay_one_send_or_render(
+                &mut host_write,
+                &mut host_read,
+                &mut daemon_reader,
+                &mut daemon_write,
+                &stream_id,
+            )
+            .await;
+            let s = |p: &serde_json::Value, k: &str| {
+                p.get(k).and_then(serde_json::Value::as_str).map(str::to_string)
+            };
+            // Snapshot the recorded calls (guard dropped immediately) so no
+            // lock lives across the await below.
+            let calls: Vec<(String, serde_json::Value)> = seen.lock().unwrap().clone();
+            let created = calls.iter().any(|(m, p)| {
+                m == daemon_methods::HANGAR_ISSUE_CREATE
+                    && s(p, "title").as_deref() == Some("Wizard task")
+            });
+            let updated = calls.iter().any(|(m, p)| {
+                m == daemon_methods::HANGAR_ISSUE_UPDATE
+                    && s(p, "issue_id").as_deref() == Some("issue-9")
+                    && s(p, "repo_ref").as_deref() == Some("scratch")
+                    && s(p, "agent").as_deref() == Some("claude")
+                    && s(p, "source_branch").as_deref() == Some("main")
+                    && s(p, "target_branch").as_deref() == Some("main")
+            });
+            let ran = calls.iter().any(|(m, p)| {
+                m == daemon_methods::HANGAR_ISSUE_RUN
+                    && s(p, "issue_id").as_deref() == Some("issue-9")
+                    && s(p, "mode").as_deref() == Some("headless")
+                    && s(p, "repo_ref").as_deref() == Some("scratch")
+                    && s(p, "agent").as_deref() == Some("claude")
+                    && s(p, "source_branch").as_deref() == Some("main")
+            });
+            if created && updated && ran {
+                done = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            done,
+            "wizard commit must chain issue_create → issue_update(repo/agent/branches) \
+             → issue_run(headless) for the created issue; saw: {:?}",
+            seen.lock().unwrap()
+        );
+
+        drop(host_write);
+        server.abort();
+    };
+    tokio::time::timeout(BUDGET, body)
+        .await
+        .expect("exceeded wizard-dispatch budget");
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
@@ -37,6 +37,13 @@ fn issue_with_pr(pr_url: Option<&str>) -> IssueRow {
         labels: Vec::new(),
         pr_url: pr_url.map(String::from),
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
@@ -36,6 +36,13 @@ fn issue(pr_url: Option<&str>) -> IssueRow {
         labels: Vec::new(),
         pr_url: pr_url.map(String::from),
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -36,6 +36,13 @@ fn issue_row() -> IssueRow {
         labels: Vec::new(),
         pr_url: None,
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
@@ -33,6 +33,13 @@ fn issue_row() -> IssueRow {
         labels: Vec::new(),
         pr_url: None,
         branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -143,6 +143,13 @@ fn seeded_issues() -> serde_json::Value {
             labels: Vec::new(),
             pr_url: None,
             branch: None,
+            repo_ref: None,
+            agent: None,
+            source_branch: None,
+            target_branch: None,
+            run_count: 0,
+            last_run_status: None,
+            last_run_at: None,
         }],
     })
     .unwrap()

--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -66,6 +66,27 @@ test-live:
     cargo build -p ainb --bin ainb
     cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e live_dispatch_writes_nonce_artifact -- --nocapture --test-threads=1
 
+# Run the LIVE remote-repo + source-branch e2e leg (REAL daemon + claude).
+#
+# Proves the 0042 dispatch chain: a file:// remote is cloned, the worktree is
+# based on the chosen feature branch (sentinel asserted FIRST), the agent's
+# nonce lands in that tree, and only then task=done is trusted. Skips CLEAN +
+# LOUD without an authenticated claude. Mutation: LIVE_E2E_BREAK_SOURCE_BRANCH=1
+# must turn it RED.
+test-live-branch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "SKIPPED: no authenticated claude on PATH"
+        exit 0
+    fi
+    if ! claude -p --model haiku -- "reply with the single word PONG" 2>/dev/null | grep -qi PONG; then
+        echo "SKIPPED: no authenticated claude on PATH"
+        exit 0
+    fi
+    cargo build -p ainb --bin ainb
+    cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e live_dispatch_remote_repo_source_branch -- --nocapture --test-threads=1
+
 # Run the LIVE, no-mock e2e tripwire against the REAL codex binary.
 #
 # The codex leg of `test-live`: same law (assert the on-disk nonce artifact
@@ -98,7 +119,7 @@ test-live-codex:
     cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e live_dispatch_codex_writes_nonce_artifact -- --nocapture --test-threads=1
 
 # Run BOTH live e2e legs (claude + codex); each self-skips CLEAN + LOUD.
-test-live-all: test-live test-live-codex
+test-live-all: test-live test-live-codex test-live-branch
 
 # Format code
 fmt:


### PR DESCRIPTION
## What (plans/hangar-task-agent-model.md, all phases)
The user-confirmed split: **agent = worker identity**, **task = the work + where it runs.**

- **P1 — schema 0042 + plumbing**: `agent.token_budget` (NULL = unlimited; stored + CLI-editable, enforcement later), `issue.source_branch`/`target_branch`, `agent_task_queue.source_branch` (distinct from the PRODUCED `branch`). Card-parity accessors mirror the repo_ref precedent; retry INSERT copies the source so a retried child never falls back silently. CLI: `agent edit --token-budget/--clear-token-budget` (live-proven on a real home).
- **P2 — dispatch**: worktrees branch off the chosen source (`git worktree add … <start-point>`, resolved local → `origin/<src>`, unresolvable FAILS CLOSED). `None` keeps HEAD (the repo default) — hardcoding `main` would break `master` repos. New board-less **`hangar/issue_run`** RPC (same launch core as `board_card_run`, no board needed).
- **P3 — live proof**: `just test-live-branch` — REAL daemon clones a `file://` bare remote, provisions off `feature/x`, REAL claude (haiku) writes the nonce into that tree. Ladder: feature sentinel FIRST, head-only file absent, nonce bytes, then `done`.
- **P5 — Issues create wizard**: `c` → Title → Repo (@ fuzzy, REQUIRED) → Source[main] → Target[main] → Agent (REQUIRED, the only commit path) → `issue_create → issue_update → issue_run`. A title-only inert `◇ None` card is now **unrepresentable** from the Issues screen; Esc cancels the whole overlay from any stage. CLI parity: `issue create --repo <path|scratch|remote> --source-branch --target-branch` (remotes ensure_clone'd like the board path).
- **P4 (deferred → bead)**: no TUI agent-config editor exists to extend (`AgentUpdateParams` had zero plugin callers); CLI covers budget; bead filed for the full editor.

## Proof
- Live green: remote clone + `feature/x` worktree + nonce + done in 45s (real spend).
- Live mutation RED: `LIVE_E2E_BREAK_SOURCE_BRANCH=1` → sentinel assert trips **with status=done** — catches wrong-base dispatch even when the FSM looks happy.
- Unit mutation RED: dropping the start-point flips the chosen-branch test.
- Wizard: 9 reducer tests (incl. no-pre-agent-commit-path + Esc-from-every-stage) + per-stage render pins + a NEW over-socket harness driving real keystrokes through the real plugin and asserting the wire sequence.
- Suites green across store/proto/daemon/plugin; migration 0042 applied cleanly to the populated real home. Pre-existing reds not touched: kanban tmux test (fails on main), hangar-core doc-lint drift.

## Held for human checkpoint
TUI walk: `just dev` → `1` → `c` → wizard → watch the card dispatch. Merge after that walk.

https://claude.ai/code/session_0198zcU8Br9b8M1WdqkLVk3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided issue-creation wizard with repository, source branch, target branch, and agent selection.
  * Issues can now be created and launched directly from the wizard.
  * Added issue deletion support (with confirmation and active-task safety checks).
  * Added agent token-budget controls (set/clear behavior) and branch overrides for issue runs.
* **Bug Fixes**
  * Runs now provision workspaces from the selected source branch, including remote repositories.
  * Preserved branch settings across retries and assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->