### PR TITLE
fix(hangar): guard wizard Brief Enter against seeding a leading newline

### DIFF
--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -1338,8 +1338,16 @@ fn reduce_wizard_key(state: &IssueListState, key: WizardKey) -> IssueListReducti
     match key {
         // Enter on the Brief inserts a NEWLINE (multi-line editing) and must NOT
         // fire create; every other row's Enter is the existing commit point.
+        // Guard the empty buffer: Enter with nothing typed is a no-op, never a
+        // seeded leading `\n`. That newline would otherwise reach
+        // `issue.description` byte-verbatim (see `wizard_try_create`, which sends
+        // the brief EXACTLY as typed and only trims to detect all-blank),
+        // displacing any leading `/name` skill line off position 0 and breaking
+        // headless dispatch under `claude -p`.
         WizardKey::Enter if wizard.focus == WizardRow::Brief => {
-            wizard.brief.push('\n');
+            if !wizard.brief.is_empty() {
+                wizard.brief.push('\n');
+            }
             set_wizard(state, wizard)
         }
         WizardKey::Enter => wizard_try_create(state, wizard),
@@ -2829,6 +2837,44 @@ mod tests {
             painted_row_span(&s) > empty_span,
             "card must grow for a multi-line brief ({} !> {empty_span})",
             painted_row_span(&s)
+        );
+    }
+
+    /// Enter on an EMPTY Brief must be a no-op — never seed a leading `\n`. That
+    /// stray newline would flow byte-verbatim into `issue.description` and shove a
+    /// leading `/name` skill line off position 0, breaking headless `claude -p`
+    /// dispatch. Enter AFTER typed text still inserts a newline for genuine
+    /// multi-line editing, and no leading newline ever appears.
+    #[test]
+    fn wizard_brief_enter_on_empty_does_not_seed_leading_newline() {
+        // Open the wizard, focus the Brief row.
+        let s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
+        assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
+
+        // Enter on the empty buffer: no-op (RED before the fix — would be "\n").
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Enter)).state;
+        assert_eq!(
+            s.wizard().unwrap().brief(),
+            "",
+            "Enter on an empty Brief must not seed a leading newline"
+        );
+        // Enter still does NOT fire create — the wizard is still open.
+        assert!(s.wizard().is_some(), "Enter on Brief must not create");
+
+        // Type text, Enter (inserts a newline), type more: the embedded newline is
+        // preserved and there is no leading newline.
+        let s = type_into(&s, "Read");
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Enter)).state;
+        let s = type_into(&s, "the docs");
+        assert_eq!(
+            s.wizard().unwrap().brief(),
+            "Read\nthe docs",
+            "mid-content Enter must preserve embedded newlines with no leading \\n"
+        );
+        assert!(
+            !s.wizard().unwrap().brief().starts_with('\n'),
+            "brief must never begin with a newline"
         );
     }
 


### PR DESCRIPTION
## Problem

In `reduce_wizard_key` (`crates/ainb-plugin-hangar/src/screen/issue_list.rs`), the `WizardKey::Enter if wizard.focus == WizardRow::Brief` arm unconditionally ran `wizard.brief.push('\n')`. When Enter fired while the Brief buffer was empty (position 0), it seeded a spurious leading `0x0A`.

That newline flows byte-verbatim into `issue.description` at `wizard_try_create` (which only trims to detect an all-blank brief and otherwise sends it EXACTLY as typed), so the stored description begins with `\n` before the first real line.

Confirmed by the e2e loop via hexdump: stored brief was `0a 52 65 61 64` (`\nRead`) vs the expected `52 65 61 64` (`Read`). This is a real dispatch risk: a brief that begins with a `/skill` line has its skill invocation displaced off position 0, which can break headless skill execution under `claude -p` (build_prompt = title + description).

## Fix

Guard the empty-buffer case in the Brief-Enter arm: when `wizard.brief` is empty, Enter is a no-op (no seeded newline). The mid-content path still pushes `\n` for genuine multi-line editing, and Enter on the Brief still never fires create. Updated the invariant comment to document the guard and reference the byte-verbatim contract in `wizard_try_create`.

## Test

Added reducer behavioral test `wizard_brief_enter_on_empty_does_not_seed_leading_newline`:
- Open wizard, focus Brief, send Enter on the empty buffer, assert `brief == ""` (RED before fix: was `"\n"`).
- Assert the wizard is still open (Enter on Brief never creates).
- Type `Read`, Enter, type `the docs`; assert `brief == "Read\nthe docs"` (embedded newline preserved, no leading `\n`).

Mutation spot-check: reverting the guard turns the new test red (verified).

## Validation

- `cargo test -p ainb-plugin-hangar` — full crate suite green
- `cargo build -p ainb` — clean (exit 0)
- Pre-existing clippy drift in dependency crates (`ainb-hangar-core`, `ainb-plugin-protocol`) is untouched by this change (newer-toolchain lints on unrelated files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Enter with an empty Brief no longer adds an unwanted leading line break.
  * The issue creation wizard now remains open when Enter is pressed without any Brief text.
  * Multi-line Brief editing continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->