### PR TITLE
fix(hangar): make Issues filter chips (All/Members/Agents/Mine) reachable

### DIFF
--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -172,6 +172,7 @@ fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
                 ("c", "create"),
                 ("x", "delete"),
                 ("/", "filter"),
+                ("tab", "chip"),
             ]
         }
         Screen::TaskDetail(_) => vec![("R", "retry"), ("X", "cancel"), ("x", "delete")],

--- a/ainb-tui/crates/ainb-plugin-hangar/src/mouse.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/mouse.rs
@@ -62,7 +62,9 @@ pub enum Target {
     /// rects sit *inside* this rect, so the hit-test resolves a card first and a
     /// bare drop-zone only on the column background.
     DropZone(IssueLifecycle),
-    /// A top tab-bar entry, tagged with the 0-based view index it switches to.
+    /// A filter-chip-bar entry, tagged with the 0-based chip index it selects
+    /// (`All` / `Members` / `Agents` / `Mine`). Sits on the chip row above the
+    /// board, so it never overlaps a card/column target.
     Tab(usize),
 }
 
@@ -97,8 +99,8 @@ impl HitMap {
     /// is skipped rather than panicking. Cards are pushed LAST so they win the
     /// priority tie against the drop zone they sit inside (see [`hit_test`]).
     ///
-    /// The top tab bar is added separately by the caller (it is chrome, not part
-    /// of the board layout) via [`HitMap::push`] with a [`Target::Tab`].
+    /// The filter-chip bar is added separately by the caller (it is chrome, not
+    /// part of the board layout) via [`HitMap::push`] with a [`Target::Tab`].
     ///
     /// [`hit_test`]: HitMap::hit_test
     #[must_use]
@@ -316,7 +318,8 @@ pub enum MouseIntent {
     NewIssue(IssueLifecycle),
     /// Focus a column (a column-header / column-background click).
     FocusColumn(IssueLifecycle),
-    /// Switch to a top-bar tab by its 0-based view index (a tab click).
+    /// Select a filter chip by its 0-based index (a chip-bar click): the plugin
+    /// glue maps it onto `IssueListEvent::SetFilter(FilterChip::all()[idx])`.
     SwitchTab(usize),
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3273,6 +3273,29 @@ impl HangarPlugin {
                 );
                 // The issue board uses the lifecycle-typed FSM hit-map.
                 self.hit_map = HitMap::from_board_layout(&layout);
+                // The filter-chip bar sits on the row above the board (chip row
+                // = body top, i.e. board `top - 1`). Record one `Target::Tab` per
+                // chip so a click selects that filter — the chip bar is chrome,
+                // not part of the board layout, so it is pushed here. Geometry
+                // mirrors `render_chip_bar`: each chip is `[Label] ` starting at
+                // x=0, the clickable span being `[Label]` (bracket + label +
+                // bracket) with a one-column trailing gap.
+                let chip_row = top.saturating_sub(1);
+                let mut chip_x = 0u16;
+                for (idx, chip) in
+                    crate::screen::issue_list::FilterChip::all().into_iter().enumerate()
+                {
+                    if chip_x >= w {
+                        break;
+                    }
+                    let span =
+                        u16::try_from(chip.label().chars().count()).unwrap_or(0).saturating_add(2);
+                    self.hit_map.push(
+                        crate::mouse::Rect::new(chip_x, chip_row, span, 1),
+                        crate::mouse::Target::Tab(idx),
+                    );
+                    chip_x = chip_x.saturating_add(span).saturating_add(1);
+                }
             }
             // 63l.6: the Kanban / Autopilots / Skills list screens record the
             // card-board layout the lifecycle-free `fold_board_mouse` hit-tests
@@ -3353,9 +3376,10 @@ impl HangarPlugin {
     ///   anchored at the click, seeded with the issue's current state/priority + the
     ///   cached actor snapshot.
     ///
-    /// The remaining intents (`NewIssue`, `FocusColumn`, `PanColumns`, `SwitchTab`)
-    /// land in later board sub-beads (the seeded create flow); they are consumed
-    /// here so they never accumulate.
+    /// `SwitchTab` selects the clicked filter chip (via the issue-list
+    /// `SetFilter` reducer). The remaining intents (`NewIssue`, `FocusColumn`,
+    /// `PanColumns`) land in later board sub-beads (the seeded create flow); they
+    /// are consumed here so they never accumulate.
     fn drain_mouse_intents(&mut self) {
         use crate::mouse::MouseIntent;
         use crate::screen::issue_list::IssueColumn;
@@ -3405,11 +3429,25 @@ impl HangarPlugin {
                 MouseIntent::OpenContextMenu { issue_id, at } => {
                     self.open_context_menu(&issue_id, at);
                 }
+                // A chip-bar click selects that filter chip (All / Members /
+                // Agents / Mine) — fold it through the issue-list reducer so the
+                // keyboard `Tab` path and the mouse path converge on `SetFilter`.
+                MouseIntent::SwitchTab(idx) => {
+                    use crate::screen::issue_list::{
+                        FilterChip, IssueListEvent, reduce_issue_list,
+                    };
+                    if let Some(chip) = FilterChip::all().get(idx).copied() {
+                        let out = reduce_issue_list(
+                            &self.screens.issue_list,
+                            IssueListEvent::SetFilter(chip),
+                        );
+                        self.screens.issue_list = out.state;
+                    }
+                }
                 // The remaining intents land in later board sub-beads.
                 MouseIntent::NewIssue(_)
                 | MouseIntent::FocusColumn(_)
-                | MouseIntent::PanColumns { .. }
-                | MouseIntent::SwitchTab(_) => {}
+                | MouseIntent::PanColumns { .. } => {}
             }
         }
     }
@@ -5198,6 +5236,39 @@ mod tests {
         assert_eq!(
             before, after,
             "empty-space press leaves the selection alone"
+        );
+    }
+
+    /// USER-VISIBLE PROOF (issue-list-filter-chip-unreachable): a left-click on a
+    /// filter chip in the chip bar selects that filter. Before this fix the chip
+    /// row had no mouse hit-test target (`Target::Tab` was never pushed and
+    /// `SwitchTab` was a no-op), so a click fell through and the filter stayed on
+    /// `All`. Drives the REAL plugin mouse path (`on_mouse` → FSM → intent stash
+    /// → `drain_mouse_intents`).
+    #[test]
+    fn clicking_a_filter_chip_selects_it() {
+        use crate::screen::issue_list::FilterChip;
+        use ainb_plugin_sdk::{MouseButton, MouseKind};
+
+        let mut p = connected_plugin_with_issue();
+        p.rebuild_hit_map(120, 24);
+        assert_eq!(p.screens.issue_list.filter(), FilterChip::All);
+
+        // The chip bar renders on row 1 (board top - 1). `render_chip_bar` paints
+        // "[All] [Members] …": the `[All] ` chip occupies cols 0..=5, so the
+        // `[Members]` chip starts at col 6 — a click at col 7 lands inside it.
+        p.on_mouse(mouse_at(
+            MouseKind::Down {
+                button: MouseButton::Left,
+            },
+            7,
+            1,
+        ));
+        p.drain_mouse_intents();
+        assert_eq!(
+            p.screens.issue_list.filter(),
+            FilterChip::Members,
+            "a click on the Members chip must select the Members filter"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -33,7 +33,9 @@ use super::control_center::{
 };
 use super::daemon_health::DaemonHealthState;
 use super::inbox::InboxState;
-use super::issue_list::{IssueListEvent, IssueListIntent, IssueListState, reduce_issue_list};
+use super::issue_list::{
+    IssueListEvent, IssueListIntent, IssueListMode, IssueListState, reduce_issue_list,
+};
 use super::kanban::{KanbanEvent, KanbanIntent, KanbanState, reduce_kanban};
 use super::logs::LogsState;
 use super::profiles::{ProfilesEvent, ProfilesIntent, ProfilesState, reduce_profiles};
@@ -1452,7 +1454,19 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
         };
         IssueListEvent::Wizard(k)
     } else {
-        IssueListEvent::Key(key_char(key)?)
+        // Normal-mode Tab / Shift+Tab cycle the filter-chip bar
+        // (All → Members → Agents → Mine → All). Guarded on Normal mode so the
+        // binding never hijacks Tab while the `/` filter-query input or a confirm
+        // overlay is focused; those still fall through to the plain-char path.
+        match &key.code {
+            KeyCode::Tab if states.issue_list.mode() == IssueListMode::Normal => {
+                IssueListEvent::SetFilter(states.issue_list.filter().next())
+            }
+            KeyCode::BackTab if states.issue_list.mode() == IssueListMode::Normal => {
+                IssueListEvent::SetFilter(states.issue_list.filter().prev())
+            }
+            _ => IssueListEvent::Key(key_char(key)?),
+        }
     };
     let out = reduce_issue_list(&states.issue_list, ev);
     states.issue_list = out.state;
@@ -2039,5 +2053,52 @@ fn route_command_palette(states: &mut ScreenStates, key: &KeyEvent) -> Option<Na
         Some(NavIntent::CloseModal)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod filter_chip_route_tests {
+    use super::*;
+    use crate::screen::issue_list::FilterChip;
+    use ainb_plugin_sdk::{KeyCode, KeyEvent, KeyKind};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            mods: 0,
+            kind: KeyKind::Press,
+        }
+    }
+
+    /// Tab cycles the Issues filter chip forward through the whole ring
+    /// (All → Members → Agents → Mine → All). Regression guard for
+    /// `issue-list-filter-chip-unreachable`: before this binding the chip bar was
+    /// rendered but had no keyboard input path, so the filter was permanently
+    /// stuck on `All`. RED before the `KeyCode::Tab` arm in `route_issue_list`.
+    #[test]
+    fn tab_cycles_filter_chip_forward() {
+        let mut states = ScreenStates::default();
+        assert_eq!(states.issue_list.filter(), FilterChip::All);
+
+        for expected in [
+            FilterChip::Members,
+            FilterChip::Agents,
+            FilterChip::Mine,
+            FilterChip::All,
+        ] {
+            let intent = route_issue_list(&mut states, &key(KeyCode::Tab));
+            assert!(intent.is_none(), "a chip cycle raises no cross-screen nav");
+            assert_eq!(states.issue_list.filter(), expected);
+        }
+    }
+
+    /// Shift+Tab (BackTab) cycles the chip backward (All → Mine → Agents → …).
+    #[test]
+    fn back_tab_cycles_filter_chip_backward() {
+        let mut states = ScreenStates::default();
+        route_issue_list(&mut states, &key(KeyCode::BackTab));
+        assert_eq!(states.issue_list.filter(), FilterChip::Mine);
+        route_issue_list(&mut states, &key(KeyCode::BackTab));
+        assert_eq!(states.issue_list.filter(), FilterChip::Agents);
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -176,6 +176,30 @@ impl FilterChip {
         [Self::All, Self::Members, Self::Agents, Self::Mine]
     }
 
+    /// The next chip in display order, wrapping `Mine → All`. Drives the
+    /// `Tab` chip-cycle binding on the Issues screen.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        match self {
+            Self::All => Self::Members,
+            Self::Members => Self::Agents,
+            Self::Agents => Self::Mine,
+            Self::Mine => Self::All,
+        }
+    }
+
+    /// The previous chip in display order, wrapping `All → Mine`. Drives the
+    /// `Shift+Tab` chip-cycle binding on the Issues screen.
+    #[must_use]
+    pub const fn prev(self) -> Self {
+        match self {
+            Self::All => Self::Mine,
+            Self::Members => Self::All,
+            Self::Agents => Self::Members,
+            Self::Mine => Self::Agents,
+        }
+    }
+
     /// Whether `row` passes this filter.
     ///
     /// An unassigned row passes only the [`FilterChip::All`] / [`FilterChip::Mine`]


### PR DESCRIPTION
## Bug: issue-list-filter-chip-unreachable

Found by the hangar e2e loop. The Issues-screen filter-chip bar
(`All` / `Members` / `Agents` / `Mine`) was rendered but had **no input
path** to change the active chip, so it was permanently stuck on `All` and
`Members` / `Agents` / `Mine` could never be selected by keyboard or mouse.

- Keyboard: `reduce_normal_key` bound `j/k/'/'/c/x/a/Enter` only; there was
  no chip-cycle key, so `IssueListEvent::SetFilter` was never constructed
  outside a unit test.
- Mouse: `MouseIntent::SwitchTab(_)` was an explicit no-op in
  `drain_mouse_intents`, and the chip row had no hit-test `Target` (both
  `Target::Tab` and `SwitchTab` were entirely dead code).

Off the journey critical path (non-blocking), but a real defect.

## Fix

1. **Keyboard** (`app_screens.rs`, `issue_list.rs`, `chrome.rs`): in the
   non-wizard `route_issue_list` path, `Tab` -> next chip / `Shift+Tab` ->
   prev chip (Normal mode only, so it never hijacks the `/` filter-query
   input or a confirm overlay), dispatching `IssueListEvent::SetFilter` via
   new `FilterChip::next`/`prev`. Added a `tab: chip` footer hint for
   discoverability.
2. **Mouse** (`mouse.rs`, `plugin.rs`): record one `Target::Tab` per chip in
   `rebuild_hit_map` (geometry mirrors `render_chip_bar`), and bind
   `SwitchTab(idx)` in `drain_mouse_intents` to
   `SetFilter(FilterChip::all()[idx])`. The previously-dead `Target::Tab` /
   `SwitchTab` doc comments were repointed at the chip bar.

## Tests (red before / green after — proven by in-place mutation)

- `filter_chip_route_tests::tab_cycles_filter_chip_forward` /
  `back_tab_cycles_filter_chip_backward` — drive the real `route_issue_list`
  key path and assert the filter advances `All -> Members -> Agents -> Mine ->
  All` (and back). RED when the `Tab`/`BackTab` arms are removed.
- `plugin::tests::clicking_a_filter_chip_selects_it` — drives the real
  `on_mouse` -> FSM -> `drain_mouse_intents` path; a left-click on the
  `Members` chip selects the Members filter. RED when the `SwitchTab` bind is
  a no-op.

## Verification

- `cargo test -p ainb-plugin-hangar` — 327 lib + all integration tests green.
- `cargo build -p ainb` — clean (exit 0).
- `cargo fmt` (pre-existing drift in `squads.rs` / `squads_screen_snapshot.rs`
  / `live_e2e.rs` reverted, untouched).
- Note: `cargo clippy` has pre-existing failures in `ainb-hangar-core` /
  `ainb-plugin-protocol` on the newer toolchain, unrelated to this change;
  none of the five touched files are implicated.