### PR TITLE
fix(hangar): finalize pre-start setup faults instead of stranding tasks dispatched (zombie-dispatch)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -566,7 +566,18 @@ async fn execute_claimed(
         .ok_or_else(|| anyhow::anyhow!("claimed task {} vanished", claimed.id))?;
     let ws_slug = workspace_slug(pool, &task.workspace_id).await?;
     let home = hangar_home();
-    let env = prepare_env(&task, &ws_slug, &home, clock)?;
+    // A `prepare_env` fault is a PRE-START setup fault: the row is still
+    // `dispatched` (the `dispatched -> running` transition is far below). Returning
+    // it via `?` would leave the row `dispatched` for the stale-dispatch sweeper to
+    // reclaim forever (fresh `dispatched_at`, unchanged `attempt`) — the
+    // zombie-dispatch bug. Instead drive it terminal through the shared fail seam.
+    let env = match prepare_env(&task, &ws_slug, &home, clock) {
+        Ok(env) => env,
+        Err(e) => {
+            tracing::error!(task_id = %task.id, error = %e, "prepare_env failed pre-start; failing task");
+            return finalize_pre_start_failure(pool, &task, None, clock, stats, events).await;
+        }
+    };
 
     // e38.21: inject the workspace's context prompt into the task's execenv as a
     // `CLAUDE.md` so the agent run actually sees the per-workspace context (the
@@ -619,12 +630,16 @@ async fn execute_claimed(
     // scratch repo; a chat / autopilot task has no `repo_ref` and runs in the
     // in-tree fallback workdir (the pre-F5 behaviour). The short-id slug is unique
     // per task, so N cards on ONE repo provision N distinct worktrees that never
-    // collide (the F5 concurrency guarantee). A provision fault is treated like
-    // any other setup fault (`prepare_env` above): it propagates so the row stays
-    // `dispatched` and the stale-dispatch sweeper reclaims + re-queues it, rather
-    // than dispatching a run into an unprovisioned dir. The injected `CLAUDE.md`
-    // (above) + skills stay in the task tree, NOT the worktree, so teardown's
-    // keep-if-dirty check sees only genuine agent work.
+    // collide (the F5 concurrency guarantee). A provision fault (e.g. a bad /
+    // unclonable `repo_ref`) is a PRE-START setup fault, like `prepare_env` above:
+    // it is FINALISED terminal through `finalize_pre_start_failure` (a
+    // `SetupError`, bounded by `max_attempts` via the F06 retry chain), NOT
+    // returned via `?`. Returning it would leave the row `dispatched`, where the
+    // stale-dispatch sweeper redelivers it every reclaim window with a fresh
+    // `dispatched_at` and an unchanged `attempt` — so it never ages past the
+    // dispatch TTL for the fail step and reclaims forever (the zombie-dispatch
+    // bug). The injected `CLAUDE.md` (above) + skills stay in the task tree, NOT
+    // the worktree, so teardown's keep-if-dirty check sees only genuine agent work.
     //
     // tcp 19n: the repo is read straight off the claimed `Task` (which now carries
     // `repo_ref` verbatim from the row) rather than a second `card_parity` query.
@@ -647,14 +662,23 @@ async fn execute_claimed(
         || run_slug.clone(),
         |issue| format!("{}-{}", issue, task.agent_id),
     );
-    let run_wd = crate::workdir_provision::provision(
+    let run_wd = match crate::workdir_provision::provision(
         task.repo_ref.as_deref(),
         &run_slug,
         &scratch_slug,
         &home,
         &env.workdir,
         task.source_branch.as_deref(),
-    )?;
+    ) {
+        Ok(wd) => wd,
+        Err(e) => {
+            tracing::error!(task_id = %task.id, error = %e, "workdir provision failed pre-start; failing task");
+            // No `RunWorkdir` handle exists (provision faulted); any partial
+            // checkout is reclaimed by the worktree-GC sweeper. Drive the row
+            // terminal instead of stranding it `dispatched`.
+            return finalize_pre_start_failure(pool, &task, None, clock, stats, events).await;
+        }
+    };
     let location = run_location_for(&run_wd);
     tracing::info!(task_id = %task.id, cwd = %run_wd.path().display(), "run workdir provisioned");
 
@@ -1355,6 +1379,121 @@ async fn finalize_failure(
     // can collide with the per-issue pending-unique index — that is a benign
     // already-pending outcome (a sibling holds the slot), logged not propagated,
     // so one failed retry never downs the claim loop.
+    maybe_spawn_retry(pool, &task.id, clock).await;
+    Ok(())
+}
+
+/// Finalise a PRE-START setup fault — `prepare_env` or
+/// `workdir_provision::provision` faulted while the row was still `dispatched`,
+/// so the run never reached `running`.
+///
+/// Left unhandled, such a fault returned via `?` to the claim loop, which only
+/// logged `task execution errored`. The row stayed `dispatched`, and the
+/// stale-dispatch sweeper redelivered it every reclaim window with a FRESH
+/// `dispatched_at` and an UNCHANGED `attempt` — so it never aged past the
+/// dispatch TTL for `sweep_stale_dispatched`'s fail step, never consumed
+/// `max_attempts`, and reclaimed forever: a zombie dispatch, never terminal, its
+/// card stuck in Todo with no failure badge. This drives the row TERMINAL
+/// instead, so a deterministic setup fault (e.g. a bad `repo_ref`) burns the F06
+/// retry chain to exhaustion and lands `failed` rather than looping.
+///
+/// The row is walked `dispatched -> running -> failed` through the two legal FSM
+/// edges — [`FailTaskService::fail`] accepts only `running` / `queued`, so the
+/// `running` hop is required — with reason [`FailureReason::SetupError`], then the
+/// same terminal side-effects the runner-failure path drives: the health tick,
+/// the `TaskFinished(Failure)` event, the card auto-move (out of Todo into the
+/// board's failed column), dependent unblocking, the durable blocker comment,
+/// worktree teardown (if a handle exists), and [`maybe_spawn_retry`] — so the F06
+/// chain bounds the retries by `max_attempts` and lands the chain terminal
+/// `failed` on exhaustion. The per-run artifacts a never-run task has none of
+/// (session id, usage, branch, run-history) are simply omitted.
+///
+/// `run_wd` is the provisioned worktree when one exists. It never does for the
+/// two current callers (a `prepare_env` fault precedes provisioning, and a
+/// `provision` fault yields no handle — any partial checkout is reclaimed by the
+/// worktree-GC sweeper), but the parameter keeps the seam honest for a future
+/// pre-`running` fault that already holds a checkout.
+///
+/// # Errors
+///
+/// Propagates a genuine DB fault from the `start` / `fail` transitions. A cancel
+/// that beat the transition is honored (teardown + `Ok`), never surfaced as an
+/// error.
+async fn finalize_pre_start_failure(
+    pool: &SqlitePool,
+    task: &Task,
+    run_wd: Option<&crate::workdir_provision::RunWorkdir>,
+    clock: &dyn HangarClock,
+    stats: &HealthStats,
+    events: &EventSink,
+) -> anyhow::Result<()> {
+    use ainb_hangar_store::service::fail::FailureReason;
+
+    let reason = FailureReason::SetupError;
+    let mut lifecycle = crate::fsm::LifecycleGuard::claimed();
+
+    // dispatched -> running: the terminal `running -> failed` edge below needs the
+    // row in `running` (FailTaskService::fail rejects `dispatched`). A cancel that
+    // flipped the row `-> cancelled` first wins — honor it (teardown + return).
+    lifecycle.fire(crate::fsm::LifecycleEvent::Start)?;
+    match StartTaskService::start(pool, &task.id, clock).await {
+        Ok(_) => {}
+        Err(FinalizeError::TerminalMismatch {
+            found: TaskState::Cancelled,
+            ..
+        }) => {
+            tracing::info!(task_id = %task.id, "cancelled before setup-fail; tearing down without failing");
+            if let Some(wd) = run_wd {
+                teardown_workdir(wd, &task.id);
+            }
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    // running -> failed with the setup reason.
+    lifecycle.fire(crate::fsm::LifecycleEvent::Fail)?;
+    match FailTaskService::fail(pool, &task.id, reason, clock).await {
+        Ok(_) => {}
+        // A human cancel beat the fail — honor it (mirrors `finalize_failure`).
+        Err(FinalizeError::TerminalMismatch {
+            found: TaskState::Cancelled,
+            ..
+        }) => {
+            tracing::info!(task_id = %task.id, "setup fault but cancelled first; honoring cancel");
+            if let Some(wd) = run_wd {
+                teardown_workdir(wd, &task.id);
+            }
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    stats.record_failed(clock.now_ms() / 1_000);
+    emit_task_finished(
+        events,
+        task,
+        ainb_hangar_proto::events::TaskResult::Failure,
+        clock,
+    );
+    crate::board::auto_move_after_terminal(pool, task).await;
+    crate::board::unblock_dependents_after_terminal(pool, task).await;
+    progress_comment::emit_checkpoint(
+        pool,
+        &SystemIdGen,
+        clock,
+        task,
+        progress_comment::Checkpoint::Failed { reason },
+    )
+    .await;
+    if let Some(wd) = run_wd {
+        teardown_workdir(wd, &task.id);
+    }
+    tracing::warn!(
+        task_id = %task.id,
+        reason = reason.as_db_str(),
+        "task failed (pre-start setup fault)"
+    );
     maybe_spawn_retry(pool, &task.id, clock).await;
     Ok(())
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_setup_fault_fails_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_setup_fault_fails_task.rs
@@ -1,0 +1,243 @@
+//! Regression tripwire: a PRE-START setup fault (a bad / unclonable `repo_ref`
+//! that faults `workdir_provision::provision`) must drive the task chain TERMINAL
+//! (`failed`, bounded by `max_attempts`) — never leave it reclaiming forever.
+//!
+//! ```text
+//!  seed DB (ws+user+rt+agent)          spawn daemon in tmux
+//!         │                                    │
+//!         ▼                                    ▼
+//!  INSERT queued task ──▶ claim ─▶ dispatched ─▶ provision(bad repo_ref) ─▶ Err
+//!  (repo_ref = non-git path)                          │
+//!                                                      ▼
+//!                           finalize_pre_start_failure ─▶ running ─▶ failed
+//!                           reason = "setup_error"          │
+//!                                                           ▼
+//!                              maybe_spawn_retry ─▶ child (attempt+1) … until
+//!                              attempt == max_attempts ─▶ chain terminal, STOP
+//! ```
+//!
+//! # The bug this pins (zombie-dispatch)
+//!
+//! When `execute_claimed` hit a pre-start setup fault (`prepare_env` /
+//! `workdir_provision::provision`) it returned the `Err` via `?`. The claim loop
+//! only logged `task execution errored`; the row stayed `dispatched`. The
+//! stale-dispatch sweeper then redelivered it every reclaim window (~90s) with a
+//! FRESH `dispatched_at` and an UNCHANGED `attempt` — so it never aged past the
+//! dispatch TTL for the fail step, never consumed `max_attempts`, and reclaimed
+//! FOREVER. A user saw a task frozen `dispatched`, `attempt` stuck at 1, its card
+//! stuck in Todo with no failure badge, cycle after cycle.
+//!
+//! The fix finalises a pre-start fault terminal (a `setup_error`) through the
+//! shared fail seam, so the F06 retry chain bounds it by `max_attempts` and the
+//! chain lands `failed` on exhaustion.
+//!
+//! # Why no real provider / repo is needed
+//!
+//! A NON-GIT `repo_ref` path IS the whole test — `provision` faults before any
+//! provider is spawned, so it needs no auth, no spend, no clone, and no
+//! `live-e2e` gate. It exercises the GENUINE `execute_claimed` → provision-fault
+//! → finalize path in the real daemon binary, and asserts the DB task ROWS reach
+//! terminal `failed` — not merely that a log line was emitted.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::time::{Duration, Instant};
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
+use tripwire_support::{DaemonSession, daemon_bin, seed_world, wait_for_db};
+
+#[tokio::test]
+async fn pre_start_setup_fault_fails_chain_within_max_attempts() {
+    // Skip cleanly when tmux is unavailable, so the tripwire never produces a
+    // false failure on a host without the tool.
+    if !tripwire_support::tmux_available() {
+        eprintln!("SKIPPED: tmux not available; skipping setup-fault tripwire");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    // 1. Bring the DB up to schema and seed the minimal (claude-backed) world.
+    let pool = open_pool(&db_path).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    // 2. A `repo_ref` that points at a path that is NOT a git repo, so
+    //    `workdir_provision::provision` faults BEFORE any provider spawn — the
+    //    exact pre-start stranding trigger the fix must finalise.
+    let bogus_repo = home.path().join("not_a_git_repo");
+    assert!(!bogus_repo.exists(), "the bogus repo path must not exist");
+
+    // 3. Spawn the real daemon binary in a uniquely-named tmux session. Sandbox
+    //    off + a bogus claude path are harmless (the provider is never reached);
+    //    fast poll so the claim + retry chain settle quickly. Sweeper timing is
+    //    left at defaults — the fix makes the row terminal in `execute_claimed`,
+    //    so this test must pass WITHOUT relying on any sweeper pass.
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", home.path().to_str().unwrap()),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_CLAUDE_PATH", "/nonexistent/claude"),
+            ("HANGAR_DAEMON_DISABLE_SANDBOX", "1"),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+        ],
+    );
+
+    // 4. Enqueue a queued task with the bad `repo_ref` and `max_attempts = 2`.
+    //    `created_at` ~now so the queued-TTL sweeper does not reap it first.
+    let task_id = "task-setup-fault-1";
+    let max_attempts: i64 = 2;
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, repo_ref, max_attempts, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(task_id)
+    .bind(&ids.workspace_id)
+    .bind(&ids.runtime_id)
+    .bind(&ids.agent_id)
+    .bind(bogus_repo.to_str().unwrap())
+    .bind(max_attempts)
+    .bind(tripwire_support::now_ms())
+    .execute(&pool)
+    .await
+    .expect("enqueue task");
+
+    // 5. The ORIGINAL (attempt 1) row must reach `failed` fast — far below any
+    //    sweeper cadence, so a pass here can only come from the finalize-on-
+    //    setup-fault path, never a sweeper backstop. Before the fix this times out
+    //    with `last=Some(("dispatched", None))` (the zombie state).
+    let row = wait_for_db(&pool, task_id, "failed", Duration::from_secs(30)).await;
+    let reason: Option<String> = row.get("failure_reason");
+    assert_eq!(
+        reason.as_deref(),
+        Some("setup_error"),
+        "the failed row must carry the setup_error reason, not sit reason-less"
+    );
+    let finished_at: Option<i64> = row.get("finished_at");
+    assert!(
+        finished_at.is_some(),
+        "a finalized failed row stamps finished_at"
+    );
+    let attempt: i64 = row.get("attempt");
+    assert_eq!(attempt, 1, "the original row is attempt 1");
+
+    // 6. The CHAIN must settle terminal: the F06 retry bounds the setup fault by
+    //    `max_attempts`, so within a bounded budget there is a `failed` row at
+    //    `attempt == max_attempts` AND no row for this agent is left `dispatched`
+    //    or `queued` (the proof there is no infinite reclaim loop).
+    let settled =
+        wait_for_chain_settled(&pool, &ids.agent_id, max_attempts, Duration::from_secs(30)).await;
+
+    // Kill the tmux session by exact name before the final assertions so the
+    // daemon cannot mutate rows underneath them.
+    drop(session);
+
+    assert!(
+        settled.terminal_at_max,
+        "expected a failed row at attempt=={max_attempts}; rows={:?}",
+        settled.rows
+    );
+    assert_eq!(
+        settled.non_terminal, 0,
+        "no row may be left dispatched/queued (would be an infinite reclaim loop); rows={:?}",
+        settled.rows
+    );
+    // Bounded: exactly `max_attempts` rows (attempt 1 + one retry child), never an
+    // unbounded pile of reclaim-spawned children.
+    assert_eq!(
+        settled.rows.len() as i64,
+        max_attempts,
+        "the chain must be bounded by max_attempts; rows={:?}",
+        settled.rows
+    );
+    // Every terminal row carries the setup reason (no reason-less zombie left).
+    for (_id, status, r_attempt, r_reason) in &settled.rows {
+        assert_eq!(status, "failed", "every chain row must be terminal failed");
+        assert_eq!(
+            r_reason.as_deref(),
+            Some("setup_error"),
+            "chain row (attempt {r_attempt}) must carry setup_error"
+        );
+    }
+}
+
+/// The observed state of a task chain (all rows sharing one agent).
+struct ChainState {
+    /// `(id, status, attempt, failure_reason)` for every chain row.
+    rows: Vec<(String, String, i64, Option<String>)>,
+    /// Rows still `dispatched` or `queued` (a non-zero count is the zombie bug).
+    non_terminal: usize,
+    /// Whether some `failed` row reached `attempt == max_attempts`.
+    terminal_at_max: bool,
+}
+
+/// Poll the agent's task rows until the chain has settled — no `dispatched` /
+/// `queued` row remains AND a `failed` row reached `attempt == max_attempts` — or
+/// the budget elapses (returning the last-seen state either way, so the caller's
+/// assertions render the failure).
+async fn wait_for_chain_settled(
+    pool: &SqlitePool,
+    agent_id: &str,
+    max_attempts: i64,
+    budget: Duration,
+) -> ChainState {
+    let deadline = Instant::now() + budget;
+    loop {
+        let state = fetch_chain(pool, agent_id, max_attempts).await;
+        let settled = state.non_terminal == 0 && state.terminal_at_max;
+        if settled || Instant::now() >= deadline {
+            return state;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+/// Snapshot every task row for `agent_id` and summarise the chain state.
+async fn fetch_chain(pool: &SqlitePool, agent_id: &str, max_attempts: i64) -> ChainState {
+    let rows = sqlx::query(
+        "SELECT id, status, attempt, failure_reason FROM agent_task_queue \
+         WHERE agent_id = ? ORDER BY attempt",
+    )
+    .bind(agent_id)
+    .fetch_all(pool)
+    .await
+    .expect("query chain");
+
+    let mut out = Vec::new();
+    let mut non_terminal = 0usize;
+    let mut terminal_at_max = false;
+    for row in rows {
+        let id: String = row.get("id");
+        let status: String = row.get("status");
+        let attempt: i64 = row.get("attempt");
+        let reason: Option<String> = row.get("failure_reason");
+        if status == "dispatched" || status == "queued" {
+            non_terminal += 1;
+        }
+        if status == "failed" && attempt == max_attempts {
+            terminal_at_max = true;
+        }
+        out.push((id, status, attempt, reason));
+    }
+    ChainState {
+        rows: out,
+        non_terminal,
+        terminal_at_max,
+    }
+}
+
+/// Open a `SQLite` WAL pool at `db_path` (creating the file if absent).
+async fn open_pool(db_path: &std::path::Path) -> SqlitePool {
+    let opts = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+    SqlitePoolOptions::new().connect_with(opts).await.expect("open pool")
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
@@ -77,6 +77,18 @@ pub enum FailureReason {
     /// identically, so a retry only burns the chain — the fix is updating the
     /// parser, not re-running.
     ProviderContractDrift,
+    /// A PRE-START setup fault stranded the run before the provider ever ran:
+    /// preparing the isolated execenv (`prepare_env`) or provisioning the run's
+    /// working directory (`workdir_provision::provision` — e.g. a bad / unclonable
+    /// `repo_ref`) faulted while the row was still `dispatched`. Distinct from
+    /// [`Self::SpawnError`] (the workdir was ready and the *provider binary* would
+    /// not spawn) and [`Self::AgentError`] (the agent ran and gave up): here
+    /// neither the workdir nor the agent ever came up. Classed as INFRASTRUCTURE
+    /// (retryable, bounded by `max_attempts`) because a setup fault is often
+    /// transient (a network blip cloning, momentary disk / runtime pressure); the
+    /// deterministic case (a permanently-bad repo) simply burns the retry chain to
+    /// exhaustion and lands terminal `failed` rather than reclaiming forever.
+    SetupError,
     /// An unclassified failure.
     Unknown,
 }
@@ -101,6 +113,7 @@ impl FailureReason {
             Self::SemanticInactivity => "semantic_inactivity",
             Self::SpawnError => "spawn_error",
             Self::ProviderContractDrift => "provider_contract_drift",
+            Self::SetupError => "setup_error",
             Self::Unknown => "unknown",
         }
     }
@@ -166,6 +179,7 @@ mod tests {
             FailureReason::SemanticInactivity,
             FailureReason::SpawnError,
             FailureReason::ProviderContractDrift,
+            FailureReason::SetupError,
             FailureReason::Unknown,
         ] {
             let serde_token = serde_json::to_value(reason)

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -16,9 +16,11 @@
 //! [`RetryDisposition`]s ([`RetryService::retry_disposition`]):
 //!
 //! - **[`RetryDisposition::ResumeRetry`]** —
-//!   [`FailureReason::RuntimeOffline`] / [`FailureReason::RuntimeRecovery`]: the
-//!   *infrastructure* failed, not the agent, so the retry **resumes** the
-//!   parent's provider session (`session_id` is carried onto the child).
+//!   [`FailureReason::RuntimeOffline`] / [`FailureReason::RuntimeRecovery`] /
+//!   [`FailureReason::SetupError`]: the *infrastructure* failed, not the agent, so
+//!   the retry **resumes** the parent's provider session (`session_id` is carried
+//!   onto the child). A `SetupError` never ran an agent, so its inherited
+//!   `session_id` is NULL and the retry simply starts fresh.
 //! - **[`RetryDisposition::FreshRetry`]** — the conversation-poisoning terminals
 //!   [`FailureReason::IterationLimit`] / [`FailureReason::ApiInvalidRequest`] /
 //!   [`FailureReason::SemanticInactivity`]: the model wedged on its own context,
@@ -238,9 +240,16 @@ impl RetryService {
     pub const fn retry_disposition(reason: FailureReason) -> RetryDisposition {
         match reason {
             // Infrastructure failed, not the agent — resume the conversation.
-            FailureReason::RuntimeOffline | FailureReason::RuntimeRecovery => {
-                RetryDisposition::ResumeRetry
-            }
+            // `SetupError` is a PRE-START setup fault (execenv prep / workdir
+            // provision): infrastructure, not the agent, and often transient, so it
+            // retries — bounded by `max_attempts`. It never ran an agent, so there
+            // is no session to resume (the child's `session_id` inherits NULL and a
+            // fresh attempt begins naturally); `ResumeRetry` is the honest class
+            // ("infra failed, not the agent"), and the missing session makes the
+            // resume-vs-fresh distinction moot here.
+            FailureReason::RuntimeOffline
+            | FailureReason::RuntimeRecovery
+            | FailureReason::SetupError => RetryDisposition::ResumeRetry,
             // Conversation-poisoning terminals — retry, but in a fresh session.
             FailureReason::IterationLimit
             | FailureReason::ApiInvalidRequest
@@ -286,6 +295,7 @@ const FAILURE_REASONS: &[FailureReason] = &[
     FailureReason::SemanticInactivity,
     FailureReason::SpawnError,
     FailureReason::ProviderContractDrift,
+    FailureReason::SetupError,
     FailureReason::Unknown,
 ];
 
@@ -311,6 +321,7 @@ mod tests {
             FailureReason::SemanticInactivity,
             FailureReason::SpawnError,
             FailureReason::ProviderContractDrift,
+            FailureReason::SetupError,
             FailureReason::Unknown,
         ] {
             assert!(
@@ -320,7 +331,7 @@ mod tests {
         }
         assert_eq!(
             FAILURE_REASONS.len(),
-            11,
+            12,
             "FAILURE_REASONS length drifted from the FailureReason variant count",
         );
     }
@@ -354,6 +365,7 @@ mod tests {
             RetryService::retry_disposition(ProviderContractDrift),
             NoRetry
         );
+        assert_eq!(RetryService::retry_disposition(SetupError), ResumeRetry);
         assert_eq!(RetryService::retry_disposition(Unknown), NoRetry);
     }
 }


### PR DESCRIPTION
## Bug: zombie-dispatch

Found by the hangar e2e loop. A pre-start setup fault in `execute_claimed` left a
task frozen `dispatched` and reclaiming forever.

### Root cause

`prepare_env` and `workdir_provision::provision` run BEFORE the
`dispatched -> running` transition. On fault they returned via `?`. The claim
loop's only handling is `tracing::error!("task execution errored")`
(`run_loop.rs`), so the row stayed `dispatched`. `reclaim_stale_dispatched`
(`sweeper.rs`) then redelivered the row to `queued` every reclaim window (~90s)
with a **fresh `dispatched_at`** and **`attempt` unchanged** — so it never aged
past `dispatched_ttl` for `sweep_stale_dispatched`'s fail step and never consumed
`max_attempts`. Evidence: a task sat `status=dispatched, attempt=1`
(`max_attempts=2`), `failure_reason` NULL across 3 cycles ~90s apart; its card sat
in Todo with no badge. The terminal-failure path (`finalize_failed` → attempt +
`failure_reason` + `TaskFinished(Failure)` + `auto_move_after_terminal` +
`maybe_spawn_retry`) only runs after the provider actually runs, so a pre-running
fault never reached it.

### Fix

Make a pre-start setup fault **terminal** instead of a silent `dispatched`:

- **`ainb-hangar-store`** — add `FailureReason::SetupError` (token `setup_error`),
  classed as infrastructure (`ResumeRetry`), so a setup fault retries bounded by
  `max_attempts` (it never ran an agent, so the inherited `session_id` is NULL and
  the retry starts fresh).
- **`ainb-hangar-daemon`** — guard both pre-start setup sites in `execute_claimed`.
  On fault, drive the row terminal through the new `finalize_pre_start_failure`:
  `dispatched -> running -> failed` (the two legal FSM edges; `FailTaskService::fail`
  accepts only `running`/`queued`) with `SetupError`, then the same terminal tail
  the runner-failure path drives — health tick, `TaskFinished(Failure)`, card
  `auto_move_after_terminal` (out of Todo into the failed column), dependent
  unblock, durable blocker comment, worktree teardown if any, and
  `maybe_spawn_retry`. So the F06 chain bounds retries by `max_attempts` and lands
  the chain terminal `failed` on exhaustion — no infinite reclaim loop.
- Updated the stale `run_loop.rs` comment that claimed the sweeper would
  "reclaim + re-queue" a provision fault (reclaim is for lost claims, not
  deterministic setup faults).

### Test (fails before / passes after)

`tripwire_setup_fault_fails_task.rs` drives the REAL daemon binary with a task
whose `repo_ref` is a non-git path (faults `provision` before any provider spawn)
and asserts the chain reaches terminal `failed` at `attempt == max_attempts`, with
no row left `dispatched`/`queued` and every row carrying `setup_error`. Verified
red against the pre-fix logic (bare `?`): `last=Some(("dispatched", None))` — the
exact zombie state — then green with the fix.

### Verification

- `cargo test -p ainb-hangar-store` (full) — green
- `cargo test -p ainb-hangar-daemon --lib` (282) + sweeper/scheduler/retry/spawn-error/ttl-sweeper/new tripwire — green
- `cargo build -p ainb` — clean
- `cargo fmt` on touched crates (pre-existing drift file `live_e2e.rs` reverted)

Clippy findings on this host are all in the untouched `ainb-hangar-core` crate
(host clippy 1.96.0 noise, `profile.rs` byte-identical to main); none in the
changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tasks that encounter setup failures before execution now transition to a terminal failed state instead of remaining stuck in dispatch.
  - Setup failures are clearly recorded with a dedicated `setup_error` reason.
  - Failed tasks now complete cleanup, unblock dependent work, and correctly follow retry limits.
  - Added regression coverage to verify setup-failure chains settle within the configured maximum attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->