### PR TITLE
fix(hangar): stale sibling daemon binary defeats hangar fixes

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -32,7 +32,11 @@ members = [
     "crates/ainb-plugin-hangar",
     "xtask",
 ]
-default-members = ["crates/ainb-core"]
+# `ainb hangar daemon start` launches the sibling `ainb-hangar-daemon` binary
+# (built beside `ainb` in the same target dir). It MUST be in default-members so
+# a plain `cargo build` rebuilds it alongside `ainb` — otherwise the sibling
+# goes stale and `start` silently runs pre-fix daemon code (the build-skew bug).
+default-members = ["crates/ainb-core", "crates/ainb-hangar-daemon"]
 # Phase 7c: burndown returns as a subprocess plugin (native binary,
 # stdio JSON-RPC over the SDK). session-reader is being re-shipped in
 # parallel under agents-in-a-box-4is.

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -3361,11 +3361,55 @@ fn resolve_daemon_launch() -> (std::path::PathBuf, Vec<&'static str>) {
     if let Some(p) = std::env::var_os(DAEMON_BIN_ENV).filter(|p| !p.is_empty()) {
         return (std::path::PathBuf::from(p), Vec::new());
     }
-    if let Ok(exe) = std::env::current_exe() {
+    let exe = std::env::current_exe().ok();
+    resolve_daemon_launch_for(exe.as_deref())
+}
+
+/// Modification time of `path`, or `None` if it can't be read.
+fn file_mtime(path: &std::path::Path) -> Option<std::time::SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Is a sibling `ainb-hangar-daemon` fresh enough to prefer over the self-exec
+/// fallback, given the sibling's and this `ainb`'s modification times?
+///
+/// The daemon library is compiled INTO `ainb`, so the self-exec fallback
+/// (`ainb hangar daemon run`) always executes code exactly as fresh as this
+/// binary. The standalone sibling is therefore only a nicety — and a *stale*
+/// one is actively harmful: a plain `cargo build` (default-members) historically
+/// rebuilt only `ainb`, leaving an older `ainb-hangar-daemon` beside it, so
+/// `start` silently launched pre-fix daemon code. We consequently prefer the
+/// sibling ONLY when it is at least as new as `ainb`; an older sibling is
+/// treated as a stale build and skipped in favour of the fresh embedded daemon.
+/// When either mtime is unreadable we degrade to trusting the sibling, preserving
+/// the prior behaviour for layouts where file times are unavailable.
+fn sibling_daemon_is_fresh(
+    sibling_mtime: Option<std::time::SystemTime>,
+    exe_mtime: Option<std::time::SystemTime>,
+) -> bool {
+    match (sibling_mtime, exe_mtime) {
+        (Some(sibling), Some(exe)) => sibling >= exe,
+        _ => true,
+    }
+}
+
+/// The `current_exe`-parameterised core of [`resolve_daemon_launch`], split out
+/// so the sibling-vs-self-exec decision is unit-testable without depending on
+/// the test runner's own executable path. `exe` is the resolved path of the
+/// running `ainb` (`None` iff `current_exe` failed).
+fn resolve_daemon_launch_for(
+    exe: Option<&std::path::Path>,
+) -> (std::path::PathBuf, Vec<&'static str>) {
+    if let Some(exe) = exe {
         if let Some(dir) = exe.parent() {
             let sibling = dir.join("ainb-hangar-daemon");
             if sibling.exists() {
-                return (sibling, Vec::new());
+                if sibling_daemon_is_fresh(file_mtime(&sibling), file_mtime(exe)) {
+                    return (sibling, Vec::new());
+                }
+                // Stale sibling (older than this `ainb`): don't silently launch
+                // pre-fix daemon code. Self-exec the fresh embedded daemon.
+                return (exe.to_path_buf(), vec!["hangar", "daemon", "run"]);
             }
         }
     }
@@ -3374,7 +3418,10 @@ fn resolve_daemon_launch() -> (std::path::PathBuf, Vec<&'static str>) {
     }
     // Self-exec fallback. `current_exe` failing is effectively unreachable;
     // degrade to the bare `ainb` name resolved by the OS if it does.
-    let me = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("ainb"));
+    let me = exe.map_or_else(
+        || std::path::PathBuf::from("ainb"),
+        std::path::Path::to_path_buf,
+    );
     (me, vec!["hangar", "daemon", "run"])
 }
 
@@ -4961,6 +5008,83 @@ mod tests {
         assert_eq!(daemon_version_skew(Some("1.16.0"), "1.16.0"), None);
         assert_eq!(daemon_version_skew(None, "1.16.0"), None);
         assert_eq!(daemon_version_skew(Some(""), "1.16.0"), None);
+    }
+
+    /// The freshness predicate: a sibling at least as new as `ainb` is fresh; an
+    /// older sibling is stale; an unreadable mtime degrades to trusting it.
+    #[test]
+    fn sibling_daemon_freshness_prefers_a_sibling_no_older_than_ainb() {
+        use std::time::{Duration, SystemTime};
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let newer = base + Duration::from_secs(3600);
+        // Sibling newer or equal → fresh.
+        assert!(sibling_daemon_is_fresh(Some(newer), Some(base)));
+        assert!(sibling_daemon_is_fresh(Some(base), Some(base)));
+        // Sibling older than ainb → stale.
+        assert!(!sibling_daemon_is_fresh(Some(base), Some(newer)));
+        // Either mtime unknown → degrade to trusting the sibling.
+        assert!(sibling_daemon_is_fresh(None, Some(base)));
+        assert!(sibling_daemon_is_fresh(Some(base), None));
+    }
+
+    /// Set a file's mtime to an absolute instant (Rust 1.75+ `set_modified`).
+    fn set_mtime(path: &std::path::Path, when: std::time::SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(when)
+            .unwrap();
+    }
+
+    /// The build-skew guard: with a sibling `ainb-hangar-daemon` OLDER than the
+    /// spawning `ainb` present, `start`'s launch resolution must NOT run it — it
+    /// falls back to self-exec (`ainb hangar daemon run`, the fresh embedded
+    /// daemon) instead of the stale sibling. This is the regression that let
+    /// pre-#441 daemon code keep serving after a plain `cargo build`.
+    #[test]
+    fn resolve_daemon_launch_skips_a_sibling_older_than_ainb() {
+        use std::time::{Duration, SystemTime};
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("ainb");
+        let sibling = dir.path().join("ainb-hangar-daemon");
+        std::fs::write(&exe, b"ainb").unwrap();
+        std::fs::write(&sibling, b"daemon").unwrap();
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        // Sibling built BEFORE ainb — the stale-build signature.
+        set_mtime(&sibling, base);
+        set_mtime(&exe, base + Duration::from_secs(3600));
+
+        let (bin, args) = resolve_daemon_launch_for(Some(&exe));
+        assert_eq!(
+            args,
+            vec!["hangar", "daemon", "run"],
+            "a sibling older than ainb must not be launched"
+        );
+        assert_eq!(bin, exe, "self-exec must run this very ainb binary");
+    }
+
+    /// The companion: a sibling at least as new as `ainb` IS launched directly
+    /// (empty argv), so the freshness guard doesn't defeat the standalone binary
+    /// on a clean co-build.
+    #[test]
+    fn resolve_daemon_launch_uses_a_sibling_no_older_than_ainb() {
+        use std::time::{Duration, SystemTime};
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("ainb");
+        let sibling = dir.path().join("ainb-hangar-daemon");
+        std::fs::write(&exe, b"ainb").unwrap();
+        std::fs::write(&sibling, b"daemon").unwrap();
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        set_mtime(&exe, base);
+        set_mtime(&sibling, base + Duration::from_secs(3600));
+
+        let (bin, args) = resolve_daemon_launch_for(Some(&exe));
+        assert!(
+            args.is_empty(),
+            "a fresh sibling should be launched directly"
+        );
+        assert_eq!(bin, sibling);
     }
 
     /// Build the real `ainb` clap surface (root + every registered command,


### PR DESCRIPTION
## Problem

The hangar e2e loop hit the **same-bug-twice** signature: #441 correctly turned the macOS Seatbelt sandbox OFF by default in source, yet a hangar-dispatched Claude child was still write-confined and the provider spawn early-failed (exit 65, ~13ms, no stdout/stderr — the `sandbox-exec` early-fail signature documented in `imp_macos.rs`). The fix was correct in source but never reached the **running daemon binary**.

Root cause is the **build/launch path**, not the sandbox logic:

- `ainb hangar daemon start` launches the sibling `target/debug/ainb-hangar-daemon` binary (`resolve_daemon_launch` prefers sibling-of-exe over self-exec).
- `default-members = ["crates/ainb-core"]` meant a plain `cargo build` rebuilt only `ainb`, **never** `ainb-hangar-daemon`.
- So the running daemon executed a stale sibling built ~5.5h before #441 — pre-fix code where the sandbox defaults ON.

Proven during triage: the daemon-spawned child was write-confined (worktree OK, `/tmp` DENIED); rebuilding **only** `ainb-hangar-daemon` (22s) flipped it to unconfined (`/tmp` write succeeded).

## Fix (two-part, durable)

1. **`Cargo.toml`** — add `crates/ainb-hangar-daemon` to `default-members` so a plain `cargo build` always rebuilds the daemon binary alongside `ainb`. Proven: `rm target/debug/ainb-hangar-daemon && cargo build` now re-produces it.

2. **`crates/ainb-core/src/cli/hangar/mod.rs`** — a build-skew guard in the launch path. The daemon library is compiled **into** `ainb`, so the self-exec fallback (`ainb hangar daemon run`) always runs code exactly as fresh as this binary. We therefore prefer the standalone sibling **only when it is at least as new as `ainb`** (mtime comparison); an older sibling is treated as a stale build and skipped in favour of the fresh embedded daemon.

### Why mtime, not `daemon_version_skew`?

Both binaries share the workspace version (`1.15.0`), so a same-version stale co-build (the proven case) is invisible to a semver check — the sibling was `1.15.0` and so is `ainb`. File modification time is the discriminator that actually distinguishes "rebuilt only `ainb`" from "co-built". Falling back to self-exec is always *correct* (it runs the fresh embedded daemon), so the guard errs safely toward it when a sibling is older or its mtime is unreadable.

## Tests

`resolve_daemon_launch` was split into a `current_exe`-parameterised seam (`resolve_daemon_launch_for`) so the decision is unit-testable without the runner's own exe path. Added:

- `sibling_daemon_freshness_prefers_a_sibling_no_older_than_ainb` — the pure predicate.
- `resolve_daemon_launch_skips_a_sibling_older_than_ainb` — **the behavioral regression test**: with a sibling older than `ainb` on disk, resolution returns the self-exec form, not the stale sibling. Proven red-before / green-after via in-place mutation.
- `resolve_daemon_launch_uses_a_sibling_no_older_than_ainb` — companion: a fresh sibling is still launched directly, so the guard doesn't defeat the standalone binary on a clean co-build.

## Verification

- `cargo test -p ainb --lib`: 1609 passed. One unrelated failure (`paste_lands_in_onboarding_otel_field`) is **environmental** — it reads the live `~/.agents-in-a-box` OTEL config; it passes green under an isolated `HOME`/`AINB_HANGAR_HOME`. Not touched by this change (diff is `Cargo.toml` + `hangar/mod.rs` only).
- `cargo build -p ainb`: clean.
- `cargo fmt` applied (pre-existing drift files reverted).

Clippy `-D warnings` reds are all in `ainb-hangar-core` (pedantic/nursery), a crate this PR does not touch — pre-existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hangar daemon startup to avoid launching an outdated companion binary.
  * Automatically falls back to the current executable when the companion daemon is stale.
  * Ensured standard builds include the Hangar daemon binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->