### PR TITLE
fix(hangar): kill immortal dispatched rows + inline cancel-and-delete

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1340,7 +1340,7 @@ async fn handle_issue_cancel_active(
     let active = TaskRepo::active_tasks_for_issue(pool, ws.as_str(), &params.issue_id)
         .await
         .map_err(|e| store_err(&e))?;
-    let Some(primary) = active.first().cloned() else {
+    let Some(primary) = active.first() else {
         return to_value(&ainb_hangar_proto::snapshots::IssueCancelActiveResult { cancelled: 0 });
     };
 
@@ -1390,8 +1390,8 @@ async fn handle_issue_cancel_active(
         // Reconcile any board placement of this issue now the set has drained
         // (best-effort + idempotent, matching the card-cancel path). Harmless when
         // the issue is not on any board.
-        crate::board::auto_move_after_terminal(pool, &primary).await;
-        crate::board::unblock_dependents_after_terminal(pool, &primary).await;
+        crate::board::auto_move_after_terminal(pool, primary).await;
+        crate::board::unblock_dependents_after_terminal(pool, primary).await;
     }
 
     to_value(&ainb_hangar_proto::snapshots::IssueCancelActiveResult { cancelled })

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1280,8 +1280,16 @@ async fn handle_issue_delete(
             IssueDeleteError::NotFound => {
                 invalid_params(&format!("no issue `{}` in this workspace", params.issue_id))
             }
-            // A live run blocks the delete — surface the "cancel first" message.
-            IssueDeleteError::ActiveTasks(_) => invalid_params(&e.to_string()),
+            // A live run blocks the delete — surface the "cancel first" message,
+            // tagged with a machine-readable marker so the TUI can offer an inline
+            // "cancel the run(s) & delete" instead of dead-ending on the text. The
+            // `data` field is append-only (an older client ignores it and still
+            // reads the human message).
+            IssueDeleteError::ActiveTasks(n) => RpcError {
+                code: INVALID_PARAMS,
+                message: e.to_string(),
+                data: Some(serde_json::json!({ "reason": "active_tasks", "active": n })),
+            },
             IssueDeleteError::Db(ref db) => store_err(db),
         })?;
     // A committed delete announces the removal so a subscribed issue list drops

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -651,6 +651,7 @@ async fn handle(
         methods::HANGAR_TASK_TRANSITION => handle_task_transition(pool, req, events).await,
         methods::HANGAR_ISSUE_CREATE => handle_issue_create(pool, req, events).await,
         methods::HANGAR_ISSUE_DELETE => handle_issue_delete(pool, req, events).await,
+        methods::HANGAR_ISSUE_CANCEL_ACTIVE => handle_issue_cancel_active(pool, req, events).await,
         methods::HANGAR_ISSUE_UPDATE => handle_issue_update(pool, req, events).await,
         methods::HANGAR_ISSUE_LABEL_ATTACH => handle_issue_label(pool, req, events, true).await,
         methods::HANGAR_ISSUE_LABEL_DETACH => handle_issue_label(pool, req, events, false).await,
@@ -1298,6 +1299,102 @@ async fn handle_issue_delete(
         .map_err(|e| invalid_params(&format!("malformed issue id: {e}")))?;
     events.emit(ws.as_str(), HangarEvent::IssueDeleted { issue_id });
     to_value(&serde_json::json!({}))
+}
+
+/// Dispatch `hangar/issue_cancel_active`: cancel EVERY active task on one issue,
+/// with no board coordinates — the Issues-screen "cancel the run(s) & delete"
+/// affordance.
+///
+/// The board-less sibling of [`handle_board_card_cancel`]: it resolves the issue's
+/// ENTIRE active set (a squad card fans out N tasks onto one issue, so there may be
+/// several) and cancels each via the idempotent `CancelTaskService` FSM edge,
+/// signalling each live run to KILL and pushing its terminal event. Per-task
+/// outcomes:
+/// - `Transitioned` — this call won the cancel: SIGNAL kill + push terminal.
+/// - `AlreadyTerminal` — an idempotent replay; counted, nothing more.
+/// - `TerminalMismatch` — that task finished naturally first; leave it.
+/// A per-task store fault is logged and the loop continues (a surviving sibling is
+/// worse than a clean error); it only surfaces if siblings remain active after the
+/// pass. An issue with no active task is a clean `{ cancelled: 0 }`, never an error.
+/// On any cancel the card's board placement (if any) is aggregate-auto-moved and
+/// its dependents re-evaluated, matching the card-cancel path.
+async fn handle_issue_cancel_active(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::task::TaskRepo;
+    use ainb_hangar_store::service::cancel::CancelTaskService;
+    use ainb_hangar_store::service::finalize::{FinalizeError, FinalizeOutcome};
+
+    let params: ainb_hangar_proto::snapshots::IssueCancelActiveParams =
+        parse_params(req, "{ workspace_id, issue_id }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    if params.issue_id.trim().is_empty() {
+        return Err(invalid_params("issue_id must not be empty"));
+    }
+
+    // The issue's ENTIRE active set (newest first). Empty = nothing to cancel — a
+    // clean `{ cancelled: 0 }` the caller surfaces as a note, never an error. The
+    // newest task is the "primary" whose board card the post-drain reconcile keys off.
+    let active = TaskRepo::active_tasks_for_issue(pool, ws.as_str(), &params.issue_id)
+        .await
+        .map_err(|e| store_err(&e))?;
+    let Some(primary) = active.first().cloned() else {
+        return to_value(&ainb_hangar_proto::snapshots::IssueCancelActiveResult { cancelled: 0 });
+    };
+
+    let mut cancelled: u64 = 0;
+    let mut last_err: Option<String> = None;
+    for task in &active {
+        match CancelTaskService::cancel(pool, &task.id, &SystemClock).await {
+            Ok(FinalizeOutcome::Transitioned) => {
+                // `false` = no live run was registered (queued-but-unclaimed, or
+                // owned by another daemon) — the DB flip alone cancels it.
+                let signalled = crate::cancel::registry().signal(&task.id);
+                crate::run_loop::emit_task_finished(
+                    events,
+                    task,
+                    ainb_hangar_proto::events::TaskResult::Cancelled,
+                    &SystemClock,
+                );
+                tracing::info!(task_id = %task.id, signalled, issue = %params.issue_id, "issue cancel: task cancelled");
+                cancelled += 1;
+            }
+            Ok(FinalizeOutcome::AlreadyTerminal) => cancelled += 1,
+            Err(FinalizeError::TerminalMismatch { .. }) => {}
+            Err(e) => {
+                tracing::warn!(task_id = %task.id, error = %e, "issue cancel: a task cancel errored; continuing");
+                last_err = Some(e.to_string());
+            }
+        }
+    }
+
+    // Honesty guard: if any per-task cancel raised a store fault, the cancel may be
+    // PARTIAL — re-read the active set and surface an error while siblings survive,
+    // rather than reporting a clean success (which would let the caller's delete
+    // retry get refused again with no explanation).
+    if let Some(e) = last_err {
+        let residual = TaskRepo::active_tasks_for_issue(pool, ws.as_str(), &params.issue_id)
+            .await
+            .map_err(|e| store_err(&e))?;
+        if !residual.is_empty() {
+            return Err(internal(&format!(
+                "cancel partially failed: {} task(s) still active ({e})",
+                residual.len()
+            )));
+        }
+    }
+
+    if cancelled > 0 {
+        // Reconcile any board placement of this issue now the set has drained
+        // (best-effort + idempotent, matching the card-cancel path). Harmless when
+        // the issue is not on any board.
+        crate::board::auto_move_after_terminal(pool, &primary).await;
+        crate::board::unblock_dependents_after_terminal(pool, &primary).await;
+    }
+
+    to_value(&ainb_hangar_proto::snapshots::IssueCancelActiveResult { cancelled })
 }
 
 /// Dispatch `hangar/issue_update` (e38.8): edit one issue's fields, push the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -212,6 +212,11 @@ pub async fn sweep_stale_running(
 /// stuck dispatch is failed by [`sweep_stale_dispatched`]. Mirrors the reference
 /// control plane `agent.sql.go:1979 ReclaimStaleDispatchedTaskForRuntime`.
 ///
+/// A `dispatched` row with a NULL `dispatched_at` (a claim whose timestamp was
+/// never stamped) is also reclaimed here: with no timestamp it cannot be inside
+/// the protection window, and leaving it would make it immortal — invisible to
+/// every time-based pass and thus a permanent block on its issue's delete.
+///
 /// Returns the number of rows reclaimed in this pass.
 ///
 /// # Errors
@@ -233,17 +238,24 @@ pub async fn reclaim_stale_dispatched(
     // `ReclaimStaleDispatchedTaskForRuntime`.)
     let window_cutoff = now - ms(cfg.reclaim_window);
     let ttl_cutoff = now - ms(cfg.dispatched_ttl);
+    // A NULL `dispatched_at` is a *stranded* claim: the row is `dispatched` but its
+    // dispatch timestamp was never stamped (a lost/never-recorded claim response),
+    // so the time-based band can never see it and it is immortal. Treat it as
+    // reclaimable — it is by definition outside the 90s protection window (there is
+    // no fresh in-flight timestamp to protect) — so it is redelivered to `queued`
+    // like any dispatch past the window. Stamped rows keep the exact band
+    // (`reclaim_window < age <= dispatched_ttl`): a fresh (<90s) dispatch stays
+    // protected and a past-TTL dispatch is still left to the fail step.
     let reclaimed = sqlx::query(
         "UPDATE agent_task_queue \
          SET status = 'queued', dispatched_at = NULL \
          WHERE id IN ( \
              SELECT id FROM agent_task_queue \
              WHERE status = 'dispatched' \
-               AND dispatched_at IS NOT NULL \
-               AND dispatched_at < ?1 \
-               AND dispatched_at >= ?2 \
                AND started_at IS NULL \
-             ORDER BY dispatched_at \
+               AND ( dispatched_at IS NULL \
+                     OR (dispatched_at < ?1 AND dispatched_at >= ?2) ) \
+             ORDER BY COALESCE(dispatched_at, 0) \
              LIMIT ?3 \
          )",
     )

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -375,6 +375,13 @@ pub async fn reclaim_orphaned_on_startup(
 /// The `from_status` and `age_column` arguments are fixed string literals chosen
 /// by the three callers (never user input), so interpolating them into the SQL
 /// is injection-safe; the time bounds and batch cap are parameter-bound.
+///
+/// A NULL `age_column` is treated as *infinitely old* (`COALESCE(age_column, 0)`),
+/// so a `running` row whose `started_at` was never stamped — or a `dispatched`
+/// row with a NULL `dispatched_at` the reclaim step did not already redeliver — is
+/// failed rather than skipped forever. Without this a NULL-timestamp row is
+/// immortal (the old `IS NOT NULL` guard excluded it from every pass), which is
+/// exactly what strands a task and blocks its issue's delete.
 async fn fail_batch(
     pool: &SqlitePool,
     from_status: &str,
@@ -389,9 +396,8 @@ async fn fail_batch(
          WHERE id IN ( \
              SELECT id FROM agent_task_queue \
              WHERE status = '{from_status}' \
-               AND {age_column} IS NOT NULL \
-               AND {age_column} < ?2 \
-             ORDER BY {age_column} \
+               AND COALESCE({age_column}, 0) < ?2 \
+             ORDER BY COALESCE({age_column}, 0) \
              LIMIT ?3 \
          )"
     );

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -255,7 +255,7 @@ pub async fn reclaim_stale_dispatched(
                AND started_at IS NULL \
                AND ( dispatched_at IS NULL \
                      OR (dispatched_at < ?1 AND dispatched_at >= ?2) ) \
-             ORDER BY COALESCE(dispatched_at, 0) \
+             ORDER BY dispatched_at \
              LIMIT ?3 \
          )",
     )
@@ -376,8 +376,9 @@ pub async fn reclaim_orphaned_on_startup(
 /// by the three callers (never user input), so interpolating them into the SQL
 /// is injection-safe; the time bounds and batch cap are parameter-bound.
 ///
-/// A NULL `age_column` is treated as *infinitely old* (`COALESCE(age_column, 0)`),
-/// so a `running` row whose `started_at` was never stamped — or a `dispatched`
+/// A NULL `age_column` is treated as *infinitely old* (`age_column IS NULL` is
+/// matched explicitly, keeping the predicate index-friendly), so a `running` row
+/// whose `started_at` was never stamped — or a `dispatched`
 /// row with a NULL `dispatched_at` the reclaim step did not already redeliver — is
 /// failed rather than skipped forever. Without this a NULL-timestamp row is
 /// immortal (the old `IS NOT NULL` guard excluded it from every pass), which is
@@ -396,8 +397,8 @@ async fn fail_batch(
          WHERE id IN ( \
              SELECT id FROM agent_task_queue \
              WHERE status = '{from_status}' \
-               AND COALESCE({age_column}, 0) < ?2 \
-             ORDER BY COALESCE({age_column}, 0) \
+               AND ( {age_column} IS NULL OR {age_column} < ?2 ) \
+             ORDER BY {age_column} \
              LIMIT ?3 \
          )"
     );

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_cancel_active.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_cancel_active.rs
@@ -1,0 +1,302 @@
+//! Integration: the `hangar/issue_cancel_active` RPC cancels every active task on
+//! one issue over a real framed `UnixStream`, WITHOUT any board coordinates — the
+//! board-less "cancel the run(s) & delete" affordance.
+//!
+//! The end-to-end story: an issue with a live task refuses `issue_delete` with a
+//! machine-readable `data.reason = "active_tasks"` marker; `issue_cancel_active`
+//! then clears the run (`{ cancelled: 1 }`), after which the same `issue_delete`
+//! succeeds. Also asserts a no-active-task issue is a clean `{ cancelled: 0 }` and
+//! a mistyped workspace is rejected, never a silent cancel.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_ID, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    async fn subscribe(&mut self, workspace_id: &str) {
+        let resp = self
+            .call(
+                methods::WORKSPACE_SUBSCRIBE,
+                serde_json::json!({ "workspace_id": workspace_id }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "subscribe must ack: {resp}");
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// Enqueue a task on `issue_id` forced to `status` (an active status), returning
+/// nothing — the row exists after this.
+async fn seed_active_task(store: &Store, task_id: &str, issue_id: &str, status: &str) {
+    let (runtime_id, agent_id): (String, String) =
+        sqlx::query_as("SELECT a.runtime_id, a.id FROM agent a WHERE a.workspace_id = ? LIMIT 1")
+            .bind(WS_ID)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, 0)",
+    )
+    .bind(task_id)
+    .bind(WS_ID)
+    .bind(&runtime_id)
+    .bind(&agent_id)
+    .bind(issue_id)
+    .bind(status)
+    .execute(store.pool())
+    .await
+    .unwrap();
+}
+
+/// The full board-less flow: a live task blocks delete (with a machine-readable
+/// `active_tasks` marker), `issue_cancel_active` cancels it, and the retried
+/// delete then succeeds.
+#[tokio::test]
+async fn cancel_active_unblocks_a_delete_refused_for_active_tasks() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_active_task(&store, "t-live", "issue-2", "running").await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    // 1. The delete is refused, and the error carries the machine-readable marker
+    //    the TUI keys its "cancel & delete" offer off.
+    let refused = c
+        .call(
+            methods::HANGAR_ISSUE_DELETE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-2" }),
+        )
+        .await;
+    assert!(
+        !refused["error"].is_null(),
+        "active task must refuse delete: {refused}"
+    );
+    assert_eq!(
+        refused["error"]["data"]["reason"], "active_tasks",
+        "refusal carries the active_tasks marker: {refused}"
+    );
+    assert_eq!(
+        refused["error"]["data"]["active"], 1,
+        "one active task reported"
+    );
+
+    // 2. Cancel the active run(s) for the issue — no board coordinates.
+    let cancelled = c
+        .call(
+            methods::HANGAR_ISSUE_CANCEL_ACTIVE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-2" }),
+        )
+        .await;
+    assert!(cancelled["error"].is_null(), "cancel must ack: {cancelled}");
+    assert_eq!(cancelled["result"]["cancelled"], 1, "one task cancelled");
+
+    // The task row is now terminal (`cancelled`), so nothing is active.
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM agent_task_queue WHERE id = 't-live'")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(status, "cancelled", "the run is cancelled in the store");
+
+    // 3. The retried delete now succeeds and pushes issue_deleted.
+    let deleted = c
+        .call(
+            methods::HANGAR_ISSUE_DELETE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-2" }),
+        )
+        .await;
+    assert!(
+        deleted["error"].is_null(),
+        "delete after cancel must ack: {deleted}"
+    );
+
+    // The issue is gone from a fresh snapshot.
+    let list = c
+        .call(
+            methods::HANGAR_ISSUES_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    let issues = list["result"]["issues"].as_array().unwrap();
+    assert!(
+        issues.iter().all(|i| i["id"] != "issue-2"),
+        "issue-2 deleted after the runs were cancelled"
+    );
+}
+
+/// An issue with no active task is a clean `{ cancelled: 0 }` — a no-op the caller
+/// surfaces as a note, never an error.
+#[tokio::test]
+async fn cancel_active_is_a_clean_noop_with_no_active_tasks() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    // issue-3 carries no task in the fixture.
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_CANCEL_ACTIVE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-3" }),
+        )
+        .await;
+    assert!(
+        resp["error"].is_null(),
+        "a no-active-task cancel is not an error: {resp}"
+    );
+    assert_eq!(resp["result"]["cancelled"], 0, "nothing to cancel");
+}
+
+/// A mistyped / foreign workspace is rejected — never a silent cross-tenant
+/// cancel.
+#[tokio::test]
+async fn cancel_active_rejects_unknown_workspace() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_active_task(&store, "t-live", "issue-1", "running").await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_CANCEL_ACTIVE,
+            serde_json::json!({ "workspace_id": "nope-not-a-workspace", "issue_id": "issue-1" }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an unknown workspace must be rejected, not a silent cancel: {resp}"
+    );
+
+    // The task is untouched (still active) under its real workspace.
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM agent_task_queue WHERE id = 't-live'")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(status, "running", "rejected cancel left the run running");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_delete.rs
@@ -252,6 +252,12 @@ async fn issue_delete_refuses_while_a_task_is_active() {
             .contains("cancel the run first"),
         "refusal must tell the caller to cancel first: {resp}"
     );
+    // The refusal carries a machine-readable marker so a client can offer an
+    // inline cancel-and-delete instead of dead-ending on the message text.
+    assert_eq!(
+        resp["error"]["data"]["reason"], "active_tasks",
+        "refusal must tag the active-tasks marker: {resp}"
+    );
 
     // issue-2 survives.
     let list = c

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
@@ -382,6 +382,64 @@ async fn dispatched_with_started_at_not_reclaimed() {
     );
 }
 
+// ---- NULL-age immortality fix ---------------------------------------------
+
+/// **Regression for the immortal-dispatch bug.** A `dispatched` row whose
+/// `dispatched_at` was never stamped (NULL) used to be skipped by every
+/// time-based pass (the old `dispatched_at IS NOT NULL` guard), so it was
+/// immortal and blocked its issue's delete forever. It must now be reclaimed to
+/// `queued` — outside the protection window by definition (no timestamp to
+/// protect), a redelivery, not a retry. Fails before the fix (reclaimed = 0).
+#[tokio::test]
+async fn dispatched_with_null_dispatched_at_reclaimed() {
+    let (_dir, store) = open_seeded().await;
+    // A `dispatched` row with a NULL dispatch timestamp (the stranded-claim state).
+    seed_task(store.pool(), "z1", "dispatched", BASE_MS, None).await;
+    let (_, _, attempt_before, dispatched_before) = read_task(store.pool(), "z1").await;
+    assert_eq!(dispatched_before, None, "seeded with NULL dispatched_at");
+    // The clock value is irrelevant — a NULL-age row is reclaimable regardless.
+    let clock = FixedClock(BASE_MS + 5_000);
+
+    let reclaimed = reclaim_stale_dispatched(store.pool(), &clock, &SweeperConfig::default())
+        .await
+        .expect("reclaim ok");
+    assert_eq!(reclaimed, 1, "the NULL-dispatched_at row is reclaimed");
+
+    let (status, reason, attempt_after, dispatched_after) = read_task(store.pool(), "z1").await;
+    assert_eq!(status, "queued", "reclaimed back to queued, not stranded");
+    assert_eq!(reason, None, "reclaim records no failure");
+    assert_eq!(
+        attempt_after, attempt_before,
+        "attempt unchanged (redelivery)"
+    );
+    assert_eq!(dispatched_after, None, "dispatched_at stays clear");
+}
+
+/// The full dispatched sweep (`reclaim` then `fail`) redelivers a NULL-timestamp
+/// dispatch to `queued` — it is reclaimed, not failed — so it leaves the active
+/// set on the very next pass instead of stranding.
+#[tokio::test]
+async fn sweep_stale_dispatched_reclaims_null_timestamp_row() {
+    let (_dir, store) = open_seeded().await;
+    seed_task(store.pool(), "z1", "dispatched", BASE_MS, None).await;
+    let clock = FixedClock(BASE_MS + 5_000);
+
+    let outcome = sweep_stale_dispatched(store.pool(), &clock, &SweeperConfig::default())
+        .await
+        .expect("sweep ok");
+    assert_eq!(outcome.reclaimed, 1, "NULL dispatch reclaimed, not failed");
+    assert_eq!(
+        outcome.failed, 0,
+        "reclaim clears dispatched_at before the fail step"
+    );
+
+    let (status, ..) = read_task(store.pool(), "z1").await;
+    assert_eq!(
+        status, "queued",
+        "left the dispatched active set for queued"
+    );
+}
+
 // ---- running TTL (2.5h) ---------------------------------------------------
 
 /// `runtime_sweeper.go:40` — a running task older than 2.5h is failed with

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
@@ -440,6 +440,34 @@ async fn sweep_stale_dispatched_reclaims_null_timestamp_row() {
     );
 }
 
+/// A NULL-`started_at` `running` row (a start that was never stamped) is failed
+/// by the running-TTL sweep instead of being skipped forever — the same
+/// immortality hole on the running side. Fails before the fix (swept = 0).
+#[tokio::test]
+async fn running_with_null_started_at_failed() {
+    let (_dir, store) = open_seeded().await;
+    // `running` with started_at left NULL (never stamped).
+    seed_task(store.pool(), "r-null", "running", BASE_MS, None).await;
+    let started_at: Option<i64> =
+        sqlx::query("SELECT started_at FROM agent_task_queue WHERE id = 'r-null'")
+            .fetch_one(store.pool())
+            .await
+            .expect("read started_at")
+            .try_get("started_at")
+            .unwrap();
+    assert_eq!(started_at, None, "seeded with NULL started_at");
+    let clock = FixedClock(BASE_MS + RUNNING_TTL.as_millis() as i64 + 1_000);
+
+    let swept = sweep_stale_running(store.pool(), &clock, &SweeperConfig::default())
+        .await
+        .expect("sweep ok");
+    assert_eq!(swept, 1, "the NULL-started_at running row is failed");
+
+    let (status, reason, _, _) = read_task(store.pool(), "r-null").await;
+    assert_eq!(status, "failed", "no longer immortal");
+    assert_eq!(reason.as_deref(), Some("timeout"));
+}
+
 // ---- running TTL (2.5h) ---------------------------------------------------
 
 /// `runtime_sweeper.go:40` — a running task older than 2.5h is failed with

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -219,6 +219,20 @@ pub const HANGAR_ISSUE_CREATE: &str = "hangar/issue_create";
 /// the row without a full re-pull.
 pub const HANGAR_ISSUE_DELETE: &str = "hangar/issue_delete";
 
+/// `hangar/issue_cancel_active` — cancel EVERY active task on one issue, WITHOUT a
+/// board (the Issues-screen "cancel the run(s) & delete" affordance).
+///
+/// The board-less sibling of [`HANGAR_BOARD_CARD_CANCEL`]: it resolves the issue's
+/// entire active set ([`ainb_hangar_store::repo::task::TaskRepo::active_tasks_for_issue`])
+/// and cancels each via the idempotent `CancelTaskService` FSM edge (signalling
+/// each live run to KILL + pushing its terminal event), so a delete blocked by
+/// live runs can be unblocked in place — no board coordinates required. Params:
+/// [`crate::snapshots::IssueCancelActiveParams`]; result:
+/// [`crate::snapshots::IssueCancelActiveResult`] (`{ cancelled }`). Mutating +
+/// workspace-scoped, mirroring [`HANGAR_ISSUE_DELETE`]. An issue with no active
+/// task is a clean `{ cancelled: 0 }`, never an error.
+pub const HANGAR_ISSUE_CANCEL_ACTIVE: &str = "hangar/issue_cancel_active";
+
 /// `hangar/issue_run` — enqueue a run of one issue WITHOUT a board (the Issues
 /// screen's create-wizard dispatch; plans/hangar-task-agent-model.md).
 ///
@@ -1040,6 +1054,8 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_DAEMON_CONFIG_LIST,
     // Issue delete (63d) is APPENDED at the catalogue tail — append-only wire.
     HANGAR_ISSUE_DELETE,
+    // Issue-scoped cancel-active (board-less cancel-and-delete), likewise appended.
+    HANGAR_ISSUE_CANCEL_ACTIVE,
 ];
 
 #[cfg(test)]
@@ -1238,6 +1254,7 @@ mod tests {
             HANGAR_AGENT_CREATE,
             HANGAR_DAEMON_CONFIG_LIST,
             HANGAR_ISSUE_DELETE,
+            HANGAR_ISSUE_CANCEL_ACTIVE,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1648,6 +1648,29 @@ pub struct IssueDeleteParams {
     pub issue_id: String,
 }
 
+/// Params for [`crate::methods::HANGAR_ISSUE_CANCEL_ACTIVE`]: cancel every active
+/// task on one issue (the board-less "cancel the run(s) & delete" affordance).
+///
+/// Workspace-scoped like every mutation: the daemon rejects a mistyped
+/// `workspace_id` with `INVALID_PARAMS`. The issue carries no board coordinates —
+/// the daemon resolves the active set from the issue id alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueCancelActiveParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue whose active run(s) to cancel.
+    pub issue_id: String,
+}
+
+/// Result of [`crate::methods::HANGAR_ISSUE_CANCEL_ACTIVE`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueCancelActiveResult {
+    /// How many of the issue's active tasks this call transitioned to
+    /// `cancelled`. `0` when the issue had no active task (a clean no-op the
+    /// caller surfaces as a note, never an error).
+    pub cancelled: u64,
+}
+
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_RUN`] (ccc / D6, D16): launch a
 /// card's issue on its assignee profile now.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -234,6 +234,10 @@ const ISSUE_RUN_REQ_ID: i64 = 52;
 /// error (e.g. an active task) is surfaced as a transient issue-list note — never
 /// silent.
 const ISSUE_DELETE_REQ_ID: i64 = 53;
+/// JSON-RPC id for the `hangar/issue_cancel_active` mutation (board-less "cancel
+/// run(s) & delete"). On success the plugin retries the `issue_delete`; an error
+/// surfaces as a transient issue-list note.
+const ISSUE_CANCEL_ACTIVE_REQ_ID: i64 = 54;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -387,6 +391,14 @@ pub struct HangarPlugin {
     /// `issue_id` plus the stashed payload, awaiting the next `render` pass (host
     /// IO is safe there) to fire `issue_update` + `issue_run`. `None` when idle.
     pending_issue_dispatch: Option<(String, WizardDispatch)>,
+    /// The issue whose `hangar/issue_delete` is in flight, stashed so a delete
+    /// REFUSED for active tasks can re-target the "cancel run(s) & delete" overlay
+    /// at the right issue (the reply carries no issue id). `None` when idle.
+    delete_in_flight: Option<ainb_hangar_core::ids::IssueId>,
+    /// The issue whose `hangar/issue_cancel_active` is in flight, awaiting its
+    /// reply to arm the follow-up `hangar/issue_delete` retry (cancel commits
+    /// before the delete). `None` when idle.
+    cancel_delete_in_flight: Option<ainb_hangar_core::ids::IssueId>,
 }
 
 /// The Issues create-wizard fields that ride ALONGSIDE the `issue_create` call
@@ -463,6 +475,8 @@ impl Default for HangarPlugin {
             list_context_menu: None,
             wizard_dispatch_in_flight: None,
             pending_issue_dispatch: None,
+            delete_in_flight: None,
+            cancel_delete_in_flight: None,
         }
     }
 }
@@ -899,8 +913,38 @@ impl HangarPlugin {
             // already dropped the row, so nothing to fold; an error (e.g. an active
             // task) surfaces as an issue-list note, never silent.
             RpcId::Number(ISSUE_DELETE_REQ_ID) => {
+                let target = self.delete_in_flight.take();
                 if let Some(e) = &resp.error {
-                    self.screens.issue_list.set_note(format!("delete failed: {}", e.message));
+                    // A delete refused because the issue still has active run(s)
+                    // carries `data.reason = "active_tasks"`: offer the inline
+                    // "cancel run(s) & delete" instead of dead-ending on the text.
+                    let is_active_tasks = e
+                        .data
+                        .as_ref()
+                        .and_then(|d| d.get("reason"))
+                        .and_then(serde_json::Value::as_str)
+                        == Some("active_tasks");
+                    match (is_active_tasks, target) {
+                        (true, Some(id)) => self
+                            .screens
+                            .issue_list
+                            .open_confirm_cancel_delete_for(id.as_str()),
+                        _ => self.screens.issue_list.set_note(format!("delete failed: {}", e.message)),
+                    }
+                }
+                self.conn.on_event();
+            }
+            // The board-less cancel-active reply: on success retry the delete
+            // (cancel has committed server-side); on error surface a note and do
+            // NOT delete.
+            RpcId::Number(ISSUE_CANCEL_ACTIVE_REQ_ID) => {
+                let target = self.cancel_delete_in_flight.take();
+                if let Some(e) = &resp.error {
+                    self.screens.issue_list.set_note(format!("cancel failed: {}", e.message));
+                } else if let Some(id) = target {
+                    // Retry the delete now the run(s) are cancelled — armed as a
+                    // pending action the render pass drains + fires.
+                    self.screens.pending_delete_action = Some(id);
                 }
                 self.conn.on_event();
             }
@@ -2549,9 +2593,48 @@ impl HangarPlugin {
             self.screens.issue_list.set_note("delete failed: could not encode request");
             return;
         };
+        // Stash the target BEFORE the send so a delete refused for active tasks can
+        // re-target the "cancel run(s) & delete" overlay (the reply carries no id);
+        // a send failure clears it (nothing will answer).
+        self.delete_in_flight = Some(issue_id);
         if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            self.delete_in_flight = None;
             self.screens.issue_list.set_note(format!("delete failed: {e}"));
             let _ = host.log_info(format!("hangar: issue delete send failed: {e}")).await;
+        }
+    }
+
+    /// Fire the board-less "cancel run(s) & delete" first leg: encode + send one
+    /// `hangar/issue_cancel_active` over the daemon socket. On its success reply the
+    /// plugin retries the `issue_delete` (cancel commits before delete); an error —
+    /// or a send failure — surfaces as an issue-list note, never silent.
+    async fn apply_cancel_delete_action(
+        &mut self,
+        host: &HostClient,
+        issue_id: ainb_hangar_core::ids::IssueId,
+    ) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            self.screens.issue_list.set_note("cancel failed: daemon link is down");
+            return;
+        };
+        let ws = self.app_state().ws_id.as_str().to_string();
+        let params = serde_json::json!({
+            "workspace_id": ws, "issue_id": issue_id.as_str()
+        });
+        let Ok(body) = encode_request(
+            ISSUE_CANCEL_ACTIVE_REQ_ID,
+            daemon_methods::HANGAR_ISSUE_CANCEL_ACTIVE,
+            params,
+        ) else {
+            self.screens.issue_list.set_note("cancel failed: could not encode request");
+            return;
+        };
+        // Stash the target so the reply can arm the follow-up delete retry.
+        self.cancel_delete_in_flight = Some(issue_id);
+        if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            self.cancel_delete_in_flight = None;
+            self.screens.issue_list.set_note(format!("cancel failed: {e}"));
+            let _ = host.log_info(format!("hangar: issue cancel-active send failed: {e}")).await;
         }
     }
 
@@ -4141,6 +4224,12 @@ impl Plugin for HangarPlugin {
         if let Some(issue_id) = self.screens.take_pending_delete_action() {
             self.apply_delete_action(host, issue_id).await;
         }
+        // Drain a deferred "cancel run(s) & delete" (confirm on the active-tasks
+        // overlay) and fire `hangar/issue_cancel_active`; its reply retries the
+        // delete once the run(s) are cancelled.
+        if let Some(issue_id) = self.screens.take_pending_cancel_delete_action() {
+            self.apply_cancel_delete_action(host, issue_id).await;
+        }
         // Phase 5: drain a dispatch armed by a successful wizard `issue_create`
         // reply — fire `hangar/issue_update` (persist repo / agent / branches on
         // the new issue) then `hangar/issue_run` (the actual launch).
@@ -5481,6 +5570,116 @@ mod tests {
             p.screens.take_pending_delete_action().map(|id| id.as_str().to_string()),
             Some("card-b".to_string()),
             "confirming the overlay arms hangar/issue_delete for card-b"
+        );
+    }
+
+    /// A `hangar/issue_delete` refused with the `active_tasks` marker arms the
+    /// issue-list "cancel run(s) & delete" overlay for the in-flight issue —
+    /// instead of dead-ending on a note.
+    #[test]
+    fn delete_refused_for_active_tasks_arms_cancel_delete_overlay() {
+        let mut p = connected_plugin_with_two_cards();
+        // Simulate a delete of card-b in flight (as apply_delete_action would stash).
+        p.delete_in_flight = Some(ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap());
+
+        let resp = ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(ISSUE_DELETE_REQ_ID),
+            result: None,
+            error: Some(ainb_hangar_proto::RpcError {
+                code: -32602,
+                message: "1 active task(s) on this issue — cancel the run first, then delete"
+                    .into(),
+                data: Some(serde_json::json!({ "reason": "active_tasks", "active": 1 })),
+            }),
+        };
+        p.on_daemon_response(&resp);
+
+        assert!(
+            p.screens
+                .issue_list
+                .confirm_cancel_delete()
+                .is_some_and(|pd| pd.id.as_str() == "card-b"),
+            "an active-tasks refusal arms the cancel-delete overlay for card-b"
+        );
+        assert!(
+            p.delete_in_flight.is_none(),
+            "the in-flight marker is consumed"
+        );
+    }
+
+    /// A plain (non-active-tasks) delete error just surfaces a note — no overlay.
+    #[test]
+    fn delete_error_without_marker_only_notes() {
+        let mut p = connected_plugin_with_two_cards();
+        p.delete_in_flight = Some(ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap());
+        let resp = ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(ISSUE_DELETE_REQ_ID),
+            result: None,
+            error: Some(ainb_hangar_proto::RpcError {
+                code: -32603,
+                message: "store error: disk full".into(),
+                data: None,
+            }),
+        };
+        p.on_daemon_response(&resp);
+        assert!(
+            p.screens.issue_list.confirm_cancel_delete().is_none(),
+            "a non-active-tasks error opens no overlay"
+        );
+    }
+
+    /// A successful `hangar/issue_cancel_active` reply retries the delete: it arms
+    /// `pending_delete_action` for the in-flight issue (cancel committed → delete).
+    #[test]
+    fn cancel_active_success_retries_the_delete() {
+        let mut p = connected_plugin_with_two_cards();
+        p.cancel_delete_in_flight =
+            Some(ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap());
+
+        let resp = ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(ISSUE_CANCEL_ACTIVE_REQ_ID),
+            result: Some(serde_json::json!({ "cancelled": 1 })),
+            error: None,
+        };
+        p.on_daemon_response(&resp);
+
+        assert_eq!(
+            p.screens.take_pending_delete_action().map(|id| id.as_str().to_string()),
+            Some("card-b".to_string()),
+            "cancel success arms the delete retry for card-b (cancel before delete)"
+        );
+        assert!(
+            p.cancel_delete_in_flight.is_none(),
+            "the in-flight marker is consumed"
+        );
+    }
+
+    /// A failed `hangar/issue_cancel_active` reply does NOT delete — it surfaces a
+    /// note and leaves the issue intact.
+    #[test]
+    fn cancel_active_failure_does_not_delete() {
+        let mut p = connected_plugin_with_two_cards();
+        p.cancel_delete_in_flight =
+            Some(ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap());
+
+        let resp = ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(ISSUE_CANCEL_ACTIVE_REQ_ID),
+            result: None,
+            error: Some(ainb_hangar_proto::RpcError {
+                code: -32603,
+                message: "cancel partially failed: 1 task(s) still active".into(),
+                data: None,
+            }),
+        };
+        p.on_daemon_response(&resp);
+
+        assert!(
+            p.screens.pending_delete_action.is_none(),
+            "a failed cancel must NOT arm a delete"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -2577,6 +2577,14 @@ impl HangarPlugin {
         host: &HostClient,
         issue_id: ainb_hangar_core::ids::IssueId,
     ) {
+        // Only one delete may be in flight: the fixed ISSUE_DELETE_REQ_ID is not a
+        // per-call correlation token, so a second delete before the first reply
+        // lands would overwrite `delete_in_flight` and misattribute the reply to
+        // the wrong issue. Refuse the overlap instead.
+        if self.delete_in_flight.is_some() {
+            self.screens.issue_list.set_note("delete already in flight — please wait");
+            return;
+        }
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             self.screens.issue_list.set_note("delete failed: daemon link is down");
             return;
@@ -2613,6 +2621,14 @@ impl HangarPlugin {
         host: &HostClient,
         issue_id: ainb_hangar_core::ids::IssueId,
     ) {
+        // Only one cancel-and-delete may be in flight: ISSUE_CANCEL_ACTIVE_REQ_ID is
+        // a fixed per-method id, so an overlapping flow would overwrite
+        // `cancel_delete_in_flight` and could fire the delete retry against the
+        // wrong issue. Refuse the overlap.
+        if self.cancel_delete_in_flight.is_some() {
+            self.screens.issue_list.set_note("cancel already in flight — please wait");
+            return;
+        }
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             self.screens.issue_list.set_note("cancel failed: daemon link is down");
             return;

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -539,6 +539,11 @@ pub struct ScreenStates {
     /// overlay), awaiting the `render` pass to fire `hangar/issue_delete` over the
     /// daemon socket (63d). Carries the issue to delete. `None` when idle.
     pub pending_delete_action: Option<ainb_hangar_core::ids::IssueId>,
+    /// A "cancel run(s) & delete" raised by the issue-list confirm overlay after a
+    /// delete was refused for active tasks, awaiting the `render` pass to fire
+    /// `hangar/issue_cancel_active` (then, on its reply, retry `hangar/issue_delete`)
+    /// over the daemon socket. Carries the issue. `None` when idle.
+    pub pending_cancel_delete_action: Option<ainb_hangar_core::ids::IssueId>,
     /// A search RPC raised by the command-palette modal (each keystroke),
     /// awaiting the `render` pass to fire `hangar/search` over the daemon socket
     /// (e38.13). `None` when idle.
@@ -959,6 +964,15 @@ impl ScreenStates {
     /// (63d). The `render` pass drains it and fires `hangar/issue_delete`.
     pub const fn take_pending_delete_action(&mut self) -> Option<ainb_hangar_core::ids::IssueId> {
         self.pending_delete_action.take()
+    }
+
+    /// Take the pending "cancel run(s) & delete" raised by the issue-list confirm
+    /// overlay, if any. The `render` pass drains it and fires
+    /// `hangar/issue_cancel_active`.
+    pub const fn take_pending_cancel_delete_action(
+        &mut self,
+    ) -> Option<ainb_hangar_core::ids::IssueId> {
+        self.pending_cancel_delete_action.take()
     }
 
     /// Take the pending search RPC raised by the command palette, if any
@@ -1442,6 +1456,13 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
         // router can't `await`). The daemon's IssueDeleted push then drops the row.
         Some(IssueListIntent::DeleteIssue(id)) => {
             states.pending_delete_action = Some(id);
+            None
+        }
+        // Confirming the "cancel run(s) & delete" overlay lifts into a deferred
+        // `hangar/issue_cancel_active` the `render` pass drains + fires; on its
+        // reply the plugin retries the delete (cancel commits before delete).
+        Some(IssueListIntent::CancelAndDeleteIssue(id)) => {
+            states.pending_cancel_delete_action = Some(id);
             None
         }
         None => None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -230,6 +230,13 @@ pub enum IssueListMode {
     /// [`IssueListIntent::DeleteIssue`], Esc cancels in one press; every other key
     /// is captured (so a stray tab-switch char never fires behind the modal).
     ConfirmDelete,
+    /// Second-chance confirm raised when a delete was REFUSED because the issue
+    /// still has active run(s): an amber overlay offering to cancel the run(s)
+    /// and delete ([`IssueListState::confirm_cancel_delete`]). `c`/`C`/Enter emit
+    /// [`IssueListIntent::CancelAndDeleteIssue`], Esc backs out; every other key
+    /// is captured. Entered from the plugin glue on the daemon's active-tasks
+    /// delete rejection, never directly by a key press.
+    ConfirmCancelDelete,
 }
 
 /// The target of an open `x` delete-confirm overlay (63d): the issue id the
@@ -454,6 +461,10 @@ pub struct IssueListState {
     /// The open `x` delete-confirm target (63d), set while `mode` is
     /// [`IssueListMode::ConfirmDelete`]. `None` otherwise.
     confirm_delete: Option<PendingDelete>,
+    /// The open "cancel run(s) & delete" target, set while `mode` is
+    /// [`IssueListMode::ConfirmCancelDelete`] (armed by the plugin glue when a
+    /// delete is refused for active tasks). `None` otherwise.
+    confirm_cancel_delete: Option<PendingDelete>,
 }
 
 impl Default for IssueListState {
@@ -472,6 +483,7 @@ impl Default for IssueListState {
             scroll_offsets: [0; COLUMN_COUNT],
             hovered_id: None,
             confirm_delete: None,
+            confirm_cancel_delete: None,
         }
     }
 }
@@ -505,7 +517,10 @@ impl IssueListState {
     pub const fn is_capturing_text(&self) -> bool {
         matches!(
             self.mode,
-            IssueListMode::FilterInput | IssueListMode::CreateInput | IssueListMode::ConfirmDelete
+            IssueListMode::FilterInput
+                | IssueListMode::CreateInput
+                | IssueListMode::ConfirmDelete
+                | IssueListMode::ConfirmCancelDelete
         )
     }
 
@@ -533,6 +548,47 @@ impl IssueListState {
     #[must_use]
     pub const fn confirm_delete(&self) -> Option<&PendingDelete> {
         self.confirm_delete.as_ref()
+    }
+
+    /// Cancel the "cancel run(s) & delete" overlay (Esc): drop it and return to
+    /// normal navigation in one press. A no-op when not in that mode.
+    pub fn abort_confirm_cancel_delete(&mut self) {
+        if self.mode == IssueListMode::ConfirmCancelDelete {
+            self.mode = IssueListMode::Normal;
+            self.confirm_cancel_delete = None;
+        }
+    }
+
+    /// The open "cancel run(s) & delete" target, or `None` when not in that mode —
+    /// the renderer draws the amber overlay from this.
+    #[must_use]
+    pub const fn confirm_cancel_delete(&self) -> Option<&PendingDelete> {
+        self.confirm_cancel_delete.as_ref()
+    }
+
+    /// Arm the "cancel run(s) & delete" overlay for issue `id` — the seam the
+    /// plugin glue drives when the daemon refuses a delete because the issue still
+    /// has active run(s). Selects the row (so the target is visible) and enters
+    /// [`IssueListMode::ConfirmCancelDelete`]; a `c`/`C`/Enter then emits
+    /// [`IssueListIntent::CancelAndDeleteIssue`]. A no-op when no cached row
+    /// carries that id (the row already vanished).
+    pub fn open_confirm_cancel_delete_for(&mut self, id: &str) {
+        self.select_by_id(id);
+        let Some(row) = self.selected_row().filter(|r| r.id.as_str() == id) else {
+            return;
+        };
+        let label = match &row.display_id {
+            Some(display) => format!("{display} {}", row.title),
+            None => row.title.clone(),
+        };
+        let pending = PendingDelete {
+            id: row.id.clone(),
+            label,
+        };
+        self.mode = IssueListMode::ConfirmCancelDelete;
+        self.confirm_cancel_delete = Some(pending);
+        // Supersede any stale dispatch / delete-failure note.
+        self.note = None;
     }
 
     /// Open the `x` RED confirm overlay over the row carrying issue `id` (63l.5):
@@ -923,6 +979,12 @@ pub enum IssueListIntent {
     /// confirm overlay. The plugin glue lifts it into `hangar/issue_delete`; the
     /// daemon's `IssueDeleted` push then drops the row from the list.
     DeleteIssue(IssueId),
+    /// Cancel the issue's active run(s) THEN delete it: raised by confirming the
+    /// "cancel run(s) & delete" overlay (armed after a delete was refused for
+    /// active tasks). The plugin glue fires `hangar/issue_cancel_active` and, on
+    /// its success reply, retries `hangar/issue_delete` (cancel commits before the
+    /// delete).
+    CancelAndDeleteIssue(IssueId),
 }
 
 /// The result of folding one [`IssueListEvent`] into an [`IssueListState`].
@@ -955,6 +1017,7 @@ fn reduce_key(state: &IssueListState, c: char) -> IssueListReduction {
         // working alongside the structured [`IssueListEvent::Wizard`] events.
         IssueListMode::CreateInput => reduce_wizard_key(state, wizard_key_from_char(c)),
         IssueListMode::ConfirmDelete => reduce_confirm_delete_key(state, c),
+        IssueListMode::ConfirmCancelDelete => reduce_confirm_cancel_delete_key(state, c),
         IssueListMode::Normal => reduce_normal_key(state, c),
     }
 }
@@ -1112,6 +1175,38 @@ fn cancel_confirm_delete(state: &IssueListState) -> IssueListReduction {
     let mut next = state.clone();
     next.mode = IssueListMode::Normal;
     next.confirm_delete = None;
+    no_intent(next)
+}
+
+/// "Cancel run(s) & delete" key handling: `c` / `C` / Enter emit
+/// [`IssueListIntent::CancelAndDeleteIssue`] for the pending target, Esc backs
+/// out; every other key is captured (the overlay is modal). All exits reset back
+/// to normal navigation.
+fn reduce_confirm_cancel_delete_key(state: &IssueListState, c: char) -> IssueListReduction {
+    match c {
+        // Confirm: `c`/`C` (matching the "[C] cancel & delete" hint) or Enter.
+        'c' | 'C' | '\n' | '\r' => {
+            let Some(pending) = state.confirm_cancel_delete.clone() else {
+                return cancel_confirm_cancel_delete(state);
+            };
+            let mut next = state.clone();
+            next.mode = IssueListMode::Normal;
+            next.confirm_cancel_delete = None;
+            with_intent(next, IssueListIntent::CancelAndDeleteIssue(pending.id))
+        }
+        // Esc backs out, leaving the run(s) untouched.
+        '\u{1b}' => cancel_confirm_cancel_delete(state),
+        // Any other key is swallowed — the modal stays open until confirm / Esc.
+        _ => unchanged(state),
+    }
+}
+
+/// Back out of the "cancel run(s) & delete" overlay (Esc): normal navigation,
+/// target dropped, no intent.
+fn cancel_confirm_cancel_delete(state: &IssueListState) -> IssueListReduction {
+    let mut next = state.clone();
+    next.mode = IssueListMode::Normal;
+    next.confirm_cancel_delete = None;
     no_intent(next)
 }
 
@@ -1487,6 +1582,15 @@ pub fn render_issue_list(
             bottom.saturating_sub(1),
             pending,
         );
+    } else if let Some(pending) = state.confirm_cancel_delete() {
+        // The amber "cancel run(s) & delete" overlay on the two bottom rows.
+        render_confirm_cancel_delete(
+            buf,
+            area_w,
+            bottom.saturating_sub(2),
+            bottom.saturating_sub(1),
+            pending,
+        );
     } else if let Some(note) = state.note() {
         put_str(
             buf,
@@ -1532,6 +1636,40 @@ fn render_confirm_delete(
         value_row,
         "Enter=delete  Esc=cancel",
         OFFLINE_RED,
+        area_w,
+    );
+}
+
+/// Amber used for the "cancel run(s) & delete" overlay — a caution accent
+/// distinct from the destructive clay-red, so the second-chance prompt reads as a
+/// recoverable choice rather than the point of no return.
+const CAUTION_AMBER: Color = Color::rgb(230, 180, 90);
+
+/// Render the amber "cancel run(s) & delete" overlay on the two bottom rows: the
+/// prompt explaining the issue still has active run(s), then the key legend.
+/// Char-safe via [`put_str`]. `c`/`C`/Enter cancels-then-deletes, Esc backs out —
+/// all wired in the reducer.
+fn render_confirm_cancel_delete(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    row: u16,
+    value_row: u16,
+    pending: &PendingDelete,
+) {
+    put_str(
+        buf,
+        0,
+        row,
+        &format!("{} has active run(s) blocking delete.", pending.label),
+        CAUTION_AMBER,
+        area_w,
+    );
+    put_str(
+        buf,
+        0,
+        value_row,
+        "c=cancel run(s) & delete  Esc=keep",
+        CAUTION_AMBER,
         area_w,
     );
 }
@@ -2518,6 +2656,75 @@ mod tests {
         assert!(
             out.state.confirm_delete().is_none(),
             "target dropped after commit"
+        );
+    }
+
+    /// Arming the "cancel run(s) & delete" overlay (the plugin-glue seam for a
+    /// delete refused on active tasks) selects the target row, enters the modal
+    /// capture mode, and raises no intent yet.
+    #[test]
+    fn open_confirm_cancel_delete_arms_the_overlay() {
+        let mut s =
+            IssueListState::with_rows(vec![row("i1", "open", None), row("i2", "open", None)]);
+        s.open_confirm_cancel_delete_for("i2");
+        assert_eq!(s.mode(), IssueListMode::ConfirmCancelDelete);
+        assert!(
+            s.is_capturing_text(),
+            "the cancel-delete overlay is a modal capture"
+        );
+        let pending = s.confirm_cancel_delete().expect("a target is set");
+        assert_eq!(pending.id, IssueId::from_str("i2").unwrap());
+        // Arming for an unknown id (the row already vanished) is a no-op.
+        let mut gone = IssueListState::with_rows(vec![row("i1", "open", None)]);
+        gone.open_confirm_cancel_delete_for("nope");
+        assert_eq!(
+            gone.mode(),
+            IssueListMode::Normal,
+            "unknown id arms nothing"
+        );
+        assert!(gone.confirm_cancel_delete().is_none());
+    }
+
+    /// `c` (and Enter) on the cancel-delete overlay emits `CancelAndDeleteIssue`
+    /// for the target and returns to normal navigation; Esc backs out cleanly.
+    #[test]
+    fn confirm_cancel_delete_emits_intent_and_esc_backs_out() {
+        let mut s =
+            IssueListState::with_rows(vec![row("i1", "open", None), row("i2", "open", None)]);
+        s.open_confirm_cancel_delete_for("i2");
+
+        // `c` confirms → cancel-then-delete intent for i2.
+        let out = reduce_issue_list(&s, IssueListEvent::Key('c'));
+        assert_eq!(
+            out.intent,
+            Some(IssueListIntent::CancelAndDeleteIssue(
+                IssueId::from_str("i2").unwrap()
+            )),
+            "c emits CancelAndDeleteIssue for the target"
+        );
+        assert_eq!(out.state.mode(), IssueListMode::Normal);
+        assert!(
+            out.state.confirm_cancel_delete().is_none(),
+            "target dropped after commit"
+        );
+
+        // Enter is an equivalent confirm.
+        let via_enter = reduce_issue_list(&s, IssueListEvent::Key('\n'));
+        assert_eq!(
+            via_enter.intent,
+            Some(IssueListIntent::CancelAndDeleteIssue(
+                IssueId::from_str("i2").unwrap()
+            )),
+            "Enter also confirms cancel-and-delete"
+        );
+
+        // Esc backs out with no intent, target dropped.
+        let esc = reduce_issue_list(&s, IssueListEvent::Key('\u{1b}'));
+        assert_eq!(esc.intent, None, "Esc raises no intent");
+        assert_eq!(esc.state.mode(), IssueListMode::Normal);
+        assert!(
+            esc.state.confirm_cancel_delete().is_none(),
+            "target dropped on Esc"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes a bug where an issue whose task row is stuck in `dispatched` can never be deleted, with no way out from the TUI. Root-caused live: HGR-1 had a 2-day-old `dispatched` row with a NULL `dispatched_at` that survived every daemon restart, and the board's delete error ("cancel the run first") offered no cancel affordance.

Two independent fixes:

### A. No dispatched/running row is immortal (`sweeper.rs`)
- `reclaim_stale_dispatched`: a `dispatched` row with NULL `dispatched_at` (a claim whose timestamp was never stamped) is now reclaimed → `queued`. It cannot be inside the 90s protection window (no fresh timestamp to protect), so it is redelivered like any past-window dispatch. Stamped rows keep the exact `reclaim_window < age <= ttl` band — a fresh (<90s) in-flight dispatch stays protected.
- `fail_batch`: `COALESCE(age_column, 0)` so a NULL age column (a `running` row with NULL `started_at`, or a dispatched row the reclaim step didn't catch) is treated as past-TTL and failed rather than skipped forever. The queued-TTL sweep keys on `created_at`, which is `NOT NULL` at the schema level, so this is a provable no-op for the queued path — zero regression there.

### B. Inline cancel-and-delete on the Issues board
- The daemon tags the active-tasks delete refusal with a machine-readable marker; a new `issue_cancel_active` RPC cancels every active (queued/dispatched/running) task for an issue, scoped by workspace + issue id.
- The board's delete-confirm overlay gains a `ConfirmCancelDelete` step: when delete is refused for active runs, the user can cancel the run(s) and delete in place. The delete retry is armed ONLY after the cancel RPC commits successfully; on cancel failure no delete fires and the error surfaces. No more dead-end.

## Testing
- New behavioral tests: `sweeper_ttls` (NULL dispatched_at → reclaimed; fresh <90s → protected; NULL started_at running → failed), `rpc_issue_cancel_active`, `rpc_issue_delete` marker assertion, plugin reducer + glue tests for the cancel→delete ordering.
- `cargo test -p ainb-hangar-daemon -p ainb-plugin-hangar`: touched surfaces green (sweeper_ttls 16, rpc_issue_cancel_active 3, rpc_issue_delete 3, plugin lib 316).
- `bash scripts/hangar/run_acceptance_tests.sh`: ran=92 failed=0.
- 2 mutation spot-checks (revert reclaim guard → NULL-dispatched test RED; break cancel-before-delete ordering → ordering test RED), both restored.
- Pre-existing, unrelated: the real-subprocess `tripwire_*` e2e tests flake under full-suite concurrency (timing contention) — reproduced identically on unmodified main; not this branch.

## Notes
- Split into 7 small single-concern signed commits, each buildable + testable standalone.
- New proto types/method are append-only (serde-default), no field reordering. No migration. No `.snap` regression fixtures changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `hangar/issue_cancel_active` to cancel all active runs for a workspace-scoped issue.
  * Extended the issue deletion flow with a “cancel active runs & delete” confirmation overlay and retry after successful cancellation.
  * Deletion refusal errors now include structured `error.data` (reason and active task count).
* **Bug Fixes**
  * Fixed sweeper behavior so `NULL` timestamps are correctly reclaimed/treated (preventing “immortal” dispatched items) and timed-out running tasks are detected.
* **Tests**
  * Added integration and unit coverage for cancel/delete behavior, workspace safety, modal routing, and `NULL`-timestamp timeout/reclaim scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->