### PR TITLE
fix(hangar): make agent_error failure path self-diagnosing

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -1080,6 +1080,7 @@ async fn execute_claimed(
                 pool,
                 &task,
                 &run_wd,
+                &env,
                 ainb_hangar_store::service::fail::FailureReason::SpawnTimeout,
                 crate::runner::RunnerResult::default(),
                 provider,
@@ -1230,7 +1231,7 @@ async fn execute_claimed(
             // running -> failed: type the terminal edge before the store finalize.
             lifecycle.fire(crate::fsm::LifecycleEvent::Fail)?;
             finalize_failure(
-                pool, &task, &run_wd, reason, result, provider, clock, stats, events,
+                pool, &task, &run_wd, &env, reason, result, provider, clock, stats, events,
             )
             .await?;
         }
@@ -1551,10 +1552,52 @@ async fn finalize_success(
 ///
 /// Propagates a [`persist_session_id`] or [`FailTaskService`] FSM/DB fault. The
 /// progress comment and the retry evaluation are best-effort and never error.
+/// Compose the human-readable `result`-column detail for a failed run from the
+/// runner's captured output tails, or `None` when the runner captured NOTHING
+/// (the bare `fail` path with no stored detail).
+///
+/// BOTH tails are folded, each under its own labelled section, because the two
+/// providers surface their terminal error on different streams: `claude
+/// --output-format stream-json` writes the failing `{"type":"result",...}` line
+/// to STDOUT, while a crashed CLI or a shell wrapper writes to STDERR. Persisting
+/// only stderr (the previous behaviour) therefore dropped exactly the evidence an
+/// exit-65 claude agent_error leaves behind, making it undiagnosable from the DB.
+fn failure_detail(
+    reason: ainb_hangar_store::service::fail::FailureReason,
+    stdout_tail: &str,
+    stderr_tail: &str,
+) -> Option<String> {
+    let stdout = stdout_tail.trim();
+    let stderr = stderr_tail.trim();
+    if stdout.is_empty() && stderr.is_empty() {
+        return None;
+    }
+    let mut detail = format!("run failed ({}):", reason.as_db_str());
+    if !stdout.is_empty() {
+        detail.push_str("\n\nstdout:\n");
+        detail.push_str(stdout);
+    }
+    if !stderr.is_empty() {
+        detail.push_str("\n\nstderr:\n");
+        detail.push_str(stderr);
+    }
+    Some(detail)
+}
+
+/// hangar-e2e-6 escape hatch: when `HANGAR_KEEP_FAILED_RUNS=1` the daemon
+/// PRESERVES a failed run's worktree + provider-log dir instead of tearing the
+/// clean worktree down, so the e2e loop can inspect the transcript
+/// (`{logs}/claude.jsonl`) of a zero-output failure. Off by default — production
+/// keeps the keep-if-dirty teardown so a clean failed run never leaks disk.
+fn keep_failed_runs() -> bool {
+    std::env::var_os("HANGAR_KEEP_FAILED_RUNS").is_some_and(|v| v == "1")
+}
+
 async fn finalize_failure(
     pool: &SqlitePool,
     task: &Task,
     run_wd: &crate::workdir_provision::RunWorkdir,
+    env: &crate::execenv::ExecEnv,
     reason: ainb_hangar_store::service::fail::FailureReason,
     result: crate::runner::RunnerResult,
     provider: &str,
@@ -1565,17 +1608,17 @@ async fn finalize_failure(
     // Persist the session id (if any) before failing so a retry can resume the
     // provider conversation.
     persist_session_id(pool, &task.id, result.session_id.as_deref()).await?;
-    // When the runner captured a stderr tail (a crashed / gave-up provider),
+    // When the runner captured any output tail (a crashed / gave-up provider),
     // persist it into the `result` column (in the TaskResult `{"content": ...}`
     // shape the detail surface renders) so the failure is diagnosable from stored
     // evidence alone. The bare `fail` path left `result` blank, making every
-    // `agent_error` crash undiagnosable from the DB. No tail → the plain `fail`.
-    let fail_outcome = {
-        let tail = result.stderr_tail.trim();
-        if tail.is_empty() {
-            FailTaskService::fail(pool, &task.id, reason, clock).await
-        } else {
-            let detail = format!("run failed ({}):\n\n{tail}", reason.as_db_str());
+    // `agent_error` crash undiagnosable from the DB. Both tails are folded:
+    // `claude --output-format stream-json` writes its terminal ERROR line to
+    // STDOUT, so persisting only stderr dropped exactly the evidence an exit-65
+    // agent_error leaves behind. Neither tail → the plain `fail`.
+    let fail_outcome = match failure_detail(reason, &result.stdout_tail, &result.stderr_tail) {
+        None => FailTaskService::fail(pool, &task.id, reason, clock).await,
+        Some(detail) => {
             FailTaskService::fail_with_detail(pool, &task.id, reason, &detail, clock).await
         }
     };
@@ -1670,7 +1713,23 @@ async fn finalize_failure(
     // rerun / inspection); a clean one is removed. Done BEFORE the retry spawn so
     // a retryable failure's fresh child re-provisions a clean worktree rather than
     // resuming into this run's residue.
-    teardown_workdir(run_wd, &task.id);
+    //
+    // hangar-e2e-6: the escape hatch preserves BOTH the worktree AND the
+    // provider-log dir for a clean (zero-work) failure so the e2e loop can read
+    // `{logs}/claude.jsonl` — the transcript a 36ms exit-65 crash would otherwise
+    // lose to keep-if-dirty teardown. The retry child is a NEW task row with a
+    // NEW full-id-keyed worktree, so keeping this run's residue never collides.
+    if keep_failed_runs() {
+        tracing::warn!(
+            task_id = %task.id,
+            reason = reason.as_db_str(),
+            worktree = %run_wd.path().display(),
+            logs_dir = %env.logs.display(),
+            "HANGAR_KEEP_FAILED_RUNS=1: preserving failed run's worktree + provider logs for inspection"
+        );
+    } else {
+        teardown_workdir(run_wd, &task.id);
+    }
     // F06 retry chain: a retryable (infra) failure with attempts remaining
     // spawns a fresh `queued` child carrying `parent_task_id`, which the next
     // claim pass re-dispatches. A terminal reason (`agent_error` / `user_cancel`
@@ -2509,6 +2568,65 @@ fn warn_danger_access(task: &Task, provider: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// hangar-e2e-6: a failed run whose runner captured BOTH stdout and stderr
+    /// tails must surface BOTH in the persisted failure detail. This is the core
+    /// observability fix: `claude --output-format stream-json` writes its terminal
+    /// error line to STDOUT, so the previous stderr-only detail left an exit-65
+    /// `agent_error` diagnosable ONLY if the crash happened to also write stderr —
+    /// which the 36ms zero-output failure did not.
+    #[test]
+    fn failure_detail_folds_both_stdout_and_stderr_tails() {
+        use ainb_hangar_store::service::fail::FailureReason;
+        let detail = failure_detail(
+            FailureReason::AgentError,
+            r#"{"type":"result","subtype":"error_during_execution","error":"boom"}"#,
+            "node: fatal: could not start",
+        )
+        .expect("both tails present → a Some detail");
+        assert!(
+            detail.contains("agent_error"),
+            "detail must name the reason: {detail}"
+        );
+        assert!(
+            detail.contains("boom"),
+            "detail must carry the STDOUT tail (claude writes its error there): {detail}"
+        );
+        assert!(
+            detail.contains("node: fatal: could not start"),
+            "detail must carry the STDERR tail: {detail}"
+        );
+    }
+
+    /// The regression this fix closes: a failure with output ONLY on stdout (the
+    /// exit-65 claude shape — a stream-json error line, empty stderr) must still
+    /// produce a stored detail. The old code keyed solely on the stderr tail and
+    /// returned the blank `fail` for exactly this case.
+    #[test]
+    fn failure_detail_surfaces_stdout_only_failures() {
+        use ainb_hangar_store::service::fail::FailureReason;
+        let detail = failure_detail(
+            FailureReason::AgentError,
+            r#"{"type":"result","subtype":"error","error":"exit 65"}"#,
+            "   ",
+        )
+        .expect("a stdout-only failure must still produce a detail");
+        assert!(
+            detail.contains("exit 65"),
+            "the stdout error line must survive into the detail: {detail}"
+        );
+    }
+
+    /// No captured output on EITHER stream → `None` (the bare `fail` with no
+    /// stored detail), and whitespace-only tails count as empty.
+    #[test]
+    fn failure_detail_is_none_when_no_output_captured() {
+        use ainb_hangar_store::service::fail::FailureReason;
+        assert!(
+            failure_detail(FailureReason::AgentError, "   ", "\n\t").is_none(),
+            "whitespace-only tails must be treated as no captured evidence"
+        );
+    }
 
     /// hangar-e2e-4: the `HANGAR_DAEMON_DISABLE_SANDBOX` override wins in both
     /// directions regardless of platform default — `=1` forces the headless OS

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -1351,6 +1351,29 @@ impl Runner {
     {
         let child_env = compose_child_env(source_env, extra_env);
 
+        // hangar-e2e-6 observability: record WHAT is about to spawn — the
+        // RESOLVED provider binary, the cwd, and the child-env KEY SET — before
+        // the process runs. A failure that destroys all output (claude exiting
+        // 65 in 36ms with zero stdout/stderr) is otherwise unattributable: there
+        // is no record of which binary ran, where, or whether the auth env was
+        // injected. Values are NEVER logged (the secret-leak boundary
+        // `compose_child_env` enforces); only key NAMES, plus explicit presence
+        // flags for the two auth vars whose absence is the usual headless-dispatch
+        // failure mode.
+        let env_keys: Vec<&str> = child_env.iter().map(|(k, _)| k.as_str()).collect();
+        let has_claude_home = child_env.iter().any(|(k, _)| k == "CLAUDE_HOME");
+        let has_claude_code_oauth_token =
+            child_env.iter().any(|(k, _)| k == "CLAUDE_CODE_OAUTH_TOKEN");
+        tracing::info!(
+            provider = spec.backend.name(),
+            binary = %program.display(),
+            cwd = %location.cwd.display(),
+            env_keys = ?env_keys,
+            has_claude_home,
+            has_claude_code_oauth_token,
+            "provider_spawn: resolved binary + cwd + child-env key set"
+        );
+
         let log_path = env.logs.join(spec.log_file);
         let log_file = std::fs::OpenOptions::new()
             .create(true)
@@ -1546,7 +1569,7 @@ fn finalize_outcome(
             if reason == FailureReason::ProviderContractDrift {
                 log_contract_drift(backend, "unrecognised result subtype", &result.stdout_tail);
             } else {
-                tracing::warn!(provider = backend.name(), ?reason, exit_code = ?exit_code, "runner_failed_structured");
+                tracing::warn!(provider = backend.name(), ?reason, exit_code = ?exit_code, stdout_tail = %result.stdout_tail, stderr_tail = %result.stderr_tail, "runner_failed_structured");
             }
             RunOutcome::Failed { reason, result }
         }
@@ -1577,6 +1600,8 @@ fn finalize_outcome(
                         provider = backend.name(),
                         ?reason,
                         reason_detail = "no_success_terminal",
+                        stdout_tail = %result.stdout_tail,
+                        stderr_tail = %result.stderr_tail,
                         "runner_failed"
                     );
                 }
@@ -1588,6 +1613,8 @@ fn finalize_outcome(
                 tracing::warn!(
                     provider = backend.name(),
                     reason = "runtime_offline",
+                    stdout_tail = %result.stdout_tail,
+                    stderr_tail = %result.stderr_tail,
                     "runner_failed"
                 );
                 RunOutcome::Failed {


### PR DESCRIPTION
## Problem

Cycle 6 of the hangar e2e loop hit a V3 solo dispatch where `claude` exited **65 in 36ms with ZERO stdout and ZERO stderr** surfaced anywhere. The exit-65 signature matches cycle-4 PR #441 (macOS Seatbelt kills the Node `claude` CLI), **but the sandbox path is NOT engaged this run**: `DaemonConfig::default_sandbox()` is `false` on macOS and no `HANGAR_DAEMON_DISABLE_SANDBOX` is set, so `build_command` takes the passthrough branch. Same exit code, **different root cause** — so per the same-bug-twice rule the #441 sandbox fix is deliberately **not re-applied here**.

The true cause is honestly un-pinnable because the failure path **destroys all evidence**:
- `finalize_outcome`'s `agent_error` WARNs log only `exit_code`, never the captured output tails.
- `finalize_failure` persists only `stderr_tail` into the `result` column — and it was empty. `claude --output-format stream-json` writes its terminal error line to **STDOUT**, which was dropped entirely.
- Teardown is keep-if-DIRTY, and a 36ms zero-work run leaves a clean tree, so the worktree + `claude.jsonl` transcript are removed before inspection.
- Nothing records which binary actually spawned, in what cwd, or whether `CLAUDE_HOME` / `CLAUDE_CODE_OAUTH_TOKEN` were injected.

The blocker is **observability**, so that is the layer this PR attacks.

## Change

- `runner.rs` `finalize_outcome`: add `stdout_tail` + `stderr_tail` to every `runner_failed` / `runner_failed_structured` WARN.
- `run_loop.rs` `finalize_failure`: fold **both** output tails into the persisted failure detail (new `failure_detail` helper), each under a labelled `stdout:` / `stderr:` section — a stdout-only claude error is now diagnosable from the DB alone.
- `run_loop.rs`: `HANGAR_KEEP_FAILED_RUNS=1` escape hatch that preserves the failed run's worktree **and** provider-log dir (`{logs}/claude.jsonl`) instead of tearing a clean one down. Off by default; production keeps keep-if-dirty teardown so a clean failed run never leaks disk.
- `runner.rs`: at spawn, log at INFO the resolved provider binary, `location.cwd`, and the child-env **KEY SET** (names only, never values) plus explicit `CLAUDE_HOME` / `CLAUDE_CODE_OAUTH_TOKEN` presence flags.

## Tests

Three new lib unit tests on `failure_detail`, proven to fail against the old stderr-only logic (verified by in-place mutation) and pass after:
- both tails folded and labelled
- **stdout-only** failure (the exit-65 claude shape) still surfaces — the regression this closes
- whitespace-only tails → `None` (bare `fail`, no stored detail)

`cargo test -p ainb-hangar-daemon --lib` → 294 passed. `cargo build -p ainb` green. The existing `agent_error_persists_captured_stderr_tail_into_result` tripwire stays compatible (skips locally without a staged TUI).

**This does NOT re-apply the #441 sandbox fix.** It makes cycle 7 pin the real cause instead of re-guessing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed tasks now retain more complete diagnostic details, including available standard output and error output.
  * Failure records are clearer when provider execution encounters errors or unexpected results.

* **New Features**
  * Failed run files and provider logs can optionally be preserved for investigation by enabling `HANGAR_KEEP_FAILED_RUNS=1`.
  * Additional execution details are available in daemon logs, including provider startup and failure output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->