### PR TITLE
feat(hangar): first-class Agents screen (nav A, create, delete)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -658,6 +658,7 @@ async fn handle(
         methods::HANGAR_ISSUE_LABEL_DETACH => handle_issue_label(pool, req, events, false).await,
         methods::HANGAR_COMMENT_ADD => handle_comment_add(pool, req, events).await,
         methods::HANGAR_AGENT_CREATE => handle_agent_create(pool, req).await,
+        methods::HANGAR_AGENT_DELETE => handle_agent_delete(pool, req).await,
         methods::HANGAR_AGENT_UPDATE => handle_agent_update(pool, req).await,
         methods::HANGAR_AGENT_ARCHIVE => handle_agent_archive(pool, req).await,
         methods::HANGAR_MEMBERS_LIST => handle_members_list(pool, req).await,
@@ -1514,9 +1515,8 @@ async fn persist_card_edits(
     // through untouched; the clone runs once, idempotently.
     let resolved_repo_ref = match repo_ref {
         Some(r) => {
-            let ainb_dir = ainb_hangar_core::hangar_home().ok_or_else(|| {
-                internal("cannot resolve hangar home to clone a remote favorite")
-            })?;
+            let ainb_dir = ainb_hangar_core::hangar_home()
+                .ok_or_else(|| internal("cannot resolve hangar home to clone a remote favorite"))?;
             Some(resolve_card_repo_ref(&ainb_dir, r).await?)
         }
         None => None,
@@ -1940,6 +1940,55 @@ async fn handle_agent_create(
     }
     // Answer with the refreshed roster (the same shape agents_list returns) so
     // the plugin folds the new agent into its cached list and the squad gate clears.
+    let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;
+    to_value(&ainb_hangar_proto::snapshots::AgentsListResult { actors })
+}
+
+/// Dispatch `hangar/agent_delete` (Agents screen `x` remove, slice 2): delete one
+/// named agent and answer with the refreshed `agents_list` so the client folds the
+/// shrunk roster back into its picker cache.
+///
+/// Mirrors [`handle_issue_delete`]'s contract: resolve + reject a mistyped
+/// workspace, then drive the workspace-scoped delete. A `(agent_id, workspace)`
+/// pair that matches no row is a not-found error (never a cross-tenant delete); an
+/// agent with a live task is refused with a machine-readable `active_tasks` marker
+/// (so the TUI can offer "cancel the run first"); an agent still FK-pinned by run
+/// history is refused with an "archive instead" message. A fresh, never-run agent
+/// deletes cleanly.
+async fn handle_agent_delete(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::agent::{AgentDeleteError, AgentRepo};
+
+    let params: ainb_hangar_proto::snapshots::AgentDeleteParams =
+        parse_params(req, "{ workspace_id, agent_id }")?;
+    // The mutating handler must not silently no-op on a typo'd workspace.
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    AgentRepo::delete(pool, ws.as_str(), &params.agent_id)
+        .await
+        .map_err(|e| match e {
+            AgentDeleteError::NotFound => {
+                invalid_params(&format!("no agent `{}` in this workspace", params.agent_id))
+            }
+            // A live run blocks the delete — surface the "cancel first" message
+            // tagged with a machine-readable marker (append-only `data`) so the TUI
+            // can offer an inline cancel instead of dead-ending on the text.
+            AgentDeleteError::ActiveTasks(n) => RpcError {
+                code: INVALID_PARAMS,
+                message: e.to_string(),
+                data: Some(serde_json::json!({ "reason": "active_tasks", "active": n })),
+            },
+            // FK-pinned history: refuse rather than orphan, pointing at archive.
+            AgentDeleteError::HasHistory => RpcError {
+                code: INVALID_PARAMS,
+                message: e.to_string(),
+                data: Some(serde_json::json!({ "reason": "has_history" })),
+            },
+            AgentDeleteError::Db(ref db) => store_err(db),
+        })?;
+    // Answer with the refreshed roster (the same shape agents_list / agent_create
+    // return) so the plugin folds the shrunk list into its picker cache.
     let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;
     to_value(&ainb_hangar_proto::snapshots::AgentsListResult { actors })
 }
@@ -5268,6 +5317,82 @@ mod tests {
         .await;
         assert!(resp.error.is_none(), "{resp:?}");
         assert_eq!(resp.result.unwrap()["actor_ref"], "agent:agent-1");
+    }
+
+    /// `hangar/agent_delete` removes a fresh (never-run) agent through the
+    /// dispatcher and answers with the refreshed roster no longer carrying it. The
+    /// agent is created via `agent_create` first so it has no FK-pinned history.
+    #[tokio::test]
+    async fn agent_delete_removes_a_fresh_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        // Create a throwaway agent, then read its id back off the refreshed roster.
+        let created = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_AGENT_CREATE,
+                serde_json::json!({ "workspace_id": "default", "name": "throwaway" }),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(created.error.is_none(), "{created:?}");
+        let actors = created.result.unwrap();
+        let new_ref = actors["actors"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["display_name"] == "throwaway")
+            .expect("created agent is on the roster")["actor_ref"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let new_id = new_ref.strip_prefix("agent:").unwrap();
+
+        let resp = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_AGENT_DELETE,
+                serde_json::json!({ "workspace_id": "default", "agent_id": new_id }),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(resp.error.is_none(), "{resp:?}");
+        let roster = resp.result.unwrap();
+        let still_there = roster["actors"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|a| a["display_name"] == "throwaway");
+        assert!(
+            !still_there,
+            "the deleted agent must be gone from the roster"
+        );
+    }
+
+    /// An unknown agent id is rejected (not a silent no-op), mirroring the mutating
+    /// workspace-reject contract.
+    #[tokio::test]
+    async fn agent_delete_unknown_agent_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+        let resp = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_AGENT_DELETE,
+                serde_json::json!({ "workspace_id": "default", "agent_id": "no-such-agent" }),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert_eq!(resp.error.unwrap().code, INVALID_PARAMS);
     }
 
     /// `hangar/skill_get` returns the seeded `commit` skill's detail, scoped to

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -354,6 +354,23 @@ pub const HANGAR_AGENT_ARCHIVE: &str = "hangar/agent_archive";
 /// task — so a `codex` agent runs codex.
 pub const HANGAR_AGENT_CREATE: &str = "hangar/agent_create";
 
+/// `hangar/agent_delete` — delete one named agent from a workspace (the Agents
+/// screen `x` remove, slice 2).
+///
+/// Params: [`crate::snapshots::AgentDeleteParams`] (`{ workspace_id, agent_id }`).
+/// Result: the refreshed [`crate::snapshots::AgentsListResult`] (the same shape
+/// [`HANGAR_AGENT_CREATE`] answers with) so the client folds the shrunk roster
+/// back into the cache that drives the Agents/Squads pickers.
+///
+/// Mutating + workspace-scoped like [`HANGAR_AGENT_ARCHIVE`]: a foreign-tenant or
+/// unknown `agent_id` is rejected as not-found (never a cross-tenant delete). The
+/// delete is REFUSED while the agent has any ACTIVE task (queued / dispatched /
+/// running) — the caller must cancel the run first — and refused when the agent
+/// still carries run HISTORY the schema pins by foreign key (archive it instead);
+/// both surface as `INVALID_PARAMS` so a fresh, never-run agent deletes cleanly
+/// while a live/historical one is guarded rather than silently orphaned.
+pub const HANGAR_AGENT_DELETE: &str = "hangar/agent_delete";
+
 /// `hangar/members_list` — snapshot the human members of a workspace (e38.11).
 ///
 /// Params: [`crate::snapshots::WorkspaceScopedParams`] (`{ workspace_id }`).
@@ -1070,6 +1087,9 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_ISSUE_DELETE,
     // Issue-scoped cancel-active (board-less cancel-and-delete), likewise appended.
     HANGAR_ISSUE_CANCEL_ACTIVE,
+    // Agent delete (Agents screen `x` remove) is APPENDED at the catalogue tail —
+    // append-only wire.
+    HANGAR_AGENT_DELETE,
 ];
 
 #[cfg(test)]
@@ -1174,6 +1194,7 @@ mod tests {
             HANGAR_SQUAD_FANOUT,
             HANGAR_RUN_HISTORY,
             HANGAR_AGENT_CREATE,
+            HANGAR_AGENT_DELETE,
             HANGAR_ISSUE_DELETE,
         ] {
             assert!(m.starts_with("hangar/"), "{m:?} not under hangar/");
@@ -1268,6 +1289,7 @@ mod tests {
             HANGAR_DAEMON_CONFIG_GET,
             HANGAR_DAEMON_CONFIG_SET,
             HANGAR_AGENT_CREATE,
+            HANGAR_AGENT_DELETE,
             HANGAR_DAEMON_CONFIG_LIST,
             HANGAR_ISSUE_DELETE,
             HANGAR_ISSUE_CANCEL_ACTIVE,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1130,6 +1130,22 @@ pub struct AgentArchiveParams {
     pub archived: bool,
 }
 
+/// Params for [`crate::methods::HANGAR_AGENT_DELETE`]: delete one named agent
+/// from a workspace (the Agents screen `x` remove, slice 2).
+///
+/// `workspace_id` is the tenant-isolation guard — the daemon resolves it and
+/// scopes the delete by `(agent_id, workspace_id)` so a foreign-tenant agent id
+/// deletes nothing. The daemon refuses the delete while the agent has an active
+/// task or still carries FK-pinned run history (see
+/// [`crate::methods::HANGAR_AGENT_DELETE`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AgentDeleteParams {
+    /// The subscribed workspace the agent must belong to (tenant guard).
+    pub workspace_id: String,
+    /// The agent to delete (`agent.id`).
+    pub agent_id: String,
+}
+
 /// Params for [`crate::methods::HANGAR_COMMENT_ADD`] (e38.5): append one comment
 /// to an issue, scoped to a workspace.
 ///

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -136,6 +136,50 @@ impl AgentConfigUpdate {
     }
 }
 
+/// Failure modes of [`AgentRepo::delete`] (Agents screen `x` remove, slice 2).
+///
+/// Mirrors [`crate::repo::issue::IssueDeleteError`]'s shape so the daemon handler
+/// maps each arm to the same `INVALID_PARAMS` contract. An agent OWNS its task /
+/// usage / autopilot rows by foreign key, so a hard delete is only safe once the
+/// agent has no active run AND no FK-pinned history — the two guarded arms below.
+#[derive(Debug)]
+pub enum AgentDeleteError {
+    /// No agent matched `(id, workspace_id)` — an unknown id or a foreign tenant.
+    NotFound,
+    /// The agent has one or more ACTIVE tasks (queued / dispatched / running);
+    /// the run must be cancelled before the agent can be deleted. Carries the
+    /// active count.
+    ActiveTasks(i64),
+    /// The agent still carries run history the schema pins by foreign key (past
+    /// tasks, usage, autopilots): a hard delete would trip an FK constraint, so it
+    /// is refused (archive the agent instead).
+    HasHistory,
+    /// An underlying store fault.
+    Db(sqlx::Error),
+}
+
+impl std::fmt::Display for AgentDeleteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no agent with that id in this workspace"),
+            Self::ActiveTasks(n) => write!(
+                f,
+                "{n} active task(s) on this agent — cancel the run first, then delete"
+            ),
+            Self::HasHistory => write!(f, "agent has run history — archive it instead of deleting"),
+            Self::Db(e) => write!(f, "store error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentDeleteError {}
+
+impl From<sqlx::Error> for AgentDeleteError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Db(e)
+    }
+}
+
 /// Stateless typed wrapper over the `agent` table.
 pub struct AgentRepo;
 
@@ -347,6 +391,83 @@ impl AgentRepo {
             .await?;
         Ok(res.rows_affected() == 1)
     }
+
+    /// Hard-delete one agent, scoped to a workspace (Agents screen `x` remove,
+    /// slice 2).
+    ///
+    /// Workspace-scoped at the SQL boundary: an `(id, workspace_id)` pair that
+    /// matches no row is [`AgentDeleteError::NotFound`] (never a cross-tenant
+    /// delete). The delete is GUARDED in two ways, mirroring
+    /// [`crate::repo::issue::IssueRepo::delete_cascade`]:
+    /// - refused while the agent has any ACTIVE task (queued / dispatched /
+    ///   running) → [`AgentDeleteError::ActiveTasks`];
+    /// - refused when the `DELETE` trips a foreign-key constraint because the agent
+    ///   still owns FK-pinned history (past tasks, usage rows, autopilots) →
+    ///   [`AgentDeleteError::HasHistory`]. `sqlx` runs `PRAGMA foreign_keys = ON`,
+    ///   so the database itself refuses to orphan those rows — this never silently
+    ///   dangles a reference.
+    ///
+    /// A fresh, never-run agent (the common case created from the Agents screen)
+    /// has no active task and no history, so it deletes cleanly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentDeleteError`]: `NotFound` / `ActiveTasks` / `HasHistory` per
+    /// the guards above, or `Db` on any other store fault.
+    pub async fn delete(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        id: &str,
+    ) -> Result<(), AgentDeleteError> {
+        // Resolve the agent within its workspace; an unknown / foreign id is
+        // NotFound rather than a silent no-op.
+        let exists: Option<String> =
+            sqlx::query_scalar("SELECT id FROM agent WHERE id = ? AND workspace_id = ?")
+                .bind(id)
+                .bind(workspace_id)
+                .fetch_optional(pool)
+                .await?;
+        if exists.is_none() {
+            return Err(AgentDeleteError::NotFound);
+        }
+
+        // Refuse while any of the agent's tasks is live — deleting would orphan the
+        // running attempt (and would trip the FK anyway; this yields the precise
+        // "cancel first" message instead of the generic history one).
+        let active: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM agent_task_queue \
+             WHERE agent_id = ? AND workspace_id = ? \
+               AND status IN ('queued','dispatched','running')",
+        )
+        .bind(id)
+        .bind(workspace_id)
+        .fetch_one(pool)
+        .await?;
+        if active > 0 {
+            return Err(AgentDeleteError::ActiveTasks(active));
+        }
+
+        match sqlx::query("DELETE FROM agent WHERE id = ? AND workspace_id = ?")
+            .bind(id)
+            .bind(workspace_id)
+            .execute(pool)
+            .await
+        {
+            Ok(_) => Ok(()),
+            // The agent still carries FK-pinned history (terminal tasks, usage,
+            // autopilots): the DB refuses the delete rather than orphaning those
+            // rows. Surface it as the archive-instead guard, not a raw store error.
+            Err(e) if is_foreign_key_violation(&e) => Err(AgentDeleteError::HasHistory),
+            Err(e) => Err(AgentDeleteError::Db(e)),
+        }
+    }
+}
+
+/// Whether a `sqlx` error is a SQLite foreign-key constraint violation. Used by
+/// [`AgentRepo::delete`] to turn a history-pinned delete into the actionable
+/// [`AgentDeleteError::HasHistory`] rather than an opaque store error.
+fn is_foreign_key_violation(e: &sqlx::Error) -> bool {
+    e.as_database_error().is_some_and(|db| db.message().contains("FOREIGN KEY"))
 }
 
 /// The full column list every `SELECT` reads, in [`Agent::from_row`] order. A
@@ -405,6 +526,111 @@ fn decode_err(column: &str, detail: &str) -> sqlx::Error {
     sqlx::Error::ColumnDecode {
         index: column.to_string(),
         source: format!("malformed '{column}': {detail}").into(),
+    }
+}
+
+#[cfg(test)]
+mod delete_tests {
+    use super::*;
+    use crate::Store;
+    use crate::bootstrap;
+
+    /// Boot a fresh store with the default workspace + owner + runtime seeded, and
+    /// create one agent on it. Returns `(store, workspace_id, agent)`; the store is
+    /// kept alive by the caller so the temp DB outlives the test.
+    async fn seed_agent(name: &str) -> (Store, String, Agent) {
+        let dir = tempfile::tempdir().unwrap();
+        // Leak the tempdir so the sqlite file survives for the store's lifetime.
+        let dir = Box::leak(Box::new(dir));
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let ws = bootstrap::ensure_default_workspace(store.pool()).await.unwrap();
+        let agent = bootstrap::create_agent(store.pool(), &ws, name, "claude", None).await.unwrap();
+        (store, ws, agent)
+    }
+
+    /// Insert one task for `agent` in `ws` at `status` (issue-less, so no issue FK
+    /// is needed) — the fixture for the active-task and history guards.
+    async fn seed_task(pool: &SqlitePool, ws: &str, agent: &Agent, id: &str, status: &str) {
+        sqlx::query(
+            "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, status, created_at) \
+             VALUES (?, ?, ?, ?, ?, 1000)",
+        )
+        .bind(id)
+        .bind(ws)
+        .bind(&agent.runtime_id)
+        .bind(&agent.id)
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// A fresh, never-run agent deletes cleanly and vanishes from the roster.
+    #[tokio::test]
+    async fn delete_removes_a_fresh_agent() {
+        let (store, ws, agent) = seed_agent("scratch").await;
+        let pool = store.pool();
+
+        AgentRepo::delete(pool, &ws, &agent.id).await.unwrap();
+
+        assert!(AgentRepo::get(pool, &agent.id).await.unwrap().is_none());
+        assert_eq!(bootstrap::agent_count(pool, &ws).await.unwrap(), 0);
+    }
+
+    /// An unknown id (never a real agent) is a not-found error, not a silent no-op.
+    #[tokio::test]
+    async fn delete_unknown_agent_is_not_found() {
+        let (store, ws, _agent) = seed_agent("keep").await;
+        let out = AgentRepo::delete(store.pool(), &ws, "no-such-agent").await;
+        assert!(matches!(out, Err(AgentDeleteError::NotFound)));
+    }
+
+    /// A real agent id but a FOREIGN workspace matches no row — a not-found error,
+    /// never a cross-tenant delete (the agent survives).
+    #[tokio::test]
+    async fn delete_is_workspace_scoped() {
+        let (store, _ws, agent) = seed_agent("tenant-a").await;
+        let pool = store.pool();
+
+        let out = AgentRepo::delete(pool, "some-other-ws", &agent.id).await;
+        assert!(matches!(out, Err(AgentDeleteError::NotFound)));
+        assert!(
+            AgentRepo::get(pool, &agent.id).await.unwrap().is_some(),
+            "a cross-tenant delete must not remove the agent"
+        );
+    }
+
+    /// An agent with a live (running) task is refused with the active-task count —
+    /// cancel the run first (mirrors the issue delete guard).
+    #[tokio::test]
+    async fn delete_refused_while_a_task_is_active() {
+        let (store, ws, agent) = seed_agent("busy").await;
+        let pool = store.pool();
+        seed_task(pool, &ws, &agent, "task-run-1", "running").await;
+
+        let out = AgentRepo::delete(pool, &ws, &agent.id).await;
+        assert!(
+            matches!(out, Err(AgentDeleteError::ActiveTasks(1))),
+            "a running task must block the delete with its count"
+        );
+        assert!(AgentRepo::get(pool, &agent.id).await.unwrap().is_some());
+    }
+
+    /// An agent whose only tasks are terminal still carries FK-pinned history, so a
+    /// hard delete is refused as `HasHistory` (archive instead) — the DB never
+    /// orphans the historical row.
+    #[tokio::test]
+    async fn delete_refused_when_history_is_fk_pinned() {
+        let (store, ws, agent) = seed_agent("veteran").await;
+        let pool = store.pool();
+        seed_task(pool, &ws, &agent, "task-done-1", "done").await;
+
+        let out = AgentRepo::delete(pool, &ws, &agent.id).await;
+        assert!(
+            matches!(out, Err(AgentDeleteError::HasHistory)),
+            "a terminal task pins the agent by FK; delete must be refused, not orphaning it"
+        );
+        assert!(AgentRepo::get(pool, &agent.id).await.unwrap().is_some());
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -42,7 +42,7 @@ const ACTIVE_TAB_BG: Color = Color::rgb(40, 40, 60);
 /// `Autopilots` shifted down to `3`/`4` to close the hole (e38.38). `Issues`/`Task`
 /// keep their `1`/`2` muscle memory; only the two tabs that sat past the removed
 /// `Agents` slot renumber, and only by one.
-const PRIMARY_TABS: [(char, &str); 14] = [
+const PRIMARY_TABS: [(char, &str); 15] = [
     ('1', "Issues"),
     ('2', "Task"),
     ('3', "Skills"),
@@ -56,6 +56,7 @@ const PRIMARY_TABS: [(char, &str); 14] = [
     ('C', "Control"),
     ('S', "Squads"),
     ('P', "Profiles"),
+    ('A', "Agents"),
     (',', "Settings"),
 ];
 
@@ -207,6 +208,9 @@ fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
         ],
         // The profile editor: navigate the roster + cycle the selected tier (P5).
         Screen::Profiles => vec![("j/k", "profiles"), ("t", "cycle tier")],
+        // The Agents roster: create + delete a named agent (slice 2). The
+        // `[n]/[x]` hints also render on the screen header row.
+        Screen::Agents => vec![("n", "create"), ("x", "delete"), ("j/k", "agents")],
         Screen::Settings => vec![("n", "add key"), ("enter", "switch")],
         // The help overlay only needs the close hint; `?` is already pressed.
         Screen::Help => vec![("esc", "close")],
@@ -244,6 +248,7 @@ const fn tab_is_active(active: &Screen, hotkey: char) -> bool {
         'C' => matches!(active, Screen::ControlCenter),
         'S' => matches!(active, Screen::Squads),
         'P' => matches!(active, Screen::Profiles),
+        'A' => matches!(active, Screen::Agents),
         ',' => matches!(active, Screen::Settings),
         _ => false,
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -380,10 +380,11 @@ mod tests {
     /// floor is covered by `chrome_renders_at_80x24_floor_without_overflow`.
     #[test]
     fn top_bar_renders_tabs_and_slug() {
-        // Wide enough that the full fourteen-tab strip (P4 added `[B]Boards`, P7
-        // `[S]Squads`, P5 `[P]Profiles` — ~155 cols) AND the right-side
-        // workspace-slug cluster both fit; the tabs win width contention, so a
-        // narrower buffer drops the slug (covered by the 80x24 floor smoke).
+        // Wide enough that the full fifteen-tab strip (P4 added `[B]Boards`, P7
+        // `[S]Squads`, P5 `[P]Profiles`, slice 2 `[A]Agents` — ~168 cols) AND the
+        // right-side workspace-slug cluster both fit; the tabs win width
+        // contention, so a narrower buffer drops the slug (covered by the 80x24
+        // floor smoke).
         let mut buf = WireBuffer::new(200, 24);
         render_top_bar(&mut buf, 200, &Screen::IssueList, "acme", Presence::Online);
         // Reconstruct row 0 text from the wire buffer cells.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -241,6 +241,11 @@ const ISSUE_CANCEL_ACTIVE_REQ_ID: i64 = 54;
 /// JSON-RPC id for the `hangar/task_retry` force-requeue raised by the Task Kanban
 /// failed-column / task-detail `R` (a human override of the auto-retry gate).
 const TASK_RETRY_REQ_ID: i64 = 55;
+/// JSON-RPC id for a `hangar/agent_delete` raised by the Agents roster `x` confirm
+/// (slice 2). The reply carries the refreshed `AgentsListResult`, so it folds
+/// through [`Self::apply_agents`] into the cached actors — the same seam
+/// [`AGENT_CREATE_REQ_ID`] uses, so the deleted row drops from the roster live.
+const AGENT_DELETE_REQ_ID: i64 = 56;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -886,6 +891,19 @@ impl HangarPlugin {
                     self.screens.squads.note_err(format!("agent create failed: {}", e.message));
                 } else {
                     self.screens.squads.note_ok("agent created");
+                }
+                self.conn.on_event();
+            }
+            // The Agents roster `x` delete reply folds the shrunk roster back
+            // through the same actor cache; an error (active tasks / FK-pinned
+            // history) surfaces on the Agents pane so the refusal is never silent.
+            RpcId::Number(AGENT_DELETE_REQ_ID) => {
+                if let Some(e) = &resp.error {
+                    self.screens
+                        .agents
+                        .note_err(format!("delete failed: {}", e.message));
+                } else {
+                    self.apply_agents(resp);
                 }
                 self.conn.on_event();
             }
@@ -2313,6 +2331,51 @@ impl HangarPlugin {
         }
     }
 
+    /// Fire a deferred agent RPC raised by the Agents roster screen (slice 2).
+    ///
+    /// Maps [`AgentsAction::Create`] to `hangar/agent_create` (fired with no ids —
+    /// the daemon fills workspace / runtime / owner) and [`AgentsAction::Delete`] to
+    /// `hangar/agent_delete` (the agent's id extracted from its `agent:<id>` ref,
+    /// scoped to the workspace). The create reply folds through [`AGENT_CREATE_REQ_ID`]
+    /// and the delete through [`AGENT_DELETE_REQ_ID`] — both refresh the roster via
+    /// the shared actor cache.
+    async fn apply_agents_action(
+        &mut self,
+        host: &HostClient,
+        action: crate::screen::AgentsAction,
+    ) {
+        use crate::screen::AgentsAction;
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            return;
+        };
+        let ws = self.app_state().ws_id.as_str().to_string();
+        let (id, method, params) = match action {
+            AgentsAction::Create { name } => (
+                AGENT_CREATE_REQ_ID,
+                daemon_methods::HANGAR_AGENT_CREATE,
+                serde_json::json!({ "workspace_id": ws, "name": name }),
+            ),
+            AgentsAction::Delete { actor_ref } => {
+                // Extract the bare agent id from the canonical `agent:<id>` ref; a
+                // malformed ref (no prefix) is a no-op rather than a bad RPC.
+                let Some(agent_id) = actor_ref.strip_prefix("agent:") else {
+                    return;
+                };
+                (
+                    AGENT_DELETE_REQ_ID,
+                    daemon_methods::HANGAR_AGENT_DELETE,
+                    serde_json::json!({ "workspace_id": ws, "agent_id": agent_id }),
+                )
+            }
+        };
+        let Ok(body) = encode_request(id, method, params) else {
+            return;
+        };
+        if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            let _ = host.log_info(format!("hangar: agent rpc send failed: {e}")).await;
+        }
+    }
+
     /// The first cached AGENT actor-ref not already the leader or a member of
     /// `squad_id` — the glue's add-member selection policy (P7). `None` when every
     /// cached agent is already on the squad.
@@ -3100,6 +3163,18 @@ impl HangarPlugin {
         // owns Esc-to-cancel), mirroring the issue-list capture guard so typing a
         // squad name like `qa` inserts instead of quitting / switching tabs.
         if matches!(app.screen, Screen::Squads) && self.screens.squads.is_creating() {
+            if let Some(nav) = route_key(&app, &mut self.screens, key) {
+                self.apply_nav(&app, nav);
+            }
+            return;
+        }
+        // The Agents roster's create-name input and delete-confirm overlay are
+        // text/decision capture surfaces too (slice 2): while one is open every key
+        // — including the tab-switch chars and `q` — belongs to the overlay, not to
+        // nav. Route straight to the reducer (which owns Esc-to-cancel) so typing an
+        // agent name like `qa` inserts instead of quitting / switching tabs, and so
+        // Enter confirms the delete rather than being eaten by the routing layer.
+        if matches!(app.screen, Screen::Agents) && self.screens.agents.is_capturing() {
             if let Some(nav) = route_key(&app, &mut self.screens, key) {
                 self.apply_nav(&app, nav);
             }
@@ -4079,7 +4154,7 @@ const fn routing_event(key: &ainb_plugin_sdk::KeyEvent, app: &AppState) -> Optio
             // numbered tabs are now contiguous `1`→`4`.
             if matches!(
                 *ch,
-                '1' | '2' | '3' | '4' | 'B' | 'K' | 'D' | 'U' | 'L' | 'I' | 'C' | 'S' | 'P' | ',' | '?' | 'q'
+                '1' | '2' | '3' | '4' | 'B' | 'K' | 'D' | 'U' | 'L' | 'I' | 'C' | 'S' | 'P' | 'A' | ',' | '?' | 'q'
             ) =>
         {
             Some(AppEvent::Key(*ch))
@@ -4322,6 +4397,12 @@ impl Plugin for HangarPlugin {
         // (`squad_fanout`) surfaces the leader+members brief note.
         if let Some(action) = self.screens.take_pending_squads_action() {
             self.apply_squad_action(host, action).await;
+        }
+        // Slice 2: drain any deferred agent mutation (`n` create / `x` delete) raised
+        // by the Agents roster and fire `hangar/agent_create` / `hangar/agent_delete`
+        // over the daemon socket; both replies fold the refreshed roster back.
+        if let Some(action) = self.screens.take_pending_agents_action() {
+            self.apply_agents_action(host, action).await;
         }
         // e38.8: drain any deferred issue-assign (Enter in the agent picker)
         // raised by the modal and fire `hangar/issue_update` over the daemon

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -1,0 +1,798 @@
+//! Agents screen (hotkey `A`, slice 2): a first-class roster of the workspace's
+//! named agents with inline create + delete.
+//!
+//! Before this screen the only TUI path to a named agent was Squads → `n`, which
+//! nobody guessed. The Agents screen is the obvious place to SEE, CREATE, and
+//! REMOVE agents. It lists every named agent from the SAME data source the pickers
+//! use — the cached `hangar/agents_list` snapshot (`ActorRow`s, filtered to
+//! `is_agent`) — so it invents no new list RPC. Each row carries the agent's name,
+//! its subtitle, and a live presence dot resolved from that snapshot.
+//!
+//! Like every Hangar screen the reducer ([`reduce_agents`]) is **pure**: it folds a
+//! key event into a new [`AgentsState`] plus an optional [`AgentsIntent`] (which the
+//! plugin glue lifts into the matching daemon JSON-RPC — `hangar/agent_create` for
+//! `n`, `hangar/agent_delete` for a confirmed `x`). The plugin owns zero domain
+//! data (`project_ainb_plugin_owns_data_plane`); the roster comes from the daemon.
+//!
+//! Keys:
+//!   * `n` — create: an inline "New agent name:" input (the exact Squads create
+//!     idiom); Enter on a non-blank name emits [`AgentsIntent::CreateAgent`].
+//!   * `x` — delete the selected agent behind a confirm overlay (the issue-list
+//!     delete-confirm pattern); Enter confirms → [`AgentsIntent::DeleteAgent`].
+//!   * `j`/`k` — move the selection.
+//!   * `Esc` — cancel whichever overlay (create input / delete confirm) is open in
+//!     a single press; never traps the user (a bare Esc leaves navigation intact,
+//!     the footer advertises the tab hotkeys + `q` to leave).
+
+use ainb_hangar_proto::events::{ActorRow, PresenceState};
+use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
+
+use crate::widgets::presence_dot::presence_dot;
+
+/// Title / accent gold.
+const GOLD: Color = Color::rgb(255, 215, 0);
+/// Selected-row marker green.
+const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
+/// Primary row text.
+const SOFT_WHITE: Color = Color::rgb(220, 220, 230);
+/// Muted text (headers, hints, empty state, subtitles).
+const MUTED_GRAY: Color = Color::rgb(120, 120, 140);
+/// Destructive-confirm red — a delete prompt is never painted like a success.
+const ERROR_RED: Color = Color::rgb(235, 90, 90);
+
+/// One agent resolved for render: its canonical ref, display name, subtitle, and
+/// live presence (drives the inline 3-state dot).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentView {
+    /// The canonical actor-ref (`agent:<id>`).
+    pub actor_ref: String,
+    /// The display name (from the `agents_list` snapshot).
+    pub name: String,
+    /// A short subtitle (the snapshot's `subtitle`, e.g. `agent`).
+    pub subtitle: String,
+    /// Live presence (drives the inline dot).
+    pub presence: PresenceState,
+}
+
+/// The render-state cache for the Agents screen.
+///
+/// Holds the resolved agents, the list selection, an optional create-name input
+/// buffer (`Some` only while `n` is open), and an optional pending-delete
+/// confirm target (`Some(actor_ref)` only while the `x` overlay is open). The two
+/// overlays are mutually exclusive (only one input at a time). All fields private;
+/// tests and the renderer read through accessors. The scroll offset is derived per
+/// render from the selection + viewport height (viewport-blind, like `squads.rs`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AgentsState {
+    agents: Vec<AgentView>,
+    selected: usize,
+    create_input: Option<String>,
+    confirm_delete: Option<String>,
+    /// A transient ERROR note rendered red above the list — a delete/create
+    /// refusal (active tasks, FK-pinned history) so the rejection is never silent.
+    /// `None` when idle.
+    note: Option<String>,
+}
+
+impl AgentsState {
+    /// A fresh screen over `agents`, first row selected, no overlay open.
+    #[must_use]
+    pub const fn new(agents: Vec<AgentView>) -> Self {
+        Self {
+            agents,
+            selected: 0,
+            create_input: None,
+            confirm_delete: None,
+            note: None,
+        }
+    }
+
+    /// Build the screen from a cached `hangar/agents_list` actor snapshot, keeping
+    /// only the agent actors (`is_agent`) — the human members belong to the Squads
+    /// / picker surfaces, not the agent roster.
+    #[must_use]
+    pub fn from_actors(actors: &[ActorRow]) -> Self {
+        let agents = actors
+            .iter()
+            .filter(|a| a.is_agent)
+            .map(|a| AgentView {
+                actor_ref: a.actor_ref.clone(),
+                name: a.display_name.clone(),
+                subtitle: a.subtitle.clone(),
+                presence: a.presence,
+            })
+            .collect();
+        Self::new(agents)
+    }
+
+    /// The resolved agents.
+    #[must_use]
+    pub fn agents(&self) -> &[AgentView] {
+        &self.agents
+    }
+
+    /// The current list selection index.
+    #[must_use]
+    pub const fn selected_index(&self) -> usize {
+        self.selected
+    }
+
+    /// Whether the create-name input is open.
+    #[must_use]
+    pub const fn is_creating(&self) -> bool {
+        self.create_input.is_some()
+    }
+
+    /// The current create-name buffer, if the input is open.
+    #[must_use]
+    pub fn create_buffer(&self) -> Option<&str> {
+        self.create_input.as_deref()
+    }
+
+    /// Whether the `x` delete-confirm overlay is open.
+    #[must_use]
+    pub const fn is_confirming(&self) -> bool {
+        self.confirm_delete.is_some()
+    }
+
+    /// The actor-ref of the agent the open delete-confirm targets, if any.
+    #[must_use]
+    pub fn confirm_target(&self) -> Option<&str> {
+        self.confirm_delete.as_deref()
+    }
+
+    /// Whether the screen is capturing input (create name OR delete confirm), so
+    /// the plugin glue routes every key — including the global tab-switch chars —
+    /// into this screen's reducer rather than letting them switch tabs.
+    #[must_use]
+    pub const fn is_capturing(&self) -> bool {
+        self.create_input.is_some() || self.confirm_delete.is_some()
+    }
+
+    /// Restore (or clear) the create-name buffer after a snapshot refresh, so a
+    /// background roster refresh mid-typing does not wipe the half-typed name.
+    pub fn set_create_buffer(&mut self, buf: Option<String>) {
+        self.create_input = buf;
+    }
+
+    /// Restore (or clear) the delete-confirm target after a refresh — but ONLY when
+    /// the targeted agent still exists on the fresh roster. An agent that vanished
+    /// (deleted by this very confirm, or by another client) drops the stale overlay
+    /// rather than confirming a delete of a row that is no longer there.
+    pub fn restore_confirm(&mut self, target: Option<String>) {
+        self.confirm_delete =
+            target.filter(|actor_ref| self.agents.iter().any(|a| &a.actor_ref == actor_ref));
+    }
+
+    /// The transient error note, if any (rendered red above the list).
+    #[must_use]
+    pub fn note(&self) -> Option<&str> {
+        self.note.as_deref()
+    }
+
+    /// Raise a transient error note (a delete/create refusal). Rendered red so it
+    /// never reads as a success.
+    pub fn note_err(&mut self, text: impl Into<String>) {
+        self.note = Some(text.into());
+    }
+
+    /// Set (or clear) the transient note — used to preserve it across a snapshot
+    /// refresh.
+    pub fn set_note(&mut self, note: Option<String>) {
+        self.note = note;
+    }
+
+    /// The agent under the selection, if any.
+    #[must_use]
+    pub fn selected_agent(&self) -> Option<&AgentView> {
+        self.agents.get(self.selected)
+    }
+
+    /// Restore the list selection after a refresh, clamped to the new row range.
+    pub fn set_selected(&mut self, idx: usize) {
+        let len = self.agents.len();
+        self.selected = if len == 0 { 0 } else { idx.min(len - 1) };
+    }
+
+    /// Move the selection by `delta`, clamped to the row range.
+    fn move_selection(&mut self, delta: i32) {
+        let len = self.agents.len();
+        if len == 0 {
+            return;
+        }
+        let max = i32::try_from(len - 1).unwrap_or(0);
+        let cur = i32::try_from(self.selected).unwrap_or(0);
+        self.selected = usize::try_from((cur + delta).clamp(0, max)).unwrap_or(0);
+    }
+}
+
+/// An input the agents reducer folds into [`AgentsState`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentsEvent {
+    /// A printable key (`'j'`, `'n'`, `'x'`, …) — or `'\n'` (Enter) / `'\u{8}'`
+    /// (Backspace) while the create input is open.
+    Key(char),
+    /// The Escape key (cancels an open overlay; a no-op otherwise).
+    Esc,
+}
+
+/// A side-effect the plugin glue performs after an agents reduction.
+///
+/// Each variant maps to one daemon RPC the glue fires; the intent carries only the
+/// values the reducer owns (the daemon fills every FK for create, and scopes the
+/// delete by id).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentsIntent {
+    /// Create an AGENT named `name` (`n` + Enter) — `hangar/agent_create`; the glue
+    /// fires it with no ids (the daemon fills workspace / runtime / owner) and folds
+    /// the refreshed roster back.
+    CreateAgent {
+        /// The new agent's name (non-blank).
+        name: String,
+    },
+    /// Delete `actor_ref` (Enter on the `x` confirm overlay) — `hangar/agent_delete`;
+    /// the glue extracts the id from the ref and scopes the delete to the workspace.
+    DeleteAgent {
+        /// The agent to delete, in canonical `agent:<id>` form.
+        actor_ref: String,
+    },
+}
+
+/// The result of folding one [`AgentsEvent`] into an [`AgentsState`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentsReduction {
+    /// The next state.
+    pub state: AgentsState,
+    /// A side-effect for the plugin glue, if any.
+    pub intent: Option<AgentsIntent>,
+}
+
+/// Fold one [`AgentsEvent`] into `state`. Pure: no IO, no input mutation.
+#[must_use]
+pub fn reduce_agents(state: &AgentsState, ev: AgentsEvent) -> AgentsReduction {
+    match ev {
+        AgentsEvent::Key(c) => {
+            if state.create_input.is_some() {
+                reduce_create_key(state, c)
+            } else if state.confirm_delete.is_some() {
+                reduce_confirm_key(state, c)
+            } else {
+                reduce_key(state, c)
+            }
+        }
+        AgentsEvent::Esc => reduce_esc(state),
+    }
+}
+
+/// Handle a key while the create-name input is open: Enter submits (when non-blank)
+/// and emits [`AgentsIntent::CreateAgent`], Backspace deletes, any other printable
+/// char appends. Mirrors the Squads create idiom exactly.
+fn reduce_create_key(state: &AgentsState, c: char) -> AgentsReduction {
+    let mut buf = state.create_input.clone().unwrap_or_default();
+    match c {
+        '\n' => {
+            let name = buf.trim().to_string();
+            if name.is_empty() {
+                // Blank submit is a no-op — keep the input open.
+                return unchanged(state);
+            }
+            let mut next = state.clone();
+            next.create_input = None;
+            with_intent(next, AgentsIntent::CreateAgent { name })
+        }
+        '\u{8}' => {
+            buf.pop();
+            let mut next = state.clone();
+            next.create_input = Some(buf);
+            no_intent(next)
+        }
+        c if !c.is_control() => {
+            buf.push(c);
+            let mut next = state.clone();
+            next.create_input = Some(buf);
+            no_intent(next)
+        }
+        _ => unchanged(state),
+    }
+}
+
+/// Handle a key while the delete-confirm overlay is open: Enter confirms and emits
+/// [`AgentsIntent::DeleteAgent`], every other key holds the overlay open (Esc — the
+/// abort — is handled in [`reduce_esc`], never here). Mirrors the issue-list
+/// confirm: only the explicit Enter deletes, so a stray keystroke never removes an
+/// agent.
+fn reduce_confirm_key(state: &AgentsState, c: char) -> AgentsReduction {
+    match c {
+        '\n' => {
+            let Some(actor_ref) = state.confirm_delete.clone() else {
+                return unchanged(state);
+            };
+            let mut next = state.clone();
+            next.confirm_delete = None;
+            with_intent(next, AgentsIntent::DeleteAgent { actor_ref })
+        }
+        _ => unchanged(state),
+    }
+}
+
+/// Handle a normal-mode key.
+fn reduce_key(state: &AgentsState, c: char) -> AgentsReduction {
+    match c {
+        'n' => {
+            let mut next = state.clone();
+            next.create_input = Some(String::new());
+            // A fresh interaction clears any stale refusal note.
+            next.note = None;
+            no_intent(next)
+        }
+        'j' => {
+            let mut next = state.clone();
+            next.move_selection(1);
+            no_intent(next)
+        }
+        'k' => {
+            let mut next = state.clone();
+            next.move_selection(-1);
+            no_intent(next)
+        }
+        // `x` opens the delete-confirm over the selected agent; a no-op on an empty
+        // roster (nothing to confirm).
+        'x' => state.selected_agent().map_or_else(
+            || unchanged(state),
+            |a| {
+                let mut next = state.clone();
+                next.confirm_delete = Some(a.actor_ref.clone());
+                // A fresh interaction clears any stale refusal note.
+                next.note = None;
+                no_intent(next)
+            },
+        ),
+        _ => unchanged(state),
+    }
+}
+
+/// Handle Esc: cancel whichever overlay (delete-confirm or create-name) is open in
+/// a SINGLE press; a no-op otherwise. Esc closes the open overlay outright, never
+/// stepping back through state.
+fn reduce_esc(state: &AgentsState) -> AgentsReduction {
+    if state.confirm_delete.is_some() {
+        let mut next = state.clone();
+        next.confirm_delete = None;
+        no_intent(next)
+    } else if state.create_input.is_some() {
+        let mut next = state.clone();
+        next.create_input = None;
+        no_intent(next)
+    } else {
+        unchanged(state)
+    }
+}
+
+/// A reduction that changes state but emits no intent.
+const fn no_intent(state: AgentsState) -> AgentsReduction {
+    AgentsReduction {
+        state,
+        intent: None,
+    }
+}
+
+/// A reduction carrying `intent` alongside `state`.
+const fn with_intent(state: AgentsState, intent: AgentsIntent) -> AgentsReduction {
+    AgentsReduction {
+        state,
+        intent: Some(intent),
+    }
+}
+
+/// A no-op reduction: state cloned unchanged, no intent.
+fn unchanged(state: &AgentsState) -> AgentsReduction {
+    no_intent(state.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Width-aware render
+// ---------------------------------------------------------------------------
+
+/// Render the Agents screen into `buf` between rows `top` and `bottom`.
+///
+/// The header row carries the action-key hints right-aligned. Below it, either the
+/// create-name input (when open), the delete-confirm overlay (when open), the
+/// empty-state help line (no agents), or the list of agent rows — each showing the
+/// `▶` selection marker, the name, a presence dot + word, and the subtitle.
+pub fn render_agents(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    top: u16,
+    bottom: u16,
+    state: &AgentsState,
+) {
+    render_action_hints(buf, top, area_w);
+    let mut row = top + 1;
+
+    // A transient refusal note (delete/create rejected), if any — rendered red so
+    // it never reads as a success confirmation.
+    if let Some(note) = state.note() {
+        put_str(buf, 0, row, note, ERROR_RED, area_w);
+        row = row.saturating_add(1);
+    }
+
+    // Create-name input takes over the body while open (the `n` prompt).
+    if let Some(buffer) = state.create_buffer() {
+        let line = format!("New agent name: {buffer}▏");
+        put_str(
+            buf,
+            0,
+            row,
+            "Enter an agent name, Esc to cancel",
+            MUTED_GRAY,
+            area_w,
+        );
+        put_str(buf, 0, row.saturating_add(1), &line, GOLD, area_w);
+        return;
+    }
+
+    // Delete-confirm overlay takes over the body while open (the `x` prompt). Its
+    // red ink marks it as destructive so it never reads as a success confirmation.
+    if let Some(actor_ref) = state.confirm_target() {
+        let name = state
+            .agents()
+            .iter()
+            .find(|a| a.actor_ref == actor_ref)
+            .map_or(actor_ref, |a| a.name.as_str());
+        let line = format!("Delete agent \"{name}\"?");
+        put_str(buf, 0, row, &line, ERROR_RED, area_w);
+        put_str(
+            buf,
+            0,
+            row.saturating_add(1),
+            "Enter to confirm, Esc to cancel",
+            MUTED_GRAY,
+            area_w,
+        );
+        return;
+    }
+
+    if state.agents().is_empty() {
+        put_str(
+            buf,
+            0,
+            row,
+            "No agents yet — press n to create one",
+            MUTED_GRAY,
+            area_w,
+        );
+        return;
+    }
+
+    // Follow the selection so the `▶` cursor stays on-screen when the roster
+    // overflows the pane (viewport-blind, the same convention as `squads.rs`).
+    let visible_rows = usize::from(bottom.saturating_sub(row));
+    let visible_from = first_visible(state.selected_index(), visible_rows);
+    let mut y = row;
+    for (idx, agent) in state.agents().iter().enumerate().skip(visible_from) {
+        if y >= bottom {
+            break;
+        }
+        render_agent_row(buf, y, area_w, agent, idx == state.selected_index());
+        y = y.saturating_add(1);
+    }
+}
+
+/// The first-visible row index for a viewport of `visible_rows` rows that must keep
+/// `selected` on-screen (mirrors `squads::first_visible`).
+const fn first_visible(selected: usize, visible_rows: usize) -> usize {
+    if visible_rows == 0 {
+        return selected;
+    }
+    selected.saturating_sub(visible_rows - 1)
+}
+
+/// Paint the action-key hints on the top row, right-aligned. Dropped on a terminal
+/// too narrow to hold them (the footer carries them too).
+fn render_action_hints(buf: &mut WireBuffer, row: u16, area_w: u16) {
+    const HINTS: &str = "[n]ew [x]remove";
+    let hint_w = u16::try_from(HINTS.chars().count()).unwrap_or(0);
+    if hint_w >= area_w {
+        return;
+    }
+    put_str(buf, area_w - hint_w, row, HINTS, GOLD, area_w);
+}
+
+/// Render one agent row: `▶ <name>  <dot> <presence>  · <subtitle>`.
+fn render_agent_row(
+    buf: &mut WireBuffer,
+    row: u16,
+    area_w: u16,
+    agent: &AgentView,
+    selected: bool,
+) {
+    let mut x = 0u16;
+    x = put_str(
+        buf,
+        x,
+        row,
+        if selected { "▶ " } else { "  " },
+        SELECTION_GREEN,
+        area_w,
+    );
+    x = put_str(
+        buf,
+        x,
+        row,
+        &agent.name,
+        if selected { GOLD } else { SOFT_WHITE },
+        area_w,
+    );
+    x = put_str(buf, x, row, "  ", MUTED_GRAY, area_w);
+    let (glyph, color) = presence_dot(agent.presence);
+    x = put_cell(buf, x, row, glyph, color, area_w);
+    x = put_str(buf, x, row, " ", MUTED_GRAY, area_w);
+    x = put_str(
+        buf,
+        x,
+        row,
+        presence_word(agent.presence),
+        MUTED_GRAY,
+        area_w,
+    );
+    if !agent.subtitle.is_empty() {
+        x = put_str(buf, x, row, "  · ", MUTED_GRAY, area_w);
+        put_str(buf, x, row, &agent.subtitle, MUTED_GRAY, area_w);
+    }
+}
+
+/// The lowercase presence word rendered next to the dot.
+const fn presence_word(presence: PresenceState) -> &'static str {
+    match presence {
+        PresenceState::Online => "online",
+        PresenceState::Unstable => "unstable",
+        PresenceState::Offline => "offline",
+    }
+}
+
+/// Write a single glyph at `(x, row)` in `color`, clipping at `area_w`. Returns the
+/// next free column.
+fn put_cell(buf: &mut WireBuffer, x: u16, row: u16, ch: char, color: Color, area_w: u16) -> u16 {
+    if x >= area_w {
+        return x;
+    }
+    let mut cell = Cell::new(ch.to_string());
+    cell.fg = Some(color);
+    buf.push(Coord::new(x, row), cell);
+    x.saturating_add(1)
+}
+
+/// Write `s` at `(x, row)` in `color`, clipping at `area_w`. Returns the next free
+/// column. Char-safe (iterates `char`s, not bytes).
+fn put_str(buf: &mut WireBuffer, x: u16, row: u16, s: &str, color: Color, area_w: u16) -> u16 {
+    let mut cx = x;
+    for ch in s.chars() {
+        if cx >= area_w {
+            break;
+        }
+        let mut cell = Cell::new(ch.to_string());
+        cell.fg = Some(color);
+        buf.push(Coord::new(cx, row), cell);
+        cx = cx.saturating_add(1);
+    }
+    cx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actor(actor_ref: &str, name: &str, is_agent: bool) -> ActorRow {
+        ActorRow {
+            actor_ref: actor_ref.into(),
+            display_name: name.into(),
+            subtitle: if is_agent {
+                "claude".into()
+            } else {
+                "member".into()
+            },
+            presence: PresenceState::Online,
+            is_agent,
+            recent_rank: None,
+        }
+    }
+
+    fn snapshot() -> Vec<ActorRow> {
+        vec![
+            actor("agent:a-1", "backend-bot", true),
+            actor("member:u-1", "alice", false),
+            actor("agent:a-2", "review-bot", true),
+        ]
+    }
+
+    /// `from_actors` keeps only the agent actors (members are filtered out) and
+    /// resolves each row's name + subtitle + presence.
+    #[test]
+    fn from_actors_keeps_only_agents() {
+        let state = AgentsState::from_actors(&snapshot());
+        assert_eq!(state.agents().len(), 2, "the human member is filtered out");
+        assert_eq!(state.agents()[0].name, "backend-bot");
+        assert_eq!(state.agents()[0].subtitle, "claude");
+        assert_eq!(state.agents()[1].name, "review-bot");
+    }
+
+    /// `j`/`k` navigate the roster, clamped at both ends.
+    #[test]
+    fn navigation_is_clamped() {
+        let state = AgentsState::from_actors(&snapshot());
+        assert_eq!(state.selected_index(), 0);
+        let down = |s: &AgentsState| reduce_agents(s, AgentsEvent::Key('j')).state;
+        let s = down(&state);
+        assert_eq!(s.selected_index(), 1);
+        // Clamped at the last row.
+        let s = down(&s);
+        assert_eq!(s.selected_index(), 1);
+        let up = reduce_agents(&s, AgentsEvent::Key('k')).state;
+        assert_eq!(up.selected_index(), 0);
+    }
+
+    /// `n` opens the create input; typing appends; Enter (non-blank) emits a
+    /// `CreateAgent` intent; a single Esc cancels it outright.
+    #[test]
+    fn create_flow_raises_intent_and_esc_cancels() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        assert_eq!(opened.create_buffer(), Some(""), "n opens the create input");
+        assert!(opened.is_capturing());
+
+        // Type "qa".
+        let typed = reduce_agents(&opened, AgentsEvent::Key('q')).state;
+        let typed = reduce_agents(&typed, AgentsEvent::Key('a')).state;
+        assert_eq!(typed.create_buffer(), Some("qa"));
+
+        // Enter submits and closes the input.
+        let out = reduce_agents(&typed, AgentsEvent::Key('\n'));
+        assert_eq!(
+            out.intent,
+            Some(AgentsIntent::CreateAgent { name: "qa".into() })
+        );
+        assert!(
+            out.state.create_buffer().is_none(),
+            "input closes on submit"
+        );
+
+        // A single Esc on the open input cancels with no intent.
+        let cancel = reduce_agents(&typed, AgentsEvent::Esc);
+        assert!(cancel.state.create_buffer().is_none());
+        assert!(cancel.intent.is_none());
+    }
+
+    /// A blank create submit is a no-op — the input stays open, no intent.
+    #[test]
+    fn blank_create_submit_is_a_noop() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        let out = reduce_agents(&opened, AgentsEvent::Key('\n'));
+        assert!(out.intent.is_none());
+        assert_eq!(
+            out.state.create_buffer(),
+            Some(""),
+            "blank submit keeps the input open"
+        );
+    }
+
+    /// `x` opens the delete-confirm over the selected agent; Enter confirms →
+    /// `DeleteAgent` for that agent; Esc aborts with no intent.
+    #[test]
+    fn delete_confirm_flow_raises_intent_and_esc_aborts() {
+        let state = AgentsState::from_actors(&snapshot());
+        let confirming = reduce_agents(&state, AgentsEvent::Key('x')).state;
+        assert_eq!(confirming.confirm_target(), Some("agent:a-1"));
+        assert!(confirming.is_capturing());
+
+        // Enter confirms the delete of the selected agent.
+        let out = reduce_agents(&confirming, AgentsEvent::Key('\n'));
+        assert_eq!(
+            out.intent,
+            Some(AgentsIntent::DeleteAgent {
+                actor_ref: "agent:a-1".into()
+            })
+        );
+        assert!(!out.state.is_confirming(), "confirm closes on delete");
+
+        // Esc aborts the confirm with no intent.
+        let aborted = reduce_agents(&confirming, AgentsEvent::Esc);
+        assert!(!aborted.state.is_confirming());
+        assert!(aborted.intent.is_none());
+    }
+
+    /// A key that is NOT Enter holds the confirm overlay open (no stray keystroke
+    /// ever deletes an agent).
+    #[test]
+    fn confirm_holds_open_on_a_stray_key() {
+        let state = AgentsState::from_actors(&snapshot());
+        let confirming = reduce_agents(&state, AgentsEvent::Key('x')).state;
+        let out = reduce_agents(&confirming, AgentsEvent::Key('j'));
+        assert!(out.intent.is_none());
+        assert!(
+            out.state.is_confirming(),
+            "a non-Enter key keeps the confirm open"
+        );
+    }
+
+    /// `x` on an empty roster is a no-op (nothing to confirm).
+    #[test]
+    fn delete_on_empty_roster_is_a_noop() {
+        let state = AgentsState::from_actors(&[]);
+        let out = reduce_agents(&state, AgentsEvent::Key('x'));
+        assert!(out.intent.is_none());
+        assert!(!out.state.is_confirming());
+    }
+
+    /// `restore_confirm` keeps an overlay whose agent still exists, and drops one
+    /// whose agent has vanished from the fresh roster (deleted out from under it).
+    #[test]
+    fn restore_confirm_drops_a_vanished_target() {
+        let mut state = AgentsState::from_actors(&snapshot());
+        state.restore_confirm(Some("agent:a-1".into()));
+        assert_eq!(state.confirm_target(), Some("agent:a-1"));
+
+        // A ref no longer on the roster is dropped, not confirmed.
+        let mut shrunk = AgentsState::from_actors(&[actor("agent:a-2", "review-bot", true)]);
+        shrunk.restore_confirm(Some("agent:a-1".into()));
+        assert!(shrunk.confirm_target().is_none());
+    }
+
+    /// The render lists the injected agents (name + subtitle visible) with the
+    /// selection marker on the first row.
+    #[test]
+    fn render_lists_agents() {
+        let state = AgentsState::from_actors(&snapshot());
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(
+            text.contains("backend-bot"),
+            "roster must list the agent name"
+        );
+        assert!(
+            text.contains("claude"),
+            "roster must show the subtitle/provider"
+        );
+        assert!(text.contains("review-bot"));
+        assert!(text.contains('▶'), "the selected row carries the marker");
+    }
+
+    /// The empty-state line renders when there are zero agents.
+    #[test]
+    fn render_shows_empty_state() {
+        let state = AgentsState::from_actors(&[]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(
+            text.contains("No agents yet"),
+            "empty roster must show the create hint"
+        );
+    }
+
+    /// The delete-confirm overlay renders the targeted agent's name.
+    #[test]
+    fn render_shows_delete_confirm() {
+        let state = AgentsState::from_actors(&snapshot());
+        let confirming = reduce_agents(&state, AgentsEvent::Key('x')).state;
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &confirming);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(text.contains("Delete agent"), "confirm overlay must render");
+        assert!(text.contains("backend-bot"), "confirm names the agent");
+    }
+
+    /// Reassemble the buffer text for render assertions.
+    fn buffer_text(buf: &WireBuffer, w: u16, h: u16) -> String {
+        let mut grid = vec![' '; (w as usize) * (h as usize)];
+        for (coord, cell) in &buf.cells {
+            if coord.x < w && coord.y < h {
+                if let Some(ch) = cell.symbol.chars().next() {
+                    grid[(coord.y as usize) * (w as usize) + coord.x as usize] = ch;
+                }
+            }
+        }
+        grid.into_iter().collect()
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -23,6 +23,7 @@ use ainb_plugin_sdk::{KeyCode, KeyEvent, WireBuffer};
 use super::agent_picker::{
     AgentPickerEvent, AgentPickerIntent, AgentPickerState, reduce_agent_picker,
 };
+use super::agents::{AgentsEvent, AgentsIntent, AgentsState, reduce_agents};
 use super::autopilots::{AutopilotsEvent, AutopilotsIntent, AutopilotsState, reduce_autopilots};
 use super::boards::{BoardsEvent, BoardsIntent, BoardsKey, BoardsState, reduce_boards};
 use super::command_palette::{
@@ -442,6 +443,29 @@ pub enum SquadAction {
     },
 }
 
+/// A deferred daemon RPC raised by the Agents roster screen (slice 2).
+///
+/// Like [`SquadAction`], the sync key router can't `await`; it stashes the action
+/// on [`ScreenStates::pending_agents_action`] and the plugin's `render` pass drains
+/// it and fires the matching agent RPC over the daemon socket. Both replies carry
+/// the refreshed `AgentsListResult`, so the roster folds back through the same
+/// `set_actors` seam the pickers use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentsAction {
+    /// Create an AGENT named `name` (`n` + Enter) — `hangar/agent_create`; the glue
+    /// fires it with no ids (the daemon fills workspace / runtime / owner).
+    Create {
+        /// The new agent's name.
+        name: String,
+    },
+    /// Delete `actor_ref` (Enter on the `x` confirm) — `hangar/agent_delete`; the
+    /// glue extracts the id and scopes the delete to the workspace.
+    Delete {
+        /// The agent to delete, in canonical `agent:<id>` form.
+        actor_ref: String,
+    },
+}
+
 /// A deferred `attention/answer` RPC raised by the control-center screen (P2).
 ///
 /// Like the other deferred actions, the sync key router can't `await`; the
@@ -504,6 +528,10 @@ pub struct ScreenStates {
     /// Squads screen cache (P7 / D17), built from `hangar/squads_list` with each
     /// leader/member resolved against the cached actor snapshot for live status.
     pub squads: SquadsState,
+    /// Agents roster screen cache (slice 2), rebuilt from the same cached
+    /// `hangar/agents_list` actor snapshot that feeds the pickers (agent actors
+    /// only), preserving selection + open create/delete overlays across a refresh.
+    pub agents: AgentsState,
     /// Profile-editor screen cache (P5), filled from `profile/list` (roster) +
     /// `profile/get` (the selected profile's detail + both compile previews).
     pub profiles: ProfilesState,
@@ -616,6 +644,10 @@ pub struct ScreenStates {
     /// awaiting the `render` pass to fire the matching `hangar/squad_*` over the
     /// daemon socket (P7 / D17). `None` when idle.
     pub pending_squads_action: Option<SquadAction>,
+    /// An agent mutation RPC raised by the Agents roster screen (`n` create / `x`
+    /// delete), awaiting the `render` pass to fire `hangar/agent_create` or
+    /// `hangar/agent_delete` over the daemon socket (slice 2). `None` when idle.
+    pub pending_agents_action: Option<AgentsAction>,
     /// A `profile/get` raised by the profile editor (selection moved to a row
     /// whose detail is not loaded), awaiting the `render` pass to fire it. Carries
     /// the slug to fetch. `None` when idle (P5).
@@ -804,6 +836,12 @@ impl ScreenStates {
         self.pending_squads_action.take()
     }
 
+    /// Take the pending agent mutation RPC raised by the Agents roster screen, if
+    /// any (slice 2).
+    pub const fn take_pending_agents_action(&mut self) -> Option<AgentsAction> {
+        self.pending_agents_action.take()
+    }
+
     /// Replace the profile-editor roster from a `profile/list` result (P5),
     /// preserving the selection where possible. Arms a `profile/get` for the
     /// selected profile when its detail is not yet loaded, so the preview pane
@@ -848,6 +886,20 @@ impl ScreenStates {
             })
             .collect();
         self.issue_list.set_agents(named);
+        // Rebuild the Agents roster screen from the same snapshot (agent actors
+        // only), preserving the selection + any open create/delete overlay so a
+        // background refresh mid-interaction does not wipe the user's input. A
+        // delete-confirm whose agent vanished (this delete landed) is dropped.
+        let selected = self.agents.selected_index();
+        let creating = self.agents.create_buffer().map(str::to_string);
+        let confirming = self.agents.confirm_target().map(str::to_string);
+        let note = self.agents.note().map(str::to_string);
+        let mut next_agents = AgentsState::from_actors(&actors);
+        next_agents.set_selected(selected);
+        next_agents.set_create_buffer(creating);
+        next_agents.restore_confirm(confirming);
+        next_agents.set_note(note);
+        self.agents = next_agents;
         self.actors = actors;
     }
 
@@ -1162,6 +1214,9 @@ pub fn render_body(buf: &mut WireBuffer, w: u16, h: u16, app: &AppState, states:
         Screen::Profiles => {
             super::profiles::render_profiles(buf, w, top, bottom, &states.profiles);
         }
+        Screen::Agents => {
+            super::agents::render_agents(buf, w, top, bottom, &states.agents);
+        }
         Screen::Settings => {
             if let Some(s) = &states.settings {
                 super::settings::render_settings(buf, w, h, top, bottom, s);
@@ -1429,6 +1484,10 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
         }
         Screen::Squads => {
             route_squads(states, key);
+            None
+        }
+        Screen::Agents => {
+            route_agents(states, key);
             None
         }
         Screen::Profiles => {
@@ -1973,6 +2032,34 @@ fn route_squads(states: &mut ScreenStates, key: &KeyEvent) {
             member_ref,
         }),
         Some(SquadsIntent::AssignIssue { squad_id }) => Some(SquadAction::Assign { squad_id }),
+        None => None,
+    };
+}
+
+/// Agents roster key routing (slice 2): fold the key into the pure reducer,
+/// lifting an [`AgentsIntent`] into a deferred [`AgentsAction`] the `render` pass
+/// fires over the daemon socket (the sync key router can't `await`).
+///
+/// Esc cancels an open create/delete overlay; every other printable key (incl.
+/// Enter / Backspace while an overlay is open) folds into the reducer. `↑`/`↓`
+/// mirror `k`/`j` for roster navigation.
+fn route_agents(states: &mut ScreenStates, key: &KeyEvent) {
+    let ev = if matches!(key.code, KeyCode::Esc) {
+        AgentsEvent::Esc
+    } else if matches!(key.code, KeyCode::Up) {
+        AgentsEvent::Key('k')
+    } else if matches!(key.code, KeyCode::Down) {
+        AgentsEvent::Key('j')
+    } else if let Some(c) = key_char(key) {
+        AgentsEvent::Key(c)
+    } else {
+        return;
+    };
+    let out = reduce_agents(&states.agents, ev);
+    states.agents = out.state;
+    states.pending_agents_action = match out.intent {
+        Some(AgentsIntent::CreateAgent { name }) => Some(AgentsAction::Create { name }),
+        Some(AgentsIntent::DeleteAgent { actor_ref }) => Some(AgentsAction::Delete { actor_ref }),
         None => None,
     };
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
@@ -14,6 +14,7 @@
 //! [`crate::chrome`]; this module owns only the routing state it renders from.
 
 pub mod agent_picker;
+pub mod agents;
 pub mod app_screens;
 pub mod autopilots;
 pub mod banner_state;
@@ -36,9 +37,9 @@ pub mod task_detail;
 pub mod usage_dashboard;
 
 pub use app_screens::{
-    AttentionAnswerAction, AutopilotAction, BoardsAction, IssueAssignAction, IssueCommentAction,
-    IssueCreateAction, KanbanAction, NavIntent, PaletteAction, ScreenStates, SkillAction,
-    SquadAction, WorkspaceAction, render_body, route_key,
+    AgentsAction, AttentionAnswerAction, AutopilotAction, BoardsAction, IssueAssignAction,
+    IssueCommentAction, IssueCreateAction, KanbanAction, NavIntent, PaletteAction, ScreenStates,
+    SkillAction, SquadAction, WorkspaceAction, render_body, route_key,
 };
 pub use router::reduce;
 
@@ -93,6 +94,11 @@ pub enum Screen {
     /// backed by `profile/list` + `profile/get`, with tier editing via
     /// `profile/upsert` (P5).
     Profiles,
+    /// Agents roster (hotkey `A`, slice 2) — the first-class list of the
+    /// workspace's named agents with inline create (`n` → `hangar/agent_create`) +
+    /// delete (`x` → `hangar/agent_delete`), backed by the cached `hangar/agents_list`
+    /// snapshot (no new list RPC).
+    Agents,
     /// Settings (hotkey `,`).
     Settings,
     /// Help overlay (hotkey `?`) — a modal listing global + screen-local
@@ -123,6 +129,7 @@ impl Screen {
             Self::ControlCenter => "Control",
             Self::Squads => "Squads",
             Self::Profiles => "Profiles",
+            Self::Agents => "Agents",
             Self::Settings => "Settings",
             Self::Help => "Help",
             Self::CommandPalette => "Search",

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
@@ -66,6 +66,10 @@ fn reduce_key(state: &AppState, c: char) -> Reduction {
         'S' => switch_tab(state, Screen::Squads),
         // `P` (capital) opens the profile editor from anywhere (P5).
         'P' => switch_tab(state, Screen::Profiles),
+        // `A` (capital) opens the Agents roster from anywhere (slice 2). `A` was
+        // free — the old `[3]Agents` tab folded into the issue-list filter chip
+        // (e38.38) and never reclaimed a letter, so this is the first `A` binding.
+        'A' => switch_tab(state, Screen::Agents),
         ',' => switch_tab(state, Screen::Settings),
         // `?` opens the help overlay over the current screen (P4.1 deliverable,
         // P4.md:78). Esc restores the prior screen, like any modal.
@@ -126,4 +130,34 @@ const fn no_intent(state: AppState) -> Reduction {
 /// A no-op reduction: state cloned unchanged, no intent.
 fn unchanged(state: &AppState) -> Reduction {
     no_intent(state.clone())
+}
+
+#[cfg(test)]
+mod agents_nav_tests {
+    use super::*;
+    use ainb_hangar_core::ids::WorkspaceId;
+
+    fn state() -> AppState {
+        AppState::new(WorkspaceId::from_str("default").unwrap())
+    }
+
+    /// `A` routes to the Agents roster from any screen, clearing modal bookkeeping.
+    #[test]
+    fn a_routes_to_agents() {
+        let out = reduce(&state(), AppEvent::Key('A'));
+        assert_eq!(out.state.screen, Screen::Agents);
+        assert!(out.state.prior_screen.is_none());
+        assert!(out.intent.is_none());
+    }
+
+    /// The Agents tab is not a modal, so a bare Esc on it is a no-op at the routing
+    /// layer (its create/delete overlays own Esc-to-cancel); the user leaves via a
+    /// tab hotkey or `q`, never trapped.
+    #[test]
+    fn esc_on_agents_is_a_routing_noop() {
+        let on_agents = reduce(&state(), AppEvent::Key('A')).state;
+        let out = reduce(&on_agents, AppEvent::Esc);
+        assert_eq!(out.state.screen, Screen::Agents);
+        assert!(out.intent.is_none());
+    }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/daemon_dial.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/daemon_dial.rs
@@ -104,12 +104,12 @@ where
         host_write
             .write_all(&host_frame(&serde_json::json!({
                 "jsonrpc": "2.0", "id": 99, "method": methods::PLUGIN_RENDER,
-                // 176 cols so the right-cluster presence dot fits alongside the
-                // thirteen-tab strip (e38.35 added Usage; P2 added Control; P7
-                // added the Squads tab, ~144 cols); the tabs win width contention,
-                // so at a narrower width the cluster yields and `online` would not
-                // render.
-                "params": { "viewport": {"width": 176, "height": 24}, "generation": 0 }
+                // 200 cols so the right-cluster presence dot fits alongside the
+                // fifteen-tab strip (e38.35 added Usage; P2 added Control; P7 added
+                // Squads; slice 2 added the Agents tab, pushing the strip to ~168
+                // cols); the tabs win width contention, so at a narrower width the
+                // cluster yields and `online` would not render.
+                "params": { "viewport": {"width": 200, "height": 24}, "generation": 0 }
             })))
             .await
             .unwrap();

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_hangar_plugin_connects.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_hangar_plugin_connects.rs
@@ -194,12 +194,12 @@ where
         host_write
             .write_all(&host_frame(&serde_json::json!({
                 "jsonrpc": "2.0", "id": 99, "method": methods::PLUGIN_RENDER,
-                // 176 cols so the right-cluster presence dot fits alongside the
-                // thirteen-tab strip (e38.35 added Usage; P2 added Control; P7
-                // added the Squads tab, ~144 cols); the tabs win width contention,
-                // so at a narrower width the cluster yields and `online` would not
-                // render.
-                "params": { "viewport": {"width": 176, "height": 24}, "generation": 0 }
+                // 200 cols so the right-cluster presence dot fits alongside the
+                // fifteen-tab strip (e38.35 added Usage; P2 added Control; P7 added
+                // Squads; slice 2 added the Agents tab, pushing the strip to ~168
+                // cols); the tabs win width contention, so at a narrower width the
+                // cluster yields and `online` would not render.
+                "params": { "viewport": {"width": 200, "height": 24}, "generation": 0 }
             })))
             .await
             .unwrap();


### PR DESCRIPTION
## Slice 2 — first-class Agents screen (hangar TUI)

Adds an obvious top-nav place to see, create, and delete named agents. Before
this, the only TUI path to a named agent was Squads → `n`, which nobody guessed.
Independent of Slice 1 (the screen lists whatever agents exist).

### Nav letter
`A` was **free** — the old `[3]Agents` tab folded into the issue-list filter chip
(e38.38) and never reclaimed a letter, so `[A]Agents` is the first `A` binding.
Verified against the `Screen` enum and the nav-bar render.

### What it does
- **New `[A]Agents` top-nav tab** wired end to end (Screen variant → router `A`
  key → chrome tab + footer → `render_body` → `route_key`), mirroring how
  Squads/Profiles are wired.
- **Lists named agents from the cached `hangar/agents_list` snapshot** (agent
  actors only, via the shared `set_actors` seam) — **no new list RPC**. Each row:
  name, presence dot + word, subtitle.
- **`n` create** — inline "New agent name:" input reusing the **exact Squads
  create idiom**; Enter (non-blank) fires `hangar/agent_create`.
- **`x` delete** — a confirm overlay mirroring the issue-list delete-confirm;
  Enter fires `hangar/agent_delete`. A refusal (active tasks / FK-pinned history)
  surfaces as a red note (never silent).
- **`j`/`k` navigate**, empty-state prompt, and the create/delete overlays are
  text-capture surfaces so tab-switch chars (`q`, `S`, …) type instead of
  switching tabs. Esc cancels an open overlay in one press.

### `agent_delete` RPC — **added** (none existed)
Grepped `AGENT_DELETE` / `agent_delete` / `handle_agent_delete` across the daemon
rpc + proto: **no delete RPC existed**, so I added one append-only:
- **proto**: `HANGAR_AGENT_DELETE` const (+ `ALL_METHODS` + drift-guard lists) and
  `AgentDeleteParams { workspace_id, agent_id }`; result reuses `AgentsListResult`
  so the reply refreshes the roster like `agent_create`.
- **store**: `AgentRepo::delete` — workspace-scoped, guarded exactly like
  `IssueRepo::delete_cascade`: `NotFound` (unknown/foreign id), `ActiveTasks(n)`
  (a live run), `HasHistory` (the `DELETE` trips an FK because past tasks / usage /
  autopilots pin the agent). It's a **real hard delete**, not a soft archive: a
  fresh, never-run agent (the common thing you'd delete from this screen) deletes
  cleanly. sqlx enforces `PRAGMA foreign_keys`, so the DB **refuses to orphan**
  historical rows rather than dangling a reference — a deliberately conservative
  choice over a wide destructive cascade across the agent's FK-owned tables.
- **daemon**: `handle_agent_delete` maps each guard to the `INVALID_PARAMS`
  contract with machine-readable `data` markers (`active_tasks` / `has_history`)
  and answers with the refreshed roster.

### Tests (behavioral)
- **Agents reducer/render** (agents.rs, 11 tests): `n` opens input / typing / Enter
  emits create / blank holds / Esc cancels; `x` opens confirm / Enter deletes / Esc
  aborts / stray key holds / empty-roster no-op; `restore_confirm` drops a vanished
  target; render lists agents (name+subtitle) + empty-state + confirm overlay.
- **Nav** (router.rs, 2 tests): `A` routes to `Screen::Agents`; bare Esc is a
  routing no-op (overlays own Esc; user leaves via a tab hotkey or `q`).
- **store** (agent.rs, 5 tests): clean delete of a fresh agent; unknown-id NotFound;
  workspace-scoped (foreign ws NotFound, agent survives); ActiveTasks refusal;
  HasHistory refusal (terminal task FK-pins the agent).
- **daemon** (rpc/mod.rs, 2 tests): socket round-trip create→delete drops the row;
  unknown-id rejected.
- Net plugin test count increases (no drop). `daemon_dial`'s render width widened
  176→200 for the now-15-tab strip (the presence cluster yields to tabs below that).

### Verification
- `cargo build -p ainb` ✓  ·  `cargo build -p ainb-hangar-{proto,store,daemon} -p ainb-plugin-hangar` ✓
- `cargo test -p ainb-hangar-proto -p ainb-hangar-store` ✓ (incl. 5 delete tests)
- `cargo test -p ainb-hangar-daemon` ✓ **fully green** (111 result-ok, 0 failed)
- `cargo test -p ainb-plugin-hangar` ✓ **except one pre-existing failure**:
  `render_full_health_pane_snapshot` — the committed `.snap` on origin/main reads
  `daemon: 1.15.0` while the workspace version is `1.16.0`, so it already fails on
  main (version drift, unrelated to this PR). Left untouched.
- `cargo fmt` applied to my files; reverted pre-existing fmt drift that `fmt` also
  touched in `squads.rs` / `squads_screen_snapshot.rs` / `live_e2e.rs` / `run_loop.rs`.
- clippy `-p ainb-plugin-hangar`: one new lint in agents.rs (`needless_pass_by_value`
  on `reduce_agents`) — **identical to the `reduce_squads` sibling** it mirrors
  (same category, already in the crate's pre-existing baseline); no new categories.

### Notes
- **Delete shipped** (not a fast-follow), scoped to a safe hard delete guarded on
  active tasks + FK history rather than a destructive multi-table cascade.
- Commits are small, single-concern, signed.

Do not merge — orchestrator lands after validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Agents tab for viewing and navigating the agent roster.
  * Added agent creation with inline name entry.
  * Added agent deletion with confirmation prompts.
  * Refreshes the roster after successful changes and displays actionable errors.
  * Prevents deletion of agents with active tasks or retained run history.
* **Bug Fixes**
  * Enforced workspace-scoped agent deletion and clear handling for unknown agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->