### PR TITLE
fix(hangar): advance issue lifecycle on plain task FSM

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -21,8 +21,10 @@
 //! with no matching auto-move column is a silent no-op.
 
 use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_proto::lifecycle::IssueLifecycle;
 use ainb_hangar_store::repo::board::BoardRepo;
 use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+use ainb_hangar_store::repo::issue::IssueRepo;
 use ainb_hangar_store::repo::task::Task;
 use sqlx::SqlitePool;
 
@@ -68,6 +70,119 @@ pub async fn auto_move_after_transition(pool: &SqlitePool, task: &Task, new_stat
         }
         Err(e) => {
             tracing::warn!(error = %e, task_id = %task.id, "board auto-move failed; proceeding");
+        }
+    }
+}
+
+/// Forward-advance the task's ISSUE lifecycle `state` to match a task-status
+/// token — the durable-issue twin of [`auto_move_after_transition`].
+///
+/// The default hangar issue board buckets cards by `issue.state` alone
+/// (`hangar/issues_list` serves it verbatim), while the board auto-move only
+/// touches durable `board_card` rows — which the default screen never
+/// materialises. So a plain dispatched task walked its FSM (`running` → `done`)
+/// with its issue frozen at `todo`/`open`, stranding the card in Todo through the
+/// whole run and after it finished. This seam makes `issue.state` authoritative:
+/// the running transition promotes the issue to `in_progress` and terminal
+/// success to `done`, so the next snapshot re-pull renders the correct column.
+///
+/// `new_state` is a task-status token (`running` / `done` / …). Only the two that
+/// have an issue-lifecycle meaning advance the issue:
+/// * `running` → [`IssueLifecycle::InProgress`]
+/// * `done`    → [`IssueLifecycle::Done`]
+///
+/// Every other token (`failed` / `cancelled` / an unknown) is a deliberate no-op:
+/// a failed run must NOT mark its issue `done`, and the issue simply stays where
+/// it is.
+///
+/// # Advance-only
+///
+/// The write is guarded to only ever move the issue FORWARD along the canonical
+/// column order ([`IssueLifecycle::order`]): a target at or behind the issue's
+/// current column is skipped. This mirrors the `if issue.state == …` guard the
+/// PR-merge snapshot uses (snapshots.rs) so a manually-set or PR-merged terminal
+/// state is never regressed — e.g. a re-run's `running` transition can never drag
+/// an already-`done` issue back to `in_progress`.
+///
+/// # Best-effort
+///
+/// A NULL-issue chat task, a missing issue row, or a store fault is logged and
+/// swallowed exactly like the board auto-move: the task's FSM state has already
+/// committed and a lifecycle write must never down the claim loop.
+pub async fn advance_issue_lifecycle_after_transition(
+    pool: &SqlitePool,
+    task: &Task,
+    new_state: &str,
+) {
+    let Some(issue_id) = task.issue_id.as_deref() else {
+        return;
+    };
+    let target = match new_state {
+        "running" => IssueLifecycle::InProgress,
+        "done" => IssueLifecycle::Done,
+        // `failed` / `cancelled` / unknown carry no forward issue-lifecycle
+        // meaning — leave the issue where it is.
+        _ => return,
+    };
+    let current = match IssueRepo::get_by_id(pool, issue_id).await {
+        Ok(Some(issue)) => issue,
+        // The issue vanished (or never existed) — nothing to advance.
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = %task.id, "issue lifecycle advance: reading issue failed; proceeding");
+            return;
+        }
+    };
+    // Advance-only: never regress an issue that already sits at or beyond the
+    // target column (a manually-set or PR-merged terminal state, or the same
+    // state twice → idempotent no-op).
+    if target.order() <= IssueLifecycle::for_state(&current.state).order() {
+        return;
+    }
+    match IssueRepo::update_state(pool, issue_id, target.as_str()).await {
+        Ok(()) => tracing::info!(
+            task_id = %task.id,
+            issue_id = %issue_id,
+            from = %current.state,
+            to = target.as_str(),
+            "issue lifecycle advanced"
+        ),
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = %task.id, "issue lifecycle advance failed; proceeding");
+        }
+    }
+}
+
+/// Forward-advance the task's ISSUE lifecycle by its issue's AGGREGATE terminal
+/// outcome — the durable-issue twin of [`auto_move_after_terminal`], gated on the
+/// same drain.
+///
+/// A squad card fans out N tasks onto one issue, so a single sibling reaching
+/// `done` must not mark the whole issue `done` while others still run.
+/// [`TaskRepo::issue_aggregate_terminal_state`] returns `None` until the active
+/// set drains, then the aggregate token (`failed` > `cancelled` > `done`). Only
+/// the aggregate `done` promotes the issue (via
+/// [`advance_issue_lifecycle_after_transition`], which no-ops on `failed` /
+/// `cancelled`), so a failed or still-running set never advances the issue.
+///
+/// Best-effort — every fault is logged and swallowed (the task's terminal state
+/// has already committed).
+pub async fn advance_issue_lifecycle_after_terminal(pool: &SqlitePool, task: &Task) {
+    use ainb_hangar_store::repo::task::TaskRepo;
+
+    let Some(issue_id) = task.issue_id.as_deref() else {
+        return;
+    };
+    let Ok(ws) = WorkspaceId::from_str(task.workspace_id.clone()) else {
+        tracing::warn!(task_id = %task.id, "issue lifecycle terminal advance: empty workspace id; skipping");
+        return;
+    };
+    match TaskRepo::issue_aggregate_terminal_state(pool, ws.as_str(), issue_id).await {
+        // Active set not drained — a sibling still runs; do not advance yet.
+        Ok(None) => {}
+        Ok(Some(state)) => advance_issue_lifecycle_after_transition(pool, task, &state).await,
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = %task.id, "issue lifecycle terminal advance: aggregate read failed");
         }
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -952,6 +952,11 @@ async fn execute_claimed(
         // P4 / D8: auto-move the task's issue card into any board's `running`
         // auto-move column.
         crate::board::auto_move_after_transition(pool, &task, "running").await;
+        // The default issue board buckets by `issue.state`, not the durable
+        // `board_card` the auto-move touches — so also forward-advance the issue's
+        // own lifecycle to `in_progress`, or a plain task's card strands in Todo
+        // through its whole run. Advance-only + best-effort.
+        crate::board::advance_issue_lifecycle_after_transition(pool, &task, "running").await;
         // e38.6: write a durable, agent-authored "started" comment to the task's
         // issue so the agent's activity survives beyond the bounded transcript
         // buffer. A NULL-issue chat task writes nothing.
@@ -1423,6 +1428,10 @@ async fn finalize_success(
     // card does not slide to `done` while its leader / other members still run.
     // Best-effort; never blocks.
     crate::board::auto_move_after_terminal(pool, task).await;
+    // Twin the durable-card move on the issue's own `state` (the default board
+    // buckets by it): an aggregate-`done` set promotes the issue to `done`;
+    // failed/cancelled sets leave it untouched. Advance-only + best-effort.
+    crate::board::advance_issue_lifecycle_after_terminal(pool, task).await;
     // tcp T4 / F7 + FANOUT-SEMANTICS: a task of this card just went terminal, so
     // re-evaluate every card that DEPENDS on it — a dependent whose blockers are now
     // all FINISHED (their active sets drained with a `done`) becomes runnable (the 🔒
@@ -1552,6 +1561,10 @@ async fn finalize_failure(
     // and one failed sibling lands the whole card in the `failed` column (aggregate
     // precedence). Best-effort; never blocks.
     crate::board::auto_move_after_terminal(pool, task).await;
+    // Twin on `issue.state`: the aggregate is `failed`/`cancelled` here (this
+    // task's own failure is in the set), so this no-ops — but it keeps the
+    // lifecycle seam symmetric with the board seam. Advance-only + best-effort.
+    crate::board::advance_issue_lifecycle_after_terminal(pool, task).await;
     // tcp T4 / F7 + FANOUT-SEMANTICS: this member going terminal may have drained a
     // blocker whose set already held a `done` sibling — re-evaluate dependents so a
     // squad blocker that finished on a mixed done/failed drain still unblocks. The
@@ -1656,6 +1669,9 @@ async fn finalize_setup_failure(
         clock,
     );
     crate::board::auto_move_after_terminal(pool, task).await;
+    // Twin on `issue.state`; no-ops on the failed aggregate, kept for symmetry
+    // with the board seam. Advance-only + best-effort.
+    crate::board::advance_issue_lifecycle_after_terminal(pool, task).await;
     crate::board::unblock_dependents_after_terminal(pool, task).await;
     progress_comment::emit_checkpoint(
         pool,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/issue_lifecycle_advances_on_task_fsm.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/issue_lifecycle_advances_on_task_fsm.rs
@@ -1,0 +1,145 @@
+//! The plain-task issue lifecycle: `hangar/issues_list` `state` must walk
+//! `todo -> in_progress -> done` as a dispatched task walks its FSM.
+//!
+//! The default hangar issue board buckets cards by `issue.state` alone (the
+//! `issues_list` snapshot serves it verbatim), while the board auto-move only
+//! touches durable `board_card` rows the default screen never materialises. So a
+//! plain dispatched task used to walk its FSM (`running -> done`) with its issue
+//! frozen at `open`/`todo`, stranding its card in Todo through the whole run and
+//! after it finished. The fix advances `issue.state` at the same FSM seams the
+//! board auto-move fires — [`board::advance_issue_lifecycle_after_transition`] on
+//! the `running` transition, [`board::advance_issue_lifecycle_after_terminal`] on
+//! the terminal drain — so the snapshot renders the right column.
+//!
+//! These tests assert the SNAPSHOT the plugin actually reads (not the raw row),
+//! prove the advance-only guard never regresses a terminal state, and prove a
+//! FAILED task never marks its issue `done`. Removing the `IssueRepo::update_state`
+//! call in `board::advance_issue_lifecycle_after_transition` turns the first test
+//! red (the mutation spot-check).
+
+use ainb_hangar_daemon::board::{
+    advance_issue_lifecycle_after_terminal, advance_issue_lifecycle_after_transition,
+};
+use ainb_hangar_daemon::rpc::snapshots::issues_list;
+use ainb_hangar_daemon::seed::{WS_ID, seed_p4_fixture};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::task::{Task, TaskRepo};
+use sqlx::SqlitePool;
+
+/// The snapshot `state` the plugin's board buckets `issue-1` by.
+async fn issue1_state(pool: &SqlitePool) -> String {
+    let issues = issues_list(pool, WS_ID).await.expect("issues_list snapshot");
+    issues
+        .iter()
+        .find(|i| i.id.as_str() == "issue-1")
+        .expect("issue-1 present in snapshot")
+        .state
+        .clone()
+}
+
+/// Re-read `task-1` as a [`Task`] (the board seams take `&Task`).
+async fn task1(pool: &SqlitePool) -> Task {
+    TaskRepo::get_by_id(pool, "task-1")
+        .await
+        .expect("task get")
+        .expect("task-1 present")
+}
+
+/// Force `task-1`'s queue status to `new_status` so the aggregate-terminal read
+/// the terminal seam performs sees the FSM outcome under test.
+async fn set_task1_status(pool: &SqlitePool, new_status: &str) {
+    sqlx::query("UPDATE agent_task_queue SET status = ? WHERE id = 'task-1'")
+        .bind(new_status)
+        .execute(pool)
+        .await
+        .expect("update task status");
+}
+
+#[tokio::test]
+async fn issue_state_walks_todo_in_progress_done_across_task_fsm() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_p4_fixture(store.pool()).await.unwrap();
+    let pool = store.pool();
+
+    // Pre: the seed leaves issue-1 in the legacy `open` state, which the board
+    // buckets under Todo — the exact "stranded in Todo" starting point.
+    assert_eq!(
+        issue1_state(pool).await,
+        "open",
+        "seed starts issue-1 in the Todo bucket"
+    );
+
+    // running: the dispatched task started → issue promotes to in_progress.
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_transition(pool, &task, "running").await;
+    assert_eq!(
+        issue1_state(pool).await,
+        "in_progress",
+        "the running transition promotes the issue to In Progress"
+    );
+
+    // terminal success: the task's whole active set drained `done` → issue done.
+    set_task1_status(pool, "done").await;
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_terminal(pool, &task).await;
+    assert_eq!(
+        issue1_state(pool).await,
+        "done",
+        "terminal success advances the issue to Done"
+    );
+
+    // advance-only: a stray re-run's `running` transition must never drag an
+    // already-Done issue back to In Progress.
+    advance_issue_lifecycle_after_transition(pool, &task, "running").await;
+    assert_eq!(
+        issue1_state(pool).await,
+        "done",
+        "advance-only guard never regresses a terminal issue"
+    );
+}
+
+#[tokio::test]
+async fn failed_task_never_marks_its_issue_done() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_p4_fixture(store.pool()).await.unwrap();
+    let pool = store.pool();
+
+    // Drive to in_progress, then fail the run.
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_transition(pool, &task, "running").await;
+    assert_eq!(issue1_state(pool).await, "in_progress");
+
+    set_task1_status(pool, "failed").await;
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_terminal(pool, &task).await;
+
+    // A failed run has no `done` aggregate → the issue stays In Progress, never Done.
+    assert_eq!(
+        issue1_state(pool).await,
+        "in_progress",
+        "a failed task must not mark its issue Done"
+    );
+}
+
+#[tokio::test]
+async fn null_issue_chat_task_advance_is_a_noop() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_p4_fixture(store.pool()).await.unwrap();
+    let pool = store.pool();
+
+    // A chat task carries no issue: the seam resolves no issue_id and must simply
+    // do nothing (no panic, no cross-issue write).
+    let mut task = task1(pool).await;
+    task.issue_id = None;
+    advance_issue_lifecycle_after_transition(pool, &task, "running").await;
+    advance_issue_lifecycle_after_terminal(pool, &task).await;
+
+    assert_eq!(
+        issue1_state(pool).await,
+        "open",
+        "a null-issue chat task leaves every issue untouched"
+    );
+}


### PR DESCRIPTION
## Problem

Found by the hangar e2e journey loop: an issue driven through a plain
dispatched task (create → dispatch → done) stays frozen at `open`/`todo`,
so its card is stranded in the **Todo** column through the whole run and
after it finishes.

Root cause: the default hangar issue board buckets cards by `issue.state`
alone (`hangar/issues_list` serves it verbatim). The task FSM only moves
durable `board_card` rows via the board auto-move (`auto_move_after_transition`
/ `auto_move_after_terminal`), and `board_card` is **empty** on the default
screen. `IssueRepo::update_state` was only ever called by the PR-merge
snapshot and the Beads inbound reconciler — never for a plain dispatched
task — so `issue.state` never advanced. (The plugin's optimistic
`promote_to_in_progress` on `TaskStarted` was clobbered on the next
snapshot re-pull, so it never stuck either.)

## Fix

Make `issue.state` authoritative at the daemon FSM seams. Two helpers added
beside the board auto-move in `board.rs`:

- `advance_issue_lifecycle_after_transition(pool, task, "running")` →
  promotes the issue to `in_progress`, called at the running seam.
- `advance_issue_lifecycle_after_terminal(pool, task)` → mirrors
  `auto_move_after_terminal`: reads the issue's aggregate terminal state
  and, only when the whole active set drained `done`, promotes to `done`.
  Called at all three terminal seams.

Guards, mirroring the existing PR-merge guard:

- **Advance-only** via the canonical `IssueLifecycle` column order — a
  re-run's `running` transition can never drag an already-`done` (or
  manually-set / PR-merged) issue backwards.
- **Failed/cancelled never mark an issue `done`** — the aggregate is
  `failed`/`cancelled`, which the helper no-ops on.
- **Null-issue chat tasks** are skipped.
- Best-effort and logged, exactly like the auto-move calls — a lifecycle
  write can never down the claim loop.

The plugin reducer and the `needs_refetch` snapshot re-pull are **not**
touched: once `issue.state` is authoritative the re-pull renders the
correct column on its own.

## Test

`tests/issue_lifecycle_advances_on_task_fsm.rs` asserts the
`hangar/issues_list` snapshot `state` walks `open → in_progress → done`
across the FSM, that the advance-only guard never regresses a terminal
issue, that a failed task never marks its issue `done`, and that a
null-issue chat task is a no-op. Mutation spot-check: removing the
`IssueRepo::update_state` call turns the primary test red.

Full `ainb-hangar-daemon` suite green; `cargo build -p ainb` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue lifecycle states now advance automatically as associated tasks start running and complete successfully.
  * Lifecycle updates are advance-only, preventing completed issues from moving backward.
  * Tasks without a linked issue are safely ignored.

* **Bug Fixes**
  * Issue states now stay synchronized with task outcomes, including setup and terminal transitions.
  * Failed tasks no longer incorrectly mark associated issues as complete.

* **Tests**
  * Added coverage for successful, failed, repeated, and unlinked-task lifecycle transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->