### PR TITLE
docs: fix hangar CLI reference + journey docs drift

### DIFF
--- a/docs/hangar/tui-keybindings.md
+++ b/docs/hangar/tui-keybindings.md
@@ -118,10 +118,24 @@ pair (`hangar/skill_attach` returns an error).
 
 ## Settings (`,`)
 
+Six stacked sections: Daemon, Providers, Keys, Workspaces, Members,
+Notifications. `j` / `k` switch sections; `J` / `K` (and `↑` / `↓`) move the
+row cursor within the focused section.
+
 | Key | Action |
 |-----|--------|
-| `j` / `k` | Move between sections / rows |
-| `Enter` / `Space` | Edit / toggle the selected row (section-dependent) |
+| `j` / `k` | Move between sections |
+| `J` / `K` / `↑` / `↓` | Move the row cursor within the section |
+| `Enter` / `Space` | Edit / toggle the focused row — Daemon only |
+| `Space` / `t` | Toggle the selected kind×channel cell — Notifications only |
+
+Edit/toggle is section-scoped. On **Daemon**, `Enter` or `Space` acts on the
+focused config knob by type: toggle a bool, cycle an enum, or open the numeric
+overlay for an int. On **Notifications**, `Space` / `t` toggles the selected
+kind×channel cell (`h` / `l` move the channel column; `g` flips the edit scope
+between the host-wide global rule and the active-workspace override). The
+Providers, Keys, Workspaces, and Members panes are read-only here (their
+mutations are CLI-first, e.g. `ainb hangar member set-role`).
 
 ## Agent picker (modal)
 

--- a/docs/hangar/tui-keybindings.md
+++ b/docs/hangar/tui-keybindings.md
@@ -14,7 +14,17 @@ Hints are rendered next to the control they affect (per
 |-----|--------|
 | `1` | Issue list (landing) |
 | `2` | Task detail (only when a task is selected) |
-| `4` | Skill manager |
+| `3` | Skill manager |
+| `4` | Autopilots |
+| `K` | Kanban |
+| `B` | Boards |
+| `C` | Control center |
+| `S` | Squads |
+| `P` | Profile editor |
+| `D` | Daemon health |
+| `U` | Usage dashboard |
+| `L` | Logs |
+| `I` | Inbox |
 | `,` | Settings |
 | `?` | Help overlay |
 | `Esc` | Close the active modal |
@@ -26,10 +36,65 @@ Hints are rendered next to the control they affect (per
 |-----|--------|
 | `j` / `k` | Move the selection |
 | `Enter` | Open the selected issue's task detail |
-| `a` | Open the agent picker for the selected issue |
+| `c` | Open the create-issue wizard |
+| `a` | Open the agent picker for the selected issue (sets the assignee) |
+| `x` | Delete the selected issue (confirm overlay; Enter confirms, Esc cancels) |
 | `/` | Filter |
 
-## Skill manager (`4`) — P6.5
+If a delete is refused because the issue still has active run(s), a
+second-chance amber overlay offers to cancel the run(s) and delete
+(`c` / `Enter` confirms, Esc backs out).
+
+## Create-issue wizard (`c` on the Issue list)
+
+A single centered form showing every field at once, with a focused-row cursor.
+The rows, in focus order:
+
+| Row | Required? | Notes |
+|-----|-----------|-------|
+| Title | required | A trimmed-blank title blocks create. |
+| Brief | optional | Multi-line free text; becomes the issue description and the dispatched prompt. Enter here inserts a newline (it never fires create). |
+| Linked issue | optional | Single-line upstream reference (a URL or `owner/repo#123`); stored as the issue's `external_ref` and appended to the dispatched brief. |
+| Repo | required | `@` opens a fuzzy dropdown (favorites-first roster, `scratch` always offered); `←` / `→` cycle the roster. A repo-less create is impossible. |
+| Source branch | — | The branch the run branches FROM (prefilled `main`; blank = repo default). |
+| PR-into (target) branch | — | The branch a future PR lands INTO (prefilled `main`). |
+| Agent | — | `←` / `→` cycle the workspace's named agents (or the provider chips `claude`/`codex`/`copilot` when no named agents exist). Always valid. |
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` / `Tab` / `Shift+Tab` | Move focus between rows (wrapping) |
+| `←` / `→` | Cycle the focused picker row (Repo / Agent) |
+| `@` | Open the repo fuzzy dropdown (on the Repo row) |
+| `Enter` | On Brief: insert a newline. Anywhere else: create the issue AND dispatch it — only when Title and Repo are set, otherwise focus jumps to the missing required row |
+| `Esc` | Cancel the whole wizard (from any row) |
+
+### Brief-or-link run guard
+
+A dispatch (wizard Enter, or a later run of the issue) is **refused by the
+daemon when the issue has neither a Brief nor a Linked issue reference** — a
+title-only card would run a useless prompt. The refusal surfaces as a note:
+`add a brief or link an issue before running`. Add a Brief or a Linked issue
+and re-run.
+
+## Task detail (`2` / Enter on an issue)
+
+The screen opens on the issue's **detail card**: title (with display id),
+Status / Priority / Created, Assignee / Agent, Repo / Source → Target branches,
+Labels, a `Linked: ⧉ <ref>` line when an upstream issue is linked, the wrapped
+description, and a run-history line — with the live transcript below.
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Scroll |
+| `c` | Compose a comment (Enter submits, Esc cancels) |
+| `R` | Retry the task (only once terminal) |
+| `X` | Cancel the running task (confirm overlay) |
+| `x` | Delete the bound issue (confirm overlay; the daemon rejects a delete with active tasks and the rejection surfaces as a note) |
+
+Issue deletion here and on the Issue list mirrors the `ainb hangar issue delete`
+CLI command (dry-run preview without `--yes`).
+
+## Skill manager (`3`) — P6.5
 
 The three panes: a left skill list, a middle file tree (collapses below ~100
 cols), and a right detail/editor pane. The action-key hints
@@ -56,13 +121,12 @@ pair (`hangar/skill_attach` returns an error).
 | Key | Action |
 |-----|--------|
 | `j` / `k` | Move between sections / rows |
-| `s` | Set the selected workspace active (Workspaces section) |
-| `d` | Toggle the selected workspace's default flag (Workspaces section) |
+| `Enter` / `Space` | Edit / toggle the selected row (section-dependent) |
 
 ## Agent picker (modal)
 
 | Key | Action |
 |-----|--------|
 | `j` / `k` | Move the selection |
-| `Enter` | Assign the selected actor |
+| `Enter` | Assign the selected actor (`hangar/issue_update`) |
 | `Esc` | Close without assigning |

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2862,6 +2862,7 @@ Commands:
   search  Search issues by title, description, or comment body (ranked)
   show    Show one issue by id
   update  Edit an existing issue's state, assignee, priority, or due date
+  delete  Delete an issue and all its history (dry-run without `--yes`)
   label   Attach or detach a label on an issue
   help    Print this message or the help of the given subcommand(s)
 
@@ -2919,6 +2920,15 @@ Options:
           A label to attach to the issue (repeatable: `--label bug --label p0`).
           
           Persisted as the issue's label list. The full labels table + attach/detach is a separate concern; create just records the labels it is handed.
+
+      --repo <REPO>
+          The repo the run executes in: an absolute checkout path, the literal `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`) — a remote is cloned once into the shared clone cache and the local path persisted, exactly like the board card-create path (migration 0032/0042)
+
+      --source-branch <SOURCE_BRANCH>
+          The SOURCE branch the run branches FROM (migration 0042); omitted uses the repo's default branch. Persisted on the issue AND the enqueued task
+
+      --target-branch <TARGET_BRANCH>
+          The TARGET branch a future PR lands INTO (migration 0042); stored on the issue for later PR automation
 
   -h, --help
           Print help (see a summary with '-h')
@@ -3025,6 +3035,26 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+```
+
+#### `ainb hangar issue delete`
+
+Delete an issue and all its history (dry-run without `--yes`)
+
+```console
+$ ainb hangar issue delete --help
+Delete an issue and all its history (dry-run without `--yes`)
+
+Usage: ainb hangar issue delete [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Issue id (ULID) to delete
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --yes                    Actually perform the delete. Without this flag the command only PREVIEWS what would be removed and exits without touching the database
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
 ```
 
 #### `ainb hangar issue label`
@@ -3174,6 +3204,8 @@ Commands:
   stop     Stop the running daemon: signal the exact recorded PID, then remove the PID file
   restart  Restart the daemon: `stop` (if running) then `start`
   setup    One-command bring-up: ensure the store + socket-auth token, then `start`
+  config   View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+  cred     Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3281,6 +3313,48 @@ $ ainb hangar daemon setup --help
 One-command bring-up: ensure the store + socket-auth token, then `start`
 
 Usage: ainb hangar daemon setup [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar daemon config`
+
+View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+
+```console
+$ ainb hangar daemon config --help
+View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+
+Usage: ainb hangar daemon config [OPTIONS] <COMMAND>
+
+Commands:
+  list  List every configurable: key, current value (or default), default, type
+  get   Print one knob's current value (or its default when unset)
+  set   Validate + persist one knob's value (rejects unknown keys / bad values)
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar daemon cred`
+
+Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
+
+```console
+$ ainb hangar daemon cred --help
+Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
+
+Usage: ainb hangar daemon cred [OPTIONS] <COMMAND>
+
+Commands:
+  status  Report whether a credential is configured and where it resolves from (env override / secret store / not set). Never prints the value
+  set     Store a long-lived token. Reads the token from STDIN by default (so it never lands on argv or in shell history); `--setup-token` instead drives the interactive `claude setup-token` browser flow and captures the result
+  clear   Remove the stored credential. Idempotent
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -3526,6 +3600,7 @@ Edit, archive, and list workspace agents
 Usage: ainb hangar agent [OPTIONS] <COMMAND>
 
 Commands:
+  create     Create a new agent from scratch (fills workspace/runtime/owner behind the scenes)
   list       List the workspace's agents (active by default; `--all` includes archived)
   edit       Edit an agent's config knobs (model / args / MCP / thinking / env / name)
   archive    Archive an agent (hide it from the active picker)
@@ -3535,6 +3610,25 @@ Commands:
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
   -h, --help             Print help
+```
+
+#### `ainb hangar agent create`
+
+Create a new agent from scratch (fills workspace/runtime/owner behind the scenes)
+
+```console
+$ ainb hangar agent create --help
+Create a new agent from scratch (fills workspace/runtime/owner behind the scenes)
+
+Usage: ainb hangar agent create [OPTIONS] --name <NAME>
+
+Options:
+      --format <format>              Output format [default: text] [possible values: text, json, csv, markdown]
+      --name <NAME>                  The new agent's name
+      --provider <PROVIDER>          Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`
+      --instructions <INSTRUCTIONS>  Optional instructions / system prompt for the agent
+      --workspace <WORKSPACE>        Workspace slug to create the agent in. Defaults to the bootstrapped `default` workspace (created if absent)
+  -h, --help                         Print help
 ```
 
 #### `ainb hangar agent list`
@@ -3580,6 +3674,8 @@ Options:
       --thinking <THINKING>          New thinking level (e.g. `low`/`medium`/`high`); omitted leaves it. Mutually exclusive with `--clear-thinking`
       --clear-thinking               Clear the thinking level; omitted leaves it
       --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable). When ANY `--env` is given the whole env map is REPLACED with the values
+      --token-budget <TOKEN_BUDGET>  New token budget (rtk/headroom, migration 0042); omitted leaves it. Mutually exclusive with `--clear-token-budget`
+      --clear-token-budget           Clear the token budget (back to unlimited); omitted leaves it
       --workspace <WORKSPACE>        Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                         Print help
 ```


### PR DESCRIPTION
Closes #429

## What

Resolves the documentation drift tracked in #429: the `CLI reference freshness` CI gate is red on `main` because `docs/tui/cli.md` no longer matches what `scripts/gen-cli-reference.sh` produces from the shipped `ainb` binary, and the narrative Hangar docs predate the current create-task wizard.

## Drift fixed

**`docs/tui/cli.md` — regenerated from the current binary** (via `AINB_BIN=target/debug/ainb bash ainb-tui/scripts/gen-cli-reference.sh`, byte-identical to generator output so the freshness gate goes green). New/corrected surface:

- `ainb hangar issue delete` — entire subcommand (dry-run preview, `--yes`, `--workspace`).
- `ainb hangar issue create` — `--repo`, `--source-branch`, `--target-branch` (migrations 0032/0042).
- `ainb hangar daemon config` — entire subcommand (`list`/`get`/`set`).
- `ainb hangar daemon cred` — entire subcommand (`status`/`set`/`clear`).
- `ainb hangar agent create` — entire subcommand (`--name`/`--provider`/`--instructions`/`--workspace`).
- `ainb hangar agent edit` — `--token-budget` / `--clear-token-budget` (migration 0042).

**`docs/hangar/tui-keybindings.md` — matched to the shipped TUI:**

- Full top-nav route table (`1`/`2`/`3`/`4`, `K`/`B`/`C`/`S`/`P`/`D`/`U`/`L`/`I`), traced to `router.rs`.
- Create-issue wizard field set (Title, Brief, Linked issue, Repo, Source branch, PR-into/target branch, Agent), focus order, and `@` repo dropdown.
- `c` create, `a` agent picker, `x` delete keybindings; task detail card; brief-or-link run guard.
- Settings screen corrected to the six real sections and the section-scoped Daemon/Notifications edit behaviour.

## Verification

- CLI reference: 3 subcommands (`issue delete`, `daemon config`, `agent create`) spot-checked against live `--help` output — exact match. `CLI reference freshness` CI is the authoritative gate on this PR.
- Narrative keybindings traced to `crates/ainb-plugin-hangar/src/screen/{router,issue_list,settings}.rs`.

Docs-only; no code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hangar TUI keybinding guidance for routing, issue management, task details, settings, and agent selection.
  * Documented the create-issue wizard, including validation, cancellation, filtering, deletion safeguards, and run controls.
  * Added CLI documentation for issue deletion, repository and branch options, daemon configuration and credentials, agent creation, and token-budget settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->