### PR TITLE
fix(hangar): resolve provider path to absolute before sandbox profile

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -37,7 +37,7 @@
 #![allow(clippy::duration_suboptimal_units)]
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -172,12 +172,29 @@ impl DaemonConfig {
         // bound to it, so the claim loop (run_loop.rs, skipped when `None`) is
         // enabled out of the box. `HANGAR_DAEMON_RUNTIME_ID` still overrides.
         let runtime_id = Some(ainb_hangar_store::bootstrap::default_runtime_id());
-        let claude_path = std::env::var_os("HANGAR_CLAUDE_PATH")
-            .map_or_else(|| PathBuf::from("claude"), PathBuf::from);
-        let codex_path = std::env::var_os("HANGAR_CODEX_PATH")
-            .map_or_else(|| PathBuf::from("codex"), PathBuf::from);
-        let copilot_path = std::env::var_os("HANGAR_COPILOT_PATH")
-            .map_or_else(|| PathBuf::from("copilot"), PathBuf::from);
+        // Resolve each provider path to an absolute, symlink-canonicalized
+        // binary ONCE here, before it ever reaches `RunnerConfig` and the
+        // sandbox profile generator. A bare default (`claude`/`codex`/`copilot`)
+        // is otherwise emitted into the Seatbelt profile as a meaningless
+        // `(literal "claude")` rule that the kernel never matches, so the OS
+        // sandbox denies exec of the real PATH-resolved binary (e.g. a
+        // `~/.local/bin/claude` symlink outside every system read root) and the
+        // task finalizes `failed` in milliseconds with an empty transcript.
+        let claude_path = resolve_provider_path(
+            std::env::var_os("HANGAR_CLAUDE_PATH")
+                .map_or_else(|| PathBuf::from("claude"), PathBuf::from),
+            "claude",
+        );
+        let codex_path = resolve_provider_path(
+            std::env::var_os("HANGAR_CODEX_PATH")
+                .map_or_else(|| PathBuf::from("codex"), PathBuf::from),
+            "codex",
+        );
+        let copilot_path = resolve_provider_path(
+            std::env::var_os("HANGAR_COPILOT_PATH")
+                .map_or_else(|| PathBuf::from("copilot"), PathBuf::from),
+            "copilot",
+        );
         let poll_interval =
             Duration::from_millis(env_u64("HANGAR_DAEMON_POLL_MS", DEFAULT_POLL_MS));
         let provider_max_runtime = env_u64_opt("HANGAR_PROVIDER_MAX_RUNTIME_MS")
@@ -253,6 +270,50 @@ impl DaemonConfig {
     #[cfg(not(target_os = "macos"))]
     const fn default_sandbox() -> bool {
         true
+    }
+}
+
+/// Resolve a provider binary to an absolute, symlink-canonicalized path once at
+/// daemon startup, before it flows into [`RunnerConfig`] and the sandbox profile
+/// generator ([`ainb_hangar_sandbox`]).
+///
+/// A bare name (no path separator, the default `claude`/`codex`/`copilot`) is
+/// located on `$PATH`; an explicit `HANGAR_*_PATH` override is honored as given.
+/// Either way the result is canonicalized so the Seatbelt/Landlock profile
+/// references the real binary the OS will exec (e.g. a `~/.local/bin/claude`
+/// symlink into `~/.local/share/claude/versions/…`), which no system read root
+/// covers. If a bare name resolves nowhere on `$PATH`, falls back to the bare
+/// name and logs a warning so the otherwise-silent sandbox denial is
+/// diagnosable rather than a 40ms `agent_error` with an empty transcript.
+fn resolve_provider_path(raw: PathBuf, provider: &str) -> PathBuf {
+    let is_bare = raw.parent() == Some(Path::new(""));
+    let located = if is_bare {
+        match ainb_hangar_sandbox::find_on_path(&raw) {
+            Some(found) => found,
+            None => {
+                tracing::warn!(
+                    provider,
+                    name = %raw.display(),
+                    "provider binary not found on PATH; the OS sandbox will likely deny \
+                     exec; set the HANGAR_*_PATH override to an absolute binary path"
+                );
+                raw
+            }
+        }
+    } else {
+        raw
+    };
+    match std::fs::canonicalize(&located) {
+        Ok(abs) => abs,
+        Err(e) => {
+            tracing::warn!(
+                provider,
+                path = %located.display(),
+                error = %e,
+                "failed to canonicalize provider path; using as given"
+            );
+            located
+        }
     }
 }
 
@@ -2463,6 +2524,60 @@ mod tests {
         assert!(
             posture,
             "non-macOS: headless sandbox must default ON (Landlock runs the CLI fine)"
+        );
+    }
+
+    /// A bare provider name is resolved to an absolute binary via `$PATH`:
+    /// `sh` stands in for `claude`, reliably present on `$PATH` on any unix host.
+    /// Before this fix the bare `PathBuf::from("claude")` flowed unresolved into
+    /// the sandbox profile as a `(literal "claude")` rule the kernel never
+    /// matched.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_provider_path_resolves_bare_name_to_absolute() {
+        let resolved = resolve_provider_path(PathBuf::from("sh"), "claude");
+        assert!(
+            resolved.is_absolute(),
+            "bare provider name must resolve to an absolute path: {resolved:?}"
+        );
+        assert!(
+            resolved.is_file(),
+            "resolved provider path must be a real file: {resolved:?}"
+        );
+    }
+
+    /// An explicit override path is canonicalized (symlink-resolved) so the
+    /// profile references the real target the OS execs.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_provider_path_canonicalizes_explicit_symlink() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real-claude");
+        std::fs::write(&real, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let link = dir.path().join("claude-link");
+        symlink(&real, &link).unwrap();
+
+        let resolved = resolve_provider_path(link.clone(), "claude");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&real).unwrap(),
+            "explicit path must be symlink-canonicalized to its real target"
+        );
+        assert!(resolved.is_absolute());
+    }
+
+    /// A bare name absent from `$PATH` falls back to the bare name (and warns) so
+    /// the daemon still boots; the sandbox denial is diagnosable, not a panic.
+    #[test]
+    fn resolve_provider_path_falls_back_when_absent() {
+        let bare = PathBuf::from("definitely-not-a-real-provider-xyz123");
+        let resolved = resolve_provider_path(bare.clone(), "claude");
+        assert_eq!(
+            resolved, bare,
+            "an unresolvable bare name is returned as-is"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-sandbox/src/imp_macos.rs
+++ b/ainb-tui/crates/ainb-hangar-sandbox/src/imp_macos.rs
@@ -31,7 +31,9 @@
 use std::fmt::Write as _;
 use std::path::Path;
 
-use crate::{Enforcement, SandboxError, SandboxPolicy, SandboxedCommand, canonical_or_self};
+use crate::{
+    Enforcement, SandboxError, SandboxPolicy, SandboxedCommand, canonical_or_self, resolve_program,
+};
 
 /// The system launcher that applies a Seatbelt profile to a child process.
 const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
@@ -83,8 +85,11 @@ fn render_profile(program: &Path, policy: &SandboxPolicy) -> String {
         let _ = writeln!(p, "(allow file-read* (subpath {}))", sb_quote(&c));
     }
     // The program binary itself must be readable even if its dir is not a
-    // configured read root (e.g. a test stand-in under a tempdir).
-    let prog = canonical_or_self(program);
+    // configured read root (e.g. a test stand-in under a tempdir). A bare name
+    // (the daemon's default, e.g. `claude`) is PATH-resolved to the absolute
+    // binary the OS will exec; otherwise the rule would be a meaningless
+    // `(literal "claude")` the kernel never matches, and the sandbox denies exec.
+    let prog = resolve_program(program);
     let _ = writeln!(p, "(allow file-read* (literal {}))", sb_quote(&prog));
     if let Some(dir) = prog.parent() {
         let _ = writeln!(p, "(allow file-read* (subpath {}))", sb_quote(dir));
@@ -185,6 +190,43 @@ mod tests {
         assert!(
             !prof.contains("mach-lookup"),
             "the default task policy must grant no mach service: {prof}"
+        );
+    }
+
+    /// A bare provider name (the daemon default, e.g. `claude`) must never
+    /// survive into the profile as a `(literal "claude")` rule: that path is
+    /// relative, matches nothing the kernel resolves, and the sandbox then
+    /// denies exec of the real PATH-resolved binary. `sh` stands in as a bare
+    /// name reliably present on `$PATH` on any unix host.
+    #[cfg(unix)]
+    #[test]
+    fn bare_program_name_resolves_to_absolute_binary() {
+        let policy = SandboxPolicy {
+            read_roots: vec![PathBuf::from("/usr")],
+            write_roots: vec![PathBuf::from("/tmp/task")],
+            allow_network: true,
+            disabled: false,
+        };
+        let prof = render_profile(Path::new("sh"), &policy);
+
+        // The bare name must not appear as a literal read rule.
+        assert!(
+            !prof.contains("(allow file-read* (literal \"sh\"))"),
+            "bare program name must not survive into the profile: {prof}"
+        );
+
+        // The emitted program read rule must reference an absolute path.
+        let resolved = resolve_program(Path::new("sh"));
+        assert!(
+            resolved.is_absolute(),
+            "resolved program must be absolute: {resolved:?}"
+        );
+        assert!(
+            prof.contains(&format!(
+                "(allow file-read* (literal {}))",
+                sb_quote(&resolved)
+            )),
+            "profile must allow the resolved absolute binary {resolved:?}: {prof}"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-sandbox/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-sandbox/src/lib.rs
@@ -40,6 +40,7 @@
 //! and the workdir, both allowed) can branch on [`SandboxPolicy::disabled`] and
 //! [`Enforcement`] without touching this crate's internals.
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 mod policy;
@@ -182,4 +183,109 @@ fn passthrough(program: &Path) -> SandboxedCommand {
 /// generated profile / ruleset references real, symlink-resolved paths.
 pub(crate) fn canonical_or_self(p: &Path) -> PathBuf {
     std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Whether `p` is a bare program name: a single component with no path
+/// separator, e.g. `"claude"` (as opposed to `"./claude"` or `"/usr/bin/claude"`).
+/// Such a name is meaningless to the kernel's path-based sandbox rules: it must
+/// be resolved to the absolute binary the OS will actually exec.
+fn is_bare_name(p: &Path) -> bool {
+    p.parent() == Some(Path::new("")) && p.file_name().is_some()
+}
+
+/// Whether `p` exists as an executable regular file (used by the `PATH` search).
+#[cfg(unix)]
+fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+/// Whether `p` exists as a regular file (non-unix has no exec bit to check).
+#[cfg(not(unix))]
+fn is_executable_file(p: &Path) -> bool {
+    p.is_file()
+}
+
+/// Search `$PATH` for a bare executable `name`.
+///
+/// Returns the first entry that exists and is executable, or `None` for a
+/// non-bare path (it already names a location) or when nothing on `$PATH`
+/// matches.
+///
+/// Public so the daemon can resolve a bare provider name (the default
+/// `"claude"`/`"codex"`/`"copilot"`) to an absolute binary ONCE at startup,
+/// before the path ever reaches [`sandboxed_command`], and warn if resolution
+/// fails. This crate itself uses it as defense-in-depth ([`resolve_program`]) so
+/// a bare program name can never emit a meaningless `(literal "<bare-name>")`
+/// rule that matches nothing.
+#[must_use]
+pub fn find_on_path(name: &Path) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    find_on_path_in(name, &path_var)
+}
+
+/// [`find_on_path`] against an explicit `$PATH` value, the injectable seam so
+/// the search is testable without mutating the process environment.
+fn find_on_path_in(name: &Path, path_var: &OsStr) -> Option<PathBuf> {
+    if !is_bare_name(name) {
+        return None;
+    }
+    std::env::split_paths(path_var)
+        .map(|dir| dir.join(name))
+        .find(|candidate| is_executable_file(candidate))
+}
+
+/// Resolve a program path for a sandbox profile to a real, absolute, symlink-
+/// canonicalized binary.
+///
+/// A bare name is located on `$PATH` first (so the profile references the actual
+/// binary the OS will exec, e.g. a `~/.local/bin/claude` symlink into
+/// `~/.local/share/claude/versions/…` that no system read root covers); anything
+/// else, or a bare name not found on `$PATH`, falls back to
+/// [`canonical_or_self`].
+///
+/// Defense-in-depth: the daemon already resolves provider paths at startup, but
+/// this guarantees a bare name can never survive into the emitted profile as a
+/// meaningless `(literal "<bare-name>")` allow rule.
+pub(crate) fn resolve_program(program: &Path) -> PathBuf {
+    let located = find_on_path(program).unwrap_or_else(|| program.to_path_buf());
+    canonical_or_self(&located)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn find_on_path_resolves_bare_name_in_temp_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("myprov");
+        std::fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // A bare name on a `$PATH` that contains the temp dir resolves to the
+        // absolute file (canonicalized upstream in `resolve_program`).
+        let found = find_on_path_in(Path::new("myprov"), dir.path().as_os_str()).unwrap();
+        assert_eq!(found, bin);
+        assert!(found.is_absolute());
+
+        // A name absent from the given `$PATH` resolves to nothing.
+        assert!(
+            find_on_path_in(Path::new("definitely-absent-xyz"), dir.path().as_os_str()).is_none()
+        );
+
+        // A non-bare path is never PATH-searched.
+        assert!(find_on_path_in(Path::new("/usr/bin/myprov"), dir.path().as_os_str()).is_none());
+    }
+
+    #[test]
+    fn is_bare_name_distinguishes_plain_names_from_paths() {
+        assert!(is_bare_name(Path::new("claude")));
+        assert!(!is_bare_name(Path::new("./claude")));
+        assert!(!is_bare_name(Path::new("/usr/bin/claude")));
+        assert!(!is_bare_name(Path::new("dir/claude")));
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-sandbox/tests/sandboxed_bare_program.rs
+++ b/ainb-tui/crates/ainb-hangar-sandbox/tests/sandboxed_bare_program.rs
@@ -1,0 +1,62 @@
+//! Regression tripwire for the class of bug where a bare provider name
+//! (`claude`/`codex`/`copilot`) installed under a NON-system root cannot be
+//! exec'd under the OS sandbox because the profile referenced the unresolved
+//! relative name instead of the real PATH-resolved absolute binary.
+//!
+//! macOS-only: it drives a real `sandbox-exec` Seatbelt confinement end to end.
+//! A bare-name program placed in a tempdir (under `/private/var/folders/…`,
+//! outside every `SYSTEM_READ_ROOTS` entry) must still exec when that tempdir is
+//! on `$PATH`. Before the fix the emitted rule was `(literal "prov")`, relative,
+//! matching nothing the kernel resolves, and the sandboxed exec was denied.
+
+#![cfg(target_os = "macos")]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use ainb_hangar_sandbox::{Enforcement, SandboxPolicy, sandboxed_command};
+
+#[test]
+fn sandbox_can_exec_bare_program_installed_under_non_system_root() {
+    // A provider binary living outside every system read root (a tempdir under
+    // /private/var/folders on macOS), reachable only by name via `$PATH`.
+    let bin_dir = tempfile::tempdir().expect("temp bin dir");
+    let prog = bin_dir.path().join("prov");
+    std::fs::write(&prog, "#!/bin/sh\nexit 0\n").expect("write stub provider");
+    std::fs::set_permissions(&prog, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod +x stub provider");
+
+    // Put the tempdir on `$PATH` so a BARE name resolves to it; this is the
+    // exact shape of the daemon's default `claude` on a `~/.local/bin` install.
+    // Edition 2021: `set_var` is safe. This test is the sole test in its own
+    // integration binary, so the process-global `$PATH` mutation races nothing.
+    let orig_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir.path().to_path_buf()];
+    paths.extend(std::env::split_paths(&orig_path));
+    let joined = std::env::join_paths(paths).expect("join PATH");
+    std::env::set_var("PATH", &joined);
+
+    // A task root the child may read/write; confinement ON.
+    let task_root = tempfile::tempdir().expect("task root");
+    let policy = SandboxPolicy::confined_to(task_root.path());
+
+    let built = sandboxed_command(Path::new("prov"), &policy).expect("build sandboxed command");
+
+    // Only meaningful when the OS primitive actually enforces.
+    if built.enforcement() != Enforcement::Enforced {
+        std::env::set_var("PATH", &orig_path);
+        eprintln!("SKIP: OS sandbox not enforcing on this host");
+        return;
+    }
+
+    let status = built.into_inner().status().expect("spawn sandboxed provider");
+
+    std::env::set_var("PATH", &orig_path);
+
+    assert!(
+        status.success(),
+        "sandboxed exec of a bare-name provider under a non-system root must \
+         succeed (exit {:?}); a failure is the unresolved-path regression",
+        status.code()
+    );
+}


### PR DESCRIPTION
## Problem

Every headless hangar dispatch under the macOS Seatbelt sandbox fails in ~40ms with `exit_code=65`, `failure_reason=agent_error`, empty stdout/stderr, on any host where the provider binary is not under a system read root (nvm / homebrew / `$HOME/.local` installs).

Root cause: `DaemonConfig::from_env` defaults `claude_path`/`codex_path`/`copilot_path` to the **bare** strings `"claude"`/`"codex"`/`"copilot"` when `HANGAR_*_PATH` is unset. That bare `PathBuf` flows unchanged into `RunnerConfig` and then into the sandbox profile generator. `render_profile` resolves the program via `canonical_or_self`, but `std::fs::canonicalize("claude")` from the daemon cwd returns `NotFound`, so it silently falls back to the unresolved relative path. The emitted SBPL is `(allow file-read* (literal "claude"))` plus a subpath of the *empty* parent, which never matches the real PATH-resolved absolute binary (e.g. `/Users/x/.local/bin/claude -> .../share/claude/versions/2.1.217`). That path is outside `SYSTEM_READ_ROOTS` and outside the task root, so the OS sandbox denies exec.

Distinct from #435 (async keychain wedge) and #436 (spawn-preamble timeout).

## Fix

Two layers:

1. **Daemon (root fix)** — `DaemonConfig::from_env` now resolves each provider path **once at startup**, before it reaches `RunnerConfig`. A bare name is PATH-searched (`ainb_hangar_sandbox::find_on_path`) then canonicalized; an explicit `HANGAR_*_PATH` override is honored and still canonicalized. An unresolvable bare name falls back to the bare name with a `tracing::warn` so the denial is diagnosable, not silent.
2. **Sandbox crate (defense-in-depth)** — `render_profile` resolves the program via a new `resolve_program`, so even if a bare name reaches it, PATH resolution runs before the profile is generated and no meaningless `(literal "<bare-name>")` rule can be emitted.

## Tests (fail before, pass after)

- `render_profile` never emits a bare-name literal rule; the program rule is an absolute path.
- Hermetic PATH-search unit test (bare name in a temp PATH dir resolves to the absolute file).
- Daemon `resolve_provider_path`: bare name → absolute; explicit symlink → canonicalized target; absent bare name → clean fallback.
- **macOS sandboxed-dispatch tripwire** (`crates/ainb-hangar-sandbox/tests/sandboxed_bare_program.rs`): builds a real Seatbelt-confined command for a bare-name provider installed under a non-system root on `$PATH` and asserts it can actually exec. Reverting the fix reproduces `exit 65`; with the fix it exits 0. This catches the whole class in CI instead of only the live e2e loop.

`cargo test` green for `ainb-hangar-sandbox` + `ainb-hangar-daemon` (292 daemon lib tests); `cargo clippy -D warnings` clean on both changed crates; `cargo build -p ainb` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider executable resolution when configured by name or path.
  * Fixed macOS sandbox access for provider binaries installed outside standard system locations.
  * Ensured symbolic links resolve correctly so sandbox permissions apply to the actual executable.
* **Tests**
  * Added coverage for PATH-based resolution, symbolic links, missing binaries, and sandboxed execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->