### PR TITLE
feat(hangar): delete reachable from context menu and detail screen

### DIFF
--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -166,8 +166,15 @@ pub fn render_footer(buf: &mut WireBuffer, area_w: u16, area_h: u16, active: &Sc
 /// The contextual + global key hints for `active`, in render order.
 fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
     let mut hints: Vec<(&str, &str)> = match active {
-        Screen::IssueList => vec![("a", "assign"), ("c", "create"), ("/", "filter")],
-        Screen::TaskDetail(_) => vec![("R", "retry"), ("X", "cancel")],
+        Screen::IssueList => {
+            vec![
+                ("a", "assign"),
+                ("c", "create"),
+                ("x", "delete"),
+                ("/", "filter"),
+            ]
+        }
+        Screen::TaskDetail(_) => vec![("R", "retry"), ("X", "cancel"), ("x", "delete")],
         Screen::AgentPicker(_) => vec![("enter", "assign"), ("esc", "close")],
         Screen::SkillManager => vec![("i", "import"), ("/", "filter")],
         Screen::Autopilots => vec![("a", "add"), ("r", "run"), ("d", "disable"), ("e", "edit")],
@@ -332,6 +339,21 @@ mod tests {
             assert!(hints.contains(&("?", "help")));
             assert!(hints.contains(&("q", "quit")));
         }
+    }
+
+    /// The issue-list and task-detail footers both advertise the `x:delete`
+    /// keybinding (63l.5) alongside their other hints.
+    #[test]
+    fn footer_advertises_delete_on_issue_list_and_detail() {
+        assert!(
+            footer_hints(&Screen::IssueList).contains(&("x", "delete")),
+            "issue list footer must show x:delete"
+        );
+        let task = ainb_hangar_core::ids::TaskId::from_str("t1").unwrap();
+        assert!(
+            footer_hints(&Screen::TaskDetail(task)).contains(&("x", "delete")),
+            "task-detail footer must show x:delete"
+        );
     }
 
     /// The right cluster yields to the tabs: when there isn't room after the

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3710,6 +3710,13 @@ impl HangarPlugin {
             ContextMenuIntent::CopyId { display_id } => {
                 tracing::info!(%display_id, "hangar: context-menu copy id");
             }
+            // Delete routes into the issue list's `x` RED confirm overlay (the SAME
+            // `hangar/issue_delete` path the keyboard `x` uses) — never an inline
+            // delete. The overlay's Enter arms `pending_delete_action`, drained +
+            // fired in `render`.
+            ContextMenuIntent::Delete { issue_id } => {
+                self.screens.issue_list.open_confirm_delete_for(&issue_id);
+            }
         }
     }
 
@@ -5430,6 +5437,44 @@ mod tests {
             p.pending_issue_assignee_update,
             Some(("card-b".to_string(), "member:alice".to_string())),
             "Assign > alice arms issue_update with assignee=member:alice for card-b"
+        );
+    }
+
+    /// USER-VISIBLE PROOF (63l.5): `Delete` closes the menu and opens the issue
+    /// list's `x` RED confirm overlay for THAT card — NOT an inline delete. A
+    /// second Enter on the overlay then arms the SAME `pending_delete_action` the
+    /// keyboard `x` path uses (the one deferred `hangar/issue_delete` seam).
+    #[test]
+    fn context_menu_delete_opens_confirm_overlay_then_arms_delete() {
+        let mut p = connected_plugin_with_two_cards();
+        p.open_context_menu("card-b", (40, 6));
+
+        // Down x5 to `Delete` (Open→Move to→Priority→Assign→Copy id→Delete), Enter.
+        for _ in 0..5 {
+            p.on_key(&key_press(KeyCode::Down));
+        }
+        p.on_key(&key_press(KeyCode::Enter)); // fire Delete
+
+        // The menu closed and NO delete fired yet — only the confirm overlay opened.
+        assert!(p.context_menu.is_none(), "Delete closes the menu");
+        assert!(
+            p.screens
+                .issue_list
+                .confirm_delete()
+                .is_some_and(|pd| pd.id.as_str() == "card-b"),
+            "Delete opens the issue-list confirm overlay for card-b"
+        );
+        assert!(
+            p.screens.pending_delete_action.is_none(),
+            "no delete is armed until the overlay is confirmed"
+        );
+
+        // Enter on the open overlay confirms → arms the deferred issue_delete.
+        p.on_key(&key_press(KeyCode::Enter));
+        assert_eq!(
+            p.screens.take_pending_delete_action().map(|id| id.as_str().to_string()),
+            Some("card-b".to_string()),
+            "confirming the overlay arms hangar/issue_delete for card-b"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3779,6 +3779,12 @@ impl HangarPlugin {
                 let reduction = crate::screen::reduce(app, AppEvent::Esc);
                 self.app = Some(reduction.state);
             }
+            NavIntent::BackToIssueList => {
+                let mut next = app.clone();
+                next.screen = Screen::IssueList;
+                next.prior_screen = None;
+                self.app = Some(next);
+            }
             NavIntent::NavigateToEntity { screen, id, kind } => {
                 self.navigate_to_entity(app, &screen, &id, &kind);
             }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -1033,6 +1033,9 @@ pub enum NavIntent {
     OpenPrUrl(String),
     /// Close the active modal back to its prior screen (raised by Esc on a modal).
     CloseModal,
+    /// Switch to the issue-list tab (raised by a confirmed task-detail `x` delete,
+    /// 63l.5) so the deleted card's screen doesn't linger after the row is gone.
+    BackToIssueList,
     /// Jump to an entity's screen from the command palette (raised by Enter on a
     /// palette result, e38.13). Carries the jump-target screen token, the entity
     /// id, and the kind tag so the glue can switch the routing screen and select
@@ -1473,14 +1476,26 @@ fn route_task_detail(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInt
     // Lift the compose-submit intent into a deferred `hangar/comment_add` RPC the
     // `render` pass drains + fires (the sync key router can't `await`). Retry /
     // cancel intents are not yet wired to an RPC, so they fold as before.
-    if let Some(TaskDetailIntent::AddComment { issue_id, body }) = out.intent {
-        states.pending_comment_action = Some(IssueCommentAction::Add {
-            issue_id: issue_id.as_str().to_string(),
-            body,
-        });
+    let mut nav = None;
+    match &out.intent {
+        Some(TaskDetailIntent::AddComment { issue_id, body }) => {
+            states.pending_comment_action = Some(IssueCommentAction::Add {
+                issue_id: issue_id.as_str().to_string(),
+                body: body.clone(),
+            });
+        }
+        // 63l.5: confirmed `x` delete arms the SAME deferred `hangar/issue_delete`
+        // the issue-list `x` uses, then navigates back to the issue list so the
+        // card is gone once the daemon's `IssueDeleted` push lands. A daemon
+        // rejection (active tasks) surfaces as an issue-list note there.
+        Some(TaskDetailIntent::DeleteIssue(issue_id)) => {
+            states.pending_delete_action = Some(issue_id.clone());
+            nav = Some(NavIntent::BackToIssueList);
+        }
+        _ => {}
     }
     states.task_detail = Some(out.state);
-    None
+    nav
 }
 
 /// Kanban board key routing (P8.4): map the arrow keys (plus Shift) into the

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/context_menu.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/context_menu.rs
@@ -17,7 +17,7 @@
 //!                         │ Priority       ▸ │  └─▶│ Backlog      │
 //!                         │ Assign         ▸ │     │ Todo         │
 //!                         │ Copy id          │     │ In Progress  │── issue_update
-//!                         │ Delete  (greyed) │     │ In Review    │   {state}
+//!                         │ Delete           │     │ In Review    │   {state}
 //!                         └──────────────────┘     │ Done         │
 //!                                                  └──────────────┘
 //! ```
@@ -32,10 +32,11 @@
 //! - `Copy id` → [`ContextMenuIntent::CopyId`] → a copied-confirmation (no host
 //!   clipboard cap exists yet, so the menu shows a transient `copied` note rather
 //!   than touching the OS clipboard).
-//! - `Delete` is **greyed** — no issue-delete RPC exists in the daemon yet
-//!   (`hangar/issue_update` mutates fields; there is no destructive
-//!   `hangar/issue_delete`). The item paints muted and a footer note explains it,
-//!   rather than dispatching nothing silently or pretending to delete.
+//! - `Delete` → [`ContextMenuIntent::Delete`]. It does NOT delete inline: it
+//!   closes the menu and hands the target issue id to the plugin glue, which
+//!   opens the issue list's existing `x` RED confirm overlay for that id — the
+//!   same `hangar/issue_delete` path the keyboard `x` uses, never a second
+//!   confirm UI.
 //!
 //! ## Navigation
 //!
@@ -62,8 +63,6 @@ const TEXT: Color = Color::rgb(220, 220, 230);
 const SELECTED: Color = Color::rgb(255, 255, 255);
 /// Highlighted-item background fill so the cursor row reads as raised.
 const SELECTED_BG: Color = Color::rgb(60, 70, 110);
-/// Muted text for the disabled `Delete` item and the footer note.
-const DISABLED: Color = Color::rgb(120, 120, 135);
 /// A marker accent flagging the issue's CURRENT state / priority in a submenu so
 /// the user sees what is set before changing it.
 const CURRENT: Color = Color::rgb(150, 200, 150);
@@ -100,7 +99,7 @@ pub enum RootItem {
     Assign,
     /// Copy the `HGR-<n>` display id (a copied-confirmation note).
     CopyId,
-    /// Delete — greyed (no daemon issue-delete RPC exists yet).
+    /// Delete — routes into the issue list's `x` confirm overlay.
     Delete,
 }
 
@@ -130,11 +129,6 @@ impl RootItem {
     /// Whether this row opens a cascading submenu (painted with a `▸` caret).
     const fn has_submenu(self) -> bool {
         matches!(self, Self::MoveTo | Self::Priority | Self::Assign)
-    }
-
-    /// Whether this row is selectable. `Delete` is disabled (no delete RPC yet).
-    const fn is_enabled(self) -> bool {
-        !matches!(self, Self::Delete)
     }
 }
 
@@ -207,6 +201,13 @@ pub enum ContextMenuIntent {
     CopyId {
         /// The `HGR-<n>` display id copied.
         display_id: String,
+    },
+    /// Delete the issue — routed into the issue list's `x` RED confirm overlay by
+    /// the plugin glue (never an inline delete; the overlay's Enter fires the
+    /// `hangar/issue_delete` RPC, reusing the keyboard `x` path).
+    Delete {
+        /// The issue id the menu was raised for.
+        issue_id: String,
     },
 }
 
@@ -421,10 +422,6 @@ impl ContextMenuState {
         }
         if let Some(i) = self.hit_map.root_at(col, row) {
             self.root_selected = i;
-            // A click on a disabled row (Delete) is inert but keeps the menu open.
-            if !self.selected_root().is_enabled() {
-                return None;
-            }
             self.submenu = SubMenu::None;
             return self.activate();
         }
@@ -505,13 +502,17 @@ impl ContextMenuState {
                     display_id: self.display_id.clone(),
                 })
             }
-            // Disabled — inert.
-            RootItem::Delete => None,
+            RootItem::Delete => {
+                self.closed = true;
+                Some(ContextMenuIntent::Delete {
+                    issue_id: self.issue_id.clone(),
+                })
+            }
         }
     }
 
     /// Move the selection one row in `step`'s direction in the open submenu, else
-    /// the root list (skipping the disabled `Delete` root row).
+    /// the root list.
     const fn move_selection(&mut self, step: Step) {
         if matches!(self.submenu, SubMenu::None) {
             self.move_root_selection(step);
@@ -520,22 +521,12 @@ impl ContextMenuState {
         }
     }
 
-    /// Step the root selection to the next ENABLED row in `step`'s direction, so
-    /// the cursor never rests on the disabled `Delete` row. Stays put when there
-    /// is no enabled row further in that direction (a clamp at the edge).
+    /// Step the root selection one row in `step`'s direction, clamped at the list
+    /// edges (a step off the edge keeps the prior selection).
     const fn move_root_selection(&mut self, step: Step) {
         let last = RootItem::ALL.len() - 1;
-        let mut idx = self.root_selected;
-        loop {
-            let Some(next) = step.apply(idx, last) else {
-                // Hit the edge with no enabled row — keep the prior selection.
-                return;
-            };
-            idx = next;
-            if RootItem::ALL[idx].is_enabled() {
-                self.root_selected = idx;
-                return;
-            }
+        if let Some(next) = step.apply(self.root_selected, last) {
+            self.root_selected = next;
         }
     }
 
@@ -592,8 +583,7 @@ const SUB_W: u16 = 18;
 /// would overflow the right edge, and up when it would overflow the bottom). An
 /// open submenu cascades to the right of the root (flipping left when it would
 /// overflow). The selected row in each box paints with a filled background so the
-/// cursor is visible; the disabled `Delete` row paints muted; a submenu marks the
-/// issue's current value with a `✓`.
+/// cursor is visible; a submenu marks the issue's current value with a `✓`.
 pub fn render_context_menu(
     buf: &mut WireBuffer,
     area_w: u16,
@@ -632,21 +622,10 @@ pub fn render_context_menu(
                 label: item.label(),
                 trailing: caret,
                 selected: i == state.root_selected,
-                enabled: item.is_enabled(),
             },
         );
         hit_map.push_root(Rect::new(root_x + 1, row, MENU_W - 2, 1), i);
     }
-
-    // The greyed-Delete footer note, on the bottom border row.
-    put_str(
-        buf,
-        root_x + 1,
-        root_y + root_h - 1,
-        " delete: no RPC ",
-        DISABLED,
-        root_x + MENU_W - 1,
-    );
 
     // The copied-confirmation note replaces the title-row tail when armed.
     if state.copied {
@@ -716,7 +695,6 @@ fn render_submenu(
                 label,
                 trailing: marker,
                 selected: idx == sub_sel,
-                enabled: true,
             },
         );
         hit_map.push_sub(Rect::new(sub_x + 1, row, SUB_W - 2, 1), idx);
@@ -739,24 +717,16 @@ struct MenuRow<'a> {
     trailing: &'a str,
     /// Whether this row is the cursor selection (gets a highlight background).
     selected: bool,
-    /// Whether this row is enabled (a disabled row paints muted).
-    enabled: bool,
 }
 
 /// Paint one menu row inside a box: a backdrop fill, the label, and a trailing
 /// caret/marker glyph one cell in from the right border. The selected row gets a
-/// highlight background; a disabled row paints muted.
+/// highlight background.
 fn paint_row(buf: &mut WireBuffer, r: &MenuRow) {
     let inner_x = r.box_x + 1;
     let inner_right = r.box_x + r.box_w - 1;
     let bg = if r.selected { SELECTED_BG } else { BACKDROP };
-    let fg = if !r.enabled {
-        DISABLED
-    } else if r.selected {
-        SELECTED
-    } else {
-        TEXT
-    };
+    let fg = if r.selected { SELECTED } else { TEXT };
     // Backdrop fill across the inner row.
     for cx in inner_x..inner_right {
         let mut cell = Cell::new(" ");
@@ -995,25 +965,30 @@ mod tests {
         );
     }
 
-    /// Keyboard: the cursor skips the disabled `Delete` row — stepping down past
-    /// `Copy id` (index 4) cannot land on `Delete` (index 5), and the disabled
-    /// row fires nothing when activated directly.
+    /// Keyboard: the cursor reaches the `Delete` row (index 5) and activating it
+    /// fires a [`ContextMenuIntent::Delete`] for the raised issue, then closes the
+    /// menu (the plugin glue routes it into the `x` confirm overlay).
     #[test]
-    fn delete_row_is_disabled_and_unreachable() {
+    fn delete_row_is_enabled_and_fires_delete_intent() {
         let mut m = menu();
         for _ in 0..10 {
             m.handle_key(ContextMenuKey::Down);
         }
-        // The selection clamps at `Copy id` (4), never `Delete` (5).
+        // The cursor now rests on `Delete` (5), the last row, not clamped above it.
         assert_eq!(
             m.root_selected(),
-            4,
-            "cursor stops above the disabled Delete"
+            5,
+            "cursor reaches the enabled Delete row"
         );
-        // The Delete row, even when force-selected, fires no intent (no RPC).
-        m.root_selected = 5;
-        assert_eq!(m.handle_key(ContextMenuKey::Enter), None);
-        assert!(!m.is_closed(), "activating the disabled Delete is inert");
+        let fired = m.handle_key(ContextMenuKey::Enter);
+        assert_eq!(
+            fired,
+            Some(ContextMenuIntent::Delete {
+                issue_id: "issue-b".into(),
+            }),
+            "Delete fires a Delete intent for the raised issue"
+        );
+        assert!(m.is_closed(), "firing Delete closes the menu");
     }
 
     /// Keyboard: Esc inside an open submenu collapses back to the root; Esc at the
@@ -1115,16 +1090,18 @@ mod tests {
         assert!(text.contains('✓'), "the current status is marked with a ✓");
     }
 
-    /// Render: the greyed-Delete footer note is painted so the disabled item is
-    /// explained, not silently inert.
+    /// Render: the `Delete` row paints as a normal enabled item, with NO stale
+    /// "delete: no RPC" note now that the row routes into the confirm overlay.
     #[test]
-    fn render_paints_delete_disabled_note() {
+    fn render_paints_delete_without_disabled_note() {
         let mut buf = WireBuffer::new(80, 24);
         let mut m = menu();
         render_context_menu(&mut buf, 80, 24, &mut m);
+        let text = painted_text(&buf);
+        assert!(text.contains("Delete"), "the Delete row is painted");
         assert!(
-            painted_text(&buf).contains("delete: no RPC"),
-            "the disabled Delete item must carry an explanatory note"
+            !text.contains("delete: no RPC"),
+            "the stale disabled note must be gone"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -462,6 +462,47 @@ impl IssueListState {
         self.confirm_delete.as_ref()
     }
 
+    /// Open the `x` RED confirm overlay over the row carrying issue `id` (63l.5):
+    /// the seam the context-menu Delete uses so it lands in the SAME confirm flow
+    /// as the keyboard `x`. Selects the row first (resetting the chip/query so the
+    /// target is visible), then arms the overlay from it. A no-op when no cached
+    /// row carries that id (a stale menu). Enter then fires
+    /// [`IssueListIntent::DeleteIssue`] exactly as the keyboard path does.
+    pub fn open_confirm_delete_for(&mut self, id: &str) {
+        self.select_by_id(id);
+        // Only arm the overlay when the selection actually resolved to that id —
+        // `select_by_id` is a no-op for an unknown id, so guard against confirming
+        // a delete on whatever row happened to be selected.
+        if self.selected_row().map(|r| r.id.as_str()) != Some(id) {
+            return;
+        }
+        self.arm_confirm_delete();
+    }
+
+    /// Arm the delete-confirm overlay over the CURRENT selection (63d): build the
+    /// pending target from the selected row and enter [`IssueListMode::ConfirmDelete`].
+    /// A no-op when nothing is selected. Shared by the keyboard `x` path and the
+    /// context-menu Delete route so both raise an identical overlay.
+    fn arm_confirm_delete(&mut self) {
+        let Some(row) = self.selected_row() else {
+            return;
+        };
+        // Prefer the human display id (`HGR-7`) with the title; fall back to the
+        // raw id when a pre-63l.3 snapshot lacks a display id.
+        let label = match &row.display_id {
+            Some(display) => format!("{display} {}", row.title),
+            None => row.title.clone(),
+        };
+        let pending = PendingDelete {
+            id: row.id.clone(),
+            label,
+        };
+        self.mode = IssueListMode::ConfirmDelete;
+        self.confirm_delete = Some(pending);
+        // A fresh confirm supersedes any stale dispatch note.
+        self.note = None;
+    }
+
     /// The active filter chip.
     #[must_use]
     pub const fn filter(&self) -> FilterChip {
@@ -962,24 +1003,11 @@ fn cancel_wizard(state: &IssueListState) -> IssueListReduction {
 /// — the RED overlay collects the Enter/Esc decision first. A no-op when the list
 /// has no rows (nothing to delete), so `x` on an empty board never traps the user.
 fn enter_confirm_delete(state: &IssueListState) -> IssueListReduction {
-    let Some(row) = state.selected_row() else {
+    if state.selected_row().is_none() {
         return unchanged(state);
-    };
-    // Prefer the human display id (`HGR-7`) with the title; fall back to the raw
-    // id when a pre-63l.3 snapshot lacks a display id.
-    let label = match &row.display_id {
-        Some(display) => format!("{display} {}", row.title),
-        None => row.title.clone(),
-    };
-    let pending = PendingDelete {
-        id: row.id.clone(),
-        label,
-    };
+    }
     let mut next = state.clone();
-    next.mode = IssueListMode::ConfirmDelete;
-    next.confirm_delete = Some(pending);
-    // A fresh confirm supersedes any stale dispatch note.
-    next.note = None;
+    next.arm_confirm_delete();
     no_intent(next)
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -31,7 +31,10 @@
 //! (succeeded / failed); `X` (cancel) is only meaningful while it is running, and
 //! opens a confirm modal (Esc aborts, Enter confirms → [`TaskDetailIntent::CancelTask`]).
 //! The reducer tracks lifecycle from the task events themselves so these keys are
-//! total no-ops when not applicable.
+//! total no-ops when not applicable. `x` (delete the bound issue) opens its own
+//! confirm modal the same way (Esc aborts, Enter → [`TaskDetailIntent::DeleteIssue`]);
+//! it is not lifecycle-gated — the daemon rejects a delete with active tasks and
+//! that rejection surfaces as a note.
 //!
 //! ## Collapsible thinking runs
 //!
@@ -88,6 +91,8 @@ const COMPOSE_ACCENT: Color = Color::rgb(120, 220, 160);
 const COMPOSE_PREFIX: &str = "💬 ";
 /// The keybinding hint painted after the caret on the compose bar.
 const COMPOSE_HINT: &str = "  [enter] post  [esc] cancel";
+/// The keybinding hint painted after the target on the delete-confirm bar (63l.5).
+const DELETE_HINT: &str = "  [enter] confirm  [esc] cancel";
 
 /// Where the task is in its lifecycle, derived from the task event stream.
 ///
@@ -215,6 +220,11 @@ pub struct TaskDetailState {
     stuck_to_bottom: bool,
     /// Whether the cancel-confirm modal is open.
     cancel_modal_open: bool,
+    /// Whether the `x` delete-confirm modal is open (63l.5). Mutually exclusive
+    /// with the cancel + compose modals; Enter confirms → [`TaskDetailIntent::DeleteIssue`],
+    /// Esc aborts. The daemon guards against deleting an issue with active tasks,
+    /// so the confirm always opens and a rejection surfaces as a note downstream.
+    delete_modal_open: bool,
     /// The comment-compose modal buffer (e38.5). `Some(buf)` while the modal is
     /// open (`buf` is the in-progress comment text, possibly empty); `None` when
     /// closed. While open the modal captures every key as text input, so it is
@@ -255,6 +265,7 @@ impl TaskDetailState {
             scroll_offset: 0,
             stuck_to_bottom: true,
             cancel_modal_open: false,
+            delete_modal_open: false,
             compose: None,
             pr_status: UNKNOWN_PR_STATUS,
             branch: None,
@@ -345,6 +356,12 @@ impl TaskDetailState {
         self.cancel_modal_open
     }
 
+    /// Whether the `x` delete-confirm modal is open (63l.5).
+    #[must_use]
+    pub const fn delete_modal_open(&self) -> bool {
+        self.delete_modal_open
+    }
+
     /// The comment-compose buffer when the compose modal is open (e38.5), or
     /// `None` when it is closed. `Some("")` is an open-but-empty modal.
     #[must_use]
@@ -416,6 +433,11 @@ pub enum TaskDetailIntent {
     RetryTask(TaskId),
     /// Cancel the (running) task, confirmed in the modal (`X` then Enter).
     CancelTask(TaskId),
+    /// Delete the bound issue, confirmed in the `x` modal (`x` then Enter, 63l.5).
+    /// The plugin glue fires `hangar/issue_delete` over the same deferred seam the
+    /// issue-list `x` uses, then navigates back to the issue list. Carries the
+    /// bound issue id.
+    DeleteIssue(ainb_hangar_core::ids::IssueId),
     /// Post a comment on the bound issue (`c`, type, Enter) — the plugin glue
     /// fires `hangar/comment_add` over the daemon socket (e38.5). Carries the
     /// issue the comment is for and the (non-empty) typed body.
@@ -463,6 +485,14 @@ fn reduce_key(state: &TaskDetailState, c: char) -> TaskDetailReduction {
             _ => unchanged(state),
         };
     }
+    if state.delete_modal_open {
+        return match c {
+            '\n' | '\r' => confirm_delete(state),
+            // Any other key while the modal is open does nothing (Esc aborts via
+            // the dedicated event).
+            _ => unchanged(state),
+        };
+    }
     match c {
         'j' => scroll_down(state),
         'k' => scroll_up(state),
@@ -475,6 +505,10 @@ fn reduce_key(state: &TaskDetailState, c: char) -> TaskDetailReduction {
         ),
         // Cancel only while running; opens the confirm modal (no intent yet).
         'X' if state.lifecycle == TaskLifecycle::Running => open_cancel_modal(state),
+        // Delete the bound issue (`x`); opens the confirm modal (no intent yet).
+        // Not lifecycle-gated: the daemon rejects a delete with active tasks and
+        // that rejection surfaces as a note, so the confirm always opens.
+        'x' => open_delete_modal(state),
         _ => unchanged(state),
     }
 }
@@ -529,6 +563,10 @@ fn reduce_esc(state: &TaskDetailState) -> TaskDetailReduction {
         let mut next = state.clone();
         next.cancel_modal_open = false;
         no_intent(next)
+    } else if state.delete_modal_open {
+        let mut next = state.clone();
+        next.delete_modal_open = false;
+        no_intent(next)
     } else {
         unchanged(state)
     }
@@ -546,6 +584,21 @@ fn confirm_cancel(state: &TaskDetailState) -> TaskDetailReduction {
     let mut next = state.clone();
     next.cancel_modal_open = false;
     with_intent(next, TaskDetailIntent::CancelTask(state.task_id.clone()))
+}
+
+/// Open the `x` delete-confirm modal (63l.5; does not emit an intent yet).
+fn open_delete_modal(state: &TaskDetailState) -> TaskDetailReduction {
+    let mut next = state.clone();
+    next.delete_modal_open = true;
+    no_intent(next)
+}
+
+/// Confirm the delete modal: close it and emit the delete intent for the bound
+/// issue (63l.5).
+fn confirm_delete(state: &TaskDetailState) -> TaskDetailReduction {
+    let mut next = state.clone();
+    next.delete_modal_open = false;
+    with_intent(next, TaskDetailIntent::DeleteIssue(state.issue.id.clone()))
 }
 
 /// Scroll the viewport up one line, releasing sticky-bottom.
@@ -699,11 +752,16 @@ pub fn render_task_detail(
         }
     }
 
-    // The compose modal (e38.5), when open, takes the bottom row as an input bar,
-    // shrinking the transcript region by one row so the two never overlap.
+    // The compose modal (e38.5) / delete-confirm modal (63l.5), when open, take
+    // the bottom row as a bar, shrinking the transcript region by one row so the
+    // two never overlap. They are mutually exclusive (both capture input).
     let body_bottom = if state.compose.is_some() {
         let bar_row = bottom.saturating_sub(1);
         render_compose_bar(buf, area_w, bar_row, state.compose.as_deref().unwrap_or(""));
+        bar_row
+    } else if state.delete_modal_open {
+        let bar_row = bottom.saturating_sub(1);
+        render_delete_bar(buf, area_w, bar_row, state.issue());
         bar_row
     } else {
         bottom
@@ -741,6 +799,21 @@ fn render_compose_bar(buf: &mut WireBuffer, area_w: u16, row: u16, body: &str) {
     // A block caret so the cursor position is visible while typing.
     cx = put_clipped(buf, cx, row, "▏", COMPOSE_ACCENT, area_w);
     let _ = put_clipped(buf, cx, row, COMPOSE_HINT, HINT_MUTED, area_w);
+}
+
+/// Paint the single-row delete-confirm bar at `(0, row)` (63l.5):
+/// `🗑 delete <HGR-n · title>?` in the destructive red followed by a muted
+/// `[enter] confirm  [esc] cancel` keybinding hint. Clipped by **chars** at
+/// `area_w` (multi-byte safe) so a long title truncates cleanly. Red because the
+/// delete is irreversible — the bar makes the target unmistakable before Enter.
+fn render_delete_bar(buf: &mut WireBuffer, area_w: u16, row: u16, issue: &IssueRow) {
+    let prompt = issue.display_id.as_ref().map_or_else(
+        || format!("🗑 delete {}?", issue.title),
+        |d| format!("🗑 delete {d} · {}?", issue.title),
+    );
+    let mut cx = 0u16;
+    cx = put_clipped(buf, cx, row, &prompt, STATUS_RED, area_w);
+    let _ = put_clipped(buf, cx, row, DELETE_HINT, HINT_MUTED, area_w);
 }
 
 /// Paint the single-row PR badge at `(0, row)`: `▶ PR <url>` in gold, then the
@@ -1295,6 +1368,22 @@ mod card_tests {
             .map(|(_, cell)| cell.symbol.as_str())
             .collect();
         assert!(row0.contains("▶ PR "), "badge pinned to row 0: {row0}");
+    }
+
+    /// When the delete-confirm modal is open the bottom row paints the red
+    /// delete prompt naming the bound issue plus the confirm/cancel hint (63l.5).
+    #[test]
+    fn delete_modal_paints_confirm_bar_with_target() {
+        let mut s = state_for(full_issue());
+        s = reduce_task_detail(&s, TaskDetailEvent::Key('x')).state;
+        assert!(s.delete_modal_open(), "x opened the delete modal");
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+        assert!(text.contains("delete"), "delete prompt painted: {text}");
+        assert!(text.contains("Fix the widget"), "names the target issue");
+        assert!(text.contains("[enter] confirm"), "confirm hint painted");
+        assert!(text.contains("[esc] cancel"), "cancel hint painted");
     }
 
     /// `priority_p_label` maps the 0..3 urgency scale to P3..P0 (HIGHER = urgent).

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -218,6 +218,56 @@ fn x_key_then_esc_aborts_cancel_modal() {
     assert!(aborted.intent.is_none());
 }
 
+/// `x` opens the delete-confirm modal (no intent yet) regardless of lifecycle;
+/// Enter confirms → a `DeleteIssue` intent for the bound issue, closing the modal.
+#[test]
+fn x_key_opens_delete_modal_then_enter_deletes_bound_issue() {
+    // Queued (never ran): `x` still opens the confirm — delete is not
+    // lifecycle-gated (the daemon guards active tasks and surfaces a note).
+    let s = state_for_task();
+    let opened = reduce_task_detail(&s, TaskDetailEvent::Key('x'));
+    assert!(opened.state.delete_modal_open(), "x opens the delete modal");
+    assert!(opened.intent.is_none(), "opening emits no intent");
+
+    // Enter confirms → delete intent for the bound issue (i1).
+    let confirmed = reduce_task_detail(&opened.state, TaskDetailEvent::Key('\n'));
+    assert_eq!(
+        confirmed.intent,
+        Some(TaskDetailIntent::DeleteIssue(
+            IssueId::from_str("i1").unwrap()
+        )),
+        "Enter confirms the delete for the bound issue"
+    );
+    assert!(
+        !confirmed.state.delete_modal_open(),
+        "confirming closes the delete modal"
+    );
+}
+
+/// Opening the delete modal then pressing Esc aborts it without emitting a
+/// delete intent.
+#[test]
+fn x_key_then_esc_aborts_delete_modal() {
+    let opened = reduce_task_detail(&state_for_task(), TaskDetailEvent::Key('x')).state;
+    assert!(opened.delete_modal_open());
+    let aborted = reduce_task_detail(&opened, TaskDetailEvent::Esc);
+    assert!(!aborted.state.delete_modal_open(), "Esc closes the modal");
+    assert!(aborted.intent.is_none(), "Esc emits no delete intent");
+}
+
+/// While the delete modal is open every non-Enter/Esc key is swallowed (the
+/// modal is total), so a stray key never fires the delete or leaks to scroll.
+#[test]
+fn delete_modal_captures_other_keys() {
+    let opened = reduce_task_detail(&state_for_task(), TaskDetailEvent::Key('x')).state;
+    let after = reduce_task_detail(&opened, TaskDetailEvent::Key('j'));
+    assert!(
+        after.state.delete_modal_open(),
+        "a stray key keeps the modal open"
+    );
+    assert!(after.intent.is_none(), "a stray key fires nothing");
+}
+
 /// A long consecutive run of `Thinking` lines collapses under a single
 /// collapsible group entry rather than rendering all of them.
 #[test]


### PR DESCRIPTION
## Summary
- Enable the right-click context menu's Delete row (was hard-disabled from before `hangar/issue_delete` existed) and route it into the same red confirm overlay as the keyboard `x` path
- Add `x` delete to the task-detail screen: red confirm bar naming the target issue, Enter confirms via the existing `pending_delete_action` -> `hangar/issue_delete` seam, then navigates back to the issue list
- Advertise `x:delete` in the issue-list and task-detail footers

## Details
- All three entry points (issue-list `x`, context-menu Delete, detail `x`) converge on the single existing delete pipeline from #420 - no second confirm UI, no duplicate RPC site
- `open_confirm_delete_for(id)` guards stale/unknown ids (selected-row id must match before arming), so a context menu raised on a since-deleted card no-ops instead of deleting the wrong row
- Detail `x` is gated behind the compose and cancel modals, so typing `x` into a comment never opens the delete confirm
- Context-menu disabled-row infrastructure removed entirely (dead once nothing is disabled); the old disabled-Delete tests are inverted, not deleted

## Testing
- `cargo test -p ainb-plugin-hangar` full crate green (lib 308 + integration suites), verified independently twice
- 2 mutation spot-checks: breaking the context-menu intent emission and the detail confirm emission each turned targeted tests red; restored clean
- Zero `.snap` changes; rustfmt clean on all touched files; clippy delta vs main: zero new lints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue deletion from the context menu.
  * Added delete confirmation prompts to issue lists and task details.
  * Added keyboard shortcuts and footer hints for the delete action.
  * Returning to the issue list after deleting from task details is now supported.

* **Bug Fixes**
  * Delete actions now require explicit confirmation and can be canceled with Esc.
  * Improved navigation and selection when deleting filtered issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->