### PR TITLE
fix(hangar): persist runner stderr tail into result on run failure

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -1426,7 +1426,21 @@ async fn finalize_failure(
     // Persist the session id (if any) before failing so a retry can resume the
     // provider conversation.
     persist_session_id(pool, &task.id, result.session_id.as_deref()).await?;
-    match FailTaskService::fail(pool, &task.id, reason, clock).await {
+    // When the runner captured a stderr tail (a crashed / gave-up provider),
+    // persist it into the `result` column (in the TaskResult `{"content": ...}`
+    // shape the detail surface renders) so the failure is diagnosable from stored
+    // evidence alone. The bare `fail` path left `result` blank, making every
+    // `agent_error` crash undiagnosable from the DB. No tail → the plain `fail`.
+    let fail_outcome = {
+        let tail = result.stderr_tail.trim();
+        if tail.is_empty() {
+            FailTaskService::fail(pool, &task.id, reason, clock).await
+        } else {
+            let detail = format!("run failed ({}):\n\n{tail}", reason.as_db_str());
+            FailTaskService::fail_with_detail(pool, &task.id, reason, &detail, clock).await
+        }
+    };
+    match fail_outcome {
         Ok(_) => {}
         // tcp T3 / F6: a human cancel (`running -> cancelled`) beat this failure to
         // the conditional finalize. Cancelled wins — skip the failure side-effects
@@ -1507,7 +1521,7 @@ async fn finalize_failure(
         progress_comment::Checkpoint::Failed { reason },
     )
     .await;
-    tracing::warn!(task_id = %task.id, reason = reason.as_db_str(), "task failed");
+    tracing::warn!(task_id = %task.id, reason = reason.as_db_str(), stderr_tail = %result.stderr_tail, "task failed");
     // F5: tear down the run's provisioned worktree (keep-if-dirty). A failed run
     // that left a dirty checkout keeps it (the partial work is preserved for a
     // rerun / inspection); a clean one is removed. Done BEFORE the retry spawn so

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_retry_timeout_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_retry_timeout_e2e.rs
@@ -215,6 +215,57 @@ fn agent_error_failure_does_not_spawn_a_child() {
 }
 
 // ---------------------------------------------------------------------------
+// STDERR-TAIL-IN-RESULT (REGRESSION): an agent_error crash persists the runner's
+// captured stderr tail into the `result` column, so the failure is diagnosable
+// from stored evidence alone. Before the fix `finalize_failure` called the
+// no-message `FailTaskService::fail`, leaving `result` blank for every crash.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn agent_error_persists_captured_stderr_tail_into_result() {
+    if !can_run_tripwire() {
+        skip("retry/timeout e2e tripwire (stderr-tail leg)");
+        return;
+    }
+
+    let daemon = spawn_seeded_daemon(&write_stderr_marker_fake_claude, &[]);
+    let hangar_dir = daemon.hangar_dir();
+    let task_id = "agent-error-stderr-e2e-task";
+    enqueue_queued_task(&hangar_dir, task_id);
+
+    // Wait for the row to fail with reason = agent_error (exit 1, no success
+    // terminal), then assert the runner's captured stderr survived into `result`.
+    let reason = poll(
+        &hangar_dir,
+        Instant::now() + Duration::from_secs(60),
+        |pool_dir| {
+            let (status, reason) = status_and_reason(pool_dir, task_id);
+            (status.as_deref() == Some("failed")).then_some(reason)
+        },
+    )
+    .unwrap_or_else(|| {
+        panic!(
+            "stderr-marker task never reached `failed`; last = {:?}",
+            status_and_reason(&hangar_dir, task_id)
+        )
+    });
+    assert_eq!(
+        reason.as_deref(),
+        Some("agent_error"),
+        "the fake exits 1 with no success terminal → agent_error"
+    );
+
+    // REGRESSION: the finalize seam must persist the captured stderr into `result`
+    // so the crash is diagnosable from the DB alone. Before the fix `result` was
+    // blank for the agent_error path.
+    let result = read_result(&hangar_dir, task_id);
+    assert!(
+        result.as_deref().is_some_and(|r| r.contains(STDERR_MARKER)),
+        "the failed row's `result` must carry the captured stderr marker {STDERR_MARKER:?}, got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // TIMEOUT (POSITIVE): a provider that sleeps past the deadline is killed and the
 // row is failed with reason = timeout, within a bounded budget.
 // ---------------------------------------------------------------------------
@@ -411,6 +462,25 @@ fn write_agent_error_fake_claude(dir: &Path) -> PathBuf {
     )
 }
 
+/// A distinctive marker the stderr-tail fake writes to STDERR; the regression
+/// test asserts it survives into the failed row's `result` column. Contains no
+/// single-quote so it embeds cleanly into the single-quoted `/bin/sh` echo.
+const STDERR_MARKER: &str = "STDERR_MARKER_9f3a2b: claude panicked at src/foo.rs:42";
+
+/// Write an executable fake `claude` that prints [`STDERR_MARKER`] to STDERR then
+/// exits 1 with no success terminal (agent_error). The runner must capture that
+/// stderr tail and the finalize seam must persist it into `result`.
+fn write_stderr_marker_fake_claude(dir: &Path) -> PathBuf {
+    let body = format!(
+        "#!/bin/sh\n\
+         echo '{{\"type\":\"system\",\"session_id\":\"stderr-marker\"}}'\n\
+         echo '{STDERR_MARKER}' >&2\n\
+         echo '{{\"type\":\"result\",\"content\":\"i give up\"}}'\n\
+         exit 1\n"
+    );
+    write_executable(dir, "fake-claude-stderr-marker.sh", &body)
+}
+
 /// Write an executable fake `claude` that echoes a system line then blocks well
 /// past any test-sane provider deadline, so the daemon must kill it on timeout.
 fn write_blocking_fake_claude(dir: &Path) -> PathBuf {
@@ -444,6 +514,20 @@ fn read_status(hangar_dir: &Path, task_id: &str) -> Option<String> {
             .fetch_optional(store.pool())
             .await
             .expect("query task status")
+    })
+}
+
+/// Read the `result` column for `task_id`, or `None` if the row is absent or the
+/// column is NULL. Opens a fresh pool each call.
+fn read_result(hangar_dir: &Path, task_id: &str) -> Option<String> {
+    block_on(async {
+        let store = ainb_hangar_store::Store::open_in(hangar_dir).await.expect("open result store");
+        sqlx::query_scalar::<_, Option<String>>("SELECT result FROM agent_task_queue WHERE id = ?")
+            .bind(task_id)
+            .fetch_optional(store.pool())
+            .await
+            .expect("query task result")
+            .flatten()
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/fail.rs
@@ -171,6 +171,60 @@ impl FailTaskService {
         .await
     }
 
+    /// Transition `task_id` to `failed` like [`Self::fail`], additionally
+    /// persisting a human-readable `detail` into the `result` column so the
+    /// task-detail surface renders WHY the run failed. Legal source states are
+    /// `running` (runner failure) and `queued` (queued-TTL sweep) — the same set
+    /// [`Self::fail`] accepts.
+    ///
+    /// Where [`Self::fail`] records only the terminal + `reason`, this variant also
+    /// captures a diagnostic (e.g. the provider's captured stderr tail) so an
+    /// `agent_error` crash is diagnosable from stored evidence alone instead of
+    /// leaving `result` blank. The `detail` rides the `result` column as
+    /// `{"content": detail}` — the same
+    /// [`TaskResult`](ainb_hangar_core::result::TaskResult) shape a completed run
+    /// (and [`Self::fail_setup`]) writes — so the existing detail rendering
+    /// surfaces it with no special-casing.
+    ///
+    /// Idempotent, like [`Self::fail`].
+    ///
+    /// # Errors
+    ///
+    /// - [`FinalizeError::TerminalMismatch`] if the row is already `done` /
+    ///   `cancelled`.
+    /// - [`FinalizeError::IllegalState`] if the row is `dispatched` or absent.
+    /// - [`FinalizeError::Db`] on an underlying database error.
+    #[tracing::instrument(
+        name = "task.fail_with_detail",
+        skip(pool, detail, clock),
+        fields(task_id = %task_id, failure_reason = reason.as_db_str())
+    )]
+    pub async fn fail_with_detail(
+        pool: &SqlitePool,
+        task_id: &str,
+        reason: FailureReason,
+        detail: &str,
+        clock: &dyn HangarClock,
+    ) -> Result<FinalizeOutcome, FinalizeError> {
+        let now = clock.now_ms();
+        let reason_str = reason.as_db_str();
+        // Persist the diagnostic into `result` in the TaskResult shape so the
+        // task-detail surface renders it (a `content`-only JSON is a legal,
+        // round-tripping TaskResult).
+        let result_json = serde_json::json!({ "content": detail }).to_string();
+        finalize_idempotent(
+            pool,
+            task_id,
+            TaskState::Failed,
+            &[TaskState::Running, TaskState::Queued],
+            "UPDATE agent_task_queue \
+             SET status = 'failed', failure_reason = ?1, result = ?2, finished_at = ?3 \
+             WHERE id = ?4 AND status IN ('running','queued')",
+            move |q| q.bind(reason_str).bind(result_json).bind(now).bind(task_id),
+        )
+        .await
+    }
+
     /// Terminalise a task that faulted during PRE-RUN setup: `dispatched ->
     /// failed`, recording `reason`, a human-readable `message` (persisted into the
     /// `result` column so the task-detail surface shows WHY), and


### PR DESCRIPTION
## Problem

`finalize_failure` (`run_loop.rs`) called `FailTaskService::fail(pool, id, reason, clock)` — the **no-message** variant. So on the `agent_error` path the runner's captured `result.stderr_tail` (populated in `RunnerResult`, `runner.rs:394`) was **never persisted** into the DB `result` column, and the terminal `tracing::warn!` omitted it too.

Result: every provider crash was undiagnosable from stored evidence alone — `agent_task_queue.result` was blank for a failed task (confirmed on a real crashed task). Contrast `finalize_setup_failure`, which persists a message via `fail_setup` riding the `result` column as `{"content": message}` so the task-detail surface renders it.

## Fix

- **`ainb-hangar-store`**: add `FailTaskService::fail_with_detail` — mirrors `fail` (`running`/`queued -> failed`) but also persists a human-readable diagnostic into `result` in the same `{"content": ...}` `TaskResult` shape `fail_setup` and a completed run use. (Generalized rather than abusing the setup-only `fail_setup`, whose source state is `dispatched`.)
- **`ainb-hangar-daemon`**: in `finalize_failure`, when the runner captured a stderr tail, route through `fail_with_detail` so the tail lands in `result` (`"run failed (<reason>):\n\n<tail>"`); empty tails keep the plain `fail`. Include `stderr_tail` in the terminal warn.

## Test (fails before / passes after)

New leg in `tripwire_retry_timeout_e2e`: a fake `claude` prints a known stderr marker then exits 1 (→ `agent_error`); the test asserts the failed row's `result` column contains that marker. Verified fails-before via in-place revert (`result = None`), passes-after.

## Validation

- `cargo fmt --check` clean (reverted pre-existing `live_e2e.rs` fmt drift).
- `cargo clippy -p ainb-hangar-store -p ainb-hangar-daemon --tests`: no new warnings.
- `cargo test -p ainb-hangar-store`: full suite green.
- `cargo test -p ainb-hangar-daemon --lib`: 288 passed.
- `tripwire_retry_timeout_e2e` (all 4 legs), `tripwire_spawn_error_fails_task`, `tripwire_provision_error_fails_task`, `tripwire_ttl_sweeper_fails_stale_dispatched`: green.
- `cargo build -p ainb`: green.

Small single-concern change across two buildable atoms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed tasks now preserve useful provider error details when available.
  * Failure logs include captured error output to improve troubleshooting.
  * Added regression coverage for provider crashes and persisted failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->