### PR TITLE
feat(hangar): capture a multi-line Brief when creating an issue

### DIFF
--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -2532,6 +2532,7 @@ impl HangarPlugin {
         use crate::screen::IssueCreateAction;
         let IssueCreateAction::CreateAndRun {
             title,
+            description,
             repo_ref,
             source_branch,
             target_branch,
@@ -2542,9 +2543,15 @@ impl HangarPlugin {
             return;
         };
         let ws = self.app_state().ws_id.as_str().to_string();
-        let params = serde_json::json!({
+        // `description` is the wizard Brief: it lands on `issue.description`, which
+        // `build_prompt` turns into the `claude -p` prompt. Omitted when blank so a
+        // title-only stub creates unchanged.
+        let mut params = serde_json::json!({
             "workspace_id": ws, "title": title, "creator": SELF_AUTHOR_REF
         });
+        if let Some(brief) = description {
+            params["description"] = serde_json::Value::String(brief);
+        }
         let Ok(body) = encode_request(
             ISSUE_CREATE_REQ_ID,
             daemon_methods::HANGAR_ISSUE_CREATE,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -371,6 +371,9 @@ pub enum IssueCreateAction {
     CreateAndRun {
         /// The new issue's title (non-blank).
         title: String,
+        /// The multi-line brief (OPTIONAL) persisted as `issue.description` and
+        /// turned into the `claude -p` prompt by `build_prompt`. `None` when blank.
+        description: Option<String>,
         /// The picked repo (REQUIRED): an absolute path, `scratch`, or a remote
         /// indicator the daemon clones.
         repo_ref: String,
@@ -1437,6 +1440,7 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
         // key router can't `await`).
         Some(IssueListIntent::CreateAndRun {
             title,
+            brief,
             repo_ref,
             source_branch,
             target_branch,
@@ -1444,6 +1448,7 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
         }) => {
             states.pending_create_action = Some(IssueCreateAction::CreateAndRun {
                 title,
+                description: brief,
                 repo_ref,
                 source_branch,
                 target_branch,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -288,6 +288,11 @@ pub enum WizardKey {
 pub enum WizardRow {
     /// The issue title text row (REQUIRED — a blank title blocks create).
     Title,
+    /// The multi-line brief text row (OPTIONAL): free-form task description that
+    /// becomes `issue.description` and, via `build_prompt`, the `claude -p`
+    /// prompt. Enter here inserts a NEWLINE (never fires create); printable chars
+    /// append, Backspace edits. A `/name` typed in it reaches the agent verbatim.
+    Brief,
     /// The repo picker row (REQUIRED — `@` fuzzy dropdown or ←/→ cycle; a
     /// repo-less create is impossible).
     Repo,
@@ -300,10 +305,11 @@ pub enum WizardRow {
 }
 
 impl WizardRow {
-    /// The rows in render / focus-cycle order (Title → Repo → Source → Target →
-    /// Agent).
-    pub const ALL: [Self; 5] = [
+    /// The rows in render / focus-cycle order (Title → Brief → Repo → Source →
+    /// Target → Agent).
+    pub const ALL: [Self; 6] = [
         Self::Title,
+        Self::Brief,
         Self::Repo,
         Self::Source,
         Self::Target,
@@ -332,6 +338,9 @@ pub struct CreateWizard {
     focus: WizardRow,
     /// The title typed so far (REQUIRED — trimmed-blank blocks create).
     title: String,
+    /// The multi-line brief typed so far (OPTIONAL): free text with embedded
+    /// newlines, carried through to `issue.description`. Blank is allowed.
+    brief: String,
     /// The picked repo's wire ref, or `None` until one is chosen (REQUIRED).
     repo_ref: Option<String>,
     /// The post-`@` fuzzy query filtering the repo dropdown.
@@ -353,6 +362,7 @@ impl Default for CreateWizard {
         Self {
             focus: WizardRow::Title,
             title: String::new(),
+            brief: String::new(),
             repo_ref: None,
             repo_query: String::new(),
             repo_dropdown: None,
@@ -374,6 +384,13 @@ impl CreateWizard {
     #[must_use]
     pub fn title(&self) -> &str {
         &self.title
+    }
+
+    /// The multi-line brief typed so far (may contain embedded newlines; may be
+    /// empty).
+    #[must_use]
+    pub fn brief(&self) -> &str {
+        &self.brief
     }
 
     /// The picked repo ref, or `None` until one is chosen.
@@ -964,6 +981,9 @@ pub enum IssueListIntent {
     CreateAndRun {
         /// The non-blank title typed in stage 1.
         title: String,
+        /// The multi-line brief (OPTIONAL): free text carried through to
+        /// `issue.description` and the `claude -p` prompt. `None` when blank.
+        brief: Option<String>,
         /// The repo picked in stage 2 (REQUIRED — an absolute path, `scratch`, or
         /// a remote indicator the daemon clones).
         repo_ref: String,
@@ -1216,7 +1236,7 @@ fn cancel_confirm_cancel_delete(state: &IssueListState) -> IssueListReduction {
 /// edits the focused text row, and Enter creates (or jumps to the missing
 /// required row). A wizard key with no wizard open is a no-op.
 fn reduce_wizard_key(state: &IssueListState, key: WizardKey) -> IssueListReduction {
-    let Some(wizard) = state.wizard.clone() else {
+    let Some(mut wizard) = state.wizard.clone() else {
         return unchanged(state);
     };
     if key == WizardKey::Esc {
@@ -1228,6 +1248,12 @@ fn reduce_wizard_key(state: &IssueListState, key: WizardKey) -> IssueListReducti
         return wizard_dropdown_key(state, wizard, key);
     }
     match key {
+        // Enter on the Brief inserts a NEWLINE (multi-line editing) and must NOT
+        // fire create; every other row's Enter is the existing commit point.
+        WizardKey::Enter if wizard.focus == WizardRow::Brief => {
+            wizard.brief.push('\n');
+            set_wizard(state, wizard)
+        }
         WizardKey::Enter => wizard_try_create(state, wizard),
         WizardKey::Tab | WizardKey::Down => wizard_move_focus(state, wizard, true),
         WizardKey::BackTab | WizardKey::Up => wizard_move_focus(state, wizard, false),
@@ -1295,7 +1321,7 @@ fn wizard_cycle_value(
         WizardRow::Agent => {
             wizard.agent_cursor = ring_step(wizard.agent_cursor, AgentChip::ALL.len(), forward);
         }
-        WizardRow::Title | WizardRow::Source | WizardRow::Target => {}
+        WizardRow::Title | WizardRow::Brief | WizardRow::Source | WizardRow::Target => {}
     }
     set_wizard(state, wizard)
 }
@@ -1310,6 +1336,7 @@ fn wizard_type_char(
 ) -> IssueListReduction {
     match wizard.focus {
         WizardRow::Title => wizard.title.push(c),
+        WizardRow::Brief => wizard.brief.push(c),
         WizardRow::Source => wizard.source_branch.push(c),
         WizardRow::Target => wizard.target_branch.push(c),
         WizardRow::Repo => {
@@ -1332,6 +1359,9 @@ fn wizard_backspace(state: &IssueListState, mut wizard: CreateWizard) -> IssueLi
     match wizard.focus {
         WizardRow::Title => {
             wizard.title.pop();
+        }
+        WizardRow::Brief => {
+            wizard.brief.pop();
         }
         WizardRow::Source => {
             wizard.source_branch.pop();
@@ -1415,7 +1445,8 @@ fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueL
     let mut next = state.clone();
     next.mode = IssueListMode::Normal;
     next.wizard = None;
-    // Blank branch inputs mean "unset" — the daemon resolves the default.
+    // Blank branch inputs mean "unset" — the daemon resolves the default. Branch
+    // refs are trimmed (whitespace in a ref is never meaningful).
     let opt = |s: &str| {
         let t = s.trim();
         if t.is_empty() {
@@ -1424,10 +1455,21 @@ fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueL
             Some(t.to_string())
         }
     };
+    // The Brief is the opposite: it reaches `issue.description` VERBATIM (it may
+    // carry leading `/name` skill lines and embedded newlines that `claude -p`
+    // executes at dispatch). Only a wholly-blank brief collapses to `None`; a
+    // present brief is sent EXACTLY as typed — never trimmed, escaped, or
+    // normalised.
+    let brief = if wizard.brief.trim().is_empty() {
+        None
+    } else {
+        Some(wizard.brief.clone())
+    };
     with_intent(
         next,
         IssueListIntent::CreateAndRun {
             title: wizard.title.trim().to_string(),
+            brief,
             repo_ref,
             source_branch: opt(&wizard.source_branch),
             target_branch: opt(&wizard.target_branch),
@@ -1690,10 +1732,16 @@ const CARD_BACKDROP: Color = Color::rgb(20, 20, 28);
 const WIZARD_TITLE: &str = "✦ New task";
 /// The in-card footer hint naming the nav keys.
 const WIZARD_HINT: &str = "↑↓ row   ←→ value   Enter create   Esc cancel";
-/// The card's COMPACT height (dropdown closed): top border + 5 field rows +
-/// spacer + hint + bottom border. The card grows past this by the number of
-/// visible dropdown rows while the `@` repo picker is open (see [`render_wizard`]).
+/// The card's FIXED-row height: top border + the 5 single-line field rows
+/// (Title / Repo / Source / Target / Agent) + spacer + hint + bottom border. The
+/// multi-line Brief row adds `brief_rows` on top of this, and the `@` repo picker
+/// adds its visible dropdown rows while open (see [`render_wizard`]); the card is
+/// exactly this tall only in the degenerate all-empty single-line-brief case.
 const WIZARD_CARD_H: u16 = 9;
+/// The most wrapped Brief lines the card shows at once; a longer brief
+/// scroll-follows the newest text within this window. Bounds card growth so the
+/// Brief never blows the viewport.
+const BRIEF_WINDOW: u16 = 5;
 /// The card's preferred width (clamped to the viewport minus insets).
 const WIZARD_CARD_W: u16 = 54;
 /// The most repo candidates the open `@` dropdown shows at once; a longer roster
@@ -1723,7 +1771,9 @@ fn render_wizard(
     let region_h = bottom.saturating_sub(top).saturating_add(1);
 
     // Degenerate viewport: paint at least the title + hint (never panic / empty).
-    if card_w < 24 || region_h < WIZARD_CARD_H {
+    // The Brief always adds at least one line, so the true minimum is one row
+    // taller than the fixed-row height.
+    if card_w < 24 || region_h < WIZARD_CARD_H + 1 {
         put_card_str(buf, 0, top, WIZARD_TITLE, GOLD, area_w, false);
         put_card_str(
             buf,
@@ -1737,12 +1787,20 @@ fn render_wizard(
         return;
     }
 
+    // The Brief row grows the card by its visible wrapped-line count (always >= 1).
+    // The value column starts 12 in from the card's left and the Brief marker eats
+    // a further 2, so the wrap width is `card_w - 15` (matched inside
+    // [`render_brief`] so the counted rows equal the painted lines).
+    let brief_value_w = card_w.saturating_sub(15);
+    let brief_rows = brief_visible_rows(wizard, brief_value_w, region_h);
     // While the `@` dropdown is open the card GROWS by the number of candidate
     // rows it shows (filter line reuses the Repo row itself). The window is capped
     // at [`REPO_DROPDOWN_WINDOW`] and further shrunk to whatever the viewport can
-    // hold, so the card never spills past `region_h` — compact again on close.
-    let dropdown_rows = repo_dropdown_visible_rows(wizard, repos, region_h);
-    let card_h = WIZARD_CARD_H + dropdown_rows;
+    // hold AFTER the Brief has taken its rows, so the card never spills past
+    // `region_h` — compact again on close.
+    let dropdown_rows =
+        repo_dropdown_visible_rows(wizard, repos, region_h.saturating_sub(brief_rows));
+    let card_h = WIZARD_CARD_H + brief_rows + dropdown_rows;
 
     let left = (area_w.saturating_sub(card_w)) / 2;
     let right = left + card_w; // exclusive
@@ -1774,6 +1832,11 @@ fn render_wizard(
         let label = wizard_row_label(field);
         let label_colour = if focused { GOLD } else { MUTED_GRAY };
         put_card_str(buf, label_x, y, label, label_colour, value_x, true);
+        if field == WizardRow::Brief {
+            render_brief(buf, value_x, y, text_right, wizard, brief_rows);
+            y = y.saturating_add(brief_rows);
+            continue;
+        }
         if field == WizardRow::Repo && wizard.repo_dropdown().is_some() {
             render_repo_dropdown(buf, value_x, y, text_right, wizard, repos, dropdown_rows);
             y = y.saturating_add(1 + dropdown_rows);
@@ -1811,10 +1874,101 @@ fn repo_dropdown_visible_rows(wizard: &CreateWizard, repos: &[RepoOption], regio
     want.min(budget)
 }
 
+/// How many wrapped lines the Brief row paints: the brief's wrapped-line count
+/// (at `value_w`), floored at 1 (the empty brief still shows one row for its
+/// placeholder / cursor), capped at [`BRIEF_WINDOW`], then shrunk so the grown
+/// card still fits `region_h` (the fixed frame plus these rows). Keeps the growth
+/// bounded and the small-viewport fallback intact.
+fn brief_visible_rows(wizard: &CreateWizard, value_w: u16, region_h: u16) -> u16 {
+    let lines = u16::try_from(wrap_text(wizard.brief(), value_w as usize).len())
+        .unwrap_or(u16::MAX)
+        .max(1);
+    let want = lines.min(BRIEF_WINDOW);
+    // The fixed rows always fit (the degenerate check guaranteed region_h >=
+    // WIZARD_CARD_H + 1), so the budget is at least 1.
+    let budget = region_h.saturating_sub(WIZARD_CARD_H).max(1);
+    want.min(budget)
+}
+
+/// Wrap `text` into display lines at most `width` chars wide, honouring embedded
+/// `\n` as hard breaks. Char-boundary wrapping (not word-aware) — a brief is
+/// free text and the cells are what the card must fit. Always returns at least
+/// one (possibly empty) line so the Brief row is never zero-height.
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut out = Vec::new();
+    for segment in text.split('\n') {
+        let chars: Vec<char> = segment.chars().collect();
+        if chars.is_empty() {
+            out.push(String::new());
+            continue;
+        }
+        let mut i = 0;
+        while i < chars.len() {
+            let end = (i + width).min(chars.len());
+            out.push(chars[i..end].iter().collect());
+            i = end;
+        }
+    }
+    if out.is_empty() {
+        out.push(String::new());
+    }
+    out
+}
+
+/// The placeholder shown on an empty, unfocused Brief row so the optional field
+/// reads as skippable rather than broken.
+const BRIEF_PLACEHOLDER: &str = "(optional — describe the task)";
+
+/// Render the multi-line Brief value at `(x, y)` over `rows` lines, clipped at
+/// `right`. The focused row gets a `▶` marker + green text and a block cursor on
+/// the last line; unfocused shows soft-white (or the muted placeholder when
+/// empty). A brief longer than `rows` scroll-follows its newest line (an editor
+/// caret stays visible while typing). The marker sits on the first painted line;
+/// continuation lines indent to align under it.
+fn render_brief(
+    buf: &mut WireBuffer,
+    x: u16,
+    y: u16,
+    right: u16,
+    wizard: &CreateWizard,
+    rows: u16,
+) {
+    let focused = wizard.focus() == WizardRow::Brief;
+    let value_colour = if focused { SELECTION_GREEN } else { SOFT_WHITE };
+    let marker = if focused { "▶ " } else { "  " };
+    let value_x = x.saturating_add(2);
+    let width = right.saturating_sub(value_x).max(1) as usize;
+    let raw = wizard.brief();
+    if raw.is_empty() && !focused {
+        put_card_str(buf, x, y, marker, value_colour, right, true);
+        put_card_str(buf, value_x, y, BRIEF_PLACEHOLDER, MUTED_GRAY, right, true);
+        return;
+    }
+    let mut lines = wrap_text(raw, width);
+    if focused {
+        // A block cursor on the newest line — appended after wrapping so it never
+        // forces an extra wrap.
+        if let Some(last) = lines.last_mut() {
+            last.push('\u{2588}');
+        }
+    }
+    // Show the LAST `rows` wrapped lines so the caret stays in view while typing.
+    let rows = rows.max(1) as usize;
+    let start = lines.len().saturating_sub(rows);
+    for (i, line) in lines[start..].iter().enumerate() {
+        let ly = y.saturating_add(u16::try_from(i).unwrap_or(u16::MAX));
+        let m = if i == 0 { marker } else { "  " };
+        let cx = put_card_str(buf, x, ly, m, value_colour, right, true);
+        put_card_str(buf, cx, ly, line, value_colour, right, true);
+    }
+}
+
 /// The label shown in the card's left column for `row`.
 const fn wizard_row_label(row: WizardRow) -> &'static str {
     match row {
         WizardRow::Title => "Title",
+        WizardRow::Brief => "Brief",
         WizardRow::Repo => "Repo",
         WizardRow::Source => "Source",
         WizardRow::Target => "Target",
@@ -1850,6 +2004,9 @@ fn render_wizard_field(
         WizardRow::Title => {
             put_card_str(buf, cx, y, &text(wizard.title()), value_colour, right, true);
         }
+        // The multi-line Brief is painted by [`render_brief`] (it spans several
+        // rows), so the single-row path never routes here.
+        WizardRow::Brief => {}
         WizardRow::Repo => {
             // The open-dropdown case is painted by the caller ([`render_wizard`])
             // because it spans multiple rows; here the row is always CLOSED.
@@ -2447,6 +2604,7 @@ mod tests {
         for needle in [
             "New task",
             "Title",
+            "Brief",
             "Repo",
             "Source",
             "Target",
@@ -2470,6 +2628,50 @@ mod tests {
         assert!(
             has_gold_corner,
             "card must have a gold rounded top-left corner"
+        );
+    }
+
+    /// A multi-line Brief renders its wrapped value inside the card AND grows the
+    /// card's painted-row span versus an empty Brief — the dynamic-height contract
+    /// the repo dropdown already established, reused for the Brief region.
+    #[test]
+    fn wizard_brief_renders_wrapped_and_grows_card() {
+        let painted_row_span = |s: &IssueListState| -> u16 {
+            let mut buf = WireBuffer::new(120, 24);
+            render_issue_list(&mut buf, 120, 1, 23, s, 0);
+            let ys: Vec<u16> = buf
+                .cells
+                .iter()
+                .filter(|(_, c)| c.fg == Some(GOLD) && (c.symbol == "│" || c.symbol == "╭"))
+                .map(|(coord, _)| coord.y)
+                .collect();
+            let (min, max) = (ys.iter().min().copied(), ys.iter().max().copied());
+            max.unwrap_or(0).saturating_sub(min.unwrap_or(0))
+        };
+
+        // Empty-Brief baseline card span.
+        let empty = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
+        let empty_span = painted_row_span(&empty);
+
+        // Focus Brief, type enough to wrap onto several lines.
+        let s = reduce_issue_list(&empty, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
+        let long = "reproduce the login 500 then patch the handler and add a regression test";
+        let s = type_into(&s, long);
+
+        let mut buf = WireBuffer::new(120, 24);
+        render_issue_list(&mut buf, 120, 1, 23, &s, 0);
+        let painted = painted_text(&buf);
+        // A leading slice of the brief renders inside the card.
+        assert!(
+            painted.contains("reproduce the login"),
+            "wrapped brief value must render:\n{painted}"
+        );
+        // The card grew to make room for the wrapped brief lines.
+        assert!(
+            painted_row_span(&s) > empty_span,
+            "card must grow for a multi-line brief ({} !> {empty_span})",
+            painted_row_span(&s)
         );
     }
 
@@ -2501,8 +2703,9 @@ mod tests {
         let mut s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         s.set_repos(repo_roster());
         let s = type_into(&s, "Fix");
-        // Move focus to the Repo row, then open the dropdown.
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state;
+        // Move focus past Brief to the Repo row, then open the dropdown.
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
         let mut buf = WireBuffer::new(120, 24);
         render_issue_list(&mut buf, 120, 1, 23, &s, 0);
@@ -2545,8 +2748,9 @@ mod tests {
         let mut s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         s.set_repos(repo_roster());
         let s = type_into(&s, "Fix");
-        // Focus Repo, cycle ←→ to pick the `rosetta` scan (scratch=0, rosetta=1).
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state;
+        // Focus Repo (past Brief), cycle ←→ to pick `rosetta` (scratch=0, rosetta=1).
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state; // scratch
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state; // rosetta
         assert_eq!(
@@ -2584,7 +2788,8 @@ mod tests {
         let mut s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         s.set_repos(roster);
         let s = type_into(&s, "Fix");
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state;
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
         let mut buf = WireBuffer::new(120, 24);
         render_issue_list(&mut buf, 120, 1, 23, &s, 0);
@@ -2630,7 +2835,8 @@ mod tests {
             reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         base.set_repos(repo_roster());
         let base = type_into(&base, "Fix");
-        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state;
+        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
 
         let painted_row_span = |s: &IssueListState| -> u16 {
             let mut buf = WireBuffer::new(120, 24);
@@ -2678,7 +2884,8 @@ mod tests {
         let mut s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         s.set_repos(roster);
         let s = type_into(&s, "Fix");
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state;
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
 
         // At open the last repo is off-window (13 candidates incl. scratch, window 6).

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -141,8 +141,9 @@ fn open_wizard() -> IssueListState {
 fn ready_to_create() -> IssueListState {
     let s = open_wizard();
     let s = type_str(s, "Fix login");
-    // Move to Repo, open the dropdown (cursor at scratch), pick it.
-    let s = wiz(&s, WizardKey::Down).state;
+    // Move past Brief to Repo, open the dropdown (cursor at scratch), pick it.
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
     let s = wiz(&s, WizardKey::Char('@')).state;
     let s = wiz(&s, WizardKey::Enter).state; // pick scratch, dropdown closes
     // Land focus on the Agent row.
@@ -172,13 +173,16 @@ fn c_opens_wizard_focused_on_title() {
 }
 
 /// ↓ / Tab advance the focused row, ↑ / Shift+Tab retreat, both wrapping around
-/// the five rows (mirrors the host new-session Configure form).
+/// the six rows (Title → Brief → Repo → Source → Target → Agent; mirrors the host
+/// new-session Configure form).
 #[test]
 fn wizard_focus_moves_and_wraps() {
     let s = open_wizard();
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Title);
 
     let s = wiz(&s, WizardKey::Down).state;
+    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
+    let s = wiz(&s, WizardKey::Tab).state;
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Repo);
     let s = wiz(&s, WizardKey::Tab).state;
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Source);
@@ -236,7 +240,8 @@ fn wizard_left_right_cycles_agent_only() {
 fn wizard_left_right_cycles_repo() {
     let s = open_wizard();
     let s = type_str(s, "Fix");
-    let s = wiz(&s, WizardKey::Down).state; // focus Repo
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
     assert_eq!(s.wizard().unwrap().repo_ref(), None);
 
     // → picks the first candidate (scratch is always index 0).
@@ -252,6 +257,7 @@ fn wizard_typing_edits_focused_text_row() {
     assert_eq!(s.wizard().unwrap().title(), "Title text");
 
     // Focus Source, clear the "main" prefill, type a custom ref.
+    let s = wiz(&s, WizardKey::Down).state; // Brief
     let s = wiz(&s, WizardKey::Down).state; // Repo
     let s = wiz(&s, WizardKey::Down).state; // Source
     let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
@@ -272,7 +278,8 @@ fn wizard_typing_edits_focused_text_row() {
 fn wizard_at_opens_repo_dropdown() {
     let s = open_wizard();
     let s = type_str(s, "Fix");
-    let s = wiz(&s, WizardKey::Down).state; // focus Repo
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
     assert_eq!(s.wizard().unwrap().repo_dropdown(), None);
 
     let s = wiz(&s, WizardKey::Char('@')).state;
@@ -291,7 +298,8 @@ fn wizard_at_opens_repo_dropdown() {
 fn wizard_tab_from_dropdown_commits_highlight() {
     let s = open_wizard();
     let s = type_str(s, "Fix");
-    let s = wiz(&s, WizardKey::Down).state; // focus Repo
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
     let s = wiz(&s, WizardKey::Char('@')).state; // open dropdown, cursor on scratch
 
     let out = wiz(&s, WizardKey::Tab);
@@ -356,6 +364,7 @@ fn wizard_complete_form_commits_create_and_run() {
         out.intent,
         Some(IssueListIntent::CreateAndRun {
             title: "Fix login".to_string(),
+            brief: None,
             repo_ref: "scratch".to_string(),
             source_branch: Some("main".to_string()),
             target_branch: Some("main".to_string()),
@@ -364,6 +373,121 @@ fn wizard_complete_form_commits_create_and_run() {
     );
     assert_eq!(out.state.mode(), IssueListMode::Normal);
     assert!(out.state.wizard().is_none());
+}
+
+/// Typing on the Brief row appends (including `/`, which must reach the agent
+/// verbatim), and Backspace edits — the multi-line editor idiom.
+#[test]
+fn wizard_brief_appends_and_backspaces() {
+    let s = open_wizard();
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
+
+    let s = type_str(s, "run /fix now");
+    assert_eq!(
+        s.wizard().unwrap().brief(),
+        "run /fix now",
+        "printable chars (incl. `/`) append verbatim"
+    );
+
+    // Backspace deletes the last char.
+    let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
+    assert_eq!(s.wizard().unwrap().brief(), "run /fix");
+}
+
+/// Enter on the Brief inserts a NEWLINE and does NOT fire create — the wizard
+/// stays open and no intent is raised (create commits only from the other rows).
+#[test]
+fn wizard_brief_enter_inserts_newline_not_create() {
+    // Even a create-ready form (title + repo picked) must not commit from Brief.
+    let s = ready_to_create();
+    // Walk focus back to the Brief row (Agent → … → Brief).
+    let s = wiz(&s, WizardKey::Up).state; // Target
+    let s = wiz(&s, WizardKey::Up).state; // Source
+    let s = wiz(&s, WizardKey::Up).state; // Repo
+    let s = wiz(&s, WizardKey::Up).state; // Brief
+    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
+
+    let s = type_str(s, "line one");
+    let out = wiz(&s, WizardKey::Enter);
+
+    assert!(out.intent.is_none(), "Enter on Brief must not create");
+    assert_eq!(out.state.mode(), IssueListMode::CreateInput);
+    let w = out.state.wizard().expect("wizard still open");
+    assert_eq!(w.brief(), "line one\n", "Enter inserted a newline");
+    assert_eq!(w.focus(), WizardRow::Brief, "focus stays on Brief");
+
+    // A second line then appends after the newline.
+    let s2 = type_str(out.state, "line two");
+    assert_eq!(s2.wizard().unwrap().brief(), "line one\nline two");
+}
+
+/// A brief typed in the wizard carries through to `CreateAndRun.brief` (which the
+/// glue maps to `issue.description` → the `claude -p` prompt).
+#[test]
+fn wizard_brief_carries_to_create_intent() {
+    let s = open_wizard();
+    let s = type_str(s, "Fix login");
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    let s = type_str(s, "Reproduce then patch");
+    // Move to Repo, pick scratch, then commit from the Repo row.
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
+    let s = wiz(&s, WizardKey::Right).state; // pick scratch
+
+    let out = wiz(&s, WizardKey::Enter);
+
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { brief, title, .. }) => {
+            assert_eq!(title, "Fix login");
+            assert_eq!(brief, Some("Reproduce then patch".to_string()));
+        }
+        other => panic!("expected CreateAndRun carrying the brief, got {other:?}"),
+    }
+}
+
+/// The brief reaches the intent VERBATIM: a leading `/name` skill line, internal
+/// newlines, and a trailing newline all survive unchanged (no trim / escape /
+/// normalise), so a `claude --print` skill invocation in the brief executes as
+/// typed at dispatch.
+#[test]
+fn wizard_brief_preserved_verbatim_on_intent() {
+    let s = open_wizard();
+    let s = type_str(s, "Fix login");
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    // Line 1: a skill command. Newline. Line 2: prose. Trailing newline.
+    let s = type_str(s, "/graphify the auth flow");
+    let s = wiz(&s, WizardKey::Enter).state; // newline (not create)
+    let s = type_str(s, "then summarise findings");
+    let s = wiz(&s, WizardKey::Enter).state; // trailing newline
+    // Commit from the Repo row.
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
+    let s = wiz(&s, WizardKey::Right).state; // pick scratch
+
+    let out = wiz(&s, WizardKey::Enter);
+
+    let expected = "/graphify the auth flow\nthen summarise findings\n";
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { brief, .. }) => {
+            assert_eq!(
+                brief,
+                Some(expected.to_string()),
+                "brief must reach the intent byte-for-byte (slashes + newlines intact)"
+            );
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
+}
+
+/// A blank brief maps to `None` on the intent (title-only stubs stay allowed).
+#[test]
+fn wizard_blank_brief_is_none_on_intent() {
+    let out = wiz(&ready_to_create(), WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { brief, .. }) => {
+            assert_eq!(brief, None, "an untouched Brief creates unchanged");
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
 }
 
 /// A blanked branch input means "unset" (`None` on the intent); a custom source
@@ -386,6 +510,7 @@ fn wizard_branch_edits_and_blanks_round_trip() {
         out.intent,
         Some(IssueListIntent::CreateAndRun {
             title: "Fix login".to_string(),
+            brief: None,
             repo_ref: "scratch".to_string(),
             source_branch: Some("feature/x".to_string()),
             target_branch: None,
@@ -405,7 +530,8 @@ fn wizard_required_guard_blocks_incomplete_creates() {
 
     // Repo only, no title → Enter never creates.
     let s = open_wizard();
-    let s = wiz(&s, WizardKey::Down).state; // Repo
+    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
+    let s = wiz(&s, WizardKey::Down).state; // Brief → Repo
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
     assert_eq!(s.wizard().unwrap().repo_ref(), Some("scratch"));
     assert!(wiz(&s, WizardKey::Enter).intent.is_none());

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
@@ -345,15 +345,27 @@ async fn wizard_commit_issues_create_update_and_run() {
         .await;
 
         // Walk the single-form wizard: `c` opens it (focus Title); type the
-        // title; ↓ moves focus to the Repo row; `@` opens the dropdown (cursor at
-        // scratch); Enter picks scratch (closing the dropdown); Enter with the
-        // required fields satisfied (title + repo, branches prefilled `main`,
-        // agent defaulted to claude) commits `CreateAndRun`.
+        // title; ↓ moves focus to the Brief row; type a multi-line brief (Enter
+        // there inserts a newline, NOT a commit); ↓ moves to the Repo row; `@`
+        // opens the dropdown (cursor at scratch); Enter picks scratch (closing the
+        // dropdown); Enter with the required fields satisfied (title + repo,
+        // branches prefilled `main`, agent defaulted to claude) commits
+        // `CreateAndRun` carrying the brief as `description`.
         send_key(&mut host_write, KeyCode::Char { ch: 'c' }).await;
         for ch in "Wizard task".chars() {
             send_key(&mut host_write, KeyCode::Char { ch }).await;
         }
-        send_key(&mut host_write, KeyCode::Down).await;
+        send_key(&mut host_write, KeyCode::Down).await; // Title → Brief
+        // Lead with a `/name` skill line: `claude --print` executes a materialised
+        // skill, so the slash + newline must reach `description` verbatim.
+        for ch in "/graphify it".chars() {
+            send_key(&mut host_write, KeyCode::Char { ch }).await;
+        }
+        send_key(&mut host_write, KeyCode::Enter).await; // newline in the brief
+        for ch in "second line".chars() {
+            send_key(&mut host_write, KeyCode::Char { ch }).await;
+        }
+        send_key(&mut host_write, KeyCode::Down).await; // Brief → Repo
         send_key(&mut host_write, KeyCode::Char { ch: '@' }).await;
         send_key(&mut host_write, KeyCode::Enter).await;
         send_key(&mut host_write, KeyCode::Enter).await;
@@ -380,6 +392,11 @@ async fn wizard_commit_issues_create_update_and_run() {
             let created = calls.iter().any(|(m, p)| {
                 m == daemon_methods::HANGAR_ISSUE_CREATE
                     && s(p, "title").as_deref() == Some("Wizard task")
+                    // The Brief lands as `description` on the create call VERBATIM:
+                    // the leading `/name` slash and the embedded newline survive
+                    // unchanged (no trim / escape / normalise), so the skill runs
+                    // as typed at dispatch.
+                    && s(p, "description").as_deref() == Some("/graphify it\nsecond line")
             });
             let updated = calls.iter().any(|(m, p)| {
                 m == daemon_methods::HANGAR_ISSUE_UPDATE


### PR DESCRIPTION
## Summary
Fixes the core reason a dispatched issue ran a useless one-word prompt. The daemon dispatches an issue as `claude --print "<title>\n\n<description>"` (`build_prompt`, run_loop.rs:1743), but the TUI create-wizard never captured a description — so a card titled `test` became `claude --print "test"`. This adds a multi-line **Brief** field to the wizard that becomes `issue.description`, i.e. the actual prompt.

## Details
- New **Brief** row in the create card: multi-line. Printable chars append, Backspace deletes (across newlines), and **Enter inserts a newline** — it does NOT create. The wizard still commits only from its existing single commit point (the Agent row), so the Brief can be as long as you like.
- The card grows to show the wrapped brief (reusing the dynamic-height pattern from the repo dropdown); degenerate-viewport fallback preserved.
- The brief reaches `issue.description` **verbatim** — no trim/escape/normalize of slashes or newlines. This is load-bearing: `claude --print "/skill …"` genuinely executes a skill when it's materialised in the worktree (control-tested), so a brief like `/graphify fix the parser` runs the skill at dispatch. Only a wholly-empty/whitespace brief collapses to `None`.
- Brief is **optional** — title-only backlog stubs still create; the REQUIRED guard (repo + agent) is untouched.
- Plugin-only: `issue.description` and the create RPC's description field already existed; no schema/daemon change.

## Testing
- `cargo test -p ainb-plugin-hangar`: full crate green (lib 322); reducer tests +5 (19→24), no drop.
- Verbatim round-trip proven at two layers: a reducer test asserts a `/graphify …`-leading, multi-line, trailing-newline brief reaches the `CreateAndRun` intent byte-for-byte, and the socket round-trip test asserts the actual `issue_create` RPC param carries `description` verbatim.
- Enter-inserts-newline-not-create proven and mutation-confirmed; a mutation adding `.trim()` to the brief turns the verbatim test red.
- fmt clean on touched files; clippy delta vs main zero; no `.snap` changes.

## Follow-up (separate PR)
Slice 2: a linked-issue reference (`external_ref`) for GitHub/Jira traceability, appended to the brief at dispatch so Claude fetches it itself, plus a dispatch guard (refuse a run with neither brief nor ref).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a multi-line **Brief** field to the issue creation wizard.
  - Brief text supports line breaks, editing, wrapping, and cursor navigation.
  - Brief content is saved with the issue and used when running it.

- **Bug Fixes**
  - Issue descriptions entered during creation are now correctly persisted.
  - Preserves brief formatting, including leading text and embedded newlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->