### PR TITLE
fix(hangar): terminalize pre-run setup faults instead of looping dispatched

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -564,9 +564,22 @@ async fn execute_claimed(
     let task: Task = TaskRepo::get_by_id(pool, &claimed.id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("claimed task {} vanished", claimed.id))?;
-    let ws_slug = workspace_slug(pool, &task.workspace_id).await?;
+    // Pre-run setup faults (slug lookup / execenv prep / F5 provision below) must
+    // TERMINALISE the still-`dispatched` task as failed rather than propagate: a
+    // propagated setup error left the row `dispatched`, and the stale-dispatch
+    // sweeper reclaimed + re-dispatched it into the SAME fault, looping invisibly
+    // (the board card never leaves Todo, the detail never shows an error) until
+    // the 5min dispatch TTL relabelled it `timeout` with no cause. See
+    // `finalize_setup_failure`.
+    let ws_slug = match workspace_slug(pool, &task.workspace_id).await {
+        Ok(s) => s,
+        Err(e) => return finalize_setup_failure(pool, &task, &e, clock, stats, events).await,
+    };
     let home = hangar_home();
-    let env = prepare_env(&task, &ws_slug, &home, clock)?;
+    let env = match prepare_env(&task, &ws_slug, &home, clock) {
+        Ok(env) => env,
+        Err(e) => return finalize_setup_failure(pool, &task, &e, clock, stats, events).await,
+    };
 
     // e38.21: inject the workspace's context prompt into the task's execenv as a
     // `CLAUDE.md` so the agent run actually sees the per-workspace context (the
@@ -647,14 +660,22 @@ async fn execute_claimed(
         || run_slug.clone(),
         |issue| format!("{}-{}", issue, task.agent_id),
     );
-    let run_wd = crate::workdir_provision::provision(
+    let run_wd = match crate::workdir_provision::provision(
         task.repo_ref.as_deref(),
         &run_slug,
         &scratch_slug,
         &home,
         &env.workdir,
         task.source_branch.as_deref(),
-    )?;
+    ) {
+        Ok(wd) => wd,
+        // F5 provision failed (e.g. the card's `repo_ref` could not be
+        // worktree-added) while the row is still `dispatched`. Terminalise it as
+        // failed with the real error instead of propagating — the propagate path
+        // left it `dispatched` to be reclaimed + re-dispatched into the same fault
+        // forever, invisible to the board/detail.
+        Err(e) => return finalize_setup_failure(pool, &task, &e, clock, stats, events).await,
+    };
     let location = run_location_for(&run_wd);
     tracing::info!(task_id = %task.id, cwd = %run_wd.path().display(), "run workdir provisioned");
 
@@ -1356,6 +1377,89 @@ async fn finalize_failure(
     // already-pending outcome (a sibling holds the slot), logged not propagated,
     // so one failed retry never downs the claim loop.
     maybe_spawn_retry(pool, &task.id, clock).await;
+    Ok(())
+}
+
+/// Terminalise a task that faulted during PRE-RUN setup — before the
+/// `dispatched -> running` start transition — as `failed`, surfacing the real
+/// error instead of stranding the row.
+///
+/// The claim loop resolves the workspace slug, prepares the isolated execenv,
+/// and provisions the run's working directory (F5) while the row is still
+/// `dispatched`. A fault in that window (a `repo_ref` that will not clone, an
+/// execenv that cannot be built) used to propagate out of [`execute_claimed`]
+/// with the row left `dispatched`: the stale-dispatch sweeper then reclaimed it
+/// past the 90s window and re-dispatched it into the SAME fault, looping
+/// invisibly — the board card never left Todo and the detail never showed an
+/// error — until the 5min dispatch TTL relabelled it `timeout` with no cause.
+///
+/// This seam finalises the row to `failed` AT ONCE, from `dispatched`, recording
+/// the real error (persisted into `result` so the detail renders it) under the
+/// terminal, no-retry
+/// [`FailureReason::ProvisionError`](ainb_hangar_store::service::fail::FailureReason::ProvisionError) —
+/// so the failure is terminal, attributed, and visible on the board + detail. The
+/// side-effects (stats / event / card auto-move / comment) mirror
+/// [`finalize_failure`], minus teardown + retry: there is no worktree to reclaim
+/// and a deterministic setup fault does not warrant a retry.
+///
+/// Always returns `Ok(())` so the claim loop treats the fault as HANDLED and
+/// never re-logs it as an unhandled execution error. A concurrent cancel that won
+/// the row (`dispatched -> cancelled`) is honoured (failure side-effects skipped),
+/// and a terminalise that itself faults (row vanished / DB error) is left to the
+/// dispatch-TTL sweeper backstop rather than looping.
+async fn finalize_setup_failure(
+    pool: &SqlitePool,
+    task: &Task,
+    // `Send + Sync` so the enclosing claim-loop future stays `Send` across the
+    // `.await`s below (a bare `&dyn Display` would make it un-spawnable).
+    error: &(dyn std::fmt::Display + Send + Sync),
+    clock: &dyn HangarClock,
+    stats: &HealthStats,
+    events: &EventSink,
+) -> anyhow::Result<()> {
+    use ainb_hangar_store::service::fail::FailureReason;
+    let reason = FailureReason::ProvisionError;
+    let message = format!("run setup failed before the agent started: {error}");
+    tracing::error!(task_id = %task.id, error = %error, "task setup failed before run; failing task");
+    match FailTaskService::fail_setup(pool, &task.id, reason, &message, clock).await {
+        Ok(_) => {}
+        // A human cancel won the row first (`dispatched -> cancelled`). Honour it:
+        // skip the failure side-effects and do not log a benign race as an error.
+        Err(FinalizeError::TerminalMismatch {
+            found: TaskState::Cancelled,
+            ..
+        }) => {
+            tracing::info!(task_id = %task.id, "setup failed but task was cancelled first; honoring cancel");
+            return Ok(());
+        }
+        // Could not terminalise (row vanished / already moved / DB fault). The
+        // dispatch-TTL sweeper is the backstop; do not loop-log as an execution error.
+        Err(e) => {
+            tracing::warn!(task_id = %task.id, error = %e, "could not terminalize setup failure; leaving to sweeper backstop");
+            return Ok(());
+        }
+    }
+    // The row is terminal: record the outcome, push the terminal event, and
+    // auto-move the card so the board and detail surface the failure (the whole
+    // point of the fix). All best-effort, never blocking the claim loop.
+    stats.record_failed(clock.now_ms() / 1_000);
+    emit_task_finished(
+        events,
+        task,
+        ainb_hangar_proto::events::TaskResult::Failure,
+        clock,
+    );
+    crate::board::auto_move_after_terminal(pool, task).await;
+    crate::board::unblock_dependents_after_terminal(pool, task).await;
+    progress_comment::emit_checkpoint(
+        pool,
+        &SystemIdGen,
+        clock,
+        task,
+        progress_comment::Checkpoint::Failed { reason },
+    )
+    .await;
+    tracing::warn!(task_id = %task.id, reason = reason.as_db_str(), "task failed during setup");
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_provision_error_fails_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_provision_error_fails_task.rs
@@ -1,0 +1,161 @@
+//! Regression tripwire: a task whose PRE-RUN provisioning faults (a `repo_ref`
+//! that cannot be worktree-added) must drive the row to `failed` WITHIN the
+//! dispatch budget — never loop `dispatched -> reclaim -> re-dispatch` invisibly.
+//!
+//! ```text
+//!  seed DB (ws+user+rt+agent)             spawn daemon in tmux
+//!         │                          repo_ref = <non-existent repo path>
+//!         ▼                                       │
+//!  INSERT queued task ──▶ claim ─▶ dispatched ─▶ provision(repo_ref) → Err
+//!   (repo_ref = bad path)                              │
+//!                                                      ▼
+//!                              finalize_setup_failure ─▶ failed
+//!                              failure_reason = "provision_error"
+//!                              result.content = the real git error
+//! ```
+//!
+//! # The bug this pins
+//!
+//! The daemon claims a task (`queued -> dispatched`) and provisions its working
+//! directory from the card's `repo_ref` BEFORE the `dispatched -> running` start
+//! transition. When provisioning faulted (e.g. the repo path could not be
+//! `git worktree add`-ed), `execute_claimed` propagated the error with the row
+//! left `dispatched`. The claim loop only logged `task execution errored` and
+//! continued; the stale-dispatch sweeper then reclaimed the row past the 90s
+//! window and re-dispatched it into the SAME fault, looping — the board card
+//! never left Todo and the task-detail never showed an error — until the 5min
+//! dispatch TTL relabelled it `timeout` with NO cause recorded. The fix
+//! terminalises the still-`dispatched` row to `failed` AT ONCE via
+//! `finalize_setup_failure`, recording the real error (reason `provision_error`,
+//! message on the `result` column) so the failure is terminal AND visible.
+//!
+//! # Why no real provider / repo is needed
+//!
+//! A NON-EXISTENT repo path IS the whole test — provisioning fails before any
+//! provider is reached, so it needs no auth, no spend, and no `live-e2e` gate. It
+//! exercises the GENUINE `execute_claimed` -> `provision` -> `finalize_setup_failure`
+//! path in the real daemon binary (no mock of the loop), and asserts the DB task
+//! ROW transitions to `failed` within a bounded DISPATCH budget — not merely that
+//! a log line was emitted, and far below the 5min dispatch TTL so a pass can only
+//! come from the terminalise-on-setup-error path, never the sweeper backstop.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::time::Duration;
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
+use tripwire_support::{DaemonSession, daemon_bin, seed_world, wait_for_db};
+
+#[tokio::test]
+async fn provision_fault_fails_task_within_budget() {
+    // Skip cleanly when tmux is unavailable (CI image lacking tmux), so the
+    // tripwire never produces a false failure on a host without the tool.
+    if !tripwire_support::tmux_available() {
+        eprintln!("SKIPPED: tmux not available; skipping provision-error tripwire");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    // 1. Bring the DB up to schema and seed the minimal (claude-backed) world.
+    let pool = open_pool(&db_path).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    // 2. Spawn the real daemon binary in a uniquely-named tmux session, claiming
+    //    for the seeded runtime. No provider path override is needed — the run
+    //    fails during provisioning, before any provider is reached.
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", home.path().to_str().unwrap()),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+        ],
+    );
+
+    // 3. Enqueue a queued task whose `repo_ref` names a path that is NOT a git
+    //    repo, so `provision` -> `git worktree add` fails deterministically while
+    //    the row is still `dispatched`. `created_at` is ~now so the queued-TTL
+    //    sweeper does not reap it before the claim loop sees it.
+    let bad_repo = home.path().join("no_such_repo");
+    assert!(!bad_repo.exists(), "the bogus repo path must not exist");
+    let task_id = "task-provision-err-1";
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, repo_ref, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(task_id)
+    .bind(&ids.workspace_id)
+    .bind(&ids.runtime_id)
+    .bind(&ids.agent_id)
+    .bind(bad_repo.to_str().unwrap())
+    .bind(tripwire_support::now_ms())
+    .execute(&pool)
+    .await
+    .expect("enqueue task");
+
+    // 4. Poll for `failed` within a bounded DISPATCH budget. Before the fix this
+    //    times out (task loops `dispatched`) and `wait_for_db` panics loudly with
+    //    `last=Some(("dispatched", ...))`; after the fix it returns the failed row.
+    //    30s is far below the 5min dispatch TTL, so a pass here can only come from
+    //    the terminalise-on-setup-error path, never the sweeper timeout backstop.
+    let row = wait_for_db(&pool, task_id, "failed", Duration::from_secs(30)).await;
+    drop(session); // kill the tmux session by exact name before assertions
+
+    let status: String = row.get("status");
+    assert_eq!(
+        status, "failed",
+        "a provisioning fault must finalize the task to failed"
+    );
+
+    // The reason is captured on the row (not just logged): the operator sees a run
+    // that could not be set up, distinct from a spawn error or an agent give-up.
+    let reason: Option<String> = row.get("failure_reason");
+    assert_eq!(
+        reason.as_deref(),
+        Some("provision_error"),
+        "failed row must carry the provision_error reason"
+    );
+
+    // The real error is persisted into `result` (the detail surface renders it),
+    // so the failure is attributed, not opaque.
+    let result: Option<String> = row.get("result");
+    let result = result.expect("a terminalised setup failure persists a result blob");
+    assert!(
+        result.contains("run setup failed before the agent started"),
+        "result must carry the human-readable setup error, got {result:?}"
+    );
+
+    // `finished_at` is stamped by the finalize seam — the row is genuinely
+    // terminal, not merely relabelled.
+    let finished_at: Option<i64> = row.get("finished_at");
+    assert!(
+        finished_at.is_some(),
+        "a finalized failed row stamps finished_at"
+    );
+
+    // The attempt counter never advanced past the first claim: the fix terminalises
+    // on the FIRST fault rather than looping reclaim/re-dispatch (which is what left
+    // the old behaviour invisible — no retry increment, no terminal state).
+    let attempt: i64 = row.get("attempt");
+    assert_eq!(
+        attempt, 1,
+        "a terminalised setup failure never re-dispatches"
+    );
+}
+
+/// Open a `SQLite` WAL pool at `db_path` (creating the file if absent).
+async fn open_pool(db_path: &std::path::Path) -> SqlitePool {
+    let opts = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+    SqlitePoolOptions::new().connect_with(opts).await.expect("open pool")
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
@@ -77,6 +77,18 @@ pub enum FailureReason {
     /// identically, so a retry only burns the chain — the fix is updating the
     /// parser, not re-running.
     ProviderContractDrift,
+    /// The run could not be SET UP before the agent started — the pre-run
+    /// provisioning failed (e.g. the card's `repo_ref` could not be cloned /
+    /// worktree-added, or the isolated execenv could not be prepared). Distinct
+    /// from [`Self::SpawnError`] (the provider binary itself is missing): here the
+    /// working directory the agent needs never materialised, so no provider was
+    /// even reached. Terminal (no retry): a provisioning fault is observed by the
+    /// daemon deterministically (a bad repo path does not self-heal on a
+    /// re-dispatch), so failing the row immediately with the real error beats the
+    /// alternative it replaces — the row stranded `dispatched`, reclaimed past the
+    /// 90s window, re-dispatched, and re-failing invisibly until the 5min dispatch
+    /// TTL relabelled it `timeout` with no cause recorded.
+    ProvisionError,
     /// An unclassified failure.
     Unknown,
 }
@@ -101,6 +113,7 @@ impl FailureReason {
             Self::SemanticInactivity => "semantic_inactivity",
             Self::SpawnError => "spawn_error",
             Self::ProviderContractDrift => "provider_contract_drift",
+            Self::ProvisionError => "provision_error",
             Self::Unknown => "unknown",
         }
     }
@@ -145,6 +158,70 @@ impl FailTaskService {
         )
         .await
     }
+
+    /// Terminalise a task that faulted during PRE-RUN setup: `dispatched ->
+    /// failed`, recording `reason`, a human-readable `message` (persisted into the
+    /// `result` column so the task-detail surface shows WHY), and
+    /// `finished_at = clock.now_ms()`.
+    ///
+    /// The daemon claims a task (`queued -> dispatched`) and then provisions its
+    /// working directory BEFORE the `dispatched -> running` start transition. A
+    /// fault in that window (a `repo_ref` that cannot be cloned, an execenv that
+    /// cannot be prepared) leaves the row `dispatched` — a state [`Self::fail`]
+    /// deliberately rejects (its source set is `running` / `queued`, since the
+    /// stale-dispatch sweeper owns the *timeout* path). Without a dedicated seam
+    /// such a fault propagated out of the run loop with the row still `dispatched`,
+    /// so the sweeper reclaimed it past the 90s window and re-dispatched it into
+    /// the same fault, looping invisibly. This seam finalises it AT ONCE, from
+    /// `dispatched`, so the failure is terminal and visible.
+    ///
+    /// The `message` rides the `result` column as `{"content": message}` — the
+    /// same [`TaskResult`](ainb_hangar_core::result::TaskResult) shape a completed
+    /// run writes — so the existing detail rendering surfaces the setup error with
+    /// no special-casing.
+    ///
+    /// Idempotent, like [`Self::fail`]: a replayed call on an already-`failed` row
+    /// returns [`FinalizeOutcome::AlreadyTerminal`]; a row that a concurrent cancel
+    /// won (`dispatched -> cancelled`) returns [`FinalizeError::TerminalMismatch`]
+    /// so the caller can honour the cancel.
+    ///
+    /// # Errors
+    ///
+    /// - [`FinalizeError::TerminalMismatch`] if the row is already `done` /
+    ///   `cancelled`.
+    /// - [`FinalizeError::IllegalState`] if the row is not `dispatched` (e.g. it
+    ///   already started, or the row is absent).
+    /// - [`FinalizeError::Db`] on an underlying database error.
+    #[tracing::instrument(
+        name = "task.fail_setup",
+        skip(pool, message, clock),
+        fields(task_id = %task_id, failure_reason = reason.as_db_str())
+    )]
+    pub async fn fail_setup(
+        pool: &SqlitePool,
+        task_id: &str,
+        reason: FailureReason,
+        message: &str,
+        clock: &dyn HangarClock,
+    ) -> Result<FinalizeOutcome, FinalizeError> {
+        let now = clock.now_ms();
+        let reason_str = reason.as_db_str();
+        // Persist the real error into `result` in the TaskResult shape so the
+        // task-detail surface renders it (a killed/no-work run's `content`-only
+        // JSON is a legal, round-tripping TaskResult).
+        let result_json = serde_json::json!({ "content": message }).to_string();
+        finalize_idempotent(
+            pool,
+            task_id,
+            TaskState::Failed,
+            &[TaskState::Dispatched],
+            "UPDATE agent_task_queue \
+             SET status = 'failed', failure_reason = ?1, result = ?2, finished_at = ?3 \
+             WHERE id = ?4 AND status = 'dispatched'",
+            move |q| q.bind(reason_str).bind(result_json).bind(now).bind(task_id),
+        )
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -166,6 +243,7 @@ mod tests {
             FailureReason::SemanticInactivity,
             FailureReason::SpawnError,
             FailureReason::ProviderContractDrift,
+            FailureReason::ProvisionError,
             FailureReason::Unknown,
         ] {
             let serde_token = serde_json::to_value(reason)

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -255,6 +255,10 @@ impl RetryService {
             | FailureReason::Timeout
             | FailureReason::SpawnError
             | FailureReason::ProviderContractDrift
+            // A provisioning setup fault (bad repo_ref / execenv) is deterministic:
+            // it re-fails identically on re-dispatch, so a retry only burns the
+            // chain — terminal, no retry.
+            | FailureReason::ProvisionError
             | FailureReason::Unknown => RetryDisposition::NoRetry,
         }
     }
@@ -286,6 +290,7 @@ const FAILURE_REASONS: &[FailureReason] = &[
     FailureReason::SemanticInactivity,
     FailureReason::SpawnError,
     FailureReason::ProviderContractDrift,
+    FailureReason::ProvisionError,
     FailureReason::Unknown,
 ];
 
@@ -311,6 +316,7 @@ mod tests {
             FailureReason::SemanticInactivity,
             FailureReason::SpawnError,
             FailureReason::ProviderContractDrift,
+            FailureReason::ProvisionError,
             FailureReason::Unknown,
         ] {
             assert!(
@@ -320,7 +326,7 @@ mod tests {
         }
         assert_eq!(
             FAILURE_REASONS.len(),
-            11,
+            12,
             "FAILURE_REASONS length drifted from the FailureReason variant count",
         );
     }
@@ -354,6 +360,7 @@ mod tests {
             RetryService::retry_disposition(ProviderContractDrift),
             NoRetry
         );
+        assert_eq!(RetryService::retry_disposition(ProvisionError), NoRetry);
         assert_eq!(RetryService::retry_disposition(Unknown), NoRetry);
     }
 }


### PR DESCRIPTION
## Problem

A hangar task whose execution errors **deep in provisioning** — before the `dispatched -> running` start transition — never reaches a terminal `failed` state. `execute_claimed` provisions the run's working directory from the card's `repo_ref` (F5) while the row is still `dispatched`. When that faults (a `repo_ref` that cannot be `git worktree add`-ed, or an execenv that cannot be prepared), the error was propagated with the row left `dispatched`:

- the claim loop only logged `task execution errored` and continued;
- the stale-dispatch sweeper reclaimed the row past the 90s window (a reclaim is a *redelivery*, so `attempt` stayed 1) and re-dispatched it into the **same** fault;
- this looped invisibly — the board card never left Todo, task-detail read `Runs: 1 (last: queued)` with no error — until the 5min dispatch TTL relabelled it `timeout` with no cause recorded.

Found by the hangar e2e loop (`issue-run-failure-never-terminalizes-invisible`): two identical ERROR lines ~100s apart with a sweeper reclaim between them, status stuck `dispatched` for ~2.5 min.

This is distinct from the NULL-dispatched_at sweeper immortality bug (a separate branch) — here the row has a real `dispatched_at` and is legitimately reclaimed/re-dispatched in a loop; the fix is to terminalize on the first observed fault so it never enters the loop.

## Fix

- **`ainb-hangar-store` `fail.rs`**: new `FailureReason::ProvisionError` (terminal, no-retry) + new `FailTaskService::fail_setup` that finalizes `dispatched -> failed`, recording the reason and the real error message into the `result` column (in the `TaskResult` shape, so the existing detail rendering surfaces it). `fail()` still deliberately rejects `dispatched` — the sweeper owns the *timeout* path — so this is a purpose-built seam, not a widening of `fail()`.
- **`retry.rs`**: `ProvisionError -> NoRetry` (a provisioning fault is deterministic and re-fails identically on re-dispatch).
- **`ainb-hangar-daemon` `run_loop.rs`**: pre-run setup faults (workspace-slug lookup, `prepare_env`, F5 `provision`) now terminalize the still-`dispatched` row via a new `finalize_setup_failure` helper instead of propagating. It mirrors `finalize_failure`'s side-effects (stats tick, terminal event, board auto-move, issue comment) minus teardown/retry — there is no worktree to reclaim and no retry warranted. The board and detail surface the failure through the **existing** failed rendering (no plugin change needed).

## Test

New tripwire `tripwire_provision_error_fails_task.rs` drives the **real daemon binary** in tmux with a task whose `repo_ref` is a non-existent repo path, and asserts the row reaches `failed` (reason `provision_error`, real error persisted on `result`, `finished_at` stamped, `attempt` still 1) **within a 30s dispatch budget** — far below the 5min dispatch TTL, so a pass can only come from the terminalize-on-setup-error path, never the sweeper backstop.

TDD verified: **red** before (in-place mutation restoring the propagate behavior → `last=Some(("dispatched", None))`, times out at 30s), **green** after (0.57s).

## Verification

- `cargo test -p ainb-hangar-store` — green (incl. updated `fail`/`retry` taxonomy tests)
- `cargo test -p ainb-hangar-daemon --lib` — 280 passed
- `tripwire_provision_error_fails_task`, `tripwire_spawn_error_fails_task`, `tripwire_ttl_sweeper_fails_stale_dispatched`, `tripwire_retry_timeout_e2e`, `sweeper_ttls` — all green
- `cargo fmt --check` clean; new code clippy-clean (pre-existing `ainb-hangar-core` warnings untouched)
- `cargo build -p ainb` — success

Landing deferred pending validation; branch tip `2c3b1941`.