### PR TITLE
fix(hangar): target a named workspace agent from the Issues create wizard (V3-F3)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -201,7 +201,7 @@ async fn auto_run_dependent(pool: &SqlitePool, ws: &WorkspaceId, issue_id: &str)
     };
     // Board-agnostic (the auto-run seam does not know which board); the F4 board
     // tier is skipped, the cascade still resolves the agent. Headless run.
-    match crate::rpc::run_card(pool, ws, None, &issue, "headless", None, None, None).await {
+    match crate::rpc::run_card(pool, ws, None, &issue, "headless", None, None, None, None).await {
         Ok(_) => tracing::info!(issue = %issue_id, "card auto-run launched (last blocker done)"),
         Err(crate::rpc::CardRunError::Blocked(_) | crate::rpc::CardRunError::ActiveRun(_)) => {
             tracing::debug!(issue = %issue_id, "auto-run skipped (not launchable right now)");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -2751,6 +2751,7 @@ async fn handle_board_card_run(
         run_override,
         agent_override,
         params.source_branch.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+        None, // a board card runs under the card's own assignee (no wizard override)
     )
     .await
     .map_err(card_run_err)?;
@@ -2852,6 +2853,16 @@ async fn handle_issue_run(
     let run_override = run_override_owned.as_deref();
     let agent_override = params.agent.as_deref().and_then(AgentKind::parse);
     let source_override = params.source_branch.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    // V3-F3: a run-time assignee override names the NAMED workspace agent the run
+    // dispatches under. A malformed ref is dropped (the run then resolves the
+    // agent from the issue's persisted assignee) rather than failing the run — the
+    // wire stays forward-compatible, matching the `agent`-token drop above.
+    let assignee_override = params
+        .assignee
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<ainb_hangar_core::actor::ActorRef>().ok());
     let outcome = run_card(
         pool,
         &ws,
@@ -2861,6 +2872,7 @@ async fn handle_issue_run(
         run_override,
         agent_override,
         source_override,
+        assignee_override.as_ref(),
     )
     .await
     .map_err(card_run_err)?;
@@ -3029,6 +3041,7 @@ pub(crate) async fn run_card(
     repo_override: Option<&str>,
     agent_override: Option<ainb_hangar_core::agent_kind::AgentKind>,
     source_branch_override: Option<&str>,
+    assignee_override: Option<&ainb_hangar_core::actor::ActorRef>,
 ) -> Result<CardRunOutcome, CardRunError> {
     use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
     use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
@@ -3146,7 +3159,11 @@ pub(crate) async fn run_card(
 
     // Single-agent: resolve the assignee agent (D16), then enqueue one task keyed
     // to its `(agent_id, runtime_id)` + the resolved repo/agent-kind, in ONE tx.
-    let agent = resolve_run_agent_opt(pool, ws, issue.assignee.as_ref())
+    // A run-time `assignee_override` (V3-F3: the create wizard targeting a named
+    // agent) WINS over the issue's persisted assignee, so a run dispatches under
+    // the picked agent even if the persisting `issue_update` has not landed yet.
+    let assignee = assignee_override.or(issue.assignee.as_ref());
+    let agent = resolve_run_agent_opt(pool, ws, assignee)
         .await
         .map_err(CardRunError::Db)?
         .ok_or(CardRunError::NoAgent)?;
@@ -6669,6 +6686,7 @@ mod tests {
             Some("scratch"),
             ainb_hangar_core::agent_kind::AgentKind::parse("claude"),
             None,
+            None,
         )
         .await;
 
@@ -6677,5 +6695,166 @@ mod tests {
             "the shared run_card must launch a brief-less issue — no brief-or-link \
              guard belongs in the shared path (board_card_run / autopilot use it)"
         );
+    }
+
+    /// V3-F3 core: a run-time `assignee_override` routes the run to the NAMED
+    /// agent it names, NOT the workspace's alphabetically-first agent (the
+    /// fallback the create wizard hit before it could target a named agent).
+    ///
+    /// The mutation-provable heart of the fix: two agents `alpha` (first by name)
+    /// and `omega` (last) exist, the issue carries NO persisted assignee, and the
+    /// run is dispatched with `assignee_override = agent:<omega>`. It must launch
+    /// under `omega`. Break the override plumbing (drop the param, or prefer the
+    /// issue's `None` assignee) → resolution falls to `alpha` → this test goes red.
+    #[tokio::test]
+    async fn run_card_assignee_override_beats_alphabetical_fallback() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+        // Two named agents; `alpha` sorts first so a fallback (ORDER BY name) picks
+        // it. The override must select `omega` regardless.
+        let alpha = bootstrap::create_agent(pool, &ws, "alpha", "claude", None).await.unwrap();
+        let omega = bootstrap::create_agent(pool, &ws, "omega", "claude", None).await.unwrap();
+        assert_ne!(alpha.id, omega.id);
+
+        // Issue with NO persisted assignee — the override is the ONLY signal.
+        let id = ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        IssueRepo::insert(
+            pool,
+            &NewIssue {
+                id: id.clone(),
+                workspace_id: ws.clone(),
+                title: "hand this to omega".into(),
+                description: Some("do the work".into()),
+                state: "todo".into(),
+                creator: ainb_hangar_core::actor::ActorRef::new(
+                    ainb_hangar_core::actor::ActorKind::Member,
+                    "stevie",
+                )
+                .unwrap(),
+                created_at: 1,
+                priority: 0,
+                assignee: None,
+                due_date: None,
+                labels: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        let issue = IssueRepo::get_by_id(pool, &id).await.unwrap().unwrap();
+        let ws_id = WorkspaceId::from_str(&ws).unwrap();
+
+        let override_ref = ainb_hangar_core::actor::ActorRef::new(
+            ainb_hangar_core::actor::ActorKind::Agent,
+            omega.id.clone(),
+        )
+        .unwrap();
+
+        let outcome = run_card(
+            pool,
+            &ws_id,
+            None,
+            &issue,
+            "headless",
+            Some("scratch"),
+            None, // no provider override — the named agent's own provider drives spawn
+            None,
+            Some(&override_ref),
+        )
+        .await;
+
+        match outcome {
+            Ok(CardRunOutcome::Single { agent_id, .. }) => {
+                assert_eq!(
+                    agent_id, omega.id,
+                    "the run must dispatch under the OVERRIDE agent (omega), not the \
+                     alphabetical fallback (alpha)"
+                );
+                assert_ne!(
+                    agent_id, alpha.id,
+                    "alpha is the fallback the override must beat"
+                );
+            }
+            Ok(CardRunOutcome::Squad { .. }) => panic!("a non-squad issue must run as Single"),
+            Err(_) => panic!("the run must launch under the override agent"),
+        }
+    }
+
+    /// The override is optional: with NO `assignee_override` and NO persisted
+    /// assignee, the run still launches under the workspace's first agent (the
+    /// deterministic fallback the provider-chip wizard path relies on). This locks
+    /// the fallback so the override plumbing never silently makes a run un-runnable
+    /// when no named agent is targeted.
+    #[tokio::test]
+    async fn run_card_without_assignee_override_falls_back_to_first_agent() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+        let alpha = bootstrap::create_agent(pool, &ws, "alpha", "claude", None).await.unwrap();
+        bootstrap::create_agent(pool, &ws, "omega", "claude", None).await.unwrap();
+
+        let id = ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        IssueRepo::insert(
+            pool,
+            &NewIssue {
+                id: id.clone(),
+                workspace_id: ws.clone(),
+                title: "no target".into(),
+                description: Some("do the work".into()),
+                state: "todo".into(),
+                creator: ainb_hangar_core::actor::ActorRef::new(
+                    ainb_hangar_core::actor::ActorKind::Member,
+                    "stevie",
+                )
+                .unwrap(),
+                created_at: 1,
+                priority: 0,
+                assignee: None,
+                due_date: None,
+                labels: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        let issue = IssueRepo::get_by_id(pool, &id).await.unwrap().unwrap();
+        let ws_id = WorkspaceId::from_str(&ws).unwrap();
+
+        let outcome = run_card(
+            pool,
+            &ws_id,
+            None,
+            &issue,
+            "headless",
+            Some("scratch"),
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        match outcome {
+            Ok(CardRunOutcome::Single { agent_id, .. }) => {
+                assert_eq!(
+                    agent_id, alpha.id,
+                    "the fallback picks the first agent by name"
+                );
+            }
+            Ok(CardRunOutcome::Squad { .. }) => panic!("a non-squad issue must run as Single"),
+            Err(_) => panic!("the run must launch on the fallback agent"),
+        }
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1644,6 +1644,15 @@ pub struct IssueRunParams {
     /// persisted `source_branch`, else the repo's default branch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_branch: Option<String>,
+    /// A run-time ASSIGNEE override (`agent:<id>`) naming the NAMED workspace
+    /// agent the run dispatches under (V3-F3). APPEND-ONLY: omitted (`None`)
+    /// resolves the run agent from the issue's persisted `assignee`, else the
+    /// workspace's alphabetically-first agent. Passed ALONGSIDE the persisting
+    /// `issue_update{assignee}` (mirroring the repo/branch override discipline) so
+    /// dispatch never depends on the persist landing first — the create wizard
+    /// targets a named agent by carrying it here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_ISSUE_DELETE`] (63d): delete one issue and

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -409,8 +409,15 @@ pub struct HangarPlugin {
 struct WizardDispatch {
     /// The picked repo (REQUIRED): absolute path, `scratch`, or a remote ref.
     repo_ref: String,
-    /// The provider agent wire token (`claude` / `codex` / `copilot`).
-    agent: String,
+    /// The provider agent wire token (`claude` / `codex` / `copilot`) when the
+    /// Agent row fell back to provider chips; `None` when a NAMED agent was
+    /// targeted (its own provider drives the run — see [`Self::assignee`]).
+    agent: Option<String>,
+    /// The NAMED workspace agent targeted by the Agent row as its `agent:<id>`
+    /// ref (V3-F3): set on the `issue_update` assignee AND carried as the
+    /// `issue_run` assignee override, so the dispatch routes to it regardless of
+    /// which leg lands first. `None` when a provider chip was chosen instead.
+    assignee: Option<String>,
     /// The source branch the run branches FROM; `None` = repo default.
     source_branch: Option<String>,
     /// The target branch a future PR lands INTO; `None` = unset.
@@ -2538,6 +2545,7 @@ impl HangarPlugin {
             source_branch,
             target_branch,
             agent,
+            assignee,
         } = action;
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             self.screens.issue_list.set_note("create failed: daemon link is down");
@@ -2571,6 +2579,7 @@ impl HangarPlugin {
         self.wizard_dispatch_in_flight = Some(WizardDispatch {
             repo_ref,
             agent,
+            assignee,
             source_branch,
             target_branch,
         });
@@ -2684,11 +2693,21 @@ impl HangarPlugin {
             return;
         };
         let ws = self.app_state().ws_id.as_str().to_string();
+        // V3-F3: a NAMED-agent target persists as the issue's assignee (so the card
+        // shows the right owner and a later manual re-run resolves it) via
+        // `issue_update`, AND rides the `issue_run` as an explicit override, so the
+        // dispatch routes to it even though the daemon processes the two legs in
+        // order (same belt-and-suspenders discipline as the repo/branch overrides).
+        let assignee_update = dispatch.assignee.as_ref().map_or(
+            ainb_hangar_proto::snapshots::FieldUpdate::Keep,
+            |actor_ref| ainb_hangar_proto::snapshots::FieldUpdate::Set(actor_ref.clone()),
+        );
         let update = ainb_hangar_proto::snapshots::IssueUpdateParams {
             workspace_id: ws.clone(),
             issue_id: issue_id.clone(),
             repo_ref: Some(dispatch.repo_ref.clone()),
-            agent: Some(dispatch.agent.clone()),
+            agent: dispatch.agent.clone(),
+            assignee: assignee_update,
             source_branch: dispatch.source_branch.clone(),
             target_branch: dispatch.target_branch.clone(),
             ..Default::default()
@@ -2698,8 +2717,9 @@ impl HangarPlugin {
             issue_id,
             mode: "headless".to_string(),
             repo_ref: Some(dispatch.repo_ref),
-            agent: Some(dispatch.agent),
+            agent: dispatch.agent,
             source_branch: dispatch.source_branch,
+            assignee: dispatch.assignee,
         };
         for (id, method, params) in [
             (

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -384,8 +384,14 @@ pub enum IssueCreateAction {
         source_branch: Option<String>,
         /// The target branch a future PR lands INTO; `None` = unset.
         target_branch: Option<String>,
-        /// The provider agent wire token (`claude` / `codex` / `copilot`).
-        agent: String,
+        /// The provider agent wire token (`claude` / `codex` / `copilot`) when the
+        /// Agent row fell back to provider chips; `None` when a NAMED agent was
+        /// targeted (its own provider drives the run — see [`Self::assignee`]).
+        agent: Option<String>,
+        /// The NAMED workspace agent targeted by the Agent row as its `agent:<id>`
+        /// ref (V3-F3): persisted as the new issue's assignee AND carried as the
+        /// run's assignee override. `None` when a provider chip was chosen instead.
+        assignee: Option<String>,
     },
 }
 
@@ -817,7 +823,22 @@ impl ScreenStates {
     }
 
     /// Cache the agent snapshot rows; the picker is rebuilt from them on open.
+    ///
+    /// Also fans the NAMED workspace agents (agent actors, members filtered out)
+    /// into the Issues create wizard's Agent-row roster (V3-F3), so the wizard can
+    /// TARGET a named agent — the same `hangar/agents_list` snapshot that feeds the
+    /// `a` assign picker. An empty roster leaves the wizard on the provider-chip
+    /// fallback.
     pub fn set_actors(&mut self, actors: Vec<ActorRow>) {
+        let named: Vec<super::issue_list::WizardAgent> = actors
+            .iter()
+            .filter(|a| a.is_agent)
+            .map(|a| super::issue_list::WizardAgent {
+                actor_ref: a.actor_ref.clone(),
+                label: a.display_name.clone(),
+            })
+            .collect();
+        self.issue_list.set_agents(named);
         self.actors = actors;
     }
 
@@ -1449,6 +1470,7 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
             source_branch,
             target_branch,
             agent,
+            assignee,
         }) => {
             states.pending_create_action = Some(IssueCreateAction::CreateAndRun {
                 title,
@@ -1458,6 +1480,7 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
                 source_branch,
                 target_branch,
                 agent,
+                assignee,
             });
             None
         }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -328,6 +328,24 @@ impl WizardRow {
     }
 }
 
+/// One NAMED workspace agent the create wizard's Agent row can target (V3-F3).
+///
+/// Injected by the glue from the same `hangar/agents_list` snapshot the `a`
+/// assign picker uses (agent actors only — members are filtered out). `actor_ref`
+/// is the canonical `agent:<id>` form persisted as the new issue's assignee and
+/// carried as the run's assignee override, so the dispatch routes to THIS agent
+/// (not the alphabetically-first fallback). `label` is the display name.
+///
+/// When the roster is empty (a workspace with no named agents yet) the Agent row
+/// falls back to the [`AgentChip`] provider chips, so a create is never blocked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WizardAgent {
+    /// Canonical `agent:<id>` reference (the assignee wire form).
+    pub actor_ref: String,
+    /// Human-readable agent name shown on the row.
+    pub label: String,
+}
+
 /// The Issues create wizard (Phase 5): a single centered form showing every field
 /// at once — Title / Repo / Source / Target / Agent — with a focused-row cursor.
 ///
@@ -474,6 +492,11 @@ pub struct IssueListState {
     /// (favorites-first + recency order preserved). `scratch` is NOT in here —
     /// [`repo_candidates`] prepends it always.
     repos: Vec<RepoOption>,
+    /// The NAMED workspace-agent roster the wizard's Agent row cycles (V3-F3),
+    /// injected by the glue from the same `hangar/agents_list` snapshot the `a`
+    /// assign picker uses (agent actors only). Empty on a workspace with no named
+    /// agents, in which case the Agent row falls back to the provider chips.
+    agents: Vec<WizardAgent>,
     /// A transient status note (create/run dispatch feedback or failure),
     /// rendered on the bottom row and replaced by the next note / cleared when a
     /// new wizard opens. Errors surface HERE, never silently dropped.
@@ -511,6 +534,7 @@ impl Default for IssueListState {
             mode: IssueListMode::Normal,
             wizard: None,
             repos: Vec::new(),
+            agents: Vec::new(),
             note: None,
             task_issue: HashMap::new(),
             scroll_offsets: [0; COLUMN_COUNT],
@@ -688,6 +712,19 @@ impl IssueListState {
     /// card-create dropdown draws from).
     pub fn set_repos(&mut self, repos: Vec<RepoOption>) {
         self.repos = repos;
+    }
+
+    /// Inject the NAMED workspace-agent roster the wizard's Agent row targets
+    /// (V3-F3), from the glue's cached `hangar/agents_list` snapshot (agent actors
+    /// only). Empty leaves the Agent row on the provider-chip fallback.
+    pub fn set_agents(&mut self, agents: Vec<WizardAgent>) {
+        self.agents = agents;
+    }
+
+    /// The NAMED workspace-agent roster the wizard's Agent row cycles (V3-F3).
+    #[must_use]
+    pub fn agents(&self) -> &[WizardAgent] {
+        &self.agents
     }
 
     /// The transient status note (dispatch feedback / failure), if any.
@@ -1011,9 +1048,16 @@ pub enum IssueListIntent {
         source_branch: Option<String>,
         /// The target branch a future PR lands INTO; `None` = unset.
         target_branch: Option<String>,
-        /// The provider agent wire token (`claude` / `codex` / `copilot`) —
-        /// always a real token, never empty.
-        agent: String,
+        /// The provider agent wire token (`claude` / `codex` / `copilot`) when the
+        /// Agent row fell back to the provider chips (no named agents in the
+        /// workspace); `None` when a NAMED agent was targeted instead (its own
+        /// provider drives the run — see [`Self::CreateAndRun::assignee`]).
+        agent: Option<String>,
+        /// The NAMED workspace agent targeted by the Agent row, as its canonical
+        /// `agent:<id>` ref (V3-F3): persisted as the new issue's assignee AND
+        /// carried as the run's assignee override so the dispatch routes to it.
+        /// `None` when the roster was empty and a provider chip was chosen instead.
+        assignee: Option<String>,
     },
     /// Delete the confirmed issue (63d): raised ONLY by Enter on the `x` RED
     /// confirm overlay. The plugin glue lifts it into `hangar/issue_delete`; the
@@ -1339,7 +1383,16 @@ fn wizard_cycle_value(
             wizard.repo_ref = Some(candidates[next].repo_ref.clone());
         }
         WizardRow::Agent => {
-            wizard.agent_cursor = ring_step(wizard.agent_cursor, AgentChip::ALL.len(), forward);
+            // Cycle the NAMED workspace-agent roster when the glue injected one
+            // (V3-F3); otherwise cycle the provider chips (the fallback for a
+            // workspace with no named agents). `agent_cursor` indexes whichever is
+            // active — the fixed roster length keeps the cursor in range.
+            let n = if state.agents.is_empty() {
+                AgentChip::ALL.len()
+            } else {
+                state.agents.len()
+            };
+            wizard.agent_cursor = ring_step(wizard.agent_cursor, n, forward);
         }
         WizardRow::Title
         | WizardRow::Brief
@@ -1493,6 +1546,18 @@ fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueL
     } else {
         Some(wizard.brief.clone())
     };
+    // The Agent row resolves to EITHER a named workspace agent (its `agent:<id>`
+    // ref becomes the issue's assignee + the run's assignee override, so dispatch
+    // routes to it) OR — when the roster is empty — a provider chip (today's
+    // deterministic fallback: no assignee, so the daemon resolves the workspace's
+    // first agent under the chosen provider). Exactly one of the two is set.
+    let (agent, assignee) = match state.agents.get(wizard.agent_cursor) {
+        Some(named) => (None, Some(named.actor_ref.clone())),
+        None => (
+            Some(AgentChip::at(wizard.agent_cursor).wire().to_string()),
+            None,
+        ),
+    };
     with_intent(
         next,
         IssueListIntent::CreateAndRun {
@@ -1504,7 +1569,8 @@ fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueL
             repo_ref,
             source_branch: opt(&wizard.source_branch),
             target_branch: opt(&wizard.target_branch),
-            agent: AgentChip::at(wizard.agent_cursor).wire().to_string(),
+            agent,
+            assignee,
         },
     )
 }
@@ -1645,7 +1711,15 @@ pub fn render_issue_list(
     // otherwise a transient dispatch note (launch feedback / failure) paints on
     // the bottom row.
     if let Some(wizard) = state.wizard() {
-        render_wizard(buf, area_w, col_top, bottom, wizard, &state.repos);
+        render_wizard(
+            buf,
+            area_w,
+            col_top,
+            bottom,
+            wizard,
+            &state.repos,
+            &state.agents,
+        );
     } else if let Some(pending) = state.confirm_delete() {
         // 63d: the RED delete-confirm overlay on the two bottom rows.
         render_confirm_delete(
@@ -1796,6 +1870,7 @@ fn render_wizard(
     bottom: u16,
     wizard: &CreateWizard,
     repos: &[RepoOption],
+    agents: &[WizardAgent],
 ) {
     let inset: u16 = 2;
     let max_w = area_w.saturating_sub(inset * 2);
@@ -1874,7 +1949,7 @@ fn render_wizard(
             y = y.saturating_add(1 + dropdown_rows);
             continue;
         }
-        render_wizard_field(buf, value_x, y, text_right, field, wizard, repos);
+        render_wizard_field(buf, value_x, y, text_right, field, wizard, repos, agents);
         y = y.saturating_add(1);
     }
 
@@ -2013,6 +2088,7 @@ const fn wizard_row_label(row: WizardRow) -> &'static str {
 /// row gets a `▶` marker + green value; the others a blank marker + soft-white.
 /// The Repo row expands the inline `@` dropdown when it is open; the Target row
 /// shows `(unset)` only when blank + unfocused.
+#[allow(clippy::too_many_arguments)]
 fn render_wizard_field(
     buf: &mut WireBuffer,
     x: u16,
@@ -2021,6 +2097,7 @@ fn render_wizard_field(
     row: WizardRow,
     wizard: &CreateWizard,
     repos: &[RepoOption],
+    agents: &[WizardAgent],
 ) {
     let focused = wizard.focus() == row;
     let value_colour = if focused { SELECTION_GREEN } else { SOFT_WHITE };
@@ -2084,7 +2161,13 @@ fn render_wizard_field(
             put_card_str(buf, cx, y, &shown, value_colour, right, true);
         }
         WizardRow::Agent => {
-            let label = AgentChip::at(wizard.agent_cursor()).label();
+            // A named workspace agent when the roster is injected (V3-F3), else the
+            // provider-chip fallback label. `agent_cursor` indexes whichever list
+            // is active; an out-of-range cursor degrades to the provider chip.
+            let label = agents.get(wizard.agent_cursor()).map_or_else(
+                || AgentChip::at(wizard.agent_cursor()).label(),
+                |named| named.label.as_str(),
+            );
             put_card_str(buf, cx, y, label, value_colour, right, true);
         }
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -11,7 +11,7 @@ use ainb_hangar_core::ids::{AgentId, IssueId, TaskId};
 use ainb_hangar_proto::events::{HangarEvent, IssueRow};
 use ainb_plugin_hangar::screen::issue_list::{
     FilterChip, IssueColumn, IssueListEvent, IssueListIntent, IssueListMode, IssueListState,
-    WizardKey, WizardRow, reduce_issue_list,
+    WizardAgent, WizardKey, WizardRow, reduce_issue_list,
 };
 
 /// A wire `IssueRow` for tests. `state` drives column grouping (`open` → Todo,
@@ -377,7 +377,9 @@ fn wizard_complete_form_commits_create_and_run() {
             repo_ref: "scratch".to_string(),
             source_branch: Some("main".to_string()),
             target_branch: Some("main".to_string()),
-            agent: "codex".to_string(),
+            // No named-agent roster injected → provider-chip fallback (no assignee).
+            agent: Some("codex".to_string()),
+            assignee: None,
         })
     );
     assert_eq!(out.state.mode(), IssueListMode::Normal);
@@ -577,7 +579,9 @@ fn wizard_branch_edits_and_blanks_round_trip() {
             repo_ref: "scratch".to_string(),
             source_branch: Some("feature/x".to_string()),
             target_branch: None,
-            agent: "claude".to_string(),
+            // No named-agent roster injected → provider-chip fallback (no assignee).
+            agent: Some("claude".to_string()),
+            assignee: None,
         })
     );
 }
@@ -600,11 +604,16 @@ fn wizard_required_guard_blocks_incomplete_creates() {
     assert_eq!(s.wizard().unwrap().repo_ref(), Some("scratch"));
     assert!(wiz(&s, WizardKey::Enter).intent.is_none());
 
-    // Both present → the ONLY path that creates, always with a real agent token.
+    // Both present → the ONLY path that creates. With no named-agent roster the
+    // Agent row falls back to a real provider token (and carries no assignee).
     let out = wiz(&ready_to_create(), WizardKey::Enter);
     match out.intent {
-        Some(IssueListIntent::CreateAndRun { agent, .. }) => {
+        Some(IssueListIntent::CreateAndRun {
+            agent, assignee, ..
+        }) => {
+            let agent = agent.expect("provider-chip fallback carries a token");
             assert!(["claude", "codex", "copilot"].contains(&agent.as_str()));
+            assert!(assignee.is_none(), "no named agent targeted → no assignee");
         }
         other => panic!("complete form must commit CreateAndRun, got {other:?}"),
     }
@@ -680,4 +689,122 @@ fn event_task_started_promotes_issue_to_in_progress() {
         .map(|r| r.id.as_str())
         .collect();
     assert_eq!(in_prog, vec!["i1"]);
+}
+
+// ---------------------------------------------------------------------------
+// V3-F3: the create wizard's Agent row targets a NAMED workspace agent.
+// ---------------------------------------------------------------------------
+
+/// A `ready_to_create` wizard with a NAMED-agent roster injected, focus on the
+/// Agent row (so ←/→ cycles the roster and Enter commits).
+fn ready_to_create_with_agents(agents: Vec<WizardAgent>) -> IssueListState {
+    let mut s = ready_to_create();
+    s.set_agents(agents);
+    s
+}
+
+fn agent(actor_ref: &str, label: &str) -> WizardAgent {
+    WizardAgent {
+        actor_ref: actor_ref.to_string(),
+        label: label.to_string(),
+    }
+}
+
+/// With a named-agent roster injected, Enter commits `CreateAndRun` carrying the
+/// picked agent's `agent:<id>` ref as the assignee (and NO provider token — the
+/// named agent's own provider drives the run).
+#[test]
+fn wizard_targets_named_agent_as_assignee() {
+    let s = ready_to_create_with_agents(vec![
+        agent("agent:dev-id", "dev"),
+        agent("agent:reviewer-id", "reviewer"),
+    ]);
+    // Cursor starts at 0 (the first named agent, "dev").
+    let out = wiz(&s, WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun {
+            agent, assignee, ..
+        }) => {
+            assert_eq!(
+                assignee,
+                Some("agent:dev-id".to_string()),
+                "targets the named agent"
+            );
+            assert!(agent.is_none(), "a named target carries no provider token");
+        }
+        other => panic!("expected CreateAndRun targeting a named agent, got {other:?}"),
+    }
+}
+
+/// ←/→ on the Agent row cycles the NAMED roster (not the provider chips) when a
+/// roster is injected, and the picked agent round-trips to the assignee.
+#[test]
+fn wizard_agent_row_cycles_named_roster() {
+    let s = ready_to_create_with_agents(vec![
+        agent("agent:dev-id", "dev"),
+        agent("agent:reviewer-id", "reviewer"),
+    ]);
+    // → advances from "dev" (0) to "reviewer" (1).
+    let s = wiz(&s, WizardKey::Right).state;
+    let out = wiz(&s, WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { assignee, .. }) => {
+            assert_eq!(assignee, Some("agent:reviewer-id".to_string()));
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
+
+    // → wraps the two-agent roster back to "dev".
+    let s = ready_to_create_with_agents(vec![
+        agent("agent:dev-id", "dev"),
+        agent("agent:reviewer-id", "reviewer"),
+    ]);
+    let s = wiz(&s, WizardKey::Right).state; // reviewer
+    let s = wiz(&s, WizardKey::Right).state; // wrap → dev
+    let out = wiz(&s, WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { assignee, .. }) => {
+            assert_eq!(
+                assignee,
+                Some("agent:dev-id".to_string()),
+                "two-agent roster wraps"
+            );
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
+}
+
+/// With an EMPTY named-agent roster the Agent row falls back to the provider
+/// chips: Enter commits a provider token and NO assignee (the pre-fix behaviour,
+/// which dispatches deterministically to the workspace's first agent).
+#[test]
+fn wizard_agent_row_falls_back_to_provider_chips_when_roster_empty() {
+    // ready_to_create injects no agents, so the roster is empty.
+    let out = wiz(&ready_to_create(), WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun {
+            agent, assignee, ..
+        }) => {
+            assert_eq!(
+                agent,
+                Some("claude".to_string()),
+                "provider-chip fallback token"
+            );
+            assert!(assignee.is_none(), "no named target → no assignee");
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
+
+    // And ←/→ cycles the PROVIDER chips (claude → codex), not a named roster.
+    let s = wiz(&ready_to_create(), WizardKey::Right).state;
+    let out = wiz(&s, WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun {
+            agent, assignee, ..
+        }) => {
+            assert_eq!(agent, Some("codex".to_string()));
+            assert!(assignee.is_none());
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
@@ -428,6 +428,25 @@ async fn wizard_commit_issues_create_update_and_run() {
             seen.lock().unwrap()
         );
 
+        // Ordering discipline (V3-F3 depends on it): the persisting `issue_update`
+        // must reach the daemon BEFORE the `issue_run`, so a run that resolves the
+        // issue's persisted assignee (the named-agent target) never races the
+        // write. The daemon serves one connection's frames in order, so send order
+        // == apply order.
+        let calls = seen.lock().unwrap().clone();
+        let update_ix = calls
+            .iter()
+            .position(|(m, _)| m == daemon_methods::HANGAR_ISSUE_UPDATE)
+            .expect("issue_update was sent");
+        let run_ix = calls
+            .iter()
+            .position(|(m, _)| m == daemon_methods::HANGAR_ISSUE_RUN)
+            .expect("issue_run was sent");
+        assert!(
+            update_ix < run_ix,
+            "issue_update must precede issue_run (update @ {update_ix}, run @ {run_ix})"
+        );
+
         drop(host_write);
         server.abort();
     };


### PR DESCRIPTION
## What

The Issues create-wizard Agent row can now target a **named workspace agent**, and that choice actually drives dispatch. Before this, the row was a provider chip (`claude`/`codex`/`copilot`) and the run fell back to the alphabetically-first workspace agent, so sequential handover between named agents (e.g. `dev` -> `reviewer`) was inexpressible from the TUI.

## Evidence (live e2e loop — V3-F3)

`/Users/.../hangar-e2e/cycle-2/v3_result.json`: with agents `dev` and `reviewer` created, a wizard run executed under bootstrap agent `claude` (`01KY1W2BYT1XM4S8DDFBDV2RSJ`) — an alphabetical accident via `resolve_run_agent_opt` -> `AgentRepo::list_by_workspace ORDER BY name`.

## Design — assignee-driven

The daemon already routes a run to the issue's assignee when it names an agent (`resolve_run_agent_opt`), and at spawn `resolve_dispatch(task.agent_id)` picks the backend from that named agent's own `provider`. So **targeting a named agent = setting the issue's assignee to `agent:<id>`** — no new resolution path needed.

- **Wire (append-only, serde-default):** `IssueRunParams.assignee` — a run-time override.
- **Daemon:** `run_card` takes an `assignee_override` that wins over the persisted assignee; `handle_issue_run` parses the param (malformed refs drop to the issue assignee, never a hard error). Board-card / auto-run callers pass `None`.
- **Plugin/wizard:** the Agent row cycles the named-agent roster (same `agents_list` snapshot the `a` assign picker uses) when one exists, else the provider chips. A named pick is persisted as the new issue's assignee via `issue_update` **and** carried as the `issue_run` assignee override — mirroring the existing repo/branch override discipline, so dispatch never races the write (the daemon serves one connection's frames in order anyway).

The REQUIRED guard is intact: a valid selection always exists (a named agent, else a provider chip), so create is never blocked. The provider-chip fallback dispatches deterministically to `list_by_workspace().next()` under the chosen provider — the pre-fix behaviour, preserved for workspaces with no named agents.

## Tests

- **Daemon (mutation-provable core):** `run_card_assignee_override_beats_alphabetical_fallback` — two agents `alpha`/`omega`, no persisted assignee, override = `omega` -> run dispatches under `omega`, not `alpha`. Break the plumbing -> resolves `alpha` -> red. Plus `run_card_without_assignee_override_falls_back_to_first_agent`.
- **Reducer:** named-roster cycling, assignee round-trip to the intent, and provider-chip fallback when the roster is empty.
- **Glue:** the socket test now asserts `issue_update` precedes `issue_run` (the ordering the assignee resolution relies on).

`cargo test -p ainb-plugin-hangar` (324 lib + suites) and `-p ainb-hangar-daemon` (286) green; the one `test_concurrent_invocations_serialize_per_beads_dir` failure is a pre-existing parallel-contention flake (passes on isolated rerun, unrelated to this change). `cargo build -p ainb` clean.

Do not merge — for review.