### PR TITLE
fix(hangar): manual R retry re-queues a terminal agent_error task

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -649,6 +649,7 @@ async fn handle(
         | methods::HANGAR_AUTOPILOT_SET_ENABLED => handle_autopilot(pool, req, events).await,
         methods::HANGAR_TASKS_LIST => handle_tasks_list(pool, req).await,
         methods::HANGAR_TASK_TRANSITION => handle_task_transition(pool, req, events).await,
+        methods::HANGAR_TASK_RETRY => handle_task_retry(pool, req, events).await,
         methods::HANGAR_ISSUE_CREATE => handle_issue_create(pool, req, events).await,
         methods::HANGAR_ISSUE_DELETE => handle_issue_delete(pool, req, events).await,
         methods::HANGAR_ISSUE_CANCEL_ACTIVE => handle_issue_cancel_active(pool, req, events).await,
@@ -977,6 +978,79 @@ async fn handle_task_transition(
         }
     }
     Ok(serde_json::json!({}))
+}
+
+/// Dispatch `hangar/task_retry`: force-requeue one terminal task at an operator's
+/// explicit request (the Task Kanban failed-column / task-detail `R`).
+///
+/// Unlike the automatic retry seam in the run loop, this is a HUMAN override:
+/// [`RetryService::force_requeue`] bypasses both the `RetryDisposition` reason gate
+/// and the `max_attempts` cap, so a terminal `agent_error` (which never
+/// auto-retries) still spawns a fresh `queued` child. On a spawn we emit
+/// [`HangarEvent::TaskQueued`] so every subscribed board re-pulls its task list and
+/// the new attempt card appears in the queued column — the visible confirmation of
+/// the requeue.
+///
+/// Workspace-scoped like the sibling mutators: an unknown workspace or a foreign /
+/// missing task id is an `INVALID_PARAMS` rejection (a mutating handler must not
+/// silently no-op on a typo). A non-terminal task answers `{ new_task_id: null }`
+/// (nothing to requeue). A per-(issue, agent) pending-slot collision surfaces the
+/// store error.
+async fn handle_task_retry(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+    use ainb_hangar_store::repo::task::TaskRepo;
+    use ainb_hangar_store::service::retry::{RetryDecision, RetryService};
+
+    let params: ainb_hangar_proto::snapshots::TaskRetryParams =
+        parse_params(req, "{ workspace_id, task_id }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let task = TaskRepo::get_by_id(pool, &params.task_id)
+        .await
+        .map_err(|e| store_err(&e))?
+        .filter(|t| t.workspace_id == ws.as_str())
+        .ok_or_else(|| {
+            invalid_params(&format!("no task `{}` in this workspace", params.task_id))
+        })?;
+
+    let new_id = SystemIdGen.new_ulid();
+    let decision = RetryService::force_requeue(pool, &task, &new_id, &SystemClock)
+        .await
+        .map_err(|e| store_err(&e))?;
+
+    let new_task_id = match decision {
+        RetryDecision::Spawned { new_task_id } => {
+            // Announce the fresh attempt so boards re-pull and surface the queued
+            // card. TaskQueued needs the issue + agent ids; a task with no issue
+            // still requeues, it just publishes no queue event (the next snapshot
+            // pull reconciles either way).
+            if let (Ok(task_id), Some(issue_raw)) = (
+                ainb_hangar_core::ids::TaskId::from_str(new_task_id.clone()),
+                task.issue_id.clone(),
+            ) {
+                if let (Ok(issue_id), Ok(agent_id)) = (
+                    ainb_hangar_core::ids::IssueId::from_str(issue_raw),
+                    AgentId::from_str(task.agent_id.clone()),
+                ) {
+                    events.emit(
+                        ws.as_str(),
+                        ainb_hangar_proto::events::HangarEvent::TaskQueued {
+                            task_id,
+                            issue_id,
+                            agent_id,
+                        },
+                    );
+                }
+            }
+            Some(new_task_id)
+        }
+        RetryDecision::DoNotRetry => None,
+    };
+
+    to_value(&ainb_hangar_proto::snapshots::TaskRetryResult { new_task_id })
 }
 
 /// Map a committed task transition onto its wire [`HangarEvent`] (e38.2).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_task_retry.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_task_retry.rs
@@ -1,0 +1,226 @@
+//! Integration: the `hangar/task_retry` RPC force-requeues a terminal task at an
+//! operator's explicit request (the Task Kanban failed-column / task-detail `R`).
+//!
+//! The bite: a terminal `agent_error` task NEVER auto-retries (its
+//! `RetryDisposition` is `NoRetry`), so the run-loop retry seam leaves it dead.
+//! This handler is the HUMAN override — it must spawn a fresh `parent_task_id`-
+//! chained `queued` child anyway, and publish a `TaskQueued` event so boards
+//! re-pull and the new attempt card appears. We call `rpc::dispatch` directly (it
+//! is IO-free) against a store seeded with a failed `agent_error` task and assert:
+//! (a) the reply carries a `new_task_id`, (b) a fresh queued child exists chained
+//! to the parent, (c) a `TaskQueued` event fired, and (d) a foreign task id is a
+//! rejection, never a silent no-op.
+
+use ainb_hangar_daemon::events::EventBroker;
+use ainb_hangar_daemon::health_stats::HealthStats;
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_proto::events::HangarEvent;
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use std::sync::Arc;
+use std::time::Instant;
+
+fn health() -> DaemonHealth {
+    DaemonHealth {
+        socket_path: "/tmp/task-retry.sock".into(),
+        pid: 1,
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: Arc::new(HealthStats::default()),
+    }
+}
+
+/// Seed the workspace + user + runtime + agent + issue rows the task FKs require.
+async fn seed_graph(store: &Store) {
+    let pool = store.pool();
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
+        .bind("ws-1")
+        .bind("alpha")
+        .bind("Alpha")
+        .bind(0_i64)
+        .execute(pool)
+        .await
+        .expect("insert workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
+        .bind("user-1")
+        .bind("a@example.com")
+        .bind(0_i64)
+        .execute(pool)
+        .await
+        .expect("insert user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind("rt-1")
+    .bind("ws-1")
+    .bind("daemon-rt-1")
+    .bind("claude")
+    .bind("local")
+    .execute(pool)
+    .await
+    .expect("insert runtime");
+    sqlx::query(
+        "INSERT INTO agent \
+         (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("agent-1")
+    .bind("ws-1")
+    .bind("Agent")
+    .bind("rt-1")
+    .bind("workspace")
+    .bind("user-1")
+    .bind(5_i64)
+    .execute(pool)
+    .await
+    .expect("insert agent");
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("issue-1")
+    .bind("ws-1")
+    .bind("An issue")
+    .bind("open")
+    .bind("member")
+    .bind("user-1")
+    .bind(0_i64)
+    .execute(pool)
+    .await
+    .expect("insert issue");
+}
+
+/// Insert a task and drive it to `failed` with `agent_error` — the terminal that
+/// the automatic retry path refuses. `attempt = max_attempts` so this doubly
+/// proves the manual override (past both the reason gate AND the chain cap).
+async fn seed_failed_agent_error(store: &Store) {
+    use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
+    use ainb_hangar_store::service::fail::{FailTaskService, FailureReason};
+    TaskRepo::insert(
+        store.pool(),
+        &NewTask {
+            id: "t1".to_string(),
+            workspace_id: "ws-1".to_string(),
+            runtime_id: "rt-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            issue_id: Some("issue-1".to_string()),
+            work_dir: Some("/tmp/wd".to_string()),
+            priority: 0,
+            created_at: 1,
+            autopilot_run_id: None,
+            generation: 0,
+        },
+    )
+    .await
+    .expect("enqueue");
+    sqlx::query(
+        "UPDATE agent_task_queue SET attempt = 2, max_attempts = 2, status = 'running' WHERE id = 't1'",
+    )
+    .execute(store.pool())
+    .await
+    .expect("force attempt/state");
+    FailTaskService::fail(
+        store.pool(),
+        "t1",
+        FailureReason::AgentError,
+        &ainb_hangar_core::clock::SystemClock,
+    )
+    .await
+    .expect("fail seed task");
+}
+
+/// The queued child rows (other than the parent) for the workspace.
+async fn queued_children(store: &Store) -> Vec<(String, Option<String>, i64)> {
+    sqlx::query_as::<_, (String, Option<String>, i64)>(
+        "SELECT id, parent_task_id, attempt FROM agent_task_queue \
+         WHERE status = 'queued' ORDER BY id",
+    )
+    .fetch_all(store.pool())
+    .await
+    .expect("select queued children")
+}
+
+#[tokio::test]
+async fn task_retry_force_requeues_terminal_agent_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_graph(&store).await;
+    seed_failed_agent_error(&store).await;
+
+    let broker = EventBroker::new();
+    let sink = broker.sink();
+    let mut rx = broker.subscribe();
+    let health = health();
+
+    // Precondition: no queued children yet.
+    assert!(
+        queued_children(&store).await.is_empty(),
+        "no children before retry"
+    );
+
+    let req = RpcRequest {
+        jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+        id: RpcId::Number(1),
+        method: methods::HANGAR_TASK_RETRY.into(),
+        params: serde_json::json!({ "workspace_id": "ws-1", "task_id": "t1" }),
+    };
+    let resp = rpc::dispatch(store.pool(), &req, &health, &sink).await;
+    assert!(
+        resp.error.is_none(),
+        "task_retry must ack: {:?}",
+        resp.error
+    );
+    let new_task_id = resp
+        .result
+        .expect("result")
+        .get("new_task_id")
+        .and_then(|v| v.as_str())
+        .expect("new_task_id present")
+        .to_string();
+
+    // A fresh queued child exists, chained to the parent, attempt past the cap.
+    let children = queued_children(&store).await;
+    assert_eq!(children.len(), 1, "exactly one requeued child");
+    let (id, parent, attempt) = &children[0];
+    assert_eq!(id, &new_task_id, "reply id matches the inserted row");
+    assert_eq!(
+        parent.as_deref(),
+        Some("t1"),
+        "child chains to the failed parent"
+    );
+    assert_eq!(
+        *attempt, 3,
+        "manual override grows attempt past max_attempts=2"
+    );
+
+    // A TaskQueued event fired so boards re-pull and the queued card appears.
+    let scoped = rx.try_recv().expect("a TaskQueued event was published");
+    assert_eq!(scoped.workspace_id, "ws-1");
+    assert!(
+        matches!(scoped.event, HangarEvent::TaskQueued { .. }),
+        "expected TaskQueued, got {:?}",
+        scoped.event
+    );
+}
+
+#[tokio::test]
+async fn task_retry_rejects_foreign_task_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_graph(&store).await;
+    let broker = EventBroker::new();
+    let sink = broker.sink();
+    let health = health();
+
+    // A task id that does not exist must be rejected, never a silent no-op.
+    let req = RpcRequest {
+        jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+        id: RpcId::Number(2),
+        method: methods::HANGAR_TASK_RETRY.into(),
+        params: serde_json::json!({ "workspace_id": "ws-1", "task_id": "does-not-exist" }),
+    };
+    let resp = rpc::dispatch(store.pool(), &req, &health, &sink).await;
+    assert!(resp.error.is_some(), "a foreign task id must be rejected");
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -164,6 +164,19 @@ pub const HANGAR_TASKS_LIST: &str = "hangar/tasks_list";
 /// transition is an `INVALID_PARAMS` error.
 pub const HANGAR_TASK_TRANSITION: &str = "hangar/task_transition";
 
+/// `hangar/task_retry` — force-requeue one terminal task at an operator's explicit
+/// request (the Task Kanban failed-column / task-detail `R`).
+///
+/// Params: [`crate::snapshots::TaskRetryParams`] (`{ workspace_id, task_id }`).
+/// Result: `{ new_task_id: String }` on a fresh queued attempt, or
+/// `{ new_task_id: null }` when the task was not terminal (nothing to requeue).
+/// Unlike the automatic retry, this is a HUMAN override: it bypasses the
+/// `RetryDisposition` reason gate AND the `max_attempts` cap, so a terminal
+/// `agent_error` (which never auto-retries) still re-queues a `parent_task_id`-
+/// chained child. Workspace-scoped: a foreign task id is an `INVALID_PARAMS`
+/// rejection (the mutating handler must not silently no-op on a typo).
+pub const HANGAR_TASK_RETRY: &str = "hangar/task_retry";
+
 /// `hangar/issue_update` — edit fields of one existing issue (e38.8).
 ///
 /// Params: [`crate::snapshots::IssueUpdateParams`]
@@ -966,6 +979,7 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_AUTOPILOT_SET_ENABLED,
     HANGAR_TASKS_LIST,
     HANGAR_TASK_TRANSITION,
+    HANGAR_TASK_RETRY,
     HANGAR_ISSUE_UPDATE,
     HANGAR_ISSUE_LABEL_ATTACH,
     HANGAR_ISSUE_LABEL_DETACH,
@@ -1126,6 +1140,7 @@ mod tests {
             HANGAR_AUTOPILOT_SET_ENABLED,
             HANGAR_TASKS_LIST,
             HANGAR_TASK_TRANSITION,
+            HANGAR_TASK_RETRY,
             HANGAR_ISSUE_UPDATE,
             HANGAR_ISSUE_LABEL_ATTACH,
             HANGAR_ISSUE_LABEL_DETACH,
@@ -1192,6 +1207,7 @@ mod tests {
             HANGAR_AUTOPILOT_SET_ENABLED,
             HANGAR_TASKS_LIST,
             HANGAR_TASK_TRANSITION,
+            HANGAR_TASK_RETRY,
             HANGAR_ISSUE_UPDATE,
             HANGAR_ISSUE_LABEL_ATTACH,
             HANGAR_ISSUE_LABEL_DETACH,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -864,6 +864,25 @@ pub struct TaskTransitionParams {
     pub to_status: String,
 }
 
+/// Params for [`crate::methods::HANGAR_TASK_RETRY`]: the workspace (tenant guard)
+/// and the terminal task to force-requeue at an operator's explicit request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskRetryParams {
+    /// The subscribed workspace the task must belong to.
+    pub workspace_id: String,
+    /// The terminal task to requeue.
+    pub task_id: String,
+}
+
+/// Result of [`crate::methods::HANGAR_TASK_RETRY`]: the id of the freshly-queued
+/// child attempt, or `None` when the task was not terminal (nothing to requeue).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskRetryResult {
+    /// The `parent_task_id`-chained child that was enqueued, or `None` when the
+    /// task was not in a terminal state.
+    pub new_task_id: Option<String>,
+}
+
 /// A three-state edit instruction for a nullable issue field (e38.8).
 ///
 /// A bare `Option<T>` collapses "leave this field unchanged" and "clear this

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -185,31 +185,7 @@ impl RetryService {
         };
 
         let attempt = failed_task.attempt + 1;
-        // One atomic INSERT: the child lands fully-formed (status='queued',
-        // attempt / max_attempts / parent_task_id / session_id all set) or not at
-        // all. There is no intermediate row with the schema defaults, so a crash
-        // here can never strand an orphan that resets the chain cap or loses its
-        // parent linkage. The remaining per-run columns (result / failure_reason /
-        // started_at / finished_at / dispatched_at) reset by being omitted (NULL).
-        sqlx::query(SPAWN_CHILD_SQL)
-            .bind(new_id)
-            .bind(&failed_task.workspace_id)
-            .bind(&failed_task.runtime_id)
-            .bind(&failed_task.agent_id)
-            .bind(&failed_task.issue_id)
-            .bind(&failed_task.work_dir)
-            .bind(failed_task.priority)
-            .bind(attempt)
-            .bind(failed_task.max_attempts)
-            .bind(&failed_task.id)
-            .bind(child_session_id)
-            .bind(&failed_task.repo_ref)
-            .bind(&failed_task.agent_kind)
-            .bind(failed_task.generation)
-            .bind(&failed_task.source_branch)
-            .bind(clock.now_ms())
-            .execute(pool)
-            .await?;
+        Self::spawn_child(pool, failed_task, new_id, child_session_id, clock).await?;
 
         // `task_disposition` already guaranteed `failure_reason` is `Some` (it
         // returns `None` otherwise), so the parent always has a reason to log.
@@ -225,6 +201,111 @@ impl RetryService {
         Ok(RetryDecision::Spawned {
             new_task_id: new_id.to_string(),
         })
+    }
+
+    /// Force-requeue a terminal task at an operator's **explicit** request (the
+    /// manual `R` retry in the Task Kanban's failed column / task-detail),
+    /// bypassing BOTH the [`RetryDisposition`] reason gate AND the `max_attempts`
+    /// cap.
+    ///
+    /// The automatic [`Self::maybe_retry_failed`] path correctly refuses an
+    /// `AgentError` / `UserCancel` / exhausted-chain terminal: a re-dispatch under
+    /// the same daemon config would only re-fail identically, so an *auto* retry
+    /// there burns the chain for nothing. A HUMAN retry is a different contract —
+    /// an explicit override. The operator has judged the terminal recoverable
+    /// (edited the issue, fixed the environment, updated the CLI, …), so *any*
+    /// terminal reason re-queues a fresh attempt; without this the operator has no
+    /// in-product recovery for a terminal `agent_error` and the `R` key silently
+    /// no-ops.
+    ///
+    /// Inserts the same `parent_task_id`-chained `queued` child as the auto path
+    /// (`attempt = parent.attempt + 1`; repo / provider / priority / generation
+    /// inherited) via the one atomic [`SPAWN_CHILD_SQL`] INSERT, so the row is
+    /// correct-or-absent. Session inheritance follows the recorded reason's
+    /// disposition where it *resumes* (an infra terminal carries the parent's
+    /// `session_id`), else starts fresh — a force-requeued `agent_error` clears
+    /// `session_id` so the override never re-enters a wedged conversation.
+    ///
+    /// Returns [`RetryDecision::DoNotRetry`] only when the task is NOT terminal (a
+    /// `running` / `queued` / `dispatched` task is still in-flight and must not be
+    /// forked); otherwise [`RetryDecision::Spawned`] with the child id.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the child insert fails — notably the
+    /// `idx_one_pending_task_per_issue_agent` UNIQUE violation when another pending
+    /// task already holds the per-(issue, agent) slot (mirroring the auto path).
+    pub async fn force_requeue(
+        pool: &SqlitePool,
+        task: &Task,
+        new_id: &str,
+        clock: &dyn HangarClock,
+    ) -> Result<RetryDecision, sqlx::Error> {
+        // Only a terminal task can be requeued; a live task is already in-flight.
+        if !matches!(task.status.as_str(), "failed" | "cancelled") {
+            return Ok(RetryDecision::DoNotRetry);
+        }
+        // Resume the parent's session only when its recorded reason is an infra
+        // ResumeRetry; every other reason (agent_error, timeout, …) starts fresh
+        // so the override does not re-enter a poisoned conversation.
+        let child_session_id: Option<&str> = match Self::task_disposition(task) {
+            Some(d) if d.resumes_session() => task.session_id.as_deref(),
+            _ => None,
+        };
+        Self::spawn_child(pool, task, new_id, child_session_id, clock).await?;
+
+        tracing::info!(
+            parent_task_id = %task.id,
+            new_task_id = new_id,
+            attempt = task.attempt + 1,
+            reason = task.failure_reason.as_deref().unwrap_or_default(),
+            "task_manual_requeue",
+        );
+
+        Ok(RetryDecision::Spawned {
+            new_task_id: new_id.to_string(),
+        })
+    }
+
+    /// The single atomic child INSERT shared by the auto ([`Self::maybe_retry_failed`])
+    /// and manual ([`Self::force_requeue`]) retry paths.
+    ///
+    /// Writes `status='queued'` together with the retry bookkeeping
+    /// (`attempt = parent.attempt + 1`, `max_attempts`, `parent_task_id`,
+    /// `session_id`) in one statement so the child is correct-or-absent rather than
+    /// transiently carrying the schema defaults. `repo_ref` / `agent_kind` /
+    /// `priority` / `generation` / `source_branch` are inherited; the per-run
+    /// columns (`result` / `failure_reason` / `started_at` / `finished_at` /
+    /// `dispatched_at` / `branch`) reset by being omitted (NULL). `session_id` is
+    /// bound by the caller per the retry/resume taxonomy.
+    async fn spawn_child(
+        pool: &SqlitePool,
+        parent: &Task,
+        new_id: &str,
+        session_id: Option<&str>,
+        clock: &dyn HangarClock,
+    ) -> Result<(), sqlx::Error> {
+        let attempt = parent.attempt + 1;
+        sqlx::query(SPAWN_CHILD_SQL)
+            .bind(new_id)
+            .bind(&parent.workspace_id)
+            .bind(&parent.runtime_id)
+            .bind(&parent.agent_id)
+            .bind(&parent.issue_id)
+            .bind(&parent.work_dir)
+            .bind(parent.priority)
+            .bind(attempt)
+            .bind(parent.max_attempts)
+            .bind(&parent.id)
+            .bind(session_id)
+            .bind(&parent.repo_ref)
+            .bind(&parent.agent_kind)
+            .bind(parent.generation)
+            .bind(&parent.source_branch)
+            .bind(clock.now_ms())
+            .execute(pool)
+            .await?;
+        Ok(())
     }
 
     /// Classify a [`FailureReason`] into its [`RetryDisposition`] — the

--- a/ainb-tui/crates/ainb-hangar-store/tests/retry_chain.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/retry_chain.rs
@@ -545,6 +545,167 @@ async fn retry_chain_walk_via_parent_task_id() {
 }
 
 #[tokio::test]
+async fn force_requeue_agent_error_spawns_child_despite_no_retry_disposition() {
+    // A human-initiated manual retry (the Task Kanban failed-column / task-detail
+    // `R`) is an explicit override: it MUST re-queue a fresh attempt for a terminal
+    // `agent_error` task that the AUTOMATIC path (`maybe_retry_failed`) correctly
+    // refuses (AgentError => RetryDisposition::NoRetry). Without this the operator
+    // has no in-product recovery and `R` silently no-ops.
+    let (_dir, store) = open_seeded().await;
+    let parent = seed_failed_task(
+        &store,
+        "t1",
+        None,
+        Some("/tmp/wd"),
+        1,
+        2,
+        FailureReason::AgentError,
+    )
+    .await;
+    let clock = FixedClock(NOW_MS);
+
+    // The auto path refuses agent_error: no child row.
+    let auto = RetryService::maybe_retry_failed(store.pool(), &parent, "auto-child", &clock)
+        .await
+        .expect("auto decision ok");
+    assert_eq!(auto, RetryDecision::DoNotRetry);
+    assert!(
+        TaskRepo::get_by_id(store.pool(), "auto-child").await.unwrap().is_none(),
+        "the automatic path must not spawn a child for agent_error"
+    );
+
+    // The manual force path overrides the reason gate and spawns the child.
+    let forced = RetryService::force_requeue(store.pool(), &parent, "manual-child", &clock)
+        .await
+        .expect("force ok");
+    assert_eq!(
+        forced,
+        RetryDecision::Spawned {
+            new_task_id: "manual-child".to_string()
+        }
+    );
+
+    let child = TaskRepo::get_by_id(store.pool(), "manual-child")
+        .await
+        .unwrap()
+        .expect("manual child row exists");
+    assert_eq!(child.parent_task_id.as_deref(), Some("t1"));
+    assert_eq!(child.attempt, parent.attempt + 1);
+    assert_eq!(child.status, "queued");
+    assert_eq!(child.workspace_id, parent.workspace_id);
+    assert_eq!(child.agent_id, parent.agent_id);
+    assert_eq!(child.work_dir.as_deref(), Some("/tmp/wd"));
+    // An agent_error requeue starts a FRESH session (never resumes a wedged one).
+    assert_eq!(child.session_id, None);
+    // Per-run columns reset on the fresh attempt.
+    assert_eq!(child.failure_reason, None);
+    assert_eq!(child.result, None);
+    assert_eq!(child.started_at, None);
+    assert_eq!(child.finished_at, None);
+}
+
+#[tokio::test]
+async fn force_requeue_bypasses_max_attempts_cap() {
+    // Chain exhausted (attempt == max_attempts): the auto path caps regardless of
+    // reason, but a human override still re-queues a fresh attempt.
+    let (_dir, store) = open_seeded().await;
+    let parent = seed_failed_task(&store, "t1", None, None, 2, 2, FailureReason::AgentError).await;
+    let clock = FixedClock(NOW_MS);
+
+    let forced = RetryService::force_requeue(store.pool(), &parent, "child-1", &clock)
+        .await
+        .expect("force ok");
+    assert_eq!(
+        forced,
+        RetryDecision::Spawned {
+            new_task_id: "child-1".to_string()
+        }
+    );
+    let child = TaskRepo::get_by_id(store.pool(), "child-1")
+        .await
+        .unwrap()
+        .expect("child row exists");
+    assert_eq!(
+        child.attempt, 3,
+        "attempt grows past the cap on a deliberate manual override"
+    );
+}
+
+#[tokio::test]
+async fn force_requeue_refuses_non_terminal_task() {
+    // A running task is still in-flight; force_requeue must not fork a live run.
+    let (_dir, store) = open_seeded().await;
+    TaskRepo::insert(
+        store.pool(),
+        &NewTask {
+            id: "t1".to_string(),
+            workspace_id: "ws-1".to_string(),
+            runtime_id: "rt-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            issue_id: None,
+            work_dir: None,
+            priority: 0,
+            created_at: 1,
+            autopilot_run_id: None,
+            generation: 0,
+        },
+    )
+    .await
+    .expect("enqueue");
+    sqlx::query("UPDATE agent_task_queue SET status='running' WHERE id='t1'")
+        .execute(store.pool())
+        .await
+        .expect("force running");
+    let running = TaskRepo::get_by_id(store.pool(), "t1").await.unwrap().unwrap();
+    let clock = FixedClock(NOW_MS);
+
+    let decision = RetryService::force_requeue(store.pool(), &running, "child-1", &clock)
+        .await
+        .expect("decision ok");
+    assert_eq!(decision, RetryDecision::DoNotRetry);
+    assert!(TaskRepo::get_by_id(store.pool(), "child-1").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn force_requeue_resumes_session_for_infra_terminal() {
+    // A force-requeued RuntimeOffline (infra) terminal follows the resume
+    // disposition: the child carries the parent's session_id so the manual retry
+    // continues the intact conversation rather than starting cold.
+    let (_dir, store) = open_seeded().await;
+    let parent_seed = seed_failed_task(
+        &store,
+        "t1",
+        None,
+        None,
+        1,
+        2,
+        FailureReason::RuntimeOffline,
+    )
+    .await;
+    sqlx::query("UPDATE agent_task_queue SET session_id = ? WHERE id = ?")
+        .bind("sess-abc")
+        .bind(&parent_seed.id)
+        .execute(store.pool())
+        .await
+        .expect("stamp session on parent");
+    let parent = TaskRepo::get_by_id(store.pool(), &parent_seed.id).await.unwrap().unwrap();
+
+    let clock = FixedClock(NOW_MS);
+    RetryService::force_requeue(store.pool(), &parent, "child-1", &clock)
+        .await
+        .expect("force ok");
+    let child = TaskRepo::get_by_id(store.pool(), "child-1")
+        .await
+        .unwrap()
+        .expect("child exists");
+    assert_eq!(
+        child.session_id.as_deref(),
+        Some("sess-abc"),
+        "an infra terminal's manual requeue resumes the parent's session"
+    );
+}
+
+#[tokio::test]
 async fn partial_unique_index_blocks_retry_when_existing_pending() {
     // The failed task carries an issue_id; a *new* manually-enqueued queued task
     // already exists for the same issue AND the same agent. The retry insert

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -179,7 +179,7 @@ fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
         Screen::AgentPicker(_) => vec![("enter", "assign"), ("esc", "close")],
         Screen::SkillManager => vec![("i", "import"), ("/", "filter")],
         Screen::Autopilots => vec![("a", "add"), ("r", "run"), ("d", "disable"), ("e", "edit")],
-        Screen::Kanban => vec![("←→", "focus"), ("⇧←→", "move")],
+        Screen::Kanban => vec![("←→", "focus"), ("⇧←→", "move"), ("R", "retry")],
         Screen::Boards => vec![
             ("↵", "run"),
             ("a", "attach"),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -238,6 +238,9 @@ const ISSUE_DELETE_REQ_ID: i64 = 53;
 /// run(s) & delete"). On success the plugin retries the `issue_delete`; an error
 /// surfaces as a transient issue-list note.
 const ISSUE_CANCEL_ACTIVE_REQ_ID: i64 = 54;
+/// JSON-RPC id for the `hangar/task_retry` force-requeue raised by the Task Kanban
+/// failed-column / task-detail `R` (a human override of the auto-retry gate).
+const TASK_RETRY_REQ_ID: i64 = 55;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -1967,6 +1970,30 @@ impl HangarPlugin {
         };
         if let Err(e) = host.unix_socket_send(stream_id, body).await {
             let _ = host.log_info(format!("hangar: task transition send failed: {e}")).await;
+        }
+    }
+
+    /// Fire the deferred `hangar/task_retry` raised by the Task Kanban failed-column
+    /// `R` / task-detail `R` — the operator's manual force-requeue of a terminal
+    /// task.
+    ///
+    /// Unlike the automatic retry seam (which correctly refuses `agent_error` and a
+    /// capped chain), this is a HUMAN override: the daemon requeues ANY terminal
+    /// reason. On success the daemon emits `TaskQueued`, which drives the plugin's
+    /// snapshot re-fetch so the fresh attempt card appears in the queued column —
+    /// the visible confirmation. A send failure is logged but non-fatal.
+    async fn apply_task_retry_action(&mut self, host: &HostClient, task_id: String) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            return;
+        };
+        let ws = self.app_state().ws_id.as_str().to_string();
+        let params = serde_json::json!({ "workspace_id": ws, "task_id": task_id });
+        let Ok(body) = encode_request(TASK_RETRY_REQ_ID, daemon_methods::HANGAR_TASK_RETRY, params)
+        else {
+            return;
+        };
+        if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            let _ = host.log_info(format!("hangar: task retry send failed: {e}")).await;
         }
     }
 
@@ -4275,6 +4302,13 @@ impl Plugin for HangarPlugin {
         // board and fire `hangar/task_transition` over the daemon socket.
         if let Some(action) = self.screens.take_pending_kanban_action() {
             self.apply_kanban_action(host, action).await;
+        }
+        // Drain any deferred manual task-retry (`R` on a terminal card in the Task
+        // Kanban failed column / task-detail) and fire `hangar/task_retry` over the
+        // daemon socket; the daemon's TaskQueued push re-fetches the board so the
+        // fresh queued attempt appears.
+        if let Some(task_id) = self.screens.take_pending_task_retry_action() {
+            self.apply_task_retry_action(host, task_id).await;
         }
         // P4 / D8: drain any deferred board mutation (`⇧←/→`, `x`, `n`, `m`) raised
         // by the Boards screen and fire the matching `hangar/board_*` over the

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -536,6 +536,13 @@ pub struct ScreenStates {
     /// `render` pass to fire `hangar/task_transition` over the daemon socket
     /// (P8.4). `None` when idle.
     pub pending_kanban_action: Option<KanbanAction>,
+    /// A manual task-retry RPC raised by the Task Kanban failed-column `R` or the
+    /// task-detail `R`, awaiting the `render` pass to fire `hangar/task_retry` over
+    /// the daemon socket. Carries the terminal task id to force-requeue. `None`
+    /// when idle. Unlike the automatic retry seam, this is an operator override:
+    /// the daemon requeues ANY terminal reason (including `agent_error`, which
+    /// never auto-retries).
+    pub pending_task_retry_action: Option<String>,
     /// An issue-assign RPC raised by the agent-picker modal (Enter on a picked
     /// actor), awaiting the `render` pass to fire `hangar/issue_update` over the
     /// daemon socket (e38.8). `None` when idle.
@@ -969,6 +976,12 @@ impl ScreenStates {
     /// Take the pending Kanban card-move RPC raised by the board, if any (P8.4).
     pub const fn take_pending_kanban_action(&mut self) -> Option<KanbanAction> {
         self.pending_kanban_action.take()
+    }
+
+    /// Take the pending manual task-retry RPC raised by the Kanban / task-detail
+    /// `R`, if any.
+    pub const fn take_pending_task_retry_action(&mut self) -> Option<String> {
+        self.pending_task_retry_action.take()
     }
 
     /// Take the pending issue-assign RPC raised by the agent picker, if any
@@ -1546,8 +1559,9 @@ fn route_task_detail(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInt
     };
     let out = reduce_task_detail(&td, ev);
     // Lift the compose-submit intent into a deferred `hangar/comment_add` RPC the
-    // `render` pass drains + fires (the sync key router can't `await`). Retry /
-    // cancel intents are not yet wired to an RPC, so they fold as before.
+    // `render` pass drains + fires (the sync key router can't `await`). The retry
+    // intent lifts into a deferred `hangar/task_retry`; the cancel intent still
+    // folds as before.
     let mut nav = None;
     match &out.intent {
         Some(TaskDetailIntent::AddComment { issue_id, body }) => {
@@ -1555,6 +1569,13 @@ fn route_task_detail(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInt
                 issue_id: issue_id.as_str().to_string(),
                 body: body.clone(),
             });
+        }
+        // The `R` retry on a terminal task lifts into a deferred `hangar/task_retry`
+        // the `render` pass fires — a HUMAN override that force-requeues ANY
+        // terminal reason (the daemon bypasses the auto-retry disposition gate). The
+        // freshly-queued attempt then surfaces on the board via the TaskQueued push.
+        Some(TaskDetailIntent::RetryTask(task_id)) => {
+            states.pending_task_retry_action = Some(task_id.as_str().to_string());
         }
         // 63l.5: confirmed `x` delete arms the SAME deferred `hangar/issue_delete`
         // the issue-list `x` uses, then navigates back to the issue list so the
@@ -1577,6 +1598,21 @@ fn route_task_detail(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInt
 /// pass drains `pending_kanban_action` and fires it). `h/j/k/l` mirror the arrows
 /// for vi-style navigation.
 fn route_kanban(states: &mut ScreenStates, key: &KeyEvent) {
+    // `R` force-requeues the focused card when it is terminal (the failed /
+    // cancelled columns). A HUMAN override: it lifts a deferred `hangar/task_retry`
+    // the `render` pass fires, which the daemon force-requeues regardless of the
+    // auto-retry disposition (so a terminal `agent_error` — which never
+    // auto-retries — still gets a fresh attempt). A non-terminal focused card (or
+    // an empty column) is a no-op. Intercepted before the focus/drag reducer so it
+    // never folds into navigation.
+    if key.code == (KeyCode::Char { ch: 'R' }) {
+        if let Some(card) = states.kanban.focused_card() {
+            if matches!(card.status.as_str(), "failed" | "cancelled") {
+                states.pending_task_retry_action = Some(card.task_id.clone());
+            }
+        }
+        return;
+    }
     let shift = key.mods & ainb_plugin_sdk::KEY_MOD_SHIFT != 0;
     let ev = match &key.code {
         KeyCode::Left => Some(if shift {
@@ -2100,5 +2136,78 @@ mod filter_chip_route_tests {
         assert_eq!(states.issue_list.filter(), FilterChip::Mine);
         route_issue_list(&mut states, &key(KeyCode::BackTab));
         assert_eq!(states.issue_list.filter(), FilterChip::Agents);
+    }
+}
+
+#[cfg(test)]
+mod kanban_retry_route_tests {
+    use super::*;
+    use ainb_hangar_proto::events::TaskCardRow;
+    use ainb_plugin_sdk::{KeyCode, KeyEvent, KeyKind};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            mods: 0,
+            kind: KeyKind::Press,
+        }
+    }
+
+    fn card(id: &str, status: &str) -> TaskCardRow {
+        TaskCardRow {
+            id: ainb_hangar_core::ids::TaskId::from_str(id).unwrap(),
+            workspace_id: "ws".into(),
+            agent_id: "agent-1".into(),
+            issue_id: Some("issue-1".into()),
+            status: status.into(),
+            priority: 0,
+            created_at: 0,
+            branch: None,
+            pr_url: None,
+            pr_status: None,
+        }
+    }
+
+    /// Focus the failed column (index 3 of [Queued, Running, Done, Failed]).
+    fn focus_failed_column(states: &mut ScreenStates) {
+        for _ in 0..3 {
+            route_kanban(states, &key(KeyCode::Right));
+        }
+    }
+
+    /// `R` on a focused FAILED card lifts a `hangar/task_retry` for that task —
+    /// the in-product recovery for a terminal `agent_error` that never auto-retries.
+    /// Regression guard for `manual-retry-noop-on-agent-error-task`: before the `R`
+    /// arm in `route_kanban` the key folded into navigation and no attempt row was
+    /// ever requeued.
+    #[test]
+    fn r_on_failed_card_lifts_task_retry() {
+        let mut states = ScreenStates::default();
+        states.set_tasks(&[card("01HANGARTASKFAILED0001", "failed")]);
+        focus_failed_column(&mut states);
+
+        route_kanban(&mut states, &key(KeyCode::Char { ch: 'R' }));
+
+        assert_eq!(
+            states.take_pending_task_retry_action().as_deref(),
+            Some("01HANGARTASKFAILED0001"),
+            "R on a failed card must lift a task_retry for that task id"
+        );
+    }
+
+    /// `R` on a non-terminal (queued) card is a no-op: only a terminal card can be
+    /// requeued, so a live run is never forked.
+    #[test]
+    fn r_on_queued_card_is_a_noop() {
+        let mut states = ScreenStates::default();
+        states.set_tasks(&[card("01HANGARTASKQUEUED0001", "queued")]);
+        // Focus stays on the queued column (index 0), where the card lives.
+
+        route_kanban(&mut states, &key(KeyCode::Char { ch: 'R' }));
+
+        assert!(
+            states.take_pending_task_retry_action().is_none(),
+            "R on a non-terminal card must not lift a retry"
+        );
     }
 }


### PR DESCRIPTION
## Bug

Found by the hangar e2e loop (`manual-retry-noop-on-agent-error-task`). Pressing `R` on a failed task in the Task Kanban's failed column created no new attempt row. Two distinct facts were tangled here:

- The **absence of an automatic retry** for `agent_error` is BY DESIGN: `retry.rs` maps `FailureReason::AgentError -> RetryDisposition::NoRetry` (only `RuntimeOffline` / `RuntimeRecovery` auto-retry). "No auto-retry despite max_attempts=2" is expected, not a bug.
- But a **human-initiated retry is an explicit override** and must re-queue a terminal `agent_error` task. Today it silently no-ops, leaving the operator with zero in-product recovery. That is the bug fixed here.

Root cause of the no-op: the `R` retry was raised as a `TaskDetailIntent::RetryTask` but never wired to any RPC (app_screens.rs literally noted "Retry / cancel intents are not yet wired to an RPC"), and the Task Kanban ignored `R` entirely.

## Fix

A new force-requeue path, wired end-to-end, distinct from the auto-retry seam:

- **store**: `RetryService::force_requeue` bypasses BOTH the `RetryDisposition` reason gate AND the `max_attempts` cap — any terminal reason spawns a fresh `parent_task_id`-chained `queued` child (`attempt+1`, repo/provider/priority/generation inherited). Session inheritance resumes only for infra terminals, else starts fresh (a force-requeued `agent_error` never re-enters a wedged conversation). The atomic child INSERT is extracted into a shared `spawn_child` helper the auto path also uses.
- **proto**: `hangar/task_retry` method + `TaskRetryParams` / `TaskRetryResult`.
- **daemon**: `handle_task_retry` — workspace-scoped (a foreign/missing task id is rejected, never a silent no-op), calls `force_requeue`, and emits `TaskQueued` so subscribed boards re-pull and the fresh attempt card appears in the queued column (the visible confirmation).
- **plugin**: lifts both surfaces (task-detail `R`, and Kanban `R` on a terminal failed/cancelled card) into a deferred `hangar/task_retry` action the render pass fires; `R` added to the Kanban legend. A non-terminal card is a no-op so a live run is never forked.

## Tests (fail-before / pass-after)

- `retry_chain.rs`: `force_requeue` spawns a child for a terminal `agent_error` that `maybe_retry_failed` refuses; bypasses the max_attempts cap; refuses a non-terminal task; resumes the session for an infra terminal.
- `rpc_task_retry.rs`: the RPC force-requeues a terminal `agent_error` (attempt past the cap), chains to the parent, publishes `TaskQueued`, and rejects a foreign task id.
- `app_screens.rs`: `R` on a focused failed Kanban card lifts a `task_retry` for that task id; `R` on a queued card is a no-op.

## Validation

- `cargo test` green for all four touched crates (store / proto / daemon / plugin), full unfiltered. One daemon lib test (`workdir_provision::...worktree_bases_on_chosen_source_branch`) failed once under concurrency with `gpg: signing failed: Cannot allocate memory` — an environmental GPG-agent OOM in a file this PR does not touch; it passes in isolation.
- `cargo build -p ainb` clean; `cargo fmt` applied (pre-existing drift in squads.rs / squads_screen_snapshot.rs / live_e2e.rs reverted, untouched by this PR).
- No clippy warnings introduced in the changed line ranges.

Adjacent to cycle-2 PR #438. Its own small PR per the spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added manual retry for terminal tasks from the Kanban view and task details.
  - Press **R** on a failed or cancelled task to create a new queued attempt.
  - Manual retries can bypass automatic retry limits while preserving eligible sessions.
  - Added task retry status updates so boards refresh after a retry.

- **Bug Fixes**
  - Invalid or out-of-scope task retry requests now return an error.
  - Non-terminal tasks cannot be manually retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->